### PR TITLE
Fix CI: test for warning->error promotion, ruff format

### DIFF
--- a/hooks/tests/test_integration.py
+++ b/hooks/tests/test_integration.py
@@ -150,10 +150,7 @@ def test_database_stats():
     assert "by_category" in stats
     assert "high_confidence" in stats
 
-    print(
-        f"  Stats: {stats['total_learnings']} learnings, "
-        f"{stats.get('high_confidence', 0)} high-confidence"
-    )
+    print(f"  Stats: {stats['total_learnings']} learnings, {stats.get('high_confidence', 0)} high-confidence")
     print("  ✓ Database statistics working correctly")
 
 

--- a/scripts/scan-ai-patterns.py
+++ b/scripts/scan-ai-patterns.py
@@ -143,7 +143,7 @@ def main():
                 error_count = sum(1 for h in file_hits if h["severity"] == "error")
                 print(f"\n{filepath}: {len(file_hits)} hits ({error_count} errors)")
                 for h in sorted(file_hits, key=lambda x: x["line"]):
-                    print(f"  L{h['line']} [{h['severity']}] {h['category']}: \"{h['pattern']}\"")
+                    print(f'  L{h["line"]} [{h["severity"]}] {h["category"]}: "{h["pattern"]}"')
                     print(f"    {h['context']}")
 
             total_errors = sum(1 for h in all_hits if h["severity"] == "error")

--- a/scripts/tests/test_voice_validator.py
+++ b/scripts/tests/test_voice_validator.py
@@ -362,13 +362,17 @@ class TestScoreCalculation:
         assert result["score"] < 100
 
     def test_warning_reduces_score(self):
-        """Warnings should reduce the score."""
+        """Non-error violations should reduce the score."""
         text = "Let me delve into this journey. We explore the landscape."
         returncode, stdout, stderr = run_validator(["validate", "--voice", "voice_a", "--json"], text)
 
         result = parse_result(stdout)
+        # Count all non-error violations (warnings + info)
         warning_count = len(result["violations"]["warnings"])
-        assert warning_count > 0
+        info_count = len(result["violations"]["info"])
+        error_count = len(result["violations"]["errors"])
+        total_violations = warning_count + info_count + error_count
+        assert total_violations > 0
         assert result["score"] < 100
 
     def test_score_matches_formula(self, sample_voice_bad):


### PR DESCRIPTION
## Summary

- Fixed `test_warning_reduces_score` which expected warning-severity violations but all warnings were promoted to errors in the previous PR. Test now checks total violations.
- Ran `ruff format` on 2 files that were not formatted before push.
- 483 tests pass, 144 files formatted.

## Test plan

- [x] `pytest --tb=short -q` passes (483/483)
- [x] `ruff format --check .` passes (144 files clean)