### PR TITLE
Force-route push/commit/PR through quality-gated skills

### DIFF
--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -127,8 +127,13 @@ These skills have MANDATORY routing. They MUST be invoked when triggers appear:
 | **retro-pipeline** | run retro, retro pipeline, phase checkpoint retro, retro checkpoint |
 | **system-upgrade** | upgrade agents, system upgrade, claude update, upgrade skills, apply claude update, apply update, new claude version, apply retro to system |
 | **de-ai-pipeline** | de-ai docs, clean ai patterns, fix ai writing, scan and fix docs, remove ai tells |
+| **pr-sync** | push, push this, push changes, commit and push, push to GitHub, sync to GitHub, create a PR, create PR, open PR, open pull request, ship this, send this |
+| **git-commit-flow** | commit, commit this, commit changes, stage and commit |
+| **github-actions-check** | check CI, CI status, actions status, did CI pass, are tests passing |
 
 If a force-route trigger matches, invoke that skill BEFORE any other action.
+
+**Critical**: "push", "commit", "create PR", "merge" are NOT trivial git commands. They MUST route through skills that run quality gates (lint, tests, review) before executing. Running raw `git push` or `gh pr create` without routing through pr-sync or pr-pipeline bypasses all quality gates.
 
 **Step 2: Select domain agent**
 
@@ -479,6 +484,11 @@ Solution:
 **What it looks like**: Fixing 3 independent test failures one at a time
 **Why wrong**: Independent work items can run concurrently, saving significant time
 **Do instead**: Detect independent items and use dispatching-parallel-agents.
+
+### Anti-Pattern 5: Raw Git Commands Instead of Skills
+**What it looks like**: Running `git push`, `git commit`, `gh pr create`, or `gh pr merge` directly without routing through pr-sync, git-commit-flow, or pr-pipeline
+**Why wrong**: Bypasses lint checks, test runs, review loops, CI verification, and repo classification. This is how broken code gets merged. A CI failure after merge costs more than a pre-push check.
+**Do instead**: Route ALL git submission actions through their skills. "push" routes to pr-sync. "commit" routes to git-commit-flow. "create PR" routes to pr-pipeline. No exceptions, even when the user asks to "just push it."
 
 ---
 

--- a/skills/do/references/routing-tables.md
+++ b/skills/do/references/routing-tables.md
@@ -67,7 +67,10 @@ Extended routing tables for the `/do` router. The main SKILL.md contains the cor
 | Triggers | Skill |
 |----------|-------|
 | submit PR, create pull request | pr-pipeline |
-| sync to GitHub, push and PR | pr-sync |
+| **push, push this, push changes, commit and push, sync to GitHub, push to GitHub** | **pr-sync (FORCE)** |
+| **create a PR, create PR, open PR, open pull request, ship this, send this** | **pr-sync (FORCE)** |
+| **commit, commit this, commit changes, stage and commit** | **git-commit-flow (FORCE)** |
+| **check CI, CI status, actions status, did CI pass** | **github-actions-check (FORCE)** |
 | PR cleanup, merged branch | pr-cleanup |
 | PR review comments, fix feedback | pr-fix |
 | address PR feedback, what did reviewers say | pr-review-address-feedback |


### PR DESCRIPTION
## Summary

- Added force-route triggers so casual git phrases route through skills instead of raw commands:
  - "push", "push this", "commit and push" -> `pr-sync` (runs lint, tests, review loop)
  - "commit", "commit this" -> `git-commit-flow` (validates staging, conventional format)
  - "check CI", "CI status" -> `github-actions-check`
  - "create PR", "open PR", "ship this" -> `pr-sync`
- Added Anti-Pattern 5: Raw Git Commands Instead of Skills
- The `classify-repo.py` script and org-gated workflows were already present from the original repo

## Context

PR #1 was merged with failing CI because `git push` and `gh pr create` were run directly, bypassing the pr-pipeline and pr-sync skills that enforce lint, tests, and review gates.

## Test plan

- [x] `ruff format --check .` passes (144 files clean)
- [x] `pytest --tb=short -q` passes (483/483)
- [x] Force-route table updated in both SKILL.md and routing-tables.md