### PR TITLE
Add group-prefix naming convention to creation pipelines

### DIFF
--- a/agents/skill-creator-engineer.md
+++ b/agents/skill-creator-engineer.md
@@ -325,6 +325,7 @@ STOP and ask the user (do NOT proceed autonomously) when:
 
 ### Never Guess On
 - Skill naming conventions (ask if unsure about {domain}-{action} pattern)
+- Group-prefix consistency (run `ls skills/ | grep {domain}` to find existing group before naming. Related skills share a prefix: `voice-*`, `go-*`, `pr-*`, `writing-*`, `review-*`, `feature-*`, `testing-*`, `git-*`. If a group exists, use its prefix. If none exists, the new skill starts one.)
 - Whether to create new skill vs improve existing skill
 - Routing category (language/infrastructure/review/meta/content)
 - Whether Python script automation is needed (deterministic operations)

--- a/skills/pipeline-scaffolder/SKILL.md
+++ b/skills/pipeline-scaffolder/SKILL.md
@@ -39,7 +39,8 @@ This skill operates as the build engine of the self-improving pipeline generator
 ### Default Behaviors (ON unless disabled)
 - **Communication Style**: Report facts without self-congratulation. Show generated file paths, component counts, and key decisions rather than describing them.
 - **Temporary File Cleanup**: Remove any intermediate generation files. Keep only the final pipeline components.
-- **Naming Convention**: Agents follow `{domain}-{function}-engineer` pattern. Skills use `{domain}-{function}`. Hooks use `{pipeline-name}-detector.py`. Scripts use `{domain}-{function}.py`.
+- **Naming Convention**: Agents follow `{domain}-{function}-engineer` pattern. Skills use `{group}-{function}`. Hooks use `{pipeline-name}-detector.py`. Scripts use `{domain}-{function}.py`.
+- **Group-Prefix Consistency**: New skills MUST use the same prefix as related existing skills. Before naming, check `ls skills/ | grep {domain}` to find the group. Examples: voice skills start with `voice-`, Go skills with `go-`, PR skills with `pr-`, writing/content skills with `writing-`, review skills with `review-`. If no group exists, the new skill starts one.
 - **Profile-Aware Generation**: Respect the `operator_profile` field from the Pipeline Spec. Include or exclude safety/interaction steps based on the profile. WHY: Personal profiles don't need APPROVE gates; production profiles require them. Over-gating personal workflows adds friction; under-gating production workflows creates risk.
 
 ### Optional Behaviors (OFF unless enabled)

--- a/skills/skill-creation-pipeline/SKILL.md
+++ b/skills/skill-creation-pipeline/SKILL.md
@@ -33,6 +33,7 @@ the creator agent; it provides the scaffolding around it.
 - **DISCOVER Before Any Files**: Phase 1 (DISCOVER) must complete before any
   SKILL.md is written. No exceptions. This prevents duplicate skills from being
   added to the repo.
+- **Group-Prefix Naming**: New skills MUST use the same prefix as related existing skills. During DISCOVER, run `ls skills/ | grep {domain}` to find the group. Examples: voice skills start with `voice-`, Go skills with `go-`, PR skills with `pr-`, writing/content skills with `writing-`, review skills with `review-`. If no group exists, the new skill starts one. The directory name and the `name:` frontmatter field must match.
 - **Design Brief Before SCAFFOLD**: Phase 2 (DESIGN) must produce a saved design
   brief before Phase 3 begins. Writing a skill without a tier decision and phase
   list produces inconsistent results.


### PR DESCRIPTION
## Summary

- pipeline-scaffolder: added group-prefix consistency to naming convention rule
- skill-creation-pipeline: added as hardcoded behavior in DISCOVER phase
- skill-creator-engineer: added to Never Guess On section

New skills must share a prefix with related existing skills (voice-*, go-*, pr-*, writing-*, review-*, etc). The creation pipelines now check `ls skills/ | grep {domain}` during DISCOVER before naming.

## Test plan

- [x] `ruff format --check .` passes (144 files clean)
- [x] `pytest --tb=short -q` passes (483/483)
- [x] Changes are documentation/process only (no code behavior changes)