### PR TITLE
Add --force flag to installer for non-interactive symlink mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd ~/claude-code-toolkit
 ./install.sh --copy           # alternative: stable snapshot
 ```
 
-The installer places agents, skills, hooks, commands, and scripts in `~/.claude/`. It configures hooks in `settings.json` and prompts before overwriting files. Use `--uninstall` to remove.
+The installer places agents, skills, hooks, commands, and scripts in `~/.claude/`. It configures hooks in `settings.json`. Use `--uninstall` to remove. Add `--force` to replace existing directories without prompting (needed when switching from copy to symlink mode).
 
 Back up any existing Claude Code customizations before installing. Symlink mode replaces directories.
 

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,7 @@ echo ""
 # Parse arguments
 MODE=""
 DRY_RUN=false
+FORCE=false
 while [[ $# -gt 0 ]]; do
     case $1 in
         --symlink)
@@ -58,14 +59,19 @@ while [[ $# -gt 0 ]]; do
             DRY_RUN=true
             shift
             ;;
+        --force|-f)
+            FORCE=true
+            shift
+            ;;
         --help|-h)
-            echo "Usage: $0 [--symlink|--copy|--uninstall|--dry-run]"
+            echo "Usage: $0 [--symlink|--copy|--uninstall|--dry-run|--force]"
             echo ""
             echo "Options:"
             echo "  --symlink    Create symlinks to this repo (recommended for development)"
             echo "  --copy       Copy files to ~/.claude (recommended for stability)"
             echo "  --uninstall  Remove the installation"
             echo "  --dry-run    Show what would happen without making changes"
+            echo "  --force      Replace existing directories without prompting"
             echo ""
             echo "If no option provided, will prompt interactively."
             exit 0
@@ -200,7 +206,10 @@ install_component() {
         else
             echo -e "${YELLOW}  Warning: $target exists and is not a symlink${NC}"
             if [ "$DRY_RUN" = true ]; then
-                echo -e "${BLUE}  Would prompt for overwrite${NC}"
+                echo -e "${BLUE}  Would replace existing directory${NC}"
+            elif [ "$FORCE" = true ]; then
+                echo "  Replacing existing directory (--force): $target"
+                rm -rf "$target"
             else
                 read -p "  Overwrite? [y/N]: " confirm
                 if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then


### PR DESCRIPTION
## Summary

The installer silently skipped directory creation when switching from copy to symlink mode because `read -p "Overwrite?"` defaulted to N on non-interactive input.

Added `--force` flag that replaces existing directories without prompting:
```bash
./install.sh --symlink --force
```

## The bug

1. User runs `./install.sh --copy` (first install)
2. Later runs `./install.sh --symlink` to switch modes
3. Installer hits `read -p "Overwrite? [y/N]"` for each of 5 directories
4. With piped input, stdin is empty, defaults to N, skips all 5
5. Installer prints "Installation Complete!" with nothing changed

## Test plan

- [x] `./install.sh --symlink --force --dry-run` shows "Would replace existing directory" (no prompt)
- [x] `ruff format --check .` passes (144 files)
- [x] `pytest --tb=short -q` passes (483/483)