### PR TITLE
Add Phase 7 CLEANUP to pr-pipeline for branch deletion after merge

### DIFF
--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -242,7 +242,7 @@ For pipeline skills — add the Pipeline: line with all phases in order:
 | `retro-pipeline` | WALK → MERGE → GATE → APPLY → REPORT |
 | `explore-pipeline` | SCAN → MAP → ANALYZE → REPORT |
 | `research-to-article` | RESEARCH → COMPILE → GROUND → GENERATE → VALIDATE → REFINE → OUTPUT |
-| `pr-pipeline` | CLASSIFY → STAGE → REVIEW → COMMIT → PUSH → CREATE → VERIFY |
+| `pr-pipeline` | CLASSIFY → STAGE → REVIEW → COMMIT → PUSH → CREATE → VERIFY → CLEANUP |
 | `voice-orchestrator` | LOAD → GROUND → GENERATE → VALIDATE → REFINE → OUTPUT → CLEANUP |
 | `github-profile-rules` | PROFILE-SCAN → CODE-ANALYSIS → REVIEW-MINING → PATTERN-SYNTHESIS → RULES-GENERATION → VALIDATION → OUTPUT |
 | `doc-pipeline` | RESEARCH → OUTLINE → GENERATE → VERIFY → OUTPUT |

--- a/skills/pr-pipeline/SKILL.md
+++ b/skills/pr-pipeline/SKILL.md
@@ -383,7 +383,33 @@ If CI fails, report which checks failed and the PR URL. Do not attempt to fix CI
 
 If `--no-wait` was passed, skip this phase and report the PR URL immediately.
 
-**Gate**: CI status reported. Pipeline complete.
+**Gate**: CI status reported. Proceed to Phase 7.
+
+### Phase 7: CLEANUP
+
+**Goal**: Delete the feature branch after successful merge or PR creation.
+
+For personal repos where CI passed and PR was merged:
+```bash
+# Switch to main and pull
+git checkout main
+git pull origin main
+
+# Delete local branch
+git branch -d <branch-name>
+
+# Delete remote branch
+git push origin --delete <branch-name>
+
+# Prune stale tracking refs
+git fetch --prune
+```
+
+For personal repos where PR was created but not yet merged: skip cleanup (branch is still active).
+
+For protected-org repos: skip cleanup (their processes handle branch lifecycle).
+
+**Gate**: Branch cleaned up (or skipped if PR is still open). Pipeline complete.
 
 ---
 


### PR DESCRIPTION
## Summary

The pr-pipeline ended at Phase 6 VERIFY with no branch cleanup. Merged branches accumulated (5 stale branches from this session).

Added Phase 7 CLEANUP that deletes local and remote branches after successful merge on personal repos. Skipped for open PRs and protected-org repos.

## Test plan

- [x] `ruff format --check .` passes (144 files)
- [x] `pytest --tb=short -q` passes (483/483)
- [x] Pipeline registry updated in /do SKILL.md