### PR TITLE
feat: add learning capture hooks, simplify /do Phase 5

### DIFF
--- a/hooks/review-capture.py
+++ b/hooks/review-capture.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+PostToolUse Hook: Review Findings Capture
+
+Captures review findings from subagent (Agent tool) results and records
+them to learning.db for cross-session knowledge retention.
+
+Watches for severity-tagged findings (CRITICAL, HIGH, MUST-FIX) and
+verdict markers (NEEDS_CHANGES, FAILURES_FOUND, ISSUES_FOUND) in
+Agent tool output.
+
+Design Principles:
+- SILENT output (records to DB, no context injection)
+- Non-blocking (always exits 0)
+- Fast execution (<50ms target)
+- Only processes Agent tool results
+"""
+
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+# Add lib directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+
+from hook_utils import empty_output
+from learning_db_v2 import record_learning
+
+EVENT_NAME = "PostToolUse"
+
+# Severity header patterns — match lines like "### CRITICAL: some finding"
+SEVERITY_HEADER_RE = re.compile(
+    r"###\s+(CRITICAL|HIGH|MEDIUM|MUST-FIX|SHOULD-FIX)\s*:\s*(.+)",
+    re.IGNORECASE,
+)
+
+# Verdict patterns indicating review found issues
+VERDICT_PATTERNS = [
+    re.compile(r"VERDICT\s*:\s*NEEDS_CHANGES", re.IGNORECASE),
+    re.compile(r"VERDICT\s*:\s*FAILURES_FOUND", re.IGNORECASE),
+    re.compile(r"VERDICT\s*:\s*ISSUES_FOUND", re.IGNORECASE),
+    re.compile(r"\*\*Status\*\*\s*:\s*ISSUES\s+FOUND", re.IGNORECASE),
+]
+
+
+def has_review_findings(text: str) -> bool:
+    """Check if text contains any review finding patterns.
+
+    Args:
+        text: Agent tool result text to scan.
+
+    Returns:
+        True if severity headers or verdict markers are present.
+    """
+    if SEVERITY_HEADER_RE.search(text):
+        return True
+    return any(p.search(text) for p in VERDICT_PATTERNS)
+
+
+def extract_findings(text: str) -> dict[str, int | list[str]]:
+    """Extract severity counts and first 3 finding summaries from text.
+
+    Args:
+        text: Agent tool result text containing review findings.
+
+    Returns:
+        Dict with severity counts and list of finding summaries.
+    """
+    counts: dict[str, int] = {
+        "CRITICAL": 0,
+        "HIGH": 0,
+        "MEDIUM": 0,
+        "MUST-FIX": 0,
+        "SHOULD-FIX": 0,
+    }
+    summaries: list[str] = []
+
+    for match in SEVERITY_HEADER_RE.finditer(text):
+        severity = match.group(1).upper()
+        summary = match.group(2).strip()
+
+        if severity in counts:
+            counts[severity] += 1
+
+        if len(summaries) < 3:
+            summaries.append(summary[:200])
+
+    return {
+        "critical": counts["CRITICAL"],
+        "high": counts["HIGH"],
+        "medium": counts["MEDIUM"],
+        "must_fix": counts["MUST-FIX"],
+        "should_fix": counts["SHOULD-FIX"],
+        "summaries": summaries,
+    }
+
+
+def main() -> None:
+    """Process PostToolUse events for Agent tool review findings.
+
+    Flow:
+    1. Read stdin JSON, check tool_name == "Agent"
+    2. Scan tool_result for review finding patterns
+    3. Extract severity counts and finding summaries
+    4. Record to learning.db
+    5. Exit silently (no context injection)
+    """
+    try:
+        event_data = sys.stdin.read()
+        if not event_data:
+            return
+
+        event = json.loads(event_data)
+
+        # Only process Agent tool results
+        tool_name = event.get("tool_name", "")
+        if tool_name != "Agent":
+            return
+
+        # Get tool result text
+        tool_result = event.get("tool_result", "")
+        if isinstance(tool_result, dict):
+            tool_result = tool_result.get("output", "")
+        if not isinstance(tool_result, str) or not tool_result:
+            return
+
+        # Check for review finding patterns
+        if not has_review_findings(tool_result):
+            return
+
+        # Extract findings
+        findings = extract_findings(tool_result)
+        critical_count = findings["critical"]
+        high_count = findings["high"]
+        medium_count = findings["medium"]
+        must_fix_count = findings["must_fix"]
+        should_fix_count = findings["should_fix"]
+        summaries = findings["summaries"]
+
+        # Build findings summary for DB storage
+        summary_parts = []
+        if critical_count:
+            summary_parts.append(f"{critical_count} CRITICAL")
+        if high_count:
+            summary_parts.append(f"{high_count} HIGH")
+        if medium_count:
+            summary_parts.append(f"{medium_count} MEDIUM")
+        if must_fix_count:
+            summary_parts.append(f"{must_fix_count} MUST-FIX")
+        if should_fix_count:
+            summary_parts.append(f"{should_fix_count} SHOULD-FIX")
+
+        findings_header = ", ".join(summary_parts) if summary_parts else "issues found"
+        findings_detail = "; ".join(summaries) if summaries else "review flagged issues"
+        findings_summary = f"{findings_header}: {findings_detail}"
+
+        # Generate dedup key from summary content
+        key_hash = hashlib.md5(findings_summary.encode()).hexdigest()[:8]
+
+        # Source detail with counts
+        source_detail = f"{critical_count}C/{high_count}H/{medium_count}M findings"
+
+        # Record to learning.db
+        record_learning(
+            topic="review-findings",
+            key=f"review-{key_hash}",
+            value=findings_summary,
+            category="review",
+            source="hook:review-capture",
+            source_detail=source_detail,
+        )
+
+        # Silent output — learning recorded to DB, not injected into context
+        empty_output(EVENT_NAME).print_and_exit()
+
+    except Exception as e:
+        print(f"[review-capture] error: {e}", file=sys.stderr)
+    finally:
+        sys.exit(0)  # Never block
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/session-learning-recorder.py
+++ b/hooks/session-learning-recorder.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Stop Hook: Session Learning Gap Detector
+
+Fires at session end to check whether the session recorded any learnings.
+Prints a gap warning for substantive sessions with zero learnings, or a
+summary count when learnings were captured.
+
+Design Principles:
+- Observability only, not enforcement
+- Non-blocking (always exits 0)
+- Fast execution (<50ms target)
+- Silent on trivial sessions
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+# Add lib directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+
+from hook_utils import empty_output, get_session_id
+from learning_db_v2 import get_connection, init_db
+
+EVENT_NAME = "Stop"
+
+SUBSTANTIVE_TOOL_THRESHOLD = 5
+
+
+def count_session_learnings(session_id: str) -> int:
+    """Count learnings recorded for this session.
+
+    Falls back to time-based query (last hour) if no session_id match.
+    """
+    init_db()
+
+    with get_connection() as conn:
+        # Primary: match by session_id
+        row = conn.execute(
+            "SELECT COUNT(*) FROM learnings WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        count = row[0] if row else 0
+
+        if count > 0:
+            return count
+
+        # Fallback: learnings recorded in the last hour
+        cutoff = (datetime.now() - timedelta(hours=1)).isoformat()
+        row = conn.execute(
+            "SELECT COUNT(*) FROM learnings WHERE last_seen >= ?",
+            (cutoff,),
+        ).fetchone()
+        return row[0] if row else 0
+
+
+def is_substantive_session(event: dict) -> bool:
+    """Determine if the session was substantive enough to warrant a gap check."""
+    session_data = event.get("session_data", {})
+
+    # Check tool call count
+    tool_uses = session_data.get("tool_uses", [])
+    if len(tool_uses) > SUBSTANTIVE_TOOL_THRESHOLD:
+        return True
+
+    # Check if files were modified
+    files_modified = session_data.get("files_modified", [])
+    if len(files_modified) > 0:
+        return True
+
+    return False
+
+
+def main():
+    """Check learning gap at session end."""
+    try:
+        event_data = sys.stdin.read()
+        if not event_data:
+            empty_output(EVENT_NAME).print_and_exit()
+
+        event = json.loads(event_data)
+        session_id = event.get("session_id") or get_session_id()
+
+        # Skip trivial sessions
+        if not is_substantive_session(event):
+            empty_output(EVENT_NAME).print_and_exit()
+
+        learning_count = count_session_learnings(session_id)
+
+        if learning_count == 0:
+            print(
+                "[learning-gap] Substantive session with 0 learnings recorded. Consider recording insights.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"[learning-summary] Session recorded {learning_count} learnings",
+                file=sys.stderr,
+            )
+
+        empty_output(EVENT_NAME).print_and_exit()
+
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            print(f"[session-learning-recorder] Error: {e}", file=sys.stderr)
+
+    empty_output(EVENT_NAME).print_and_exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -383,22 +383,14 @@ When uncertain which route: **ROUTE ANYWAY.** Route to the most likely agent + s
 
 ### Phase 5: LEARN
 
-**Goal**: Review auto-captured learnings, upgrade valuable entries, and record new insights to the unified knowledge store (`~/.claude/learning/learning.db`).
+**Goal**: Ensure session insights are captured to `learning.db`.
 
-**Architecture**: Hooks automatically capture errors, approach pivots, and review findings during the session (zero LLM cost). The LEARN phase reviews what was captured and adds human-quality context — it's a **curator**, not the sole capture point.
+**Auto-capture** (hooks, zero LLM cost):
+- `error-learner.py` (PostToolUse) → captures tool errors + solutions
+- `review-capture.py` (PostToolUse) → captures review agent findings
+- `session-learning-recorder.py` (Stop) → warns on substantive sessions with no learnings
 
-**When to run**: After every Simple+ task that produced substantive work. Skip for Trivial tasks and read-only operations.
-
-**Step 1: Check what was auto-captured**
-
-Hooks automatically record to `learning.db` during the session:
-- `error-learner.py` → category:error (tool errors + solutions)
-- Future: `pivot-detector.py` → category:pivot (approach changes)
-- Future: `review-capture.py` → category:review (PR review findings)
-
-**Step 2: Record NEW insights not captured by hooks**
-
-For insights that require LLM judgment (design decisions, gotchas, debugging insights):
+**Manual recording** (for design decisions, gotchas, and insights hooks can't detect):
 
 ```bash
 python3 scripts/learning-db.py record TOPIC KEY "VALUE" --category CATEGORY
@@ -406,38 +398,9 @@ python3 scripts/learning-db.py record TOPIC KEY "VALUE" --category CATEGORY
 
 Categories: `error | pivot | review | design | debug | gotcha | effectiveness`
 
-Examples:
-```bash
-python3 scripts/learning-db.py record go-patterns mutex-over-atomics "sync.Mutex beats atomics for multi-field state machines — correctness > micro-optimization" --category design
-python3 scripts/learning-db.py record debugging hook-timing "UserPromptSubmit hooks fire BEFORE /do routing. Agent-scoped injection must happen in /do Phase 4, not in hooks." --category gotcha
-```
+Record specific, actionable insights — not generic advice. "Force-route triggers must not contain sibling skill names" is good. "Be careful with routing" is not.
 
-**Fallback** (when learning-db.py is not available):
-```bash
-python3 scripts/feature-state.py retro-record-adhoc TOPIC KEY "VALUE"
-```
-
-**Cross-repo** (when outside agents repo):
-```bash
-python3 ~/.claude/scripts/learning-db.py record TOPIC KEY "VALUE" --category CATEGORY
-```
-
-**Step 3: Report what was learned**
-
-```
-CAPTURED: N auto-captured, M new recordings
-  [key] → [topic] (category)
-```
-
-**Quality gate**: Record liberally, inject conservatively. The confidence threshold at injection time (≥0.5) filters noise — so when in doubt, record it. Low-value entries naturally decay via pruning.
-
-| Record this | Don't record this |
-|-------------|-------------------|
-| "sync.Mutex is better than atomics for multi-field state machines" | "Use proper concurrency patterns" |
-| "Edit tool fails with multiple matches — use replace_all=True" | "Handle errors properly" |
-| "Tried shutil.rmtree+copytree, lost cross-repo files — switched to additive sync" | "Be careful with file operations" |
-
-**Gate**: Learning recorded (or skipped if nothing reusable). Routing fully complete.
+**Gate**: Hooks handle capture automatically. Manual recording is for high-value insights only.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `review-capture.py` PostToolUse hook that extracts review findings from subagent results and records to learning.db
- Adds `session-learning-recorder.py` Stop hook that warns on substantive sessions with zero learnings
- Simplifies `/do` Phase 5 from 57 lines of advisory text to 15 lines of hook-driven architecture

## Context

ADR-005 identified that the retro learning system captures errors automatically but misses review findings and design insights. The root cause: Phase 5 (LEARN) was advisory text the LLM skipped. Fix: replace advisory text with deterministic hooks.

## Components

| Hook | Event | What it captures |
|------|-------|-----------------|
| `review-capture.py` | PostToolUse (Agent only) | CRITICAL/HIGH/MUST-FIX findings from reviewer agents |
| `session-learning-recorder.py` | Stop | Gap detection: warns if substantive session recorded nothing |

## Test plan

- [x] ruff check + format pass on both hooks
- [x] review-capture: pattern detection for VERDICT, severity headers, finding extraction
- [x] session-learning-recorder: all three paths (empty, non-substantive, substantive) produce valid output
- [ ] CI lint + test checks