### PR TITLE
fix: repo health quick wins

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/repo-hero.png" alt="Claude Code Toolkit - /do routes to specialized agents" width="100%">
 
-A collection of 59 agents, 111 skills, and 27 hooks for Claude Code. Built over a year of daily use.
+A collection of 60+ agents, 115+ skills, and 30+ hooks for Claude Code. Built over a year of daily use.
 
 ## The problem and the fix
 

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "generated": "2026-03-18T15:06:26Z",
+  "generated": "2026-03-19T17:13:35Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": [
     {
@@ -302,6 +302,22 @@
       "category": "analysis",
       "version": "1.0.0",
       "user-invocable": false
+    },
+    {
+      "name": "de-ai-pipeline",
+      "description": "Scan-fix-verify loop for removing AI writing patterns from docs.",
+      "file": "skills/de-ai-pipeline/SKILL.md",
+      "triggers": [
+        "de-ai docs",
+        "clean ai patterns",
+        "fix ai writing",
+        "scan and fix docs",
+        "remove ai tells",
+        "de-ai pipeline"
+      ],
+      "category": "content",
+      "version": "1.0.0",
+      "user-invocable": true
     },
     {
       "name": "dispatching-parallel-agents",
@@ -675,7 +691,7 @@
     },
     {
       "name": "go-sapcc-conventions",
-      "description": "SAP Converged Cloud Go coding conventions. Enforces architecture patterns, library usage rules, error handling, testing patterns, and anti-over-engineering principles for sapcc repos.",
+      "description": "SAP Converged Cloud Go coding conventions extracted from sapcc/keppel and sapcc/go-bits PR reviews.",
       "file": "skills/go-sapcc-conventions/SKILL.md",
       "triggers": [
         "sapcc",
@@ -687,6 +703,7 @@
         "sapcc/go-bits",
         "sap-cloud-infrastructure/go-bits"
       ],
+      "category": "language",
       "version": "1.0.0",
       "user-invocable": false
     },
@@ -804,7 +821,7 @@
         "image generation app",
         "gemini-2.5-flash-image",
         "gemini-3-pro-image-preview",
-        "text to image"
+        "web image generator"
       ],
       "version": "2.0.0",
       "user-invocable": false
@@ -1154,27 +1171,33 @@
     },
     {
       "name": "sapcc-audit",
-      "description": "Full-repo SAP CC Go compliance audit. Reviews every package against established review standards — focusing on over-engineering, error quality, dead code, and pattern consistency.",
+      "description": "Full-repo SAP Converged Cloud Go compliance audit.",
       "file": "skills/sapcc-audit/SKILL.md",
       "triggers": [
         "sapcc audit",
         "sapcc compliance",
+        "check sapcc rules",
         "full repo audit",
+        "sapcc secondary review",
         "sapcc standards check"
       ],
+      "category": "language",
       "version": "2.0.0",
       "user-invocable": true
     },
     {
       "name": "sapcc-review",
-      "description": "10-agent domain-specialist code review for SAP CC Go repositories. Each agent masters one rule domain and scans every package for violations.",
+      "description": "Gold-standard code review for SAP CC Go repositories against the project's lead review standards.",
       "file": "skills/sapcc-review/SKILL.md",
       "triggers": [
         "sapcc review",
+        "sapcc lead review",
         "sapcc compliance review",
         "comprehensive sapcc audit",
-        "full sapcc check"
+        "full sapcc check",
+        "review sapcc standards"
       ],
+      "category": "language",
       "version": "1.0.0",
       "user-invocable": true
     },

--- a/skills/nano-banana-builder/SKILL.md
+++ b/skills/nano-banana-builder/SKILL.md
@@ -28,7 +28,7 @@ routing:
     - image generation app
     - gemini-2.5-flash-image
     - gemini-3-pro-image-preview
-    - text to image
+    - web image generator
   pairs_with:
     - typescript-frontend-engineer
     - nodejs-api-engineer

--- a/skills/pr-status/SKILL.md
+++ b/skills/pr-status/SKILL.md
@@ -128,7 +128,7 @@ CLAUDE_COMMENTS=$(gh pr view --json comments --jq '[.comments[] | select(
 if [[ "$CLAUDE_COMMENTS" -gt 0 ]]; then
     echo "Claude review completed ($CLAUDE_COMMENTS comments)"
 else
-    CLAUDE_WORKFLOW=$(gh run list --workflow=claude-code-review.yml --limit 1 --json conclusion,status --jq '.[0]' 2>/dev/null)
+    CLAUDE_WORKFLOW=$(gh run list --workflow=claude.yml --limit 1 --json conclusion,status --jq '.[0]' 2>/dev/null)
     if [[ -n "$CLAUDE_WORKFLOW" ]]; then
         STATUS=$(echo "$CLAUDE_WORKFLOW" | jq -r '.status // .conclusion')
         echo "Claude review status: $STATUS"


### PR DESCRIPTION
## Summary

- Add `de-ai-pipeline` to skills/INDEX.json (was missing despite SKILL.md existing)
- Fix duplicate `text to image` routing trigger between gemini-image-generator and nano-banana-builder
- Update README component counts to use `60+/115+/30+` (won't go stale)
- Fix pr-status skill referencing deleted `claude-code-review.yml` workflow → now uses `claude.yml`

## What was NOT changed

- `hooks/lib/quality_gate.py` and `builtin_checks.py` — initially flagged as orphaned but they ARE used by `skills/universal-quality-gate/scripts/run_quality_gate.py`. Correctly left in place.

## Test plan

- [x] ruff format + check pass
- [x] INDEX.json regenerated via generate-skill-index.py
- [x] Verified 'text to image' trigger now unique to gemini-image-generator
- [ ] CI lint + test checks