### PR TITLE
feat: first graduation round — 9 learnings embedded into agents/skills

### DIFF
--- a/agents/skill-creator-engineer.md
+++ b/agents/skill-creator-engineer.md
@@ -104,6 +104,8 @@ This agent operates as an operator for skill creation and improvement, configuri
 - **Progressive Disclosure Enforcement**: Main SKILL.md under 10k words (aim for complexity tier target). Move verbose content to linked files. Always use 3-level hierarchy: frontmatter summary → body workflows → reference files.
 - **What+When Formula**: Every skill description must answer "Do WHAT when WHEN" — vague descriptions cause undertriggering, which means the skill sits unused even when it would help.
 - **Routing Metadata Required**: All skills need triggers, pairs_with (even if empty), complexity, category.
+- **context:fork Documentation**: Pipeline skills that omit `context: fork` MUST document WHY in their Operator Context (e.g., "requires interactive user gate"). Skills with `context: fork` need no explanation — it is the default for pipelines. This prevents maintainers from adding fork and breaking interactive gates.
+  *Graduated from learning.db — code-review-patterns/context-fork-interactive-gate*
 - **Motivation over Mandate**: Every MUST/ALWAYS/NEVER in a skill should be accompanied by a WHY. Bare imperatives don't generalize to edge cases — when the model understands the reasoning, it makes better decisions in situations the skill author didn't anticipate. Still enforce with gates; motivation and gates are complementary layers.
 
 ### Default Behaviors (ON unless disabled)
@@ -287,6 +289,12 @@ Common mistakes when designing skills. See [references/anti-patterns.md](referen
 ### Phase 2: Execute
 - Step 3
 ```
+
+### ❌ Hardcoded File/Line Counts in Descriptions
+**What it looks like**: Description says "Covers 47 patterns across 1200 lines" or "Scans all 93 agent files"
+**Why wrong**: Counts go stale immediately when files are added, removed, or edited. The description becomes inaccurate, eroding trust in the skill's metadata.
+**✅ Do instead**: Use relative language ("comprehensive patterns", "all agent files") or generate counts dynamically at runtime via a script.
+*Graduated from learning.db — skill-design/hardcoded-counts-go-stale*
 
 ### ❌ Everything in Main File
 **What it looks like**: Complex+ skill with all error catalogs, code examples, and workflows inline (3000+ line SKILL.md)

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -200,6 +200,15 @@ Solution: Revert conflicting changes. Re-investigate the conflicting pair sequen
 Cause: Problem depends on state from another subsystem, or environment mismatch
 Solution: Provide additional context. If still cannot reproduce, the problem may not be independent -- move it to a sequential investigation.
 
+### Error: "Worktree Agent Commits to Wrong Branch"
+Cause: When multiple worktrees exist, agents may operate on an unexpected branch because the worktree's branch and push target can diverge.
+Solution:
+1. In each agent's dispatch prompt, explicitly state the target branch name
+2. Include `git branch --show-current` as the first verification step in each agent
+3. After all agents return, verify each commit landed on the intended branch
+4. If a commit landed on the wrong branch, cherry-pick to the correct branch and reset
+*Graduated from learning.db — multi-agent-coordination/worktree-branch-confusion*
+
 ---
 
 ## Anti-Patterns

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -454,6 +454,18 @@ Solution:
 **Why wrong**: Bypasses lint checks, test runs, review loops, CI verification, and repo classification. This is how broken code gets merged. A CI failure after merge costs more than a pre-push check.
 **Do instead**: Route ALL git submission actions through their skills. "push" routes to pr-sync. "commit" routes to git-commit-flow. "create PR" routes to pr-pipeline. No exceptions, even when the user asks to "just push it."
 
+### Anti-Pattern 6: Force-Route Triggers Containing Sibling Skill Names
+**What it looks like**: A force-route trigger list includes the name of another skill (e.g., `go-testing` trigger includes "go-concurrency")
+**Why wrong**: The router matches the sibling skill's name as a trigger for the wrong skill, swallowing requests that should route elsewhere.
+**Do instead**: Force-route triggers must contain only base-level keywords (user language), never sibling skill names. Test each trigger against the full force-route table to confirm it matches exactly one skill.
+*Graduated from learning.db — routing/force-route-swallows-siblings*
+
+### Anti-Pattern 7: Duplicate Trigger Phrases Across Skills
+**What it looks like**: Two skills both claim the same trigger phrase (e.g., both `go-testing` and `go-anti-patterns` claim "test smell")
+**Why wrong**: The router cannot deterministically pick between them — which skill fires depends on table ordering, not intent.
+**Do instead**: Each trigger phrase must map to exactly one skill. Check for collisions before adding new force-routes.
+*Graduated from learning.db — routing/trigger-collision-causes-nondeterministic-routing*
+
 ---
 
 ## References

--- a/skills/git-commit-flow/SKILL.md
+++ b/skills/git-commit-flow/SKILL.md
@@ -306,6 +306,12 @@ Runs VALIDATE and STAGE phases, shows commit message preview, but does not execu
 **Why wrong**: Credentials in git history are permanent. Requires history rewrite and credential rotation to fix.
 **Do instead**: IMMEDIATELY add to `.gitignore`, unstage, and rotate any exposed credentials.
 
+### Anti-Pattern 6: Stash/Pop Across Branch Merges
+**What it looks like**: Running `git stash`, switching branches to merge or rebase, then `git stash pop` back on the original branch.
+**Why wrong**: Stashed changes were based on the pre-merge state. Popping after a merge can silently apply changes to the wrong base, causing branch drift.
+**Do instead**: Commit changes before switching branches. If stash is unavoidable, verify the working tree diff after pop with `git diff` to confirm changes still make sense against the new base.
+*Graduated from learning.db — multi-agent-coordination/stash-pop-branch-drift*
+
 ---
 
 ## References

--- a/skills/pr-sync/SKILL.md
+++ b/skills/pr-sync/SKILL.md
@@ -342,6 +342,14 @@ Solution:
 3. Retry the branch deletion or PR merge with `--delete-branch`
 4. This commonly happens when worktree agents (`isolation: "worktree"`) created the branch
 
+### Error: "git push says up-to-date but changes are missing on remote"
+Cause: `git push origin master` reports "up-to-date" when HEAD is on a different branch. Git pushes the named remote ref, not the current branch, so feature branch commits are never pushed.
+Solution:
+1. Always push the current branch: `git push -u origin $(git branch --show-current)`
+2. Never hardcode branch names in push commands
+3. Verify after push: `git log origin/$(git branch --show-current)..HEAD` should show 0 commits
+*Graduated from learning.db — multi-agent-coordination/worktree-push-from-wrong-branch*
+
 ---
 
 ## Anti-Patterns


### PR DESCRIPTION
## Summary

- First-ever use of LLM-driven `/retro graduate` (ADR-006 feature)
- 7 learnings graduated into 5 agent/skill files as permanent guidance
- 2 entries marked "already applied" (equivalent guidance existed)
- Pruned project-specific entries from learning.db
- Re-recorded generic WordPress learnings under clean topic

## Graduated entries

| Learning | Target | Section |
|----------|--------|---------|
| force-route-swallows-siblings | skills/do/SKILL.md | Anti-Pattern 6 |
| trigger-collision-causes-nondeterministic-routing | skills/do/SKILL.md | Anti-Pattern 7 |
| hardcoded-counts-go-stale | agents/skill-creator-engineer.md | Anti-Pattern |
| context-fork-interactive-gate | agents/skill-creator-engineer.md | Hardcoded Behavior |
| worktree-branch-confusion | skills/dispatching-parallel-agents/SKILL.md | Error case |
| stash-pop-branch-drift | skills/git-commit-flow/SKILL.md | Anti-Pattern 6 |
| worktree-push-from-wrong-branch | skills/pr-sync/SKILL.md | Error case |

## learning.db cleanup

- Removed project-specific pipeline entries (not relevant to generic toolkit)
- Re-recorded 3 generic WordPress entries: featured-image-min-size, delete-old-drafts, inline-images

## Test plan

- [x] learning-db.py stats shows 9 graduated, 83 total
- [x] Graduated entries excluded from injection (verified in ADR-006 PR)
- [x] New anti-patterns/error cases correctly placed in target files
- [x] CI passes (lint + test 3.10 + test 3.12)