### PR TITLE
feat: security header checks + bandit routing

### DIFF
--- a/adr/007-sast-tool-integration.md
+++ b/adr/007-sast-tool-integration.md
@@ -1,0 +1,85 @@
+# ADR-007: Security Improvements (bandit routing, security headers)
+
+## Status
+
+Implemented
+
+## Date
+
+2026-03-19
+
+## Context
+
+Research into external tooling (prompted by evaluating the FreeAgent repo) revealed
+minor gaps in our security posture. We have LLM-based static analysis
+(`reviewer-security`), dependency CVE scanning (`reviewer-dependency-audit`), and
+Go SAST via golangci-lint (which already includes gosec). Two small improvements
+were identified.
+
+### What works today
+
+```
+STATIC REVIEW      → reviewer-security          ✅ (LLM reads code, checks OWASP Top 10)
+CVE SCANNING       → reviewer-dependency-audit   ✅ (govulncheck, npm audit, pip-audit)
+CONFIG SAFETY      → reviewer-config-safety      ✅ (hardcoded secrets, env var validation)
+GO SAST            → golangci-lint (gosec)        ✅ (already runs via make check in CI)
+```
+
+### What's missing
+
+| Gap | Impact |
+|-----|--------|
+| Bandit buried in python-quality-gate | Can't route "Python security scan" without knowing the skill name |
+| No security header validation | endpoint-validator checks health but not CSP/HSTS/X-Frame-Options |
+
+### Decision: gosec NOT added
+
+gosec was initially considered for the go-pr-quality-gate but dropped after
+investigation revealed all Go repos (log-router, go-bits, hermez) already run
+gosec through golangci-lint in their `.golangci.yaml` configs. Adding standalone
+gosec would be redundant — double-scanning the same code for the same patterns.
+
+## Decision
+
+Make two small, focused changes following existing patterns:
+
+### 1. Add bandit force-route trigger
+
+Bandit already runs inside python-quality-gate. Add force-route triggers
+so "run bandit" or "Python security scan" routes to python-quality-gate
+rather than requiring the user to know the skill name. The full quality
+gate runs (not bandit standalone), which is the correct behavior — bandit
+findings are more actionable in the context of the full quality report.
+
+### 2. Add security header checks to endpoint-validator
+
+Extend the existing HTTP validation to check response headers for common
+security headers: Strict-Transport-Security, Content-Security-Policy,
+X-Frame-Options, X-Content-Type-Options. Report missing headers as warnings
+(not failures) since not all endpoints require all headers. Skip for
+localhost/127.0.0.1 endpoints.
+
+## Components
+
+| Change | File | Type |
+|--------|------|------|
+| Bandit route | `skills/do/SKILL.md` | Routing edit |
+| Security headers | `skills/endpoint-validator/SKILL.md` | Skill edit |
+
+## Consequences
+
+### Positive
+
+- Python security scanning is accessible via natural language ("run bandit")
+- Endpoint validation now covers basic security posture, not just availability
+
+### Negative
+
+- Security headers check may produce noise for internal/development endpoints
+  (mitigated by localhost skip)
+
+### Neutral
+
+- No new skills, agents, or hooks created
+- No changes to comprehensive-review pipeline
+- No changes to Go quality gate (gosec already covered by golangci-lint)

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -117,6 +117,7 @@ These skills have MANDATORY routing. They MUST be invoked when triggers appear:
 | **go-error-handling** | error handling, fmt.Errorf, errors.Is, errors.As, %w, sentinel error |
 | **go-code-review** | review Go, Go PR, Go code review, check Go quality |
 | **go-anti-patterns** | anti-pattern, code smell, over-engineering, premature abstraction |
+| **python-quality-gate** | bandit, Python security scan, Python SAST |
 | **go-sapcc-conventions** | sapcc, sap-cloud-infrastructure, go-bits, keppel, go-api-declarations, go-makefile-maker |
 | **create-voice** | create voice, new voice, build voice, voice from samples, calibrate voice |
 | **voice-orchestrator** | write in voice, generate voice content, voice workflow |

--- a/skills/endpoint-validator/SKILL.md
+++ b/skills/endpoint-validator/SKILL.md
@@ -119,6 +119,13 @@ For each response, check in order:
 1. **Status code**: Does it match `expect_status`? If not, mark FAIL.
 2. **JSON key**: If `expect_key` set, parse JSON and check key exists. If missing or not valid JSON, mark FAIL.
 3. **Response time**: If `max_time` set and elapsed exceeds it, mark SLOW.
+4. **Security headers**: Check response headers for common security headers. Report missing headers as WARN (not FAIL):
+   - `Strict-Transport-Security` — HSTS enforcement (expected on HTTPS endpoints)
+   - `Content-Security-Policy` — XSS mitigation
+   - `X-Content-Type-Options` — should be `nosniff`
+   - `X-Frame-Options` — clickjacking prevention (or CSP `frame-ancestors`)
+
+Skip security header checks for localhost/127.0.0.1 endpoints (development environments don't typically set these). Only check on non-localhost base URLs unless explicitly configured.
 
 **Step 3: Handle failures gracefully**
 
@@ -146,6 +153,11 @@ RESULTS:
   /api/users                     200 OK     123ms
   /api/products                  500 FAIL   "Internal Server Error"
   /api/slow                      200 SLOW   3.2s > 2.0s threshold
+
+SECURITY HEADERS (non-localhost only):
+  /api/health                    WARN  Missing: Content-Security-Policy, X-Frame-Options
+  /api/users                     OK    All security headers present
+  /api/products                  SKIP  (endpoint failed)
 ```
 
 **Step 2: Produce summary**
@@ -155,6 +167,7 @@ SUMMARY:
   Passed: 13/15 (86.7%)
   Failed: 1 (status error)
   Slow: 1 (exceeded threshold)
+  Security header warnings: 3 endpoints missing headers
 ```
 
 **Step 3: Set exit code**


### PR DESCRIPTION
## Summary
- Add security header validation (HSTS, CSP, X-Content-Type-Options, X-Frame-Options) to endpoint-validator as WARN-level checks, skipped for localhost
- Add force-route trigger so "bandit" / "Python security scan" routes to python-quality-gate
- ADR-007 documents the decision, including why gosec was evaluated and dropped (already runs via golangci-lint in CI)

## Context
Prompted by evaluating the [FreeAgent](https://github.com/transformer24/freeagent) repo for adoptable patterns. After deep research, the only additions that genuinely add value are these two small changes — 14 lines across 2 skill files.

## Test plan
- [x] gosec installed and tested against log-router — produces structured JSON with severity, CWE IDs, autofix suggestions
- [x] Confirmed gosec already runs in CI via golangci-lint for log-router, go-bits, hermez — redundant to add standalone
- [x] PR review loop completed — found and fixed: optional/mandatory contradiction, severity mapping (G402/G403 → HIGH), deprecated G601 note, ADR-to-implementation mismatch on bandit routing
- [x] Security header check properly scoped (localhost skip documented)
- [x] Force-route triggers checked for collisions with existing table