### PR TITLE
feat: add repo-value-analysis pipeline skill

### DIFF
--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "generated": "2026-03-20T02:49:23Z",
+  "generated": "2026-03-20T02:58:51Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": [
     {
@@ -1094,11 +1094,11 @@
       "user-invocable": false
     },
     {
-      "name": "repo-competitive-analysis",
-      "description": "Systematic 6-phase competitive analysis of external repositories against our toolkit: clone, parallel deep-read, self-inventory, synthesize gaps, t...",
-      "file": "skills/repo-competitive-analysis/SKILL.md",
+      "name": "repo-value-analysis",
+      "description": "Systematic 6-phase analysis of external repositories for ideas worth adopting: clone, parallel deep-read, self-inventory, synthesize gaps, targeted...",
+      "file": "skills/repo-value-analysis/SKILL.md",
       "triggers": [
-        "competitive analysis",
+        "repo value analysis",
         "does repo add value",
         "analyze repo for ideas",
         "what can we learn from",

--- a/skills/repo-value-analysis/SKILL.md
+++ b/skills/repo-value-analysis/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: repo-competitive-analysis
+name: repo-value-analysis
 description: |
-  Systematic 6-phase competitive analysis of external repositories against our
-  toolkit: clone, parallel deep-read, self-inventory, synthesize gaps, targeted
-  audit of affected subsystems, reality-grounded report. Use when evaluating
-  whether an external repo provides value, comparing toolkits, or analyzing
-  repos for ideas worth adopting.
+  Systematic 6-phase analysis of external repositories for ideas worth adopting:
+  clone, parallel deep-read, self-inventory, synthesize gaps, targeted audit of
+  affected subsystems, reality-grounded report. Use when evaluating whether an
+  external repo provides value, analyzing repos for useful patterns, or
+  comparing approaches.
   Do NOT use for general codebase exploration (use explore-pipeline instead).
 version: 1.0.0
 user-invocable: true
@@ -20,7 +20,7 @@ allowed-tools:
   - Glob
 routing:
   triggers:
-    - competitive analysis
+    - repo value analysis
     - does repo add value
     - analyze repo for ideas
     - what can we learn from
@@ -36,7 +36,7 @@ routing:
 
 ## Operator Context
 
-This skill operates as an operator for systematic competitive analysis of external repositories against our toolkit. It implements a **6-phase Pipeline Architecture** — clone, parallel deep-read, self-inventory, synthesis, targeted audit, reality-grounded report — with parallel subagents dispatched via the Agent tool.
+This skill operates as an operator for systematic repo value analysis of external repositories against our toolkit. It implements a **6-phase Pipeline Architecture** — clone, parallel deep-read, self-inventory, synthesis, targeted audit, reality-grounded report — with parallel subagents dispatched via the Agent tool.
 
 ### Hardcoded Behaviors (Always Apply)
 - **Full File Reading**: Agents MUST read every file in their assigned zone, not sample or skim
@@ -137,7 +137,7 @@ Dispatch 1 Agent per analysis zone (background). Each agent receives:
 - Instructions to read EVERY file (not sample, not skim)
 - A structured output template
 
-**Agent instructions template** (adapt per zone):
+**Agent instructions template** (replace ALL bracketed placeholders with actual values before dispatching):
 
 ```
 You are analyzing the "[zone]" zone of repository [REPO_NAME].
@@ -198,7 +198,7 @@ For each category, note:
 Save your inventory to /tmp/self-inventory.md
 ```
 
-**Gate**: Self-inventory agent completed. `/tmp/self-inventory.md` exists and contains counts for all 4 component types. Proceed only when gate passes.
+**Gate**: Self-inventory agent completed (or timed out after 5 minutes). `/tmp/self-inventory.md` exists and contains counts for all 4 component types. Proceed only when gate passes.
 
 ### Phase 4: SYNTHESIZE
 


### PR DESCRIPTION
## Summary
- New 6-phase pipeline skill for systematically analyzing external repos for ideas worth adopting
- Pipeline: CLONE → DEEP-READ → INVENTORY → SYNTHESIZE → AUDIT → REPORT
- Dispatches parallel agents per analysis zone, self-inventories our system, identifies gaps, then audits specific subsystems for reality-grounded recommendations

## Changes
- **Created** `skills/repo-value-analysis/SKILL.md` — 430-line pipeline skill
- **Updated** `skills/INDEX.json` — new skill entry with 6 triggers
- **Updated** `/do` routing tables — added to Analysis & Discovery section
- **Updated** `/do` Pipeline Phase Registry — added phase sequence

## Review History
- Round 1: Fixed run_in_background misattribution, added agent field, removed Edit from allowed-tools
- Round 2: Renamed from repo-competitive-analysis → repo-value-analysis, added placeholder interpolation instruction, Phase 3 timeout, /do routing integration
- Round 3: CLEAN — all naming consistent, directory matches frontmatter, INDEX.json accurate

## Test plan
- [ ] Verify `skills/repo-value-analysis/SKILL.md` exists with `name: repo-value-analysis`
- [ ] Verify zero matches for `repo-competitive-analysis` in repo
- [ ] Verify `repo-value-analysis` in `skills/INDEX.json`
- [ ] Verify all 6 phases have gates with timeouts
- [ ] Validate against `rlancemartin/claude-diary` repo (post-merge integration test)