### PR TITLE
feat: add caller tracing and Copilot-parity review improvements

### DIFF
--- a/agents/reviewer-business-logic.md
+++ b/agents/reviewer-business-logic.md
@@ -84,6 +84,9 @@ This agent operates as an operator for business logic code review, configuring C
 - **Structured Output**: All findings must use Reviewer Schema with VERDICT and severity classification.
 - **Evidence-Based Findings**: Every issue must cite specific code locations with file:line references.
 - **No Auto-Fix**: Reviewers report findings with recommendations. Never attempt to fix issues directly.
+- **Caller Tracing**: When reviewing changes to interfaces or functions with contract semantics (sentinel values, special parameters, state preconditions), grep for ALL callers across the entire repo. For Go repos, use gopls `go_symbol_references` via ToolSearch("gopls"). Verify every caller honors the contract. Do NOT claim "no caller passes X" without searching — verify by grepping for `.MethodName(` across the codebase.
+- **Extraction Severity Escalation**: When a diff extracts inline code into a named helper, re-evaluate all defensive guards. A missing check rated LOW as inline code (1 caller) becomes MEDIUM as a reusable function (N potential callers). See severity-classification.md.
+- **Value Space Analysis**: When tracing a parameter through a call chain, identify not just the SOURCE but the VALUE SPACE. For query parameters (`r.FormValue`, `r.URL.Query`): the value is user-controlled — ANY string including sentinel values like `"*"` is reachable. For token/auth fields: server-controlled (UUIDs, structured IDs). For constants: fixed. Do NOT conclude a sentinel is "unreachable" because no Go code constructs that string — if the source is user input, the user constructs it. "I don't see code that builds `*`" is not proof of unreachability when `r.FormValue("x")` returns whatever the user sends.
 
 ### Default Behaviors (ON unless disabled)
 - **Communication Style**:

--- a/agents/reviewer-security.md
+++ b/agents/reviewer-security.md
@@ -87,6 +87,8 @@ This agent operates as an operator for security code review, configuring Claude'
 - **Structured Output**: All findings must use Reviewer Schema with VERDICT and severity classification.
 - **Evidence-Based Findings**: Every vulnerability must cite specific code locations with file:line references.
 - **No Auto-Fix**: Reviewers report findings with recommendations. Never attempt to fix issues directly.
+- **Caller Tracing**: When reviewing changes to functions that accept security-sensitive parameters (auth tokens, filter flags, sentinel values like `"*"` meaning "unfiltered"), grep for ALL callers of that function across the entire repo. For Go repos, use gopls `go_symbol_references` via ToolSearch("gopls"). Verify every caller validates the parameter before passing it. Do NOT trust PR descriptions about who calls the function — verify independently. Report any unvalidated path as a BLOCKING finding.
+- **Value Space Analysis**: When tracing parameters, classify the VALUE SPACE of each source: query parameters (`r.FormValue`) are user-controlled (any string including `"*"`); auth token fields are server-controlled; constants are fixed. If the source is user input, ANY string is reachable — do not conclude a sentinel is "unreachable" just because no Go code constructs it.
 
 ### Default Behaviors (ON unless disabled)
 - **Communication Style**:

--- a/agents/reviewer-silent-failures.md
+++ b/agents/reviewer-silent-failures.md
@@ -97,6 +97,7 @@ This agent operates as an operator for silent failure detection, configuring Cla
 - **Evidence-Based Findings**: Every finding must show the exact code that swallows, ignores, or inadequately handles the error.
 - **Blast Radius Assessment**: Every finding must include impact analysis (what happens when this fails silently).
 - **Review-First in Fix Mode**: When `--fix` is requested, complete the full analysis first, then apply error handling corrections.
+- **Extraction Severity Escalation**: When a diff extracts inline code into a named helper function, re-evaluate all defensive guards. A missing check that was LOW as inline code (1 caller, "upstream validates") becomes MEDIUM as a reusable function (N potential callers who may skip upstream validation). See severity-classification.md for the full rule.
 
 ### Default Behaviors (ON unless disabled)
 - **Communication Style**:

--- a/agents/reviewer-test-analyzer.md
+++ b/agents/reviewer-test-analyzer.md
@@ -97,6 +97,7 @@ This agent operates as an operator for test coverage analysis, configuring Claud
 - **Evidence-Based Findings**: Every gap must cite specific untested code with file:line references.
 - **Pragmatic Tests**: Recommend tests that catch real bugs. Avoid recommending tests that only increase coverage numbers.
 - **Review-First in Fix Mode**: When `--fix` is requested, complete the full analysis first, then write tests.
+- **Assertion Depth Check**: For security-sensitive code (auth, filtering, tenant isolation, access control), presence-only assertions (`NotEmpty`, `NotNil`, `hasKey`, `assert.True(t, ok)`) are INSUFFICIENT. Tests MUST verify the actual VALUE matches the expected input. Flag any test where a wrong field name, wrong value, or swapped arguments would still pass. Example: `assert.True(t, hasFilter)` passes even if the filter is on the wrong field — the test must assert the field name AND value (e.g., `assert.Equal(t, expectedID, filters[0]["term"]["tenant_ids"])`).
 
 ### Default Behaviors (ON unless disabled)
 - **Communication Style**:

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -471,11 +471,11 @@ Return findings as:
 
 | Agent | Extra Instructions |
 |-------|-------------------|
-| `reviewer-security` | Focus on OWASP Top 10, auth, input validation, secrets. **MCP**: For Go, use gopls `go_symbol_references` to trace tainted input flows |
-| `reviewer-business-logic` | Focus on requirements coverage, edge cases, state transitions |
+| `reviewer-security` | Focus on OWASP Top 10, auth, input validation, secrets. **MCP**: For Go, use gopls `go_symbol_references` to trace tainted input flows. **CALLER TRACING (mandatory)**: When the diff modifies functions with security-sensitive parameters (auth tokens, filter flags, sentinel values like `"*"`), grep for ALL callers across the repo and verify each validates the parameter. Do NOT trust PR descriptions — verify independently. |
+| `reviewer-business-logic` | Focus on requirements coverage, edge cases, state transitions. **CALLER TRACING (mandatory)**: When the diff changes interface semantics or introduces sentinel values, grep for ALL callers (`.MethodName(`) across the repo and verify each honors the contract. Do NOT claim "no caller passes X" without searching. |
 | Architecture reviewer | Focus on patterns, naming, structure, maintainability. **MCP**: For Go, use gopls `go_file_context` to understand cross-file dependencies |
 | `reviewer-silent-failures` | Focus on catch blocks, error swallowing, fallback behavior. **MCP**: For Go, use gopls `go_diagnostics` to verify error handling correctness |
-| `reviewer-test-analyzer` | Focus on coverage gaps, missing edge case tests, test quality |
+| `reviewer-test-analyzer` | Focus on coverage gaps, missing edge case tests, test quality. **ASSERTION DEPTH CHECK (mandatory)**: For security-sensitive code, flag presence-only assertions (NotEmpty, NotNil, hasKey). Tests MUST verify actual values, not just existence. |
 | `reviewer-type-design` | Focus on invariants, encapsulation, type safety. **MCP**: For Go, use gopls `go_package_api` to understand type surface area |
 | `reviewer-code-quality` | Focus on CLAUDE.md compliance, conventions, style |
 | `reviewer-comment-analyzer` | Focus on comment accuracy, rot, misleading docs |

--- a/skills/sapcc-review/SKILL.md
+++ b/skills/sapcc-review/SKILL.md
@@ -254,6 +254,7 @@ Write ALL findings to: [output file path]
 - Pointer receivers where value receiver is appropriate (or vice versa)
 - Type exported when only constructor needs to be public
 - **Contract cohesion (§36)**: Constants, error sentinels, or validation functions in a different file from the interface/type they belong to. If `ErrFoo` is returned by `FooDriver` methods, both must live in `foo_driver.go`. MEDIUM for new violations, LOW for pre-existing.
+- **Interface consumer audit**: When a sentinel value or special parameter is introduced on an interface method, grep for ALL implementations AND all callers of that interface method across the entire repo. Use gopls `go_symbol_references` when available. Verify every caller validates the sentinel before passing it. Do not rely on the PR description's claim about authorization — verify the call chain independently.
 
 ---
 
@@ -328,6 +329,7 @@ Write ALL findings to: [output file path]
 - Using `require` package instead of `must` from go-bits
 - Not using `must.SucceedT` / `must.ReturnT` for error-checked returns
 - Not using `assert.ErrEqual` for flexible error matching
+- **Assertion depth check**: For security-sensitive code (auth, filtering, tenant isolation), presence-only assertions (`NotEmpty`, `NotNil`, `assert.True(t, ok)`) are INSUFFICIENT. Tests must verify the actual VALUE matches the expected input (e.g., `assert.Equal(t, expectedID, filters[0]["term"]["tenant_ids"])`)
 
 ---
 
@@ -411,6 +413,7 @@ Write ALL findings to: [output file path]
 - Manual row scanning instead of `sqlext.ForeachRow`
 - Test setup in `TestMain` instead of per-test
 - Verbose error checking instead of `assert.ErrEqual` / `must.SucceedT`
+- **Extraction without guard transfer**: When inline code is extracted into a named helper, ALL defensive checks that relied on "the caller handles it" must be re-evaluated. A missing guard rated LOW as inline code becomes MEDIUM as a reusable function. Flag extracted helpers that lack self-contained validation.
 
 ---
 
@@ -421,6 +424,10 @@ Write ALL findings to: [output file path]
 ### Phase 3: AGGREGATE
 
 **Goal**: Compile all agent findings into a single prioritized report.
+
+**Step 0: Full file inventory**
+
+Run `git status --short` (not just `git diff --stat`) to capture both modified AND untracked (new) files. This ensures new files created during the review session are not missed in the report.
 
 **Step 1: Collect all findings**
 

--- a/skills/shared-patterns/severity-classification.md
+++ b/skills/shared-patterns/severity-classification.md
@@ -127,3 +127,19 @@ When unsure about severity:
 2. Note uncertainty: "Potential CRITICAL - please verify"
 3. Explain reasoning
 4. Let reviewer/author make final call
+
+## Extraction Severity Escalation
+
+When a diff extracts inline code into a named helper function, **re-evaluate all defensive guards** that were previously rated LOW because "the caller handles it."
+
+| Before extraction | After extraction | Action |
+|---|---|---|
+| Inline code, 1 caller | Named function, N potential callers | Escalate LOW → MEDIUM for any guard relying on caller discipline |
+| "validateX catches it upstream" | Function callable without validateX | The guard must be self-contained |
+| Missing defensive check rated LOW | Same check on reusable function | Rate as MEDIUM — "fix in this PR" |
+
+**The rule**: inline code has exactly 1 caller (the enclosing function). An extracted helper has N potential callers. Guards that were safe as inline code may be unsafe as reusable functions.
+
+**Trigger**: any diff that creates a new named function from code previously inline in another function.
+
+*Graduated from hermez PR #338: empty-string guard rated LOW 3 times, then Copilot caught it post-extraction as the correct MEDIUM finding. The 2-line fix was trivial but severity classification delayed it.*

--- a/skills/systematic-code-review/SKILL.md
+++ b/skills/systematic-code-review/SKILL.md
@@ -75,6 +75,25 @@ This skill operates as an operator for systematic code review, configuring Claud
 - Use Grep to find all callers/consumers of changed code
 - Note any comments that make claims about behavior
 
+**Step 2a: Caller Tracing** (mandatory when diff modifies function signatures, parameter semantics, or introduces sentinel/special values)
+
+When the change modifies how a function/method is called or what parameters mean:
+
+1. **Find ALL callers** — Grep for the function name with receiver syntax (e.g., `.GetEvents(` not just `GetEvents`) across the entire repo. For Go repos, prefer gopls `go_symbol_references` via ToolSearch("gopls") — it's type-aware and catches interface implementations.
+2. **Trace the VALUE SPACE** — For each parameter source, classify what values can flow through:
+   - Query parameters (`r.FormValue`, `r.URL.Query`): user-controlled — ANY string including sentinel values like `"*"`
+   - Auth token fields: server-controlled (UUIDs, structured IDs)
+   - Constants/enums: fixed set
+   - Do NOT conclude a sentinel is "unreachable" because no Go code constructs that string. If the source is user input, the user constructs it.
+3. **Verify each caller** — For each call site, check that parameters are validated before being passed. Pay special attention to sentinel values (e.g., `"*"` meaning "all/unfiltered") that bypass security filtering.
+4. **Report unvalidated paths** — Any caller that passes user input to a security-sensitive parameter without validation is a BLOCKING finding.
+5. **Do NOT trust PR descriptions** about who calls the function — verify independently. The PR author may have forgotten about callers, or new callers may have been added in other branches.
+
+This step catches:
+- Unchecked paths where user input reaches a security-sensitive parameter
+- Callers the PR author forgot about or didn't mention
+- Interface implementations that don't enforce the same preconditions
+
 **Step 3: Document scope**
 
 ```
@@ -91,11 +110,17 @@ Scope Assessment:
   - Secondary: [what's affected by the change]
   - Dependencies: [external systems/files impacted]
 
+Caller Tracing (if signature/parameter semantics changed):
+  - [function/method]: [N] callers found
+    - [caller1:line] — parameter validated: [yes/no]
+    - [caller2:line] — parameter validated: [yes/no]
+  - Unvalidated paths: [list or "none"]
+
 Questions for Author:
   - [Any unclear aspects that need clarification]
 ```
 
-**Gate**: All changed files read, scope fully mapped. Proceed only when gate passes.
+**Gate**: All changed files read, scope fully mapped, callers traced (if applicable). Proceed only when gate passes.
 
 ### Phase 2: VERIFY
 
@@ -147,6 +172,11 @@ Behavior Verification:
 **Step 3: Architectural assessment**
 - Compare patterns to existing codebase conventions
 - Assess breaking change potential
+
+**Step 4: Extraction severity escalation**
+- If the diff extracts inline code into named helper functions, re-evaluate all defensive guards
+- A missing check rated LOW as inline code (1 caller, "upstream validates") becomes MEDIUM as a reusable function (N potential callers)
+- See `skills/shared-patterns/severity-classification.md` for the full rule
 
 **Step 4: Document assessment**
 

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -72,10 +72,16 @@ Before verification, understand the scope of changes:
 git diff --name-only
 ```
 
+Use `git status --short` (not just `git diff`) to capture both modified AND untracked (new) files. New files created during the session are easy to miss in status summaries.
+
 For each changed file:
 - Read the file with the Read tool
 - Summarize what changed
 - Identify affected systems/modules and dependencies
+
+Report separately:
+- **New files**: [files with `??` or `A` status in git]
+- **Modified files**: [files with `M` status]
 
 ### Step 2: Run Domain-Specific Tests
 


### PR DESCRIPTION
## Summary
Addresses gaps found comparing our review agents against GitHub Copilot Code Review on hermez PR #338.

- **Caller Tracing** (systematic-code-review Step 2a): Mandatory step to grep for ALL callers of modified functions and verify parameter validation at each call site. Hardcoded in reviewer-security + reviewer-business-logic.
- **Value Space Analysis**: Classifies parameter sources as user-controlled/server-controlled/fixed. Prevents false "unreachable" conclusions for user input paths.
- **Assertion Depth Check** (reviewer-test-analyzer): Flags presence-only assertions as insufficient for security-sensitive code.
- **Extraction Severity Escalation** (severity-classification.md): Guards rated LOW as inline code escalate to MEDIUM when extracted into named helpers.
- **Full Status Reporting**: git status --short alongside diff --stat in verification-before-completion + sapcc-review Phase 3.

## Files changed (9)
- `agents/reviewer-security.md` — caller tracing + value space analysis
- `agents/reviewer-business-logic.md` — caller tracing + value space + extraction escalation
- `agents/reviewer-silent-failures.md` — extraction severity escalation
- `agents/reviewer-test-analyzer.md` — assertion depth check
- `skills/systematic-code-review/SKILL.md` — Step 2a caller tracing + Phase 3 Step 4 extraction escalation
- `skills/comprehensive-review/SKILL.md` — Wave 1 dispatch prompts for security, business-logic, test-analyzer
- `skills/sapcc-review/SKILL.md` — Agent 2 interface consumer audit, Agent 6 assertion depth, Agent 10 extraction pattern, Phase 3 full status
- `skills/verification-before-completion/SKILL.md` — git status --short + new file reporting
- `skills/shared-patterns/severity-classification.md` — Extraction Severity Escalation canonical rule

## Test plan
- [x] Tested reviewer-security: performed caller tracing + value space analysis on learning-db.py
- [x] Tested reviewer-business-logic: found 2 invalid category callers via caller tracing
- [x] Tested reviewer-test-analyzer: flagged 11 presence-only assertions in test_learning_system.py
- [x] Tested reviewer-security on hermez Go repo: traced full call chain, classified value spaces, found CRITICAL cross-tenant issue — all without explicit instructions
- [x] Structural review passed (3 MEDIUM findings fixed)