### PR TITLE
feat(hooks): add git-submission-gate to block raw push/PR/merge

### DIFF
--- a/hooks/pretool-git-submission-gate.py
+++ b/hooks/pretool-git-submission-gate.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+PreToolUse:Bash Hook: Git Submission Gate
+
+Blocks raw git push, gh pr create, and gh pr merge commands that bypass
+quality gate skills (pr-sync, pr-pipeline). Forces the LLM to route
+through proper skills that run review loops before submission.
+
+This is a HARD GATE — it physically prevents the command from executing.
+The LLM receives a [fix-with-skill] directive telling it which skill to use.
+
+Bypass: Skills that legitimately need to run these commands prefix them with
+CLAUDE_GATE_BYPASS=1 in the command string. The hook detects this prefix
+and allows passthrough. Example:
+    CLAUDE_GATE_BYPASS=1 git push -u origin branch
+
+Design Principles:
+- Sub-5ms for non-matching commands (early exit)
+- Blocks with exit 2 + stderr message
+- Non-blocking for read-only git operations (status, diff, log, branch)
+- Passthrough when command contains CLAUDE_GATE_BYPASS=1 prefix
+- Intentionally matches inside strings/comments — over-blocking preferred
+"""
+
+import json
+import re
+import sys
+
+# Bypass prefix that skills include when they legitimately need to run blocked commands.
+# Checked as a string prefix in the command, not as an env var.
+_BYPASS_PREFIX = "CLAUDE_GATE_BYPASS=1"
+
+# Commands that MUST go through skills, not raw Bash.
+# \b ensures "git stash push" does not match (stash breaks word boundary before push).
+BLOCKED_PATTERNS = [
+    (re.compile(r"\bgit\s+push\b"), "pr-sync", "Use /pr-sync to push (runs review loop first)"),
+    (re.compile(r"\bgh\s+pr\s+create\b"), "pr-pipeline", "Use /pr-pipeline to create PR (runs review loop first)"),
+    (re.compile(r"\bgh\s+pr\s+merge\b"), "pr-pipeline", "Use /pr-pipeline to merge (requires review to pass first)"),
+]
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    try:
+        event = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    tool_name = event.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    tool_input = event.get("tool_input", {})
+    command = tool_input.get("command", "")
+    if not command:
+        sys.exit(0)
+
+    # Skills prefix blocked commands with CLAUDE_GATE_BYPASS=1 to pass through
+    if command.lstrip().startswith(_BYPASS_PREFIX):
+        sys.exit(0)
+
+    for pattern, skill_name, message in BLOCKED_PATTERNS:
+        if pattern.search(command):
+            print(
+                f"[git-submission-gate] BLOCKED: {message}\n"
+                f"[fix-with-skill] {skill_name}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -524,6 +524,8 @@ This skill uses these shared patterns:
 | "Force-route doesn't apply here" | If triggers match, force-route applies. No exceptions | Check trigger table literally |
 | "Routing overhead isn't worth it for this" | Routing overhead < cost of unreviewed code changes | Route anyway; tokens are cheap |
 | "User wants it fast, skip the plan" | Fast without a plan produces wrong results faster | Create plan, then execute |
+| "User seems impatient, skip the review" | **There is never time pressure.** The user wants correct, reviewed results — not fast broken ones. A denied tool call or follow-up message is NOT permission to skip quality gates. | Run the full review loop. If a tool is denied, try a different approach — never skip the step entirely |
+| "Just push it, we can fix later" | Post-merge fixes cost 2 PRs instead of 1. Review before merge is always cheaper | Route through pr-sync/pr-pipeline. The git-submission-gate hook will block raw git push anyway |
 
 ### Reference Files
 - `${CLAUDE_SKILL_DIR}/references/routing-tables.md`: Complete category-specific skill routing (Process, Analysis, PR, Content, Voice, Pipeline, Validation, Roaster Agents, Quick Examples)

--- a/skills/pr-pipeline/SKILL.md
+++ b/skills/pr-pipeline/SKILL.md
@@ -243,14 +243,15 @@ Use branch-naming skill if available for compliant names.
 **Step 2: Push with tracking**
 
 ```bash
-git push -u origin $(git branch --show-current)
+# CLAUDE_GATE_BYPASS=1 bypasses the git-submission-gate hook (this skill IS the gate)
+CLAUDE_GATE_BYPASS=1 git push -u origin $(git branch --show-current)
 ```
 
 **Step 3: Verify push**
 
 Confirm push succeeded by checking output. If push fails (e.g., rejected), report error and stop.
 
-**Protected-org repos**: Before executing the push, present the branch name, remote, and list of commits that will be pushed. Wait for user to confirm before executing `git push`.
+**Protected-org repos**: Before executing the push, present the branch name, remote, and list of commits that will be pushed. Wait for user to confirm before executing `CLAUDE_GATE_BYPASS=1 git push`.
 
 **Gate**: Changes pushed to remote. Branch tracks upstream. (protected-org: user confirmed.)
 
@@ -300,7 +301,7 @@ Address each issue found by the review. This includes:
 ```bash
 git add [fixed files]
 git commit --amend --no-edit
-git push --force-with-lease
+CLAUDE_GATE_BYPASS=1 git push --force-with-lease
 ```
 
 **Step 5: Report iteration**
@@ -328,7 +329,7 @@ Analyze the full diff against the base branch and all commit messages to draft:
 **Step 2: Create PR**
 
 ```bash
-gh pr create --title "type(scope): description" --body "$(cat <<'EOF'
+CLAUDE_GATE_BYPASS=1 gh pr create --title "type(scope): description" --body "$(cat <<'EOF'
 ## Summary
 - [Key change 1]
 - [Key change 2]
@@ -399,7 +400,7 @@ git pull origin main
 git branch -d <branch-name>
 
 # Delete remote branch
-git push origin --delete <branch-name>
+CLAUDE_GATE_BYPASS=1 git push origin --delete <branch-name>
 
 # Prune stale tracking refs
 git fetch --prune

--- a/skills/pr-sync/SKILL.md
+++ b/skills/pr-sync/SKILL.md
@@ -153,8 +153,8 @@ If no uncommitted changes exist, skip to Step 4.
 ### Step 4: Push to Remote
 
 ```bash
-# Push with upstream tracking
-git push -u origin "$CURRENT_BRANCH"
+# Push with upstream tracking (CLAUDE_GATE_BYPASS=1 bypasses the git-submission-gate hook)
+CLAUDE_GATE_BYPASS=1 git push -u origin "$CURRENT_BRANCH"
 ```
 
 **Protected-org repos**: Before executing the push, present the branch name, remote, and commits that will be pushed. Wait for explicit approval before pushing.
@@ -169,7 +169,7 @@ Iteratively review and fix issues before creating the PR. Up to 3 iterations of:
 1. Run `/pr-review` comprehensive review
 2. If clean → exit loop, proceed to Step 5
 3. Fix all reported issues
-4. `git add [fixes] && git commit --amend --no-edit && git push --force-with-lease`
+4. `git add [fixes] && git commit --amend --no-edit && CLAUDE_GATE_BYPASS=1 git push --force-with-lease`
 5. Report iteration: `REVIEW-FIX [N/3]: X found, Y fixed, Z remaining`
 
 After 3 iterations, proceed to Step 5 with any remaining issues documented in the PR body.
@@ -182,7 +182,7 @@ EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].numbe
 
 if [[ -z "$EXISTING_PR" ]]; then
     # Create new PR
-    gh pr create --title "$PR_TITLE" --body "$(cat <<'EOF'
+    CLAUDE_GATE_BYPASS=1 gh pr create --title "$PR_TITLE" --body "$(cat <<'EOF'
 ## Summary
 [Description of changes]
 


### PR DESCRIPTION
## Summary
- Add `hooks/pretool-git-submission-gate.py` — PreToolUse:Bash hook that blocks raw `git push`, `gh pr create`, `gh pr merge` and redirects to pr-sync/pr-pipeline skills
- Update `skills/pr-sync/SKILL.md` and `skills/pr-pipeline/SKILL.md` with `CLAUDE_GATE_BYPASS=1` prefix on all git submission commands
- Add "no time pressure" anti-rationalization entries to `/do` SKILL.md

## Context
During the reddit-moderate feature, the pre-merge review loop was bypassed because the LLM ran raw git commands instead of routing through skills. This hook physically prevents that from happening again.

## Test plan
- [x] 10/10 unit tests pass (block push/pr/merge, allow status/commit/stash, bypass prefix works)
- [x] `ruff check` — passed
- [x] Code review iteration 1 — APPROVE after addressing bypass mechanism
- [x] pr-sync and pr-pipeline updated with bypass prefix

## Note
The hook still needs to be registered in `~/.claude/settings.json` to activate. This PR adds the hook file and skill updates only. Registration is a user config change done separately.