### PR TITLE
fix(ci): ruff format hook + CI gate before merge

### DIFF
--- a/hooks/pretool-git-submission-gate.py
+++ b/hooks/pretool-git-submission-gate.py
@@ -62,8 +62,7 @@ def main() -> None:
     for pattern, skill_name, message in BLOCKED_PATTERNS:
         if pattern.search(command):
             print(
-                f"[git-submission-gate] BLOCKED: {message}\n"
-                f"[fix-with-skill] {skill_name}",
+                f"[git-submission-gate] BLOCKED: {message}\n[fix-with-skill] {skill_name}",
                 file=sys.stderr,
             )
             sys.exit(2)

--- a/skills/pr-pipeline/SKILL.md
+++ b/skills/pr-pipeline/SKILL.md
@@ -379,12 +379,18 @@ gh run list --branch $(git branch --show-current) --limit 1
 gh run watch [run-id] --exit-status
 ```
 
-If CI passes, report success with PR URL.
-If CI fails, report which checks failed and the PR URL. Do not attempt to fix CI failures automatically.
+If CI fails, report which checks failed and the PR URL. Do NOT merge. Do NOT proceed to cleanup.
+
+If CI passes and user requested merge:
+```bash
+CLAUDE_GATE_BYPASS=1 gh pr merge --merge --delete-branch
+```
+
+**HARD RULE**: Never merge a PR with failing or pending CI. CI must pass first.
 
 If `--no-wait` was passed, skip this phase and report the PR URL immediately.
 
-**Gate**: CI status reported. Proceed to Phase 7.
+**Gate**: CI green + merged (if requested). Proceed to Phase 7.
 
 ### Phase 7: CLEANUP
 


### PR DESCRIPTION
## Summary
- Apply ruff format to `hooks/pretool-git-submission-gate.py` (string concat style fix)
- Add explicit `gh pr merge` step to pr-pipeline Phase 6 with hard rule: never merge with failing/pending CI

## Context
The hook was merged with a ruff format inconsistency. The pr-pipeline Phase 6 had CI checking but no merge step — merges were happening outside the pipeline.

## Test plan
- [x] `ruff check` + `ruff format --check` — both pass
- [x] Hook functional test — blocks/allows correctly
- [x] Hook synced to `~/.claude/hooks/`
- [x] Hook registered in `~/.claude/settings.json`