### PR TITLE
feat(mcp): add Chrome DevTools MCP integration with registry

### DIFF
--- a/scripts/install-doctor.py
+++ b/scripts/install-doctor.py
@@ -7,6 +7,7 @@ Usage:
     python3 ~/.claude/scripts/install-doctor.py check # From anywhere
     python3 scripts/install-doctor.py check --json    # Machine-readable output
     python3 scripts/install-doctor.py inventory       # Count installed components
+    python3 scripts/install-doctor.py mcp             # List MCP servers from registry
 
 Exit codes:
     0 — All checks passed
@@ -15,6 +16,7 @@ Exit codes:
 """
 
 import importlib
+import importlib.util
 import json
 import os
 import sys
@@ -335,6 +337,94 @@ def check_permissions() -> list[dict]:
     return results
 
 
+def check_mcp_servers() -> list[dict]:
+    """Check which MCP servers from the registry are configured.
+
+    Loads the REGISTRY from mcp-registry.py (same directory) and checks
+    whether each server's tool_prefix appears in the mcpServers key of
+    ~/.claude/settings.json or ~/.claude/settings.local.json.
+    """
+    results = []
+
+    # Import REGISTRY from mcp-registry.py in the same directory
+    script_dir = Path(__file__).resolve().parent
+    registry_path = script_dir / "mcp-registry.py"
+    if not registry_path.exists():
+        return [
+            {
+                "name": "mcp_registry",
+                "label": "MCP registry available",
+                "passed": True,
+                "detail": "mcp-registry.py not found (MCP inventory not available yet)",
+            }
+        ]
+
+    try:
+        spec = importlib.util.spec_from_file_location("mcp_registry", registry_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        registry = getattr(mod, "REGISTRY", None)
+    except Exception as e:
+        return [
+            {
+                "name": "mcp_registry",
+                "label": "MCP registry loadable",
+                "passed": False,
+                "detail": f"Failed to load mcp-registry.py: {e}",
+            }
+        ]
+
+    if not registry:
+        return [
+            {
+                "name": "mcp_registry",
+                "label": "MCP registry has entries",
+                "passed": True,
+                "detail": "REGISTRY is empty or not defined",
+            }
+        ]
+
+    # Collect configured mcpServers keys from settings files
+    configured_servers: set[str] = set()
+    for settings_name in ["settings.json", "settings.local.json"]:
+        settings_path = CLAUDE_DIR / settings_name
+        if not settings_path.exists():
+            continue
+        try:
+            with open(settings_path) as f:
+                data = json.load(f)
+            for key in data.get("mcpServers", {}):
+                configured_servers.add(key)
+        except (json.JSONDecodeError, OSError):
+            continue
+
+    # Also check ~/.claude.json (global config)
+    global_config = Path.home() / ".claude.json"
+    if global_config.exists():
+        try:
+            with open(global_config) as f:
+                data = json.load(f)
+            for key in data.get("mcpServers", {}):
+                configured_servers.add(key)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    for key, entry in registry.items():
+        display_name = entry.get("name", key)
+        # Match if the registry key appears in configured server names
+        found = key in configured_servers
+        results.append(
+            {
+                "name": f"mcp_{key}",
+                "label": f"MCP: {display_name}",
+                "passed": found,
+                "detail": "configured" if found else "not configured",
+            }
+        )
+
+    return results
+
+
 def inventory() -> dict:
     """Count installed components."""
     counts = {}
@@ -364,6 +454,15 @@ def inventory() -> dict:
         elif comp == "scripts":
             counts[comp] = len([f for f in real_dir.glob("*.py") if f.name != "__init__.py"])
 
+    # Count MCP servers from registry
+    mcp_results = check_mcp_servers()
+    mcp_total = sum(1 for r in mcp_results if r["name"].startswith("mcp_") and r["name"] != "mcp_registry")
+    mcp_configured = sum(
+        1 for r in mcp_results if r["name"].startswith("mcp_") and r["name"] != "mcp_registry" and r["passed"]
+    )
+    counts["mcps"] = mcp_total
+    counts["mcps_configured"] = mcp_configured
+
     return counts
 
 
@@ -378,6 +477,7 @@ def run_all_checks() -> list[dict]:
     results.extend(check_python_deps())
     results.append(check_learning_db())
     results.extend(check_permissions())
+    results.extend(check_mcp_servers())
     return results
 
 
@@ -394,7 +494,7 @@ def print_results(results: list[dict]) -> bool:
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: install-doctor.py [check|inventory] [--json]")
+        print("Usage: install-doctor.py [check|inventory|mcp] [--json]")
         sys.exit(2)
 
     try:
@@ -427,8 +527,24 @@ def main():
                 print(f"  Hooks:    {counts.get('hooks', 0)}")
                 print(f"  Commands: {counts.get('commands', 0)}")
                 print(f"  Scripts:  {counts.get('scripts', 0)}")
+                print(f"  MCPs:     {counts.get('mcps', 0)} ({counts.get('mcps_configured', 0)} configured)")
                 print()
             sys.exit(0)
+
+        elif command == "mcp":
+            import subprocess
+
+            # Delegate to mcp-registry.py list
+            script_dir = Path(__file__).resolve().parent
+            registry_script = script_dir / "mcp-registry.py"
+            if not registry_script.exists():
+                print("mcp-registry.py not found. MCP inventory not available yet.", file=sys.stderr)
+                sys.exit(2)
+            result = subprocess.run(
+                [sys.executable, str(registry_script), "list"],
+                check=False,
+            )
+            sys.exit(result.returncode)
 
         else:
             print(f"Unknown command: {command}")

--- a/scripts/mcp-registry.py
+++ b/scripts/mcp-registry.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+mcp-registry.py -- Single source of truth for MCP server metadata.
+
+Used by /install, /do router, and install-doctor.py to discover,
+configure, and validate MCP servers in the Claude Code Toolkit.
+
+Usage:
+    python3 scripts/mcp-registry.py list              # Table of all MCPs
+    python3 scripts/mcp-registry.py list --json        # JSON array
+    python3 scripts/mcp-registry.py get chrome-devtools        # Details for one MCP
+    python3 scripts/mcp-registry.py get chrome-devtools --json # JSON for one MCP
+    python3 scripts/mcp-registry.py check              # Check which MCPs are configured
+
+Exit codes:
+    0 -- Success
+    1 -- MCP not found (get) or no MCPs configured (check)
+    2 -- Usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REGISTRY: dict[str, dict[str, Any]] = {
+    "chrome-devtools": {
+        "name": "Chrome DevTools MCP",
+        "description": "Live browser debugging, performance profiling, network inspection",
+        "install_command": "claude mcp add chrome-devtools -- npx chrome-devtools-mcp@latest",
+        "docs_url": "https://developer.chrome.com/blog/chrome-devtools-mcp",
+        "tool_prefix": "mcp__chrome-devtools__",
+        "paired_skills": ["wordpress-live-validation"],
+        "use_cases": [
+            "inspect page",
+            "lighthouse",
+            "console errors",
+            "network requests",
+            "performance profile",
+            "debug in browser",
+            "check my site",
+        ],
+        "category": "browser",
+        "requires": "Chrome browser with DevTools MCP enabled",
+    },
+    "playwright": {
+        "name": "Playwright MCP",
+        "description": "Automated browser testing, validation workflows, screenshot comparison",
+        "install_command": "claude mcp add playwright -- npx @anthropic-ai/mcp-playwright@latest",
+        "docs_url": "https://github.com/anthropics/mcp-playwright",
+        "tool_prefix": "mcp__plugin_playwright_playwright__",
+        "paired_skills": ["wordpress-live-validation"],
+        "use_cases": [
+            "validate page",
+            "test layout",
+            "automated check",
+            "screenshot test",
+            "responsive check",
+            "browser test",
+        ],
+        "category": "browser",
+        "requires": "Node.js 20+",
+    },
+    "gopls": {
+        "name": "gopls MCP",
+        "description": "Go workspace intelligence: symbols, diagnostics, references, vulncheck",
+        "install_command": "claude mcp add gopls -- gopls mcp",
+        "docs_url": "https://pkg.go.dev/golang.org/x/tools/gopls",
+        "tool_prefix": "mcp__gopls__",
+        "paired_skills": ["go-code-review", "go-testing", "go-concurrency"],
+        "use_cases": ["Go workspace", ".go files", "go.mod", "Go symbols", "Go diagnostics"],
+        "category": "language",
+        "requires": "gopls installed (go install golang.org/x/tools/gopls@latest)",
+    },
+    "context7": {
+        "name": "Context7 MCP",
+        "description": "Library documentation lookups and API reference",
+        "install_command": "claude mcp add context7 -- npx @anthropic-ai/mcp-context7@latest",
+        "docs_url": "https://context7.com",
+        "tool_prefix": "mcp__plugin_context7_context7__",
+        "paired_skills": [],
+        "use_cases": ["library docs", "API reference", "how do I use X", "unfamiliar library"],
+        "category": "documentation",
+        "requires": "Node.js 20+",
+    },
+}
+
+# Settings files where MCP servers may be configured
+SETTINGS_PATHS = [
+    Path.home() / ".claude" / "settings.json",
+    Path.home() / ".claude" / "settings.local.json",
+    Path.home() / ".claude.json",
+]
+
+
+def _load_configured_servers() -> set[str]:
+    """Parse all known settings files and return configured mcpServers keys."""
+    configured: set[str] = set()
+    for path in SETTINGS_PATHS:
+        try:
+            data = json.loads(path.read_text())
+            for key in data.get("mcpServers", {}):
+                configured.add(key)
+        except (json.JSONDecodeError, OSError):
+            continue
+    return configured
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+
+def cmd_list(*, use_json: bool) -> int:
+    """List all registered MCP servers."""
+    if use_json:
+        print(json.dumps([{**v, "key": k} for k, v in REGISTRY.items()], indent=2))
+        return 0
+
+    # Table header
+    print()
+    print(f"  {'Name':<24} {'Category':<16} {'Description'}")
+    print(f"  {'----':<24} {'--------':<16} {'-----------'}")
+    for key, entry in REGISTRY.items():
+        print(f"  {key:<24} {entry['category']:<16} {entry['description']}")
+    print()
+    return 0
+
+
+def cmd_get(name: str, *, use_json: bool) -> int:
+    """Get details for a single MCP server."""
+    entry = REGISTRY.get(name)
+    if entry is None:
+        print(f"Unknown MCP server: {name}", file=sys.stderr)
+        print(f"Available: {', '.join(REGISTRY)}", file=sys.stderr)
+        return 1
+
+    if use_json:
+        print(json.dumps(entry, indent=2))
+        return 0
+
+    print()
+    print(f"  {entry['name']}")
+    print(f"  {'-' * len(entry['name'])}")
+    print(f"  Description:  {entry['description']}")
+    print(f"  Category:     {entry['category']}")
+    print(f"  Requires:     {entry['requires']}")
+    print(f"  Docs:         {entry['docs_url']}")
+    print(f"  Tool prefix:  {entry['tool_prefix']}")
+    print(f"  Install:      {entry['install_command']}")
+    if entry["paired_skills"]:
+        print(f"  Skills:       {', '.join(entry['paired_skills'])}")
+    print(f"  Use cases:    {', '.join(entry['use_cases'])}")
+    print()
+    return 0
+
+
+def cmd_check(*, use_json: bool) -> int:
+    """Check which MCP servers appear configured in settings files."""
+    configured_servers = _load_configured_servers()
+    results: list[dict[str, Any]] = []
+
+    for key, entry in REGISTRY.items():
+        configured = key in configured_servers
+        results.append({**entry, "key": key, "configured": configured})
+
+    if use_json:
+        print(json.dumps(results, indent=2))
+    else:
+        print()
+        print(f"  {'Name':<24} {'Category':<16} {'Configured'}")
+        print(f"  {'----':<24} {'--------':<16} {'----------'}")
+        for r in results:
+            status = "yes" if r["configured"] else "no"
+            print(f"  {r['key']:<24} {r['category']:<16} {status}")
+        print()
+
+        configured_count = sum(1 for r in results if r["configured"])
+        print(f"  {configured_count}/{len(results)} MCP servers configured")
+        print()
+
+    any_configured = any(r["configured"] for r in results)
+    return 0 if any_configured else 1
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="mcp-registry.py",
+        description="MCP server registry for the Claude Code Toolkit.",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    list_p = sub.add_parser("list", help="List all registered MCP servers")
+    list_p.add_argument("--json", action="store_true", help="Output as JSON")
+
+    get_p = sub.add_parser("get", help="Get details for one MCP server")
+    get_p.add_argument("name", help="MCP server key (e.g. chrome-devtools)")
+    get_p.add_argument("--json", action="store_true", help="Output as JSON")
+
+    check_p = sub.add_parser("check", help="Check which MCPs are configured")
+    check_p.add_argument("--json", action="store_true", help="Output as JSON")
+
+    return parser
+
+
+def main() -> int:
+    """Entry point."""
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command is None:
+        parser.print_help()
+        return 2
+
+    if args.command == "list":
+        return cmd_list(use_json=args.json)
+    elif args.command == "get":
+        return cmd_get(args.name, use_json=args.json)
+    elif args.command == "check":
+        return cmd_check(use_json=args.json)
+
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)
+    except BrokenPipeError:
+        sys.exit(0)

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -366,10 +366,14 @@ MCP TOOL DISCOVERY (do this FIRST, before reading code):
 - Use ToolSearch("context7") to check for library documentation tools
   (resolve-library-id, query-docs). If found: use for verifying library
   API usage and looking up unfamiliar dependencies.
-- If ToolSearch returns no results for either, proceed without them.
+- Use ToolSearch("chrome-devtools") to check for browser inspection tools
+  (list_pages, navigate_page, take_screenshot, lighthouse_audit,
+  list_console_messages, list_network_requests). If found: use for live
+  browser debugging, page inspection, and performance profiling tasks.
+- If ToolSearch returns no results for any of these, proceed without them.
 ```
 
-**When to include**: Include gopls block when dispatching Go-related agents (`golang-general-engineer`, `golang-general-engineer-compact`, or any agent working on `.go` files). Include Context7 block for any agent that may encounter library/dependency questions. Skip entirely for trivial tasks or non-code agents.
+**When to include**: Include gopls block when dispatching Go-related agents (`golang-general-engineer`, `golang-general-engineer-compact`, or any agent working on `.go` files). Include Context7 block for any agent that may encounter library/dependency questions. Include chrome-devtools block when dispatching agents that need to inspect live browser pages (performance-optimization-engineer, testing-automation-engineer, or any agent working on frontend debugging). Skip entirely for trivial tasks or non-code agents.
 
 **Step 3: Invoke agent with skill**
 
@@ -434,6 +438,8 @@ Record specific, actionable insights — not generic advice. "Force-route trigge
 
 | MCP | Triggers | Rule |
 |-----|----------|------|
+| **Chrome DevTools** | inspect page, lighthouse, console errors, network requests, performance profile, debug in browser, check my site, what's on this page | **AUTO-USE for live browser debugging** — controls the user's real Chrome browser. Use for interactive inspection, profiling, and Lighthouse audits. Requires Chrome to be open. |
+| **Playwright** | validate page, test layout, automated check, screenshot test, responsive check, browser test | **AUTO-USE for automated browser validation** — spins up a headless browser instance. Use for deterministic testing workflows, screenshot comparisons, and repeatable validation. |
 | **Context7** | Library/API docs, unfamiliar library, setup steps, "how do I use X", **Claude Code hooks/settings/slash commands/API** | **AUTO-USE for documentation lookups** |
 | **gopls** | Go workspace, .go files, go.mod, Go symbols, Go diagnostics | **AUTO-USE for Go development** — use `go_workspace` at session start, `go_file_context` after reading .go files, `go_diagnostics` after edits, `go_symbol_references` before renaming. Scoped to Go agents/skills only. |
 

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -123,7 +123,40 @@ Your toolkit is ready. Here's what's installed:
   Scripts:  [N] utility scripts
 ```
 
-**Gate**: User sees their inventory. Proceed to Phase 4.
+**Gate**: User sees their inventory. Proceed to Phase 3.5.
+
+### Phase 3.5: MCP INVENTORY
+
+**Goal**: Show which MCP servers are available and their status.
+
+**Step 1: Run MCP registry check**
+
+```bash
+python3 scripts/mcp-registry.py list
+```
+
+If the script is not found at `scripts/mcp-registry.py`, try `~/.claude/scripts/mcp-registry.py`.
+
+**Step 2: Display MCP status**
+
+Show the MCP inventory as:
+
+```
+MCP Servers:
+
+  [✓] Chrome DevTools MCP  — Live browser debugging
+      Paired skills: wordpress-live-validation
+  [✓] Playwright MCP       — Automated browser testing
+      Paired skills: wordpress-live-validation
+  [✓] gopls MCP            — Go workspace intelligence
+      Paired skills: go-code-review, go-testing, go-concurrency
+  [✗] Context7 MCP         — Library documentation lookups
+      Install: claude mcp add context7 -- npx @anthropic-ai/mcp-context7@latest
+```
+
+Use ✓ for connected MCPs and ✗ for missing ones. For missing MCPs, show the install command.
+
+**Gate**: MCP inventory displayed. Proceed to Phase 4.
 
 ### Phase 4: ORIENT
 

--- a/skills/wordpress-live-validation/SKILL.md
+++ b/skills/wordpress-live-validation/SKILL.md
@@ -4,11 +4,12 @@ description: |
   Validate a published or draft-preview WordPress post in a real browser using
   Playwright. Checks rendered title, heading structure, image loading, OG/meta
   tags, JavaScript errors, and responsive layout at mobile/tablet/desktop
-  breakpoints. Use for "validate wordpress post", "check live post",
-  "verify published post", "wordpress post looks right", "check og tags",
-  or "responsive check wordpress". Do NOT use for source markdown validation
-  (use pre-publish-checker), SEO keyword analysis (use seo-optimizer), or
-  uploading content (use wordpress-uploader).
+  breakpoints. When Chrome DevTools MCP is available, can use it for live browser
+  inspection as an alternative to Playwright. Use for "validate wordpress post",
+  "check live post", "verify published post", "wordpress post looks right",
+  "check og tags", or "responsive check wordpress". Do NOT use for source
+  markdown validation (use pre-publish-checker), SEO keyword analysis
+  (use seo-optimizer), or uploading content (use wordpress-uploader).
 version: 1.0.0
 user-invocable: false
 allowed-tools:
@@ -23,6 +24,13 @@ allowed-tools:
   - mcp__plugin_playwright_playwright__browser_console_messages
   - mcp__plugin_playwright_playwright__browser_resize
   - mcp__plugin_playwright_playwright__browser_take_screenshot
+  - mcp__chrome-devtools__navigate_page
+  - mcp__chrome-devtools__take_screenshot
+  - mcp__chrome-devtools__take_snapshot
+  - mcp__chrome-devtools__list_console_messages
+  - mcp__chrome-devtools__list_network_requests
+  - mcp__chrome-devtools__lighthouse_audit
+  - mcp__chrome-devtools__resize_page
 routing:
   triggers:
     - validate wordpress post
@@ -54,6 +62,22 @@ This skill operates as an operator for post-publish browser validation, configur
 - **Non-Blocking by Default**: Failed validation produces a report but does not revert the upload or block the pipeline. Why: the user decides how to act on findings; automated rollback is a separate, riskier concern.
 - **Severity Accuracy**: BLOCKER means readers see broken content. WARNING means degraded quality. INFO means informational. Never inflate or deflate severity. Why: inflated severity causes alert fatigue; deflated severity hides real problems.
 
+### Browser Backend Selection
+
+This skill supports two browser backends:
+
+| Backend | When to Use | How |
+|---------|-------------|-----|
+| **Playwright MCP** (default) | Automated validation, repeatable checks, CI/CD | Headless browser, deterministic |
+| **Chrome DevTools MCP** (alternative) | Live debugging, user watching the browser, performance profiling | User's real Chrome browser |
+
+**Selection logic**: Use Chrome DevTools MCP when:
+1. The user explicitly asks to "check in my browser" or "debug live"
+2. The task involves Lighthouse audits or performance profiling
+3. The user has Chrome DevTools MCP connected AND is actively debugging
+
+Otherwise, default to Playwright MCP for deterministic, repeatable validation.
+
 ### Default Behaviors (ON unless disabled)
 - **Full Validation**: Run all check categories (content integrity, SEO/social, responsive)
 - **Three Breakpoints**: Test mobile (375px), tablet (768px), desktop (1440px)
@@ -83,10 +107,10 @@ This skill operates as an operator for post-publish browser validation, configur
 - **Modify WordPress content**: Read-only inspection; use wordpress-uploader for edits
 - **Validate source markdown**: Use pre-publish-checker for pre-upload validation
 - **Visual regression testing**: No pixel-level comparison against golden baselines
-- **Performance testing**: No Lighthouse scores, load times, or Core Web Vitals
-- **Cross-browser testing**: Playwright MCP runs Chromium only
+- **Performance testing**: Lighthouse audits available via Chrome DevTools MCP; no load time benchmarking or Core Web Vitals tracking
+- **Cross-browser testing**: Playwright runs Chromium only; Chrome DevTools MCP runs Chrome only
 - **Authenticate to wp-admin**: Draft preview requires the user to provide an authenticated session or use published posts
-- **Work without Playwright MCP**: If the Playwright server is unavailable, the skill exits with a skip report
+- **Work without a browser MCP**: Requires either Playwright MCP or Chrome DevTools MCP. If neither is available, the skill exits with a skip report
 
 ---
 


### PR DESCRIPTION
## Summary
- Create `scripts/mcp-registry.py` as single source of truth for all MCP server metadata (Chrome DevTools, Playwright, gopls, Context7)
- Add Chrome DevTools + Playwright to `/do` MCP Auto-Invocation table with use-case-based routing
- Update Step 2.5 subagent propagation with `ToolSearch("chrome-devtools")` discovery
- Add Phase 3.5 MCP INVENTORY to `/install` skill
- Add `check_mcp_servers()` and MCP counts to `install-doctor.py`
- Add Chrome DevTools as alternative browser backend in `wordpress-live-validation`

## Changes

| File | Action |
|------|--------|
| `scripts/mcp-registry.py` | **New** — registry CLI with `list`, `get`, `check` subcommands |
| `scripts/install-doctor.py` | **Modified** — MCP health checks + inventory counts |
| `skills/do/SKILL.md` | **Modified** — MCP Auto-Invocation routing table + Step 2.5 |
| `skills/install/SKILL.md` | **Modified** — Phase 3.5 MCP Inventory |
| `skills/wordpress-live-validation/SKILL.md` | **Modified** — Browser Backend Selection |

## Test plan
- [x] `mcp-registry.py list` — shows all 4 MCPs
- [x] `mcp-registry.py get chrome-devtools` — shows full details with install command
- [x] `mcp-registry.py list --json` — includes registry keys
- [x] `mcp-registry.py check` — properly parses JSON settings (not substring match)
- [x] `install-doctor.py inventory` — shows MCP counts
- [x] `install-doctor.py check` — includes MCP server checks
- [x] `ruff check` — all passed
- [x] `ruff format --check` — all formatted
- [x] PR review: 7 issues found, 7 fixed