### PR TITLE
fix(docs): restore hero image, reorder paths by complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Claude Code Toolkit
 
+<img src="docs/repo-hero.png" alt="Claude Code Toolkit" width="100%">
+
 Agents, skills, and hooks that make Claude Code behave like a team instead of a generalist.
 
 You say `/do debug this Go test` and a router picks a Go specialist, loads a debugging methodology, and enforces gated phases. You get domain expertise and structured workflows without managing any of it yourself. Built over a year of daily use.
@@ -16,15 +18,15 @@ More details in [start-here.md](docs/start-here.md).
 
 ## Choose Your Path
 
-**[I just want to use it](docs/start-here.md)** — Install in 2 minutes, learn 3 commands. Done.
-
-**[I'm a developer](docs/for-developers.md)** — Architecture, extension points, how to add your own agents and skills. The repo internals tour.
+**[I just want to use it](docs/start-here.md)** — Install in 2 minutes, learn a few commands. Done.
 
 **[I do knowledge work](docs/for-knowledge-workers.md)** — Content pipelines, research workflows, community moderation. No code required.
 
-**[I'm an AI power user](docs/for-ai-wizards.md)** — Routing tables, pipeline architecture, hook system internals, the learning database.
+**[I'm a developer](docs/for-developers.md)** — Architecture, extension points, how to add your own agents and skills.
 
-**[I'm an AI agent](docs/for-claude-code.md)** — Machine-dense component inventory. Tables, file paths, schemas, routing rules. If you're an LLM operating in this repo, start here.
+**[I'm an AI power user](docs/for-ai-wizards.md)** — Routing tables, pipeline architecture, hook system, the learning database.
+
+**[I'm an AI agent](docs/for-claude-code.md)** — Machine-dense component inventory. Tables, file paths, schemas, routing rules.
 
 **[I'm on LinkedIn](docs/for-linkedin.md)** — 🚀 Thought leadership. Agree? 👇
 


### PR DESCRIPTION
## Summary

- Restore `repo-hero.png` to README (dropped during docs rewrite in PR #38)
- Reorder choose-your-path links from least to most complex: start-here → knowledge-workers → developers → ai-wizards → ai-agents → linkedin
- Graduated "gradual complexity" principle into doc-pipeline skill

## Also done (local, gitignored)

Updated all ADR statuses to match reality:
- ADR-001, 002: Superseded (repo already public)
- ADR-004, 005, 008, 009, auto-retro, standardized-services: Implemented
- Only ADR-010 remains partially implemented (PR pipeline RETRO phase)

## Test plan

- [x] `docs/repo-hero.png` exists and is referenced correctly
- [x] Path ordering: simple → complex
- [ ] CI green