### PR TITLE
feat: ADR lifecycle tooling and docs simplification

### DIFF
--- a/docs/for-developers.md
+++ b/docs/for-developers.md
@@ -51,269 +51,72 @@ adr/                 Architecture Decision Records. Numbered markdown files trac
 
 A few things that aren't obvious from the listing: `agents/` and `skills/` both have INDEX.json files that are *generated* by scripts (`scripts/generate-agent-index.py` and `scripts/generate-skill-index.py`). The `hooks/lib/` directory is where shared code lives -- hooks import from there, not from each other. And the `services/` directory exists for optional service integrations.
 
-## Adding an Agent
+## Creating Components
 
-Agents are markdown files with YAML frontmatter. The frontmatter tells the router when to use the agent. The body tells Claude *how to be* that agent.
+The toolkit has specialized creator agents for each component type. Tell `/do` what you want, describe the domain and purpose in your prompt, and the creator agent handles structure, registration, and routing integration.
 
-### Step 1: Create the file
-
-```bash
-touch agents/my-domain-engineer.md
-```
-
-Naming convention: `{domain}-{function}-engineer.md`. The `-engineer` suffix isn't mandatory but it's what most agents use. Look at the existing ones -- `golang-general-engineer.md`, `python-general-engineer.md`, `kubernetes-helm-engineer.md`.
-
-### Step 2: Write the frontmatter
-
-Here's the minimum viable frontmatter:
-
-```yaml
----
-name: my-domain-engineer
-version: 1.0.0
-description: |
-  Use this agent when you need help with [your domain].
-  The agent specializes in [specific things].
-
-  Examples:
-
-  <example>
-  Context: User wants to do X
-  user: "Help me do X"
-  assistant: "[Routes to my-domain-engineer] Doing X with proper patterns."
-  <commentary>
-  Routes here because: (1) X is a trigger keyword, (2) requires domain expertise.
-  </commentary>
-  </example>
-
-color: blue
-routing:
-  triggers:
-    - my-domain
-    - relevant-keyword
-    - .file-extension
-  pairs_with:
-    - verification-before-completion
-  complexity: Medium
-  category: language
----
-```
-
-The `color` field sets the accent in the Claude Code UI. Pick from: blue, green, orange, red, purple.
-
-The `routing` block is what `/do` uses to match requests to your agent. Triggers are fuzzy-matched against the user's request. `pairs_with` lists skills that work well with this agent. `complexity` tells the planner how much scaffolding to set up. `category` groups agents for discovery.
-
-### Step 3: Write the body
-
-The body follows a pattern you'll see in every agent. Look at `agents/python-general-engineer.md` for a real example. The key sections:
-
-1. **Operator context preamble** -- "You are an operator for X, configuring Claude's behavior for Y"
-2. **Hardcoded behaviors** -- things this agent always does (CLAUDE.md compliance, over-engineering prevention, plus domain-specific rules)
-3. **Default behaviors** -- on by default, can be turned off (communication style, cleanup habits, domain defaults)
-4. **Optional behaviors** -- off by default (things users can enable)
-5. **Capabilities and limitations** -- what the agent CAN and CANNOT do
-6. **Anti-patterns** -- common mistakes with what-why-instead format
-7. **Anti-rationalization table** -- domain-specific rationalization patterns to watch for
-
-The full template lives at `AGENT_TEMPLATE_V2.md` in the repo root. It's worth reading -- it shows the complete structure including reference file organization.
-
-### Step 4: Register in the index
-
-```bash
-python3 scripts/generate-agent-index.py
-```
-
-This reads all `agents/*.md` files, extracts routing metadata from frontmatter, and writes `agents/INDEX.json`. The `/do` router reads that index at runtime. Don't hand-edit INDEX.json -- it gets overwritten.
-
-### Step 5: Test routing
-
-Start a Claude Code session and try:
+### Creating an Agent
 
 ```
-/do [request that should trigger your agent]
+/do create an agent for [your domain]
 ```
 
-The routing banner should show your agent being selected. If it doesn't, check your triggers -- they might be too narrow, or another agent's triggers might be matching first.
+Describe what the agent should specialize in, what triggers should route to it, and what patterns it should enforce. The `agent-creator-engineer` handles the rest: file creation, frontmatter, operator context, anti-patterns, index registration, and routing table integration.
 
-### Optional: Reference files
+**Example prompts:**
+- `/do create an agent for Terraform infrastructure management that knows HCL, state management, and module patterns`
+- `/do create an agent for Redis caching that specializes in data structures, eviction policies, and cluster management`
 
-For agents with deep domain knowledge, create a references subdirectory:
+The agent creator uses the `AGENT_TEMPLATE_V2.md` template and produces a complete agent with operator context, hardcoded/default/optional behaviors, anti-patterns, and reference files.
+
+### Creating a Skill
 
 ```
-agents/my-domain-engineer/
-  references/
-    error-catalog.md
-    anti-patterns.md
-    code-examples.md
+/do create a skill for [your workflow]
 ```
 
-The agent can reference these when it needs detailed examples or error resolution steps. Keeps the main agent file under 10k words.
+Describe the methodology, phases, and quality gates. The `skill-creator-engineer` builds the skill directory, SKILL.md with frontmatter, phase definitions, and updates the index.
 
-## Adding a Skill
+**Example prompts:**
+- `/do create a skill for database migration safety with pre-migration checks, rollback validation, and post-migration verification`
+- `/do create a skill for API contract testing that validates OpenAPI specs against implementation`
 
-Skills are workflow methodologies. Where agents know *what* to do, skills know *how* to structure the work. A skill might be "test-driven development" or "systematic debugging" or "PR pipeline."
+### Creating a Hook
 
-### Step 1: Create the directory and SKILL.md
-
-```bash
-mkdir -p skills/my-workflow
-touch skills/my-workflow/SKILL.md
+```
+/do create a hook for [your purpose]
 ```
 
-### Step 2: Write the frontmatter
+Describe the event type, what it should detect or inject, and any performance constraints. The `hook-development-engineer` creates the hook with proper event handling, `hooks/lib/` integration, and settings.json registration.
 
-```yaml
----
-name: my-workflow
-description: |
-  One-paragraph description of what this skill does and when to use it.
-  Include trigger phrases so the router can match it.
-version: 1.0.0
-user-invocable: true
-agent: python-general-engineer
-allowed-tools:
-  - Bash
-  - Read
-  - Edit
----
+**Example prompts:**
+- `/do create a hook that warns when test files are modified without updating test fixtures`
+- `/do create a PostToolUse hook that detects when a git merge conflict marker is written to a file`
+
+Hooks must meet a **50ms performance target** since they fire on every tool call or prompt.
+
+### Creating a Pipeline
+
+```
+/do create a pipeline for [your domain]
 ```
 
-Key fields:
+The `pipeline-orchestrator-engineer` decomposes the domain into subdomains, composes pipeline chains, scaffolds skills, and wires routing. See `commands/create-pipeline.md` for details.
 
-- `user-invocable`: set to `true` if users can call it directly as `/my-workflow`. Set to `false` for skills that only get invoked by the router or other skills.
-- `agent`: declares which agent should execute this skill. Optional -- some skills are agent-agnostic.
-- `allowed-tools`: restricts which tools the skill can use. Good for security (a read-only skill shouldn't need Write).
-- `context: fork` -- add this if the skill should run in an isolated sub-agent context. Used for skills that do heavy work and shouldn't pollute the main conversation.
+### Key Architecture Points
 
-### Step 3: Write the body
+- **Agents** (`agents/*.md`) know *what* to do -- domain expertise, patterns, anti-patterns
+- **Skills** (`skills/*/SKILL.md`) know *how* to structure work -- phases, gates, methodology
+- **Hooks** (`hooks/*.py`) fire on lifecycle events -- JSON in, JSON out, 50ms budget
+- **Scripts** (`scripts/*.py`) do deterministic work -- linting, indexing, validation
 
-The body is the methodology. It tells the agent *how* to work through the task. Look at `skills/reddit-moderate/SKILL.md` for a concrete example -- it defines modes, prerequisites, commands, and a step-by-step workflow.
+The `/do` router connects everything. After creating any component, test it:
 
-Skills often include:
-- Operator context (hardcoded/default/optional behaviors)
-- Phase definitions (if it's a pipeline)
-- Quality gates between phases
-- Commands or scripts to invoke
-- Error handling and troubleshooting
-
-### Step 4: Update the index
-
-```bash
-python3 scripts/generate-skill-index.py
+```
+/do [request that should trigger your new component]
 ```
 
-Same idea as the agent index. Reads all `skills/*/SKILL.md` files, extracts frontmatter, writes `skills/INDEX.json`.
-
-### Step 5: Force-route triggers (optional)
-
-Some skills need to be invoked whenever certain keywords appear, regardless of what agent is selected. These go in the `/do` skill's routing table. For example, Go test files *always* trigger the `go-testing` skill. If your skill has that kind of mandatory coupling, you'll need to add it to the force-route list in `skills/do/SKILL.md`.
-
-## Writing a Hook
-
-Hooks are Python scripts that fire on Claude Code lifecycle events. They read JSON from stdin and print JSON to stdout. That's the whole contract.
-
-### The event types
-
-| Event | When it fires | Typical use |
-|-------|--------------|-------------|
-| `SessionStart` | Session begins | Load context, sync files, detect environment |
-| `UserPromptSubmit` | Before processing a prompt | Inject skills, detect task complexity |
-| `PreToolUse` | Before a tool runs | Gate tool calls, inject learning hints |
-| `PostToolUse` | After a tool runs | Detect errors, suggest fixes, capture learnings |
-| `PreCompact` | Before context compression | Archive important state |
-| `TaskCompleted` | After a task finishes | Record learnings, cleanup |
-| `SubagentStop` | Sub-agent finishes | Guard completion quality |
-| `Stop` | Session ends | Generate summary, save state |
-
-### The contract
-
-Your hook receives JSON on stdin describing the event. The shape varies by event type but always includes the event name and relevant context. Your hook prints JSON to stdout. The output format uses the `HookOutput` structure from `hooks/lib/hook_utils.py`:
-
-```python
-#!/usr/bin/env python3
-import json
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent / "lib"))
-from hook_utils import context_output, empty_output
-
-def main():
-    event = json.loads(sys.stdin.read())
-
-    # Your logic here
-    if should_inject_context(event):
-        output = context_output("PostToolUse", "Context to inject into Claude's next response")
-        output.print_and_exit()
-    else:
-        empty_output("PostToolUse").print_and_exit()
-
-if __name__ == "__main__":
-    main()
-```
-
-Three output modes:
-- `empty_output(event_name)` -- nothing to say, no injection
-- `context_output(event_name, text)` -- inject system context (Claude sees it, user doesn't)
-- `user_message_output(event_name, message)` -- message displayed verbatim to the user
-
-### Performance budget
-
-Hooks have a **50ms target**. They fire on every tool call (PostToolUse) or every prompt (UserPromptSubmit), so slow hooks add up fast. The settings.json registration supports a `timeout` field (in milliseconds) -- default varies but keep it tight. If your hook needs to do anything heavy, do it asynchronously or cache aggressively.
-
-### The lib directory
-
-Don't reinvent the wheel. `hooks/lib/` has:
-
-- `hook_utils.py` -- output formatting, JSON escaping, environment helpers, frontmatter parsing, file discovery, cascading fallbacks
-- `learning_db_v2.py` -- SQLite-backed learning database for cross-session pattern storage
-- `feedback_tracker.py` -- automatic feedback loop for error-learning confidence tracking
-- `quality_gate.py` -- shared quality gate logic
-- `usage_db.py` -- usage tracking database
-
-Import from lib by adding it to your path:
-
-```python
-sys.path.insert(0, str(Path(__file__).parent / "lib"))
-from hook_utils import context_output, get_project_dir
-```
-
-### Registration
-
-Hooks are registered in `settings.json` under the `hooks` key. Each event type has an array of hook groups, each group containing an array of hooks:
-
-```json
-{
-  "hooks": {
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 \"$HOME/.claude/hooks/my-hook.py\"",
-            "description": "What my hook does",
-            "timeout": 3000
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-Note the path uses `$HOME/.claude/hooks/` -- that's where the sync hook deploys files at session start. You write your hook in the repo's `hooks/` directory. The `sync-to-user-claude.py` hook (which runs on SessionStart) copies it to `~/.claude/hooks/`. The settings.json in the repo is the source of truth for hook registration -- sync replaces the hooks section entirely.
-
-Add `"once": true` for hooks that should only fire once per session (like SessionStart hooks that load initial context).
-
-### Testing hooks
-
-Hook tests live in `hooks/tests/`. Use pytest:
-
-```bash
-pytest hooks/tests/test_my_hook.py -v
-```
-
-Feed your hook test JSON via stdin and assert on the stdout JSON. Look at `hooks/tests/test_feedback_tracker.py` or `hooks/tests/test_learning_system.py` for patterns.
+The routing banner shows which agent and skill were selected. If routing doesn't match, the creator agents handle trigger registration automatically.
 
 ## The PR Workflow
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -523,67 +523,23 @@ frontmatter = parse_frontmatter(content)  # Uses PyYAML if available, regex fall
 
 ## Creating New Hooks
 
-1. Create Python script in `hooks/`:
+Use the `/do` router to create hooks — it dispatches the `hook-development-engineer` agent which handles the full lifecycle:
 
-```python
-#!/usr/bin/env python3
-"""
-Hook description.
-Event: PostToolUse/UserPromptSubmit/SessionStart/Stop/PreCompact
-"""
-
-import json
-import sys
-from pathlib import Path
-
-# Add lib directory for shared libraries
-sys.path.insert(0, str(Path(__file__).parent / "lib"))
-
-def main():
-    try:
-        event_data = sys.stdin.read()
-        if not event_data:
-            return
-
-        event = json.loads(event_data)
-
-        # Check event type
-        event_type = event.get("hook_event_name") or event.get("type", "")
-        if event_type != "YourEvent":
-            return
-
-        # Your logic here
-        # Use lib/learning_db_v2.py for database access
-        # Use lib/feedback_tracker.py for feedback state
-
-    except (json.JSONDecodeError, Exception):
-        pass  # Silent failure - never print errors
-    finally:
-        sys.exit(0)  # Always exit 0 - never block
-
-if __name__ == "__main__":
-    main()
+```
+/do create a hook for [your purpose]
 ```
 
-2. Register in `~/.claude/settings.json`:
+Describe the event type (PostToolUse, PreToolUse, UserPromptSubmit, SessionStart, Stop, PreCompact), what it should detect or inject, and any constraints. The creator agent handles file creation, `hooks/lib/` integration, settings.json registration, and testing.
 
-```json
-{
-  "hooks": {
-    "PostToolUse": [
-      {"type": "command", "command": "python3 hooks/your-hook.py"}
-    ]
-  }
-}
-```
+**Example prompts:**
+- `/do create a PostToolUse hook that detects failed SQL queries and suggests index improvements`
+- `/do create a PreToolUse hook that blocks writes to files matching a custom pattern list`
 
-3. Make executable:
-
-```bash
-chmod +x hooks/your-hook.py
-```
-
-See [`hook-development-engineer`](../agents/hook-development-engineer.md) for comprehensive guidance.
+Key constraints for all hooks:
+- **50ms performance target** — hooks fire on every tool call
+- **JSON in, JSON out** — read from stdin, write to stdout
+- **Never block unexpectedly** — exit 0 unless intentionally gating (exit 2 to block PreToolUse)
+- **Use `hooks/lib/`** — shared utilities for output formatting, learning database, feedback tracking
 
 ---
 

--- a/scripts/adr-status.py
+++ b/scripts/adr-status.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""
+ADR Status Report — scan adr/ directory and output a status summary.
+
+Parses each ADR markdown file for title, status, date, and number,
+then outputs a formatted table grouped by status or validates structure.
+
+Usage:
+    python3 scripts/adr-status.py status              # Table grouped by status
+    python3 scripts/adr-status.py status --json        # JSON output
+    python3 scripts/adr-status.py check                # Validate required sections
+    python3 scripts/adr-status.py check --json         # Validation results as JSON
+    python3 scripts/adr-status.py --dir /path/to/adrs  # Override ADR directory
+
+Exit codes:
+    0 = success (status), all valid (check)
+    1 = validation warnings found (check)
+    2 = usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AdrRecord:
+    """Parsed metadata from a single ADR file."""
+
+    filename: str
+    number: int | None
+    title: str
+    status: str
+    date: str
+    path: Path
+
+
+@dataclass
+class AdrWarning:
+    """Validation warning for a single ADR file."""
+
+    filename: str
+    warnings: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+# Matches numbered ADR titles like "# ADR-012: Dangerous Command Guard"
+_NUMBERED_TITLE_RE = re.compile(r"^#\s+ADR-?(\d+):\s*(.+)$")
+
+# Matches unnumbered ADR titles like "# ADR: LLM-Powered Report Classification"
+_UNNUMBERED_TITLE_RE = re.compile(r"^#\s+ADR:\s*(.+)$")
+
+# Matches a generic top-level heading as fallback
+_GENERIC_TITLE_RE = re.compile(r"^#\s+(.+)$")
+
+# Matches number prefix in filenames like "012-dangerous-command-guard.md"
+_FILENAME_NUMBER_RE = re.compile(r"^(\d+)-")
+
+# Required sections for the check subcommand
+_REQUIRED_SECTIONS = ["Status", "Date", "Context"]
+
+
+def _extract_section_value(content: str, heading: str) -> str | None:
+    """Extract the first non-blank line after a ## heading.
+
+    Args:
+        content: Full markdown file content.
+        heading: Section heading name (e.g. "Status", "Date").
+
+    Returns:
+        First non-blank line after the heading, or None if heading not found.
+    """
+    pattern = re.compile(rf"^##\s+{re.escape(heading)}\s*$", re.MULTILINE)
+    match = pattern.search(content)
+    if not match:
+        return None
+
+    # Get text after the heading line
+    rest = content[match.end() :]
+    for line in rest.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+
+    return None
+
+
+def _parse_title(first_line: str) -> tuple[int | None, str]:
+    """Parse the title from the first line of an ADR file.
+
+    Args:
+        first_line: First line of the ADR markdown file.
+
+    Returns:
+        Tuple of (number or None, title string).
+    """
+    # Try numbered: "# ADR-012: Title"
+    m = _NUMBERED_TITLE_RE.match(first_line.strip())
+    if m:
+        return int(m.group(1)), m.group(2).strip()
+
+    # Try unnumbered: "# ADR: Title"
+    m = _UNNUMBERED_TITLE_RE.match(first_line.strip())
+    if m:
+        return None, m.group(1).strip()
+
+    # Fallback: generic heading
+    m = _GENERIC_TITLE_RE.match(first_line.strip())
+    if m:
+        return None, m.group(1).strip()
+
+    return None, first_line.strip()
+
+
+def _extract_number_from_filename(filename: str) -> int | None:
+    """Extract numeric prefix from ADR filename.
+
+    Args:
+        filename: Filename like "012-dangerous-command-guard.md".
+
+    Returns:
+        Integer prefix (e.g. 12) or None for unnumbered files.
+    """
+    m = _FILENAME_NUMBER_RE.match(filename)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def parse_adr(path: Path) -> AdrRecord:
+    """Parse an ADR markdown file into an AdrRecord.
+
+    Args:
+        path: Path to the ADR .md file.
+
+    Returns:
+        Populated AdrRecord with parsed metadata.
+    """
+    content = path.read_text(encoding="utf-8")
+    lines = content.splitlines()
+
+    # Title from first line
+    first_line = lines[0] if lines else ""
+    title_number, title = _parse_title(first_line)
+
+    # Number: prefer filename prefix, fall back to title
+    file_number = _extract_number_from_filename(path.name)
+    number = file_number if file_number is not None else title_number
+
+    # Status
+    status_raw = _extract_section_value(content, "Status")
+    status = status_raw if status_raw else ""
+
+    # Date
+    date_raw = _extract_section_value(content, "Date")
+    date = date_raw if date_raw else ""
+
+    return AdrRecord(
+        filename=path.name,
+        number=number,
+        title=title,
+        status=status,
+        date=date,
+        path=path,
+    )
+
+
+def validate_adr(path: Path) -> AdrWarning:
+    """Validate an ADR file for required sections.
+
+    Args:
+        path: Path to the ADR .md file.
+
+    Returns:
+        AdrWarning with any issues found.
+    """
+    content = path.read_text(encoding="utf-8")
+    result = AdrWarning(filename=path.name)
+
+    for section in _REQUIRED_SECTIONS:
+        pattern = re.compile(rf"^##\s+{re.escape(section)}\s*$", re.MULTILINE)
+        if not pattern.search(content):
+            result.warnings.append(f"Missing ## {section} heading")
+
+    # Check if Status has a value (not just heading present)
+    status_val = _extract_section_value(content, "Status")
+    has_status_heading = bool(re.search(r"^##\s+Status\s*$", content, re.MULTILINE))
+    if has_status_heading and not status_val:
+        result.warnings.append("Status field is empty/blank")
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Sorting
+# ---------------------------------------------------------------------------
+
+
+def _sort_key(record: AdrRecord) -> tuple[int, int, str]:
+    """Sort key: numbered ADRs first (by number), then unnumbered (alphabetically).
+
+    Returns:
+        Tuple of (0 for numbered / 1 for unnumbered, number or 0, filename).
+    """
+    if record.number is not None:
+        return (0, record.number, "")
+    return (1, 0, record.filename)
+
+
+def _normalize_status(raw_status: str) -> str:
+    """Normalize status to a canonical display form.
+
+    Takes the first word of the status line (before any dash or extra text)
+    and title-cases it. E.g. "Implemented — details..." -> "Implemented",
+    "Proposed" -> "Proposed".
+
+    Args:
+        raw_status: Raw status string from the ADR.
+
+    Returns:
+        Normalized status string for grouping.
+    """
+    if not raw_status:
+        return "Unknown"
+    # Take text before em-dash (U+2014), en-dash (U+2013), or hyphen followed by space
+    first_part = re.split(r"\s*[\u2014\u2013-]\s+", raw_status, maxsplit=1)[0]
+    # Take just the first word for grouping
+    first_word = first_part.strip().split()[0] if first_part.strip() else "Unknown"
+    # Capitalize first letter, keep rest
+    return first_word[0].upper() + first_word[1:] if first_word else "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Status group ordering
+# ---------------------------------------------------------------------------
+
+# Display order for status groups; unlisted statuses sort after these
+_STATUS_ORDER = ["Proposed", "Accepted", "Implemented", "Superseded", "Deprecated", "Rejected"]
+
+
+def _status_sort_key(status: str) -> tuple[int, str]:
+    """Sort key for status groups, following conventional ADR lifecycle order."""
+    try:
+        return (0, str(_STATUS_ORDER.index(status)).zfill(3))
+    except ValueError:
+        return (1, status.lower())
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: status
+# ---------------------------------------------------------------------------
+
+
+def cmd_status(adr_dir: Path, *, as_json: bool) -> int:
+    """Scan ADR directory and output a status report.
+
+    Args:
+        adr_dir: Path to the ADR directory.
+        as_json: If True, output JSON instead of formatted table.
+
+    Returns:
+        Exit code (always 0).
+    """
+    if not adr_dir.is_dir():
+        print(f"error: ADR directory not found: {adr_dir}", file=sys.stderr)
+        return 2
+
+    md_files = sorted(adr_dir.glob("*.md"))
+    records = [parse_adr(f) for f in md_files]
+
+    if as_json:
+        output = [
+            {
+                "filename": r.filename,
+                "number": r.number,
+                "title": r.title,
+                "status": r.status,
+                "status_group": _normalize_status(r.status),
+                "date": r.date if r.date else None,
+            }
+            for r in records
+        ]
+        print(json.dumps(output, indent=2))
+        return 0
+
+    # Group by normalized status
+    groups: dict[str, list[AdrRecord]] = defaultdict(list)
+    for record in records:
+        normalized = _normalize_status(record.status)
+        groups[normalized].append(record)
+
+    # Sort within each group
+    for group_records in groups.values():
+        group_records.sort(key=_sort_key)
+
+    # Print header
+    print("ADR Status Report")
+    print("=================")
+
+    if not groups:
+        print("\nNo ADRs found.")
+        return 0
+
+    # Print groups in lifecycle order
+    sorted_statuses = sorted(groups.keys(), key=_status_sort_key)
+    for status in sorted_statuses:
+        group_records = groups[status]
+        print(f"\n{status} ({len(group_records)})")
+        for record in group_records:
+            num_str = f"{record.number:03d}" if record.number is not None else "---"
+            date_str = record.date if record.date else "(no date)"
+            print(f"  {num_str}  {record.title:<45s} {date_str}")
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: check
+# ---------------------------------------------------------------------------
+
+
+def cmd_check(adr_dir: Path, *, as_json: bool) -> int:
+    """Validate all ADR files for required sections.
+
+    Args:
+        adr_dir: Path to the ADR directory.
+        as_json: If True, output JSON instead of human-readable warnings.
+
+    Returns:
+        Exit code 0 if all pass, 1 if any warnings.
+    """
+    if not adr_dir.is_dir():
+        print(f"error: ADR directory not found: {adr_dir}", file=sys.stderr)
+        return 2
+
+    md_files = sorted(adr_dir.glob("*.md"))
+    results = [validate_adr(f) for f in md_files]
+    has_warnings = any(r.warnings for r in results)
+
+    if as_json:
+        output = [{"filename": r.filename, "warnings": r.warnings, "valid": len(r.warnings) == 0} for r in results]
+        print(json.dumps(output, indent=2))
+        return 1 if has_warnings else 0
+
+    if not results:
+        print("No ADRs found.")
+        return 0
+
+    warn_count = 0
+    for result in results:
+        if result.warnings:
+            for warning in result.warnings:
+                print(f"  WARN  {result.filename}: {warning}")
+                warn_count += 1
+
+    if warn_count:
+        print(f"\n{warn_count} warning(s) in {sum(1 for r in results if r.warnings)} file(s)")
+        return 1
+
+    print(f"All {len(results)} ADRs pass validation.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build and return the argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="adr-status.py",
+        description="Scan adr/ directory and output a status report of Architecture Decision Records.",
+    )
+    parser.add_argument(
+        "--dir",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="ADR directory path (default: adr/ relative to repo root)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Output as JSON instead of formatted table",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
+
+    # Add shared flags to each subparser so they work in both positions
+    # (e.g. both "adr-status.py --json status" and "adr-status.py status --json").
+    # Use store_const with default=None so subparser defaults don't clobber
+    # values already set by the parent parser.
+    for p in [
+        subparsers.add_parser("status", help="Show ADR status report grouped by status (default)"),
+        subparsers.add_parser("check", help="Validate ADR files for required sections"),
+    ]:
+        p.add_argument(
+            "--json", action="store_const", const=True, default=None, dest="sub_json", help=argparse.SUPPRESS
+        )
+        p.add_argument("--dir", type=Path, default=None, dest="sub_dir", metavar="PATH", help=argparse.SUPPRESS)
+
+    return parser
+
+
+def main() -> int:
+    """Entry point -- parse args and dispatch to subcommand handler."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    # Default subcommand is 'status'
+    command = args.command or "status"
+
+    # Merge flags: subparser value wins if set, otherwise parent value
+    as_json = getattr(args, "sub_json", None) or args.as_json
+    dir_override = getattr(args, "sub_dir", None) or args.dir
+
+    # Resolve ADR directory
+    if dir_override is not None:
+        adr_dir = dir_override.resolve()
+    else:
+        adr_dir = Path(__file__).resolve().parent.parent / "adr"
+
+    dispatch = {
+        "status": lambda: cmd_status(adr_dir, as_json=as_json),
+        "check": lambda: cmd_check(adr_dir, as_json=as_json),
+    }
+
+    handler = dispatch.get(command)
+    if handler is None:
+        parser.print_help(sys.stderr)
+        return 2
+
+    return handler()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/pr-pipeline/SKILL.md
+++ b/skills/pr-pipeline/SKILL.md
@@ -395,6 +395,33 @@ These changes will be included in the existing commit (amend in next push cycle)
 
 **Gate**: All review findings recorded in learning.db, graduated to 1.0, and embedded in the responsible agent/skill files. Updated files staged for commit.
 
+### Phase 4d: ADR VALIDATION (toolkit repo only)
+
+**Goal**: Verify that all ADRs in the `adr/` directory have consistent format and valid status fields before the PR is created.
+
+**Skip condition**: Same as Phase 4c — only runs in the toolkit repo (both `agents/` and `skills/` directories exist at root).
+
+**Step 1: Run ADR format check**
+
+```bash
+python3 scripts/adr-status.py check
+```
+
+If exit code 1 (warnings found):
+- Review each warning (missing headings, empty status)
+- Fix formatting issues in the ADR files
+- Stage the fixes: `git add adr/`
+
+**Step 2: Run ADR status report**
+
+```bash
+python3 scripts/adr-status.py status
+```
+
+Include the status summary in the PR body if the PR touches any `adr/*.md` files. This gives reviewers an at-a-glance view of ADR state.
+
+**Gate**: `python3 scripts/adr-status.py check` exits 0. All ADRs have valid format.
+
 ### Phase 5: CREATE PR
 
 **Goal**: Create the pull request with meaningful title and body.
@@ -511,8 +538,9 @@ Actions:
 5. Push branch to remote with tracking (PUSH)
 6. Run review-fix loop: `/pr-review` → fix → re-review, up to 3 iterations (REVIEW-FIX LOOP)
 7. Record and graduate review findings, embed in responsible agents/skills (RETRO, toolkit repo only)
-8. Create PR with summary and review findings (CREATE PR)
-9. Wait for CI, report status (VERIFY)
+8. Validate ADR format consistency (ADR VALIDATION, toolkit repo only)
+9. Create PR with summary and review findings (CREATE PR)
+10. Wait for CI, report status (VERIFY)
 Result: PR URL with CI status and review-fix iteration count
 
 ### Example 2: Draft PR for Work in Progress (personal repo)
@@ -525,8 +553,9 @@ Actions:
 5. Push to feature branch (PUSH)
 6. Run review-fix loop (REVIEW-FIX LOOP)
 7. Record and graduate review findings (RETRO, toolkit repo only)
-8. Create PR with `--draft` flag (CREATE PR)
-9. Report PR URL, skip CI wait if `--no-wait` (VERIFY)
+8. Validate ADR format consistency (ADR VALIDATION, toolkit repo only)
+9. Create PR with `--draft` flag (CREATE PR)
+10. Report PR URL, skip CI wait if `--no-wait` (VERIFY)
 Result: Draft PR URL
 
 ### Example 3: Trivial Change with Skip Parallel Review (personal repo)
@@ -539,8 +568,9 @@ Actions:
 5. Push to branch (PUSH)
 6. Run review-fix loop — Phase 4b still runs even with --skip-review (REVIEW-FIX LOOP)
 7. Record and graduate review findings (RETRO, toolkit repo only)
-8. Create PR with minimal body (CREATE PR)
-9. Wait for CI (VERIFY)
+8. Validate ADR format consistency (ADR VALIDATION, toolkit repo only)
+9. Create PR with minimal body (CREATE PR)
+10. Wait for CI (VERIFY)
 Result: PR URL for typo fix
 
 ### Example 4: Protected-Org Repo (human-gated workflow)


### PR DESCRIPTION
## Summary
- Add `scripts/adr-status.py` — scans `adr/` directory, outputs grouped status table, validates format consistency (`status` and `check` subcommands with `--json` flag)
- Integrate ADR validation as Phase 4d in `pr-pipeline` (toolkit repo only) — runs `adr-status.py check` between RETRO and CREATE PR phases
- Simplify component creation docs — replace step-by-step instructions in `docs/for-developers.md` and `hooks/README.md` with pointers to `/do create an agent/skill/hook/pipeline for [purpose]`

## Motivation
ADR format was inconsistent (some used inline `**Status**:`, others used `## Status` heading). Creation docs duplicated knowledge that lives in creator agents and went stale. The ADR status script enables automated format enforcement in the PR pipeline.

## Test plan
- [ ] `python3 scripts/adr-status.py status` outputs grouped table
- [ ] `python3 scripts/adr-status.py check` validates format, exits 1 on warnings
- [ ] `python3 scripts/adr-status.py status --json` outputs valid JSON
- [ ] `docs/for-developers.md` creation sections point to `/do` router
- [ ] `hooks/README.md` creation section points to `/do` router
- [ ] `skills/pr-pipeline/SKILL.md` includes Phase 4d ADR VALIDATION