### PR TITLE
feat(hooks): add dangerous command guard hook (ADR-012)

### DIFF
--- a/hooks/pretool-dangerous-command-guard.py
+++ b/hooks/pretool-dangerous-command-guard.py
@@ -41,28 +41,22 @@ DANGEROUS_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
     (re.compile(r"\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+)?-[a-zA-Z]*r[a-zA-Z]*\s+/\*"), "filesystem", "rm -rf /*"),
     (re.compile(r"\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+)?-[a-zA-Z]*r[a-zA-Z]*\s+~/?(\s|$)"), "filesystem", "rm -rf ~"),
     (re.compile(r"\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+)?-[a-zA-Z]*r[a-zA-Z]*\s+\./?(\s|$)"), "filesystem", "rm -rf ."),
-
     # Database destruction
     (re.compile(r"\bDROP\s+DATABASE\b", re.IGNORECASE), "database", "DROP DATABASE"),
     (re.compile(r"\bDROP\s+SCHEMA\b", re.IGNORECASE), "database", "DROP SCHEMA"),
     (re.compile(r"\bTRUNCATE\s+TABLE\b", re.IGNORECASE), "database", "TRUNCATE TABLE"),
-
     # Permission escalation
     (re.compile(r"\bchmod\s+(-R\s+)?777\b"), "permissions", "chmod 777"),
-
     # Force-push to protected branches
     (re.compile(r"\bgit\s+push\s+.*--force\s+.*\b(main|master)\b"), "git", "git push --force main/master"),
     (re.compile(r"\bgit\s+push\s+-f\s+.*\b(main|master)\b"), "git", "git push -f main/master"),
-
     # Container mass-kill
     (re.compile(r"\bdocker\s+system\s+prune\s+-af\b"), "container", "docker system prune -af"),
     (re.compile(r"\bkubectl\s+delete\s+namespace\b"), "container", "kubectl delete namespace"),
     (re.compile(r"\bkubectl\s+delete\s+ns\b"), "container", "kubectl delete ns"),
-
     # System-level danger
     (re.compile(r"\bmkfs\b"), "system", "mkfs (format disk)"),
     (re.compile(r"\bdd\s+if="), "system", "dd (raw disk write)"),
-
     # Cloud destructive
     (re.compile(r"\bterraform\s+destroy\b(?!.*-target)"), "cloud", "terraform destroy (no -target)"),
     (re.compile(r"\baws\s+s3\s+rb\s+.*--force\b"), "cloud", "aws s3 rb --force"),


### PR DESCRIPTION
## Summary
- Add `hooks/pretool-dangerous-command-guard.py` — PreToolUse hook on Bash that blocks known-destructive commands before execution
- Covers 7 categories: filesystem destruction, database destruction, permission escalation, force-push to protected branches, container mass-kill, system-level danger, cloud destructive
- Per-project `.guard-whitelist` for exceptions, `DANGEROUS_GUARD_BYPASS=1` env var for pipeline bypass
- Fails open on hook crash, <10ms via compiled regex

## ADR
`adr/012-dangerous-command-guard.md`

## Test plan
- [x] `ruff check` passes
- [x] 13/13 pattern tests pass (true positives and true negatives)
- [x] Safe commands pass through (ls, git push feature-branch, chmod 755)
- [x] Dangerous commands blocked (rm -rf /, DROP DATABASE, kubectl delete namespace)
- [x] Specific-path rm allowed (rm -rf build/ not blocked)
- [x] terraform destroy with -target allowed, without -target blocked