### PR TITLE
feat(skills): add decision-helper weighted scoring skill (ADR-017)

### DIFF
--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "generated": "2026-03-20T02:58:51Z",
+  "generated": "2026-03-21T22:13:16Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": [
     {
@@ -306,6 +306,18 @@
       "category": "content",
       "version": "1.0.0",
       "user-invocable": true
+    },
+    {
+      "name": "decision-helper",
+      "description": "Weighted decision scoring framework for architectural and technology choices.",
+      "file": "skills/decision-helper/SKILL.md",
+      "triggers": [
+        "decision-helper",
+        "decision",
+        "helper"
+      ],
+      "version": "1.0.0",
+      "user-invocable": false
     },
     {
       "name": "dispatching-parallel-agents",
@@ -760,6 +772,17 @@
       "user-invocable": false
     },
     {
+      "name": "install",
+      "description": "Verify Claude Code Toolkit installation, diagnose issues, and guide new users through first-time setup",
+      "file": "skills/install/SKILL.md",
+      "triggers": [
+        "install",
+        "install"
+      ],
+      "version": "1.0.0",
+      "user-invocable": true
+    },
+    {
       "name": "learn",
       "description": "Manually teach Claude Code an error pattern and its solution, storing it in the learning database with high confidence.",
       "file": "skills/learn/SKILL.md",
@@ -823,6 +846,209 @@
         "parallel",
         "code",
         "review"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-code-review",
+      "description": "Perses-aware code review: check Go backend against Perses patterns, React components against Perses UI conventions, CUE schemas against plugin spec, and dashboard definitions against best practices.",
+      "file": "skills/perses-code-review/SKILL.md",
+      "triggers": [
+        "perses-code-review",
+        "perses",
+        "code",
+        "review"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-cue-schema",
+      "description": "CUE schema authoring for Perses plugins: define data models, write validation constraints, create JSON examples, implement Grafana migration schemas in migrate/migrate.cue.",
+      "file": "skills/perses-cue-schema/SKILL.md",
+      "triggers": [
+        "perses-cue-schema",
+        "perses",
+        "cue",
+        "schema"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-dac-pipeline",
+      "description": "Dashboard-as-Code pipeline: initialize CUE or Go module with percli dac setup, write dashboard definitions, build with percli dac build, validate, ...",
+      "file": "skills/perses-dac-pipeline/SKILL.md",
+      "triggers": [
+        "perses-dac-pipeline",
+        "perses",
+        "dac"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-dashboard-create",
+      "description": "Guided Perses dashboard creation: gather requirements (metrics, datasource, layout), generate CUE definition or JSON spec, validate with percli lin...",
+      "file": "skills/perses-dashboard-create/SKILL.md",
+      "triggers": [
+        "perses-dashboard-create",
+        "perses",
+        "dashboard",
+        "create"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-dashboard-review",
+      "description": "Review existing Perses dashboards for quality: fetch via MCP or API, analyze panel layout, query efficiency, variable usage, datasource configuration.",
+      "file": "skills/perses-dashboard-review/SKILL.md",
+      "triggers": [
+        "perses-dashboard-review",
+        "perses",
+        "dashboard",
+        "review"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-datasource-manage",
+      "description": "Perses datasource lifecycle management: create, update, delete datasources at global, project, or dashboard scope.",
+      "file": "skills/perses-datasource-manage/SKILL.md",
+      "triggers": [
+        "perses-datasource-manage",
+        "perses",
+        "datasource",
+        "manage"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-deploy",
+      "description": "Deploy Perses server: Docker Compose for local dev, Helm chart for K8s, or binary for bare metal.",
+      "file": "skills/perses-deploy/SKILL.md",
+      "triggers": [
+        "perses-deploy",
+        "perses",
+        "deploy"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-grafana-migrate",
+      "description": "Grafana-to-Perses dashboard migration: export Grafana dashboards, convert with percli migrate, validate converted output, fix incompatibilities, deploy to Perses.",
+      "file": "skills/perses-grafana-migrate/SKILL.md",
+      "triggers": [
+        "perses-grafana-migrate",
+        "perses",
+        "grafana",
+        "migrate"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-lint",
+      "description": "Validate Perses resources: run percli lint locally or with --online against a server.",
+      "file": "skills/perses-lint/SKILL.md",
+      "triggers": [
+        "perses-lint",
+        "perses",
+        "lint"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-onboard",
+      "description": "First-time Perses setup pipeline: discover or deploy server, configure MCP connection, create initial project, add datasources, and verify connectivity.",
+      "file": "skills/perses-onboard/SKILL.md",
+      "triggers": [
+        "perses-onboard",
+        "perses",
+        "onboard"
+      ],
+      "version": "2.0.0",
+      "user-invocable": true
+    },
+    {
+      "name": "perses-plugin-create",
+      "description": "Perses plugin scaffolding and creation: select plugin type (Panel, Datasource, Query, Variable, Explore), generate with percli plugin generate, imp...",
+      "file": "skills/perses-plugin-create/SKILL.md",
+      "triggers": [
+        "perses-plugin-create",
+        "perses",
+        "plugin",
+        "create"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-plugin-pipeline",
+      "description": "End-to-end Perses plugin development pipeline: SCAFFOLD, SCHEMA, IMPLEMENT, TEST, BUILD, DEPLOY.",
+      "file": "skills/perses-plugin-pipeline/SKILL.md",
+      "triggers": [
+        "perses-plugin-pipeline",
+        "perses",
+        "plugin"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-plugin-test",
+      "description": "Perses plugin testing: CUE schema unit tests with percli plugin test-schemas, React component tests, integration testing with local Perses server, and Grafana migration compatibility testing.",
+      "file": "skills/perses-plugin-test/SKILL.md",
+      "triggers": [
+        "perses-plugin-test",
+        "perses",
+        "plugin",
+        "test"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-project-manage",
+      "description": "Perses project lifecycle management: create, list, switch, and configure projects.",
+      "file": "skills/perses-project-manage/SKILL.md",
+      "triggers": [
+        "perses-project-manage",
+        "perses",
+        "project",
+        "manage"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-query-builder",
+      "description": "Build PromQL, LogQL, TraceQL queries for Perses panels.",
+      "file": "skills/perses-query-builder/SKILL.md",
+      "triggers": [
+        "perses-query-builder",
+        "perses",
+        "query",
+        "builder"
+      ],
+      "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "perses-variable-manage",
+      "description": "Perses variable lifecycle management: create Text and List variables at global, project, or dashboard scope.",
+      "file": "skills/perses-variable-manage/SKILL.md",
+      "triggers": [
+        "perses-variable-manage",
+        "perses",
+        "variable",
+        "manage"
       ],
       "version": "2.0.0",
       "user-invocable": false
@@ -1080,6 +1306,18 @@
       ],
       "version": "2.0.0",
       "user-invocable": false
+    },
+    {
+      "name": "reddit-moderate",
+      "description": "Reddit community moderation via PRAW with LLM-powered report classification: fetch modqueue, classify reports against subreddit rules and author history, and take mod actions (approve, remove, lock).",
+      "file": "skills/reddit-moderate/SKILL.md",
+      "triggers": [
+        "reddit-moderate",
+        "reddit",
+        "moderate"
+      ],
+      "version": "1.0.0",
+      "user-invocable": true
     },
     {
       "name": "repo-value-analysis",

--- a/skills/decision-helper/SKILL.md
+++ b/skills/decision-helper/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: decision-helper
+description: |
+  Weighted decision scoring framework for architectural and technology choices.
+  Frames decisions with 2-4 options, scores against weighted criteria, detects
+  close calls, and records decisions in the active ADR or task plan.
+
+  Use when: "should I use X or Y", "which approach", "compare options",
+  "trade-offs between", "help me decide", "evaluate alternatives"
+version: 1.0.0
+user-invocable: false
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Grep
+  - Glob
+  - Edit
+---
+
+# Decision Helper Skill
+
+## Operator Context
+
+This skill operates as an operator for structured decision-making, configuring Claude's behavior for weighted scoring of architectural and technology choices. Runs inline (no context fork) because users adjust criteria and weights interactively.
+
+### Hardcoded Behaviors (Always Apply)
+- **CLAUDE.md Compliance**: Read and follow repository CLAUDE.md files before execution
+- **Option Limit**: Maximum 4 options. More than 4 = decompose into sub-decisions first
+- **Close-Call Detection**: Always flag when top two options differ by <0.5 weighted score
+- **No Gut Overrides**: If the matrix contradicts intuition, fix the criteria -- never override the math
+
+### Default Behaviors (ON unless disabled)
+- **Default Criteria**: Use the standard criteria table unless the user provides custom criteria
+- **ADR Persistence**: Check `.adr-session.json` and append decision there; fall back to task plan
+- **Score Justification**: Brief (1 sentence) justification for each score
+
+### Optional Behaviors (OFF unless enabled)
+- **Custom Criteria**: User replaces or supplements default criteria and weights
+- **Sensitivity Analysis**: Re-score with adjusted weights to test recommendation stability
+- **Skip Persistence**: Don't record the decision (for informal exploration)
+
+---
+
+## Instructions
+
+### Step 1: Frame the Decision
+
+**Goal**: Turn the user's question into a clear, scorable decision.
+
+- State the decision in one sentence (e.g., "Which HTTP router should we use for the API service?")
+- List 2-4 concrete options. If the user provides more than 4, help them eliminate or group options before proceeding
+- Identify hard constraints that eliminate options immediately (e.g., "must be MIT licensed" eliminates Option C)
+
+If the user's request is too vague to frame, ask clarifying questions. Do not guess at options.
+
+**Gate**: Decision statement defined, 2-4 options listed, hard constraints applied.
+
+### Step 2: Define Criteria
+
+**Goal**: Establish what matters for this decision and how much.
+
+Present the default criteria table. Ask the user if they want to adjust weights or add/remove criteria.
+
+| Criterion | Weight | What It Measures |
+|-----------|--------|-----------------|
+| Correctness | 5 | Does it solve the actual problem? |
+| Complexity | 3 | How much complexity does it add? (lower = better) |
+| Maintainability | 3 | How easy to change/debug later? |
+| Risk | 3 | What can go wrong? How bad is the failure mode? |
+| Effort | 2 | Implementation time and difficulty |
+| Familiarity | 2 | Team/user comfort with this approach |
+| Ecosystem | 1 | Library support, documentation, community |
+
+WHY these defaults: Correctness dominates because a wrong solution has zero value regardless of other factors. Complexity/Maintainability/Risk form a middle tier because they determine long-term cost. Effort/Familiarity are lower because they're temporary (teams learn, effort is one-time). Ecosystem is lowest because it rarely decides between otherwise-equal options.
+
+**Gate**: Criteria and weights confirmed (default or custom).
+
+### Step 3: Score Each Option
+
+**Goal**: Rate each option against each criterion with justification.
+
+Score every criterion 1-10 (1-3 poor, 4-6 adequate, 7-9 strong, 10 exceptional). Provide a one-sentence justification per score to prevent arbitrary numbers.
+
+Calculate weighted score: `sum(score * weight) / sum(weights)`
+
+**Gate**: All options scored, all scores justified, weighted scores calculated.
+
+### Step 4: Analyze Results
+
+**Goal**: Interpret the scores and provide a clear recommendation.
+
+Apply these rules in order:
+
+1. **No Good Option** (all weighted scores <6.0): Flag that none of the options are strong. Suggest the user explore alternatives or revisit constraints
+2. **Close Call** (top two within 0.5): Flag as "close call -- additional factors should decide." Identify which criteria drive the difference and ask the user what matters most
+3. **Clear Winner** (top option leads by >0.5): Recommend the winner. Note which high-weight criteria drove the result
+4. **Dominant Option** (top option leads on ALL weight-5 criteria): Note the dominance -- this is a high-confidence recommendation
+
+Present the output table:
+
+```
+## Decision: [statement]
+
+| Criterion (weight) | Option A | Option B | Option C |
+|---------------------|----------|----------|----------|
+| Correctness (5)     | 8        | 7        | 9        |
+| Complexity (3)      | 6        | 8        | 4        |
+| Maintainability (3) | 7        | 7        | 5        |
+| Risk (3)            | 6        | 8        | 4        |
+| Effort (2)          | 7        | 5        | 3        |
+| Familiarity (2)     | 8        | 4        | 2        |
+| Ecosystem (1)       | 7        | 6        | 8        |
+| **Weighted Score**  | **7.0**  | **6.7**  | **5.2**  |
+
+**Recommendation**: Option A (7.0) — [key reasoning]
+**Confidence**: High / Medium (scores within 0.5) / Low (no option >6.0)
+```
+
+**Gate**: Recommendation stated with confidence level. Close calls flagged.
+
+### Step 5: Persist Decision
+
+**Goal**: Record the decision for future reference.
+
+Check for an active ADR session:
+
+```bash
+cat .adr-session.json 2>/dev/null
+```
+
+**If ADR exists**: Append a decision record (statement, options, winner, key reasoning, confidence, date) to the ADR's decisions section.
+
+**If no ADR**: Note the decision in the active task plan (`plan/active/*.md`). If neither exists, present the record to the user for manual recording.
+
+**Gate**: Decision recorded or presented. Workflow complete.
+
+---
+
+## Error Handling
+
+### Error: "Too many options"
+**Cause**: User presents 5+ options
+**Solution**: Help decompose. Group similar options or eliminate clearly inferior ones first. Then score the remaining 2-4.
+
+### Error: "Criteria don't fit this decision"
+**Cause**: Default criteria aren't relevant (e.g., scoring a content strategy, not a technical choice)
+**Solution**: Ask the user to define custom criteria. Suggest domain-appropriate alternatives.
+
+### Error: "Scores feel wrong"
+**Cause**: User disagrees with a score after seeing the matrix
+**Solution**: Adjust the score and recalculate. The matrix is a tool for the user, not an authority over them. If many scores feel wrong, the criteria may need revisiting.
+
+---
+
+## Anti-Patterns
+
+### Analysis Paralysis
+**What it looks like**: User agonizes over whether Complexity should be weight 3 or 4
+**Why wrong**: Weight differences of 1 rarely change the outcome. The framework exists to make decisions faster, not slower.
+**Do instead**: Use defaults. Only customize weights when the user has a strong reason.
+
+### False Precision
+**What it looks like**: "Option A scores 7.21 vs Option B at 7.18, so A wins"
+**Why wrong**: A 0.03 difference is noise. Scores are subjective estimates, not measurements.
+**Do instead**: Close-call detection handles this. Scores within 0.5 are flagged as ties needing additional context.
+
+### Gut Override
+**What it looks like**: "The matrix says B, but I just feel like A is right"
+**Why wrong**: If the matrix contradicts your intuition, the criteria or scores are wrong -- not the math. Overriding teaches you nothing about WHY your gut disagrees.
+**Do instead**: Ask which criterion is missing or mis-weighted. Add it, re-score, and see if the matrix now agrees with intuition. If it does, you found the hidden factor. If it doesn't, trust the matrix.
+
+---
+
+## References
+
+This skill uses these shared patterns:
+- [Anti-Rationalization](../shared-patterns/anti-rationalization-core.md) - Prevents shortcut rationalizations
+
+### Domain-Specific Anti-Rationalization
+
+| Rationalization | Why It's Wrong | Required Action |
+|-----------------|----------------|-----------------|
+| "The answer is obvious, no need to score" | Obvious answers don't need a skill; if you're here, it's not obvious | Run the full framework |
+| "Close enough, just pick one" | Close calls deserve explicit acknowledgment, not hand-waving | Flag the close call, identify differentiating factors |
+| "I'll adjust weights until my preferred option wins" | That's confirmation bias with extra steps | Set weights BEFORE scoring, don't adjust to fit a desired outcome |
+| "This decision is too small for a matrix" | Then don't invoke the skill -- but if you did, commit to the process | Either skip the skill or run it fully |


### PR DESCRIPTION
## Summary
- Add `skills/decision-helper/SKILL.md` — weighted decision scoring framework for architectural and technology choices
- 5-step methodology: Frame Decision, Define Criteria, Score Options, Analyze Results, Persist Decision
- 7 default weighted criteria (Correctness, Complexity, Maintainability, Risk, Effort, Familiarity, Ecosystem)
- Close-call detection (<0.5 weighted score difference), no-good-option detection (all <6.0)
- Persists decisions to active ADR or task plan
- Routed through `/do` (not user-invocable)

## ADR
`adr/017-decision-helper-weighted-scoring.md`

## Test plan
- [x] SKILL.md follows operator context pattern
- [x] Skill index regenerated
- [x] 187 lines (under 200 target)
- [x] Trigger phrases don't collide with existing force-routes