### PR TITLE
feat: add security and testing reference files

### DIFF
--- a/agents/reviewer-security.md
+++ b/agents/reviewer-security.md
@@ -292,4 +292,9 @@ For detailed security patterns:
 - **Severity Classification**: [shared-patterns/severity-classification.md](../skills/shared-patterns/severity-classification.md)
 - **Security Anti-Rationalization**: [shared-patterns/anti-rationalization-security.md](../skills/shared-patterns/anti-rationalization-security.md)
 
+### Domain-Specific References
+- **STRIDE Threat Model**: [references/stride-threat-model.md](reviewer-security/references/stride-threat-model.md) — Proactive threat identification methodology for auth, data storage, and external communication
+- **Compliance Checklists**: [references/compliance-checklists.md](reviewer-security/references/compliance-checklists.md) — GDPR, SOC2, PCI-DSS, HIPAA code-level checks
+- **Sovereign Cloud & Data Residency**: [references/sovereign-cloud-data-residency.md](reviewer-security/references/sovereign-cloud-data-residency.md) — German BDSG/DSGVO, BSI C5, EU data residency, sovereign cloud patterns
+
 See [shared-patterns/output-schemas.md](../skills/shared-patterns/output-schemas.md) for Reviewer Schema details.

--- a/agents/reviewer-security/references/compliance-checklists.md
+++ b/agents/reviewer-security/references/compliance-checklists.md
@@ -1,0 +1,85 @@
+# Compliance Checklists Reference
+
+Quick-reference checklists for regulatory compliance reviews. Use when
+reviewing code that handles personal data, payment information, health
+records, or operates in regulated environments.
+
+These are code-level checks — not full compliance audits. They catch
+the most common violations that appear in pull requests.
+
+## GDPR (General Data Protection Regulation)
+
+Applies to: any system processing EU resident personal data.
+
+| # | Requirement | Code-Level Check |
+|---|------------|-----------------|
+| 1 | Lawful basis for processing | Is consent collected before data processing? Is the purpose documented? |
+| 2 | Data minimization | Are you collecting only the fields you actually use? |
+| 3 | Right to erasure | Can user data be deleted? Are cascading deletes handled? |
+| 4 | Right to export | Can user data be exported in a portable format (JSON/CSV)? |
+| 5 | Data retention limits | Are records auto-deleted after retention period? Is there a TTL? |
+| 6 | Encryption at rest | Is PII encrypted in the database? Are encryption keys rotated? |
+| 7 | Encryption in transit | Is TLS enforced? Are internal service calls encrypted? |
+| 8 | Access logging | Are accesses to personal data logged with who/when/why? |
+| 9 | Cross-border transfer | Does data leave the EU? Are transfer mechanisms documented? |
+| 10 | Breach notification | Can affected users be identified within 72 hours? |
+
+## SOC 2 (Service Organization Control)
+
+Applies to: SaaS providers, cloud services, data processors.
+
+| # | Trust Principle | Code-Level Check |
+|---|----------------|-----------------|
+| 1 | Security — Access control | Role-based access with least privilege? No shared credentials? |
+| 2 | Security — Authentication | MFA available? Password policy enforced? Session timeouts? |
+| 3 | Security — Encryption | Data encrypted at rest and in transit? Key management documented? |
+| 4 | Security — Logging | Security events logged? Logs tamper-evident? Retention policy? |
+| 5 | Availability — Monitoring | Health checks implemented? Alerting on failures? SLOs defined? |
+| 6 | Availability — Backup | Automated backups? Tested restore procedures? |
+| 7 | Availability — Redundancy | Single points of failure identified? Failover tested? |
+| 8 | Confidentiality — Classification | Is data classified (public/internal/confidential/restricted)? |
+| 9 | Confidentiality — Access | Need-to-know access enforced? Data masking for non-prod? |
+| 10 | Processing integrity | Input validation? Output verification? Error handling? |
+
+## PCI-DSS (Payment Card Industry)
+
+Applies to: any system that stores, processes, or transmits cardholder data.
+
+| # | Requirement | Code-Level Check |
+|---|------------|-----------------|
+| 1 | No plaintext card storage | Card numbers never stored in plaintext. Never logged. |
+| 2 | Tokenization | Raw card numbers replaced with tokens after initial processing? |
+| 3 | Encryption of stored data | If card data must be stored, is it encrypted with AES-256+? |
+| 4 | TLS 1.2+ | All cardholder data transmitted over TLS 1.2 or higher? |
+| 5 | No card data in logs | Grep logs for card number patterns (4/5/6xxx-xxxx-xxxx-xxxx). |
+| 6 | Access control | Cardholder data access restricted to need-to-know roles? |
+| 7 | Unique IDs | Each user accessing cardholder data has unique credentials? |
+| 8 | Input validation | All payment form inputs validated and sanitized? |
+| 9 | Error handling | Payment errors don't leak card data or processing details? |
+| 10 | Key management | Encryption keys rotated? Split knowledge for key custodians? |
+
+## HIPAA (Health Insurance Portability)
+
+Applies to: systems handling Protected Health Information (PHI).
+
+| # | Requirement | Code-Level Check |
+|---|------------|-----------------|
+| 1 | PHI encryption at rest | All PHI fields encrypted in database? |
+| 2 | PHI encryption in transit | TLS enforced for all PHI transmission? |
+| 3 | Access controls | Role-based access to PHI with audit trail? |
+| 4 | Audit logging | All PHI access logged with user, timestamp, action? |
+| 5 | Minimum necessary | Only minimum PHI needed for the function is accessed? |
+| 6 | De-identification | Can PHI be de-identified for analytics/testing? |
+| 7 | Backup and recovery | PHI backups encrypted? Recovery procedures tested? |
+| 8 | Business associate agreements | Third-party services handling PHI have BAAs? |
+| 9 | Breach notification | Can affected individuals be identified for breach notification? |
+| 10 | Disposal | PHI properly purged when no longer needed? |
+
+## How to Use in Reviews
+
+1. Identify which frameworks apply (usually from project context or ADR)
+2. Scan the relevant checklist against the changed code
+3. Report violations with the specific requirement number
+4. Distinguish between hard violations (must fix) and gaps (should address)
+
+Not every checklist item applies to every PR. Focus on items relevant to the specific code changes being reviewed.

--- a/agents/reviewer-security/references/sovereign-cloud-data-residency.md
+++ b/agents/reviewer-security/references/sovereign-cloud-data-residency.md
@@ -1,0 +1,130 @@
+# Sovereign Cloud & Data Residency Reference
+
+Requirements for systems operating in sovereign cloud environments, particularly
+German/EU data residency regulations. Relevant for SAP Converged Cloud and
+similar sovereign infrastructure.
+
+## German Federal Data Protection (BDSG / DSGVO)
+
+The BDSG (Bundesdatenschutzgesetz) supplements GDPR with German-specific requirements.
+DSGVO is the German implementation of GDPR.
+
+| # | Requirement | Code-Level Check |
+|---|------------|-----------------|
+| 1 | Data processing in Germany/EU | No data leaves German/EU data centers. Check API endpoints, CDN configs, analytics services. |
+| 2 | German DPO (Datenschutzbeauftragter) | Contact information accessible. Privacy policy in German. |
+| 3 | Employee data protection (§26 BDSG) | Employee PII has stricter handling than customer data. Separate access controls. |
+| 4 | Automated decision-making (Art. 22 DSGVO) | If automated decisions affect individuals, is there a human override mechanism? |
+| 5 | Data processing agreements | Third-party processors have Auftragsverarbeitungsvertrag (AVV)? |
+| 6 | Technical-organizational measures (TOMs) | Encryption, pseudonymization, access controls documented per §64 BDSG? |
+
+## BSI C5 (Cloud Computing Compliance Criteria Catalogue)
+
+German Federal Office for Information Security standard for cloud providers.
+Required for German government cloud usage.
+
+| # | Domain | Code-Level Check |
+|---|--------|-----------------|
+| 1 | Identity & Access (IDM) | MFA enforced? Role separation between tenant admin and provider admin? |
+| 2 | Cryptography (CRY) | German-approved algorithms? Key management within EU boundaries? |
+| 3 | Communication Security (COS) | Inter-service encryption? No unencrypted internal traffic? |
+| 4 | Asset Management (AM) | Data classification implemented? Asset inventory automated? |
+| 5 | Physical Security (PS) | Data centers in Germany? Geo-redundancy within German borders? |
+| 6 | Operations Security (OPS) | Change management documented? Deployment audit trails? |
+| 7 | Logging & Monitoring (LOG) | Security events logged immutably? Retention per BSI requirements? |
+| 8 | Business Continuity (BCM) | DR within German data centers? No failover outside jurisdiction? |
+| 9 | Supply Chain (SSO) | Subprocessors evaluated? No non-EU subprocessors for sovereign data? |
+| 10 | Portability (PI) | Data exportable in open formats? No vendor lock-in for sovereign data? |
+
+## EU Data Residency Requirements
+
+For systems that must keep data within EU boundaries.
+
+| # | Requirement | Code-Level Check |
+|---|------------|-----------------|
+| 1 | No transatlantic data transfer | Check all external API calls — do any hit US endpoints? |
+| 2 | EU-based DNS resolution | DNS queries stay within EU? No US-based DNS providers? |
+| 3 | EU-based logging/monitoring | Log aggregation services hosted in EU? Sentry, Datadog, etc. — check region config. |
+| 4 | EU-based CDN nodes | Static assets served from EU edge nodes only? |
+| 5 | EU-based CI/CD | Build systems in EU? GitHub Actions runners in EU? |
+| 6 | EU-based error tracking | Exception reporting (Sentry, Bugsnag) configured for EU region? |
+| 7 | EU-based email services | Transactional email (SendGrid, SES) in EU region? |
+| 8 | Backup residency | Backups stored in EU? Cross-region replication stays within EU? |
+
+## IT-Sicherheitsgesetz (IT Security Act) & KRITIS
+
+German IT Security Act 2.0 requirements for critical infrastructure operators
+and their suppliers. Applies to energy, water, food, IT/telecom, health,
+finance, transport, and government sectors.
+
+| # | Requirement | Code-Level Check |
+|---|------------|-----------------|
+| 1 | Attack detection systems | IDS/IPS deployed? Security event correlation implemented? |
+| 2 | Incident reporting (BSI) | Can security incidents be reported to BSI within 24 hours? Automated alerting? |
+| 3 | Security audit readiness | System documentation sufficient for BSI audit? Architecture diagrams current? |
+| 4 | Supply chain security | Dependencies from trusted sources? SBOM (Software Bill of Materials) generated? |
+| 5 | Vulnerability management | CVE scanning automated? Patch timeline documented? |
+| 6 | Network segmentation | KRITIS systems isolated from general IT? Micro-segmentation? |
+| 7 | Backup isolation | Backups air-gapped or immutable? Ransomware-resistant? |
+| 8 | Minimum privilege | Service accounts with least privilege? No shared admin credentials? |
+
+## Personnel Security (SÜG — Sicherheitsüberprüfungsgesetz)
+
+German security clearance requirements for personnel working on sovereign
+and classified systems. The Sicherheitsüberprüfung (security vetting) requires
+EU/EEA nationality for access to certain infrastructure tiers.
+
+| Level | Name | Applies To |
+|-------|------|-----------|
+| Ü1 | Einfache Sicherheitsüberprüfung | Access to classified information (VS-NfD) |
+| Ü2 | Erweiterte Sicherheitsüberprüfung | Access to SECRET-classified systems |
+| Ü3 | Erweiterte mit Sicherheitsermittlungen | Access to TOP SECRET systems |
+
+**Code-level implications:**
+
+| # | Requirement | What It Means for Development |
+|---|------------|------------------------------|
+| 1 | EU/EEA national requirement | Non-EU personnel cannot access production sovereign systems. CI/CD pipelines must not expose sovereign secrets to non-cleared contexts. |
+| 2 | Need-to-know access | Code repos for sovereign components may require separate access groups. No blanket org-wide read access. |
+| 3 | Cleared environment only | Development of sovereign components on cleared workstations. No personal devices, no coffee-shop coding. |
+| 4 | Audit trail on personnel access | Who accessed what sovereign system when — logged and reviewable. |
+| 5 | Separation of duties | No single person can deploy AND approve sovereign system changes. Dual-control enforcement. |
+
+## BSI Technical Guidelines (TR)
+
+Specific technical standards referenced by BSI C5 and KRITIS:
+
+| Guideline | Topic | Relevance |
+|-----------|-------|-----------|
+| BSI TR-02102 | Cryptographic algorithms | Which ciphers/key lengths are approved for German government use |
+| BSI TR-03116 | TLS configurations | Minimum TLS versions, cipher suites for sovereign systems |
+| BSI TR-03107 | eID and authentication | Electronic identity card integration requirements |
+| BSI TR-03125 | Trusted archiving (TR-ESOR) | Long-term data preservation with integrity guarantees |
+
+## Sovereign Cloud Architecture Patterns
+
+| Pattern | Description | When to Apply |
+|---------|------------|---------------|
+| Data boundary enforcement | API gateway validates that requests carrying PII route only to EU services | Any multi-region architecture |
+| Encryption key residency | HSM/KMS located within sovereign jurisdiction, keys never exported | Whenever encryption at rest is required |
+| Audit log immutability | Append-only audit logs with cryptographic chaining | Any system processing regulated data |
+| Tenant isolation | Hard tenant boundaries — no shared compute for sensitive workloads | Multi-tenant sovereign platforms |
+| Geo-fenced failover | DR stays within jurisdiction even during outages | Business continuity planning |
+
+## Common Violations in Code Reviews
+
+| Violation | Where It Hides | How to Detect |
+|-----------|---------------|---------------|
+| US-region SaaS in production code | Hardcoded `us-east-1`, `.com` endpoints without EU equivalent | Grep for region identifiers in config |
+| Analytics sending data abroad | Google Analytics, Mixpanel without EU data residency config | Check analytics SDK initialization |
+| Error tracking to US | Default Sentry DSN pointing to US ingest | Verify Sentry DSN uses EU endpoint |
+| Cloud storage in US | S3 bucket without explicit EU region | Check bucket creation / terraform configs |
+| Third-party JS loading from US CDNs | Script tags pointing to US-hosted libraries | Audit external script sources |
+
+## How to Use in Reviews
+
+1. Identify if the system operates in sovereign context (SAP CC, German government, EU-only)
+2. Apply BDSG + BSI C5 checks for German sovereign cloud
+3. Apply EU data residency for general EU compliance
+4. Report violations with specific requirement numbers
+5. Check both application code AND infrastructure config (terraform, helm values, docker compose)

--- a/agents/reviewer-security/references/stride-threat-model.md
+++ b/agents/reviewer-security/references/stride-threat-model.md
@@ -1,0 +1,108 @@
+# STRIDE Threat Modeling Reference
+
+Structured methodology for proactive threat identification. Use when reviewing
+code that handles authentication, authorization, data storage, or external
+communication — not just looking for bugs, but modeling what an attacker would target.
+
+## When to Apply
+
+- New service or API endpoint being added
+- Authentication/authorization logic changes
+- Data storage or transmission patterns change
+- External service integration added
+- User input handling modified
+
+## The STRIDE Framework
+
+For each component or data flow, check all 6 categories:
+
+### S — Spoofing (Identity)
+
+Can an attacker pretend to be someone else?
+
+| Check | What to Look For |
+|-------|-----------------|
+| Authentication bypass | Missing auth checks on endpoints, default credentials |
+| Token forgery | Weak JWT signing (HS256 with guessable secret), no signature verification |
+| Session hijacking | Session IDs in URLs, missing secure/httponly cookie flags |
+| Certificate spoofing | Missing TLS certificate validation, self-signed cert acceptance |
+
+### T — Tampering (Data Integrity)
+
+Can an attacker modify data they shouldn't?
+
+| Check | What to Look For |
+|-------|-----------------|
+| Input manipulation | Missing validation on request bodies, query params, headers |
+| Database tampering | SQL injection, mass assignment, unparameterized queries |
+| File tampering | Path traversal, arbitrary file write, symlink attacks |
+| Message tampering | Missing HMAC/signature on webhooks, unsigned API responses |
+
+### R — Repudiation (Accountability)
+
+Can an attacker deny they performed an action?
+
+| Check | What to Look For |
+|-------|-----------------|
+| Missing audit logs | State-changing operations without logging who/what/when |
+| Log tampering | Logs writable by application user, no log integrity checks |
+| Unsigned transactions | Financial or permission changes without audit trail |
+| Missing request IDs | No correlation ID for tracing actions across services |
+
+### I — Information Disclosure
+
+Can an attacker access data they shouldn't?
+
+| Check | What to Look For |
+|-------|-----------------|
+| Error message leakage | Stack traces, SQL errors, internal paths in responses |
+| Verbose logging | PII, tokens, passwords in log output |
+| Insecure storage | Plaintext passwords, unencrypted PII at rest |
+| Side channels | Timing differences in auth (valid vs invalid username) |
+| Directory listing | Exposed .git/, .env, backup files, admin panels |
+
+### D — Denial of Service
+
+Can an attacker make the system unavailable?
+
+| Check | What to Look For |
+|-------|-----------------|
+| Resource exhaustion | Unbounded queries, missing pagination, no request size limits |
+| Algorithmic complexity | Regex DoS (ReDoS), quadratic parsing, hash collision attacks |
+| Connection exhaustion | Missing connection pool limits, no timeouts on external calls |
+| Storage exhaustion | Unbounded file uploads, log flooding, cache poisoning |
+
+### E — Elevation of Privilege
+
+Can an attacker gain permissions they shouldn't have?
+
+| Check | What to Look For |
+|-------|-----------------|
+| Broken access control | IDOR (incrementing IDs), missing ownership checks |
+| Role escalation | User can modify their own role, missing role validation |
+| Privilege inheritance | Child resources inheriting parent permissions incorrectly |
+| Default permissions | New resources created with overly permissive defaults |
+
+## Threat Assessment Output
+
+For each identified threat, document:
+
+```
+Threat: [description]
+Category: [S/T/R/I/D/E]
+Asset: [what's at risk]
+Attack Vector: [how it could be exploited]
+Impact: [1-5] — what happens if exploited
+Likelihood: [1-5] — how easy to exploit
+Risk Score: Impact x Likelihood [1-25]
+Mitigation: [specific fix]
+```
+
+## Risk Scoring Guide
+
+| Score Range | Classification | Action |
+|-------------|---------------|--------|
+| 15-25 | Critical | Block PR, fix immediately |
+| 10-14 | High | Fix before merge |
+| 5-9 | Medium | Track, fix in next sprint |
+| 1-4 | Low | Accept or defer |

--- a/skills/testing-anti-patterns/SKILL.md
+++ b/skills/testing-anti-patterns/SKILL.md
@@ -352,3 +352,4 @@ If you find anti-patterns in a codebase, check if TDD discipline slipped.
 - `${CLAUDE_SKILL_DIR}/references/anti-pattern-catalog.md`: Detailed code examples for all 10 anti-patterns (Go, Python, JavaScript)
 - `${CLAUDE_SKILL_DIR}/references/fix-strategies.md`: Language-specific fix patterns and tooling
 - `${CLAUDE_SKILL_DIR}/references/blind-spot-taxonomy.md`: 6-category taxonomy of what high-coverage test suites commonly miss (concurrency, state, boundaries, security, integration, resilience)
+- `${CLAUDE_SKILL_DIR}/references/load-test-scenarios.md`: 6 load test scenario types (smoke, load, stress, spike, soak, breakpoint) with configurations and critical endpoint priorities

--- a/skills/testing-anti-patterns/references/load-test-scenarios.md
+++ b/skills/testing-anti-patterns/references/load-test-scenarios.md
@@ -1,0 +1,125 @@
+# Load Test Scenario Reference
+
+Structured taxonomy of load testing approaches. Use when generating test
+scripts (k6, Artillery, Locust) or reviewing load test coverage.
+
+## Scenario Types
+
+### 1. Smoke Test
+**Purpose**: Verify the system works at all under minimal load.
+**Configuration**: 1-2 virtual users, 1-2 minutes.
+**When to use**: After every deployment. Quick sanity check.
+
+```
+Duration: 1-2 minutes
+Users: 1-2
+Thresholds:
+  - All requests succeed (error rate = 0%)
+  - p95 response time < baseline + 50%
+```
+
+### 2. Load Test
+**Purpose**: Verify the system handles expected production load.
+**Configuration**: Target production user count, 10-15 minutes sustained.
+**When to use**: Before releases. Baseline performance validation.
+
+```
+Duration: 10-15 minutes
+Users: Expected production peak (from analytics)
+Ramp-up: 30 seconds per 10% of target
+Thresholds:
+  - Error rate < 1%
+  - p95 response time < SLO target
+  - p99 response time < 3x SLO target
+```
+
+### 3. Stress Test
+**Purpose**: Find the breaking point. How far past normal can we go?
+**Configuration**: Ramp beyond expected load until failures appear.
+**When to use**: Capacity planning. Finding bottlenecks.
+
+```
+Duration: 15-20 minutes
+Users: Ramp from 0 to 200-300% of expected peak
+Ramp-up: Gradual increase every 2 minutes
+Watch for:
+  - Error rate spike (which endpoint breaks first?)
+  - Response time degradation curve (linear or exponential?)
+  - Resource exhaustion (CPU, memory, connections, disk I/O)
+```
+
+### 4. Spike Test
+**Purpose**: How does the system handle sudden traffic bursts?
+**Configuration**: Normal load → instant jump to peak → back to normal.
+**When to use**: Systems exposed to viral traffic, marketing campaigns, flash sales.
+
+```
+Duration: 10 minutes
+Pattern: 2min normal → instant spike to 500% → hold 3min → drop to normal → 3min recovery
+Watch for:
+  - Recovery time after spike subsides
+  - Error rate during spike
+  - Queue depth behavior
+  - Auto-scaling response time (if applicable)
+```
+
+### 5. Soak Test (Endurance)
+**Purpose**: Find memory leaks, connection pool exhaustion, log disk fill.
+**Configuration**: Normal load sustained for hours.
+**When to use**: Before major releases. Detecting slow-burn issues.
+
+```
+Duration: 2-8 hours
+Users: Expected production average (not peak)
+Thresholds:
+  - Memory usage doesn't trend upward over time
+  - Response times don't degrade over time
+  - Error rate stays flat
+  - No file descriptor / connection pool exhaustion
+```
+
+### 6. Breakpoint Test
+**Purpose**: Find exact capacity ceiling with precision.
+**Configuration**: Slow, controlled ramp until SLO violation.
+**When to use**: Capacity planning with specific numbers.
+
+```
+Duration: Until SLO breach
+Users: Start at 50%, increase by 5% every 2 minutes
+Record:
+  - Exact user count where p95 exceeds SLO
+  - Exact user count where error rate exceeds threshold
+  - Resource utilization at breakpoint (CPU%, memory%, connections)
+```
+
+## Critical Endpoints to Test
+
+For any web service, prioritize these in load tests:
+
+| Priority | Endpoint Type | Why |
+|----------|--------------|-----|
+| 1 | Authentication (login/token refresh) | Gate to everything else. If auth breaks, nothing works. |
+| 2 | Most-hit read endpoint | Highest traffic volume. Often the first to show degradation. |
+| 3 | Write endpoints (create/update) | Database contention, lock conflicts surface here. |
+| 4 | Search/query with filters | Complex queries degrade fastest under load. |
+| 5 | File upload/download | I/O bound, different bottleneck profile than compute. |
+| 6 | Webhook receivers | External systems don't respect your capacity limits. |
+
+## Common Mistakes in Load Tests
+
+| Mistake | Why It's Wrong | Fix |
+|---------|---------------|-----|
+| Testing from same machine as server | Network isn't tested, localhost is unrealistic | Use separate load generator machine or cloud service |
+| Single endpoint only | Real traffic hits many endpoints concurrently | Create realistic user journey scenarios |
+| No think time between requests | Real users pause between actions | Add 1-5 second think time between requests |
+| Ignoring ramp-up | Instant full load triggers different failures than gradual | Always ramp up over 30-60 seconds minimum |
+| Not checking server-side metrics | Client-side metrics miss server resource exhaustion | Monitor CPU, memory, DB connections, disk I/O during test |
+| Testing against production | Risk of outage, data corruption | Use staging with production-like data volume |
+
+## How to Use This Reference
+
+1. **Start with smoke**: Every deployment gets a smoke test
+2. **Baseline with load**: Establish normal performance baseline before optimizing
+3. **Find limits with stress**: Know your breaking point before production tells you
+4. **Test resilience with spike**: Validate auto-scaling and recovery
+5. **Catch leaks with soak**: Run overnight before major releases


### PR DESCRIPTION
## Summary
Add domain-specific reference files to existing agents and skills — no new components, just enriching what we have.

**reviewer-security** (3 new reference files):
- `references/stride-threat-model.md` — STRIDE methodology for proactive threat identification with risk scoring (Impact x Likelihood)
- `references/compliance-checklists.md` — GDPR, SOC2, PCI-DSS, HIPAA code-level requirement checklists (10 items each)
- `references/sovereign-cloud-data-residency.md` — German BDSG/DSGVO, BSI C5, IT-Sicherheitsgesetz/KRITIS, SÜG personnel clearance (Ü1-Ü3), BSI Technical Guidelines, EU data residency patterns

**testing-anti-patterns** (1 new reference file):
- `references/load-test-scenarios.md` — 6 load test scenario types (smoke/load/stress/spike/soak/breakpoint) with configurations, endpoint priorities, and common mistakes

## Test plan
- [x] All files are reference markdown — no code to lint
- [x] reviewer-security.md updated with reference pointers
- [x] testing-anti-patterns SKILL.md updated with reference pointer
- [x] Sovereign cloud covers BDSG, BSI C5, KRITIS, SÜG, BSI TR standards