### PR TITLE
feat: adopt Go automation scripts and revive linter requirement

### DIFF
--- a/skills/go-code-review/SKILL.md
+++ b/skills/go-code-review/SKILL.md
@@ -64,6 +64,10 @@ This skill operates as an operator for Go code review workflows, configuring Cla
 - **API Compatibility Check**: Verify exported API changes against semver expectations
 - **Dependency Audit**: Deep review of new or changed dependencies
 
+## Available Scripts
+
+- **`scripts/check-interface-compliance.sh`** — Find exported interfaces missing compile-time `var _ I = (*T)(nil)` checks. Run `bash scripts/check-interface-compliance.sh --help` for options.
+
 ## What This Skill CAN Do
 - Systematically review Go code across 6 structured phases
 - Run automated checks (build, test, vet, staticcheck, coverage)

--- a/skills/go-code-review/scripts/check-interface-compliance.sh
+++ b/skills/go-code-review/scripts/check-interface-compliance.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="1.0.0"
+SCRIPT_NAME="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+$SCRIPT_NAME v$VERSION — Check for missing compile-time interface compliance verifications
+
+USAGE
+    bash $SCRIPT_NAME [options] [path]
+
+DESCRIPTION
+    Scans Go files for exported interface definitions and checks whether each
+    has a corresponding compile-time compliance assertion like:
+
+        var _ MyInterface = (*MyImpl)(nil)
+        var _ MyInterface = MyImpl{}
+
+    Reports interfaces that lack such compile-time checks. This helps catch
+    interface drift at compile time instead of runtime.
+
+    Exits 0 if all interfaces are verified, 1 if missing checks found, 2 on error.
+
+OPTIONS
+    -h, --help       Show this help message
+    -v, --version    Show version
+    --json           Output results as JSON
+    --include-test   Also scan _test.go files for compliance checks
+    --limit N        Show at most N results (default: all)
+
+ARGUMENTS
+    path             Directory to scan (default: current directory)
+
+EXAMPLES
+    bash $SCRIPT_NAME
+    bash $SCRIPT_NAME ./pkg/storage
+    bash $SCRIPT_NAME --json .
+    bash $SCRIPT_NAME --include-test ./internal
+EOF
+}
+
+JSON_OUTPUT=false
+INCLUDE_TEST=false
+LIMIT=0
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)       usage; exit 0 ;;
+        -v|--version)    echo "$SCRIPT_NAME v$VERSION"; exit 0 ;;
+        --json)          JSON_OUTPUT=true; shift ;;
+        --include-test)  INCLUDE_TEST=true; shift ;;
+        --limit)         LIMIT="${2:?error: --limit requires a number}"; shift 2 ;;
+        -*)              echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *)               TARGET="$1"; shift ;;
+    esac
+done
+
+TARGET="${TARGET:-.}"
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+    echo "error: --limit must be a non-negative integer, got: $LIMIT" >&2
+    exit 2
+fi
+
+if [[ ! -d "$TARGET" && ! -f "$TARGET" ]]; then
+    # Handle ./... patterns
+    dir="${TARGET%%/...}"
+    dir="${dir:-.}"
+    if [[ ! -d "$dir" ]]; then
+        echo "error: path not found: $TARGET" >&2
+        exit 2
+    fi
+    TARGET="$dir"
+fi
+
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/}"
+    s="${s//$'\n'/\\n}"
+    printf '%s' "$s"
+}
+
+# Collect all Go source files
+find_go_files() {
+    local t="$1"
+    if $INCLUDE_TEST; then
+        find "$t" -name '*.go' ! -path '*/vendor/*' ! -path '*/.git/*' 2>/dev/null
+    else
+        find "$t" -name '*.go' ! -name '*_test.go' ! -path '*/vendor/*' ! -path '*/.git/*' 2>/dev/null
+    fi
+}
+
+# Collect all Go files (including tests) for checking compliance vars
+find_all_go_files() {
+    find "$1" -name '*.go' ! -path '*/vendor/*' ! -path '*/.git/*' 2>/dev/null
+}
+
+# Step 1: Find all exported interface definitions
+IFACE_NAMES=()
+IFACE_LOCATIONS=()
+
+while IFS= read -r file; do
+    [[ -n "$file" ]] || continue
+    line_num=0
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+        # Match: type ExportedName interface {
+        pat='^[[:space:]]*type[[:space:]]+([A-Z][a-zA-Z0-9]*)[[:space:]]+interface[[:space:]]*\{'
+        if [[ "$line" =~ $pat ]]; then
+            iface_name="${BASH_REMATCH[1]}"
+            IFACE_NAMES+=("$iface_name")
+            IFACE_LOCATIONS+=("$file:$line_num")
+        fi
+    done < "$file"
+done < <(find_go_files "$TARGET")
+
+if [[ ${#IFACE_NAMES[@]} -eq 0 ]]; then
+    if $JSON_OUTPUT; then
+        echo '{"interfaces":[],"missing":[],"count_interfaces":0,"count_missing":0}'
+    else
+        echo "No exported interfaces found in: $TARGET"
+    fi
+    exit 0
+fi
+
+# Step 2: Scan all Go files (including tests) for compliance checks
+# Pattern: var _ InterfaceName = ...
+ALL_GO_FILES=()
+while IFS= read -r f; do
+    [[ -n "$f" ]] && ALL_GO_FILES+=("$f")
+done < <(find_all_go_files "$TARGET")
+
+MISSING=()
+
+for ((i=0; i<${#IFACE_NAMES[@]}; i++)); do
+    iface_name="${IFACE_NAMES[$i]}"
+    location="${IFACE_LOCATIONS[$i]}"
+    # Look for: var _ InterfaceName = (various patterns)
+    if ! grep -qlE "var[[:space:]]+_[[:space:]]+${iface_name}[[:space:]]*=" \
+         "${ALL_GO_FILES[@]}" 2>/dev/null; then
+        MISSING+=("${iface_name}|${location}")
+    fi
+done
+
+# Sort for stable output
+IFS=$'\n' MISSING=($(sort <<<"${MISSING[*]}")); unset IFS
+
+# Truncation
+TOTAL=${#MISSING[@]}
+TRUNCATED=false
+if [[ $LIMIT -gt 0 && $TOTAL -gt $LIMIT ]]; then
+    MISSING=("${MISSING[@]:0:$LIMIT}")
+    TRUNCATED=true
+fi
+
+# Output results
+if $JSON_OUTPUT; then
+    echo "{"
+    echo '  "interfaces": ['
+    first=true
+    SORTED_INDICES=()
+    for ((i=0; i<${#IFACE_NAMES[@]}; i++)); do
+        SORTED_INDICES+=("$i|${IFACE_NAMES[$i]}")
+    done
+    IFS=$'\n' SORTED_INDICES=($(sort -t'|' -k2 <<<"${SORTED_INDICES[*]}")); unset IFS
+
+    for entry in "${SORTED_INDICES[@]}"; do
+        i="${entry%%|*}"
+        iface_name="${IFACE_NAMES[$i]}"
+        location="${IFACE_LOCATIONS[$i]}"
+        file="${location%%:*}"
+        line="${location#*:}"
+        $first || echo ","
+        first=false
+        printf '    {"name":"%s","file":"%s","line":%s}' "$(json_escape "$iface_name")" "$(json_escape "$file")" "$line"
+    done
+    echo ""
+    echo "  ],"
+    echo '  "missing": ['
+    first=true
+    for entry in "${MISSING[@]+"${MISSING[@]}"}"; do
+        IFS='|' read -r name location <<< "$entry"
+        file="${location%%:*}"
+        line="${location#*:}"
+        $first || echo ","
+        first=false
+        printf '    {"name":"%s","file":"%s","line":%s}' "$(json_escape "$name")" "$(json_escape "$file")" "$line"
+    done
+    echo ""
+    echo "  ],"
+    printf '  "count_interfaces": %d,\n' "${#IFACE_NAMES[@]}"
+    printf '  "count_missing": %d,\n' "$TOTAL"
+    printf '  "truncated": %s\n' "$TRUNCATED"
+    echo "}"
+else
+    echo "Exported interfaces found: ${#IFACE_NAMES[@]}"
+    echo ""
+
+    if [[ $TOTAL -eq 0 ]]; then
+        echo "All interfaces have compile-time compliance checks."
+        exit 0
+    fi
+
+    echo "Missing compile-time compliance checks:"
+    echo ""
+    for entry in "${MISSING[@]}"; do
+        IFS='|' read -r name location <<< "$entry"
+        printf "  %s  interface '%s' has no 'var _ %s = ...' assertion\n" "$location" "$name" "$name"
+    done
+    if $TRUNCATED; then
+        echo "  ... and $((TOTAL - LIMIT)) more (use --limit to adjust)"
+    fi
+    echo ""
+    echo "Add compile-time checks like:"
+    echo "  var _ MyInterface = (*MyImpl)(nil)"
+    echo ""
+    echo "Total: $TOTAL interface(s) missing verification"
+fi
+
+if [[ $TOTAL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/skills/go-error-handling/SKILL.md
+++ b/skills/go-error-handling/SKILL.md
@@ -65,6 +65,10 @@ This skill operates as an operator for Go error handling implementation, configu
 - **Error Wrapping Audit**: Scan for naked `return err` statements and missing `%w` verbs
 - **Table-Driven Error Tests**: Generate table-driven tests for error paths
 
+## Available Scripts
+
+- **`scripts/check-errors.sh`** — Detect bare `return err` and log-and-return anti-patterns. Run `bash scripts/check-errors.sh --help` for options.
+
 ## What This Skill CAN Do
 - Guide idiomatic error wrapping with `fmt.Errorf` and `%w`
 - Define and use sentinel errors (`errors.New` package-level vars)

--- a/skills/go-error-handling/scripts/check-errors.sh
+++ b/skills/go-error-handling/scripts/check-errors.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Adapted from cxuu/golang-skills (Apache-2.0)
+# Modified: removed string-error-compare check (covered by golangci-lint errorlint)
+
+VERSION="1.0.0"
+SCRIPT_NAME="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+$SCRIPT_NAME v$VERSION — Check Go code for error handling anti-patterns
+
+USAGE
+    bash $SCRIPT_NAME [options] [path]
+
+DESCRIPTION
+    Scans Go source files for error handling anti-patterns:
+      - Bare 'return err' without wrapping context
+      - Errors that are both logged and returned (handle once)
+
+    Note: err.Error() string comparison is NOT checked here — it is
+    already covered by golangci-lint's errorlint linter.
+
+    Exits 0 if no issues found, 1 if anti-patterns detected, 2 on error.
+
+OPTIONS
+    -h, --help       Show this help message
+    -v, --version    Show version
+    --json           Output results as JSON
+    --no-bare-return Skip the bare 'return err' check (high false-positive rate)
+    --limit N        Show at most N results (default: all)
+
+ARGUMENTS
+    path             Directory or file to check (default: current directory)
+
+EXAMPLES
+    bash $SCRIPT_NAME
+    bash $SCRIPT_NAME ./pkg/api
+    bash $SCRIPT_NAME --json .
+    bash $SCRIPT_NAME --no-bare-return ./internal
+EOF
+}
+
+JSON_OUTPUT=false
+CHECK_BARE_RETURN=true
+LIMIT=0
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)         usage; exit 0 ;;
+        -v|--version)      echo "$SCRIPT_NAME v$VERSION"; exit 0 ;;
+        --json)            JSON_OUTPUT=true; shift ;;
+        --no-bare-return)  CHECK_BARE_RETURN=false; shift ;;
+        --limit)           LIMIT="${2:?error: --limit requires a number}"; shift 2 ;;
+        -*)                echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *)                 TARGET="$1"; shift ;;
+    esac
+done
+
+TARGET="${TARGET:-.}"
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+    echo "error: --limit must be a non-negative integer, got: $LIMIT" >&2
+    exit 2
+fi
+
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/}"
+    s="${s//$'\n'/\\n}"
+    printf '%s' "$s"
+}
+
+find_go_files() {
+    local t="$1"
+    if [[ -f "$t" ]]; then
+        echo "$t"
+    elif [[ -d "$t" ]]; then
+        find "$t" -name '*.go' ! -name '*_test.go' ! -path '*/vendor/*' ! -path '*/.git/*' 2>/dev/null
+    else
+        local dir="${t%%/...}"
+        dir="${dir:-.}"
+        if [[ -d "$dir" ]]; then
+            find "$dir" -name '*.go' ! -name '*_test.go' ! -path '*/vendor/*' ! -path '*/.git/*' 2>/dev/null
+        else
+            echo "error: path not found: $t" >&2
+            exit 2
+        fi
+    fi
+}
+
+FINDINGS=()
+
+add_finding() {
+    local file="$1" line="$2" rule="$3" message="$4"
+    FINDINGS+=("${file}:${line}|${rule}|${message}")
+}
+
+# Rule 1: Bare return err (no wrapping)
+check_bare_return_err() {
+    local file="$1"
+    local line_num=0
+    local in_error_block=false
+
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+
+        # Detect if err != nil { block
+        pat='if[[:space:]]+(.*err[[:space:]]*(!=|==)[[:space:]]*nil|err[[:space:]]*:=)'
+        if [[ "$line" =~ $pat ]]; then
+            in_error_block=true
+        fi
+
+        # Check for bare "return err" that is not wrapped
+        pat='^[[:space:]]*return[[:space:]]+(.*,)?[[:space:]]*err[[:space:]]*$'
+        if $in_error_block && [[ "$line" =~ $pat ]]; then
+            local trimmed
+            trimmed=$(echo "$line" | sed 's/^[[:space:]]*//')
+            if [[ "$trimmed" == "return err" ]]; then
+                add_finding "$file" "$line_num" "bare-return-err" \
+                    "bare 'return err' without wrapping context; consider fmt.Errorf('...: %w', err)"
+            fi
+        fi
+
+        # Reset error block tracking on closing brace
+        pat_close='^[[:space:]]*\}[[:space:]]*$'
+        if $in_error_block && [[ "$line" =~ $pat_close ]]; then
+            in_error_block=false
+        fi
+    done < "$file"
+}
+
+# Rule 2: Log-and-return (handle errors once)
+check_log_and_return() {
+    local file="$1"
+    local line_num=0
+    local prev_lines=()
+
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+        prev_lines+=("$line")
+
+        # Keep a small window to detect log followed by return err
+        if [[ ${#prev_lines[@]} -gt 5 ]]; then
+            prev_lines=("${prev_lines[@]:1}")
+        fi
+
+        # Check if current line is 'return ... err' and a recent line logged the error
+        pat='^[[:space:]]*return[[:space:]]+(.*,)?[[:space:]]*err'
+        if [[ "$line" =~ $pat ]]; then
+            local window_size=${#prev_lines[@]}
+            for ((i=0; i<window_size-1; i++)); do
+                local prev="${prev_lines[$i]}"
+                # Match log.Print/Printf/Println/Error/Errorf/Warn/Warnf with err
+                # Also match logg.Error (sapcc go-bits pattern)
+                pat_log1='(log\.|logger\.|slog\.|logg\.)[a-zA-Z]*\(.*[^a-zA-Z]err[^a-zA-Z]'
+                pat_log2='(log\.|logger\.|slog\.|logg\.)[a-zA-Z]*\(err[,\)]'
+                if [[ "$prev" =~ $pat_log1 ]] || \
+                   [[ "$prev" =~ $pat_log2 ]]; then
+                    local log_line=$((line_num - window_size + 1 + i))
+                    add_finding "$file" "$log_line" "log-and-return" \
+                        "error is both logged (line $log_line) and returned (line $line_num); handle errors once"
+                    break
+                fi
+            done
+        fi
+    done < "$file"
+}
+
+FILES=()
+while IFS= read -r f; do
+    [[ -n "$f" ]] && FILES+=("$f")
+done < <(find_go_files "$TARGET")
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    if $JSON_OUTPUT; then
+        echo '{"findings":[],"total":0,"truncated":false,"status":"no_go_files"}'
+    else
+        echo "No Go files found in: $TARGET"
+    fi
+    exit 0
+fi
+
+for file in "${FILES[@]}"; do
+    if $CHECK_BARE_RETURN; then
+        check_bare_return_err "$file"
+    fi
+    check_log_and_return "$file"
+done
+
+# Truncation
+TOTAL=${#FINDINGS[@]}
+TRUNCATED=false
+if [[ $LIMIT -gt 0 && $TOTAL -gt $LIMIT ]]; then
+    FINDINGS=("${FINDINGS[@]:0:$LIMIT}")
+    TRUNCATED=true
+fi
+
+if $JSON_OUTPUT; then
+    echo "{"
+    echo '  "findings": ['
+    first=true
+    for entry in "${FINDINGS[@]+"${FINDINGS[@]}"}"; do
+        IFS='|' read -r location rule message <<< "$entry"
+        file="${location%%:*}"
+        line="${location#*:}"
+        $first || echo ","
+        first=false
+        printf '    {"file":"%s","line":%s,"rule":"%s","message":"%s"}' \
+            "$(json_escape "$file")" "$line" "$(json_escape "$rule")" "$(json_escape "$message")"
+    done
+    echo ""
+    echo "  ],"
+    printf '  "total": %d,\n' "$TOTAL"
+    printf '  "truncated": %s\n' "$TRUNCATED"
+    echo "}"
+else
+    if [[ $TOTAL -eq 0 ]]; then
+        echo "No error handling anti-patterns found."
+        exit 0
+    fi
+
+    echo "Error handling anti-patterns found:"
+    echo ""
+    for entry in "${FINDINGS[@]}"; do
+        IFS='|' read -r location rule message <<< "$entry"
+        printf "  %s  [%s] %s\n" "$location" "$rule" "$message"
+    done
+    if $TRUNCATED; then
+        echo "  ... and $((TOTAL - LIMIT)) more (use --limit to adjust)"
+    fi
+    echo ""
+    echo "Total: $TOTAL finding(s)"
+fi
+
+if [[ $TOTAL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/skills/go-sapcc-conventions/SKILL.md
+++ b/skills/go-sapcc-conventions/SKILL.md
@@ -592,7 +592,7 @@ All build config is generated from `Makefile.maker.yaml`. Do NOT edit these file
 
 ### golangci-lint v2 Configuration
 
-35 enabled linters. Key settings:
+35+ enabled linters. Key settings:
 
 | Setting | Value | Rationale |
 |---------|-------|-----------|
@@ -607,6 +607,25 @@ All build config is generated from `Makefile.maker.yaml`. Do NOT edit these file
 - `encoding/json.Marshal`
 - `(net/http.ResponseWriter).Write`
 - `(*github.com/spf13/cobra.Command).Help`
+
+### revive Linter (REQUIRED — check on every sapcc repo)
+
+As of 2026-03-20, go-makefile-maker supports `revive` as an optional linter. **All sapcc repos should enable it.** When working in an sapcc repo, check `Makefile.maker.yaml` for `reviveRules`. If absent, recommend adding:
+
+```yaml
+golangciLint:
+  reviveRules:
+    - name: exported
+      arguments:
+        - checkPrivateReceivers
+        - disableChecksOnConstants
+```
+
+This catches:
+- Exported functions/types/methods without doc comments
+- Private receivers on exported methods
+
+After adding, run `go-makefile-maker` to regenerate `.golangci.yaml`, then `make run-golangci-lint` to verify.
 
 ### Build Commands
 

--- a/skills/go-testing/SKILL.md
+++ b/skills/go-testing/SKILL.md
@@ -73,6 +73,11 @@ This skill operates as an operator for Go testing workflows, configuring Claude'
 - **Coverage HTML Report**: Generate and open HTML coverage visualization
 - **Interface Deduplication**: Test multiple interface implementations with shared test functions
 
+## Available Scripts
+
+- **`scripts/gen-table-test.sh`** — Scaffold a table-driven test file for a Go function. Run `bash scripts/gen-table-test.sh --help` for options.
+- **`scripts/bench-compare.sh`** — Run Go benchmarks with optional benchstat comparison. Run `bash scripts/bench-compare.sh --help` for options.
+
 ## What This Skill CAN Do
 - Write idiomatic table-driven tests with `t.Run` subtests
 - Create test helpers with proper `t.Helper()` marking

--- a/skills/go-testing/scripts/bench-compare.sh
+++ b/skills/go-testing/scripts/bench-compare.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="1.1.0"
+SCRIPT_NAME="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+$SCRIPT_NAME v$VERSION — Run Go benchmarks with optional comparison
+
+USAGE
+    bash $SCRIPT_NAME [options] [package]
+
+DESCRIPTION
+    Wrapper around 'go test -bench' that runs benchmarks multiple times and
+    optionally compares results against a saved baseline using benchstat.
+
+    Results can be saved to a file for future comparison. If benchstat is
+    installed and a baseline is provided, a statistical comparison is shown.
+
+EXIT CODES
+    0    Benchmarks ran successfully
+    1    go test failed (compilation error, test failure, no benchmarks found)
+    2    Usage error (missing arguments, bad flags, file exists without --force)
+
+OPTIONS
+    -h, --help           Show this help message
+    -v, --version        Show version
+    -n, --count N        Number of benchmark iterations (default: 5)
+    -b, --baseline FILE  Compare results against this baseline file
+    -s, --save FILE      Save benchmark results to this file
+    -f, --filter REGEX   Benchmark filter regex (default: ".")
+    --json               Output metadata as JSON (human output goes to stderr)
+    --benchmem           Include memory allocation stats (default: on)
+    --no-benchmem        Disable memory allocation stats
+    --force              Allow --save to overwrite existing files
+    --limit N            Max benchmark result lines to include (default: 0 = all)
+
+ARGUMENTS
+    package              Go package to benchmark (default: ./...)
+
+EXAMPLES
+    bash $SCRIPT_NAME
+    bash $SCRIPT_NAME -n 10 ./pkg/parser
+    bash $SCRIPT_NAME --save baseline.txt ./...
+    bash $SCRIPT_NAME --baseline baseline.txt --save current.txt ./...
+    bash $SCRIPT_NAME --filter BenchmarkSort -n 3
+    bash $SCRIPT_NAME --json --limit 5 ./...
+    bash $SCRIPT_NAME --save results.txt --force ./...
+EOF
+}
+
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/}"
+    s="${s//$'\n'/\\n}"
+    printf '%s' "$s"
+}
+
+# Print human-readable output: stdout in text mode, stderr in JSON mode.
+log() {
+    if $JSON_OUTPUT; then
+        echo "$@" >&2
+    else
+        echo "$@"
+    fi
+}
+
+COUNT=5
+BASELINE=""
+SAVE=""
+FILTER="."
+PACKAGE=""
+JSON_OUTPUT=false
+BENCHMEM=true
+FORCE=false
+LIMIT=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)      usage; exit 0 ;;
+        -v|--version)   echo "$SCRIPT_NAME v$VERSION"; exit 0 ;;
+        -n|--count)     COUNT="${2:?error: --count requires a number}"; shift 2 ;;
+        -b|--baseline)  BASELINE="${2:?error: --baseline requires a file path}"; shift 2 ;;
+        -s|--save)      SAVE="${2:?error: --save requires a file path}"; shift 2 ;;
+        -f|--filter)    FILTER="${2:?error: --filter requires a regex}"; shift 2 ;;
+        --json)         JSON_OUTPUT=true; shift ;;
+        --benchmem)     BENCHMEM=true; shift ;;
+        --no-benchmem)  BENCHMEM=false; shift ;;
+        --force)        FORCE=true; shift ;;
+        --limit)        LIMIT="${2:?error: --limit requires a number}"; shift 2 ;;
+        -*)             echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *)              PACKAGE="$1"; shift ;;
+    esac
+done
+
+PACKAGE="${PACKAGE:-./...}"
+
+if ! command -v go &>/dev/null; then
+    echo "error: 'go' command not found in PATH" >&2
+    exit 2
+fi
+
+if ! [[ "$COUNT" =~ ^[1-9][0-9]*$ ]]; then
+    echo "error: --count must be a positive integer, got: $COUNT" >&2
+    exit 2
+fi
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+    echo "error: --limit must be a non-negative integer, got: $LIMIT" >&2
+    exit 2
+fi
+
+if [[ -n "$BASELINE" && ! -f "$BASELINE" ]]; then
+    echo "error: baseline file not found: $BASELINE" >&2
+    exit 2
+fi
+
+if [[ -n "$SAVE" && -f "$SAVE" ]] && ! $FORCE; then
+    echo "error: save target already exists: $SAVE (use --force to overwrite)" >&2
+    exit 2
+fi
+
+HAS_BENCHSTAT=false
+if command -v benchstat &>/dev/null; then
+    HAS_BENCHSTAT=true
+fi
+
+BENCH_ARGS=(-bench "$FILTER" -count "$COUNT" -run '^$')
+if $BENCHMEM; then
+    BENCH_ARGS+=(-benchmem)
+fi
+
+TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-XXXXXX.txt")
+trap 'rm -f "$TMPFILE"' EXIT
+
+log "Running benchmarks: go test ${BENCH_ARGS[*]} $PACKAGE"
+log "Iterations: $COUNT"
+log ""
+
+GO_EXIT=0
+if $JSON_OUTPUT; then
+    go test "${BENCH_ARGS[@]}" "$PACKAGE" 2>&1 | tee "$TMPFILE" >&2 || GO_EXIT=$?
+else
+    go test "${BENCH_ARGS[@]}" "$PACKAGE" 2>&1 | tee "$TMPFILE" || GO_EXIT=$?
+fi
+
+BENCH_COUNT=$(grep -cE '^Benchmark' "$TMPFILE" || true)
+
+TRUNCATED=false
+if [[ $LIMIT -gt 0 && $BENCH_COUNT -gt $LIMIT ]]; then
+    TRUNCATED=true
+fi
+
+if ! $JSON_OUTPUT && $TRUNCATED; then
+    log ""
+    log "Note: $BENCH_COUNT benchmark results found, showing first $LIMIT (--limit $LIMIT)"
+fi
+
+if [[ -n "$SAVE" ]]; then
+    cp "$TMPFILE" "$SAVE"
+    log ""
+    log "Results saved to: $SAVE"
+fi
+
+if [[ -n "$BASELINE" ]]; then
+    log ""
+    log "=== Comparison with baseline: $BASELINE ==="
+    log ""
+    if $HAS_BENCHSTAT; then
+        if $JSON_OUTPUT; then
+            benchstat "$BASELINE" "$TMPFILE" >&2 || true
+        else
+            benchstat "$BASELINE" "$TMPFILE" || true
+        fi
+    else
+        log "note: install benchstat for statistical comparison:"
+        log "  go install golang.org/x/perf/cmd/benchstat@latest"
+        log ""
+        log "--- Baseline ---"
+        if $JSON_OUTPUT; then
+            grep -E '^Benchmark' "$BASELINE" >&2 || true
+        else
+            grep -E '^Benchmark' "$BASELINE" || true
+        fi
+        log ""
+        log "--- Current ---"
+        if $JSON_OUTPUT; then
+            grep -E '^Benchmark' "$TMPFILE" >&2 || true
+        else
+            grep -E '^Benchmark' "$TMPFILE" || true
+        fi
+    fi
+fi
+
+FINAL_EXIT=0
+if [[ $GO_EXIT -ne 0 ]]; then
+    FINAL_EXIT=1
+    if ! $JSON_OUTPUT; then
+        log ""
+        log "error: go test exited with code $GO_EXIT"
+    fi
+elif [[ $BENCH_COUNT -eq 0 ]]; then
+    FINAL_EXIT=1
+    if ! $JSON_OUTPUT; then
+        log ""
+        log "error: no benchmarks found matching filter: $FILTER"
+    fi
+fi
+
+if $JSON_OUTPUT; then
+    BENCH_OUTPUT=$(<"$TMPFILE")
+    if $TRUNCATED; then
+        limited=""
+        bench_seen=0
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^Benchmark ]]; then
+                bench_seen=$((bench_seen + 1))
+                if [[ $bench_seen -le $LIMIT ]]; then
+                    limited+="$line"$'\n'
+                fi
+            else
+                limited+="$line"$'\n'
+            fi
+        done < "$TMPFILE"
+        BENCH_OUTPUT="$limited"
+    fi
+
+    escaped_package=$(json_escape "$PACKAGE")
+    escaped_filter=$(json_escape "$FILTER")
+    escaped_baseline=$(json_escape "$BASELINE")
+    escaped_save=$(json_escape "$SAVE")
+    escaped_output=$(json_escape "$BENCH_OUTPUT")
+
+    printf '{"count":%d,' "$COUNT"
+    printf '"package":"%s",' "$escaped_package"
+    printf '"filter":"%s",' "$escaped_filter"
+    printf '"benchmarks_found":%d,' "$BENCH_COUNT"
+    printf '"baseline":"%s",' "$escaped_baseline"
+    printf '"save":"%s",' "$escaped_save"
+    printf '"exit_code":%d,' "$GO_EXIT"
+    printf '"output":"%s"' "$escaped_output"
+    if $TRUNCATED; then
+        printf ',"truncated":true'
+    fi
+    printf '}\n'
+fi
+
+exit $FINAL_EXIT

--- a/skills/go-testing/scripts/gen-table-test.sh
+++ b/skills/go-testing/scripts/gen-table-test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="1.0.0"
+SCRIPT_NAME="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+$SCRIPT_NAME v$VERSION — Generate a table-driven test scaffold for a Go function
+
+USAGE
+    bash $SCRIPT_NAME [options] <FuncName> <package>
+
+DESCRIPTION
+    Outputs a table-driven test file for the given function and package.
+    By default writes to stdout; use --output to write to a file.
+
+    Exits 0 on success, 2 on error.
+
+OPTIONS
+    -h, --help           Show this help message
+    -v, --version        Show version
+    --output FILE        Write to FILE instead of stdout
+    --force              Allow --output to overwrite an existing file
+    --parallel           Include t.Parallel() in generated test
+    --json               Output structured JSON metadata to stdout
+
+ARGUMENTS
+    FuncName             Name of the function to test (must be exported/uppercase)
+    package              Go package name for the test file
+
+EXAMPLES
+    bash $SCRIPT_NAME ParseConfig config
+    bash $SCRIPT_NAME --parallel ParseConfig config
+    bash $SCRIPT_NAME --output config/parse_config_test.go ParseConfig config
+    bash $SCRIPT_NAME --force --output config/parse_config_test.go ParseConfig config
+    bash $SCRIPT_NAME --json --output config/parse_config_test.go ParseConfig config
+    bash $SCRIPT_NAME ParseConfig config > config/parse_config_test.go
+EOF
+}
+
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/}"
+    s="${s//$'\n'/\\n}"
+    printf '%s' "$s"
+}
+
+OUTPUT=""
+PARALLEL=false
+JSON_OUTPUT=false
+FORCE=false
+POSITIONAL=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)    usage; exit 0 ;;
+        -v|--version) echo "$SCRIPT_NAME v$VERSION"; exit 0 ;;
+        --output)     OUTPUT="${2:?error: --output requires a file path}"; shift 2 ;;
+        --force)      FORCE=true; shift ;;
+        --parallel)   PARALLEL=true; shift ;;
+        --json)       JSON_OUTPUT=true; shift ;;
+        -*)           echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *)            POSITIONAL+=("$1"); shift ;;
+    esac
+done
+
+if [[ ${#POSITIONAL[@]} -lt 2 ]]; then
+    echo "error: FuncName and package are required" >&2
+    usage >&2
+    exit 2
+fi
+
+FUNC="${POSITIONAL[0]}"
+PKG="${POSITIONAL[1]}"
+
+if [[ ! "$FUNC" =~ ^[A-Z] ]]; then
+    echo "error: FuncName '$FUNC' must start with an uppercase letter" >&2
+    exit 2
+fi
+
+generate_test() {
+    local parallel_top="" parallel_sub=""
+    if $PARALLEL; then
+        parallel_top=$'\tt.Parallel()\n'
+        parallel_sub=$'\t\t\tt.Parallel()\n'
+    fi
+
+    cat <<EOF
+package ${PKG}
+
+import (
+	"testing"
+)
+
+func Test${FUNC}(t *testing.T) {
+${parallel_top}	tests := []struct {
+		name string
+		give string // TODO: replace with actual input type
+		want string // TODO: replace with actual output type
+	}{
+		{
+			name: "basic case",
+			give: "",
+			want: "",
+		},
+		// TODO: add more test cases
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+${parallel_sub}			got := ${FUNC}(tt.give)
+			if got != tt.want {
+				t.Errorf("${FUNC}(%q) = %q, want %q", tt.give, got, tt.want)
+			}
+			// For richer diffs, consider:
+			//   if diff := cmp.Diff(tt.want, got); diff != "" {
+			//       t.Errorf("${FUNC}() mismatch (-want +got):\n%s", diff)
+			//   }
+		})
+	}
+}
+EOF
+}
+
+if [[ -n "$OUTPUT" ]]; then
+    OUTPUT_DIR="$(dirname "$OUTPUT")"
+    if [[ ! -d "$OUTPUT_DIR" ]]; then
+        echo "error: directory '$OUTPUT_DIR' does not exist" >&2
+        exit 2
+    fi
+    if [[ -f "$OUTPUT" ]] && ! $FORCE; then
+        echo "error: '$OUTPUT' already exists (use --force to overwrite)" >&2
+        exit 2
+    fi
+    generate_test > "$OUTPUT"
+    if $JSON_OUTPUT; then
+        FUNC_ESC="$(json_escape "$FUNC")"
+        PKG_ESC="$(json_escape "$PKG")"
+        OUTPUT_ESC="$(json_escape "$OUTPUT")"
+        cat <<EOF
+{"func":"$FUNC_ESC","package":"$PKG_ESC","output_file":"$OUTPUT_ESC","parallel":$PARALLEL,"written":true}
+EOF
+    else
+        echo "Wrote test scaffold to $OUTPUT"
+    fi
+else
+    if $JSON_OUTPUT; then
+        generate_test >&2
+        FUNC_ESC="$(json_escape "$FUNC")"
+        PKG_ESC="$(json_escape "$PKG")"
+        cat <<EOF
+{"func":"$FUNC_ESC","package":"$PKG_ESC","output_file":"","parallel":$PARALLEL,"written":false}
+EOF
+    else
+        generate_test
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Add 4 automation scripts from [cxuu/golang-skills](https://github.com/cxuu/golang-skills) (Apache-2.0) into existing Go skills (ADRs 024-026)
- Add `revive:exported` linter requirement to go-sapcc-conventions (ADR-027)
- Scripts fill gaps where golangci-lint has no coverage: bare `return err`, log-and-return, missing interface compliance checks, benchmark comparison, test scaffolding

## Scripts Added

| Script | Destination Skill | What It Catches |
|--------|------------------|----------------|
| `gen-table-test.sh` | go-testing | Scaffolds table-driven test files |
| `bench-compare.sh` | go-testing | Benchmark runner with benchstat comparison |
| `check-errors.sh` | go-error-handling | Bare `return err`, log-and-return anti-pattern |
| `check-interface-compliance.sh` | go-code-review | Missing `var _ I = (*T)(nil)` assertions |

## Adaptations from upstream
- `check-errors.sh`: removed string-error-compare check (covered by golangci-lint errorlint), added `logg.*` pattern for sapcc compatibility
- All scripts: verified --limit numeric validation consistency (review finding, fixed)
- All scripts: verified JSON field naming consistency (review finding, fixed)

## ADRs
- ADR-024: bench-compare.sh (skill rejected after real-code validation, script kept)
- ADR-025: 3 automation scripts into existing skills
- ADR-026: Script wiring into skill SKILL.md files
- ADR-027: sapcc revive requirement (implemented in this PR)

## Test plan
- [x] All 4 scripts pass `--help` and `--version`
- [x] Scripts verified for bash 3.2 / macOS compatibility (no associative arrays, no GNU sed)
- [x] JSON output field naming consistency verified
- [x] --limit numeric validation added to all scripts
- [x] Code review round 1 completed, 2 findings fixed