### PR TITLE
feat: add 6 sapcc-specific deterministic check scripts (ADR-027)

### DIFF
--- a/skills/go-sapcc-conventions/SKILL.md
+++ b/skills/go-sapcc-conventions/SKILL.md
@@ -752,6 +752,23 @@ See [references/anti-patterns.md](references/anti-patterns.md) for the full cata
 
 ---
 
+## Available Scripts
+
+Deterministic checks for sapcc-specific patterns that no linter covers. Run these during code review or as part of quality gates. All support `--help`, `--json`, `--limit`, and meaningful exit codes (0 = clean, 1 = violations, 2 = error).
+
+| Script | What It Checks |
+|--------|---------------|
+| `scripts/check-sapcc-identify-endpoint.sh` | HTTP handlers missing `httpapi.IdentifyEndpoint` call |
+| `scripts/check-sapcc-auth-ordering.sh` | Data access before authentication in handlers |
+| `scripts/check-sapcc-json-strict.sh` | `json.NewDecoder` without `DisallowUnknownFields()` |
+| `scripts/check-sapcc-time-now.sh` | Direct `time.Now()` in testable code (inject clock instead) |
+| `scripts/check-sapcc-httptest.sh` | `httptest.NewRecorder` instead of `assert.HTTPRequest` |
+| `scripts/check-sapcc-todo-format.sh` | Bare TODO comments without context/links |
+
+These scripts only apply to sapcc repos (detected by `github.com/sapcc/go-bits` in go.mod).
+
+---
+
 ## Anti-Rationalization
 
 ### SAP CC Domain-Specific Rationalizations

--- a/skills/go-sapcc-conventions/scripts/check-sapcc-auth-ordering.sh
+++ b/skills/go-sapcc-conventions/scripts/check-sapcc-auth-ordering.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Checks that authentication happens before data access in HTTP handlers.
+# Rule: sapcc handler pattern requires auth check before any db/resource load.
+
+VERSION="1.0.0"
+SCRIPT_NAME="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+$SCRIPT_NAME v$VERSION — Check sapcc HTTP handlers for data access before authentication
+
+USAGE
+    bash $SCRIPT_NAME [options] [path]
+
+DESCRIPTION
+    Scans Go source files in internal/api/ directories for HTTP handlers
+    that access data (db.Get, db.Select, findAccount, etc.) before calling
+    authenticateRequest or similar auth functions.
+
+    Exits 0 if auth ordering is correct, 1 if violations found, 2 on error.
+
+OPTIONS
+    -h, --help       Show this help message
+    -v, --version    Show version
+    --json           Output results as JSON
+    --limit N        Show at most N results (default: all)
+
+ARGUMENTS
+    path             Directory to scan (default: current directory)
+
+EXAMPLES
+    bash $SCRIPT_NAME ./internal/api
+    bash $SCRIPT_NAME --json .
+EOF
+}
+
+JSON_OUTPUT=false
+LIMIT=0
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)    usage; exit 0 ;;
+        -v|--version) echo "$SCRIPT_NAME v$VERSION"; exit 0 ;;
+        --json)       JSON_OUTPUT=true; shift ;;
+        --limit)      LIMIT="${2:?error: --limit requires a number}"; shift 2 ;;
+        -*)           echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *)            TARGET="$1"; shift ;;
+    esac
+done
+
+TARGET="${TARGET:-.}"
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+    echo "error: --limit must be a non-negative integer, got: $LIMIT" >&2
+    exit 2
+fi
+
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/}"
+    s="${s//$'\n'/\\n}"
+    printf '%s' "$s"
+}
+
+FINDINGS=()
+
+# Auth patterns (must appear before data access)
+AUTH_PATTERNS='authenticate|authorize|authz|gopherpolicy\.Token'
+# Data access patterns (must appear after auth)
+DATA_PATTERNS='\.Get\(|\.Select\(|\.Find\(|\.findAccount|\.findRepo|db\.Get|db\.Select|db\.Query'
+
+check_file() {
+    local file="$1"
+    local in_handler=false
+    local handler_line=0
+    local handler_name=""
+    local found_auth=false
+    local line_num=0
+
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+
+        # Detect handler function
+        if [[ "$line" =~ func[[:space:]] ]] && \
+           [[ "$line" =~ http\.ResponseWriter ]] && [[ "$line" =~ \*http\.Request ]]; then
+            in_handler=true
+            handler_line=$line_num
+            handler_name=$(echo "$line" | grep -oE 'func[[:space:]]+(\([^)]+\)[[:space:]]+)?[a-zA-Z_][a-zA-Z0-9_]*' | head -1 | sed 's/func[[:space:]]*//' | sed 's/([^)]*)[[:space:]]*//')
+            found_auth=false
+        fi
+
+        if $in_handler; then
+            # Check for auth call
+            if echo "$line" | grep -qE "$AUTH_PATTERNS"; then
+                found_auth=true
+            fi
+
+            # Check for data access before auth
+            if ! $found_auth && echo "$line" | grep -qE "$DATA_PATTERNS"; then
+                # Skip comments
+                local trimmed
+                trimmed=$(echo "$line" | sed 's/^[[:space:]]*//')
+                if [[ ! "$trimmed" =~ ^// ]]; then
+                    FINDINGS+=("${file}:${line_num}|${handler_name}|data access before authentication")
+                    in_handler=false  # Only report first violation per handler
+                fi
+            fi
+
+            # End of function (simple heuristic: closing brace at column 0-1)
+            if [[ "$line" =~ ^[[:space:]]?\}[[:space:]]*$ ]] && [[ $((line_num - handler_line)) -gt 2 ]]; then
+                in_handler=false
+            fi
+        fi
+    done < "$file"
+}
+
+FILES=()
+while IFS= read -r f; do
+    [[ -n "$f" ]] && FILES+=("$f")
+done < <(find "$TARGET" -name '*.go' ! -name '*_test.go' ! -path '*/vendor/*' ! -path '*/.git/*' 2>/dev/null)
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    if $JSON_OUTPUT; then
+        echo '{"findings":[],"total":0,"truncated":false,"status":"no_go_files"}'
+    else
+        echo "No Go files found in: $TARGET"
+    fi
+    exit 0
+fi
+
+for file in "${FILES[@]}"; do
+    if grep -q 'http\.ResponseWriter' "$file" 2>/dev/null; then
+        check_file "$file"
+    fi
+done
+
+TOTAL=${#FINDINGS[@]}
+TRUNCATED=false
+if [[ $LIMIT -gt 0 && $TOTAL -gt $LIMIT ]]; then
+    FINDINGS=("${FINDINGS[@]:0:$LIMIT}")
+    TRUNCATED=true
+fi
+
+if $JSON_OUTPUT; then
+    echo "{"
+    echo '  "findings": ['
+    first=true
+    for entry in "${FINDINGS[@]+"${FINDINGS[@]}"}"; do
+        IFS='|' read -r location name message <<< "$entry"
+        file="${location%%:*}"
+        line="${location#*:}"
+        $first || echo ","
+        first=false
+        printf '    {"file":"%s","line":%s,"handler":"%s","message":"%s"}' \
+            "$(json_escape "$file")" "$line" "$(json_escape "$name")" "$(json_escape "$message")"
+    done
+    echo ""
+    echo "  ],"
+    printf '  "total": %d,\n' "$TOTAL"
+    printf '  "truncated": %s\n' "$TRUNCATED"
+    echo "}"
+else
+    if [[ $TOTAL -eq 0 ]]; then
+        echo "All handlers authenticate before data access."
+        exit 0
+    fi
+    echo "Handlers with data access before authentication:"
+    echo ""
+    for entry in "${FINDINGS[@]}"; do
+        IFS='|' read -r location name message <<< "$entry"
+        printf "  %s  handler '%s': %s\n" "$location" "$name" "$message"
+    done
+    if $TRUNCATED; then
+        echo "  ... and $((TOTAL - LIMIT)) more"
+    fi
+    echo ""
+    echo "Total: $TOTAL violation(s)"
+fi
+
+[[ $TOTAL -gt 0 ]] && exit 1
+exit 0

--- a/skills/go-sapcc-conventions/scripts/check-sapcc-httptest.sh
+++ b/skills/go-sapcc-conventions/scripts/check-sapcc-httptest.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Checks for direct httptest.NewRecorder usage instead of assert.HTTPRequest.
+# Rule: sapcc uses go-bits/assert.HTTPRequest for HTTP testing.
+
+VERSION="1.0.0"
+SCRIPT_NAME="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+$SCRIPT_NAME v$VERSION — Check for httptest.NewRecorder instead of assert.HTTPRequest
+
+USAGE
+    bash $SCRIPT_NAME [options] [path]
+
+DESCRIPTION
+    Scans Go test files for direct use of httptest.NewRecorder().
+    sapcc convention uses go-bits/assert.HTTPRequest{}.Check(t, h)
+    instead of manual recorder setup.
+
+    Exits 0 if no violations found, 1 if violations found, 2 on error.
+
+OPTIONS
+    -h, --help       Show this help message
+    -v, --version    Show version
+    --json           Output results as JSON
+    --limit N        Show at most N results (default: all)
+
+ARGUMENTS
+    path             Directory to scan (default: current directory)
+
+EXAMPLES
+    bash $SCRIPT_NAME ./internal
+    bash $SCRIPT_NAME --json .
+EOF
+}
+
+JSON_OUTPUT=false
+LIMIT=0
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)    usage; exit 0 ;;
+        -v|--version) echo "$SCRIPT_NAME v$VERSION"; exit 0 ;;
+        --json)       JSON_OUTPUT=true; shift ;;
+        --limit)      LIMIT="${2:?error: --limit requires a number}"; shift 2 ;;
+        -*)           echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *)            TARGET="$1"; shift ;;
+    esac
+done
+
+TARGET="${TARGET:-.}"
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+    echo "error: --limit must be a non-negative integer, got: $LIMIT" >&2
+    exit 2
+fi
+
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/}"
+    s="${s//$'\n'/\\n}"
+    printf '%s' "$s"
+}
+
+FINDINGS=()
+
+# Only scan test files
+FILES=()
+while IFS= read -r f; do
+    [[ -n "$f" ]] && FILES+=("$f")
+done < <(find "$TARGET" -name '*_test.go' ! -path '*/vendor/*' ! -path '*/.git/*' 2>/dev/null)
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    if $JSON_OUTPUT; then
+        echo '{"findings":[],"total":0,"truncated":false,"status":"no_test_files"}'
+    else
+        echo "No Go test files found in: $TARGET"
+    fi
+    exit 0
+fi
+
+for file in "${FILES[@]}"; do
+    if ! grep -q 'httptest\.NewRecorder' "$file" 2>/dev/null; then
+        continue
+    fi
+    line_num=0
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+        if [[ "$line" =~ httptest\.NewRecorder ]]; then
+            FINDINGS+=("${file}:${line_num}|use assert.HTTPRequest{}.Check(t, h) instead of httptest.NewRecorder()")
+        fi
+    done < "$file"
+done
+
+TOTAL=${#FINDINGS[@]}
+TRUNCATED=false
+if [[ $LIMIT -gt 0 && $TOTAL -gt $LIMIT ]]; then
+    FINDINGS=("${FINDINGS[@]:0:$LIMIT}")
+    TRUNCATED=true
+fi
+
+if $JSON_OUTPUT; then
+    echo "{"
+    echo '  "findings": ['
+    first=true
+    for entry in "${FINDINGS[@]+"${FINDINGS[@]}"}"; do
+        IFS='|' read -r location message <<< "$entry"
+        file="${location%%:*}"
+        line="${location#*:}"
+        $first || echo ","
+        first=false
+        printf '    {"file":"%s","line":%s,"message":"%s"}' \
+            "$(json_escape "$file")" "$line" "$(json_escape "$message")"
+    done
+    echo ""
+    echo "  ],"
+    printf '  "total": %d,\n' "$TOTAL"
+    printf '  "truncated": %s\n' "$TRUNCATED"
+    echo "}"
+else
+    if [[ $TOTAL -eq 0 ]]; then
+        echo "No direct httptest.NewRecorder usage found."
+        exit 0
+    fi
+    echo "Direct httptest.NewRecorder usage (use assert.HTTPRequest instead):"
+    echo ""
+    for entry in "${FINDINGS[@]}"; do
+        IFS='|' read -r location message <<< "$entry"
+        printf "  %s  %s\n" "$location" "$message"
+    done
+    if $TRUNCATED; then
+        echo "  ... and $((TOTAL - LIMIT)) more"
+    fi
+    echo ""
+    echo "Total: $TOTAL finding(s)"
+fi
+
+[[ $TOTAL -gt 0 ]] && exit 1
+exit 0

--- a/skills/go-sapcc-conventions/scripts/check-sapcc-identify-endpoint.sh
+++ b/skills/go-sapcc-conventions/scripts/check-sapcc-identify-endpoint.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Checks that every HTTP handler calls httpapi.IdentifyEndpoint as its first operation.
+# Rule: sapcc handler pattern requires endpoint identification for metrics.
+
+VERSION="1.0.0"
+SCRIPT_NAME="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+$SCRIPT_NAME v$VERSION — Check sapcc HTTP handlers for missing httpapi.IdentifyEndpoint
+
+USAGE
+    bash $SCRIPT_NAME [options] [path]
+
+DESCRIPTION
+    Scans Go source files for HTTP handler functions (accepting
+    http.ResponseWriter and *http.Request) and checks that
+    httpapi.IdentifyEndpoint is called within the first 5 lines
+    of the function body.
+
+    Exits 0 if all handlers are compliant, 1 if violations found, 2 on error.
+
+OPTIONS
+    -h, --help       Show this help message
+    -v, --version    Show version
+    --json           Output results as JSON
+    --limit N        Show at most N results (default: all)
+
+ARGUMENTS
+    path             Directory to scan (default: current directory)
+
+EXAMPLES
+    bash $SCRIPT_NAME ./internal/api
+    bash $SCRIPT_NAME --json .
+EOF
+}
+
+JSON_OUTPUT=false
+LIMIT=0
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)    usage; exit 0 ;;
+        -v|--version) echo "$SCRIPT_NAME v$VERSION"; exit 0 ;;
+        --json)       JSON_OUTPUT=true; shift ;;
+        --limit)      LIMIT="${2:?error: --limit requires a number}"; shift 2 ;;
+        -*)           echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *)            TARGET="$1"; shift ;;
+    esac
+done
+
+TARGET="${TARGET:-.}"
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+    echo "error: --limit must be a non-negative integer, got: $LIMIT" >&2
+    exit 2
+fi
+
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/}"
+    s="${s//$'\n'/\\n}"
+    printf '%s' "$s"
+}
+
+FINDINGS=()
+
+# Scan a file for handler functions missing IdentifyEndpoint
+check_file() {
+    local file="$1"
+    local in_handler=false
+    local handler_line=0
+    local handler_name=""
+    local lines_into_body=0
+    local found_identify=false
+    local brace_depth=0
+    local line_num=0
+
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+
+        # Detect handler function signature: func ... (w http.ResponseWriter, r *http.Request)
+        if [[ "$line" =~ func[[:space:]]+\(?[^)]*\)?[[:space:]]*[a-zA-Z_][a-zA-Z0-9_]*\( ]] && \
+           [[ "$line" =~ http\.ResponseWriter ]] && [[ "$line" =~ \*http\.Request ]]; then
+            in_handler=true
+            handler_line=$line_num
+            handler_name=$(echo "$line" | grep -oE 'func[[:space:]]+(\([^)]+\)[[:space:]]+)?[a-zA-Z_][a-zA-Z0-9_]*' | head -1 | sed 's/func[[:space:]]*//' | sed 's/([^)]*)[[:space:]]*//')
+            lines_into_body=0
+            found_identify=false
+            brace_depth=0
+        fi
+
+        if $in_handler; then
+            # Count opening braces to track we're in the function body
+            local opens="${line//[^\{]/}"
+            local closes="${line//[^\}]/}"
+            brace_depth=$((brace_depth + ${#opens} - ${#closes}))
+            lines_into_body=$((lines_into_body + 1))
+
+            # Check for IdentifyEndpoint call
+            if [[ "$line" =~ httpapi\.IdentifyEndpoint ]] || [[ "$line" =~ IdentifyEndpoint ]]; then
+                found_identify=true
+            fi
+
+            # After 8 lines into the handler, check if we found it
+            if [[ $lines_into_body -ge 8 ]] || [[ $brace_depth -le 0 && $lines_into_body -gt 1 ]]; then
+                if ! $found_identify; then
+                    FINDINGS+=("${file}:${handler_line}|${handler_name}|missing httpapi.IdentifyEndpoint call in handler")
+                fi
+                in_handler=false
+            fi
+        fi
+    done < "$file"
+
+    # Handle case where handler is at end of file
+    if $in_handler && ! $found_identify; then
+        FINDINGS+=("${file}:${handler_line}|${handler_name}|missing httpapi.IdentifyEndpoint call in handler")
+    fi
+}
+
+# Find Go files (exclude tests and vendor)
+FILES=()
+while IFS= read -r f; do
+    [[ -n "$f" ]] && FILES+=("$f")
+done < <(find "$TARGET" -name '*.go' ! -name '*_test.go' ! -path '*/vendor/*' ! -path '*/.git/*' 2>/dev/null)
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    if $JSON_OUTPUT; then
+        echo '{"findings":[],"total":0,"truncated":false,"status":"no_go_files"}'
+    else
+        echo "No Go files found in: $TARGET"
+    fi
+    exit 0
+fi
+
+for file in "${FILES[@]}"; do
+    # Only check files that import httpapi or have handler-like signatures
+    if grep -q 'http\.ResponseWriter' "$file" 2>/dev/null; then
+        check_file "$file"
+    fi
+done
+
+TOTAL=${#FINDINGS[@]}
+TRUNCATED=false
+if [[ $LIMIT -gt 0 && $TOTAL -gt $LIMIT ]]; then
+    FINDINGS=("${FINDINGS[@]:0:$LIMIT}")
+    TRUNCATED=true
+fi
+
+if $JSON_OUTPUT; then
+    echo "{"
+    echo '  "findings": ['
+    first=true
+    for entry in "${FINDINGS[@]+"${FINDINGS[@]}"}"; do
+        IFS='|' read -r location name message <<< "$entry"
+        file="${location%%:*}"
+        line="${location#*:}"
+        $first || echo ","
+        first=false
+        printf '    {"file":"%s","line":%s,"handler":"%s","message":"%s"}' \
+            "$(json_escape "$file")" "$line" "$(json_escape "$name")" "$(json_escape "$message")"
+    done
+    echo ""
+    echo "  ],"
+    printf '  "total": %d,\n' "$TOTAL"
+    printf '  "truncated": %s\n' "$TRUNCATED"
+    echo "}"
+else
+    if [[ $TOTAL -eq 0 ]]; then
+        echo "All HTTP handlers call httpapi.IdentifyEndpoint."
+        exit 0
+    fi
+    echo "Handlers missing httpapi.IdentifyEndpoint:"
+    echo ""
+    for entry in "${FINDINGS[@]}"; do
+        IFS='|' read -r location name message <<< "$entry"
+        printf "  %s  handler '%s': %s\n" "$location" "$name" "$message"
+    done
+    if $TRUNCATED; then
+        echo "  ... and $((TOTAL - LIMIT)) more"
+    fi
+    echo ""
+    echo "Total: $TOTAL handler(s) missing IdentifyEndpoint"
+fi
+
+[[ $TOTAL -gt 0 ]] && exit 1
+exit 0

--- a/skills/go-sapcc-conventions/scripts/check-sapcc-json-strict.sh
+++ b/skills/go-sapcc-conventions/scripts/check-sapcc-json-strict.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Checks that json.NewDecoder calls use DisallowUnknownFields().
+# Rule: sapcc requires strict JSON parsing for request bodies.
+
+VERSION="1.0.0"
+SCRIPT_NAME="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+$SCRIPT_NAME v$VERSION — Check for json.NewDecoder without DisallowUnknownFields
+
+USAGE
+    bash $SCRIPT_NAME [options] [path]
+
+DESCRIPTION
+    Scans Go source files for json.NewDecoder() calls and checks
+    that DisallowUnknownFields() is called before Decode().
+
+    Exits 0 if all decoders are strict, 1 if violations found, 2 on error.
+
+OPTIONS
+    -h, --help       Show this help message
+    -v, --version    Show version
+    --json           Output results as JSON
+    --limit N        Show at most N results (default: all)
+
+ARGUMENTS
+    path             Directory to scan (default: current directory)
+
+EXAMPLES
+    bash $SCRIPT_NAME ./internal/api
+    bash $SCRIPT_NAME --json .
+EOF
+}
+
+JSON_OUTPUT=false
+LIMIT=0
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)    usage; exit 0 ;;
+        -v|--version) echo "$SCRIPT_NAME v$VERSION"; exit 0 ;;
+        --json)       JSON_OUTPUT=true; shift ;;
+        --limit)      LIMIT="${2:?error: --limit requires a number}"; shift 2 ;;
+        -*)           echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *)            TARGET="$1"; shift ;;
+    esac
+done
+
+TARGET="${TARGET:-.}"
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+    echo "error: --limit must be a non-negative integer, got: $LIMIT" >&2
+    exit 2
+fi
+
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/}"
+    s="${s//$'\n'/\\n}"
+    printf '%s' "$s"
+}
+
+FINDINGS=()
+
+check_file() {
+    local file="$1"
+    local decoder_line=0
+    local found_decoder=false
+    local found_disallow=false
+    local line_num=0
+
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+
+        # Detect json.NewDecoder
+        if [[ "$line" =~ json\.NewDecoder ]]; then
+            # If we had a previous decoder without disallow, report it
+            if $found_decoder && ! $found_disallow; then
+                FINDINGS+=("${file}:${decoder_line}|json.NewDecoder without DisallowUnknownFields()")
+            fi
+            found_decoder=true
+            found_disallow=false
+            decoder_line=$line_num
+        fi
+
+        # Check for DisallowUnknownFields
+        if $found_decoder && [[ "$line" =~ DisallowUnknownFields ]]; then
+            found_disallow=true
+        fi
+
+        # Check for Decode call — if we hit Decode before DisallowUnknownFields, that's a violation
+        if $found_decoder && ! $found_disallow && [[ "$line" =~ \.Decode\( ]]; then
+            FINDINGS+=("${file}:${decoder_line}|json.NewDecoder without DisallowUnknownFields() before Decode()")
+            found_decoder=false
+        fi
+
+        # Reset on Decode after DisallowUnknownFields (correct usage)
+        if $found_decoder && $found_disallow && [[ "$line" =~ \.Decode\( ]]; then
+            found_decoder=false
+        fi
+    done < "$file"
+
+    # Handle trailing decoder without disallow
+    if $found_decoder && ! $found_disallow; then
+        FINDINGS+=("${file}:${decoder_line}|json.NewDecoder without DisallowUnknownFields()")
+    fi
+}
+
+FILES=()
+while IFS= read -r f; do
+    [[ -n "$f" ]] && FILES+=("$f")
+done < <(find "$TARGET" -name '*.go' ! -name '*_test.go' ! -path '*/vendor/*' ! -path '*/.git/*' 2>/dev/null)
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    if $JSON_OUTPUT; then
+        echo '{"findings":[],"total":0,"truncated":false,"status":"no_go_files"}'
+    else
+        echo "No Go files found in: $TARGET"
+    fi
+    exit 0
+fi
+
+for file in "${FILES[@]}"; do
+    if grep -q 'json\.NewDecoder' "$file" 2>/dev/null; then
+        check_file "$file"
+    fi
+done
+
+TOTAL=${#FINDINGS[@]}
+TRUNCATED=false
+if [[ $LIMIT -gt 0 && $TOTAL -gt $LIMIT ]]; then
+    FINDINGS=("${FINDINGS[@]:0:$LIMIT}")
+    TRUNCATED=true
+fi
+
+if $JSON_OUTPUT; then
+    echo "{"
+    echo '  "findings": ['
+    first=true
+    for entry in "${FINDINGS[@]+"${FINDINGS[@]}"}"; do
+        IFS='|' read -r location message <<< "$entry"
+        file="${location%%:*}"
+        line="${location#*:}"
+        $first || echo ","
+        first=false
+        printf '    {"file":"%s","line":%s,"message":"%s"}' \
+            "$(json_escape "$file")" "$line" "$(json_escape "$message")"
+    done
+    echo ""
+    echo "  ],"
+    printf '  "total": %d,\n' "$TOTAL"
+    printf '  "truncated": %s\n' "$TRUNCATED"
+    echo "}"
+else
+    if [[ $TOTAL -eq 0 ]]; then
+        echo "All json.NewDecoder calls use DisallowUnknownFields()."
+        exit 0
+    fi
+    echo "Missing DisallowUnknownFields():"
+    echo ""
+    for entry in "${FINDINGS[@]}"; do
+        IFS='|' read -r location message <<< "$entry"
+        printf "  %s  %s\n" "$location" "$message"
+    done
+    if $TRUNCATED; then
+        echo "  ... and $((TOTAL - LIMIT)) more"
+    fi
+    echo ""
+    echo "Total: $TOTAL violation(s)"
+fi
+
+[[ $TOTAL -gt 0 ]] && exit 1
+exit 0

--- a/skills/go-sapcc-conventions/scripts/check-sapcc-time-now.sh
+++ b/skills/go-sapcc-conventions/scripts/check-sapcc-time-now.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Checks for direct time.Now() calls in testable code.
+# Rule: sapcc prefers injected clock functions for testability.
+
+VERSION="1.0.0"
+SCRIPT_NAME="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+$SCRIPT_NAME v$VERSION — Check for direct time.Now() calls in testable Go code
+
+USAGE
+    bash $SCRIPT_NAME [options] [path]
+
+DESCRIPTION
+    Scans Go source files for direct time.Now() calls outside of
+    main.go, cmd/, and test files. Direct time calls make code
+    harder to test — prefer injecting a clock function.
+
+    Lines with '// time.Now OK' are excluded (opt-out annotation).
+
+    Exits 0 if no issues found, 1 if violations found, 2 on error.
+
+OPTIONS
+    -h, --help       Show this help message
+    -v, --version    Show version
+    --json           Output results as JSON
+    --limit N        Show at most N results (default: all)
+
+ARGUMENTS
+    path             Directory to scan (default: current directory)
+
+EXAMPLES
+    bash $SCRIPT_NAME ./internal
+    bash $SCRIPT_NAME --json .
+EOF
+}
+
+JSON_OUTPUT=false
+LIMIT=0
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)    usage; exit 0 ;;
+        -v|--version) echo "$SCRIPT_NAME v$VERSION"; exit 0 ;;
+        --json)       JSON_OUTPUT=true; shift ;;
+        --limit)      LIMIT="${2:?error: --limit requires a number}"; shift 2 ;;
+        -*)           echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *)            TARGET="$1"; shift ;;
+    esac
+done
+
+TARGET="${TARGET:-.}"
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+    echo "error: --limit must be a non-negative integer, got: $LIMIT" >&2
+    exit 2
+fi
+
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/}"
+    s="${s//$'\n'/\\n}"
+    printf '%s' "$s"
+}
+
+FINDINGS=()
+
+# Find Go files excluding tests, vendor, main.go, and cmd/
+FILES=()
+while IFS= read -r f; do
+    [[ -n "$f" ]] && FILES+=("$f")
+done < <(find "$TARGET" -name '*.go' \
+    ! -name '*_test.go' \
+    ! -name 'main.go' \
+    ! -path '*/vendor/*' \
+    ! -path '*/.git/*' \
+    ! -path '*/cmd/*' \
+    2>/dev/null)
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    if $JSON_OUTPUT; then
+        echo '{"findings":[],"total":0,"truncated":false,"status":"no_go_files"}'
+    else
+        echo "No applicable Go files found in: $TARGET"
+    fi
+    exit 0
+fi
+
+for file in "${FILES[@]}"; do
+    if ! grep -q 'time\.Now()' "$file" 2>/dev/null; then
+        continue
+    fi
+    line_num=0
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+        if [[ "$line" =~ time\.Now\(\) ]] && [[ ! "$line" =~ "// time.Now OK" ]]; then
+            # Skip comment lines
+            local trimmed
+            trimmed=$(echo "$line" | sed 's/^[[:space:]]*//')
+            if [[ ! "$trimmed" =~ ^// ]]; then
+                FINDINGS+=("${file}:${line_num}|direct time.Now() call — consider injecting a clock function for testability")
+            fi
+        fi
+    done < "$file"
+done
+
+TOTAL=${#FINDINGS[@]}
+TRUNCATED=false
+if [[ $LIMIT -gt 0 && $TOTAL -gt $LIMIT ]]; then
+    FINDINGS=("${FINDINGS[@]:0:$LIMIT}")
+    TRUNCATED=true
+fi
+
+if $JSON_OUTPUT; then
+    echo "{"
+    echo '  "findings": ['
+    first=true
+    for entry in "${FINDINGS[@]+"${FINDINGS[@]}"}"; do
+        IFS='|' read -r location message <<< "$entry"
+        file="${location%%:*}"
+        line="${location#*:}"
+        $first || echo ","
+        first=false
+        printf '    {"file":"%s","line":%s,"message":"%s"}' \
+            "$(json_escape "$file")" "$line" "$(json_escape "$message")"
+    done
+    echo ""
+    echo "  ],"
+    printf '  "total": %d,\n' "$TOTAL"
+    printf '  "truncated": %s\n' "$TRUNCATED"
+    echo "}"
+else
+    if [[ $TOTAL -eq 0 ]]; then
+        echo "No direct time.Now() calls found in testable code."
+        exit 0
+    fi
+    echo "Direct time.Now() calls in testable code:"
+    echo ""
+    for entry in "${FINDINGS[@]}"; do
+        IFS='|' read -r location message <<< "$entry"
+        printf "  %s  %s\n" "$location" "$message"
+    done
+    if $TRUNCATED; then
+        echo "  ... and $((TOTAL - LIMIT)) more"
+    fi
+    echo ""
+    echo "Total: $TOTAL finding(s)"
+    echo "Suppress with: // time.Now OK"
+fi
+
+[[ $TOTAL -gt 0 ]] && exit 1
+exit 0

--- a/skills/go-sapcc-conventions/scripts/check-sapcc-todo-format.sh
+++ b/skills/go-sapcc-conventions/scripts/check-sapcc-todo-format.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Checks that TODO comments include context (what, link, why not now).
+# Rule: sapcc requires TODOs with actionable context, not bare "TODO: fix".
+
+VERSION="1.0.0"
+SCRIPT_NAME="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+$SCRIPT_NAME v$VERSION — Check for bare TODO comments without context
+
+USAGE
+    bash $SCRIPT_NAME [options] [path]
+
+DESCRIPTION
+    Scans Go source files for TODO comments that lack actionable context.
+    Good TODOs include what needs doing, a link or issue reference, and
+    why it's not done now. Bare "TODO: fix this" or "TODO" alone are flagged.
+
+    Exits 0 if all TODOs have context, 1 if bare TODOs found, 2 on error.
+
+OPTIONS
+    -h, --help       Show this help message
+    -v, --version    Show version
+    --json           Output results as JSON
+    --limit N        Show at most N results (default: all)
+
+ARGUMENTS
+    path             Directory to scan (default: current directory)
+
+EXAMPLES
+    bash $SCRIPT_NAME ./internal
+    bash $SCRIPT_NAME --json .
+EOF
+}
+
+JSON_OUTPUT=false
+LIMIT=0
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)    usage; exit 0 ;;
+        -v|--version) echo "$SCRIPT_NAME v$VERSION"; exit 0 ;;
+        --json)       JSON_OUTPUT=true; shift ;;
+        --limit)      LIMIT="${2:?error: --limit requires a number}"; shift 2 ;;
+        -*)           echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *)            TARGET="$1"; shift ;;
+    esac
+done
+
+TARGET="${TARGET:-.}"
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+    echo "error: --limit must be a non-negative integer, got: $LIMIT" >&2
+    exit 2
+fi
+
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/}"
+    s="${s//$'\n'/\\n}"
+    printf '%s' "$s"
+}
+
+FINDINGS=()
+
+FILES=()
+while IFS= read -r f; do
+    [[ -n "$f" ]] && FILES+=("$f")
+done < <(find "$TARGET" -name '*.go' ! -path '*/vendor/*' ! -path '*/.git/*' 2>/dev/null)
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    if $JSON_OUTPUT; then
+        echo '{"findings":[],"total":0,"truncated":false,"status":"no_go_files"}'
+    else
+        echo "No Go files found in: $TARGET"
+    fi
+    exit 0
+fi
+
+for file in "${FILES[@]}"; do
+    if ! grep -q 'TODO' "$file" 2>/dev/null; then
+        continue
+    fi
+    line_num=0
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+        # Match TODO in comments
+        if [[ "$line" =~ //.*TODO ]]; then
+            # Extract the TODO text after "TODO" (with optional colon)
+            local todo_text
+            todo_text=$(echo "$line" | sed 's/.*TODO[[:space:]]*:*[[:space:]]*//')
+
+            # Flag if TODO text is too short (less than 10 chars) or has no URL/issue ref
+            if [[ ${#todo_text} -lt 10 ]]; then
+                FINDINGS+=("${file}:${line_num}|bare TODO without context — add what, a link, and why not now")
+            fi
+        fi
+    done < "$file"
+done
+
+TOTAL=${#FINDINGS[@]}
+TRUNCATED=false
+if [[ $LIMIT -gt 0 && $TOTAL -gt $LIMIT ]]; then
+    FINDINGS=("${FINDINGS[@]:0:$LIMIT}")
+    TRUNCATED=true
+fi
+
+if $JSON_OUTPUT; then
+    echo "{"
+    echo '  "findings": ['
+    first=true
+    for entry in "${FINDINGS[@]+"${FINDINGS[@]}"}"; do
+        IFS='|' read -r location message <<< "$entry"
+        file="${location%%:*}"
+        line="${location#*:}"
+        $first || echo ","
+        first=false
+        printf '    {"file":"%s","line":%s,"message":"%s"}' \
+            "$(json_escape "$file")" "$line" "$(json_escape "$message")"
+    done
+    echo ""
+    echo "  ],"
+    printf '  "total": %d,\n' "$TOTAL"
+    printf '  "truncated": %s\n' "$TRUNCATED"
+    echo "}"
+else
+    if [[ $TOTAL -eq 0 ]]; then
+        echo "All TODO comments have sufficient context."
+        exit 0
+    fi
+    echo "Bare TODO comments without context:"
+    echo ""
+    for entry in "${FINDINGS[@]}"; do
+        IFS='|' read -r location message <<< "$entry"
+        printf "  %s  %s\n" "$location" "$message"
+    done
+    if $TRUNCATED; then
+        echo "  ... and $((TOTAL - LIMIT)) more"
+    fi
+    echo ""
+    echo "Total: $TOTAL bare TODO(s)"
+    echo "Good format: // TODO(user): description with link (reason not done now)"
+fi
+
+[[ $TOTAL -gt 0 ]] && exit 1
+exit 0

--- a/skills/pr-pipeline/SKILL.md
+++ b/skills/pr-pipeline/SKILL.md
@@ -522,6 +522,8 @@ For personal repos where PR was created but not yet merged: skip cleanup (branch
 
 For protected-org repos: skip cleanup (their processes handle branch lifecycle).
 
+**ADR status update** (toolkit repo only): If this PR implements an ADR (commit message or PR title contains "ADR-NNN"), update the local ADR file's status from "Proposed" to "Implemented — PR #N". ADRs are gitignored (local-only), so this is a local file update, not a git operation.
+
 **Gate**: Branch cleaned up (or skipped if PR is still open). Pipeline complete.
 
 ---


### PR DESCRIPTION
## Summary
- Add 6 deterministic bash scripts that check sapcc-specific conventions no linter covers (ADR-027)
- Update go-sapcc-conventions SKILL.md with Available Scripts section
- Minor pr-pipeline fix: ADR status update step in cleanup phase

## Scripts Added

| Script | What It Catches | Priority |
|--------|----------------|----------|
| `check-sapcc-identify-endpoint.sh` | HTTP handlers missing `httpapi.IdentifyEndpoint` | High |
| `check-sapcc-auth-ordering.sh` | Data access before authentication in handlers | High |
| `check-sapcc-json-strict.sh` | `json.NewDecoder` without `DisallowUnknownFields()` | Medium |
| `check-sapcc-time-now.sh` | Direct `time.Now()` in testable code | Medium |
| `check-sapcc-httptest.sh` | `httptest.NewRecorder` instead of `assert.HTTPRequest` | Medium |
| `check-sapcc-todo-format.sh` | Bare TODO comments without context/links | Low |

## Why scripts over linters
These check **project-specific architectural patterns** that no golangci-lint linter can know about (handler ordering, framework-specific testing patterns, project TODO format). They complement the 35+ linters already in the generated .golangci.yaml.

## Skipped (already covered)
- ~~check-sapcc-license.sh~~ — REUSE tool via `make static-check`
- ~~check-sapcc-docs.sh~~ — `revive:exported` linter (go-makefile-maker PR #469)

## Test plan
- [x] All 6 scripts pass `--help` and `--version`
- [x] Scripts verified for bash 3.2 / macOS compatibility
- [x] --limit numeric validation on all scripts
- [x] Consistent JSON field naming across all scripts
- [x] Scripts only scan sapcc-relevant code (handlers, test files, etc.)