### PR TITLE
feat: private components infrastructure and content pipeline tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,12 @@ service-account*.json
 
 # Reddit moderation local data (per-subreddit context, audit logs)
 reddit-data/
+
+# Private components (personal skills, agents, hooks not for public repo)
+private-skills/
+private-agents/
+private-hooks/
+
+# Draft articles (work in progress, not committed)
+drafts/
+draft-*.md

--- a/install.sh
+++ b/install.sh
@@ -245,6 +245,44 @@ for component in agents skills hooks commands scripts; do
     fi
 done
 
+# Install private components (if they exist, gitignored)
+for private_dir in private-agents private-skills private-hooks; do
+    public_name="${private_dir#private-}"  # strips "private-" prefix
+    if [ -d "${SCRIPT_DIR}/${private_dir}" ]; then
+        echo ""
+        echo -e "${YELLOW}Installing private ${public_name}...${NC}"
+        # Copy/link private components into the same ~/.claude target
+        # Private overrides public when same name exists
+        if [ "$MODE" = "symlink" ]; then
+            for item in "${SCRIPT_DIR}/${private_dir}/"*; do
+                [ -e "$item" ] || continue
+                item_name=$(basename "$item")
+                target="${CLAUDE_DIR}/${public_name}/${item_name}"
+                if [ "$DRY_RUN" = true ]; then
+                    echo -e "${BLUE}  Would link private: ${item_name}${NC}"
+                else
+                    rm -rf "$target" 2>/dev/null
+                    ln -sf "$item" "$target"
+                    echo -e "${GREEN}  ✓ Linked private ${item_name}${NC}"
+                fi
+            done
+        else
+            for item in "${SCRIPT_DIR}/${private_dir}/"*; do
+                [ -e "$item" ] || continue
+                item_name=$(basename "$item")
+                target="${CLAUDE_DIR}/${public_name}/${item_name}"
+                if [ "$DRY_RUN" = true ]; then
+                    echo -e "${BLUE}  Would copy private: ${item_name}${NC}"
+                else
+                    rm -rf "$target" 2>/dev/null
+                    cp -r "$item" "$target"
+                    echo -e "${GREEN}  ✓ Copied private ${item_name}${NC}"
+                fi
+            done
+        fi
+    fi
+done
+
 # Set up local overlay
 echo ""
 echo -e "${YELLOW}Setting up local overlay...${NC}"
@@ -384,6 +422,21 @@ echo -e "${GREEN}✓ Permissions set${NC}"
 
 # Summary
 echo ""
+# Regenerate INDEX.json files with private components included
+echo ""
+echo -e "${YELLOW}Regenerating indexes (including private components)...${NC}"
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}  Would regenerate skills/INDEX.json with ${NC}"
+    echo -e "${BLUE}  Would regenerate agents/INDEX.json with ${NC}"
+else
+    python3 "${SCRIPT_DIR}/scripts/generate-skill-index.py"  >/dev/null 2>&1 && \
+        echo -e "${GREEN}  ✓ Skills index regenerated${NC}" || \
+        echo -e "${YELLOW}  ⚠ Skills index generation failed (non-critical)${NC}"
+    python3 "${SCRIPT_DIR}/scripts/generate-agent-index.py"  >/dev/null 2>&1 && \
+        echo -e "${GREEN}  ✓ Agents index regenerated${NC}" || \
+        echo -e "${YELLOW}  ⚠ Agents index generation failed (non-critical)${NC}"
+fi
+
 if [ "$DRY_RUN" = true ]; then
     echo -e "${YELLOW}╔════════════════════════════════════════════════════════════════╗${NC}"
     echo -e "${YELLOW}║                       Dry Run Complete!                        ║${NC}"

--- a/scripts/data/banned-patterns.json
+++ b/scripts/data/banned-patterns.json
@@ -379,6 +379,11 @@
         "it turns out that",
         "as it turns out",
         "what's interesting is",
+        "that's the interesting part",
+        "actually interesting",
+        "what's actually interesting",
+        "the interesting part is",
+        "here's what's interesting",
         "what's worth noting",
         "what's important here",
         "the uncomfortable truth is",
@@ -517,6 +522,106 @@
       "notes": "Template narrative constructions that AI uses to simulate personal experience. 'By the time X, I was Y' is a fill-in-the-blank.",
       "message": "Formulaic narrative template. Rewrite with specific detail instead of a structural cliche.",
       "suggestion_template": "Replace the template with specific narrative: what happened, when, what you actually did"
+    },
+    "unearned_confidence": {
+      "severity": "warning",
+      "patterns": [
+        "handles all .+ gracefully",
+        "handles all edge cases",
+        "works seamlessly",
+        "fully reliable",
+        "fully tested",
+        "completely secure",
+        "bulletproof",
+        "handles any .+ you throw at it",
+        "works out of the box",
+        "zero configuration",
+        "just works",
+        "no downsides",
+        "no trade-?offs",
+        "nothing can go wrong",
+        "never fails"
+      ],
+      "notes": "AI describes systems with encyclopedic confidence and zero uncertainty. Real docs acknowledge limitations. Legitimate in marketing copy; flag in technical documentation, READMEs, and code comments.",
+      "message": "Unearned confidence. Real systems have limits. State what it actually handles, or qualify the claim.",
+      "suggestion_template": "Add specifics: 'handles UTF-8 input up to 10MB' instead of 'handles all input gracefully'"
+    },
+    "platitude_injection": {
+      "severity": "warning",
+      "patterns": [
+        "at its core,? software .+",
+        "at the end of the day,? .+ is about",
+        "at its heart,? .+ is about",
+        "the beauty of .+ is that",
+        "the power of .+ lies in",
+        "the magic of .+ is",
+        "the true .+ of .+ is",
+        "in the world of software",
+        "in the realm of",
+        "in the landscape of",
+        "when it comes to .+, .+ is key",
+        "good code is .+ about",
+        "great software .+ about",
+        "programming is .+ about"
+      ],
+      "notes": "Universal truths that add zero information. 'At its core, software is about managing complexity' wastes the reader's time. If you need a truism to introduce your point, the point isn't strong enough.",
+      "message": "Platitude. This adds no information. Lead with the specific point instead.",
+      "suggestion_template": "Delete the platitude and start with the concrete claim that follows it"
+    },
+    "false_precision": {
+      "severity": "info",
+      "patterns": [
+        "reduces .+ by exactly \\d+",
+        "improves .+ by precisely \\d+",
+        "takes exactly \\d+ (ms|seconds|minutes)",
+        "\\d+\\.\\d{2,}x (faster|slower|better|improvement)",
+        "saves exactly \\d+"
+      ],
+      "notes": "AI inserts fake-specific numbers in documentation to sound authoritative. 'Reduces latency by exactly 47.3%' when no benchmark was run. Lower severity because some precision is legitimate — flag only when the precision feels performed rather than measured.",
+      "message": "Suspiciously precise claim. Is this measured or fabricated? If measured, cite the benchmark.",
+      "suggestion_template": "Either cite the benchmark methodology, round to honest precision, or use qualitative language"
+    },
+    "redundant_explanation": {
+      "severity": "warning",
+      "patterns": [
+        "// (increment|add|subtract|set|get|return|initialize|update|delete|remove|create|check|validate) .+ (by|to|from|the) ",
+        "# (increment|add|subtract|set|get|return|initialize|update|delete|remove|create|check|validate) .+ (by|to|from|the) "
+      ],
+      "notes": "The most common AI code pattern. AI generates comments that restate what the code already says: '// increment counter by 1' above 'counter++'. Also covers docstrings that merely reword the function signature. Lower-confidence regex — structural analysis in detection-patterns.md provides better coverage for this pattern.",
+      "message": "Comment appears to restate the code. Comments should explain WHY, not WHAT.",
+      "suggestion_template": "Delete the comment if the code is self-explanatory, or rewrite to explain intent/context"
+    },
+    "dead_technical_metaphors": {
+      "severity": "info",
+      "patterns": [
+        "orchestrat(e|es|ed|ing) a (ballet|dance|symphony)",
+        "symphony of (services|systems|components)",
+        "tapestry of (services|systems|code)",
+        "swiss army knife",
+        "silver bullet",
+        "magic happens",
+        "the secret sauce",
+        "behind the scenes"
+      ],
+      "notes": "Engineering cliches that AI overuses. 'Under the hood' omitted — too ubiquitous to flag reliably. 'Heavy lifting' omitted — legitimate in perf contexts.",
+      "message": "Dead technical metaphor. Replace with what actually happens.",
+      "suggestion_template": "State the mechanism directly: 'uses goroutines with a shared channel' instead of 'orchestrates a symphony of workers'"
+    },
+    "tour_guide_transitions": {
+      "severity": "warning",
+      "patterns": [
+        "with that (in place|established|covered)",
+        "having established",
+        "now that we('ve| have) (covered|established|set up|configured)",
+        "building on (this|the previous|what we)",
+        "let's (now )?turn (our attention )?to",
+        "this (brings|leads) us to",
+        "with (this|that) (foundation|understanding|context)",
+        "now we're ready to"
+      ],
+      "notes": "AI connects every section like a museum audio guide. Real technical docs let sections stand alone — readers jump between sections.",
+      "message": "Tour guide transition. Technical docs should let sections stand independently.",
+      "suggestion_template": "Delete the transition. Start the section with its own content."
     }
   },
   "voice_specific": {

--- a/scripts/generate-agent-index.py
+++ b/scripts/generate-agent-index.py
@@ -175,8 +175,14 @@ def main():
         print(f"Error: agents directory not found at {agents_dir}")
         return 1
 
-    # Generate index
+    # Generate index from public agents
     index = generate_index(agents_dir)
+
+    # Also scan private agents if they exist (gitignored, user-specific)
+    private_agents_dir = repo_root / "private-agents"
+    if private_agents_dir.exists() and any(private_agents_dir.iterdir()):
+        private_index = generate_index(private_agents_dir)
+        index["agents"].update(private_index["agents"])
 
     # Write index file
     index_file = agents_dir / "INDEX.json"

--- a/scripts/generate-skill-index.py
+++ b/scripts/generate-skill-index.py
@@ -219,8 +219,19 @@ def main() -> int:
         print(f"Error: skills directory not found at {skills_dir}", file=sys.stderr)
         return 1
 
-    # Generate index
+    # Generate index from public skills
     index, warnings = generate_index(skills_dir)
+
+    # Also scan private skills if they exist (gitignored, user-specific)
+    private_skills_dir = repo_root / "private-skills"
+    if private_skills_dir.exists() and any(private_skills_dir.iterdir()):
+        private_index, private_warnings = generate_index(private_skills_dir)
+        existing_names = {s["name"] for s in index["skills"]}
+        for skill in private_index["skills"]:
+            if skill["name"] in existing_names:
+                index["skills"] = [s for s in index["skills"] if s["name"] != skill["name"]]
+            index["skills"].append(skill)
+        warnings.extend(private_warnings)
 
     # Report warnings if any
     if warnings:

--- a/scripts/reddit-automod-cron.sh
+++ b/scripts/reddit-automod-cron.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Reddit auto-moderation via Claude Code headless mode.
+# Designed for cron: fetches modqueue, classifies, auto-actions high-confidence items.
+#
+# Usage:
+#   # Dry run (classify but don't act)
+#   ./scripts/reddit-automod-cron.sh
+#
+#   # Live mode (execute mod actions)
+#   ./scripts/reddit-automod-cron.sh --execute
+#
+# Cron example (twice daily at 8am and 8pm):
+#   0 8,20 * * * /home/feedgen/claude-code-toolkit/scripts/reddit-automod-cron.sh --execute >> /home/feedgen/claude-code-toolkit/reddit-data/sap/cron-log/cron.log 2>&1
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUBREDDIT="${REDDIT_SUBREDDIT:-sap}"
+LOG_DIR="$REPO_DIR/reddit-data/$SUBREDDIT/cron-log"
+LOCKFILE="/tmp/reddit-automod-$SUBREDDIT.lock"
+SINCE_MINUTES="${SINCE_MINUTES:-720}"
+MAX_BUDGET="${MAX_BUDGET_USD:-2.00}"
+EXECUTE=""
+
+# Parse args
+for arg in "$@"; do
+    case "$arg" in
+        --execute) EXECUTE="--execute" ;;
+        *) echo "Unknown arg: $arg" >&2; exit 1 ;;
+    esac
+done
+
+# Create log directory
+mkdir -p "$LOG_DIR"
+
+# Prevent concurrent runs
+exec 9>"$LOCKFILE"
+if ! flock -n 9; then
+    echo "$(date -Iseconds) SKIP: another instance is running" >> "$LOG_DIR/cron.log"
+    exit 0
+fi
+
+TIMESTAMP="$(date -Iseconds)"
+echo "=== Reddit automod run: $TIMESTAMP ==="
+
+MODE="dry-run"
+[ -n "$EXECUTE" ] && MODE="live"
+echo "Mode: $MODE | Subreddit: r/$SUBREDDIT | Since: ${SINCE_MINUTES}m | Budget: \$${MAX_BUDGET}"
+
+PROMPT="You are running automated Reddit moderation for r/$SUBREDDIT.
+
+Step 1: Run this command to fetch and build classification prompts:
+python3 scripts/reddit_mod.py queue --auto --since-minutes $SINCE_MINUTES --json | python3 scripts/reddit_mod.py classify
+
+Step 2: If the queue is empty (count: 0), output 'Queue empty, no action needed.' and stop.
+
+Step 3: For each item in the output, read the 'prompt' field and classify it as one of:
+FALSE_REPORT, VALID_REPORT, MASS_REPORT_ABUSE, SPAM, BAN_RECOMMENDED, NEEDS_HUMAN_REVIEW
+
+Assign confidence 0-100 and one-sentence reasoning.
+
+Step 4: Apply actions for items meeting confidence thresholds:
+- FALSE_REPORT/MASS_REPORT_ABUSE >= 95%: python3 scripts/reddit_mod.py approve --id {id}
+- SPAM >= 90%: python3 scripts/reddit_mod.py remove --id {id} --reason '{reason}' --spam
+- VALID_REPORT >= 90%: python3 scripts/reddit_mod.py remove --id {id} --reason '{reason}'
+- BAN_RECOMMENDED: ALWAYS skip (never auto-ban)
+- Below threshold: skip (leave for human review)
+
+Step 5: Output a summary table of all items and actions taken.
+
+IMPORTANT: When in doubt, SKIP. False negatives are better than false positives.
+IMPORTANT: Never ban users. Never lock threads. These require human review."
+
+cd "$REPO_DIR"
+
+if [ -z "$EXECUTE" ]; then
+    # Dry run: replace action commands with echo
+    PROMPT="$PROMPT
+
+DRY RUN MODE: Do NOT execute any approve/remove commands. Instead, show what you WOULD do for each item."
+fi
+
+claude -p "$PROMPT" \
+    --output-format text \
+    --permission-mode auto \
+    --allowedTools "Bash Read" \
+    --max-budget-usd "$MAX_BUDGET" \
+    --no-session-persistence \
+    2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
+
+EXIT_CODE=${PIPESTATUS[0]}
+
+echo ""
+echo "=== Run complete: $(date -Iseconds) | exit: $EXIT_CODE ==="
+
+# Release lock
+exec 9>&-
+rm -f "$LOCKFILE"
+
+exit $EXIT_CODE

--- a/scripts/scan-negative-framing.py
+++ b/scripts/scan-negative-framing.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Scan content for negative framing patterns.
+
+VexJoy and WrestleJoy are joy-centered publications. Content should frame
+experiences positively or neutrally, not through grievance, accusation,
+or victimhood. This script detects negative framing patterns that don't
+match the joy-centered editorial voice.
+
+Usage:
+    python3 scripts/scan-negative-framing.py <file>
+    python3 scripts/scan-negative-framing.py <file> --format json
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+# Patterns that signal negative framing
+NEGATIVE_PATTERNS = [
+    # Victimhood framing
+    (r"\bwithout credit\b", "victimhood", "Frames as being wronged. Reframe around the experience or observation."),
+    (r"\bno attribution\b", "victimhood", "Frames as being wronged. Focus on the interesting question, not the grievance."),
+    (r"\bstolen\b", "accusation", "Implies theft. Ideas spread, they aren't stolen."),
+    (r"\btook my\b", "accusation", "Implies taking. Reframe around sharing or spreading."),
+    (r"\bcopied\b", "accusation", "Implies copying. Use 'similar patterns appeared' or 'the same ideas showed up'."),
+    (r"\bripped off\b", "accusation", "Direct accusation. Remove entirely."),
+    (r"\bplagiari", "accusation", "Direct accusation. Remove entirely."),
+
+    # Grievance language
+    (r"\bunfair\b", "grievance", "Grievance framing. Reframe around what's interesting about the situation."),
+    (r"\bdeserve\b", "grievance", "Entitlement framing. Nobody deserves credit, credit is given freely."),
+    (r"\bowed\b", "grievance", "Entitlement framing. Reframe around generosity."),
+    (r"\bshould have credited\b", "grievance", "Prescriptive grievance. Suggest, don't demand."),
+    (r"\bdidn't even\b", "grievance", "Indignation marker. Reframe neutrally."),
+
+    # Passive aggression
+    (r"\bconvenient(ly)?\b", "passive_aggression", "Implies bad faith. State facts without implying motive."),
+    (r"\binteresting timing\b", "passive_aggression", "Implies suspicion. State the timeline factually."),
+    (r"\bcoincidence\b", "passive_aggression", "Often used sarcastically. If sincere, keep. If implying suspicion, reframe."),
+
+    # Bitterness
+    (r"\bpushed me over the edge\b", "bitterness", "Frames action as reactive to negative experience. Reframe as positive decision."),
+    (r"\blast straw\b", "bitterness", "Frames as cumulative frustration. Reframe as moment of clarity."),
+    (r"\bfed up\b", "bitterness", "Frustration framing. Reframe around what you decided to do instead."),
+    (r"\btired of\b", "bitterness", "Fatigue/frustration framing. Reframe around energy and direction."),
+    (r"\bsick of\b", "bitterness", "Strong frustration. Reframe entirely."),
+
+    # Negative self-framing
+    (r"\bnobody (cares|listens|noticed)\b", "self_pity", "Self-pity framing. Reframe around what you learned or built."),
+    (r"\bno one (cares|listens|noticed)\b", "self_pity", "Self-pity framing. Reframe around what you learned or built."),
+    (r"\bfelt (ignored|invisible|unheard)\b", "self_pity", "Victimhood framing. Reframe around the experience itself."),
+    (r"\bfeels like being unheard\b", "self_pity", "Victimhood framing. Reframe around the interesting observation."),
+
+    # Accusatory structures
+    (r"\bclaim(s|ed|ing)? (to have|they|of)\b", "accusatory", "Implies the other person is lying. Use 'said' or 'explained' instead."),
+    (r"\bso-called\b", "accusatory", "Dismissive. Use the actual term without scare quotes."),
+    (r"\ballegedly\b", "accusatory", "Legal/adversarial framing. State facts directly."),
+
+    # Negative emotional framing
+    (r"\bfrustrat(ed|ing|ion)\b", "negative_emotion", "Names a negative emotion. Show it through structure or reframe positively."),
+    (r"\bangry\b", "negative_emotion", "Names a negative emotion. Andy's voice shows emotion through structure, not naming."),
+    (r"\bbothers? me\b", "negative_emotion", "Names a negative emotion. Reframe around what's interesting instead."),
+    (r"\bupset\b", "negative_emotion", "Names a negative emotion. Reframe around what you learned."),
+    (r"\bdisappoint", "negative_emotion", "Names a negative emotion. Reframe around what happened next."),
+    (r"\bresent", "negative_emotion", "Names a negative emotion. Reframe entirely."),
+
+    # Defensive framing
+    (r"\bi'm not (accusing|attacking|blaming)\b", "defensive", "Defensive disclaimer implies you might be. Remove the disclaimer and the content won't read as accusatory."),
+    (r"\bthis isn't about (blame|credit|theft)\b", "defensive", "Defensive disclaimer. If you have to say what it isn't, the framing might still be negative."),
+    (r"\bi don't want (credit|recognition|fame)\b", "defensive", "Protesting too much. Just don't mention credit at all."),
+]
+
+
+def scan_file(filepath: str) -> list[dict]:
+    """Scan a file for negative framing patterns."""
+    content = Path(filepath).read_text()
+    lines = content.split("\n")
+    hits = []
+
+    for i, line in enumerate(lines, 1):
+        # Skip frontmatter
+        if i <= 8 and (line.startswith("---") or line.startswith("title:") or
+                       line.startswith("date:") or line.startswith("description:") or
+                       line.startswith("tags:") or line.startswith("categories:") or
+                       line.startswith("draft:")):
+            continue
+
+        for pattern, category, suggestion in NEGATIVE_PATTERNS:
+            matches = list(re.finditer(pattern, line, re.IGNORECASE))
+            for match in matches:
+                hits.append({
+                    "line": i,
+                    "column": match.start() + 1,
+                    "category": category,
+                    "matched": match.group(),
+                    "context": line.strip()[:120],
+                    "suggestion": suggestion,
+                })
+
+    return hits
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scan for negative framing patterns")
+    parser.add_argument("file", help="File to scan")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args()
+
+    hits = scan_file(args.file)
+
+    if args.format == "json":
+        print(json.dumps({"hits": hits, "total": len(hits)}, indent=2))
+    else:
+        if not hits:
+            print(f"JOY CHECK PASSED. {args.file}: zero negative framing patterns detected.")
+            sys.exit(0)
+
+        print(f"{args.file}: {len(hits)} negative framing pattern(s) detected\n")
+        for hit in hits:
+            print(f"  L{hit['line']} [{hit['category']}] \"{hit['matched']}\"")
+            print(f"    {hit['context']}")
+            print(f"    -> {hit['suggestion']}")
+            print()
+
+        # Summary by category
+        categories = {}
+        for hit in hits:
+            categories[hit["category"]] = categories.get(hit["category"], 0) + 1
+        print("Summary:")
+        for cat, count in sorted(categories.items(), key=lambda x: -x[1]):
+            print(f"  {cat}: {count}")
+
+    sys.exit(1 if hits else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "generated": "2026-03-21T22:36:41Z",
+  "generated": "2026-03-22T16:16:19Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": [
     {

--- a/skills/anti-ai-editor/references/detection-patterns.md
+++ b/skills/anti-ai-editor/references/detection-patterns.md
@@ -752,3 +752,291 @@ went away. Sometimes the simplest fix is the right one.
 Expected detections: 0
 (Natural, direct, specific, varied sentence lengths)
 ```
+
+---
+
+## Code & Documentation AI Patterns (Tier CD)
+
+AI patterns specific to code comments, docstrings, READMEs, architecture docs, and technical blog posts. These are distinct from prose AI tells — they emerge when AI generates technical content rather than narrative.
+
+### Tier CD-1: Redundant Explanation
+
+The single most AI-identifiable pattern in prose, equally common in code. AI generates comments that restate what the code already says. Docstrings that merely reword the function signature. Paragraphs that explain what a code block just demonstrated.
+
+**Detection heuristic for code comments:**
+```
+1. Parse each comment and its associated code statement
+2. Extract verbs and nouns from both
+3. If comment verbs/nouns overlap >80% with code verbs/nouns → flag
+4. Common pattern: "// increment X by Y" above "x += y"
+```
+
+**Detection heuristic for docstrings:**
+```
+1. Parse function/method signature: name, parameters, return type
+2. Parse docstring first sentence
+3. If docstring merely restates signature in natural language → flag
+4. Pattern: "Gets the user by ID" docstring on getUserById(id: string): User
+```
+
+```regex
+# Code comments that restate the code (high-confidence subset)
+//\s*(increment|add|subtract|set|get|return|initialize|update|delete|remove|create|check|validate)\s
+#\s*(increment|add|subtract|set|get|return|initialize|update|delete|remove|create|check|validate)\s
+
+# Docstrings that restate the function name
+("""|\*\*|///)\s*(Gets?|Sets?|Creates?|Deletes?|Updates?|Returns?|Checks?|Validates?)\s+the\s+\w+
+```
+
+**Before/After Examples:**
+
+| AI Pattern | Human Version |
+|-----------|---------------|
+| `// increment counter by 1` above `counter++` | [Delete — the code is clear] |
+| `"""Gets the user by ID."""` on `get_user_by_id()` | `"""Fetches from cache first, falls back to DB. Returns None if soft-deleted."""` |
+| `// Check if the value is valid` above `if is_valid(value):` | [Delete — or explain what "valid" means in this context] |
+| `// Create a new instance of the service` above `svc := NewService(cfg)` | [Delete — or explain WHY a new instance is needed here] |
+
+**Fix strategy:** Delete the comment if the code is self-explanatory. If a comment is needed, explain WHY or WHEN, not WHAT. A comment that a senior engineer would find insulting is a comment that should be deleted.
+
+### Tier CD-2: Unearned Confidence
+
+AI describes systems with encyclopedic confidence and zero uncertainty. Real documentation acknowledges limitations, edge cases, and known issues. "Handles all edge cases gracefully" is never true. "Works seamlessly" is never honest.
+
+```regex
+# Absolute claims about system behavior
+\bhandles all .+ gracefully\b
+\bhandles all edge cases\b
+\bworks seamlessly\b
+\bfully reliable\b
+\bfully tested\b
+\bcompletely secure\b
+\bbulletproof\b
+\bhandles any .+ you throw at it\b
+\bjust works\b
+\bno (downsides|trade-?offs)\b
+\bnever fails\b
+```
+
+**Before/After Examples:**
+
+| AI Pattern | Human Version |
+|-----------|---------------|
+| "**Handles all edge cases gracefully**" | "Handles UTF-8 input up to 10MB. Rejects oversized payloads with 413." |
+| "**Works seamlessly** with any database" | "Tested with PostgreSQL 14+ and SQLite 3.35+. MySQL support is experimental." |
+| "**Fully tested** and production-ready" | "86% line coverage. Integration tests cover the happy path. Error injection tests are TODO." |
+| "**Completely secure** authentication" | "Uses bcrypt with cost 12. Rate-limits to 5 attempts/minute. No MFA yet." |
+
+**Fix strategy:** Replace absolute claims with specific, falsifiable statements. If you can't state what it actually handles, you don't know enough to claim it handles everything.
+
+### Tier CD-3: Platitude Injection
+
+AI inserts universal truths that add zero information. "At its core, software engineering is about managing complexity" wastes the reader's time. If a truism is needed to introduce a point, the point isn't strong enough to stand alone.
+
+```regex
+\bat its core,?\s+software\b
+\bat the end of the day,?\s+.+\s+is about\b
+\bat its heart,?\s+.+\s+is about\b
+\bthe beauty of .+ is that\b
+\bthe power of .+ lies in\b
+\bthe magic of .+ is\b
+\bin the world of software\b
+\bin the realm of\b
+\bin the landscape of\b
+\bgood code is .+ about\b
+\bgreat software .+ about\b
+\bprogramming is .+ about\b
+```
+
+**Before/After Examples:**
+
+| AI Pattern | Human Version |
+|-----------|---------------|
+| "**At its core, software engineering is about** managing complexity" | "This module has three responsibilities. Splitting it reduces coupling." |
+| "**The beauty of** this architecture **is that** it scales" | "This architecture scales horizontally because each node is stateless." |
+| "**In the world of** microservices, communication is key" | "Services communicate via gRPC. Timeouts are set to 5s." |
+| "**Good code is ultimately about** readability" | [Delete — start with the specific readability improvement you're making] |
+
+**Fix strategy:** Delete the platitude and start with the concrete claim that follows it. The concrete claim is always there — the platitude is just throat-clearing before it.
+
+### Tier CD-4: False Precision
+
+AI inserts suspiciously specific numbers to sound authoritative. "Reduces latency by 47.3%" when no benchmark was run. "Processes 1,247 requests per second" when the number was invented. Real precision comes with methodology; AI precision comes with confidence.
+
+```regex
+\breduces .+ by exactly \d+\b
+\bimproves .+ by precisely \d+\b
+\btakes exactly \d+ (ms|seconds|minutes)\b
+\d+\.\d{2,}x (faster|slower|better|improvement)
+\bsaves exactly \d+\b
+```
+
+**Before/After Examples:**
+
+| AI Pattern | Human Version |
+|-----------|---------------|
+| "Reduces latency by **exactly 47.3%**" | "Roughly halves latency (benchmarked on M2 with 10K requests)" |
+| "Processes **1,247** requests per second" | "Handles ~1K req/s on a single core (see benchmarks/)" |
+| "Saves **exactly 23 minutes** per deployment" | "Cuts deploy time from ~30min to ~10min" |
+
+**False positive note:** Precision is legitimate when citing actual measurements with methodology. "p99 latency: 12.4ms (measured over 1M requests)" is real data, not a tell. Flag only when precision appears without a citation or benchmark reference.
+
+### Tier CD-5: Template Monotony
+
+AI-generated documentation follows identical structure for every section: intro paragraph, bullet list, code example, summary sentence. Every function doc follows: description, parameters, returns, example. This structural repetition is a tell even when no individual section is bad.
+
+**Detection heuristic (structural, not regex):**
+```
+1. For each H2 or H3 section in a document:
+   a. Classify the section structure:
+      - INTRO-LIST-CODE-SUMMARY
+      - INTRO-CODE-EXPLANATION
+      - QUESTION-ANSWER
+      - NARRATIVE
+      - etc.
+   b. Record the structure type
+2. Count consecutive sections with identical structure type
+3. Flag if 3+ consecutive sections use the same structure
+4. Also flag if >60% of sections in a document use the same structure
+```
+
+**Before (monotonous):**
+```markdown
+## Authentication
+Authentication is a critical part of any application. Here are the key features:
+- JWT tokens
+- Session management
+- OAuth2 support
+
+## Authorization
+Authorization controls what users can access. Here are the key features:
+- Role-based access
+- Permission groups
+- Resource-level policies
+
+## Rate Limiting
+Rate limiting protects your API from abuse. Here are the key features:
+- Per-user limits
+- Global limits
+- Burst allowance
+```
+
+**After (varied):**
+```markdown
+## Authentication
+Uses JWT with 15-minute expiry. Refresh tokens rotate on use.
+
+## Authorization
+Three levels: role → permission group → resource policy. Checked in that order.
+See `middleware/authz.go` for the chain.
+
+## Rate Limiting
+| Scope | Default | Burst |
+|-------|---------|-------|
+| Per-user | 100/min | 20 |
+| Global | 10K/min | 2K |
+
+Override per-route with `@RateLimit(n)`.
+```
+
+**Fix strategy:** Vary section structures deliberately. Use tables where data is tabular. Use code-first where the code IS the explanation. Use narrative where context matters. No two consecutive sections should have the same structure.
+
+### Tier CD-6: Dead Technical Metaphors
+
+Code/docs-specific metaphors that AI overuses to the point of meaninglessness. Different from prose metaphors — these are engineering clichés.
+
+```regex
+\borchestrat(e|es|ed|ing) a (ballet|dance|symphony)\b
+\bsymphony of (services|systems|components)\b
+\btapestry of (services|systems|code)\b
+\bunder the hood\b
+\bswiss army knife\b
+\bsilver bullet\b
+\bheavy lifting\b
+\bmagic happens\b
+\bthe secret sauce\b
+\bbehind the scenes\b
+```
+
+**Before/After Examples:**
+
+| AI Pattern | Human Version |
+|-----------|---------------|
+| "**Under the hood**, it uses goroutines" | "Implementation: goroutines with a shared channel" |
+| "The **secret sauce** is the caching layer" | "The caching layer is the reason it's fast" |
+| "This module does the **heavy lifting**" | "This module handles parsing, validation, and storage" |
+| "**Behind the scenes**, React reconciles the DOM" | "React reconciles the DOM on each render" |
+
+**False positive note:** "Under the hood" is so ubiquitous in tech writing that it's borderline acceptable. Flag at info severity, not error.
+
+### Tier CD-7: Tour Guide Transitions
+
+AI connects every section with a transition sentence that reads like a museum audio guide. Real technical docs let sections stand independently — readers jump between sections, they don't read linearly.
+
+```regex
+\bwith that (in place|established|covered)\b
+\bhaving established\b
+\bnow that we('ve| have) (covered|established|set up|configured)\b
+\bbuilding on (this|the previous|what we)\b
+\blet's (now )?turn (our attention )?to\b
+\bthis (brings|leads) us to\b
+\bwith (this|that) (foundation|understanding|context)\b
+\bnow we're ready to\b
+```
+
+**Before/After Examples:**
+
+| AI Pattern | Human Version |
+|-----------|---------------|
+| "**With that in place**, let's configure the database" | "## Database Configuration" |
+| "**Now that we've covered** authentication, let's turn to authorization" | "## Authorization" |
+| "**Building on the previous** section, we can now..." | [Start with what this section does, not what the previous one did] |
+
+**Fix strategy:** Delete the transition entirely. Start each section with its own content. If sections must be read in order, a numbered list in the overview is better than inline tour-guiding.
+
+---
+
+## Code/Docs Pattern Testing
+
+Test against AI-generated README:
+
+```
+At its core, this library is about making API calls simple. It handles
+all edge cases gracefully and works seamlessly with any HTTP client.
+The beauty of the architecture is that it reduces boilerplate by exactly
+47.3%, saving developers hours of work.
+
+With that in place, let's turn to configuration. Configuration is a
+critical part of any application. Here are the key options:
+- **Timeout** -- sets the request timeout
+- **Retries** -- configures retry behavior
+- **Auth** -- handles authentication
+
+Under the hood, the secret sauce is the middleware pipeline that
+orchestrates a symphony of interceptors.
+
+Expected detections:
+- "At its core" (CD-3 -- platitude)
+- "handles all edge cases gracefully" (CD-2 -- unearned confidence)
+- "works seamlessly" (CD-2 -- unearned confidence)
+- "The beauty of" (CD-3 -- platitude)
+- "by exactly 47.3%" (CD-4 -- false precision)
+- "With that in place, let's turn to" (CD-7 -- tour guide)
+- "Under the hood" (CD-6 -- dead metaphor)
+- "the secret sauce" (CD-6 -- dead metaphor)
+- "orchestrates a symphony of" (CD-6 -- dead metaphor)
+```
+
+Test against natural technical writing:
+
+```
+The client retries failed requests up to 3 times with exponential
+backoff (100ms, 200ms, 400ms). Timeouts default to 5s. Override
+per-request with WithTimeout(d).
+
+Known limitation: connection pooling doesn't work with HTTP/2 proxies.
+See issue #247.
+
+Expected detections: 0
+(Specific, qualified, acknowledges limitations)
+```


### PR DESCRIPTION
## Summary
- Add private-skills/, private-agents/, private-hooks/ gitignored directories for personal components that integrate with the full system but stay out of the public repo
- Update install.sh to sync both public and private components to ~/.claude
- Update index generators to auto-scan private directories when present (no flag needed)
- Add scan-negative-framing.py regex pre-filter for joy-check tonal validation
- Add "actually interesting" AI tell variants to banned-patterns.json
- Add reddit-automod-cron.sh for headless Claude Code moderation via cron
- Add drafts/ gitignored directory for article drafts

## Test Plan
- [x] Private directories gitignored (verified: git check-ignore confirms all 4 dirs)
- [x] INDEX.json contains zero private entries (verified: 0 wrestlejoy/voice entries)
- [x] No private content in any tracked file (verified: grep across all staged files)
- [x] Index generators scan private dirs when present, skip when absent
- [x] install.sh syncs private components with public override priority