### PR TITLE
fix: add PATH export to reddit cron script for headless execution

### DIFF
--- a/scripts/reddit-automod-cron.sh
+++ b/scripts/reddit-automod-cron.sh
@@ -12,6 +12,9 @@
 # Cron example (twice daily at 8am and 8pm):
 #   0 8,20 * * * /home/feedgen/claude-code-toolkit/scripts/reddit-automod-cron.sh --execute >> /home/feedgen/claude-code-toolkit/reddit-data/sap/cron-log/cron.log 2>&1
 
+# Ensure claude CLI is in PATH (cron doesn't inherit user PATH)
+export PATH="$HOME/.local/bin:$HOME/.nvm/versions/node/$(ls $HOME/.nvm/versions/node/ 2>/dev/null | tail -1)/bin:$PATH"
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
Cron env doesn't have ~/.local/bin in PATH, causing 'claude: command not found'. Adds PATH export at script top.