### PR TITLE
fix: disable redundant routing context injectors

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,11 +61,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$HOME/.claude/hooks/skill-evaluator.py\"",
-            "description": "Evaluate applicable skills/agents for request"
-          },
-          {
-            "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/auto-plan-detector.py\"",
             "description": "Auto-detect complex tasks and inject planning reminders (Manus methodology)"
           },
@@ -90,12 +85,6 @@
             "command": "python3 \"$HOME/.claude/hooks/pipeline-context-detector.py\"",
             "description": "Detect pipeline creation requests and inject pipeline context",
             "timeout": 2000
-          },
-          {
-            "type": "command",
-            "command": "python3 \"$HOME/.claude/hooks/capability-catalog-injector.py\"",
-            "description": "Inject full agent/skill catalog for routing intelligence",
-            "timeout": 5000
           }
         ]
       }

--- a/hooks/capability-catalog-injector.py
+++ b/hooks/capability-catalog-injector.py
@@ -21,41 +21,13 @@ CATALOG_SCRIPT = REPO_ROOT / "scripts" / "list-capabilities.py"
 
 
 def main() -> None:
-    # Read the prompt from the hook input
-    hook_input = json.loads(sys.stdin.read())
-    prompt = hook_input.get("prompt", "")
-
-    # Only inject when /do is being invoked
-    if not prompt.strip().startswith("/do"):
-        return
-
-    # Run the catalog command
-    try:
-        result = subprocess.run(
-            [sys.executable, str(CATALOG_SCRIPT), "catalog", "--compact"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            cwd=str(REPO_ROOT),
-        )
-        if result.returncode != 0:
-            return
-
-        catalog = result.stdout.strip()
-        if not catalog:
-            return
-
-        # Output as context injection
-        print(f"""<available-capabilities>
-The following is the complete catalog of all skills and agents available
-for routing. Use this to inform your routing decision — skills and agents
-listed here may not appear in /do's static routing tables but ARE available.
-
-{catalog}
-</available-capabilities>""")
-
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass  # Non-blocking: if catalog fails, /do works fine without it
+    # DISABLED: The /do SKILL.md already contains structured routing tables
+    # with triggers, agent pairings, and force-route rules. This hook injected
+    # ~52KB of redundant flat JSON on every /do invocation.
+    #
+    # Originally the "treatment arm" of an A/B test (adr/cli-context-enrichment.md).
+    # The /do skill's own tables proved more useful than a flat catalog dump.
+    return
 
 
 if __name__ == "__main__":

--- a/hooks/skill-evaluator.py
+++ b/hooks/skill-evaluator.py
@@ -212,32 +212,15 @@ def should_skip(prompt: str) -> bool:
 
 
 def main():
-    """Process UserPromptSubmit hook event."""
-    try:
-        stdin_data = sys.stdin.read()
-        if not stdin_data:
-            return
+    """Process UserPromptSubmit hook event.
 
-        event = json.loads(stdin_data)
-    except (json.JSONDecodeError, ValueError):
-        return
-
-    try:
-        event_type = event.get("hook_event_name") or event.get("type", "")
-
-        if event_type != "UserPromptSubmit":
-            return
-
-        prompt = event.get("prompt", "")
-
-        if should_skip(prompt):
-            return
-
-        complexity = classify_complexity(prompt)
-        print(get_evaluation_prompt(complexity))
-
-    except Exception:
-        pass
+    DISABLED: The routing cheat sheet this hook injects (~1.8KB per prompt)
+    is redundant. When /do is active, SKILL.md has full routing tables.
+    When /do is NOT active, the user is talking directly and doesn't need
+    routing guidance injected. The Agent tool descriptions in the system
+    prompt already list all available agents.
+    """
+    return
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Disabled `capability-catalog-injector.py` (~52KB redundant JSON per /do invocation)
- Disabled `skill-evaluator.py` (~1.8KB redundant routing cheat sheet per prompt)
- Removed both from settings.json hook registrations

Saves ~54KB of context injection per /do invocation. The /do SKILL.md already has structured routing tables that are better than either hook's output.

## Test plan
- [x] Verified hooks are single-purpose (no side effects, no DB writes)
- [x] Verified no other code imports from these hooks
- [x] Settings.json updated in both repo and deployed copies