### PR TITLE
feat: migrate all hooks to stdin_timeout utility (ADR-083)

### DIFF
--- a/hooks/adr-context-injector.py
+++ b/hooks/adr-context-injector.py
@@ -35,6 +35,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import context_output, empty_output, log_warning
+from stdin_timeout import read_stdin
 
 EVENT_NAME = "UserPromptSubmit"
 
@@ -123,7 +124,7 @@ def main() -> None:
     debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
 
     try:
-        raw = sys.stdin.read()
+        raw = read_stdin(timeout=2)
         try:
             data = json.loads(raw)
         except json.JSONDecodeError:

--- a/hooks/adr-enforcement.py
+++ b/hooks/adr-enforcement.py
@@ -22,6 +22,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import context_output, empty_output, log_warning
+from stdin_timeout import read_stdin
 
 __EVENT_NAME = "PostToolUse"
 
@@ -170,7 +171,7 @@ def format_pass(file_path: str, check_result: dict) -> str:
 
 def main() -> None:
     try:
-        raw = sys.stdin.read()
+        raw = read_stdin(timeout=2)
         if not raw:
             empty_output(_EVENT_NAME).print_and_exit(0)
             return

--- a/hooks/agent-grade-on-change.py
+++ b/hooks/agent-grade-on-change.py
@@ -14,6 +14,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
 
 def is_agent_file(file_path: str) -> bool:
     """Check if a file path is an agent markdown file."""
@@ -65,11 +68,13 @@ def main():
     # Read hook input - try stdin first, then fall back to temp file
     hook_input = None
 
-    # Try reading from stdin
+    # Try reading from stdin with timeout protection
     try:
         if not sys.stdin.isatty():
-            hook_input = json.load(sys.stdin)
-    except json.JSONDecodeError:
+            raw = read_stdin(timeout=2)
+            if raw:
+                hook_input = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
         pass
 
     # Fall back to temp file (used by other hooks in the chain)

--- a/hooks/auto-plan-detector.py
+++ b/hooks/auto-plan-detector.py
@@ -29,6 +29,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import context_output, empty_output
+from stdin_timeout import read_stdin
 
 # =============================================================================
 # Detection Patterns
@@ -133,7 +134,7 @@ AGENT_TRIGGERS = {
 def get_user_prompt() -> str:
     """Get the user prompt from stdin (hook input)."""
     try:
-        hook_input = json.load(sys.stdin)
+        hook_input = json.loads(read_stdin(timeout=2))
         # Validate input is a dict (expected format from hook system)
         if not isinstance(hook_input, dict):
             print(f"[auto-plan] Expected dict input, got {type(hook_input).__name__}", file=sys.stderr)

--- a/hooks/block-attribution.py
+++ b/hooks/block-attribution.py
@@ -21,6 +21,10 @@ Design:
 import json
 import re
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
 
 FORBIDDEN_PATTERNS = [
     r"Generated with \[?Claude Code\]?",
@@ -36,7 +40,7 @@ FORBIDDEN_RE = re.compile("|".join(FORBIDDEN_PATTERNS), re.IGNORECASE)
 
 def main() -> None:
     try:
-        data = json.loads(sys.stdin.read())
+        data = json.loads(read_stdin(timeout=2))
     except (json.JSONDecodeError, OSError):
         print(json.dumps({}))
         return

--- a/hooks/block-gitignore-bypass.py
+++ b/hooks/block-gitignore-bypass.py
@@ -18,11 +18,15 @@ import json
 import re
 import subprocess
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
 
 
 def main() -> None:
     try:
-        hook_input = json.loads(sys.stdin.read())
+        hook_input = json.loads(read_stdin(timeout=2))
         tool_name = hook_input.get("tool_name", "")
 
         # Fast path: only care about Bash

--- a/hooks/ci-merge-gate.py
+++ b/hooks/ci-merge-gate.py
@@ -9,10 +9,14 @@ failing or still pending.
 import json
 import subprocess
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
 
 
 def main() -> None:
-    data = json.loads(sys.stdin.read())
+    data = json.loads(read_stdin(timeout=2))
 
     tool = data.get("tool_name", "")
     if tool != "Bash":

--- a/hooks/error-learner.py
+++ b/hooks/error-learner.py
@@ -22,6 +22,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from feedback_tracker import check_pending_feedback, set_pending_feedback
+from stdin_timeout import read_stdin
 from learning_db_v2 import (
     DEFAULT_FIX_ACTIONS,
     boost_confidence,
@@ -122,7 +123,7 @@ def main():
     4. Set pending feedback for next iteration
     """
     try:
-        event_data = sys.stdin.read()
+        event_data = read_stdin(timeout=2)
         if not event_data:
             return
 

--- a/hooks/perses-lint-gate.py
+++ b/hooks/perses-lint-gate.py
@@ -10,11 +10,15 @@ Event: PreToolUse (Bash)
 import json
 import re
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
 
 
 def main():
     try:
-        event = json.loads(sys.stdin.read())
+        event = json.loads(read_stdin(timeout=2))
     except (json.JSONDecodeError, EOFError, ValueError):
         # Fail open: if we can't parse the event, allow the tool to run.
         # Exit code 2 = block in Claude Code; broken hooks must not block.

--- a/hooks/perses-mcp-injector.py
+++ b/hooks/perses-mcp-injector.py
@@ -9,6 +9,10 @@ Event: UserPromptSubmit
 
 import json
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
 
 PERSES_KEYWORDS = [
     "perses",
@@ -45,7 +49,7 @@ plugin start, plugin test-schemas, config, whoami, refresh.
 
 def main():
     try:
-        event = json.loads(sys.stdin.read())
+        event = json.loads(read_stdin(timeout=2))
     except (json.JSONDecodeError, EOFError, ValueError):
         # Injector is non-critical — fail open (exit 0), but log
         print("[perses-mcp] WARNING: could not parse hook event", file=sys.stderr)

--- a/hooks/pipeline-context-detector.py
+++ b/hooks/pipeline-context-detector.py
@@ -36,6 +36,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import context_output, empty_output, parse_frontmatter
+from stdin_timeout import read_stdin
 
 EVENT_NAME = "UserPromptSubmit"
 
@@ -55,7 +56,7 @@ TRIGGER_PATTERN = re.compile("|".join(PIPELINE_TRIGGERS), re.IGNORECASE)
 def get_user_prompt() -> str:
     """Extract user prompt from stdin JSON."""
     try:
-        data = json.loads(sys.stdin.read())
+        data = json.loads(read_stdin(timeout=2))
         return data.get("userMessage", "")
     except (json.JSONDecodeError, KeyError):
         return ""

--- a/hooks/post-tool-lint-hint.py
+++ b/hooks/post-tool-lint-hint.py
@@ -16,6 +16,9 @@ import os
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
 # File extensions and their linters
 LINTERS = {
     ".py": "ruff check --fix",
@@ -54,7 +57,7 @@ def mark_extension_seen(ext: str):
 def main():
     """Process PostToolUse hook event."""
     try:
-        event_data = sys.stdin.read()
+        event_data = read_stdin(timeout=2)
         event = json.loads(event_data)
 
         # Check this is PostToolUse for Write or Edit

--- a/hooks/posttool-security-scan.py
+++ b/hooks/posttool-security-scan.py
@@ -26,6 +26,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
 # Code file extensions worth scanning
 _CODE_EXTENSIONS = frozenset(
     {
@@ -135,7 +138,7 @@ _PATTERNS = _build_patterns()
 
 def main() -> None:
     try:
-        raw = sys.stdin.read()
+        raw = read_stdin(timeout=2)
         event = json.loads(raw)
 
         event_type = event.get("hook_event_name") or event.get("type", "")

--- a/hooks/precompact-archive.py
+++ b/hooks/precompact-archive.py
@@ -29,6 +29,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from learning_db_v2 import classify_error, generate_signature, get_stats, record_learning
+from stdin_timeout import read_stdin
 
 
 def inject_adr_anchor(event: dict) -> None:
@@ -168,7 +169,7 @@ def main():
     """Archive learnings before context compression."""
     try:
         # Read event data from stdin
-        event_data = sys.stdin.read()
+        event_data = read_stdin(timeout=2)
         if not event_data:
             return
 

--- a/hooks/pretool-creation-gate.py
+++ b/hooks/pretool-creation-gate.py
@@ -34,6 +34,10 @@ import json
 import os
 import re
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
 
 # Env var that creator pipelines set to bypass this gate.
 _BYPASS_ENV = "CREATION_GATE_BYPASS"
@@ -45,7 +49,7 @@ _SKILL_PATTERN = re.compile(r"/skills/[^/]+/SKILL\.md$")
 
 
 def main() -> None:
-    raw = sys.stdin.read()
+    raw = read_stdin(timeout=2)
     try:
         event = json.loads(raw)
     except (json.JSONDecodeError, ValueError):

--- a/hooks/pretool-dangerous-command-guard.py
+++ b/hooks/pretool-dangerous-command-guard.py
@@ -32,6 +32,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
 _BYPASS_ENV = "DANGEROUS_GUARD_BYPASS"
 
 # Each tuple: (compiled_regex, category, human_description)
@@ -87,7 +90,7 @@ def _is_whitelisted(command: str, whitelist: list[str]) -> bool:
 
 
 def main() -> None:
-    raw = sys.stdin.read()
+    raw = read_stdin(timeout=2)
     try:
         event = json.loads(raw)
     except (json.JSONDecodeError, ValueError):

--- a/hooks/pretool-file-backup.py
+++ b/hooks/pretool-file-backup.py
@@ -29,6 +29,9 @@ import sys
 import time
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
 # 10 MB limit — skip larger files silently
 _MAX_FILE_SIZE = 10 * 1024 * 1024
 
@@ -39,7 +42,7 @@ _BACKUP_ROOT = Path("/tmp/.claude-backups") / _SESSION_ID
 
 
 def main() -> None:
-    raw = sys.stdin.read()
+    raw = read_stdin(timeout=2)
     try:
         event = json.loads(raw)
     except (json.JSONDecodeError, ValueError):

--- a/hooks/pretool-git-submission-gate.py
+++ b/hooks/pretool-git-submission-gate.py
@@ -25,6 +25,10 @@ Design Principles:
 import json
 import re
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
 
 # Bypass prefix that skills include when they legitimately need to run blocked commands.
 # Checked as a string prefix in the command, not as an env var.
@@ -40,7 +44,7 @@ BLOCKED_PATTERNS = [
 
 
 def main() -> None:
-    raw = sys.stdin.read()
+    raw = read_stdin(timeout=2)
     try:
         event = json.loads(raw)
     except (json.JSONDecodeError, ValueError):

--- a/hooks/pretool-learning-injector.py
+++ b/hooks/pretool-learning-injector.py
@@ -26,6 +26,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import context_output, empty_output
+from stdin_timeout import read_stdin
 
 EVENT_NAME = "PreToolUse"
 
@@ -152,7 +153,7 @@ def main():
     debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
 
     try:
-        event_data = sys.stdin.read()
+        event_data = read_stdin(timeout=2)
         if not event_data:
             empty_output(EVENT_NAME).print_and_exit()
 

--- a/hooks/pretool-sensitive-file-guard.py
+++ b/hooks/pretool-sensitive-file-guard.py
@@ -27,6 +27,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
 _BYPASS_ENV = "SENSITIVE_FILE_GUARD_BYPASS"
 
 # Compiled patterns for sensitive file paths.
@@ -90,7 +93,7 @@ def _is_exception(file_path: str) -> bool:
 
 
 def main() -> None:
-    raw = sys.stdin.read()
+    raw = read_stdin(timeout=2)
     try:
         event = json.loads(raw)
     except (json.JSONDecodeError, ValueError):

--- a/hooks/pretool-unified-gate.py
+++ b/hooks/pretool-unified-gate.py
@@ -23,6 +23,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
 # ═══════════════════════════════════════════════════════════════
 # 1. GITIGNORE BYPASS (block-gitignore-bypass.py)
 # ═══════════════════════════════════════════════════════════════
@@ -322,7 +325,7 @@ def check_sensitive_file(file_path: str) -> None:
 
 
 def main() -> None:
-    raw = sys.stdin.read()
+    raw = read_stdin(timeout=2)
     try:
         event = json.loads(raw)
     except (json.JSONDecodeError, ValueError):

--- a/hooks/record-activation.py
+++ b/hooks/record-activation.py
@@ -25,6 +25,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import get_session_id
+from stdin_timeout import read_stdin
 
 # Tools that represent meaningful work completing successfully
 TRACKED_TOOLS = {"Edit", "Write", "Bash"}
@@ -33,7 +34,7 @@ TRACKED_TOOLS = {"Edit", "Write", "Bash"}
 def main() -> None:
     """Record session activation stats on successful tool completions."""
     try:
-        hook_input = json.loads(sys.stdin.read())
+        hook_input = json.loads(read_stdin(timeout=2))
 
         tool_name = hook_input.get("tool_name", "")
         if tool_name not in TRACKED_TOOLS:

--- a/hooks/record-waste.py
+++ b/hooks/record-waste.py
@@ -23,6 +23,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import get_session_id
+from stdin_timeout import read_stdin
 
 # Minimum token waste estimate per failure
 MIN_WASTE_TOKENS = 100
@@ -34,7 +35,7 @@ CHARS_PER_TOKEN = 4
 def main() -> None:
     """Record wasted tokens when a tool execution fails."""
     try:
-        hook_input = json.loads(sys.stdin.read())
+        hook_input = json.loads(read_stdin(timeout=2))
 
         tool_result = hook_input.get("tool_result", {})
         if not tool_result.get("is_error", False):

--- a/hooks/retro-graduation-gate.py
+++ b/hooks/retro-graduation-gate.py
@@ -16,6 +16,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import context_output, empty_output
+from stdin_timeout import read_stdin
 
 DB_PATH = Path.home() / ".claude" / "learning" / "learning.db"
 EVENT = "PostToolUse"
@@ -23,7 +24,7 @@ EVENT = "PostToolUse"
 
 def main() -> None:
     try:
-        data = json.loads(sys.stdin.read())
+        data = json.loads(read_stdin(timeout=2))
     except (json.JSONDecodeError, OSError):
         empty_output(EVENT).print_and_exit(0)
         return

--- a/hooks/retro-knowledge-injector.py
+++ b/hooks/retro-knowledge-injector.py
@@ -29,6 +29,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import context_output, empty_output, get_session_id
+from stdin_timeout import read_stdin
 
 # Try to import learning_db_v2 for SQLite-based injection
 try:
@@ -312,7 +313,7 @@ def main():
     try:
         # Parse hook input
         try:
-            hook_input = json.load(sys.stdin)
+            hook_input = json.loads(read_stdin(timeout=2))
             if not isinstance(hook_input, dict):
                 empty_output(EVENT_NAME).print_and_exit()
             prompt = hook_input.get("prompt", "").strip()

--- a/hooks/review-capture.py
+++ b/hooks/review-capture.py
@@ -27,6 +27,7 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import empty_output
 from learning_db_v2 import record_learning
+from stdin_timeout import read_stdin
 
 EVENT_NAME = "PostToolUse"
 
@@ -108,7 +109,7 @@ def main() -> None:
     5. Exit silently (no context injection)
     """
     try:
-        event_data = sys.stdin.read()
+        event_data = read_stdin(timeout=2)
         if not event_data:
             return
 

--- a/hooks/routing-gap-recorder.py
+++ b/hooks/routing-gap-recorder.py
@@ -18,12 +18,15 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
 _GAP_PATTERN = re.compile(r"GAP DETECTED:\s*No match for\s+\[?([^\]\n]+)\]?")
 
 
 def main():
     try:
-        event_data = sys.stdin.read()
+        event_data = read_stdin(timeout=2)
         if not event_data:
             return
 

--- a/hooks/session-learning-recorder.py
+++ b/hooks/session-learning-recorder.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import empty_output, get_session_id
 from learning_db_v2 import get_connection, init_db
+from stdin_timeout import read_stdin
 
 EVENT_NAME = "Stop"
 
@@ -77,7 +78,7 @@ def is_substantive_session(event: dict) -> bool:
 def main():
     """Check learning gap at session end."""
     try:
-        event_data = sys.stdin.read()
+        event_data = read_stdin(timeout=2)
         if not event_data:
             empty_output(EVENT_NAME).print_and_exit()
 

--- a/hooks/session-summary.py
+++ b/hooks/session-summary.py
@@ -22,12 +22,13 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from learning_db_v2 import get_stats, record_session
+from stdin_timeout import read_stdin
 
 
 def main():
     """Generate session summary on conversation end."""
     try:
-        event_data = sys.stdin.read()
+        event_data = read_stdin(timeout=2)
         cwd = os.getcwd()
 
         # Generate session ID

--- a/hooks/subagent-completion-guard.py
+++ b/hooks/subagent-completion-guard.py
@@ -39,6 +39,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
 __EVENT_NAME = "SubagentStop"
 
 # Agents whose names start with this prefix are READ-ONLY by contract
@@ -466,7 +469,7 @@ def check_protected_org_workflow(cwd: str, transcript_path: str) -> str | None:
 
 def main() -> None:
     try:
-        raw = sys.stdin.read()
+        raw = read_stdin(timeout=2)
         if not raw:
             sys.exit(0)
 

--- a/hooks/task-completed-learner.py
+++ b/hooks/task-completed-learner.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
 
 EVENT_NAME = "TaskCompleted"
 
@@ -27,7 +28,7 @@ def main():
     debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
 
     try:
-        event_data = sys.stdin.read()
+        event_data = read_stdin(timeout=2)
         if not event_data:
             print("{}")
             sys.exit(0)

--- a/hooks/usage-tracker.py
+++ b/hooks/usage-tracker.py
@@ -18,12 +18,13 @@ from pathlib import Path
 
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
 
 
 def main():
     """Process PostToolUse events, recording Skill and Agent invocations."""
     try:
-        event_data = sys.stdin.read()
+        event_data = read_stdin(timeout=2)
         if not event_data:
             return
 

--- a/hooks/user-correction-capture.py
+++ b/hooks/user-correction-capture.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import empty_output, get_session_id
 from learning_db_v2 import record_learning
+from stdin_timeout import read_stdin
 
 EVENT_NAME = "UserPromptSubmit"
 
@@ -52,7 +53,7 @@ def generate_key(text: str) -> str:
 
 def main():
     try:
-        hook_input = json.load(sys.stdin)
+        hook_input = json.loads(read_stdin(timeout=2))
         prompt = (hook_input.get("prompt") or "").strip()
         if not prompt:
             empty_output(EVENT_NAME).print_and_exit()


### PR DESCRIPTION
## Summary
- Migrates all 33 Python hooks from raw `sys.stdin.read()` / `json.load(sys.stdin)` to `read_stdin(timeout=2)`
- Prevents pipe-hang deadlocks across the entire hook system
- Fixes duplicate import in subagent-completion-guard.py (review finding)
- Includes 4 hooks using `json.load(sys.stdin)` that were initially missed (review finding)

## Test Plan
- [x] Zero raw stdin reads remain outside stdin_timeout.py itself
- [x] Smoke test: `echo '{}' | python3 hooks/error-learner.py` exits cleanly
- [x] Code review: 1 critical (duplicate import), 1 important (missed hooks) — both fixed