### PR TITLE
feat: enhance codebase exploration with parallel mapping and depth tiers (ADR-082)

### DIFF
--- a/skills/codebase-overview/SKILL.md
+++ b/skills/codebase-overview/SKILL.md
@@ -35,6 +35,18 @@ This skill operates as an operator for systematic codebase exploration, configur
 - **Systematic Phases**: Follow DETECT -> EXPLORE -> MAP -> SUMMARIZE in order
 - **Project Agnostic**: Work across any language, framework, or build system
 - **Absolute Paths**: All file references in output MUST use absolute paths
+- **Forbidden-Files Guardrail**: NEVER read or quote files matching sensitive patterns. Secrets leaked into exploration output are hard to retract and easy to miss. Check every file path against the forbidden list BEFORE reading. Skip silently -- do not log the file contents or path contents in output.
+
+  ```
+  # Secrets and credentials
+  .env, .env.*, *.pem, *.key, credentials.json, secrets.*, *secret*, *credential*, *password*
+
+  # Authentication tokens
+  token.json, .npmrc, .pypirc
+
+  # Cloud provider credentials
+  .aws/credentials, .gcloud/, service-account*.json
+  ```
 
 ### Default Behaviors (ON unless disabled)
 - Report facts without self-congratulation; show evidence, not descriptions
@@ -310,11 +322,92 @@ Before outputting, verify:
 - [ ] Paths are absolute, not relative
 - [ ] Commands are real, not guessed
 
-**Step 3: Output report**
+**Step 3: Generate "Where to Add New Code" section**
+
+Append a prescriptive section to the report. Developers exploring a codebase need to know not just what exists but where to put new things. For each major code category discovered during exploration, provide the directory, a concrete example file to use as a template, and any naming conventions.
+
+```markdown
+## Where to Add New Code
+
+| I want to add... | Put it in... | Follow the pattern in... |
+|-------------------|-------------|-------------------------|
+| [category from exploration] | [directory path] | [concrete example file path] |
+```
+
+Populate this table from evidence gathered in Phases 2-3. Every entry MUST reference a real file that already exists in the codebase. If a category has no clear home, note that explicitly rather than guessing.
+
+**Step 4: Post-exploration secret scan**
+
+Before presenting results, scan all output for accidentally captured secrets. Even with the forbidden-files guardrail, secrets can appear in non-obvious places (config comments, inline connection strings, hardcoded tokens in source).
+
+```bash
+# Scan exploration output for common secret patterns
+grep -iE '(password|secret|token|api[_-]?key|auth|credential)\s*[:=]' <output_file> || true
+grep -E '(AIza|sk-|ghp_|gho_|AKIA|-----BEGIN)' <output_file> || true
+```
+
+If any matches are found:
+1. Do NOT present the raw output to the user
+2. Redact the matched lines (replace values with `[REDACTED]`)
+3. Flag the finding: "Secret pattern detected in exploration output -- redacted before display. Review [file path] manually."
+
+**Step 5: Output report**
 
 Display complete markdown report to stdout. If export behavior is enabled, also write to file.
 
-**Gate**: Report has all sections filled. All paths are absolute. All claims cite evidence. Report is actionable for onboarding. Quality check passes. Total files examined count is accurate.
+**Gate**: Report has all sections filled. All paths are absolute. All claims cite evidence. "Where to Add New Code" section populated with real file references. Secret scan passed (no unredacted secrets in output). Report is actionable for onboarding. Quality check passes. Total files examined count is accurate.
+
+---
+
+## Parallel Domain-Specific Mapping (Deep Dive Mode)
+
+When the user requests a full architectural analysis (e.g., "give me the full picture", "I'm new to this codebase", "we're considering a major refactor"), use parallel domain-specific agents instead of single-threaded sequential exploration. This is faster (parallel execution) and produces higher-quality results (each agent focuses on its domain rather than context-switching across concerns).
+
+### When to Use
+
+Use parallel mapping when the exploration goal is broad and open-ended -- full onboarding, major refactor preparation, or comprehensive architectural review. Do NOT use for targeted questions about a single subsystem; the standard 4-phase flow is more efficient for focused exploration.
+
+### Agent Domains
+
+Launch 4 parallel agents using Task, each focused on a specific domain. Each agent follows the forbidden-files guardrail and writes a structured document.
+
+| Agent | Focus | Output File |
+|-------|-------|-------------|
+| **Technology Stack** | Languages, frameworks, dependencies, build tools, CI/CD pipelines, runtime requirements | `exploration/tech-stack.md` |
+| **Architecture** | Module structure, data flow, API boundaries, state management, component relationships, entry points | `exploration/architecture.md` |
+| **Code Quality** | Test coverage patterns, linting config, type safety, documentation density, code style conventions | `exploration/code-quality.md` |
+| **Risks & Concerns** | Technical debt indicators, security patterns, dependency health, TODO/FIXME/HACK density, deprecated APIs | `exploration/risks.md` |
+
+### Orchestration Rules
+
+1. **Phase 1 (DETECT) runs first, sequentially** -- All agents need the project type context from DETECT before they can explore effectively
+2. **Agents launch after DETECT gate passes** -- Spawn all 4 agents in parallel using Task
+3. **Each agent writes its own output file** -- Agents do not share context or coordinate
+4. **Timeout: 5 minutes per agent** -- If an agent times out, proceed with completed results. Minimum 3 of 4 agents MUST complete.
+5. **Orchestrator does NOT merge results** -- The parallel documents ARE the output. The orchestrator collects confirmations and line counts, then runs the post-exploration secret scan across all output files
+6. **Slight redundancy is acceptable** -- Both Architecture and Risks agents may note the same coupling issue. This is preferable to gaps from trying to deduplicate.
+
+### Agent Instructions Template
+
+Each parallel agent receives these instructions:
+
+```
+You are exploring a [language/framework] codebase focused on [DOMAIN].
+Project root: [absolute path]
+Project type: [from DETECT phase]
+
+RULES:
+- Read-only. NEVER modify files.
+- NEVER read files matching forbidden patterns: .env, .env.*, *.pem, *.key, credentials.json, secrets.*, *secret*, *credential*, *password*, token.json, .npmrc, .pypirc, .aws/credentials, .gcloud/, service-account*.json
+- All file paths in output MUST be absolute.
+- Every claim MUST cite an examined file.
+
+Write your findings to: exploration/[domain].md
+```
+
+### Post-Parallel Gate
+
+**Gate**: At least 3 of 4 domain agents completed. All output files exist. Secret scan passed across all output files. Each file contains file-backed evidence (not generic descriptions).
 
 ---
 

--- a/skills/explore-pipeline/SKILL.md
+++ b/skills/explore-pipeline/SKILL.md
@@ -58,6 +58,7 @@ This skill operates as an operator for systematic codebase exploration, configur
 - **Deep Dive**: Use `--deep` for comprehensive multi-layer analysis
 - **Quick Mode**: Use `--quick` for high-level overview only (skip Phase 3)
 - **Specific Focus**: Use `--focus [area]` to constrain exploration to a single component
+- **Explicit Tier Selection**: Use `--tier quick|standard|deep` to set exploration depth (see Tiered Depth Model below)
 
 ## What This Skill CAN Do
 - Systematically scan repository structure using parallel subagents
@@ -238,6 +239,105 @@ Solution:
 **What it looks like**: "Here are 10 things I would improve about this codebase"
 **Why wrong**: User asked to understand, not to change. Scope creep wastes time and adds noise.
 **Do instead**: Report what exists. Only recommend if user explicitly asks.
+
+### Anti-Pattern 5: Same Depth for Every Question
+**What it looks like**: Running all 4 phases with parallel scanners when the user just wants to know "what ORM does this use?"
+**Why wrong**: Wastes time and tokens. A 15-minute pipeline for a 2-minute question erodes trust in the tool.
+**Do instead**: Match depth to the question. Use the Tiered Depth Model below to select the right scope.
+
+---
+
+## Tiered Depth Model
+
+Not every exploration question needs the same depth. Running a full pipeline for a quick fact-check wastes time; running a shallow scan for onboarding misses critical context. The tier is determined by the caller, not guessed. If depth is unspecified, default to **Standard**.
+
+### Quick Verify (2-5 minutes)
+
+**Purpose**: Confirm a specific fact about the codebase.
+
+**Scope**: Answer one question. Read only the files necessary to answer it. No document generation -- the answer IS the output.
+
+**Phases used**: Phase 1 (SCAN) only -- single targeted scanner, not parallel.
+
+**Exit criteria**: Question answered with file path evidence, or "could not determine" with a list of what was checked.
+
+**Examples**:
+- "Does this project use dependency injection?"
+- "What ORM does the API use?"
+- "Is there a CI pipeline configured?"
+- "What version of React is this using?"
+
+**Output format**: Direct answer in conversation (no saved report file).
+
+### Standard (15-30 minutes)
+
+**Purpose**: Understand a subsystem or map one area of the codebase.
+
+**Scope**: All 4 phases execute. Parallel scanners in Phase 1. Produce a single structured document covering the targeted area.
+
+**Phases used**: All 4 phases (SCAN, MAP, ANALYZE, REPORT).
+
+**Exit criteria**: Report covers the subsystem's boundaries, key patterns, and integration points. Saved as `exploration-report.md`.
+
+**Examples**:
+- "How does authentication work in this app?"
+- "Map the payment processing flow."
+- "Explain how the event system works."
+- "What's the testing strategy for this repo?"
+
+**Output format**: Saved `exploration-report.md` with all sections.
+
+### Deep Dive (1+ hour)
+
+**Purpose**: Full architectural analysis for onboarding or major refactoring decisions.
+
+**Scope**: All 4 phases with expanded scope. Phase 1 uses additional scanners for broader coverage. Phase 3 traces multiple critical paths rather than just the primary one. Cross-cutting concerns (logging, auth, error handling) get dedicated analysis.
+
+**Phases used**: All 4 phases with expanded scope at each.
+
+**Exit criteria**: Comprehensive report covers full architecture, all major subsystems, cross-cutting concerns, and integration points. Multiple artifact files may be produced.
+
+**Examples**:
+- "I'm new to this codebase, give me the full picture."
+- "We're considering a major refactor -- what do we need to know?"
+- "Onboard me to this entire repository."
+- "Full architectural review before we plan next quarter."
+
+**Output format**: Saved `exploration-report.md` plus supplementary files (`architecture-map.md`, component-specific documents as needed).
+
+### Tier Selection Logic
+
+```
+If user specifies --tier or --quick or --deep:
+  Use the specified tier.
+Else if user asks a single specific question (what/which/does/is):
+  Use Quick Verify.
+Else if user asks about a specific subsystem or flow:
+  Use Standard.
+Else if user asks for full picture / onboarding / comprehensive:
+  Use Deep Dive.
+Else:
+  Default to Standard.
+```
+
+---
+
+## Source Hierarchy for Research
+
+When exploration requires looking up external information (framework conventions, library APIs, configuration options), follow this source hierarchy strictly. Lower-quality sources introduce hallucination risk -- a wrong framework convention applied confidently is worse than admitting uncertainty.
+
+### Hierarchy (highest to lowest priority)
+
+1. **Context7 MCP** (preferred) -- Use `resolve-library-id` then `query-docs` for up-to-date library documentation. This is the most reliable source because it pulls directly from official package documentation.
+2. **Official documentation** -- Framework and library official docs via WebFetch if Context7 does not cover the library.
+3. **Web search** -- Use WebSearch as a fallback when Context7 and official docs are insufficient. Cross-reference multiple results before citing.
+
+### Rules
+
+- **Never guess framework conventions** -- If you cannot confirm a convention from the source hierarchy, state "could not confirm" rather than assuming.
+- **Cite the source tier** -- When reporting externally-sourced information, note where it came from: "(confirmed via Context7)", "(from official docs)", or "(from web search -- verify independently)".
+- **Source code is ground truth** -- External documentation describes how things SHOULD work. The codebase shows how things ACTUALLY work. When they conflict, report both and flag the discrepancy.
+- **Web search results degrade fastest** -- Blog posts and Stack Overflow answers may reference outdated APIs. Always note the date if visible and prefer recent results.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds forbidden-files guardrail to codebase-overview (never read .env, credentials, keys)
- Adds parallel domain-specific mapping (4 agents: Tech, Architecture, Quality, Risks)
- Adds "Where to Add New Code" prescriptive output section
- Adds post-exploration secret scan before presenting results
- Adds tiered depth model to explore-pipeline (Quick Verify / Standard / Deep Dive)
- Adds source hierarchy (Context7 > official docs > web search)

## Test Plan
- [x] Existing content preserved in both skills
- [x] Forbidden files list covers common secret file patterns
- [x] Depth tiers have clear scope and time boundaries
- [x] Parallel mapping has timeout and minimum-completion gate