### PR TITLE
feat: add plant-seed skill for deferred work with triggers (ADR-075)

### DIFF
--- a/skills/feature-design/SKILL.md
+++ b/skills/feature-design/SKILL.md
@@ -95,7 +95,27 @@ Transform a feature idea into a structured design document through collaborative
    python3 scripts/feature-state.py context-read "" L2 --phase design
    ```
 
-**Gate**: Feature state initialized. Context loaded. Proceed to Execute.
+5. **Surface relevant seeds** (ADR-075): Check `.seeds/index.json` for dormant seeds whose trigger conditions match the current feature. Compare the feature name and description against each seed's `trigger` field using fuzzy keyword overlap. If matches are found, present them:
+
+   ```
+   ## Relevant Seeds (N matched)
+
+   ### seed-YYYY-MM-DD-slug [Scope]
+   Trigger: "trigger condition"
+   Rationale: Why this matters...
+   Action: What to do when triggered
+   Breadcrumbs: file1.go, file2.py
+
+   > Incorporate into current design? [yes/no/defer]
+   ```
+
+   - **yes**: Include the seed's action and rationale as a design input for Phase 1. Mark seed as `active` in index.json.
+   - **no**: Dismiss the seed (move to `.seeds/archived/`, status `dismissed`).
+   - **defer**: Leave the seed dormant for future surfacing.
+
+   If `.seeds/` does not exist or contains no dormant seeds, skip this step silently.
+
+**Gate**: Feature state initialized. Context loaded. Seeds surfaced (if any). Proceed to Execute.
 
 ### Phase 1: EXECUTE (Design Dialogue)
 
@@ -231,3 +251,4 @@ If gate is `auto`: verify checklist passes.
 - [Anti-Rationalization](../shared-patterns/anti-rationalization-core.md)
 - [Retro Loop](../shared-patterns/retro-loop.md)
 - [State Conventions](../_feature-shared/state-conventions.md)
+- [Plant Seed](../plant-seed/SKILL.md) — seed-based deferred work surfaced in Phase 0 (ADR-075)

--- a/skills/plant-seed/SKILL.md
+++ b/skills/plant-seed/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: plant-seed
+description: |
+  Capture a forward-looking idea as a seed with trigger conditions, scope, and
+  rationale so it surfaces automatically during future feature design. Use for
+  "plant seed", "save this idea for later", "defer this idea", "remember this
+  for when", "seed", or "/plant-seed". Do NOT use for TODOs, immediate tasks,
+  bug reports, or work that should happen in the current session.
+version: 1.0.0
+user-invocable: true
+command: /plant-seed
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Grep
+  - Glob
+  - Edit
+routing:
+  triggers:
+    - plant seed
+    - save idea for later
+    - defer this idea
+    - remember this for when
+    - seed this
+    - plant-seed
+  pairs_with:
+    - feature-design
+  complexity: Simple
+  category: process
+---
+
+# Plant Seed Skill
+
+## Purpose
+
+Capture forward-looking ideas with trigger conditions so they resurface at the right time. Seeds carry WHY (rationale) and WHEN (trigger), making them far more valuable than bare TODO comments. Seeds are stored locally in `.seeds/` and automatically surfaced during feature-design when their trigger conditions match.
+
+## Operator Context
+
+### Hardcoded Behaviors (Always Apply)
+- **CLAUDE.md Compliance**: Read and follow repository CLAUDE.md before execution
+- **Local Storage Only**: Seeds go in `.seeds/` which is gitignored -- seeds are personal, not shared via version control. WHY: Different developers have different ideas and different trigger conditions; committing seeds pollutes the shared repo with personal notes.
+- **No Immediate Work**: Seeds are for deferred ideas. If the user describes something that should happen now, suggest creating a task or issue instead. WHY: Planting a seed for current-session work means it never gets surfaced -- it just gets forgotten in a different way.
+- **Breadcrumb Discovery**: Always grep for related files at capture time. WHY: Breadcrumbs preserve code references from capture time. Even if the codebase evolves, these paths help the user re-orient when the seed surfaces months later.
+- **Unique IDs**: Seed IDs follow the format `seed-YYYY-MM-DD-slug` to ensure uniqueness and chronological sorting.
+
+### Default Behaviors (ON unless disabled)
+- **Interactive Capture**: Ask clarifying questions about trigger condition and scope if not provided
+- **Breadcrumb Grep**: Search the codebase for files related to the seed's topic
+- **Confirmation Before Write**: Show the complete seed to the user before saving
+
+### Optional Behaviors (OFF unless enabled)
+- **Batch Planting**: Capture multiple seeds in one session (enable with "plant several seeds")
+- **Seed Review**: List and manage existing seeds (enable with "review seeds" or "list seeds")
+
+## What This Skill CAN Do
+- Capture a deferred idea with structured metadata (trigger, scope, rationale, action, breadcrumbs)
+- Search the codebase for related files to attach as breadcrumbs
+- Store seeds in `.seeds/index.json` with consistent structure
+- List existing seeds and their status
+- Archive seeds that have been harvested or dismissed
+
+## What This Skill CANNOT Do
+- Execute the deferred work (that happens during feature-design when the seed is surfaced)
+- Automatically detect when a trigger condition is met (feature-design does fuzzy matching)
+- Share seeds across machines or developers (seeds are local by design)
+- Create TODOs, issues, or tasks (use appropriate tools for immediate work)
+
+---
+
+## Instructions
+
+### Phase 1: CAPTURE
+
+**Goal**: Gather the idea, trigger condition, scope, and rationale from the user.
+
+**Step 1: Understand the idea**
+
+Extract from the user's description:
+- **What** (action): The specific thing to do when the time is right
+- **Why** (rationale): The insight or observation that motivates this idea
+- **When** (trigger): A human-readable string describing when this becomes relevant
+
+If the user provides all three, proceed. If any are missing, ask:
+
+For missing **trigger condition**:
+> When should this idea resurface? Describe the condition, e.g.:
+> - "when we add user accounts"
+> - "when performance optimization is needed"
+> - "when the API exceeds 10 endpoints"
+
+For missing **scope**:
+> How big is this work? Small (< 1 hour), Medium (1-4 hours), or Large (4+ hours)?
+
+For missing **rationale**:
+> Why does this matter? What's the insight behind this idea? (e.g., "Response times degrade linearly with DB calls per request -- at 10+ endpoints the shared query pattern becomes the bottleneck")
+
+**Step 2: Generate seed ID**
+
+Format: `seed-YYYY-MM-DD-slug`
+- Date is today's date
+- Slug is a short kebab-case summary of the action (3-5 words max)
+
+Example: `seed-2026-03-22-cache-layer`
+
+**Step 3: Discover breadcrumbs**
+
+Search the codebase for files related to the seed's topic. Use the Grep tool with 2-3 key terms from the seed's action and rationale. Collect up to 10 file paths as breadcrumbs.
+
+If no files match, breadcrumbs can be empty -- the seed is still valuable without them.
+
+**Gate**: Idea captured with all required fields (action, trigger, scope, rationale). Breadcrumbs discovered. Proceed to Confirm.
+
+### Phase 2: CONFIRM
+
+**Goal**: Show the complete seed to the user and get approval before writing.
+
+Present the seed:
+
+```
+## Seed: seed-YYYY-MM-DD-slug [Scope]
+
+Trigger: "human-readable trigger condition"
+Rationale: Why this matters...
+Action: What to do when triggered...
+Breadcrumbs: file1.go, file2.py, ...
+
+Plant this seed? [yes/no/edit]
+```
+
+Handle response:
+- **yes**: Proceed to Write
+- **no**: Discard and confirm the seed was not saved
+- **edit**: Ask what to change, update fields, re-confirm
+
+**Gate**: User approved the seed. Proceed to Write.
+
+### Phase 3: WRITE
+
+**Goal**: Persist the seed to `.seeds/index.json`.
+
+**Step 1: Ensure directory exists**
+
+```bash
+mkdir -p .seeds/archived
+```
+
+**Step 2: Read or initialize index.json**
+
+If `.seeds/index.json` exists, read it. Otherwise, initialize:
+
+```json
+{
+  "seeds": []
+}
+```
+
+**Step 3: Append seed**
+
+Add the new seed to the `seeds` array:
+
+```json
+{
+  "id": "seed-YYYY-MM-DD-slug",
+  "status": "dormant",
+  "planted": "YYYY-MM-DD",
+  "trigger": "human-readable trigger condition",
+  "scope": "Small|Medium|Large",
+  "rationale": "Why this matters...",
+  "action": "What to do when triggered...",
+  "breadcrumbs": ["path/to/file1.go", "path/to/file2.py"]
+}
+```
+
+**Step 4: Write updated index.json**
+
+Write the complete updated index back to `.seeds/index.json`.
+
+**Step 5: Confirm to user**
+
+```
+Seed planted: seed-YYYY-MM-DD-slug [Scope]
+Trigger: "condition"
+Status: dormant
+
+This seed will surface automatically during /feature-design when the
+trigger condition matches. Review all seeds with: /plant-seed "list seeds"
+```
+
+**Gate**: Seed persisted to `.seeds/index.json`. Workflow complete.
+
+---
+
+### Seed Review Mode
+
+When the user asks to "list seeds", "review seeds", or "show my seeds":
+
+1. Read `.seeds/index.json`
+2. Display all dormant seeds:
+
+```
+## Dormant Seeds (N total)
+
+| ID | Scope | Trigger | Planted |
+|----|-------|---------|---------|
+| seed-2026-03-22-cache-layer | Medium | when the API exceeds 10 endpoints | 2026-03-22 |
+| seed-2026-03-20-user-auth | Large | when we add user accounts | 2026-03-20 |
+```
+
+3. Offer actions: "Want to activate, dismiss, or edit any seed?"
+
+### Seed Lifecycle Actions
+
+**Harvest**: Move seed to `.seeds/archived/{seed-id}.json`, set status to `harvested`. Use when the seed's work has been incorporated into a feature.
+
+**Dismiss**: Move seed to `.seeds/archived/{seed-id}.json`, set status to `dismissed`. Use when the seed is no longer relevant.
+
+**Activate**: Change status from `dormant` to `active` in index.json. Use when the trigger condition has been met but work hasn't started yet.
+
+To archive: remove the seed from `index.json` and write it as a standalone file to `.seeds/archived/{seed-id}.json`.
+
+---
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `.seeds/` directory doesn't exist | First seed being planted | Create directory with `mkdir -p .seeds/archived` |
+| `index.json` is malformed | Manual edit or corruption | Back up to `index.json.bak`, reinitialize with empty seeds array, warn user |
+| Duplicate seed ID | Two seeds planted same day with same slug | Append `-2`, `-3` to slug |
+| No breadcrumbs found | Idea is forward-looking, no related code yet | Plant with empty breadcrumbs -- still valuable |
+| User describes immediate work | Seed system is for deferred work | Suggest creating a task or doing the work now |
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Wrong | Do Instead |
+|--------------|-----------|------------|
+| Planting seeds for current-session work | Seeds are for deferred ideas, not TODOs | Create a task or do the work now |
+| Vague trigger like "someday" or "eventually" | Cannot be matched during feature-design | Ask for a specific, observable condition |
+| Missing rationale ("it would be nice") | Without WHY, the seed loses value when surfaced months later | Capture the specific insight or observation |
+| Planting too many seeds at once | Seed fatigue -- too many dormant seeds become noise | Keep seeds focused and high-signal |
+| Storing seeds in version control | Seeds are personal/local; committing pollutes shared repo | Keep in gitignored `.seeds/` directory |
+
+## Anti-Rationalization
+
+See [core patterns](../shared-patterns/anti-rationalization-core.md).
+
+Domain-specific for plant-seed:
+
+| Rationalization | Why Wrong | Action |
+|-----------------|-----------|--------|
+| "I'll remember this idea" | You won't -- context is ephemeral | Plant the seed now |
+| "A TODO comment is enough" | TODOs lack trigger conditions and rationale | Use seed for deferred work, TODO for next-session work |
+| "The trigger is obvious" | Obvious to you now, opaque in 3 months | Write an explicit, human-readable trigger condition |
+| "Breadcrumbs aren't important" | Code references ground the seed in the codebase | Always grep, even if results are sparse |
+| "This seed is too small to bother" | Small seeds with good triggers have the best signal-to-noise | Plant it -- small seeds are low cost, high value |
+
+## References
+
+- [Feature Design](../feature-design/SKILL.md) - Seeds are surfaced during feature-design Phase 0
+- [Anti-Rationalization](../shared-patterns/anti-rationalization-core.md) - Core rationalization prevention


### PR DESCRIPTION
## Summary
- New plant-seed skill: capture forward-looking ideas with trigger conditions
- Seeds have: id, status (dormant/active/harvested/dismissed), trigger, scope, rationale, breadcrumbs
- Auto-surfacing during feature-design when triggers match current feature
- Stored in gitignored .seeds/index.json (local, not committed)
- Seed review mode: list/activate/harvest/dismiss lifecycle
- Feature-design enhanced with seed surfacing step in Phase 0

## Test Plan
- [x] New skill follows SKILL.md template with frontmatter
- [x] Feature-design modification is additive only
- [x] .seeds/ storage is gitignored (local to user)