### PR TITLE
feat: add fast and quick task execution tiers (ADR-077)

### DIFF
--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -150,6 +150,8 @@ These skills have MANDATORY routing. They MUST be invoked when triggers appear:
 | **pr-sync** | push, push this, push changes, commit and push, push to GitHub, sync to GitHub, create a PR, create PR, open PR, open pull request, ship this, send this |
 | **git-commit-flow** | commit, commit this, commit changes, stage and commit |
 | **github-actions-check** | check CI, CI status, actions status, did CI pass, are tests passing |
+| **fast** | quick fix, typo fix, one-line change, trivial fix, rename variable, update value, fix import |
+| **quick** | quick task, small change, ad hoc task, add a flag, extract function, small refactor, targeted fix |
 | **install** | install toolkit, verify installation, health check toolkit, toolkit setup, /install |
 
 If a force-route trigger matches, invoke that skill BEFORE any other action.

--- a/skills/do/references/routing-tables.md
+++ b/skills/do/references/routing-tables.md
@@ -8,6 +8,8 @@ Extended routing tables for the `/do` router. The main SKILL.md contains the cor
 
 | Triggers | Skill |
 |----------|-------|
+| **quick fix, typo fix, one-line change, trivial fix** | **fast (FORCE)** |
+| **quick task, small change, ad hoc task, add a flag, extract function** | **quick (FORCE)** |
 | branch name | branch-naming |
 | git commit | git-commit-flow |
 | lint, format | code-linting |
@@ -234,6 +236,10 @@ Invoked via the roast skill or directly:
 
 | Request | Routes To |
 |---------|-----------|
+| "fix the typo in main.go" | **fast (FORCE)** |
+| "rename this variable" | **fast (FORCE)** |
+| "add a --verbose flag to the CLI" | **quick (FORCE)** |
+| "small refactor: extract helper function" | **quick (FORCE)** |
 | "debug Go tests" | golang-general-engineer + systematic-debugging |
 | "write Go tests for X" | **go-testing (FORCE)** |
 | "add worker pool" | **go-concurrency (FORCE)** |

--- a/skills/fast/SKILL.md
+++ b/skills/fast/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: fast
+description: |
+  Zero-ceremony inline execution for tasks completable in 3 or fewer file
+  edits. No plan, no subagent, no research — just understand, do, commit, log.
+  Use for "quick fix", "typo fix", "one-line change", "trivial fix", "rename
+  this variable", "update this value", "fix this import". Do NOT use for tasks
+  requiring research, planning, new dependencies, or more than 3 file edits —
+  redirect to /quick instead.
+version: 1.0.0
+user-invocable: true
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+  - Skill
+routing:
+  triggers:
+    - quick fix
+    - typo fix
+    - one-line change
+    - trivial fix
+    - rename variable
+    - update value
+    - fix import
+  pairs_with: []
+  complexity: Simple
+  category: process
+---
+
+# /fast - Zero-Ceremony Execution
+
+## Operator Context
+
+This skill implements the Fast tier from the five-tier task hierarchy (Fast > Quick > Simple > Medium > Complex). It exists because the full ceremony of plan files, agent routing, and quality gates is wasteful for a typo fix. The process should scale down to match the task.
+
+### Hardcoded Behaviors (Always Apply)
+- **3-Edit Scope Limit**: If the task requires more than 3 file edits, STOP and redirect to `/quick`. The work done so far is preserved — do not restart. This gate exists because uncapped "fast" tasks silently grow into untracked large changes.
+- **No Plan File**: Do not create `task_plan.md`. The overhead of planning exceeds the task itself at this tier.
+- **No Subagent Spawning**: Execute inline. Subagents add latency and context setup cost that dwarfs the actual work.
+- **No Research Phase**: If the task requires reading documentation, investigating behavior, or understanding unfamiliar code, it is not a Fast task. Redirect to `/quick --research`.
+- **No New Dependencies**: If the task requires adding imports from new packages, installing libraries, or modifying dependency files (go.mod, package.json, requirements.txt), redirect to `/quick`.
+- **CLAUDE.md Compliance**: Read and follow repository CLAUDE.md before execution.
+- **Branch Safety**: Create a feature branch if currently on main/master. Even fast tasks get proper branches.
+- **Commit After Edit**: Every fast task ends with a commit. Uncommitted fast edits defeat the auditability that justifies using the system at all.
+
+### Default Behaviors (ON unless disabled)
+- **STATE.md Logging**: Append completed task to STATE.md quick tasks table (create if absent)
+- **Conventional Commits**: Use conventional commit format for the commit message
+- **Edit Counting**: Track edits during execution to enforce the 3-edit scope gate
+
+### Optional Behaviors (OFF unless enabled)
+- **No Commit Mode** (`--no-commit`): Skip the commit step (for when the user wants to batch changes)
+- **Dry Run** (`--dry-run`): Show what would change without editing
+
+## What This Skill CAN Do
+- Fix typos, rename variables, update config values, fix imports
+- Make 1-3 targeted file edits and commit them
+- Log the action to STATE.md for auditability
+
+## What This Skill CANNOT Do
+- Research unfamiliar code or APIs (redirect to `/quick --research`)
+- Add new dependencies (redirect to `/quick`)
+- Edit more than 3 files (redirect to `/quick`)
+- Run quality gates or parallel reviews (those belong to Simple+ tiers)
+- Create plans or spawn subagents
+
+---
+
+## Instructions
+
+### Phase 1: UNDERSTAND
+
+**Goal**: Confirm the task is Fast-eligible and know exactly what to change.
+
+**Step 1: Read the request**
+
+Parse the user's request to identify:
+- Which file(s) need editing
+- What specific change is needed
+- Whether this is clearly a 1-3 edit task
+
+**Step 2: Scope check**
+
+Ask these questions silently (do not display to user):
+- Does this need research or investigation? If yes -> redirect to `/quick --research`
+- Does this touch more than 3 files? If yes -> redirect to `/quick`
+- Does this add new dependencies? If yes -> redirect to `/quick`
+- Is the change ambiguous or underspecified? If yes -> ask user for clarification
+
+If redirecting, say:
+```
+This task exceeds /fast scope ([reason]). Redirecting to /quick.
+```
+Then invoke the quick skill with the original request.
+
+**Step 3: Locate target files**
+
+Read the file(s) that need editing. Confirm the exact lines to change.
+
+**GATE**: Task is confirmed Fast-eligible (1-3 edits, no research, no new deps). Target files identified and read.
+
+### Phase 2: DO
+
+**Goal**: Make the edits.
+
+**Step 1: Execute edits**
+
+Make the changes using Edit tool. Track the number of files edited.
+
+**Step 2: Mid-execution scope check**
+
+After each edit, check: have we hit 3 edits? If the task needs MORE edits to complete:
+
+```
+Scope exceeded during execution (3+ edits needed). Preserving work done.
+Redirecting remainder to /quick.
+```
+
+Hand off to `/quick` with context about what was already done.
+
+**GATE**: All edits complete. Edit count is 1-3.
+
+### Phase 3: COMMIT
+
+**Goal**: Commit the changes with a clean message.
+
+**Step 1: Check branch**
+
+If on main/master, create a feature branch first:
+```bash
+git checkout -b fast/<brief-description>
+```
+
+**Step 2: Stage and commit**
+
+```bash
+git add <specific-files>
+git commit -m "$(cat <<'EOF'
+<type>: <description>
+EOF
+)"
+```
+
+Use conventional commit format. The type is usually `fix:`, `chore:`, or `refactor:` for fast tasks.
+
+**GATE**: Commit succeeded. Verify with `git log -1 --oneline`.
+
+### Phase 4: LOG
+
+**Goal**: Record the task for auditability.
+
+**Step 1: Append to STATE.md**
+
+If STATE.md exists in the repo root, append to the quick tasks table. If it does not exist, create it.
+
+Format:
+```markdown
+## Quick Tasks
+
+| Date | ID | Description | Commit | Tier |
+|------|----|-------------|--------|------|
+| YYYY-MM-DD | - | <description> | <short-hash> | fast |
+```
+
+Fast tasks do not get task IDs (that is a Quick-tier feature). Use `-` for the ID column.
+
+**Step 2: Display summary**
+
+```
+===================================================================
+ FAST: <description>
+===================================================================
+
+ Files edited: <N>
+ Commit: <hash> on <branch>
+ Logged: STATE.md
+
+===================================================================
+```
+
+---
+
+## Error Handling
+
+### Error: Scope Exceeded Mid-Execution
+**Cause**: Task turned out to need more than 3 edits
+**Solution**: Stop, preserve work, redirect to `/quick` with context about completed edits. Do not undo work already done.
+
+### Error: Ambiguous Request
+**Cause**: Cannot determine exact files or changes from the request
+**Solution**: Ask user one clarifying question. If still ambiguous after one round, redirect to `/quick --discuss`.
+
+### Error: On Main Branch
+**Cause**: Currently on main/master
+**Solution**: Create `fast/<description>` branch before editing. Never commit directly to main.
+
+---
+
+## Anti-Patterns
+
+### Anti-Pattern 1: Using Fast for Investigation
+**What it looks like**: Reading 5 files to understand a bug before fixing it
+**Why wrong**: Investigation is research. Fast is for when you already know what to change.
+**Do instead**: Use `/quick --research` for tasks that need understanding first.
+
+### Anti-Pattern 2: Skipping the Commit
+**What it looks like**: Making fast edits but not committing because "it's just a small change"
+**Why wrong**: Uncommitted changes are invisible to the audit trail. The whole point of /fast over raw editing is traceability.
+**Do instead**: Always commit. Use `--no-commit` only when explicitly batching.
+
+### Anti-Pattern 3: Stretching Scope
+**What it looks like**: "While I'm here, let me also fix this other thing" — turning 2 edits into 6
+**Why wrong**: Scope creep in fast mode produces untracked large changes with no plan or review
+**Do instead**: Stop at 3 edits. Open a new `/fast` or `/quick` for additional work.
+
+---
+
+## Anti-Rationalization
+
+| Rationalization | Why It's Wrong | Required Action |
+|-----------------|----------------|-----------------|
+| "Just one more edit won't hurt" | The 3-edit gate exists to prevent silent scope creep | Redirect to /quick at edit 4 |
+| "This is basically fast, just needs a little research" | Research means uncertainty; uncertainty means /quick | Redirect to /quick --research |
+| "No need to commit a one-line change" | One-line changes cause one-line bugs that are invisible without commits | Commit every fast task |
+| "STATE.md logging is overhead" | Without logging, fast tasks are invisible — defeating auditability | Always log to STATE.md |

--- a/skills/quick/SKILL.md
+++ b/skills/quick/SKILL.md
@@ -1,0 +1,398 @@
+---
+name: quick
+description: |
+  Tracked lightweight execution with composable rigor flags for tasks between
+  a typo fix and a full feature. Plan + execute with optional --discuss,
+  --research, and --full flags to add rigor incrementally. Use for "quick task",
+  "small change", "ad hoc task", "add a flag", "extract function", "small
+  refactor", "fix bug in X". Do NOT use for multi-component features,
+  architectural changes, or anything needing wave-based parallel execution —
+  those are Simple+ tier.
+version: 1.0.0
+user-invocable: true
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+  - Skill
+  - Task
+routing:
+  triggers:
+    - quick task
+    - small change
+    - ad hoc task
+    - add a flag
+    - extract function
+    - small refactor
+    - targeted fix
+  pairs_with:
+    - fast
+  complexity: Simple
+  category: process
+---
+
+# /quick - Tracked Lightweight Execution
+
+## Operator Context
+
+This skill implements the Quick tier from the five-tier task hierarchy (Fast > Quick > Simple > Medium > Complex). It fills the gap between zero-ceremony `/fast` (1-3 edits, no plan) and full-ceremony Simple+ (task_plan.md, agent routing, quality gates). Quick tasks get a lightweight plan and tracking without the overhead of the full pipeline.
+
+The key design principle is **composable rigor**: the base mode is minimal (plan + execute), and users add process incrementally via flags rather than getting all-or-nothing ceremony.
+
+### Hardcoded Behaviors (Always Apply)
+- **CLAUDE.md Compliance**: Read and follow repository CLAUDE.md before execution.
+- **Task ID Assignment**: Every quick task gets a unique ID in YYMMDD-xxx format (Base36 sequence). This enables tracking and cross-referencing.
+- **Inline Plan**: Create a brief inline plan (not a full task_plan.md) before executing. The plan is 3-5 lines: what changes, which files, why. This is the minimum viable plan — enough to catch misunderstandings before editing.
+- **STATE.md Logging**: Log task ID, description, status, and commit hash to STATE.md.
+- **Branch Safety**: Create a feature branch if on main/master.
+- **Commit After Execute**: Every quick task ends with a commit.
+- **No Parallel Execution**: Quick tasks are single-threaded. If parallelism is needed, upgrade to Simple+.
+
+### Default Behaviors (ON unless disabled)
+- **Feature Branch Per Task**: Create `quick/<task-id>-<description>` branch for each task. This keeps quick work isolated and reviewable.
+- **Conventional Commits**: Use conventional commit format.
+- **Edit Tracking**: Count edits for scope awareness (warn at 10+, suggest upgrade at 15+).
+
+### Optional Behaviors (OFF unless enabled)
+- **`--discuss`**: Add a pre-planning discussion phase to resolve ambiguities before committing to a plan. Use when requirements are unclear or the user says "I'm not sure exactly what I want."
+- **`--research`**: Add a research phase before planning to understand existing code, read related files, and build context. Use when the change touches unfamiliar code.
+- **`--full`**: Add plan verification + full quality gates after execution. Use when the change is small but high-risk (auth, payments, data migration).
+- **`--no-branch`**: Skip feature branch creation, work on current branch. Use when contributing to an existing feature branch.
+- **`--no-commit`**: Skip the commit step. Use when batching multiple quick tasks into one commit.
+
+## What This Skill CAN Do
+- Plan and execute targeted code changes (4-15 file edits)
+- Track tasks with unique IDs for auditability
+- Compose rigor levels via flags (--discuss, --research, --full)
+- Create isolated feature branches per task
+- Escalate from /fast when scope is exceeded
+
+## What This Skill CANNOT Do
+- Spawn subagents or parallel workers (upgrade to Simple+)
+- Manage multi-component features (use feature lifecycle skills)
+- Run wave-based parallel execution (use dispatching-parallel-agents)
+- Replace full task_plan.md planning (that is Simple+ tier)
+
+---
+
+## Instructions
+
+### Phase 0: DISCUSS (only with --discuss flag)
+
+**Goal**: Resolve ambiguities before planning.
+
+This phase activates when the user passes `--discuss` or the request contains signals of uncertainty ("not sure", "maybe", "could be", "what do you think").
+
+**Step 1: Identify ambiguities**
+
+Read the request and list specific questions:
+- What exactly should change? (if underspecified)
+- Which approach among alternatives? (if multiple valid paths)
+- What are the acceptance criteria? (if success is unclear)
+
+**Step 2: Present questions**
+
+```
+===================================================================
+ QUICK DISCUSS: <task summary>
+===================================================================
+
+ Before planning, I need to resolve:
+
+ 1. <question>
+ 2. <question>
+
+===================================================================
+```
+
+Wait for user response. Do not proceed until ambiguities are resolved.
+
+**GATE**: All ambiguities resolved. Proceed to Phase 0.5 or Phase 1.
+
+### Phase 0.5: RESEARCH (only with --research flag)
+
+**Goal**: Build understanding of the relevant code before planning.
+
+This phase activates when the user passes `--research` or the task touches code that needs investigation.
+
+**Step 1: Identify scope**
+
+Determine which files and patterns need reading to understand the change.
+
+**Step 2: Read and analyze**
+
+Read relevant source files, tests, and configuration. Build a mental model of:
+- Current behavior
+- Where the change fits
+- What might break
+
+**Step 3: Summarize findings**
+
+Present a brief (3-5 line) summary of what you learned and how it affects the plan.
+
+**GATE**: Sufficient understanding to plan the change. Proceed to Phase 1.
+
+### Phase 1: PLAN
+
+**Goal**: Create a lightweight inline plan.
+
+**Step 1: Generate task ID**
+
+Format: `YYMMDD-xxx` where xxx is Base36 sequential.
+
+To determine the next sequence number:
+```bash
+# Check STATE.md for today's tasks to determine next sequence
+date_prefix=$(date +%y%m%d)
+```
+
+If STATE.md exists in the repo root, find the highest sequence number for today's date prefix and increment. If no tasks today, start at `001`. Use Base36 (0-9, a-z) for the sequence: 001, 002, ... 009, 00a, 00b, ... 00z, 010, ...
+
+**Step 2: Create inline plan**
+
+Display the plan — do NOT write a task_plan.md file:
+
+```
+===================================================================
+ QUICK [task-id]: <description>
+===================================================================
+
+ Plan:
+   1. <what to change in file X>
+   2. <what to change in file Y>
+   3. <why: brief rationale>
+
+ Files: <file1>, <file2>
+ Estimated edits: <N>
+
+===================================================================
+```
+
+If estimated edits exceed 15, suggest upgrading:
+```
+This task estimates 15+ edits. Consider using /do for full planning
+and agent routing. Proceed with /quick anyway? [Y/n]
+```
+
+**Step 3: Create feature branch** (unless --no-branch)
+
+```bash
+git checkout -b quick/<task-id>-<brief-kebab-description>
+```
+
+**GATE**: Task ID assigned, plan displayed, branch created. Proceed to Phase 2.
+
+### Phase 2: EXECUTE
+
+**Goal**: Implement the plan.
+
+**Step 1: Make edits**
+
+Execute the changes described in the plan. Track edit count.
+
+**Step 2: Scope monitoring**
+
+- At 10 edits: display a warning — "10 edits reached. Quick tasks typically stay under 15."
+- At 15 edits: suggest upgrade — "15 edits reached. This may benefit from /do with full planning. Continue? [Y/n]"
+- No hard cap — the user decides. Quick's scope is advisory, not enforced like Fast's 3-edit gate.
+
+**Step 3: Verify changes** (base mode)
+
+Run a quick sanity check:
+```bash
+# Check for syntax errors in edited files (language-appropriate)
+# e.g., python3 -m py_compile file.py, go build ./..., tsc --noEmit
+```
+
+If `--full` flag is set, run the full quality gate instead (see Phase 2.5).
+
+**GATE**: All planned edits complete. Sanity check passes.
+
+### Phase 2.5: VERIFY (only with --full flag)
+
+**Goal**: Run full quality gates on the changes.
+
+**Step 1: Run tests**
+
+```bash
+# Run tests for affected packages/modules only
+# Do not run full test suite unless explicitly requested
+```
+
+**Step 2: Lint check**
+
+Run the repo's configured linter on changed files.
+
+**Step 3: Review changes**
+
+```bash
+git diff
+```
+
+Review the diff for:
+- Unintended changes
+- Missing error handling
+- Broken imports
+
+**GATE**: Tests pass, lint clean, diff reviewed. Proceed to Phase 3.
+
+### Phase 3: COMMIT
+
+**Goal**: Commit with a clean message.
+
+**Step 1: Stage changes**
+
+```bash
+git add <specific-files>
+```
+
+**Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+<type>: <description>
+
+Quick task <task-id>
+EOF
+)"
+```
+
+Include the task ID in the commit body for traceability.
+
+**GATE**: Commit succeeded. Verify with `git log -1 --oneline`.
+
+### Phase 4: LOG
+
+**Goal**: Record the task in STATE.md.
+
+**Step 1: Update STATE.md**
+
+If STATE.md does not exist in the repo root, create it:
+
+```markdown
+# Task State
+
+## Quick Tasks
+
+| Date | ID | Description | Commit | Branch | Tier | Status |
+|------|----|-------------|--------|--------|------|--------|
+```
+
+Append the new task:
+
+```markdown
+| YYYY-MM-DD | <task-id> | <description> | <short-hash> | <branch> | quick | done |
+```
+
+If the task was escalated from `/fast`, note the tier as `fast->quick`.
+
+**Step 2: Display summary**
+
+```
+===================================================================
+ QUICK [task-id]: COMPLETE
+===================================================================
+
+ Description: <description>
+ Files edited: <N>
+ Commit: <hash> on <branch>
+ Flags: <--discuss, --research, --full, or "base">
+ Logged: STATE.md
+
+ Next steps:
+   - Push: /pr-sync
+   - More work: /quick <next task>
+   - Merge to parent: git merge quick/<task-id>-...
+
+===================================================================
+```
+
+---
+
+## Examples
+
+### Example 1: Base Mode
+User says: `/quick add --verbose flag to the CLI`
+1. Generate ID: 260322-001
+2. Plan: add flag definition, wire to handler, update help text (3 edits)
+3. Create branch: `quick/260322-001-add-verbose-flag`
+4. Execute edits, commit, log to STATE.md
+
+### Example 2: With Research
+User says: `/quick --research fix the timeout bug in auth middleware`
+1. RESEARCH: Read auth middleware, identify timeout source, trace call path
+2. PLAN: change timeout value in config, update middleware to use it (2 edits)
+3. EXECUTE, COMMIT, LOG
+
+### Example 3: Escalated from Fast
+`/fast` hit 3-edit limit while fixing a bug across 5 files.
+1. Quick picks up with context: "Continuing from /fast — 3 files already edited"
+2. PLAN: remaining 2 files to edit
+3. EXECUTE remaining edits, COMMIT all changes, LOG as tier `fast->quick`
+
+### Example 4: Full Rigor
+User says: `/quick --full update payment amount rounding logic`
+1. PLAN: identify rounding function, change to banker's rounding
+2. EXECUTE the edit
+3. VERIFY: run payment tests, lint, review diff
+4. COMMIT, LOG
+
+---
+
+## Error Handling
+
+### Error: Task ID Collision
+**Cause**: Two quick tasks started in the same second with the same sequence
+**Solution**: Increment the sequence number. If STATE.md is corrupted, scan git log for `Quick task YYMMDD-` patterns to find the true next ID.
+
+### Error: Scope Exceeds Quick Tier
+**Cause**: Task requires 15+ edits, multiple components, or parallel work
+**Solution**: Display upgrade suggestion. If user confirms, continue in quick mode. If user wants full ceremony, invoke `/do` with the original request.
+
+### Error: Test Failure in --full Mode
+**Cause**: Quality gate found issues with the changes
+**Solution**: Fix the failing tests. If the fix requires significant additional work, note it in STATE.md and suggest a follow-up `/quick` task rather than expanding scope.
+
+### Error: Branch Conflict
+**Cause**: Branch `quick/<task-id>-...` already exists
+**Solution**: Increment the task ID sequence number and try again.
+
+---
+
+## Anti-Patterns
+
+### Anti-Pattern 1: Skipping the Plan
+**What it looks like**: Jumping straight to edits without displaying the inline plan
+**Why wrong**: The plan catches misunderstandings before they become wrong edits. It takes 10 seconds and saves minutes.
+**Do instead**: Always display the inline plan. Even for obvious tasks — it confirms alignment.
+
+### Anti-Pattern 2: Using Quick for Features
+**What it looks like**: Building a multi-component feature as a series of `/quick` tasks
+**Why wrong**: Features need design docs, coordinated implementation, and integration testing. Quick tasks are isolated units.
+**Do instead**: Use the feature lifecycle (`/feature-design` -> `/feature-plan` -> `/feature-implement`).
+
+### Anti-Pattern 3: Never Using Flags
+**What it looks like**: Always running base `/quick` even when research or verification is clearly needed
+**Why wrong**: Base mode assumes you know exactly what to change. When you don't, you make wrong changes faster.
+**Do instead**: Use `--research` when touching unfamiliar code, `--discuss` when requirements are unclear, `--full` when the change is high-risk.
+
+### Anti-Pattern 4: Using Quick to Avoid Planning
+**What it looks like**: Classifying a Simple+ task as "quick" to skip task_plan.md
+**Why wrong**: The inline plan is not a substitute for full planning. Complex tasks need full plans.
+**Do instead**: If the task genuinely needs a full plan, use `/do` and let the router classify properly.
+
+---
+
+## Anti-Rationalization
+
+| Rationalization | Why It's Wrong | Required Action |
+|-----------------|----------------|-----------------|
+| "This is quick, no need for a plan" | Quick's inline plan IS the minimum — skipping it means no plan at all | Display the inline plan |
+| "15 edits but it's all simple stuff" | Edit count is a scope signal, not a difficulty signal | Show the upgrade suggestion at 15 |
+| "I'll add the task ID later" | Later never comes; untracked tasks are invisible | Assign ID in Phase 1 |
+| "No need for a branch, it's small" | Small changes on main break the same as big ones | Create feature branch (or use --no-branch explicitly) |
+| "Skip --research, I know this code" | Confidence != correctness; /fast exists for when you truly know | Use --research when touching unfamiliar code |
+| "Don't need --full for this" | Risk is about impact, not size; a one-line auth change can be catastrophic | Use --full for any security/payment/data change |


### PR DESCRIPTION
## Summary
- New fast skill: zero-ceremony for 3 or fewer file edits (no plan, no subagent)
- New quick skill: tracked lightweight pipeline with composable --discuss/--research/--full flags
- Both registered as force-route triggers in /do router
- Five-tier classification: Fast → Quick → Simple → Medium → Complex

## Test Plan
- [x] Both skills have proper frontmatter
- [x] /do router force-route entries added for both
- [x] Routing tables updated with new tiers