### PR TITLE
fix: sort imports in error-learner.py to pass ruff I001

### DIFF
--- a/hooks/error-learner.py
+++ b/hooks/error-learner.py
@@ -22,7 +22,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from feedback_tracker import check_pending_feedback, set_pending_feedback
-from stdin_timeout import read_stdin
 from learning_db_v2 import (
     DEFAULT_FIX_ACTIONS,
     boost_confidence,
@@ -32,6 +31,7 @@ from learning_db_v2 import (
     lookup_error_solution,
     record_learning,
 )
+from stdin_timeout import read_stdin
 
 
 def process_automatic_feedback(current_error: str | None) -> None:

--- a/hooks/pretool-prompt-injection-scanner.py
+++ b/hooks/pretool-prompt-injection-scanner.py
@@ -106,9 +106,7 @@ _INJECTION_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
         "Attempts to make agent assume false identity",
     ),
     (
-        re.compile(
-            r"from\s+now\s+on\s+you\s+(are|will|should|must)\b", re.IGNORECASE
-        ),
+        re.compile(r"from\s+now\s+on\s+you\s+(are|will|should|must)\b", re.IGNORECASE),
         "role-hijacking",
         "Attempts to permanently alter agent behavior",
     ),
@@ -299,9 +297,7 @@ def main() -> None:
 
     if not warnings:
         if debug:
-            print(
-                f"[injection-scanner] Clean: {file_path}", file=sys.stderr
-            )
+            print(f"[injection-scanner] Clean: {file_path}", file=sys.stderr)
         empty_output(EVENT_NAME).print_and_exit()
 
     # Format advisory output


### PR DESCRIPTION
## Summary
- Fixes ruff I001 (unsorted imports) in hooks/error-learner.py
- The stdin_timeout import was inserted in the wrong alphabetical position during the hook migration (PR #79)
- All CI runs have been failing since that merge

## Test Plan
- [x] ruff check passes locally
- [ ] GitHub Actions CI passes after merge