### PR TITLE
feat: implement two-tiered auto-pipeline system

### DIFF
--- a/pipelines/auto-pipeline/SKILL.md
+++ b/pipelines/auto-pipeline/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: auto-pipeline
+description: |
+  Automatic pipeline generation for unrouted tasks. Two tiers: Tier 1 classifies
+  the task type, selects a canonical chain (8-12 steps), and executes it inline
+  with phase gates. Tier 2 auto-crystallizes the ephemeral pattern into a permanent
+  pipeline when in the toolkit repo (immediate) or after 3+ runs elsewhere.
+  Invoked automatically by /do when no existing route matches. Includes dedup gate
+  to prevent creating pipelines that duplicate existing ones.
+  Use when /do finds no matching route for a non-trivial request.
+  Do NOT invoke directly — /do routes here automatically.
+version: 1.0.0
+user-invocable: false
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Grep
+  - Glob
+  - Agent
+  - Edit
+context: fork
+routing:
+  triggers:
+    - auto-pipeline
+    - ephemeral pipeline
+    - no route found
+    - unrouted task
+  pairs_with:
+    - chain-composer
+    - pipeline-scaffolder
+    - domain-research
+    - pipeline-test-runner
+  complexity: Complex
+  category: meta
+---
+
+# Auto-Pipeline
+
+## Operator Context
+
+This pipeline operates as the automatic fallback for `/do` when no existing route matches a non-trivial request. It classifies the task type, selects and adapts a canonical chain, executes it with phase gates, and optionally crystallizes the pattern into a permanent pipeline.
+
+### Hardcoded Behaviors (Always Apply)
+- **Dedup Gate**: ALWAYS check pipeline catalog before creating anything. If existing pipeline covers 70%+ of request, route to it instead.
+- **8-12 Step Preference**: Prefer longer chains over minimal ones. More steps = more phase gates = higher quality. A 6-step chain that could be 10 steps is under-utilizing the infrastructure.
+- **Phase Gates**: Every step must complete before the next begins. No skipping, no parallel steps unless the step explicitly supports parallelism (RESEARCH, REVIEW).
+- **Artifact Persistence**: Save intermediate output at each phase to session-local files. Context is ephemeral; files are not.
+- **Rule 12 Compliance**: RESEARCH steps MUST use parallel multi-agent dispatch (3-4 agents). Sequential grep-based research is banned.
+- **Immediate Crystallization in Toolkit Repo**: If running in this repo (detected by `pipelines/auto-pipeline/` existing in CWD), crystallize on first encounter — don't wait for 3+ runs.
+- **No Duplicate Pipelines**: The dedup gate is a HARD BLOCK. If an existing pipeline matches, route to it. Do not rationalize "this is slightly different."
+
+### Default Behaviors (ON unless disabled)
+- **Chain Adaptation**: Extend canonical chains with domain-appropriate steps from the step menu (EXTRACT, COMPILE, ASSESS, SYNTHESIZE, REFINE, COMPARE, LINT, CONFORM, MONITOR).
+- **Operator Profile Gates**: Apply personal/work/CI/production gates per the step menu's profile rules.
+- **Learning Recording**: After every ephemeral execution, record to learning.db for crystallization tracking.
+
+### Optional Behaviors (OFF unless enabled)
+- **Dry Run**: Show the proposed chain without executing it.
+- **Force Ephemeral**: Skip crystallization even in toolkit repo (for testing).
+
+## What This Pipeline CAN Do
+- Classify any user request into one of 8 canonical task types
+- Select and adapt canonical chains to 8-12 steps
+- Execute chains inline with phase gates
+- Auto-crystallize into permanent pipelines (toolkit repo: immediate; others: 3+ runs)
+- Dedup against existing pipeline catalog
+
+## What This Pipeline CANNOT Do
+- Override existing pipeline routing (dedup gate prevents this)
+- Create agents (crystallization uses existing agents or creates via pipeline-scaffolder)
+- Bypass the creation gate hook (new pipelines go through proper creation flow)
+- Execute without phase gates (every step is gated)
+
+---
+
+## Instructions
+
+### Phase 0: DEDUP CHECK
+
+**Goal**: Ensure we're not duplicating an existing pipeline.
+
+**Step 1**: Run task type classification:
+```bash
+python3 scripts/task-type-classifier.py --request "{user_request}" --check-catalog pipelines/auto-pipeline/references/pipeline-catalog.md --json
+```
+
+**Step 2**: If the classifier returns `existing_pipeline`, STOP. Route to that pipeline instead. Display:
+```
+===================================================================
+ ROUTING: Existing pipeline found
+===================================================================
+ Request matches: {pipeline_name} (coverage: {N}%)
+ Routing to existing pipeline instead of creating new.
+===================================================================
+```
+
+**Step 3**: If no existing pipeline matches, capture the classification result:
+- `task_type`: one of 8 canonical types
+- `chain`: the canonical chain for that type
+- `steps`: step count
+- `keywords_matched`: which keywords triggered this classification
+
+**Gate**: Classification complete. No existing pipeline matches. Proceed to Phase 1.
+
+### Phase 1: CHAIN SELECTION
+
+**Goal**: Select the best canonical chain variant and extend to 8-12 steps.
+
+**Step 1**: Read `pipelines/chain-composer/references/canonical-chains.md` for the full canonical chain and its variants.
+
+**Step 2**: Select the best variant based on request analysis:
+- Does the request involve unstructured input? → add EXTRACT
+- Does the request need multi-source research? → add COMPILE or use GATHER variant
+- Does the request need audience targeting? → add GROUND
+- Does the request need iterative improvement? → add REFINE
+- Does the request have verifiable syntax? → add LINT
+- Does the request need spec conformance? → add CONFORM
+- Does the request need post-execution observation? → add MONITOR
+- Does the request involve state changes? → add CHARACTERIZE before, COMPARE after
+
+**Step 3**: Verify chain has 8-12 steps. If fewer than 8:
+- Add ASSESS before any generation/execution step
+- Add COMPILE between research and generation
+- Add REFINE after validation
+- Add SYNTHESIZE before reporting
+
+**Step 4**: Apply operator profile gates:
+- Personal: remove APPROVE, PROMPT; reduce GUARD to branch-check only
+- Work: add CONFORM after GENERATE; full GUARD
+- CI: skip interaction steps; add NOTIFY
+- Production: add SIMULATE, SNAPSHOT, APPROVE (mandatory)
+
+**Gate**: Chain has 8-12 steps. All type compatibility rules satisfied. Proceed to Phase 2.
+
+### Phase 2: CONTEXT CHECK (Toolkit Repo Detection)
+
+**Goal**: Determine whether to crystallize immediately or run ephemeral.
+
+**Step 1**: Check if `pipelines/auto-pipeline/SKILL.md` exists in CWD (indicates toolkit repo).
+
+**Step 2**: If toolkit repo:
+- Check learning.db for any prior ephemeral runs in this domain (informational only — crystallize regardless)
+- Proceed to Phase 3 (CRYSTALLIZE) instead of Phase 4 (EPHEMERAL EXECUTE)
+
+**Step 3**: If NOT toolkit repo:
+- Query learning.db: `python3 scripts/learning-db.py search "ephemeral {task_type}" --json`
+- Count matching entries for this domain
+- If 3+ found: proceed to Phase 3 (CRYSTALLIZE)
+- If <3 found: proceed to Phase 4 (EPHEMERAL EXECUTE)
+
+**Gate**: Execution path determined (crystallize vs ephemeral). Proceed to appropriate phase.
+
+### Phase 3: CRYSTALLIZE (Create Permanent Pipeline)
+
+**Goal**: Create a permanent pipeline from the adapted chain and wire it into routing.
+
+This phase IS a pipeline itself (10 steps):
+
+**Step 1 — DETECT**: Confirm crystallization threshold is met (toolkit repo = always; other = 3+ prior runs).
+
+**Step 2 — GATHER**: If prior ephemeral runs exist, collect their chain descriptions and outcomes from learning.db.
+
+**Step 3 — RESEARCH**: Use accumulated evidence to inform pipeline design. Dispatch 3 parallel research agents:
+- Agent 1: Analyze what steps worked in prior ephemeral runs
+- Agent 2: Find similar existing pipelines to learn from
+- Agent 3: Identify domain-specific references/scripts needed
+
+**Step 4 — COMPOSE**: Build the final chain:
+- Start from the adapted canonical chain (from Phase 1)
+- Incorporate learnings from prior ephemeral runs (if any)
+- Ensure 8-12 steps
+- Validate type compatibility
+
+**Step 5 — VALIDATE**: Run `python3 scripts/artifact-utils.py validate-chain` against the composed chain.
+
+**Step 6 — SCAFFOLD**: Create the pipeline skill:
+- Create `pipelines/{pipeline-name}/SKILL.md` with full operator context
+- Create `pipelines/{pipeline-name}/references/` if domain references are needed
+- Follow the existing pipeline SKILL.md format (frontmatter + operator context + phases)
+
+**Step 7 — INTEGRATE**: Wire into routing:
+- Run `python3 scripts/generate-skill-index.py` to update INDEX.json
+- The routing-table-updater skill handles /do routing table updates
+
+**Step 8 — VERIFY**: Confirm the new pipeline is discoverable:
+- Check `skills/INDEX.json` contains the new pipeline
+- Verify `pipelines/{name}/SKILL.md` exists and parses
+
+**Step 9 — REGISTER**: Record in learning.db:
+- Mark all contributing ephemeral learnings as graduated
+- Record the crystallization event
+
+**Step 10 — EXECUTE**: Route the original request through the newly created permanent pipeline.
+
+**Gate**: Pipeline created, integrated, verified. Original request executing through permanent pipeline.
+
+### Phase 4: EPHEMERAL EXECUTE
+
+**Goal**: Execute the adapted chain inline with phase gates, without persistence.
+
+**Step 1**: Display the ephemeral pipeline banner:
+```
+===================================================================
+ ROUTING: [EPHEMERAL PIPELINE] {task_description}
+===================================================================
+
+ Task type: {task_type}
+ Chain ({N} steps): {step1} → {step2} → ... → {stepN}
+ Profile: {profile} ({profile_description})
+
+ Note: No permanent pipeline exists for this domain.
+       Running ephemeral chain with phase gates.
+
+===================================================================
+```
+
+**Step 2**: Execute each step in sequence:
+- For each step in the chain:
+  1. Announce: `[Phase {N}/{total}: {STEP_NAME}]`
+  2. Execute the step's action (research, compile, generate, validate, etc.)
+  3. Save output to session-local file: `/tmp/ephemeral-pipeline/{step_name}.md`
+  4. Verify gate condition is met
+  5. Proceed to next step
+
+**Step 3**: For RESEARCH steps (Rule 12): dispatch 3-4 parallel agents:
+- Agent 1: Code/content analysis
+- Agent 2: Usage patterns / ecosystem context
+- Agent 3: Examples and reference material
+- Agent 4 (optional): External documentation / API references
+
+**Step 4**: For REVIEW steps: dispatch 3+ parallel reviewers with different lenses.
+
+**Step 5**: For REFINE steps: iterate up to 3 times until validation passes.
+
+**Step 6**: On completion, record learning:
+```bash
+python3 scripts/learning-db.py learn --skill auto-pipeline "ephemeral {task_type} for {domain}: {chain_description}"
+```
+
+**Gate**: All steps executed. Output delivered. Learning recorded.
+
+---
+
+## Error Handling
+
+### Error: "Classification returns no matches"
+Cause: Request doesn't match any task type keywords.
+Solution: Default to `analysis` type (broadest applicability). Log a learning about the unclassifiable request.
+
+### Error: "Dedup gate blocks but user insists"
+Cause: Existing pipeline matches 70%+ but user says it doesn't serve their needs.
+Solution: User can say "create new pipeline for X, existing one doesn't cover Y." The explicit override bypasses dedup.
+
+### Error: "Chain validation fails"
+Cause: Type compatibility error in adapted chain.
+Solution: Fall back to the unmodified canonical chain for that task type. Log the adaptation that failed.
+
+### Error: "Crystallization fails mid-scaffold"
+Cause: Pipeline creation blocked by creation gate or ADR enforcement.
+Solution: Fall back to ephemeral execution for the current request. Record the failure for investigation.
+
+---
+
+## Anti-Patterns
+
+### Anti-Pattern 1: Creating Duplicate Pipelines
+**What it looks like**: Auto-pipeline creates a new pipeline when an existing one covers the same domain.
+**Why wrong**: Fragments routing, creates maintenance burden, confuses discovery.
+**Do instead**: ALWAYS check the pipeline catalog first. 70%+ coverage = route to existing.
+
+### Anti-Pattern 2: Minimal Chains
+**What it looks like**: Creating a 4-5 step chain when 8-10 steps would be appropriate.
+**Why wrong**: Fewer steps = fewer phase gates = fewer verification points = lower quality.
+**Do instead**: Extend chains to 8-12 steps using the step menu. Add ASSESS, COMPILE, SYNTHESIZE, REFINE where appropriate.
+
+### Anti-Pattern 3: Skipping Crystallization in Toolkit Repo
+**What it looks like**: Running ephemeral in the toolkit repo instead of creating a permanent pipeline.
+**Why wrong**: This repo IS the pipeline system. Every pipeline we create for ourselves becomes part of the toolkit.
+**Do instead**: ALWAYS crystallize in the toolkit repo. Immediate, first encounter.
+
+### Anti-Pattern 4: Sequential Research
+**What it looks like**: Running grep/search commands one at a time in a RESEARCH step.
+**Why wrong**: Rule 12 (validated by A/B test) — sequential research produces 1.40-point quality gap.
+**Do instead**: Dispatch 3-4 parallel research agents. Always.
+
+---
+
+## References
+
+- `pipelines/chain-composer/references/canonical-chains.md` — 8 canonical chain templates with variants
+- `pipelines/pipeline-scaffolder/references/step-menu.md` — 23 step families, 150+ steps, type compatibility matrix
+- `pipelines/auto-pipeline/references/pipeline-catalog.md` — auto-generated catalog of all existing pipelines (dedup reference)

--- a/pipelines/auto-pipeline/references/pipeline-catalog.json
+++ b/pipelines/auto-pipeline/references/pipeline-catalog.json
@@ -1,0 +1,553 @@
+{
+  "version": "1.0",
+  "generated": "2026-03-23T17:04:38Z",
+  "generated_by": "scripts/generate-pipeline-catalog.py",
+  "pipelines": [
+    {
+      "name": "agent-upgrade",
+      "description": "5-phase pipeline for systematically improving an existing agent or skill:",
+      "phase_count": 5,
+      "phases": [
+        "AUDIT",
+        "DIFF",
+        "PLAN",
+        "IMPLEMENT",
+        "RE-EVALUATE"
+      ],
+      "chain": "AUDIT → DIFF → PLAN → IMPLEMENT → RE-EVALUATE",
+      "task_type": "git-workflow",
+      "triggers": [
+        "agent",
+        "upgrade"
+      ]
+    },
+    {
+      "name": "article-evaluation-pipeline",
+      "description": "Wabi-sabi-aware 4-phase article evaluation: Fetch, Validate, Analyze,",
+      "phase_count": 4,
+      "phases": [
+        "FETCH",
+        "VALIDATE",
+        "ANALYZE",
+        "REPORT"
+      ],
+      "chain": "FETCH → VALIDATE → ANALYZE → REPORT",
+      "task_type": "content-validation",
+      "triggers": [
+        "evaluate article",
+        "check article voice",
+        "is this authentic",
+        "review my article",
+        "voice evaluation",
+        "article evaluation",
+        "check my voice"
+      ]
+    },
+    {
+      "name": "auto-pipeline",
+      "description": "Automatic pipeline generation for unrouted tasks. Two tiers: Tier 1 classifies",
+      "phase_count": 5,
+      "phases": [
+        "DEDUP CHECK",
+        "CHAIN SELECTION",
+        "CONTEXT CHECK",
+        "CRYSTALLIZE",
+        "EPHEMERAL EXECUTE"
+      ],
+      "chain": "DEDUP CHECK → CHAIN SELECTION → CONTEXT CHECK → CRYSTALLIZE → EPHEMERAL EXECUTE",
+      "task_type": "meta",
+      "triggers": [
+        "auto-pipeline",
+        "ephemeral pipeline",
+        "no route found",
+        "unrouted task"
+      ]
+    },
+    {
+      "name": "chain-composer",
+      "description": "Compose valid pipeline chains from the step menu for each subdomain in a",
+      "phase_count": 4,
+      "phases": [
+        "LOAD",
+        "COMPOSE",
+        "VALIDATE",
+        "PRODUCE"
+      ],
+      "chain": "LOAD → COMPOSE → VALIDATE → PRODUCE",
+      "task_type": "meta",
+      "triggers": [
+        "compose chains",
+        "build pipeline chains",
+        "chain composition",
+        "pipeline spec",
+        "compose pipeline"
+      ]
+    },
+    {
+      "name": "comprehensive-review",
+      "description": "Unified 3-wave code review: Wave 0 auto-discovers packages/modules and",
+      "phase_count": 9,
+      "phases": [
+        "SCOPE",
+        "WAVE 0 DISPATCH — PER-PACKAGE DEEP REVIEW",
+        "WAVE 0 AGGREGATE — PER-PACKAGE SUMMARY",
+        "WAVE 1 DISPATCH",
+        "WAVE 0+1 AGGREGATE",
+        "WAVE 2 DISPATCH",
+        "FULL AGGREGATE",
+        "FIX",
+        "REPORT"
+      ],
+      "chain": "SCOPE → WAVE 0 DISPATCH — PER-PACKAGE DEEP REVIEW → WAVE 0 AGGREGATE — PER-PACKAGE SUMMARY → WAVE 1 DISPATCH → WAVE 0+1 AGGREGATE → WAVE 2 DISPATCH → FULL AGGREGATE → FIX → REPORT",
+      "task_type": "review",
+      "triggers": [
+        "comprehensive review",
+        "full review",
+        "review everything",
+        "review and fix",
+        "thorough review",
+        "multi-agent review",
+        "complete code review",
+        "20-agent review",
+        "per-package review",
+        "3-wave review"
+      ]
+    },
+    {
+      "name": "de-ai-pipeline",
+      "description": "Scan-fix-verify loop for removing AI writing patterns from docs. Runs",
+      "phase_count": 4,
+      "phases": [
+        "SCAN",
+        "FIX",
+        "VERIFY",
+        "REPORT"
+      ],
+      "chain": "SCAN → FIX → VERIFY → REPORT",
+      "task_type": "content",
+      "triggers": [
+        "de-ai docs",
+        "clean ai patterns",
+        "fix ai writing",
+        "scan and fix docs",
+        "remove ai tells",
+        "de-ai pipeline"
+      ]
+    },
+    {
+      "name": "do-perspectives",
+      "description": "Inline multi-perspective analysis: 10 analytical lenses applied sequentially",
+      "phase_count": 5,
+      "phases": [
+        "VALIDATE INPUTS",
+        "MULTI-PERSPECTIVE ANALYSIS",
+        "SYNTHESIZE",
+        "APPLY",
+        "VERIFY AND REPORT"
+      ],
+      "chain": "VALIDATE INPUTS → MULTI-PERSPECTIVE ANALYSIS → SYNTHESIZE → APPLY → VERIFY AND REPORT",
+      "task_type": "content-pipeline",
+      "triggers": [
+        "perspectives"
+      ]
+    },
+    {
+      "name": "doc-pipeline",
+      "description": "Structured 5-phase documentation pipeline: Research, Outline, Generate,",
+      "phase_count": 5,
+      "phases": [
+        "RESEARCH",
+        "OUTLINE",
+        "GENERATE",
+        "VERIFY",
+        "OUTPUT"
+      ],
+      "chain": "RESEARCH → OUTLINE → GENERATE → VERIFY → OUTPUT",
+      "task_type": "documentation",
+      "triggers": [
+        "document this",
+        "create readme",
+        "write documentation",
+        "document codebase",
+        "generate docs",
+        "technical documentation"
+      ]
+    },
+    {
+      "name": "domain-research",
+      "description": "Discover and classify subdomains within a target domain for pipeline generation.",
+      "phase_count": 4,
+      "phases": [
+        "DISCOVER",
+        "CLASSIFY",
+        "MAP",
+        "PRODUCE"
+      ],
+      "chain": "DISCOVER → CLASSIFY → MAP → PRODUCE",
+      "task_type": "meta",
+      "triggers": [
+        "research domain",
+        "discover subdomains",
+        "domain decomposition",
+        "what pipelines",
+        "domain research"
+      ]
+    },
+    {
+      "name": "explore-pipeline",
+      "description": "Systematic 4-phase codebase exploration pipeline: Scan, Map, Analyze, Report",
+      "phase_count": 4,
+      "phases": [
+        "SCAN",
+        "MAP",
+        "ANALYZE",
+        "REPORT"
+      ],
+      "chain": "SCAN → MAP → ANALYZE → REPORT",
+      "task_type": "exploration",
+      "triggers": [
+        "understand codebase",
+        "explore repo",
+        "how does this work",
+        "codebase exploration",
+        "understand this code",
+        "map architecture"
+      ]
+    },
+    {
+      "name": "github-profile-rules",
+      "description": "Extract programming rules and coding conventions from a GitHub user's public",
+      "phase_count": 8,
+      "phases": [
+        "ADR",
+        "FETCH",
+        "RESEARCH",
+        "SAMPLE",
+        "COMPILE",
+        "GENERATE",
+        "VALIDATE",
+        "OUTPUT"
+      ],
+      "chain": "ADR → FETCH → RESEARCH → SAMPLE → COMPILE → GENERATE → VALIDATE → OUTPUT",
+      "task_type": "review",
+      "triggers": [
+        "github",
+        "profile",
+        "rules"
+      ]
+    },
+    {
+      "name": "hook-development-pipeline",
+      "description": "Formal 5-phase pipeline for creating production-quality hooks with mandatory",
+      "phase_count": 9,
+      "phases": [
+        "SPEC",
+        "IMPLEMENT",
+        "TEST",
+        "REGISTER",
+        "DOCUMENT",
+        "PERFORMANCE GATE FAILS",
+        "NON-BLOCKING GATE FAILS",
+        "JSON PARSE FAILS ON SETTINGS.JSON",
+        "HOOK-DEVELOPMENT-ENGINEER PRODUCES HOOK WITHOUT LAZY IMPORTS"
+      ],
+      "chain": "SPEC → IMPLEMENT → TEST → REGISTER → DOCUMENT → PERFORMANCE GATE FAILS → NON-BLOCKING GATE FAILS → JSON PARSE FAILS ON SETTINGS.JSON → HOOK-DEVELOPMENT-ENGINEER PRODUCES HOOK WITHOUT LAZY IMPORTS",
+      "task_type": "git-workflow",
+      "triggers": [
+        "hook",
+        "development",
+        "pipeline"
+      ]
+    },
+    {
+      "name": "mcp-pipeline-builder",
+      "description": "Convert any repository into a registered MCP server: ANALYZE → DESIGN →",
+      "phase_count": 5,
+      "phases": [
+        "ANALYSIS ERRORS",
+        "DESIGN ERRORS",
+        "VALIDATION ERRORS",
+        "EVALUATION ERRORS",
+        "REGISTRATION ERRORS"
+      ],
+      "chain": "ANALYSIS ERRORS → DESIGN ERRORS → VALIDATION ERRORS → EVALUATION ERRORS → REGISTRATION ERRORS",
+      "task_type": "pipeline",
+      "triggers": [
+        "mcp pipeline",
+        "repo to mcp",
+        "create mcp from repo",
+        "generate mcp",
+        "mcp builder",
+        "mcp from repo"
+      ]
+    },
+    {
+      "name": "perses-dac-pipeline",
+      "description": "Dashboard-as-Code pipeline: initialize CUE or Go module with percli dac setup,",
+      "phase_count": 6,
+      "phases": [
+        "INITIALIZE",
+        "DEFINE",
+        "BUILD",
+        "VALIDATE",
+        "DEPLOY",
+        "CI/CD INTEGRATION"
+      ],
+      "chain": "INITIALIZE → DEFINE → BUILD → VALIDATE → DEPLOY → CI/CD INTEGRATION",
+      "task_type": "general",
+      "triggers": [
+        "perses",
+        "dac",
+        "pipeline"
+      ]
+    },
+    {
+      "name": "perses-plugin-pipeline",
+      "description": "End-to-end Perses plugin development pipeline: SCAFFOLD, SCHEMA, IMPLEMENT, TEST,",
+      "phase_count": 6,
+      "phases": [
+        "SCAFFOLD",
+        "SCHEMA",
+        "IMPLEMENT",
+        "TEST",
+        "BUILD",
+        "DEPLOY"
+      ],
+      "chain": "SCAFFOLD → SCHEMA → IMPLEMENT → TEST → BUILD → DEPLOY",
+      "task_type": "git-workflow",
+      "triggers": [
+        "perses",
+        "plugin",
+        "pipeline"
+      ]
+    },
+    {
+      "name": "pipeline-retro",
+      "description": "Trace pipeline test failures to generator root causes and propose fixes using",
+      "phase_count": 5,
+      "phases": [
+        "INGEST",
+        "TRACE",
+        "PROPOSE",
+        "REGENERATE",
+        "REPORT"
+      ],
+      "chain": "INGEST → TRACE → PROPOSE → REGENERATE → REPORT",
+      "task_type": "meta",
+      "triggers": [
+        "pipeline retro",
+        "trace failures",
+        "generator improvement",
+        "three-layer fix",
+        "fix generator"
+      ]
+    },
+    {
+      "name": "pipeline-scaffolder",
+      "description": "Scaffold pipeline components from a Pipeline Spec JSON: N subdomain skills,",
+      "phase_count": 5,
+      "phases": [
+        "LOAD",
+        "SCAFFOLD AGENT",
+        "SCAFFOLD SKILLS",
+        "INTEGRATE",
+        "REPORT"
+      ],
+      "chain": "LOAD → SCAFFOLD AGENT → SCAFFOLD SKILLS → INTEGRATE → REPORT",
+      "task_type": "research",
+      "triggers": [
+        "pipeline",
+        "scaffolder"
+      ]
+    },
+    {
+      "name": "pipeline-test-runner",
+      "description": "Test generated pipeline skills against real targets. Discovers test targets",
+      "phase_count": 4,
+      "phases": [
+        "DISCOVER TARGETS",
+        "EXECUTE",
+        "VALIDATE OUTPUTS",
+        "REPORT"
+      ],
+      "chain": "DISCOVER TARGETS → EXECUTE → VALIDATE OUTPUTS → REPORT",
+      "task_type": "meta",
+      "triggers": [
+        "test generated pipelines",
+        "run pipeline tests",
+        "validate scaffolded skills",
+        "pipeline test runner"
+      ]
+    },
+    {
+      "name": "pr-pipeline",
+      "description": "End-to-end pipeline for creating pull requests: Classify Repo, Stage,",
+      "phase_count": 12,
+      "phases": [
+        "CLASSIFY REPO",
+        "PREFLIGHT CHECKLIST",
+        "STAGE",
+        "REVIEW",
+        "COMMIT",
+        "PUSH",
+        "REVIEW-FIX LOOP",
+        "RETRO",
+        "ADR VALIDATION",
+        "CREATE PR",
+        "VERIFY",
+        "CLEANUP"
+      ],
+      "chain": "CLASSIFY REPO → PREFLIGHT CHECKLIST → STAGE → REVIEW → COMMIT → PUSH → REVIEW-FIX LOOP → RETRO → ADR VALIDATION → CREATE PR → VERIFY → CLEANUP",
+      "task_type": "git-workflow",
+      "triggers": [
+        "submit PR",
+        "create pull request",
+        "send for review",
+        "push and PR",
+        "submit changes",
+        "open PR"
+      ]
+    },
+    {
+      "name": "research-pipeline",
+      "description": "Formal 5-phase research pipeline with artifact saving and source quality gates:",
+      "phase_count": 5,
+      "phases": [
+        "SCOPE",
+        "GATHER",
+        "SYNTHESIZE",
+        "VALIDATE",
+        "DELIVER"
+      ],
+      "chain": "SCOPE → GATHER → SYNTHESIZE → VALIDATE → DELIVER",
+      "task_type": "research",
+      "triggers": [
+        "research",
+        "pipeline"
+      ]
+    },
+    {
+      "name": "research-to-article",
+      "description": "Multi-agent research pipeline for voice content generation. Parallel",
+      "phase_count": 6,
+      "phases": [
+        "GATHER",
+        "COMPILE",
+        "GROUND",
+        "GENERATE",
+        "VALIDATE",
+        "OUTPUT"
+      ],
+      "chain": "GATHER → COMPILE → GROUND → GENERATE → VALIDATE → OUTPUT",
+      "task_type": "content-pipeline",
+      "triggers": [
+        "research then write",
+        "article with research",
+        "write about",
+        "research and article",
+        "full article pipeline",
+        "comprehensive article"
+      ]
+    },
+    {
+      "name": "skill-creation-pipeline",
+      "description": "Formal 5-phase pipeline for creating new skills with quality gates:",
+      "phase_count": 5,
+      "phases": [
+        "DISCOVER",
+        "DESIGN",
+        "SCAFFOLD",
+        "VALIDATE",
+        "INTEGRATE"
+      ],
+      "chain": "DISCOVER → DESIGN → SCAFFOLD → VALIDATE → INTEGRATE",
+      "task_type": "git-workflow",
+      "triggers": [
+        "skill",
+        "creation",
+        "pipeline"
+      ]
+    },
+    {
+      "name": "system-upgrade",
+      "description": "Systematic 6-phase pipeline for adapting agents, skills, hooks, and scripts to",
+      "phase_count": 6,
+      "phases": [
+        "CHANGELOG",
+        "AUDIT",
+        "PLAN",
+        "IMPLEMENT",
+        "VALIDATE",
+        "DEPLOY"
+      ],
+      "chain": "CHANGELOG → AUDIT → PLAN → IMPLEMENT → VALIDATE → DEPLOY",
+      "task_type": "git-workflow",
+      "triggers": [
+        "system",
+        "upgrade"
+      ]
+    },
+    {
+      "name": "voice-calibrator",
+      "description": "Analyze writing samples and extract voice patterns to create or update",
+      "phase_count": 3,
+      "phases": [
+        "VOICE GROUNDING",
+        "VOICE METRICS",
+        "THINKING PATTERNS"
+      ],
+      "chain": "VOICE GROUNDING → VOICE METRICS → THINKING PATTERNS",
+      "task_type": "content-pipeline",
+      "triggers": [
+        "voice",
+        "calibrator"
+      ]
+    },
+    {
+      "name": "voice-writer",
+      "description": "Unified voice content generation pipeline with mandatory validation and",
+      "phase_count": 8,
+      "phases": [
+        "LOAD",
+        "GROUND",
+        "GENERATE",
+        "VALIDATE",
+        "REFINE",
+        "JOY-CHECK",
+        "OUTPUT",
+        "CLEANUP"
+      ],
+      "chain": "LOAD → GROUND → GENERATE → VALIDATE → REFINE → JOY-CHECK → OUTPUT → CLEANUP",
+      "task_type": "content",
+      "triggers": [
+        "write article",
+        "blog post",
+        "write in voice",
+        "generate voice content",
+        "voice workflow",
+        "draft article",
+        "write about",
+        "write post",
+        "blog about",
+        "create content"
+      ]
+    },
+    {
+      "name": "workflow-orchestrator",
+      "description": "Three-phase task orchestration: BRAINSTORM requirements and approaches,",
+      "phase_count": 4,
+      "phases": [
+        "BRAINSTORM",
+        "WRITE-PLAN",
+        "VALIDATE-PLAN",
+        "EXECUTE-PLAN"
+      ],
+      "chain": "BRAINSTORM → WRITE-PLAN → VALIDATE-PLAN → EXECUTE-PLAN",
+      "task_type": "git-workflow",
+      "triggers": [
+        "workflow",
+        "orchestrator"
+      ]
+    }
+  ]
+}

--- a/pipelines/auto-pipeline/references/pipeline-catalog.md
+++ b/pipelines/auto-pipeline/references/pipeline-catalog.md
@@ -1,0 +1,32 @@
+# Pipeline Catalog
+Auto-generated reference for auto-pipeline dedup checks.
+Generated: 2026-03-23T17:04:38Z
+
+| Pipeline | Phases | Chain | Task Type | Triggers |
+|----------|--------|-------|-----------|----------|
+| agent-upgrade | 5 | AUDIT → DIFF → PLAN → IMPLEMENT → RE-EVALUATE | git-workflow | agent, upgrade |
+| article-evaluation-pipeline | 4 | FETCH → VALIDATE → ANALYZE → REPORT | content-validation | evaluate article, check article voice, is this authentic, review my article, voice evaluation |
+| auto-pipeline | 5 | DEDUP CHECK → CHAIN SELECTION → CONTEXT CHECK → CRYSTALLIZE → EPHEMERAL EXECUTE | meta | auto-pipeline, ephemeral pipeline, no route found, unrouted task |
+| chain-composer | 4 | LOAD → COMPOSE → VALIDATE → PRODUCE | meta | compose chains, build pipeline chains, chain composition, pipeline spec, compose pipeline |
+| comprehensive-review | 9 | SCOPE → WAVE 0 DISPATCH — PER-PACKAGE DEEP REVIEW → WAVE 0 AGGREGATE — PER-PACKAGE SUMMARY → WAVE 1 DISPATCH → WAVE 0+1 AGGREGATE → WAVE 2 DISPATCH → FULL AGGREGATE → FIX → REPORT | review | comprehensive review, full review, review everything, review and fix, thorough review |
+| de-ai-pipeline | 4 | SCAN → FIX → VERIFY → REPORT | content | de-ai docs, clean ai patterns, fix ai writing, scan and fix docs, remove ai tells |
+| do-perspectives | 5 | VALIDATE INPUTS → MULTI-PERSPECTIVE ANALYSIS → SYNTHESIZE → APPLY → VERIFY AND REPORT | content-pipeline | perspectives |
+| doc-pipeline | 5 | RESEARCH → OUTLINE → GENERATE → VERIFY → OUTPUT | documentation | document this, create readme, write documentation, document codebase, generate docs |
+| domain-research | 4 | DISCOVER → CLASSIFY → MAP → PRODUCE | meta | research domain, discover subdomains, domain decomposition, what pipelines, domain research |
+| explore-pipeline | 4 | SCAN → MAP → ANALYZE → REPORT | exploration | understand codebase, explore repo, how does this work, codebase exploration, understand this code |
+| github-profile-rules | 8 | ADR → FETCH → RESEARCH → SAMPLE → COMPILE → GENERATE → VALIDATE → OUTPUT | review | github, profile, rules |
+| hook-development-pipeline | 9 | SPEC → IMPLEMENT → TEST → REGISTER → DOCUMENT → PERFORMANCE GATE FAILS → NON-BLOCKING GATE FAILS → JSON PARSE FAILS ON SETTINGS.JSON → HOOK-DEVELOPMENT-ENGINEER PRODUCES HOOK WITHOUT LAZY IMPORTS | git-workflow | hook, development, pipeline |
+| mcp-pipeline-builder | 5 | ANALYSIS ERRORS → DESIGN ERRORS → VALIDATION ERRORS → EVALUATION ERRORS → REGISTRATION ERRORS | pipeline | mcp pipeline, repo to mcp, create mcp from repo, generate mcp, mcp builder |
+| perses-dac-pipeline | 6 | INITIALIZE → DEFINE → BUILD → VALIDATE → DEPLOY → CI/CD INTEGRATION | general | perses, dac, pipeline |
+| perses-plugin-pipeline | 6 | SCAFFOLD → SCHEMA → IMPLEMENT → TEST → BUILD → DEPLOY | git-workflow | perses, plugin, pipeline |
+| pipeline-retro | 5 | INGEST → TRACE → PROPOSE → REGENERATE → REPORT | meta | pipeline retro, trace failures, generator improvement, three-layer fix, fix generator |
+| pipeline-scaffolder | 5 | LOAD → SCAFFOLD AGENT → SCAFFOLD SKILLS → INTEGRATE → REPORT | research | pipeline, scaffolder |
+| pipeline-test-runner | 4 | DISCOVER TARGETS → EXECUTE → VALIDATE OUTPUTS → REPORT | meta | test generated pipelines, run pipeline tests, validate scaffolded skills, pipeline test runner |
+| pr-pipeline | 12 | CLASSIFY REPO → PREFLIGHT CHECKLIST → STAGE → REVIEW → COMMIT → PUSH → REVIEW-FIX LOOP → RETRO → ADR VALIDATION → CREATE PR → VERIFY → CLEANUP | git-workflow | submit PR, create pull request, send for review, push and PR, submit changes |
+| research-pipeline | 5 | SCOPE → GATHER → SYNTHESIZE → VALIDATE → DELIVER | research | research, pipeline |
+| research-to-article | 6 | GATHER → COMPILE → GROUND → GENERATE → VALIDATE → OUTPUT | content-pipeline | research then write, article with research, write about, research and article, full article pipeline |
+| skill-creation-pipeline | 5 | DISCOVER → DESIGN → SCAFFOLD → VALIDATE → INTEGRATE | git-workflow | skill, creation, pipeline |
+| system-upgrade | 6 | CHANGELOG → AUDIT → PLAN → IMPLEMENT → VALIDATE → DEPLOY | git-workflow | system, upgrade |
+| voice-calibrator | 3 | VOICE GROUNDING → VOICE METRICS → THINKING PATTERNS | content-pipeline | voice, calibrator |
+| voice-writer | 8 | LOAD → GROUND → GENERATE → VALIDATE → REFINE → JOY-CHECK → OUTPUT → CLEANUP | content | write article, blog post, write in voice, generate voice content, voice workflow |
+| workflow-orchestrator | 4 | BRAINSTORM → WRITE-PLAN → VALIDATE-PLAN → EXECUTE-PLAN | git-workflow | workflow, orchestrator |

--- a/scripts/generate-pipeline-catalog.py
+++ b/scripts/generate-pipeline-catalog.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""
+Generate pipeline catalog from YAML frontmatter in pipeline SKILL.md files.
+
+Scans all pipelines/*/SKILL.md files, extracts phase metadata, and generates
+a markdown reference catalog for auto-pipeline dedup checks.
+
+Usage:
+    python scripts/generate-pipeline-catalog.py --output catalog.md
+    python scripts/generate-pipeline-catalog.py --output catalog.md --json
+
+Output:
+    Markdown catalog at the specified --output path.
+    Optional JSON file alongside markdown when --json is passed.
+
+Exit codes:
+    0 - Success
+    1 - Fatal error (directory not found, write failed, no pipelines found)
+"""
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+
+def extract_frontmatter(content: str) -> dict | None:
+    """Extract YAML frontmatter from markdown content.
+
+    Attempts YAML parsing first, then falls back to regex extraction
+    for key fields when YAML parsing fails.
+
+    Args:
+        content: Full markdown file content.
+
+    Returns:
+        Parsed frontmatter dict, or None if no frontmatter found.
+    """
+    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        return None
+
+    yaml_content = match.group(1)
+
+    try:
+        result = yaml.safe_load(yaml_content)
+        return result
+    except yaml.YAMLError as e:
+        print(f"  Warning: YAML parsing failed, using regex fallback: {e}", file=sys.stderr)
+
+    # Fallback: extract key fields via regex
+    frontmatter: dict = {}
+
+    name_match = re.search(r"^name:\s*(.+)$", yaml_content, re.MULTILINE)
+    if name_match:
+        frontmatter["name"] = name_match.group(1).strip()
+
+    desc_match = re.search(
+        r"^description:\s*(?:[>|][\-+]?\s*\n\s+)?(.+?)(?=\n[a-z_-]+:|$)",
+        yaml_content,
+        re.MULTILINE | re.DOTALL,
+    )
+    if desc_match:
+        desc = desc_match.group(1).strip()
+        desc = re.sub(r"\s+", " ", desc)
+        frontmatter["description"] = desc
+
+    routing_match = re.search(r"^routing:\s*\n((?:\s+.+\n?)+)", yaml_content, re.MULTILINE)
+    if routing_match:
+        routing_content = routing_match.group(1)
+        routing: dict = {}
+
+        triggers_match = re.search(r"triggers:\s*\n((?:\s+-\s+.+\n?)+)", routing_content)
+        if triggers_match:
+            triggers = re.findall(r'-\s+["\']?([^"\'\n]+)["\']?', triggers_match.group(1))
+            routing["triggers"] = [t.strip() for t in triggers]
+
+        category_match = re.search(r"category:\s*(.+)$", routing_content, re.MULTILINE)
+        if category_match:
+            routing["category"] = category_match.group(1).strip()
+
+        if routing:
+            frontmatter["routing"] = routing
+
+    return frontmatter if frontmatter else None
+
+
+def extract_description_first_line(description: str, max_length: int = 120) -> str:
+    """Extract the first meaningful line from a description, truncated to max_length.
+
+    Args:
+        description: Raw description string (may be multiline).
+        max_length: Maximum character length for the result.
+
+    Returns:
+        First line of description, truncated if needed.
+    """
+    if not description:
+        return ""
+
+    desc = description.replace("\\n", " ").strip()
+    # Collapse whitespace but preserve sentence structure
+    lines = desc.split("\n")
+    first_line = lines[0].strip()
+    first_line = re.sub(r"\s+", " ", first_line)
+
+    if len(first_line) > max_length:
+        return first_line[: max_length - 3] + "..."
+    return first_line
+
+
+def extract_phases(content: str) -> list[str]:
+    """Extract phase names from pipeline SKILL.md content.
+
+    Looks for multiple patterns:
+    - ### Phase N: NAME or ### Phase N.N: NAME
+    - **Phase N: NAME**
+    - Lines in chain descriptions like NAME1 -> NAME2 -> NAME3
+
+    Args:
+        content: Full markdown file content (body after frontmatter).
+
+    Returns:
+        Ordered list of phase names (e.g., ["SCAN", "MAP", "ANALYZE", "REPORT"]).
+    """
+    phases: list[str] = []
+    seen: set[str] = set()
+
+    # Pattern 1: ### Phase N: NAME or ### Phase N.N: NAME (e.g., "### Phase 2.5: VALIDATE-PLAN")
+    for m in re.finditer(r"^###\s+Phase\s+[\d.]+[a-z]?:\s+(.+)$", content, re.MULTILINE):
+        raw = m.group(1).strip()
+        # Strip trailing markdown artifacts like "(Parallel Research)" or extra parens
+        name = re.split(r"\s*[\(\[]", raw)[0].strip()
+        name_upper = name.upper()
+        if name_upper not in seen:
+            phases.append(name_upper)
+            seen.add(name_upper)
+
+    if phases:
+        return phases
+
+    # Pattern 2: **Phase N: NAME** (bold inline)
+    for m in re.finditer(r"\*\*Phase\s+\d+:\s+(.+?)\*\*", content):
+        name = re.split(r"\s*[\(\[]", m.group(1).strip())[0].strip()
+        name_upper = name.upper()
+        if name_upper not in seen:
+            phases.append(name_upper)
+            seen.add(name_upper)
+
+    if phases:
+        return phases
+
+    # Pattern 3: Wave-based phases (comprehensive-review style)
+    for m in re.finditer(r"^###\s+(Wave\s+\d+[a-z]?:\s+.+?)$", content, re.MULTILINE):
+        name = m.group(1).strip()
+        name_upper = name.upper()
+        if name_upper not in seen:
+            phases.append(name_upper)
+            seen.add(name_upper)
+
+    if phases:
+        return phases
+
+    # Pattern 4: Look for chain descriptions like "SCAN -> MAP -> ANALYZE -> REPORT"
+    # or unicode arrow variants
+    chain_pattern = r"([A-Z][-A-Z_]+(?:\s*(?:->|-->|\u2192|→)\s*[A-Z][-A-Z_]+)+)"
+    for m in re.finditer(chain_pattern, content):
+        chain = m.group(1)
+        parts = re.split(r"\s*(?:->|-->|\u2192|→)\s*", chain)
+        for part in parts:
+            name = part.strip().upper()
+            if name and name not in seen:
+                phases.append(name)
+                seen.add(name)
+
+    return phases
+
+
+def infer_task_type(frontmatter: dict, description: str) -> str:
+    """Infer the task type from routing metadata or description keywords.
+
+    Args:
+        frontmatter: Parsed YAML frontmatter dict.
+        description: Pipeline description text.
+
+    Returns:
+        Task type string (e.g., "exploration", "git-workflow", "content-pipeline").
+    """
+    routing = frontmatter.get("routing", {})
+    if isinstance(routing, dict) and "category" in routing:
+        return routing["category"]
+
+    # Keyword-based inference from description
+    desc_lower = description.lower()
+    keyword_map = {
+        "review": "review",
+        "explore": "exploration",
+        "research": "research",
+        "article": "content-pipeline",
+        "voice": "content-pipeline",
+        "content": "content-pipeline",
+        "pull request": "git-workflow",
+        "PR": "git-workflow",
+        "commit": "git-workflow",
+        "test": "testing",
+        "debug": "debugging",
+        "deploy": "deployment",
+        "document": "documentation",
+        "orchestrat": "orchestration",
+        "scaffold": "scaffolding",
+        "upgrade": "maintenance",
+        "retro": "retrospective",
+    }
+
+    for keyword, task_type in keyword_map.items():
+        if keyword.lower() in desc_lower:
+            return task_type
+
+    return "general"
+
+
+def extract_triggers(frontmatter: dict, description: str) -> list[str]:
+    """Extract trigger keywords from routing metadata or description.
+
+    Args:
+        frontmatter: Parsed YAML frontmatter dict.
+        description: Pipeline description text.
+
+    Returns:
+        List of trigger keyword strings.
+    """
+    routing = frontmatter.get("routing", {})
+    if isinstance(routing, dict) and "triggers" in routing:
+        return routing["triggers"]
+
+    # Fall back to extracting keywords from description
+    name = frontmatter.get("name", "")
+    stop_words = {"the", "and", "for", "with", "use", "when", "not", "this", "that", "from", "into", "does"}
+    name_parts = name.replace("-", " ").split()
+    triggers = [p for p in name_parts if len(p) > 2 and p.lower() not in stop_words]
+    return triggers
+
+
+def scan_pipelines(pipelines_dir: Path) -> tuple[list[dict], list[str]]:
+    """Scan all pipeline directories and extract catalog entries.
+
+    Args:
+        pipelines_dir: Path to the pipelines/ directory.
+
+    Returns:
+        Tuple of (list of pipeline entry dicts, list of warning messages).
+    """
+    entries: list[dict] = []
+    warnings: list[str] = []
+
+    for pipeline_dir in sorted(pipelines_dir.iterdir()):
+        if not pipeline_dir.is_dir():
+            continue
+
+        skill_file = pipeline_dir / "SKILL.md"
+        if not skill_file.exists():
+            continue
+
+        try:
+            content = skill_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as e:
+            warnings.append(f"  - {pipeline_dir.name}: Failed to read: {e}")
+            continue
+
+        frontmatter = extract_frontmatter(content)
+        if not frontmatter:
+            warnings.append(f"  - {pipeline_dir.name}: No valid frontmatter found")
+            continue
+
+        name = frontmatter.get("name", pipeline_dir.name)
+        description = frontmatter.get("description", "")
+        description_line = extract_description_first_line(description)
+
+        phases = extract_phases(content)
+        phase_count = len(phases)
+        chain = " → ".join(phases) if phases else "—"
+
+        task_type = infer_task_type(frontmatter, description)
+        triggers = extract_triggers(frontmatter, description)
+
+        entries.append(
+            {
+                "name": name,
+                "description": description_line,
+                "phase_count": phase_count,
+                "phases": phases,
+                "chain": chain,
+                "task_type": task_type,
+                "triggers": triggers,
+            }
+        )
+
+    return entries, warnings
+
+
+def generate_markdown(entries: list[dict], timestamp: str) -> str:
+    """Generate the markdown catalog content.
+
+    Args:
+        entries: List of pipeline entry dicts.
+        timestamp: ISO-formatted generation timestamp.
+
+    Returns:
+        Formatted markdown string.
+    """
+    lines: list[str] = [
+        "# Pipeline Catalog",
+        "Auto-generated reference for auto-pipeline dedup checks.",
+        f"Generated: {timestamp}",
+        "",
+        "| Pipeline | Phases | Chain | Task Type | Triggers |",
+        "|----------|--------|-------|-----------|----------|",
+    ]
+
+    for entry in entries:
+        triggers_str = ", ".join(entry["triggers"][:5]) if entry["triggers"] else "—"
+        lines.append(
+            f"| {entry['name']} | {entry['phase_count']} | {entry['chain']} | {entry['task_type']} | {triggers_str} |"
+        )
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Argument list (defaults to sys.argv[1:]).
+
+    Returns:
+        Parsed argument namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate pipeline catalog from pipelines/*/SKILL.md frontmatter.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Path to write the markdown catalog",
+    )
+    parser.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        default=False,
+        help="Also output a JSON version alongside the markdown",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point.
+
+    Args:
+        argv: Optional argument list for testing.
+
+    Returns:
+        Exit code: 0 success, 1 error.
+    """
+    args = parse_args(argv)
+
+    script_dir = Path(__file__).parent
+    repo_root = script_dir.parent
+    pipelines_dir = repo_root / "pipelines"
+
+    if not pipelines_dir.exists():
+        print(f"Error: pipelines directory not found at {pipelines_dir}", file=sys.stderr)
+        return 1
+
+    entries, warnings = scan_pipelines(pipelines_dir)
+
+    if warnings:
+        print("Warnings during catalog generation:", file=sys.stderr)
+        for warning in warnings:
+            print(warning, file=sys.stderr)
+
+    if not entries:
+        print("Error: No pipelines found. Catalog not written.", file=sys.stderr)
+        return 1
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Write markdown catalog
+    output_path: Path = args.output
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(generate_markdown(entries, timestamp), encoding="utf-8")
+    except PermissionError:
+        print(f"Error: Permission denied writing to {output_path}", file=sys.stderr)
+        return 1
+    except OSError as e:
+        print(f"Error: Failed to write catalog: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Generated {output_path}")
+    print(f"  Total pipelines: {len(entries)}")
+
+    # Show breakdown by task type
+    categories: dict[str, int] = {}
+    for entry in entries:
+        cat = entry["task_type"]
+        categories[cat] = categories.get(cat, 0) + 1
+
+    print("  By task type:")
+    for cat, count in sorted(categories.items()):
+        print(f"    {cat}: {count}")
+
+    # Write JSON if requested
+    if args.emit_json:
+        json_path = output_path.with_suffix(".json")
+        json_data = {
+            "version": "1.0",
+            "generated": timestamp,
+            "generated_by": "scripts/generate-pipeline-catalog.py",
+            "pipelines": entries,
+        }
+        try:
+            json_path.write_text(json.dumps(json_data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        except PermissionError:
+            print(f"Error: Permission denied writing to {json_path}", file=sys.stderr)
+            return 1
+        except OSError as e:
+            print(f"Error: Failed to write JSON catalog: {e}", file=sys.stderr)
+            return 1
+
+        print(f"  JSON catalog: {json_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/task-type-classifier.py
+++ b/scripts/task-type-classifier.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Deterministic classifier for user requests into canonical task types.
+
+Classifies a request string into one of 8 canonical task types using keyword
+matching, then returns the corresponding chain template from canonical-chains.md.
+
+Usage:
+    python3 scripts/task-type-classifier.py --request "create a new Helm chart"
+    python3 scripts/task-type-classifier.py --request "debug failing tests" --json
+    python3 scripts/task-type-classifier.py --request "deploy to staging" --check-catalog pipelines/catalog.json
+
+Exit codes:
+    0 — Classification successful
+    1 — Error during classification
+    2 — Bad input (missing arguments, invalid paths)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CANONICAL_CHAINS: dict[str, list[str]] = {
+    "generation": ["ADR", "RESEARCH", "COMPILE", "GENERATE", "VALIDATE", "REFINE", "OUTPUT"],
+    "review": ["ADR", "RESEARCH", "ASSESS", "REVIEW (3+)", "AGGREGATE", "REPORT"],
+    "debugging": ["ADR", "PROBE", "SEARCH", "ASSESS", "PLAN", "EXECUTE", "VERIFY", "OUTPUT"],
+    "operations": [
+        "ADR",
+        "PROBE",
+        "ASSESS",
+        "PLAN",
+        "GUARD",
+        "EXECUTE",
+        "VALIDATE",
+        "MONITOR",
+        "OUTPUT",
+    ],
+    "configuration": [
+        "ADR",
+        "RESEARCH",
+        "COMPILE",
+        "TEMPLATE",
+        "CONFORM",
+        "VALIDATE",
+        "REFINE",
+        "OUTPUT",
+    ],
+    "analysis": [
+        "ADR",
+        "RESEARCH",
+        "COMPILE",
+        "ASSESS",
+        "BRAINSTORM",
+        "SYNTHESIZE",
+        "REFINE",
+        "REPORT",
+    ],
+    "migration": [
+        "ADR",
+        "CHARACTERIZE",
+        "PLAN",
+        "GUARD",
+        "SNAPSHOT",
+        "EXECUTE",
+        "VALIDATE",
+        "COMPARE",
+        "OUTPUT",
+    ],
+    "testing": [
+        "ADR",
+        "RESEARCH",
+        "COMPILE",
+        "CHARACTERIZE",
+        "GENERATE",
+        "VALIDATE",
+        "REFINE",
+        "REPORT",
+    ],
+}
+
+TASK_KEYWORDS: dict[str, list[str]] = {
+    "generation": ["create", "write", "generate", "build", "scaffold", "produce"],
+    "review": ["review", "check", "audit", "evaluate", "assess", "grade"],
+    "debugging": ["debug", "fix", "diagnose", "investigate", "root cause", "failing"],
+    "operations": ["deploy", "configure", "scale", "manage", "provision", "set up"],
+    "configuration": ["config", "template", "helm", "terraform", "yaml", "manifest"],
+    "analysis": ["analyze", "compare", "benchmark", "measure", "assess", "recommend"],
+    "migration": ["migrate", "convert", "upgrade", "transition", "move from"],
+    "testing": ["test", "coverage", "fuzz", "characterize", "benchmark suite"],
+}
+
+DEFAULT_TASK_TYPE = "analysis"
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClassificationResult:
+    """Result of classifying a user request."""
+
+    task_type: str
+    chain: list[str]
+    steps: int
+    confidence: float
+    keywords_matched: list[str]
+    existing_pipeline: str | None = None
+
+
+@dataclass
+class CatalogEntry:
+    """A pipeline entry from the catalog file."""
+
+    name: str
+    keywords: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Classification logic
+# ---------------------------------------------------------------------------
+
+
+def classify_request(request: str) -> ClassificationResult:
+    """Classify a request string into a canonical task type.
+
+    Args:
+        request: The user request text to classify.
+
+    Returns:
+        ClassificationResult with the best-matching task type, chain, and metadata.
+    """
+    lowered = request.lower()
+
+    scores: dict[str, list[str]] = {}
+    for task_type, keywords in TASK_KEYWORDS.items():
+        matched = [kw for kw in keywords if kw in lowered]
+        scores[task_type] = matched
+
+    max_count = max(len(v) for v in scores.values())
+
+    if max_count == 0:
+        chain = CANONICAL_CHAINS[DEFAULT_TASK_TYPE]
+        return ClassificationResult(
+            task_type=DEFAULT_TASK_TYPE,
+            chain=chain,
+            steps=len(chain),
+            confidence=0.0,
+            keywords_matched=[],
+        )
+
+    # Collect all task types with the max match count
+    candidates = [t for t, matched in scores.items() if len(matched) == max_count]
+
+    # Tie-break: prefer the type with more steps in its canonical chain
+    best = max(candidates, key=lambda t: len(CANONICAL_CHAINS[t]))
+
+    matched_keywords = scores[best]
+    total_keywords = len(TASK_KEYWORDS[best])
+    confidence = round(len(matched_keywords) / total_keywords, 2) if total_keywords > 0 else 0.0
+
+    chain = CANONICAL_CHAINS[best]
+    return ClassificationResult(
+        task_type=best,
+        chain=chain,
+        steps=len(chain),
+        confidence=confidence,
+        keywords_matched=matched_keywords,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Catalog checking
+# ---------------------------------------------------------------------------
+
+
+def load_catalog(catalog_path: Path) -> list[CatalogEntry]:
+    """Load a pipeline catalog from a JSON file.
+
+    Args:
+        catalog_path: Path to the catalog JSON file.
+
+    Returns:
+        List of CatalogEntry objects.
+
+    Raises:
+        SystemExit: If the file cannot be read or parsed.
+    """
+    try:
+        data = json.loads(catalog_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"Error: Catalog file not found: {catalog_path}", file=sys.stderr)
+        sys.exit(2)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON in catalog: {e}", file=sys.stderr)
+        sys.exit(2)
+    except OSError as e:
+        print(f"Error: Cannot read catalog: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    entries: list[CatalogEntry] = []
+    pipelines = data if isinstance(data, list) else data.get("pipelines", [])
+
+    for item in pipelines:
+        if isinstance(item, dict) and "name" in item:
+            # Accept both "keywords" and "triggers" fields
+            keywords = item.get("keywords", []) or item.get("triggers", [])
+            if isinstance(keywords, list):
+                entries.append(CatalogEntry(name=item["name"], keywords=keywords))
+
+    return entries
+
+
+def check_catalog_overlap(request: str, catalog: list[CatalogEntry], threshold: float = 0.35) -> str | None:
+    """Check if an existing pipeline covers the request with sufficient keyword overlap.
+
+    Uses word-level matching: extracts unique words from trigger phrases and
+    checks what fraction appear in the request. Threshold is 0.35 (not 0.70)
+    because trigger phrases share many words, inflating the denominator.
+    A match of 4-5 trigger words out of 10-12 unique words is a strong signal.
+
+    Args:
+        request: The user request text.
+        catalog: List of catalog entries to check against.
+        threshold: Minimum keyword overlap ratio (default 0.35).
+
+    Returns:
+        Pipeline name if overlap meets threshold, None otherwise.
+    """
+    lowered = request.lower()
+
+    best_name: str | None = None
+    best_overlap: float = 0.0
+
+    for entry in catalog:
+        if not entry.keywords:
+            continue
+
+        # Extract unique words from all trigger phrases
+        trigger_words = set()
+        for kw in entry.keywords:
+            for word in kw.lower().split():
+                if len(word) > 2:  # Skip short words (a, an, to, etc.)
+                    trigger_words.add(word)
+
+        if not trigger_words:
+            continue
+
+        # Count how many trigger words appear in the request
+        request_words = set(lowered.split())
+        matched = len(trigger_words & request_words)
+        overlap = matched / len(trigger_words)
+
+        if overlap >= threshold and overlap > best_overlap:
+            best_overlap = overlap
+            best_name = entry.name
+
+    return best_name
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def format_chain_arrow(chain: list[str]) -> str:
+    """Format a chain list as an arrow-separated string.
+
+    Args:
+        chain: List of step names.
+
+    Returns:
+        Arrow-separated string like "ADR -> RESEARCH -> OUTPUT".
+    """
+    return " -> ".join(chain)
+
+
+def format_text_output(result: ClassificationResult) -> str:
+    """Format classification result as a single-line text string.
+
+    Args:
+        result: The classification result.
+
+    Returns:
+        Formatted text output string.
+    """
+    if result.existing_pipeline:
+        return f"existing_pipeline:{result.existing_pipeline}"
+
+    chain_str = format_chain_arrow(result.chain)
+    return f"task_type:{result.task_type} chain:{chain_str} steps:{result.steps}"
+
+
+def format_json_output(result: ClassificationResult) -> str:
+    """Format classification result as a JSON string.
+
+    Args:
+        result: The classification result.
+
+    Returns:
+        JSON string with classification details.
+    """
+    if result.existing_pipeline:
+        output = {
+            "existing_pipeline": result.existing_pipeline,
+            "task_type": result.task_type,
+            "chain": result.chain,
+            "steps": result.steps,
+            "confidence": result.confidence,
+            "keywords_matched": result.keywords_matched,
+        }
+    else:
+        output = {
+            "task_type": result.task_type,
+            "chain": result.chain,
+            "steps": result.steps,
+            "confidence": result.confidence,
+            "keywords_matched": result.keywords_matched,
+        }
+
+    return json.dumps(output, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Deterministic classifier for user requests into canonical task types.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            '  python3 scripts/task-type-classifier.py --request "create a new Helm chart"\n'
+            '  python3 scripts/task-type-classifier.py --request "debug failing tests" --json\n'
+            '  python3 scripts/task-type-classifier.py --request "deploy to staging" '
+            "--check-catalog pipelines/catalog.json\n"
+        ),
+    )
+    parser.add_argument(
+        "--request",
+        required=True,
+        help="The user request text to classify",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output results as JSON",
+    )
+    parser.add_argument(
+        "--check-catalog",
+        metavar="PATH",
+        help="Path to a pipeline catalog JSON file to check for existing coverage",
+    )
+    return parser
+
+
+def main() -> int:
+    """Entry point."""
+    parser = build_parser()
+    args = parser.parse_args()
+
+    request = args.request.strip()
+    if not request:
+        print("Error: --request must not be empty", file=sys.stderr)
+        return 2
+
+    # Classify the request
+    result = classify_request(request)
+
+    # Check catalog if provided
+    if args.check_catalog:
+        catalog_path = Path(args.check_catalog)
+        if not catalog_path.is_absolute():
+            catalog_path = REPO_ROOT / catalog_path
+        catalog = load_catalog(catalog_path)
+        existing = check_catalog_overlap(request, catalog)
+        if existing:
+            result.existing_pipeline = existing
+
+    # Output
+    if args.json_output:
+        print(format_json_output(result))
+    else:
+        print(format_text_output(result))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "generated": "2026-03-23T15:43:03Z",
+  "generated": "2026-03-23T17:06:22Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": [
     {
@@ -1749,6 +1749,20 @@
       ],
       "category": "content-validation",
       "version": "2.0.0",
+      "user-invocable": false
+    },
+    {
+      "name": "auto-pipeline",
+      "description": "Automatic pipeline generation for unrouted tasks.",
+      "file": "pipelines/auto-pipeline/SKILL.md",
+      "triggers": [
+        "auto-pipeline",
+        "ephemeral pipeline",
+        "no route found",
+        "unrouted task"
+      ],
+      "category": "meta",
+      "version": "1.0.0",
       "user-invocable": false
     },
     {

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -44,7 +44,7 @@ This skill operates as the primary routing operator for the Claude Code agent sy
 - **MCP Auto-Invocation**: Use Context7 for documentation lookups; use gopls MCP for Go workspace intelligence (symbols, diagnostics, references)
 - **Dynamic Discovery**: Check `agents/INDEX.json` first, fall back to static routing tables
 - **Local Agent Discovery**: Route to `.claude/agents/` local agents when `[cross-repo]` output is present
-- **Gap Reporting**: When no agent/skill matches, report the gap and suggest creating one
+- **Auto-Pipeline Fallback**: When no agent/skill matches, invoke auto-pipeline to classify the task type, select a canonical chain (8-12 steps), and execute with phase gates. In the toolkit repo, auto-crystallize into a permanent pipeline immediately.
 - **Post-Task Learning**: After Simple+ tasks, extract reusable patterns and record via `retro-record-adhoc` to build the knowledge store from all work, not just feature lifecycles
 
 ### Optional Behaviors (OFF unless enabled)
@@ -276,6 +276,7 @@ For pipeline skills — add the Pipeline: line with all phases in order:
 | `mcp-pipeline-builder` | ANALYZE → DESIGN → GENERATE → VALIDATE → EVALUATE → REGISTER |
 | `do-perspectives` | VALIDATE → ANALYZE → SYNTHESIZE → APPLY → VERIFY |
 | `voice-calibrator` | VOICE-GROUNDING → VOICE-METRICS → THINKING-PATTERNS → VALIDATION |
+| `auto-pipeline` | DEDUP → CLASSIFY → SELECT → ADAPT → EXECUTE (ephemeral) or CRYSTALLIZE (permanent) |
 
 **Pipeline Companion Sequences** — common multi-pipeline workflows:
 
@@ -405,17 +406,18 @@ Detect: "first...then", "and also", numbered lists, semicolons.
 - Independent items: Launch multiple Task tools in single message
 - Max parallelism: 10 agents
 
-**Step 5: Handle uncertainty**
+**Step 5: Auto-Pipeline Fallback**
 
-When no agent/skill matches:
-```
-===================================================================
- GAP DETECTED: No match for [domain]
-===================================================================
- Closest: [Agent X] + [Skill Y]
- Or create: /do create an agent for [domain]
-===================================================================
-```
+When no agent/skill matches AND complexity >= Simple:
+
+1. **Dedup check**: Run `python3 scripts/task-type-classifier.py --request "{request}" --check-catalog pipelines/auto-pipeline/references/pipeline-catalog.md --json`
+2. **If existing pipeline found** (70%+ coverage): Route to that pipeline. Display routing banner with the matched pipeline.
+3. **If no match**: Invoke the `auto-pipeline` skill. It will:
+   - Classify the task type (8 canonical types)
+   - Select and adapt a canonical chain (8-12 steps)
+   - In toolkit repo: crystallize into permanent pipeline immediately, then execute
+   - In other repos: execute ephemeral chain (crystallize after 3+ runs)
+4. **If task-type-classifier fails or request is truly unclassifiable**: Fall back to closest agent + verification-before-completion as safety net.
 
 When uncertain which route: **ROUTE ANYWAY.** Route to the most likely agent + skill, add verification-before-completion as safety net, let the agent ask clarifying questions.
 

--- a/skills/do/references/routing-tables.md
+++ b/skills/do/references/routing-tables.md
@@ -175,6 +175,7 @@ All pipelines live in the `pipelines/` directory (synced to `~/.claude/skills/` 
 | voice calibration, refine voice, writing style | voice-calibrator | VOICE-GROUNDING → VOICE-METRICS → THINKING-PATTERNS → VALIDATION |
 | execute plan, run plan, orchestrate | workflow-orchestrator | BRAINSTORM → WRITE-PLAN → EXECUTE-PLAN |
 | de-ai docs, clean ai patterns, scan and fix docs | de-ai-pipeline | SCAN → FIX → VERIFY (loop max 3) → REPORT |
+| **(auto-fallback for unrouted tasks)** | **auto-pipeline** | DEDUP → CLASSIFY → SELECT → ADAPT → EXECUTE/CRYSTALLIZE |
 
 ### Pipeline Companion Map
 


### PR DESCRIPTION
## Summary
- Add automatic pipeline generation for unrouted tasks via `/do`
- Tier 1: classify task type → select canonical chain (8-12 steps) → execute ephemeral with phase gates
- Tier 2: auto-crystallize into permanent pipeline (immediate in toolkit repo, 3+ runs elsewhere)
- Dedup gate prevents creating pipelines that duplicate existing ones (pipeline catalog + 35% word-overlap threshold)

## New Components
- `scripts/task-type-classifier.py` — deterministic keyword classification into 8 canonical task types
- `scripts/generate-pipeline-catalog.py` — generates markdown + JSON catalog from `pipelines/*/SKILL.md`
- `pipelines/auto-pipeline/SKILL.md` — core pipeline with ephemeral execution and crystallization phases
- `pipelines/auto-pipeline/references/pipeline-catalog.{md,json}` — catalog of all 26 existing pipelines

## /do Integration
- Replace gap detection (Step 5) with auto-pipeline fallback
- Added to Pipeline Phase Registry and routing tables
- Philosophy: `/do` is the only command — everything else is automatic

## Test Plan
- [x] Classifier correctly identifies all 8 task types
- [x] Dedup gate catches explore-pipeline, pr-pipeline for matching requests
- [x] Novel requests pass through to auto-pipeline
- [x] All Python compiles clean, ruff formatted
- [x] INDEX.json regenerated (150 skills)