### PR TITLE
fix: add fail-open exception wrapper to ci-merge-gate hook

### DIFF
--- a/hooks/ci-merge-gate.py
+++ b/hooks/ci-merge-gate.py
@@ -103,4 +103,9 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SystemExit:
+        raise  # Let intentional exit(2) blocks propagate
+    except Exception:
+        sys.exit(0)  # Fail-open: crashed hook must never block tools


### PR DESCRIPTION
## Summary
- Add try/except wrapper to `ci-merge-gate.py` main() that exits 0 on unhandled exceptions
- Without this, malformed stdin or unexpected errors cause non-zero exit which can block tool execution
- Matches the fail-open pattern used by all other 44 hooks in the repo
- Found during hook error handling analysis via auto-pipeline

## Test Plan
- [x] Python compiles clean
- [x] Ruff format/check passes
- [x] Pattern matches all other hooks (SystemExit raised, Exception → exit 0)