### PR TITLE
feat: upgrade explore-pipeline with 8-phase deep tier for analysis

### DIFF
--- a/pipelines/auto-pipeline/references/pipeline-catalog.json
+++ b/pipelines/auto-pipeline/references/pipeline-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated": "2026-03-23T17:04:38Z",
+  "generated": "2026-03-23T17:42:13Z",
   "generated_by": "scripts/generate-pipeline-catalog.py",
   "pipelines": [
     {
@@ -195,15 +195,19 @@
     },
     {
       "name": "explore-pipeline",
-      "description": "Systematic 4-phase codebase exploration pipeline: Scan, Map, Analyze, Report",
-      "phase_count": 4,
+      "description": "Systematic codebase exploration pipeline with parallel subagents and",
+      "phase_count": 8,
       "phases": [
         "SCAN",
         "MAP",
         "ANALYZE",
+        "COMPILE",
+        "ASSESS",
+        "SYNTHESIZE",
+        "REFINE",
         "REPORT"
       ],
-      "chain": "SCAN → MAP → ANALYZE → REPORT",
+      "chain": "SCAN → MAP → ANALYZE → COMPILE → ASSESS → SYNTHESIZE → REFINE → REPORT",
       "task_type": "exploration",
       "triggers": [
         "understand codebase",
@@ -211,7 +215,11 @@
         "how does this work",
         "codebase exploration",
         "understand this code",
-        "map architecture"
+        "map architecture",
+        "analyze quality",
+        "assess consistency",
+        "evaluate patterns",
+        "analyze codebase"
       ]
     },
     {

--- a/pipelines/auto-pipeline/references/pipeline-catalog.md
+++ b/pipelines/auto-pipeline/references/pipeline-catalog.md
@@ -1,6 +1,6 @@
 # Pipeline Catalog
 Auto-generated reference for auto-pipeline dedup checks.
-Generated: 2026-03-23T17:04:38Z
+Generated: 2026-03-23T17:42:13Z
 
 | Pipeline | Phases | Chain | Task Type | Triggers |
 |----------|--------|-------|-----------|----------|
@@ -13,7 +13,7 @@ Generated: 2026-03-23T17:04:38Z
 | do-perspectives | 5 | VALIDATE INPUTS → MULTI-PERSPECTIVE ANALYSIS → SYNTHESIZE → APPLY → VERIFY AND REPORT | content-pipeline | perspectives |
 | doc-pipeline | 5 | RESEARCH → OUTLINE → GENERATE → VERIFY → OUTPUT | documentation | document this, create readme, write documentation, document codebase, generate docs |
 | domain-research | 4 | DISCOVER → CLASSIFY → MAP → PRODUCE | meta | research domain, discover subdomains, domain decomposition, what pipelines, domain research |
-| explore-pipeline | 4 | SCAN → MAP → ANALYZE → REPORT | exploration | understand codebase, explore repo, how does this work, codebase exploration, understand this code |
+| explore-pipeline | 8 | SCAN → MAP → ANALYZE → COMPILE → ASSESS → SYNTHESIZE → REFINE → REPORT | exploration | understand codebase, explore repo, how does this work, codebase exploration, understand this code |
 | github-profile-rules | 8 | ADR → FETCH → RESEARCH → SAMPLE → COMPILE → GENERATE → VALIDATE → OUTPUT | review | github, profile, rules |
 | hook-development-pipeline | 9 | SPEC → IMPLEMENT → TEST → REGISTER → DOCUMENT → PERFORMANCE GATE FAILS → NON-BLOCKING GATE FAILS → JSON PARSE FAILS ON SETTINGS.JSON → HOOK-DEVELOPMENT-ENGINEER PRODUCES HOOK WITHOUT LAZY IMPORTS | git-workflow | hook, development, pipeline |
 | mcp-pipeline-builder | 5 | ANALYSIS ERRORS → DESIGN ERRORS → VALIDATION ERRORS → EVALUATION ERRORS → REGISTRATION ERRORS | pipeline | mcp pipeline, repo to mcp, create mcp from repo, generate mcp, mcp builder |

--- a/pipelines/explore-pipeline/SKILL.md
+++ b/pipelines/explore-pipeline/SKILL.md
@@ -1,10 +1,15 @@
 ---
 name: explore-pipeline
 description: |
-  Systematic 4-phase codebase exploration pipeline: Scan, Map, Analyze, Report
-  with parallel subagents. Use when user asks to "understand codebase", "explore
-  repo", "how does X work", "map architecture", or "explain this code". Do NOT
-  use for code changes, debugging, refactoring, or any task that modifies files.
+  Systematic codebase exploration pipeline with parallel subagents and
+  tiered depth. Quick: 1 phase (targeted lookup). Standard: 4 phases
+  (Scan, Map, Analyze, Report). Deep: 8 phases (Scan, Map, Analyze,
+  Compile, Assess, Synthesize, Refine, Report) for quality evaluation,
+  consistency assessment, and pattern analysis across the codebase.
+  Use when user asks to "understand codebase", "explore repo", "how does
+  X work", "map architecture", "explain this code", "analyze quality of",
+  "assess consistency of", or "evaluate patterns in". Do NOT use for code
+  changes, debugging, refactoring, or any task that modifies files.
 version: 2.0.0
 user-invocable: false
 allowed-tools:
@@ -24,6 +29,10 @@ routing:
     - codebase exploration
     - understand this code
     - map architecture
+    - analyze quality
+    - assess consistency
+    - evaluate patterns
+    - analyze codebase
   pairs_with:
     - codebase-overview
     - codebase-analyzer
@@ -72,7 +81,7 @@ This skill operates as an operator for systematic codebase exploration, configur
 - Debug or fix bugs (use systematic-debugging instead)
 - Refactor code (use systematic-refactoring instead)
 - Generate documentation (use technical-documentation-engineer instead)
-- Skip any of the 4 phases
+- Skip phases within the selected tier (Quick: Phase 1; Standard: 1-3,8; Deep: all 8)
 
 ---
 
@@ -150,9 +159,83 @@ Document the implicit rules: how errors propagate, how state is managed, how com
 
 **Gate**: Key components analyzed with evidence from actual code. Critical paths traced. Proceed only when gate passes.
 
-### Phase 4: REPORT
+### Phase 4: COMPILE (Deep tier only)
+
+**Goal**: Structure raw findings from Phases 1-3 into a structured corpus for evaluation.
+
+**Step 1: Categorize findings**
+
+Group all Phase 1-3 findings by evaluation dimension:
+- **Consistency**: Same pattern used everywhere, or mixed approaches?
+- **Quality**: Meets best practices? Error handling complete? Tests adequate?
+- **Coverage**: Any gaps? Components without tests, docs, or error handling?
+- **Patterns**: What patterns recur? What's the dominant approach?
+
+**Step 2: Build comparison matrix**
+
+Create a structured table comparing components against each dimension. Save as `analysis-compilation.md`.
+
+**Gate**: Findings structured into evaluation dimensions with per-component data. Compilation artifact saved.
+
+### Phase 5: ASSESS (Deep tier only)
+
+**Goal**: Evaluate the compiled findings against quality criteria.
+
+**Step 1: Score each dimension**
+
+For each evaluation dimension from Phase 4:
+- Rate compliance as a percentage (X/Y components follow the pattern)
+- Identify outliers (components that deviate from the norm)
+- Assess severity of deviations (cosmetic vs functional vs safety)
+
+**Step 2: Identify root causes**
+
+For each deviation found:
+- Is it intentional (documented exception) or accidental (drift)?
+- Is it a one-off or a recurring pattern?
+- What's the fix complexity (trivial, moderate, significant)?
+
+**Gate**: All dimensions scored with evidence. Deviations cataloged with root causes.
+
+### Phase 6: SYNTHESIZE (Deep tier only)
+
+**Goal**: Combine assessment findings into actionable recommendations.
+
+**Step 1: Rank findings by impact**
+
+| Severity | Criteria |
+|----------|----------|
+| Critical | Safety issue, data loss risk, session-blocking |
+| High | Functional gap, inconsistency that causes confusion |
+| Medium | Quality gap, missing best practice |
+| Low | Cosmetic, style preference |
+
+**Step 2: Group by theme**
+
+Cluster related findings into themes (e.g., "error handling consistency", "test coverage gaps", "naming drift").
+
+**Gate**: Findings ranked by severity, grouped by theme.
+
+### Phase 7: REFINE (Deep tier only)
+
+**Goal**: Verify findings against actual code before reporting.
+
+**Step 1: Spot-check top findings**
+
+For the top 5 findings by severity, re-read the actual source code to confirm the finding is accurate. Adjust if the initial analysis was wrong.
+
+**Step 2: Remove false positives**
+
+If spot-checking reveals a finding was incorrect (e.g., the pattern is actually intentional), remove it from the report.
+
+**Gate**: Top findings verified against source. False positives removed.
+
+### Phase 8: REPORT (final phase for all tiers)
 
 **Goal**: Produce a structured, reusable exploration report.
+
+**Standard tier**: This is effectively Phase 4 (Phases 4-7 were skipped). Report covers architecture and patterns.
+**Deep tier**: This is Phase 8. Report includes everything from Standard PLUS quality assessment, consistency scores, and ranked recommendations from Phases 4-7.
 
 Generate and save `exploration-report.md` following this structure:
 
@@ -289,21 +372,23 @@ Not every exploration question needs the same depth. Running a full pipeline for
 
 ### Deep Dive (1+ hour)
 
-**Purpose**: Full architectural analysis for onboarding or major refactoring decisions.
+**Purpose**: Full analysis — architectural understanding PLUS quality evaluation, consistency assessment, and pattern analysis.
 
-**Scope**: All 4 phases with expanded scope. Phase 1 uses additional scanners for broader coverage. Phase 3 traces multiple critical paths rather than just the primary one. Cross-cutting concerns (logging, auth, error handling) get dedicated analysis.
+**Scope**: All 8 phases. Phases 1-3 explore the codebase. Phases 4-7 compile findings, assess quality, synthesize recommendations, and verify against source. Phase 8 produces a comprehensive report.
 
-**Phases used**: All 4 phases with expanded scope at each.
+**Phases used**: All 8 phases: SCAN → MAP → ANALYZE → COMPILE → ASSESS → SYNTHESIZE → REFINE → REPORT.
 
-**Exit criteria**: Comprehensive report covers full architecture, all major subsystems, cross-cutting concerns, and integration points. Multiple artifact files may be produced.
+**Exit criteria**: Comprehensive report covers full architecture, quality assessment with scores, consistency evaluation, pattern analysis, and ranked recommendations. Multiple artifact files produced.
 
 **Examples**:
 - "I'm new to this codebase, give me the full picture."
 - "We're considering a major refactor -- what do we need to know?"
-- "Onboard me to this entire repository."
+- "Analyze the quality and consistency of our error handling."
+- "Assess which patterns are used consistently vs inconsistently."
 - "Full architectural review before we plan next quarter."
+- "Evaluate the test coverage patterns across all modules."
 
-**Output format**: Saved `exploration-report.md` plus supplementary files (`architecture-map.md`, component-specific documents as needed).
+**Output format**: Saved `exploration-report.md` plus supplementary files (`architecture-map.md`, `analysis-compilation.md`, component-specific documents as needed).
 
 ### Tier Selection Logic
 
@@ -312,6 +397,8 @@ If user specifies --tier or --quick or --deep:
   Use the specified tier.
 Else if user asks a single specific question (what/which/does/is):
   Use Quick Verify.
+Else if user asks to analyze/assess/evaluate/audit quality or patterns:
+  Use Deep Dive (needs COMPILE + ASSESS + SYNTHESIZE + REFINE phases).
 Else if user asks about a specific subsystem or flow:
   Use Standard.
 Else if user asks for full picture / onboarding / comprehensive:

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "generated": "2026-03-23T17:06:22Z",
+  "generated": "2026-03-23T17:42:13Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": [
     {
@@ -1860,7 +1860,7 @@
     },
     {
       "name": "explore-pipeline",
-      "description": "Systematic 4-phase codebase exploration pipeline: Scan, Map, Analyze, Report with parallel subagents.",
+      "description": "Systematic codebase exploration pipeline with parallel subagents and tiered depth.",
       "file": "pipelines/explore-pipeline/SKILL.md",
       "triggers": [
         "understand codebase",
@@ -1868,7 +1868,11 @@
         "how does this work",
         "codebase exploration",
         "understand this code",
-        "map architecture"
+        "map architecture",
+        "analyze quality",
+        "assess consistency",
+        "evaluate patterns",
+        "analyze codebase"
       ],
       "category": "exploration",
       "version": "2.0.0",

--- a/skills/do/references/routing-tables.md
+++ b/skills/do/references/routing-tables.md
@@ -165,7 +165,7 @@ All pipelines live in the `pipelines/` directory (synced to `~/.claude/skills/` 
 | research then write, article with research | research-to-article | RESEARCH → COMPILE → GROUND → GENERATE → VALIDATE → REFINE → OUTPUT |
 | document this, create readme, write docs | doc-pipeline | RESEARCH → OUTLINE → GENERATE → VERIFY → OUTPUT |
 | submit PR, create pull request | pr-pipeline | CLASSIFY → STAGE → REVIEW → COMMIT → PUSH → CREATE → VERIFY → CLEANUP |
-| understand codebase, explore repo | explore-pipeline | SCAN → MAP → ANALYZE → REPORT |
+| understand codebase, explore repo, analyze quality, assess consistency | explore-pipeline | SCAN → MAP → ANALYZE → [COMPILE → ASSESS → SYNTHESIZE → REFINE] → REPORT |
 | evaluate article, check voice authenticity | article-evaluation-pipeline | FETCH → VALIDATE → ANALYZE → REPORT |
 | mcp pipeline, repo to mcp, create mcp from repo, generate mcp, mcp builder, mcp from repo | mcp-pipeline-builder (mcp-local-docs-engineer) | ANALYZE → DESIGN → GENERATE → VALIDATE → EVALUATE → REGISTER |
 | write in voice, generate voice content, blog post, write article | voice-writer | LOAD → GROUND → GENERATE → VALIDATE → REFINE → JOY-CHECK → OUTPUT → CLEANUP |


### PR DESCRIPTION
## Summary
- Extend explore-pipeline's Deep Dive tier from 4 to 8 phases
- New phases: COMPILE → ASSESS → SYNTHESIZE → REFINE (between ANALYZE and REPORT)
- Tier selection auto-routes analysis keywords to Deep tier
- Standard tier unchanged (4 phases), Quick unchanged (1 phase)

## Why
Ephemeral analysis chain execution showed that evaluating quality/consistency
needs structured COMPILE + ASSESS + SYNTHESIZE phases. The 4-phase pipeline
produced good exploration but shallow analysis. Graduated from learning.db
into the existing pipeline rather than creating a duplicate.

## Tiers
| Tier | Phases | When |
|------|--------|------|
| Quick | 1 (SCAN) | Single fact lookup |
| Standard | 4 (SCAN → MAP → ANALYZE → REPORT) | Understand a subsystem |
| Deep | 8 (+ COMPILE → ASSESS → SYNTHESIZE → REFINE) | Quality evaluation, pattern analysis |

## Test Plan
- [x] Pipeline catalog regenerated (26 pipelines)
- [x] INDEX.json regenerated (150 skills)
- [x] Learning graduated from learning.db
- [x] Routing tables updated with analysis triggers