### PR TITLE
feat: implement ADR-093 parallel agent branch convergence

### DIFF
--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -33,6 +33,7 @@ This skill operates as an operator for parallel dispatch workflows, configuring 
 - **CLAUDE.md Compliance**: Read and follow repository CLAUDE.md before dispatching agents
 - **Over-Engineering Prevention**: Fix only what is broken. No speculative improvements across domains
 - **Independence Verification**: MUST confirm problems are independent before parallel dispatch
+- **Branch Convergence (ADR-093)**: Orchestrator MUST create the target branch BEFORE dispatching agents. Each agent prompt MUST include the branch name with explicit instructions to commit there — NOT create a new branch. This overrides the default "always create a branch" rule for parallel-dispatched agents.
 - **Single Message Dispatch**: MUST launch all parallel agents in ONE message for true concurrency
 - **Scoped Prompts**: Each agent MUST receive explicit scope, constraints, and expected output
 - **Post-Integration Verification**: MUST run full test suite after all agents return
@@ -122,7 +123,19 @@ These are NOT caught by the scope overlap script and require manual verification
 
 ### Phase 2: DISPATCH
 
-**Goal**: Launch focused agents with clear scope in a single message.
+**Goal**: Launch focused agents with clear scope on a single shared branch.
+
+**Step 0: Create target branch (ADR-093 — Branch Convergence)**
+
+Before dispatching any agents, the orchestrator creates and checks out the target branch:
+
+```bash
+git checkout -b feat/{descriptive-name}
+```
+
+This branch is the single convergence point for all parallel agents. Individual agents MUST NOT create their own branches.
+
+**Why**: Without this step, N agents create N branches (the "scattered branches" problem). Cherry-picking and branch discovery after the fact is fragile and error-prone. Creating the branch before dispatch is simple and deterministic.
 
 **Step 1: Create agent prompts**
 
@@ -136,19 +149,26 @@ Fix [N] failing tests in [FILE/SUBSYSTEM]:
 
 Context: [What this subsystem does]
 
+Branch: Work on branch `{branch_name}`. Do NOT create a new branch.
+Do NOT checkout other branches. Commit your changes to this branch.
+Run `git branch --show-current` first to verify you are on the correct branch.
+
 Your task:
-1. Read the relevant code and understand what it does
-2. Identify root cause - is this a code issue or test issue?
-3. Fix the issue (prefer fixing implementation over changing test expectations)
-4. Run tests to verify fix
+1. Verify you are on branch `{branch_name}`
+2. Read the relevant code and understand what it does
+3. Identify root cause - is this a code issue or test issue?
+4. Fix the issue (prefer fixing implementation over changing test expectations)
+5. Run tests to verify fix
 
 Constraints:
 - Only modify files in [SCOPE]
 - Do NOT change [OUT OF SCOPE FILES]
+- Do NOT create a new branch or checkout other branches
 
 Return:
 - Root cause (1-2 sentences)
 - Files modified
+- Branch confirmed: [branch name from git branch --show-current]
 - How to verify the fix
 ```
 
@@ -169,12 +189,29 @@ Wave 2 (after wave 1): [task-3] — overlaps with task-1 on handlers/auth.go
 
 **Goal**: Combine agent results, detect conflicts, verify combined fix.
 
-**Step 1: Read each agent summary**
+**Step 1: Verify branch convergence (ADR-093)**
+
+Before reading results, verify all agent work landed on the target branch:
+
+```bash
+git branch --show-current   # Must show the target branch
+git log --oneline -10       # All recent commits should be on this branch
+```
+
+If an agent created a rogue branch:
+1. Identify the rogue branch: `git branch --list 'feat/*'`
+2. Cherry-pick its commits to the target branch: `git cherry-pick <commit-hash>`
+3. Delete the rogue branch: `git branch -d <rogue-branch>`
+
+If an agent used a worktree, its commits are on a separate branch by design — cherry-pick them to the target branch.
+
+**Step 2: Read each agent summary**
 - What was the root cause?
 - What files were modified?
 - Did the agent's local tests pass?
+- Did the agent confirm the correct branch?
 
-**Step 2: Check for conflicts**
+**Step 3: Check for conflicts**
 - Did any agent modify files outside its declared scope? (Compare actual files modified vs Phase 1 scope declarations)
 - Did any two agents modify the same file? (Should not happen if scope overlap check was clean, but verify)
 - Did any agent report the same root cause as another?
@@ -182,11 +219,11 @@ Wave 2 (after wave 1): [task-3] — overlaps with task-1 on handlers/auth.go
 
 If conflicts detected: Do NOT auto-merge. Understand which fix is correct. May need sequential re-investigation.
 
-**Step 3: Run full test suite**
+**Step 4: Run full test suite**
 
 Execute the complete test suite to verify all fixes work together without regressions.
 
-**Step 4: Spot-check at least one fix**
+**Step 5: Spot-check at least one fix**
 
 Read the actual code change from one agent and verify it makes sense.
 
@@ -231,14 +268,15 @@ Solution: Revert conflicting changes. Re-investigate the conflicting pair sequen
 Cause: Problem depends on state from another subsystem, or environment mismatch
 Solution: Provide additional context. If still cannot reproduce, the problem may not be independent -- move it to a sequential investigation.
 
-### Error: "Worktree Agent Commits to Wrong Branch"
-Cause: When multiple worktrees exist, agents may operate on an unexpected branch because the worktree's branch and push target can diverge.
-Solution:
-1. In each agent's dispatch prompt, explicitly state the target branch name
-2. Include `git branch --show-current` as the first verification step in each agent
-3. After all agents return, verify each commit landed on the intended branch
-4. If a commit landed on the wrong branch, cherry-pick to the correct branch and reset
-*Graduated from learning.db — multi-agent-coordination/worktree-branch-confusion*
+### Error: "Agent Commits to Wrong Branch"
+Cause: Agent creates its own branch (ignoring convergence protocol) or worktree diverges from target.
+Solution (ADR-093 — Branch Convergence):
+1. Orchestrator creates the target branch BEFORE dispatching agents (Phase 2, Step 0)
+2. Each agent prompt explicitly states `Work on branch: {name}. Do NOT create a new branch.`
+3. Each agent runs `git branch --show-current` as first step to verify correct branch
+4. After all agents return, Phase 3 Step 1 verifies convergence
+5. If a commit landed on the wrong branch, cherry-pick to the target and delete the rogue branch
+*Graduated from learning.db — multi-agent-coordination/worktree-branch-confusion. Superseded by ADR-093.*
 
 ---
 
@@ -264,6 +302,12 @@ Solution:
 **Why wrong**: Wastes agent effort; conflicting fixes require rework
 **Do instead**: Complete Phase 1 classification. Independence verification is not optional.
 
+### Anti-Pattern 5: Scattered Branches (ADR-093)
+**What it looks like**: Each parallel agent creates its own feature branch, producing N branches for N agents
+**Why wrong**: Orchestrator must detective-work through cherry-picks, branch discovery, and manual integration. Merge commits pollute history. Conflicts emerge during integration that could have been prevented.
+**Do instead**: Orchestrator creates the target branch BEFORE dispatch. Each agent prompt includes `Work on branch: {name}. Do NOT create a new branch.` All changes converge on a single branch.
+*Graduated from ADR-093 and learning.db — multi-agent-coordination/parallel-agents-scatter-branches*
+
 ---
 
 ## References
@@ -280,3 +324,5 @@ This skill uses these shared patterns:
 | "Agent said it's fixed" | Agent report ≠ integrated verification | Run full test suite |
 | "No conflicts in file list" | File-level ≠ logic-level conflict | Spot-check actual changes |
 | "Too many problems to classify" | Skipping classification causes rework | Classify all before dispatch |
+| "Agents will figure out the branch" | Without explicit branch, each agent creates its own | Pass branch name in every prompt (ADR-093) |
+| "I'll merge the branches after" | Post-hoc merge creates conflicts and pollutes history | Create branch before dispatch, not after |

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -692,6 +692,11 @@ Solution:
 **Do instead**: Read the library source in GOMODCACHE. The question is never "how does the protocol work?" but "how does THIS library version implement THIS method?"
 *Graduated from incident — 40 agent reviews missed segmentio/kafka-go Reader offset behavior*
 
+### Anti-Pattern 14: Parallel Agents Creating Scattered Branches
+**What it looks like**: Dispatching 4 parallel agents, each creating its own feature branch (`feat/task-1`, `feat/task-2`, etc.), then manually cherry-picking or merging to combine their work.
+**Why wrong**: Cherry-picking is fragile, merge commits pollute history, and branch discovery is manual detective work. This was the actual outcome during ADR-083 implementation.
+**Do instead**: The orchestrator creates the target branch BEFORE dispatch. Each agent prompt includes `Work on branch: {name}. Do NOT create a new branch.` See ADR-093 and `dispatching-parallel-agents` skill Phase 2, Step 0.
+
 ---
 
 ## References


### PR DESCRIPTION
## Summary
- Add branch convergence protocol to `dispatching-parallel-agents` skill: orchestrator creates target branch before dispatch, passes branch name to every agent prompt, verifies convergence after agents return
- Add Anti-Pattern 14 (Scattered Branches) to `/do` skill
- Prevents N-agents-N-branches problem observed during ADR-083 implementation

## Changes
- `skills/dispatching-parallel-agents/SKILL.md`: New hardcoded behavior, Phase 2 Step 0, updated prompt template, Phase 3 Step 1 verification, Anti-Pattern 5, error handler update, anti-rationalization entries
- `skills/do/SKILL.md`: Anti-Pattern 14

## ADR-093 Decision Point Coverage
| Decision Point | Implementation |
|---|---|
| Orchestrator creates branch before dispatch | Phase 2, Step 0 |
| Each agent prompt includes branch instruction | Prompt template with 5-layer defense |
| Orchestrator verifies convergence after | Phase 3, Step 1 |
| Safety valve for conflicts | Phase 3, Step 3 |

## Test plan
- [x] All ADR-093 decision points mapped to implementation
- [x] Step numbering verified sequential (no gaps)
- [x] Cross-references verified accurate
- [x] PR review clean (0 critical, 0 important)
- [x] Related skills verified exempt (do-parallel: read-only, subagent-driven-development: sequential)