### PR TITLE
feat: implement ADR-088 subagent warm start

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,6 +109,12 @@
             "command": "python3 \"$HOME/.claude/hooks/pretool-prompt-injection-scanner.py\"",
             "description": "Advisory scan for prompt injection patterns in agent context files (ADR-070)",
             "timeout": 3000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/pretool-subagent-warmstart.py\"",
+            "description": "Inject parent session context into subagent prompts (ADR-088)",
+            "timeout": 5000
           }
         ]
       }
@@ -157,6 +163,11 @@
             "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/record-waste.py\"",
             "description": "Record wasted tokens from tool failures for ROI tracking (ADR-032)"
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/posttool-session-reads.py\"",
+            "description": "Track files read this session for subagent warmstart (ADR-088)"
           }
         ]
       }

--- a/hooks/posttool-session-reads.py
+++ b/hooks/posttool-session-reads.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+PostToolUse Hook: Session Read Tracker
+
+Tracks files read during the session by appending file paths to
+.claude/session-reads.txt. This provides a lightweight record of
+files the parent session has seen, used by the warmstart hook to
+give subagents context about what's already been read.
+
+Design Principles:
+- SILENT output (no context injection)
+- Non-blocking (always exits 0)
+- Fast execution (<10ms target)
+- Only processes Read tool results
+- Deduplicates paths within the session file
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# Add lib directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+
+from hook_utils import empty_output
+from stdin_timeout import read_stdin
+
+EVENT_NAME = "PostToolUse"
+
+SESSION_READS_FILE = ".claude/session-reads.txt"
+
+
+def main() -> None:
+    """Process PostToolUse events for Read tool file tracking.
+
+    Flow:
+    1. Read stdin JSON, check tool_name == "Read"
+    2. Extract file_path from tool_input
+    3. Append to .claude/session-reads.txt (deduplicated)
+    4. Exit silently (no context injection)
+    """
+    try:
+        event_data = read_stdin(timeout=2)
+        if not event_data:
+            return
+
+        event = json.loads(event_data)
+
+        # Only process Read tool results
+        tool_name = event.get("tool_name", "")
+        if tool_name != "Read":
+            return
+
+        # Extract file_path from tool_input
+        tool_input = event.get("tool_input", {})
+        if isinstance(tool_input, str):
+            try:
+                tool_input = json.loads(tool_input)
+            except (json.JSONDecodeError, TypeError):
+                return
+        if not isinstance(tool_input, dict):
+            return
+
+        file_path = tool_input.get("file_path", "")
+        if not file_path:
+            return
+
+        # Resolve the session-reads file path
+        reads_path = Path(SESSION_READS_FILE)
+
+        # Ensure parent directory exists
+        reads_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Check for duplicates by reading existing entries
+        existing_paths: set[str] = set()
+        if reads_path.is_file():
+            try:
+                content = reads_path.read_text(encoding="utf-8")
+                existing_paths = {line.strip() for line in content.splitlines() if line.strip()}
+            except OSError:
+                pass
+
+        # Only append if not already tracked
+        if file_path not in existing_paths:
+            with open(reads_path, "a", encoding="utf-8") as f:
+                f.write(file_path + "\n")
+
+        # Silent output — no context injection
+        empty_output(EVENT_NAME).print_and_exit()
+
+    except Exception as e:
+        print(f"[session-reads] error: {e}", file=sys.stderr)
+    finally:
+        sys.exit(0)  # Never block
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/pretool-subagent-warmstart.py
+++ b/hooks/pretool-subagent-warmstart.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+PreToolUse Hook: Subagent Warm Start
+
+Enriches subagent (Agent tool) prompts with parent session context.
+Injects a <parent-context> block containing files seen, task plan
+status, ADR session info, key decisions, and discovery briefs.
+
+This gives subagents immediate awareness of the parent session's
+state without needing to re-discover context from scratch.
+
+Design Principles:
+- Non-blocking (always exits 0)
+- Sub-50ms execution (file reads only, no subprocess)
+- Graceful degradation on missing files
+- Caps output at ~8000 chars (~2000 tokens)
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# Add lib directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+
+from hook_utils import context_output, empty_output
+from stdin_timeout import read_stdin
+
+EVENT_NAME = "PreToolUse"
+
+SESSION_READS_FILE = ".claude/session-reads.txt"
+TASK_PLAN_FILE = "task_plan.md"
+ADR_SESSION_FILE = ".adr-session.json"
+DISCOVERIES_DIR = ".planning/discoveries"
+
+MAX_OUTPUT_CHARS = 8000
+MAX_FILES_SHOWN = 20
+
+
+def load_recent_reads(reads_path: Path, max_count: int = MAX_FILES_SHOWN) -> list[str]:
+    """Load up to max_count most recent file paths from session-reads.txt.
+
+    Args:
+        reads_path: Path to the session-reads.txt file.
+        max_count: Maximum number of paths to return.
+
+    Returns:
+        List of file path strings, most recent last (tail of file).
+    """
+    if not reads_path.is_file():
+        return []
+
+    try:
+        content = reads_path.read_text(encoding="utf-8")
+        lines = [line.strip() for line in content.splitlines() if line.strip()]
+        # Return the most recent entries (tail of file)
+        return lines[-max_count:]
+    except OSError:
+        return []
+
+
+def extract_task_plan(plan_path: Path) -> dict[str, str]:
+    """Extract Goal and Status lines from task_plan.md.
+
+    Args:
+        plan_path: Path to task_plan.md.
+
+    Returns:
+        Dict with 'goal' and 'status' keys (empty strings if not found).
+    """
+    result = {"goal": "", "status": ""}
+
+    if not plan_path.is_file():
+        return result
+
+    try:
+        content = plan_path.read_text(encoding="utf-8")
+    except OSError:
+        return result
+
+    lines = content.splitlines()
+    in_goal_section = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "## Goal":
+            in_goal_section = True
+            continue
+        if in_goal_section:
+            if stripped.startswith("## "):
+                # Hit next section heading, goal section is over
+                in_goal_section = False
+            elif stripped:
+                result["goal"] = stripped[:200]
+                in_goal_section = False
+        if stripped.startswith("**Currently in Phase") or stripped.startswith("**Status"):
+            result["status"] = stripped[:200]
+
+    return result
+
+
+def extract_decisions(plan_path: Path) -> list[str]:
+    """Extract decisions from the 'Decisions Made' section of task_plan.md.
+
+    Args:
+        plan_path: Path to task_plan.md.
+
+    Returns:
+        List of decision strings.
+    """
+    if not plan_path.is_file():
+        return []
+
+    try:
+        content = plan_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    decisions: list[str] = []
+    in_decisions = False
+
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped == "## Decisions Made":
+            in_decisions = True
+            continue
+        if in_decisions:
+            if stripped.startswith("## "):
+                break  # Next section
+            if stripped.startswith("- "):
+                decisions.append(stripped[2:].strip()[:200])
+
+    return decisions
+
+
+def load_adr_session(session_path: Path) -> dict[str, str]:
+    """Load ADR session metadata from .adr-session.json.
+
+    Args:
+        session_path: Path to .adr-session.json.
+
+    Returns:
+        Dict with 'adr_path' and 'domain' keys (empty strings if not found).
+    """
+    result = {"adr_path": "", "domain": ""}
+
+    if not session_path.is_file():
+        return result
+
+    try:
+        content = session_path.read_text(encoding="utf-8")
+        data = json.loads(content)
+        result["adr_path"] = data.get("adr_path", "")
+        result["domain"] = data.get("domain", "")
+    except (OSError, json.JSONDecodeError):
+        pass
+
+    return result
+
+
+def list_discoveries(discoveries_dir: Path) -> list[str]:
+    """List discovery brief filenames from .planning/discoveries/.
+
+    Args:
+        discoveries_dir: Path to the discoveries directory.
+
+    Returns:
+        List of filenames (not full paths).
+    """
+    if not discoveries_dir.is_dir():
+        return []
+
+    try:
+        return sorted(f.name for f in discoveries_dir.iterdir() if f.is_file())
+    except OSError:
+        return []
+
+
+def build_context_block(
+    files: list[str],
+    task_plan: dict[str, str],
+    decisions: list[str],
+    adr_session: dict[str, str],
+    discoveries: list[str],
+) -> str:
+    """Build the parent-context block for subagent injection.
+
+    Args:
+        files: List of file paths seen in the session.
+        task_plan: Dict with 'goal' and 'status' from task_plan.md.
+        decisions: List of decisions from task_plan.md.
+        adr_session: Dict with 'adr_path' and 'domain'.
+        discoveries: List of discovery brief filenames.
+
+    Returns:
+        Formatted context block string, capped at MAX_OUTPUT_CHARS.
+    """
+    parts: list[str] = []
+
+    # Files seen
+    if files:
+        file_list = ", ".join(files)
+        parts.append(f"[warmstart] Files seen ({len(files)}): {file_list}")
+    else:
+        parts.append("[warmstart] Files seen (0): none")
+
+    # Task plan
+    if task_plan["goal"]:
+        parts.append(f"[warmstart] Task: {task_plan['goal']}")
+    if task_plan["status"]:
+        parts.append(f"[warmstart] Status: {task_plan['status']}")
+
+    # ADR session
+    if adr_session["adr_path"]:
+        parts.append(f"[warmstart] ADR session: {adr_session['adr_path']} (domain: {adr_session['domain']})")
+
+    # Decisions
+    if decisions:
+        decision_text = "; ".join(decisions)
+        parts.append(f"[warmstart] Decisions: {decision_text}")
+
+    # Discoveries
+    if discoveries:
+        disc_text = ", ".join(discoveries)
+        parts.append(f"[warmstart] Discovery briefs: {disc_text}")
+
+    header = "[warmstart] Parent session context for subagent:"
+    body = "\n".join(parts)
+    full_output = f"{header}\n{body}"
+
+    # Cap at MAX_OUTPUT_CHARS
+    if len(full_output) > MAX_OUTPUT_CHARS:
+        full_output = full_output[: MAX_OUTPUT_CHARS - 3] + "..."
+
+    return full_output
+
+
+def main() -> None:
+    """Process PreToolUse events for Agent tool warm start injection.
+
+    Flow:
+    1. Read stdin JSON, check tool_name == "Agent"
+    2. Gather parent session context from various files
+    3. Build <parent-context> block
+    4. Inject via context_output
+    """
+    try:
+        event_data = read_stdin(timeout=2)
+        if not event_data:
+            return
+
+        event = json.loads(event_data)
+
+        # Only process Agent tool invocations
+        tool_name = event.get("tool_name", "")
+        if tool_name != "Agent":
+            return
+
+        # Gather context from various sources
+        files = load_recent_reads(Path(SESSION_READS_FILE))
+        task_plan = extract_task_plan(Path(TASK_PLAN_FILE))
+        decisions = extract_decisions(Path(TASK_PLAN_FILE))
+        adr_session = load_adr_session(Path(ADR_SESSION_FILE))
+        discoveries = list_discoveries(Path(DISCOVERIES_DIR))
+
+        # Build context block
+        context_block = build_context_block(
+            files=files,
+            task_plan=task_plan,
+            decisions=decisions,
+            adr_session=adr_session,
+            discoveries=discoveries,
+        )
+
+        # Inject context
+        context_output(EVENT_NAME, context_block).print_and_exit()
+
+    except Exception as e:
+        print(f"[warmstart] error: {e}", file=sys.stderr)
+        empty_output(EVENT_NAME).print_and_exit()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"[warmstart] Fatal: {e}", file=sys.stderr)
+    finally:
+        sys.exit(0)

--- a/hooks/tests/test_posttool_session_reads.py
+++ b/hooks/tests/test_posttool_session_reads.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+Tests for the posttool-session-reads hook.
+
+Run with: python3 -m pytest hooks/tests/test_posttool_session_reads.py -v
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+HOOK_PATH = Path(__file__).parent.parent / "posttool-session-reads.py"
+
+spec = importlib.util.spec_from_file_location("posttool_session_reads", HOOK_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+SESSION_READS_FILE = mod.SESSION_READS_FILE
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def run_hook(event: dict) -> tuple[str, str, int]:
+    """Run the hook with given event and return (stdout, stderr, exit_code)."""
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=json.dumps(event),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+# ---------------------------------------------------------------------------
+# Tool Name Filtering
+# ---------------------------------------------------------------------------
+
+
+class TestToolNameFiltering:
+    """Only Read tool events should be processed."""
+
+    def test_ignores_write_tool(self, tmp_path, monkeypatch):
+        """Write tool events should produce no output and no file."""
+        monkeypatch.chdir(tmp_path)
+        event = {
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/some/file.py"},
+        }
+        stdout, stderr, code = run_hook(event)
+        assert code == 0
+        # No session-reads.txt should be created
+        assert not (tmp_path / ".claude" / "session-reads.txt").exists()
+
+    def test_ignores_edit_tool(self, tmp_path, monkeypatch):
+        """Edit tool events should be ignored."""
+        monkeypatch.chdir(tmp_path)
+        event = {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "/some/file.py"},
+        }
+        stdout, stderr, code = run_hook(event)
+        assert code == 0
+
+    def test_ignores_bash_tool(self, tmp_path, monkeypatch):
+        """Bash tool events should be ignored."""
+        monkeypatch.chdir(tmp_path)
+        event = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+        }
+        stdout, stderr, code = run_hook(event)
+        assert code == 0
+
+    def test_ignores_agent_tool(self, tmp_path, monkeypatch):
+        """Agent tool events should be ignored."""
+        monkeypatch.chdir(tmp_path)
+        event = {
+            "tool_name": "Agent",
+            "tool_input": {"prompt": "do something"},
+        }
+        stdout, stderr, code = run_hook(event)
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# File Path Extraction and Tracking
+# ---------------------------------------------------------------------------
+
+
+class TestFilePathTracking:
+    """Verify file paths are correctly extracted and written."""
+
+    def test_tracks_read_file_path(self, tmp_path, monkeypatch):
+        """Read tool event should append the file path to session-reads.txt."""
+        monkeypatch.chdir(tmp_path)
+        reads_dir = tmp_path / ".claude"
+        reads_dir.mkdir()
+
+        event = {
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/home/user/project/main.py"},
+        }
+        stdout, stderr, code = run_hook(event)
+
+        assert code == 0
+        reads_file = reads_dir / "session-reads.txt"
+        assert reads_file.exists()
+        content = reads_file.read_text()
+        assert "/home/user/project/main.py" in content
+
+    def test_tracks_multiple_reads(self, tmp_path, monkeypatch):
+        """Multiple Read events should all be tracked."""
+        monkeypatch.chdir(tmp_path)
+        reads_dir = tmp_path / ".claude"
+        reads_dir.mkdir()
+
+        paths = ["/a/file1.py", "/b/file2.go", "/c/file3.rs"]
+        for p in paths:
+            event = {
+                "tool_name": "Read",
+                "tool_input": {"file_path": p},
+            }
+            run_hook(event)
+
+        reads_file = reads_dir / "session-reads.txt"
+        content = reads_file.read_text()
+        lines = [line.strip() for line in content.splitlines() if line.strip()]
+        assert len(lines) == 3
+        for p in paths:
+            assert p in lines
+
+    def test_missing_file_path_does_nothing(self, tmp_path, monkeypatch):
+        """Read event with no file_path in tool_input should be no-op."""
+        monkeypatch.chdir(tmp_path)
+        event = {
+            "tool_name": "Read",
+            "tool_input": {},
+        }
+        stdout, stderr, code = run_hook(event)
+        assert code == 0
+
+    def test_empty_file_path_does_nothing(self, tmp_path, monkeypatch):
+        """Read event with empty file_path should be no-op."""
+        monkeypatch.chdir(tmp_path)
+        event = {
+            "tool_name": "Read",
+            "tool_input": {"file_path": ""},
+        }
+        stdout, stderr, code = run_hook(event)
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplication:
+    """Same path should not appear twice in the session file."""
+
+    def test_duplicate_path_not_appended(self, tmp_path, monkeypatch):
+        """Reading the same file twice should only produce one entry."""
+        monkeypatch.chdir(tmp_path)
+        reads_dir = tmp_path / ".claude"
+        reads_dir.mkdir()
+
+        event = {
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/home/user/main.py"},
+        }
+        run_hook(event)
+        run_hook(event)
+
+        reads_file = reads_dir / "session-reads.txt"
+        content = reads_file.read_text()
+        lines = [line.strip() for line in content.splitlines() if line.strip()]
+        assert lines.count("/home/user/main.py") == 1
+
+    def test_different_paths_both_tracked(self, tmp_path, monkeypatch):
+        """Different paths should both be recorded."""
+        monkeypatch.chdir(tmp_path)
+        reads_dir = tmp_path / ".claude"
+        reads_dir.mkdir()
+
+        for p in ["/a.py", "/b.py"]:
+            event = {
+                "tool_name": "Read",
+                "tool_input": {"file_path": p},
+            }
+            run_hook(event)
+
+        reads_file = reads_dir / "session-reads.txt"
+        content = reads_file.read_text()
+        lines = [line.strip() for line in content.splitlines() if line.strip()]
+        assert len(lines) == 2
+
+
+# ---------------------------------------------------------------------------
+# Output Format
+# ---------------------------------------------------------------------------
+
+
+class TestOutputFormat:
+    """Hook should produce silent output (empty JSON)."""
+
+    def test_silent_output_on_read_event(self, tmp_path, monkeypatch):
+        """Read event should produce hook JSON output with no context."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".claude").mkdir()
+
+        event = {
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/some/file.py"},
+        }
+        stdout, stderr, code = run_hook(event)
+
+        assert code == 0
+        if stdout.strip():
+            output = json.loads(stdout)
+            hook_output = output.get("hookSpecificOutput", {})
+            assert hook_output.get("hookEventName") == "PostToolUse"
+            # No additionalContext should be present
+            assert "additionalContext" not in hook_output
+
+
+# ---------------------------------------------------------------------------
+# Non-Blocking Guarantee
+# ---------------------------------------------------------------------------
+
+
+class TestNonBlocking:
+    """Hook must always exit 0 regardless of errors."""
+
+    def test_exits_zero_on_malformed_json(self):
+        """Malformed JSON input should still exit 0."""
+        result = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input="not valid json{{{",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+
+    def test_exits_zero_on_empty_input(self):
+        """Empty stdin should still exit 0."""
+        result = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input="",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+
+    def test_exits_zero_on_missing_tool_input(self):
+        """Event with no tool_input should still exit 0."""
+        event = {"tool_name": "Read"}
+        result = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input=json.dumps(event),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+
+    def test_creates_claude_dir_if_missing(self, tmp_path, monkeypatch):
+        """Hook should create .claude/ directory if it doesn't exist."""
+        monkeypatch.chdir(tmp_path)
+        event = {
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/some/file.py"},
+        }
+        stdout, stderr, code = run_hook(event)
+        assert code == 0

--- a/hooks/tests/test_pretool_subagent_warmstart.py
+++ b/hooks/tests/test_pretool_subagent_warmstart.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+"""
+Tests for the pretool-subagent-warmstart hook.
+
+Run with: python3 -m pytest hooks/tests/test_pretool_subagent_warmstart.py -v
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+HOOK_PATH = Path(__file__).parent.parent / "pretool-subagent-warmstart.py"
+
+spec = importlib.util.spec_from_file_location("pretool_subagent_warmstart", HOOK_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+load_recent_reads = mod.load_recent_reads
+extract_task_plan = mod.extract_task_plan
+extract_decisions = mod.extract_decisions
+load_adr_session = mod.load_adr_session
+list_discoveries = mod.list_discoveries
+build_context_block = mod.build_context_block
+MAX_OUTPUT_CHARS = mod.MAX_OUTPUT_CHARS
+MAX_FILES_SHOWN = mod.MAX_FILES_SHOWN
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def run_hook(event: dict) -> tuple[str, str, int]:
+    """Run the hook with given event and return (stdout, stderr, exit_code)."""
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=json.dumps(event),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+# ---------------------------------------------------------------------------
+# Tool Name Filtering
+# ---------------------------------------------------------------------------
+
+
+class TestToolNameFiltering:
+    """Only Agent tool events should be processed."""
+
+    def test_ignores_read_tool(self):
+        """Read tool events should produce no context output."""
+        event = {"tool_name": "Read", "tool_input": {"file_path": "/x"}}
+        stdout, stderr, code = run_hook(event)
+        assert code == 0
+        # Should be empty or empty hook output (no warmstart context)
+        if stdout.strip():
+            output = json.loads(stdout)
+            hook_out = output.get("hookSpecificOutput", {})
+            assert "additionalContext" not in hook_out or "[warmstart]" not in hook_out.get("additionalContext", "")
+
+    def test_ignores_write_tool(self):
+        """Write tool events should be ignored."""
+        event = {"tool_name": "Write", "tool_input": {"file_path": "/x"}}
+        stdout, stderr, code = run_hook(event)
+        assert code == 0
+
+    def test_ignores_bash_tool(self):
+        """Bash tool events should be ignored."""
+        event = {"tool_name": "Bash", "tool_input": {"command": "ls"}}
+        stdout, stderr, code = run_hook(event)
+        assert code == 0
+
+    def test_processes_agent_tool(self, tmp_path, monkeypatch):
+        """Agent tool events should produce warmstart context."""
+        monkeypatch.chdir(tmp_path)
+        event = {"tool_name": "Agent", "tool_input": {"prompt": "do work"}}
+        stdout, stderr, code = run_hook(event)
+        assert code == 0
+        assert stdout.strip()
+        output = json.loads(stdout)
+        context = output["hookSpecificOutput"].get("additionalContext", "")
+        assert "[warmstart]" in context
+
+
+# ---------------------------------------------------------------------------
+# load_recent_reads
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRecentReads:
+    """Test reading session-reads.txt."""
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        """Non-existent file returns empty list."""
+        result = load_recent_reads(tmp_path / "nonexistent.txt")
+        assert result == []
+
+    def test_reads_file_paths(self, tmp_path):
+        """File with paths returns them as list."""
+        reads_file = tmp_path / "session-reads.txt"
+        reads_file.write_text("/a.py\n/b.go\n/c.rs\n")
+        result = load_recent_reads(reads_file)
+        assert result == ["/a.py", "/b.go", "/c.rs"]
+
+    def test_caps_at_max_count(self, tmp_path):
+        """Only returns up to max_count most recent entries."""
+        reads_file = tmp_path / "session-reads.txt"
+        paths = [f"/file{i}.py" for i in range(30)]
+        reads_file.write_text("\n".join(paths) + "\n")
+        result = load_recent_reads(reads_file, max_count=5)
+        assert len(result) == 5
+        # Should be the last 5 entries
+        assert result == [f"/file{i}.py" for i in range(25, 30)]
+
+    def test_skips_empty_lines(self, tmp_path):
+        """Empty lines in the file are ignored."""
+        reads_file = tmp_path / "session-reads.txt"
+        reads_file.write_text("/a.py\n\n\n/b.py\n")
+        result = load_recent_reads(reads_file)
+        assert result == ["/a.py", "/b.py"]
+
+    def test_default_max_is_20(self, tmp_path):
+        """Default max_count should be MAX_FILES_SHOWN (20)."""
+        reads_file = tmp_path / "session-reads.txt"
+        paths = [f"/file{i}.py" for i in range(25)]
+        reads_file.write_text("\n".join(paths) + "\n")
+        result = load_recent_reads(reads_file)
+        assert len(result) == MAX_FILES_SHOWN
+
+
+# ---------------------------------------------------------------------------
+# extract_task_plan
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTaskPlan:
+    """Test extraction of Goal and Status from task_plan.md."""
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        """Non-existent task_plan.md returns empty dict."""
+        result = extract_task_plan(tmp_path / "task_plan.md")
+        assert result == {"goal": "", "status": ""}
+
+    def test_extracts_goal_and_status(self, tmp_path):
+        """Extracts Goal line and Status line from plan."""
+        plan = tmp_path / "task_plan.md"
+        plan.write_text(
+            "# Task Plan: Test\n\n"
+            "## Goal\n"
+            "Implement the warmstart hook for subagents\n\n"
+            "## Phases\n"
+            "- [x] Phase 1: Understand\n\n"
+            "## Status\n"
+            "**Currently in Phase 2** - Implementing hooks\n"
+        )
+        result = extract_task_plan(plan)
+        assert result["goal"] == "Implement the warmstart hook for subagents"
+        assert "Phase 2" in result["status"]
+
+    def test_extracts_goal_only(self, tmp_path):
+        """Plan with goal but no status."""
+        plan = tmp_path / "task_plan.md"
+        plan.write_text("# Task Plan\n\n## Goal\nBuild the feature\n\n## Phases\n- [ ] Phase 1\n")
+        result = extract_task_plan(plan)
+        assert result["goal"] == "Build the feature"
+        assert result["status"] == ""
+
+    def test_extracts_status_only(self, tmp_path):
+        """Plan with status but heading-only goal section."""
+        plan = tmp_path / "task_plan.md"
+        plan.write_text("# Task Plan\n\n## Goal\n## Phases\n**Currently in Phase 3** - Testing\n")
+        result = extract_task_plan(plan)
+        assert result["goal"] == ""
+        assert "Phase 3" in result["status"]
+
+
+# ---------------------------------------------------------------------------
+# extract_decisions
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDecisions:
+    """Test extraction of decisions from task_plan.md."""
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        """Non-existent file returns empty list."""
+        result = extract_decisions(tmp_path / "task_plan.md")
+        assert result == []
+
+    def test_extracts_decisions(self, tmp_path):
+        """Extracts bullet items from Decisions Made section."""
+        plan = tmp_path / "task_plan.md"
+        plan.write_text(
+            "# Task Plan\n\n"
+            "## Decisions Made\n"
+            "- Use atomic file operations for safety\n"
+            "- Cap output at 8000 chars\n\n"
+            "## Errors Encountered\n"
+            "- None yet\n"
+        )
+        result = extract_decisions(plan)
+        assert len(result) == 2
+        assert "atomic file operations" in result[0]
+        assert "8000 chars" in result[1]
+
+    def test_no_decisions_section_returns_empty(self, tmp_path):
+        """Plan without Decisions Made section returns empty."""
+        plan = tmp_path / "task_plan.md"
+        plan.write_text("# Task Plan\n\n## Goal\nDo stuff\n")
+        result = extract_decisions(plan)
+        assert result == []
+
+    def test_empty_decisions_section_returns_empty(self, tmp_path):
+        """Decisions Made section with no items returns empty."""
+        plan = tmp_path / "task_plan.md"
+        plan.write_text("# Task Plan\n\n## Decisions Made\n\n## Errors Encountered\n")
+        result = extract_decisions(plan)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# load_adr_session
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAdrSession:
+    """Test loading ADR session metadata."""
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        """Non-existent file returns empty dict."""
+        result = load_adr_session(tmp_path / ".adr-session.json")
+        assert result == {"adr_path": "", "domain": ""}
+
+    def test_loads_adr_session(self, tmp_path):
+        """Loads adr_path and domain from valid JSON."""
+        session_file = tmp_path / ".adr-session.json"
+        session_file.write_text(
+            json.dumps(
+                {
+                    "adr_path": "adr/088-subagent-warmstart.md",
+                    "domain": "hooks",
+                    "adr_hash": "abc123",
+                }
+            )
+        )
+        result = load_adr_session(session_file)
+        assert result["adr_path"] == "adr/088-subagent-warmstart.md"
+        assert result["domain"] == "hooks"
+
+    def test_malformed_json_returns_empty(self, tmp_path):
+        """Malformed JSON returns empty dict gracefully."""
+        session_file = tmp_path / ".adr-session.json"
+        session_file.write_text("{broken json")
+        result = load_adr_session(session_file)
+        assert result == {"adr_path": "", "domain": ""}
+
+    def test_missing_keys_returns_empty_strings(self, tmp_path):
+        """JSON without expected keys returns empty strings."""
+        session_file = tmp_path / ".adr-session.json"
+        session_file.write_text(json.dumps({"other": "data"}))
+        result = load_adr_session(session_file)
+        assert result["adr_path"] == ""
+        assert result["domain"] == ""
+
+
+# ---------------------------------------------------------------------------
+# list_discoveries
+# ---------------------------------------------------------------------------
+
+
+class TestListDiscoveries:
+    """Test listing discovery brief files."""
+
+    def test_missing_directory_returns_empty(self, tmp_path):
+        """Non-existent directory returns empty list."""
+        result = list_discoveries(tmp_path / "nonexistent")
+        assert result == []
+
+    def test_lists_files_sorted(self, tmp_path):
+        """Lists files in sorted order."""
+        disc_dir = tmp_path / "discoveries"
+        disc_dir.mkdir()
+        (disc_dir / "002-routing.md").write_text("routing")
+        (disc_dir / "001-hooks.md").write_text("hooks")
+        (disc_dir / "003-tests.md").write_text("tests")
+        result = list_discoveries(disc_dir)
+        assert result == ["001-hooks.md", "002-routing.md", "003-tests.md"]
+
+    def test_empty_directory_returns_empty(self, tmp_path):
+        """Empty directory returns empty list."""
+        disc_dir = tmp_path / "discoveries"
+        disc_dir.mkdir()
+        result = list_discoveries(disc_dir)
+        assert result == []
+
+    def test_skips_subdirectories(self, tmp_path):
+        """Only files are listed, not subdirectories."""
+        disc_dir = tmp_path / "discoveries"
+        disc_dir.mkdir()
+        (disc_dir / "001-hooks.md").write_text("hooks")
+        (disc_dir / "subdir").mkdir()
+        result = list_discoveries(disc_dir)
+        assert result == ["001-hooks.md"]
+
+
+# ---------------------------------------------------------------------------
+# build_context_block
+# ---------------------------------------------------------------------------
+
+
+class TestBuildContextBlock:
+    """Test context block construction."""
+
+    def test_all_empty_produces_minimal_output(self):
+        """All empty inputs should produce a minimal block."""
+        result = build_context_block(
+            files=[],
+            task_plan={"goal": "", "status": ""},
+            decisions=[],
+            adr_session={"adr_path": "", "domain": ""},
+            discoveries=[],
+        )
+        assert "[warmstart] Parent session context for subagent:" in result
+        assert "[warmstart] Files seen (0): none" in result
+
+    def test_includes_files(self):
+        """Files are listed with count."""
+        result = build_context_block(
+            files=["/a.py", "/b.go"],
+            task_plan={"goal": "", "status": ""},
+            decisions=[],
+            adr_session={"adr_path": "", "domain": ""},
+            discoveries=[],
+        )
+        assert "[warmstart] Files seen (2): /a.py, /b.go" in result
+
+    def test_includes_task_plan(self):
+        """Task goal and status are included."""
+        result = build_context_block(
+            files=[],
+            task_plan={"goal": "Build the hooks", "status": "**Currently in Phase 2**"},
+            decisions=[],
+            adr_session={"adr_path": "", "domain": ""},
+            discoveries=[],
+        )
+        assert "[warmstart] Task: Build the hooks" in result
+        assert "[warmstart] Status: **Currently in Phase 2**" in result
+
+    def test_includes_adr_session(self):
+        """ADR session info is included."""
+        result = build_context_block(
+            files=[],
+            task_plan={"goal": "", "status": ""},
+            decisions=[],
+            adr_session={"adr_path": "adr/088.md", "domain": "hooks"},
+            discoveries=[],
+        )
+        assert "[warmstart] ADR session: adr/088.md (domain: hooks)" in result
+
+    def test_includes_decisions(self):
+        """Decisions are included as semicolon-separated list."""
+        result = build_context_block(
+            files=[],
+            task_plan={"goal": "", "status": ""},
+            decisions=["Use atomic ops", "Cap at 8000 chars"],
+            adr_session={"adr_path": "", "domain": ""},
+            discoveries=[],
+        )
+        assert "[warmstart] Decisions: Use atomic ops; Cap at 8000 chars" in result
+
+    def test_includes_discoveries(self):
+        """Discovery briefs are listed."""
+        result = build_context_block(
+            files=[],
+            task_plan={"goal": "", "status": ""},
+            decisions=[],
+            adr_session={"adr_path": "", "domain": ""},
+            discoveries=["001-hooks.md", "002-routing.md"],
+        )
+        assert "[warmstart] Discovery briefs: 001-hooks.md, 002-routing.md" in result
+
+    def test_full_context_block(self):
+        """Full block with all sections populated."""
+        result = build_context_block(
+            files=["/a.py", "/b.go"],
+            task_plan={"goal": "Build warmstart", "status": "**Currently in Phase 3**"},
+            decisions=["Use file reads only"],
+            adr_session={"adr_path": "adr/088.md", "domain": "hooks"},
+            discoveries=["001-hooks.md"],
+        )
+        assert "[warmstart] Parent session context for subagent:" in result
+        assert "[warmstart] Files seen (2):" in result
+        assert "[warmstart] Task: Build warmstart" in result
+        assert "[warmstart] Status:" in result
+        assert "[warmstart] ADR session: adr/088.md" in result
+        assert "[warmstart] Decisions:" in result
+        assert "[warmstart] Discovery briefs:" in result
+
+    def test_caps_at_max_chars(self):
+        """Output exceeding MAX_OUTPUT_CHARS is truncated."""
+        # Generate a huge file list
+        big_files = [f"/very/long/path/to/file_{i:04d}.py" for i in range(500)]
+        result = build_context_block(
+            files=big_files,
+            task_plan={"goal": "x" * 1000, "status": "y" * 1000},
+            decisions=["z" * 500],
+            adr_session={"adr_path": "adr/big.md", "domain": "huge"},
+            discoveries=["d" * 100 for _ in range(50)],
+        )
+        assert len(result) <= MAX_OUTPUT_CHARS
+        assert result.endswith("...")
+
+    def test_skips_empty_goal(self):
+        """Empty goal is not included in output."""
+        result = build_context_block(
+            files=[],
+            task_plan={"goal": "", "status": "**Phase 1**"},
+            decisions=[],
+            adr_session={"adr_path": "", "domain": ""},
+            discoveries=[],
+        )
+        assert "[warmstart] Task:" not in result
+        assert "[warmstart] Status:" in result
+
+    def test_skips_empty_adr_path(self):
+        """Empty ADR path means no ADR line in output."""
+        result = build_context_block(
+            files=[],
+            task_plan={"goal": "", "status": ""},
+            decisions=[],
+            adr_session={"adr_path": "", "domain": "hooks"},
+            discoveries=[],
+        )
+        assert "[warmstart] ADR session:" not in result
+
+
+# ---------------------------------------------------------------------------
+# Non-Blocking Guarantee
+# ---------------------------------------------------------------------------
+
+
+class TestNonBlocking:
+    """Hook must always exit 0 regardless of errors."""
+
+    def test_exits_zero_on_malformed_json(self):
+        """Malformed JSON input should still exit 0."""
+        result = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input="not valid json{{{",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+
+    def test_exits_zero_on_empty_input(self):
+        """Empty stdin should still exit 0."""
+        result = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input="",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+
+    def test_exits_zero_on_missing_tool_name(self):
+        """Event with no tool_name should still exit 0."""
+        event = {"tool_input": {"prompt": "hello"}}
+        result = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input=json.dumps(event),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Graceful Degradation
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulDegradation:
+    """Hook should produce valid output even when context files are missing."""
+
+    def test_no_context_files_produces_minimal_output(self, tmp_path, monkeypatch):
+        """Agent event with no context files produces minimal warmstart block."""
+        monkeypatch.chdir(tmp_path)
+        event = {"tool_name": "Agent", "tool_input": {"prompt": "do work"}}
+        stdout, stderr, code = run_hook(event)
+
+        assert code == 0
+        output = json.loads(stdout)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "[warmstart] Parent session context for subagent:" in context
+        assert "[warmstart] Files seen (0): none" in context
+
+    def test_partial_context_files(self, tmp_path, monkeypatch):
+        """Some context files present, some missing."""
+        monkeypatch.chdir(tmp_path)
+
+        # Only create session-reads.txt
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "session-reads.txt").write_text("/a.py\n/b.go\n")
+
+        event = {"tool_name": "Agent", "tool_input": {"prompt": "do work"}}
+        stdout, stderr, code = run_hook(event)
+
+        assert code == 0
+        output = json.loads(stdout)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "[warmstart] Files seen (2):" in context
+        # No task plan or ADR sections since those files don't exist
+        assert "[warmstart] ADR session:" not in context
+
+
+# ---------------------------------------------------------------------------
+# Output Format Correctness
+# ---------------------------------------------------------------------------
+
+
+class TestOutputFormat:
+    """Verify the hook JSON output structure."""
+
+    def test_agent_event_produces_valid_json(self, tmp_path, monkeypatch):
+        """Agent event output is valid JSON with correct structure."""
+        monkeypatch.chdir(tmp_path)
+        event = {"tool_name": "Agent", "tool_input": {"prompt": "work"}}
+        stdout, stderr, code = run_hook(event)
+
+        assert code == 0
+        output = json.loads(stdout)
+        assert "hookSpecificOutput" in output
+        hook_out = output["hookSpecificOutput"]
+        assert hook_out["hookEventName"] == "PreToolUse"
+        assert "additionalContext" in hook_out
+        assert "[warmstart]" in hook_out["additionalContext"]


### PR DESCRIPTION
## Summary
- New `hooks/posttool-session-reads.py` — PostToolUse:Read tracker, records file paths to `.claude/session-reads.txt` with deduplication
- New `hooks/pretool-subagent-warmstart.py` — PreToolUse:Agent injector, builds `<parent-context>` block from session reads, task plan, ADR session, key decisions, and discovery briefs
- Both hooks registered in `.claude/settings.json`
- Graceful degradation when optional dependencies missing (ADR-085 code-summary, ADR-086 discoveries)

## ADR-094 Decision Coverage Gate (stress test)
```
Decision Points:
  [COVERED]     1. Files already read this session
  [COVERED]     2. Current task plan
  [COVERED]     3. Active ADR context
  [COVERED]     4. Discovery briefs
  [COVERED]     5. Key decisions

Coverage: 5/5 (100%)
Verdict: PASS
```

## Test plan
- [x] 56/56 hook tests pass
- [x] ADR-094 coverage gate: 5/5 PASS
- [x] ruff check + format clean
- [x] Hooks deploy correctly to ~/.claude/hooks/
- [x] Non-blocking: both hooks always exit 0