### PR TITLE
feat: implement ADR-095 post-merge ADR status update

### DIFF
--- a/pipelines/pr-pipeline/SKILL.md
+++ b/pipelines/pr-pipeline/SKILL.md
@@ -610,7 +610,14 @@ For personal repos where PR was created but not yet merged: skip cleanup (branch
 
 For protected-org repos: skip cleanup (their processes handle branch lifecycle).
 
-**ADR status update** (toolkit repo only): If this PR implements an ADR (commit message or PR title contains "ADR-NNN"), update the local ADR file's status from "Proposed" to "Implemented — PR #N". ADRs are gitignored (local-only), so this is a local file update, not a git operation.
+**ADR status update (ADR-095)**: If `.adr-session.json` exists and the PR was merged:
+1. Read the active ADR path from `.adr-session.json`
+2. Update status from "Proposed" to "Accepted" in the ADR file
+3. Move the ADR file to `adr/completed/`
+4. Clear `.adr-session.json`
+5. Report: `ADR updated: {name} → Accepted, moved to completed/`
+
+ADRs are gitignored (local-only), so this is a local file operation, not a git operation.
 
 **Gate**: Branch cleaned up (or skipped if PR is still open). Pipeline complete.
 

--- a/skills/pr-sync/SKILL.md
+++ b/skills/pr-sync/SKILL.md
@@ -210,6 +210,30 @@ else
 fi
 ```
 
+### Step 6: Post-Merge ADR Status Update (conditional — ADR-095)
+
+**Skip if**: No `.adr-session.json` exists, or the PR was only created (not merged).
+
+After a PR is merged (confirmed via `gh pr view --json state`), update the ADR lifecycle:
+
+```bash
+# 1. Read active ADR path
+ADR_PATH=$(python3 -c "import json; print(json.load(open('.adr-session.json'))['adr_path'])")
+
+# 2. Update status to Accepted
+sed -i 's/^## Status$/&/' "$ADR_PATH"  # (use Edit tool in practice)
+
+# 3. Move to completed/
+mv "$ADR_PATH" adr/completed/
+
+# 4. Clear session
+rm .adr-session.json
+```
+
+Report: `ADR updated: {name} → Accepted, moved to completed/`
+
+This is local-only (ADR files are gitignored). No branch or PR needed.
+
 ### Decision Tree
 
 ```


### PR DESCRIPTION
## Summary
- Add Step 6 to `pr-sync`: after merge, update ADR status to Accepted and move to `adr/completed/`
- Update `pr-pipeline` Phase 7 CLEANUP with same ADR lifecycle closure logic
- Conditional: only runs when `.adr-session.json` exists and PR was merged

## ADR-094 Coverage Gate
```
Coverage: 3/3 (100%)
Verdict: PASS
```

## Test plan
- [x] ADR-094 coverage gate: 3/3 PASS
- [x] Markdown-only changes (no code to lint/test)
- [x] Conditional logic — zero overhead when no ADR session active