### PR TITLE
feat: add routing regression benchmark with 43 test cases

### DIFF
--- a/scripts/routing-benchmark.json
+++ b/scripts/routing-benchmark.json
@@ -1,0 +1,307 @@
+{
+  "version": "1.0",
+  "description": "Canonical routing benchmark for /do router regression testing. Each test case pairs a natural-language request with its expected agent and/or skill. Used to detect silent routing regressions when models or routing tables change.",
+  "test_cases": [
+    {
+      "request": "push my changes to GitHub",
+      "expected_agent": null,
+      "expected_skill": "pr-sync",
+      "category": "git-operations",
+      "notes": "Git push intent — force-route to pr-sync"
+    },
+    {
+      "request": "push back on this approach",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "notes": "Disagreement, not git push — must NOT route to pr-sync"
+    },
+    {
+      "request": "commit these files",
+      "expected_agent": null,
+      "expected_skill": "git-commit-flow",
+      "category": "git-operations",
+      "notes": "Git commit intent — force-route to git-commit-flow"
+    },
+    {
+      "request": "commit to this approach and move forward",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "notes": "Decision/dedication, not git commit — must NOT route to git-commit-flow"
+    },
+    {
+      "request": "did CI pass on my PR?",
+      "expected_agent": null,
+      "expected_skill": "github-actions-check",
+      "category": "git-operations",
+      "notes": "CI status check — force-route to github-actions-check"
+    },
+    {
+      "request": "check my logic in this function",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "notes": "Code review, not CI check — must NOT route to github-actions-check"
+    },
+    {
+      "request": "submit a PR with full review gates",
+      "expected_agent": null,
+      "expected_skill": "pr-pipeline",
+      "category": "git-operations",
+      "notes": "Full PR workflow with gates"
+    },
+    {
+      "request": "clean up my merged branches",
+      "expected_agent": null,
+      "expected_skill": "pr-cleanup",
+      "category": "git-operations",
+      "notes": "Post-merge branch cleanup"
+    },
+    {
+      "request": "debug the goroutine leak in the worker pool",
+      "expected_agent": "golang-general-engineer",
+      "expected_skill": "systematic-debugging",
+      "category": "go-development",
+      "notes": "Go domain + debug verb — agent + skill pairing"
+    },
+    {
+      "request": "write table-driven tests for the parser",
+      "expected_agent": null,
+      "expected_skill": "go-testing",
+      "category": "go-development",
+      "notes": "Go tests — force-route to go-testing"
+    },
+    {
+      "request": "add a worker pool with goroutines",
+      "expected_agent": null,
+      "expected_skill": "go-concurrency",
+      "category": "go-development",
+      "notes": "Go concurrency — force-route to go-concurrency"
+    },
+    {
+      "request": "wrap errors with fmt.Errorf and %w",
+      "expected_agent": null,
+      "expected_skill": "go-error-handling",
+      "category": "go-development",
+      "notes": "Go error handling — force-route to go-error-handling"
+    },
+    {
+      "request": "review this Go PR for quality",
+      "expected_agent": null,
+      "expected_skill": "go-code-review",
+      "category": "go-development",
+      "notes": "Go code review — force-route to go-code-review"
+    },
+    {
+      "request": "work on the SAPCC Go repository go-bits",
+      "expected_agent": null,
+      "expected_skill": "go-sapcc-conventions",
+      "category": "go-development",
+      "notes": "SAPCC Go repo — force-route to go-sapcc-conventions"
+    },
+    {
+      "request": "add auth middleware to the Python Flask API",
+      "expected_agent": "python-general-engineer",
+      "expected_skill": null,
+      "category": "python-development",
+      "notes": "Python domain task — routes to Python agent"
+    },
+    {
+      "request": "run ruff and mypy on this Python project",
+      "expected_agent": null,
+      "expected_skill": "python-quality-gate",
+      "category": "python-development",
+      "notes": "Python quality checks — routes to python-quality-gate"
+    },
+    {
+      "request": "write pytest fixtures for the database layer",
+      "expected_agent": "python-general-engineer",
+      "expected_skill": null,
+      "category": "python-development",
+      "notes": "Python testing — routes to Python agent"
+    },
+    {
+      "request": "fix the React component rendering bug",
+      "expected_agent": "typescript-frontend-engineer",
+      "expected_skill": null,
+      "category": "frontend-development",
+      "notes": "React/frontend domain — routes to TS frontend agent"
+    },
+    {
+      "request": "debug the async race condition in TypeScript",
+      "expected_agent": "typescript-debugging-engineer",
+      "expected_skill": "systematic-debugging",
+      "category": "frontend-development",
+      "notes": "TypeScript debugging — specialized TS debug agent"
+    },
+    {
+      "request": "fix the typo in main.go",
+      "expected_agent": null,
+      "expected_skill": "fast",
+      "category": "trivial-operations",
+      "notes": "Mechanical one-character fix — force-route to fast"
+    },
+    {
+      "request": "rename this variable across the file",
+      "expected_agent": null,
+      "expected_skill": "fast",
+      "category": "trivial-operations",
+      "notes": "Trivial rename — force-route to fast"
+    },
+    {
+      "request": "add a --verbose flag to the CLI",
+      "expected_agent": null,
+      "expected_skill": "quick",
+      "category": "trivial-operations",
+      "notes": "Small self-contained change — force-route to quick"
+    },
+    {
+      "request": "extract this block into a helper function",
+      "expected_agent": null,
+      "expected_skill": "quick",
+      "category": "trivial-operations",
+      "notes": "Contained refactor — force-route to quick"
+    },
+    {
+      "request": "design a rate limiter feature for the API",
+      "expected_agent": null,
+      "expected_skill": "feature-design",
+      "category": "feature-lifecycle",
+      "notes": "New feature entry point — force-route to feature-design"
+    },
+    {
+      "request": "plan the implementation for this feature",
+      "expected_agent": null,
+      "expected_skill": "feature-plan",
+      "category": "feature-lifecycle",
+      "notes": "Feature plan phase — force-route to feature-plan"
+    },
+    {
+      "request": "build the feature from the plan",
+      "expected_agent": null,
+      "expected_skill": "feature-implement",
+      "category": "feature-lifecycle",
+      "notes": "Feature implementation — force-route to feature-implement"
+    },
+    {
+      "request": "run quality gates on the implemented feature",
+      "expected_agent": null,
+      "expected_skill": "feature-validate",
+      "category": "feature-lifecycle",
+      "notes": "Feature validation — force-route to feature-validate"
+    },
+    {
+      "request": "migrate our Grafana dashboards to Perses",
+      "expected_agent": null,
+      "expected_skill": "perses-grafana-migrate",
+      "category": "perses-domain",
+      "notes": "Grafana-to-Perses migration — force-route"
+    },
+    {
+      "request": "create a new Perses dashboard for API latency",
+      "expected_agent": "perses-dashboard-engineer",
+      "expected_skill": "perses-dashboard-create",
+      "category": "perses-domain",
+      "notes": "Perses dashboard creation — agent + skill pairing"
+    },
+    {
+      "request": "lint this Perses dashboard definition",
+      "expected_agent": null,
+      "expected_skill": "perses-lint",
+      "category": "perses-domain",
+      "notes": "Perses lint — force-route to perses-lint"
+    },
+    {
+      "request": "create a new Perses panel plugin",
+      "expected_agent": null,
+      "expected_skill": "perses-plugin-create",
+      "category": "perses-domain",
+      "notes": "Perses plugin creation — force-route"
+    },
+    {
+      "request": "comprehensive code review from multiple perspectives",
+      "expected_agent": null,
+      "expected_skill": "parallel-code-review",
+      "category": "code-review",
+      "notes": "Multi-reviewer parallel review"
+    },
+    {
+      "request": "roast this design doc",
+      "expected_agent": null,
+      "expected_skill": "roast",
+      "category": "code-review",
+      "notes": "Multi-persona critique via roast skill"
+    },
+    {
+      "request": "fix these 3 failing test files simultaneously",
+      "expected_agent": null,
+      "expected_skill": "dispatching-parallel-agents",
+      "category": "parallel-execution",
+      "notes": "Multiple independent failures — parallel dispatch"
+    },
+    {
+      "request": "execute the plan using subagents",
+      "expected_agent": null,
+      "expected_skill": "subagent-driven-development",
+      "category": "parallel-execution",
+      "notes": "Explicit subagent execution request"
+    },
+    {
+      "request": "research the topic thoroughly then write an article",
+      "expected_agent": null,
+      "expected_skill": "research-to-article",
+      "category": "content-creation",
+      "notes": "Research-backed article — pipeline skill"
+    },
+    {
+      "request": "remove AI patterns from this blog post",
+      "expected_agent": null,
+      "expected_skill": "anti-ai-editor",
+      "category": "content-creation",
+      "notes": "De-AI editing task"
+    },
+    {
+      "request": "deploy the app to Kubernetes with Helm",
+      "expected_agent": "kubernetes-helm-engineer",
+      "expected_skill": null,
+      "category": "infrastructure",
+      "notes": "K8s domain — routes to kubernetes-helm-engineer"
+    },
+    {
+      "request": "set up Prometheus alerting rules",
+      "expected_agent": "prometheus-grafana-engineer",
+      "expected_skill": null,
+      "category": "infrastructure",
+      "notes": "Monitoring domain — routes to prometheus-grafana-engineer"
+    },
+    {
+      "request": "moderate the subreddit modqueue",
+      "expected_agent": null,
+      "expected_skill": "reddit-moderate",
+      "category": "reddit",
+      "notes": "Reddit moderation task"
+    },
+    {
+      "request": "create a new Claude Code skill with quality gates",
+      "expected_agent": "skill-creator-engineer",
+      "expected_skill": "skill-creation-pipeline",
+      "category": "meta-tooling",
+      "notes": "Skill creation — agent + pipeline pairing"
+    },
+    {
+      "request": "create a new hook for PostToolUse events",
+      "expected_agent": "hook-development-engineer",
+      "expected_skill": "hook-development-pipeline",
+      "category": "meta-tooling",
+      "notes": "Hook creation — agent + pipeline pairing"
+    },
+    {
+      "request": "go ahead and fix the bug",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "notes": "'go' as verb, not Go language — must NOT route to golang-general-engineer"
+    }
+  ]
+}

--- a/scripts/routing-benchmark.py
+++ b/scripts/routing-benchmark.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Routing regression benchmark for the /do router.
+
+Validates that all expected routing targets (agents, skills, pipelines) referenced
+in the benchmark test fixture actually exist in the INDEX.json files. This is a
+STRUCTURAL benchmark — it checks that routing targets are valid, not that the LLM
+routes correctly.
+
+Usage:
+    python3 scripts/routing-benchmark.py
+    python3 scripts/routing-benchmark.py --verbose
+    python3 scripts/routing-benchmark.py --category go-development
+    python3 scripts/routing-benchmark.py --fixture path/to/custom.json
+
+Exit codes:
+    0 - All test cases have valid targets (or all expected targets are null)
+    1 - One or more test cases reference non-existent components
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_FIXTURE = REPO_ROOT / "scripts" / "routing-benchmark.json"
+AGENTS_INDEX = REPO_ROOT / "agents" / "INDEX.json"
+SKILLS_INDEX = REPO_ROOT / "skills" / "INDEX.json"
+PIPELINES_INDEX = REPO_ROOT / "pipelines" / "INDEX.json"
+
+
+def load_json(path: Path) -> dict:
+    """Load and parse a JSON file.
+
+    Args:
+        path: Path to the JSON file.
+
+    Returns:
+        Parsed JSON as a dictionary.
+
+    Raises:
+        SystemExit: If the file is missing or contains invalid JSON.
+    """
+    if not path.exists():
+        print(f"ERROR: {path} not found", file=sys.stderr)
+        sys.exit(1)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: Invalid JSON in {path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def load_component_names() -> tuple[set[str], set[str], set[str]]:
+    """Load all known agent, skill, and pipeline names from INDEX files.
+
+    Returns:
+        Tuple of (agent_names, skill_names, pipeline_names).
+    """
+    agents: set[str] = set()
+    skills: set[str] = set()
+    pipelines: set[str] = set()
+
+    if AGENTS_INDEX.exists():
+        data = load_json(AGENTS_INDEX)
+        agents = set(data.get("agents", {}).keys())
+
+    if SKILLS_INDEX.exists():
+        data = load_json(SKILLS_INDEX)
+        skills = set(data.get("skills", {}).keys())
+
+    if PIPELINES_INDEX.exists():
+        data = load_json(PIPELINES_INDEX)
+        # Pipelines INDEX may use "pipelines" or "skills" as the key
+        pipelines = set(data.get("pipelines", data.get("skills", {})).keys())
+
+    return agents, skills, pipelines
+
+
+def validate_test_case(
+    case: dict,
+    agents: set[str],
+    skills: set[str],
+    pipelines: set[str],
+) -> list[str]:
+    """Validate a single test case against known components.
+
+    Args:
+        case: Test case dictionary with expected_agent and expected_skill.
+        agents: Set of known agent names.
+        skills: Set of known skill names.
+        pipelines: Set of known pipeline names.
+
+    Returns:
+        List of error messages (empty if valid).
+    """
+    errors: list[str] = []
+
+    expected_agent = case.get("expected_agent")
+    if expected_agent and expected_agent not in agents:
+        errors.append(f"agent '{expected_agent}' not found in agents/INDEX.json")
+
+    expected_skill = case.get("expected_skill")
+    if expected_skill and expected_skill not in skills and expected_skill not in pipelines:
+        errors.append(f"skill '{expected_skill}' not found in skills/INDEX.json or pipelines/INDEX.json")
+
+    return errors
+
+
+def run_benchmark(fixture_path: Path, *, verbose: bool = False, category_filter: str | None = None) -> bool:
+    """Run the routing benchmark and report results.
+
+    Args:
+        fixture_path: Path to the benchmark JSON fixture.
+        verbose: Show per-test-case results.
+        category_filter: Only run test cases in this category.
+
+    Returns:
+        True if all test cases pass, False otherwise.
+    """
+    fixture = load_json(fixture_path)
+    test_cases: list[dict] = fixture.get("test_cases", [])
+
+    if not test_cases:
+        print("ERROR: No test cases found in fixture", file=sys.stderr)
+        return False
+
+    agents, skills, pipelines = load_component_names()
+
+    if verbose:
+        print(f"Loaded components: {len(agents)} agents, {len(skills)} skills, {len(pipelines)} pipelines")
+        print()
+
+    # Filter by category if requested
+    if category_filter:
+        test_cases = [tc for tc in test_cases if tc.get("category") == category_filter]
+        if not test_cases:
+            print(f"ERROR: No test cases found for category '{category_filter}'", file=sys.stderr)
+            return False
+
+    pass_count = 0
+    fail_count = 0
+    null_count = 0
+    category_counts: Counter[str] = Counter()
+    failures: list[tuple[dict, list[str]]] = []
+
+    for case in test_cases:
+        category = case.get("category", "uncategorized")
+        category_counts[category] += 1
+
+        expected_agent = case.get("expected_agent")
+        expected_skill = case.get("expected_skill")
+
+        # Null targets are valid — they represent requests that should NOT route
+        if expected_agent is None and expected_skill is None:
+            null_count += 1
+            pass_count += 1
+            if verbose:
+                print(f"  PASS (null target) : {case['request']}")
+            continue
+
+        errors = validate_test_case(case, agents, skills, pipelines)
+        if errors:
+            fail_count += 1
+            failures.append((case, errors))
+            if verbose:
+                print(f"  FAIL : {case['request']}")
+                for err in errors:
+                    print(f"         -> {err}")
+        else:
+            pass_count += 1
+            if verbose:
+                targets = []
+                if expected_agent:
+                    targets.append(f"agent={expected_agent}")
+                if expected_skill:
+                    targets.append(f"skill={expected_skill}")
+                print(f"  PASS : {case['request']}  [{', '.join(targets)}]")
+
+    total = pass_count + fail_count
+
+    if verbose:
+        print()
+
+    # Summary
+    print(f"Routing Benchmark: {pass_count}/{total} test cases have valid targets", end="")
+    if null_count:
+        print(f" ({null_count} null-target guards)")
+    else:
+        print()
+
+    # Category breakdown
+    cat_parts = [f"{cat}({count})" for cat, count in sorted(category_counts.items())]
+    print(f"Categories: {', '.join(cat_parts)}")
+
+    # Report failures
+    if failures:
+        print()
+        print("FAILURES:")
+        for case, errors in failures:
+            print(f'  [{case.get("category", "?")}] "{case["request"]}"')
+            for err in errors:
+                print(f"    -> {err}")
+
+    return fail_count == 0
+
+
+def main() -> None:
+    """CLI entry point for the routing benchmark."""
+    parser = argparse.ArgumentParser(
+        description="Routing regression benchmark for the /do router",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python3 scripts/routing-benchmark.py                     # Run all tests
+  python3 scripts/routing-benchmark.py --verbose            # Show per-test results
+  python3 scripts/routing-benchmark.py --category go-development  # Filter by category
+        """,
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        default=DEFAULT_FIXTURE,
+        help=f"Path to benchmark fixture JSON (default: {DEFAULT_FIXTURE.relative_to(REPO_ROOT)})",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show per-test-case pass/fail results",
+    )
+    parser.add_argument(
+        "--category",
+        type=str,
+        default=None,
+        help="Only run test cases in this category",
+    )
+
+    args = parser.parse_args()
+    success = run_benchmark(args.fixture, verbose=args.verbose, category_filter=args.category)
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- `scripts/routing-benchmark.json` — 43 canonical request/expected-route pairs across 14 categories
- `scripts/routing-benchmark.py` — validates all routing targets exist in INDEX.json files
- Catches component renames/deletions that would silently break routing
- Supports `--verbose` and `--category` flags

## Test Plan
- [x] `python3 scripts/routing-benchmark.py` reports 43/43 valid targets
- [x] Ruff format and check pass