### PR TITLE
feat: standardize hook error handling with debug logging

### DIFF
--- a/hooks/error-learner.py
+++ b/hooks/error-learner.py
@@ -16,6 +16,7 @@ Design Principles:
 """
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -235,8 +236,12 @@ def main():
                 fix_action=fix_action,
             )
 
-    except (json.JSONDecodeError, Exception):
-        pass  # Silent failure
+    except (json.JSONDecodeError, Exception) as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[error-learner] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
     finally:
         sys.exit(0)  # Never block
 

--- a/hooks/lib/feedback_tracker.py
+++ b/hooks/lib/feedback_tracker.py
@@ -13,6 +13,8 @@ Design Principles:
 """
 
 import json
+import os
+import sys
 import time
 from pathlib import Path
 from typing import Optional
@@ -54,8 +56,12 @@ def _save_state(state: dict) -> None:
         _ensure_dir()
         state["timestamp"] = time.time()
         _STATE_FILE.write_text(json.dumps(state, indent=2))
-    except OSError:
-        pass  # Silent failure - don't block
+    except OSError as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[feedback-tracker] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
 
 
 def set_pending_feedback(signature: str, error_type: str, fix_action: str, original_error: str) -> None:
@@ -136,8 +142,12 @@ def clear_pending() -> None:
     try:
         if _STATE_FILE.exists():
             _STATE_FILE.unlink()
-    except OSError:
-        pass  # Silent failure - don't block Claude Code
+    except OSError as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[feedback-tracker] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
 
 
 def has_pending() -> bool:

--- a/hooks/post-tool-lint-hint.py
+++ b/hooks/post-tool-lint-hint.py
@@ -40,8 +40,12 @@ def get_seen_extensions() -> set:
     try:
         if SEEN_EXTENSIONS_FILE.exists():
             return set(SEEN_EXTENSIONS_FILE.read_text().strip().split("\n"))
-    except Exception:
-        pass  # Silent: state file issues shouldn't block hook execution
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[lint-hint] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
     return set()
 
 
@@ -51,8 +55,12 @@ def mark_extension_seen(ext: str):
         seen = get_seen_extensions()
         seen.add(ext)
         SEEN_EXTENSIONS_FILE.write_text("\n".join(seen))
-    except Exception:
-        pass  # Silent: state file write errors shouldn't block hook execution
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[lint-hint] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
 
 
 def main():
@@ -94,9 +102,12 @@ def main():
         filename = Path(file_path).name
         print(f"[lint-hint] {filename} modified. Consider: {linter}")
 
-    except (json.JSONDecodeError, Exception):
-        # Silent failure
-        pass
+    except (json.JSONDecodeError, Exception) as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[lint-hint] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/hooks/posttool-security-scan.py
+++ b/hooks/posttool-security-scan.py
@@ -23,6 +23,7 @@ ADR: adr/018-post-edit-security-scan.md
 """
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -193,8 +194,12 @@ def main() -> None:
             if len(findings) > 3:
                 print(f"  ... and {len(findings) - 3} more security hints")
 
-    except (json.JSONDecodeError, Exception):
-        pass  # Silent failure — never interrupt workflow
+    except (json.JSONDecodeError, Exception) as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[security-scan] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/hooks/precompact-archive.py
+++ b/hooks/precompact-archive.py
@@ -85,8 +85,12 @@ def inject_adr_anchor(event: dict) -> None:
         )
         print("[precompact-adr] ==========================================")
 
-    except Exception:
-        pass  # Silent failure — never block compaction
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[precompact-archive] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
 
 
 def extract_error_resolutions(event: dict) -> list[dict]:
@@ -240,8 +244,12 @@ def main():
             if total > 0:
                 print(f"[learning-archive]   Total learnings: {high_conf}/{total} high-confidence")
 
-    except json.JSONDecodeError:
-        pass  # Silent failure - invalid JSON
+    except json.JSONDecodeError as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[precompact-archive] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
     except Exception as e:
         # Log to stderr if debug enabled, but never fail
         if os.environ.get("CLAUDE_HOOKS_DEBUG"):

--- a/hooks/record-activation.py
+++ b/hooks/record-activation.py
@@ -88,8 +88,12 @@ def main() -> None:
 
         subprocess.run(cmd, capture_output=True, timeout=5)
 
-    except (json.JSONDecodeError, subprocess.TimeoutExpired, OSError, Exception):
-        pass  # Silent failure — never block the session
+    except (json.JSONDecodeError, subprocess.TimeoutExpired, OSError, Exception) as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[record-activation] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
     finally:
         sys.exit(0)
 

--- a/hooks/record-waste.py
+++ b/hooks/record-waste.py
@@ -16,6 +16,7 @@ Design:
 """
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -67,8 +68,12 @@ def main() -> None:
             timeout=5,
         )
 
-    except (json.JSONDecodeError, subprocess.TimeoutExpired, OSError, Exception):
-        pass  # Silent failure — never block the session
+    except (json.JSONDecodeError, subprocess.TimeoutExpired, OSError, Exception) as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[record-waste] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
     finally:
         sys.exit(0)
 

--- a/hooks/routing-gap-recorder.py
+++ b/hooks/routing-gap-recorder.py
@@ -15,6 +15,7 @@ Design Principles:
 """
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -71,8 +72,12 @@ def main():
         else:
             print(f"[routing-gap] Gap repeated: {domain} (x{result.get('observation_count', '?')})")
 
-    except Exception:
-        pass  # Silent failure
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[routing-gap-recorder] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
     finally:
         sys.exit(0)  # Never block
 

--- a/hooks/usage-tracker.py
+++ b/hooks/usage-tracker.py
@@ -14,6 +14,7 @@ Design Principles:
 """
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -74,8 +75,12 @@ def main():
                 isolation=isolation,
             )
 
-    except (json.JSONDecodeError, Exception):
-        pass  # Silent failure — never block Claude Code
+    except (json.JSONDecodeError, Exception) as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[usage-tracker] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
     finally:
         sys.exit(0)  # ALWAYS exit 0
 


### PR DESCRIPTION
## Summary
Replace bare `pass` in except blocks across 9 hooks with structured debug logging gated behind `CLAUDE_HOOKS_DEBUG` environment variable.

No behavior change — hooks still exit 0 on error. Debug logging only activates when `CLAUDE_HOOKS_DEBUG=1`.

### Files Changed (9)
- `error-learner.py`, `feedback_tracker.py`, `post-tool-lint-hint.py`
- `posttool-security-scan.py`, `precompact-archive.py`, `record-activation.py`
- `record-waste.py`, `routing-gap-recorder.py`, `usage-tracker.py`

### Pattern Applied
```python
except Exception as e:
    if os.environ.get("CLAUDE_HOOKS_DEBUG"):
        import traceback
        print(f"[hook-name] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
        traceback.print_exc(file=sys.stderr)
```

## Test Plan
- [x] All hooks still exit 0 (no behavior change)
- [x] Ruff format and check pass
- [x] Debug logging only activates with CLAUDE_HOOKS_DEBUG set