### PR TITLE
feat: KAIROS-lite proactive monitoring and briefing (ADR-148)

### DIFF
--- a/hooks/kairos-briefing-injector.py
+++ b/hooks/kairos-briefing-injector.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+SessionStart Hook: KAIROS-lite Briefing Injector
+
+Injects the most recent KAIROS monitoring briefing into session context.
+Opt-in: requires CLAUDE_KAIROS_ENABLED=true environment variable.
+Graceful degradation: always exits 0, never blocks session start.
+"""
+
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Add lib directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+
+from hook_utils import context_output, empty_output
+
+EVENT_NAME = "SessionStart"
+MAX_BRIEFING_AGE_HOURS = 24
+MAX_INJECTION_CHARS = 1600  # ~400 tokens
+
+
+def _debug(message: str) -> None:
+    """Write debug message to stderr only when CLAUDE_HOOK_DEBUG is set."""
+    if os.environ.get("CLAUDE_HOOK_DEBUG"):
+        print(f"[kairos-briefing] {message}", file=sys.stderr)
+
+
+def _find_most_recent_briefing(state_dir: Path) -> Path | None:
+    """Return the most recently modified briefing-*.md file, or None."""
+    try:
+        candidates = list(state_dir.glob("briefing-*.md"))
+    except OSError as e:
+        _debug(f"Failed to glob {state_dir}: {e}")
+        return None
+
+    if not candidates:
+        return None
+
+    # Sort by mtime descending; pick first
+    try:
+        candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    except OSError as e:
+        _debug(f"Failed to stat briefing candidates: {e}")
+        return None
+
+    return candidates[0]
+
+
+def _extract_action_required(content: str) -> str:
+    """Extract the '## Action Required' section from briefing content."""
+    lines = content.splitlines()
+    in_section = False
+    collected: list[str] = []
+
+    for line in lines:
+        if line.strip() == "## Action Required":
+            in_section = True
+            collected.append(line)
+            continue
+        if in_section and line.startswith("##"):
+            break
+        if in_section:
+            collected.append(line)
+
+    return "\n".join(collected).strip()
+
+
+def _write_sidecar(briefing_path: Path) -> None:
+    """Write injection metadata sidecar file. Informational only — never raises."""
+    try:
+        session_id = os.environ.get("CLAUDE_SESSION_ID", "unknown")
+        injected_at = datetime.now(timezone.utc).isoformat()
+        sidecar_path = briefing_path.parent / (briefing_path.name + ".meta.json")
+
+        import json
+
+        payload = {"injected_at": injected_at, "session_id": session_id}
+        # Atomic write: temp file then rename
+        tmp_path = sidecar_path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(payload))
+        tmp_path.replace(sidecar_path)
+    except Exception as e:
+        _debug(f"Sidecar write failed (non-fatal): {e}")
+
+
+def main() -> None:
+    """Inject KAIROS briefing into session context if enabled and fresh."""
+    try:
+        # Opt-in gate
+        if os.environ.get("CLAUDE_KAIROS_ENABLED", "").lower() != "true":
+            _debug("CLAUDE_KAIROS_ENABLED not set; skipping")
+            empty_output(EVENT_NAME).print_and_exit()
+            return
+
+        state_dir = Path.home() / ".claude" / "state"
+        if not state_dir.is_dir():
+            _debug(f"State directory not found: {state_dir}")
+            empty_output(EVENT_NAME).print_and_exit()
+            return
+
+        briefing_path = _find_most_recent_briefing(state_dir)
+        if briefing_path is None:
+            _debug("No briefing files found")
+            empty_output(EVENT_NAME).print_and_exit()
+            return
+
+        # Staleness check
+        try:
+            age_hours = (time.time() - briefing_path.stat().st_mtime) / 3600
+        except OSError as e:
+            _debug(f"Could not stat briefing file: {e}")
+            empty_output(EVENT_NAME).print_and_exit()
+            return
+
+        if age_hours > MAX_BRIEFING_AGE_HOURS:
+            _debug(f"Briefing too old ({age_hours:.1f}h > {MAX_BRIEFING_AGE_HOURS}h); skipping")
+            empty_output(EVENT_NAME).print_and_exit()
+            return
+
+        # Read content
+        try:
+            content = briefing_path.read_text().strip()
+        except OSError as e:
+            _debug(f"Could not read briefing file: {e}")
+            empty_output(EVENT_NAME).print_and_exit()
+            return
+
+        if not content:
+            _debug("Briefing file is empty")
+            empty_output(EVENT_NAME).print_and_exit()
+            return
+
+        # Truncate if needed, preferring the Action Required section
+        if len(content) > MAX_INJECTION_CHARS:
+            _debug(f"Content exceeds {MAX_INJECTION_CHARS} chars; extracting Action Required section")
+            action_section = _extract_action_required(content)
+            if action_section:
+                content = action_section + f"\n\nFull briefing: {briefing_path}"
+            else:
+                content = content[:MAX_INJECTION_CHARS] + f"\n\nFull briefing: {briefing_path}"
+
+        _debug(f"Injecting briefing from {briefing_path} (age={age_hours:.1f}h)")
+        _write_sidecar(briefing_path)
+        context_output(EVENT_NAME, f"<kairos-briefing>\n{content}\n</kairos-briefing>").print_and_exit()
+
+    except Exception as e:
+        _debug(f"Unexpected error: {type(e).__name__}: {e}")
+        empty_output(EVENT_NAME).print_and_exit()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOK_DEBUG"):
+            print(f"[kairos-briefing] Fatal: {type(e).__name__}: {e}", file=sys.stderr)
+    finally:
+        sys.exit(0)  # ALWAYS exit 0 — non-blocking requirement

--- a/scripts/kairos-setup.py
+++ b/scripts/kairos-setup.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""KAIROS-lite setup script.
+
+Creates the config file, validates prerequisites, and installs cron jobs for
+KAIROS-lite monitoring. Idempotent: safe to run multiple times.
+
+Usage:
+    python3 scripts/kairos-setup.py
+    python3 scripts/kairos-setup.py --non-interactive
+"""
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+KAIROS_MARKER = "KAIROS-lite"
+CONFIG_DIR = Path.home() / ".claude" / "config"
+CONFIG_FILE = CONFIG_DIR / "kairos.json"
+LOG_DIR = Path.home() / ".claude" / "logs"
+TOOLKIT_DIR = Path("/home/feedgen/claude-code-toolkit")
+
+CRON_BLOCK = """\
+# KAIROS-lite: Quick check every 4 hours during business hours
+0 8,12,16,20 * * * cd /home/feedgen/claude-code-toolkit && CLAUDE_KAIROS_ENABLED=true claude -p "$(cat skills/kairos-lite/monitor-prompt.md)" --model sonnet >> /tmp/claude-kairos.log 2>&1
+
+# KAIROS-lite: Deep scan nightly at 2:30 AM
+30 2 * * * cd /home/feedgen/claude-code-toolkit && CLAUDE_KAIROS_ENABLED=true KAIROS_MODE=deep claude -p "$(cat skills/kairos-lite/monitor-prompt.md)" --model sonnet >> /tmp/claude-kairos.log 2>&1"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def info(msg: str) -> None:
+    """Print a status message with the [kairos] prefix."""
+    print(f"[kairos] {msg}")
+
+
+def error(msg: str) -> None:
+    """Print an error message and flush immediately."""
+    print(f"[kairos] ERROR: {msg}", file=sys.stderr)
+
+
+def run(cmd: list[str], *, capture: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess and return the result."""
+    return subprocess.run(
+        cmd,
+        capture_output=capture,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+
+
+def check_gh_auth() -> bool:
+    """Return True if `gh auth status` succeeds."""
+    result = run(["gh", "auth", "status"])
+    if result.returncode != 0:
+        error("gh auth status failed — run `gh auth login` first.")
+        error(result.stderr.strip() if result.stderr else "(no output)")
+        return False
+    info("gh auth: OK")
+    return True
+
+
+def check_claude_cli() -> None:
+    """Warn (but don't abort) if the claude CLI is missing."""
+    if shutil.which("claude") is None:
+        print("[kairos] WARN: `claude` CLI not found on PATH — cron jobs will fail until it is installed.")
+    else:
+        info("claude CLI: OK")
+
+
+def check_cron() -> bool:
+    """Return True if crontab is usable."""
+    result = run(["crontab", "-l"])
+    # exit 1 with "no crontab for …" is normal on a fresh system
+    if result.returncode not in (0, 1):
+        error("crontab -l failed unexpectedly — is cron installed?")
+        return False
+    info("cron: OK")
+    return True
+
+
+def validate_prerequisites() -> bool:
+    """Run all prerequisite checks. Return False if any hard check fails."""
+    ok = True
+    if not check_gh_auth():
+        ok = False
+    check_claude_cli()  # warn only
+    if not check_cron():
+        ok = False
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# Repo detection
+# ---------------------------------------------------------------------------
+
+
+def detect_repo() -> tuple[str, str] | None:
+    """Return (owner, repo) parsed from the git remote origin URL, or None."""
+    result = run(["git", "remote", "get-url", "origin"])
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    # Handles both HTTPS and SSH variants:
+    #   https://github.com/owner/repo.git
+    #   git@github.com:owner/repo.git
+    for sep in ("github.com/", "github.com:"):
+        if sep in url:
+            path = url.split(sep, 1)[1]
+            path = path.removesuffix(".git")
+            parts = path.split("/")
+            if len(parts) >= 2:
+                return parts[0], parts[1]
+    return None
+
+
+def determine_targets(non_interactive: bool) -> tuple[str, str]:
+    """Return (owner, repo) after optional interactive confirmation."""
+    detected = detect_repo()
+    default_owner = detected[0] if detected else "unknown"
+    default_repo = detected[1] if detected else "unknown"
+
+    if non_interactive or not sys.stdin.isatty():
+        info(f"Using detected repo: {default_owner}/{default_repo}")
+        return default_owner, default_repo
+
+    # Interactive: let the user confirm or override.
+    print(f"[kairos] Detected repo: {default_owner}/{default_repo}")
+    owner_input = input(f"[kairos] Owner [{default_owner}]: ").strip()
+    repo_input = input(f"[kairos] Repo  [{default_repo}]: ").strip()
+    owner = owner_input or default_owner
+    repo = repo_input or default_repo
+    return owner, repo
+
+
+# ---------------------------------------------------------------------------
+# Config file
+# ---------------------------------------------------------------------------
+
+
+def build_config(owner: str, repo: str) -> dict:
+    """Build the kairos.json config dict."""
+    return {
+        "version": 1,
+        "enabled": True,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "repos": [
+            {
+                "owner": owner,
+                "repo": repo,
+                "branches": ["main"],
+                "check_ci": True,
+                "check_prs": True,
+                "check_issues": True,
+                "check_dependabot": True,
+            }
+        ],
+        "business_hours": {
+            "start": 8,
+            "end": 20,
+            "timezone": "UTC",
+        },
+        "deep_scan": {
+            "enabled": True,
+            "hour": 2,
+        },
+        "briefing": {
+            "max_age_hours": 24,
+            "max_injection_tokens": 400,
+        },
+        "thresholds": {
+            "stale_branch_days": 7,
+            "stale_memory_days": 14,
+            "hook_error_rate_pct": 10,
+            "pr_review_wait_hours": 24,
+        },
+    }
+
+
+def write_config(owner: str, repo: str) -> None:
+    """Write kairos.json to ~/.claude/config/, creating the directory if needed."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    config = build_config(owner, repo)
+    CONFIG_FILE.write_text(json.dumps(config, indent=2) + "\n")
+    info(f"Config written: {CONFIG_FILE}")
+
+
+# ---------------------------------------------------------------------------
+# Cron installation
+# ---------------------------------------------------------------------------
+
+
+def read_crontab() -> str:
+    """Return the current crontab as a string (empty string if none set)."""
+    result = run(["crontab", "-l"])
+    if result.returncode == 0:
+        return result.stdout
+    # "no crontab for user" — treat as empty
+    return ""
+
+
+def write_crontab(content: str) -> bool:
+    """Write content as the new crontab. Returns True on success."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".crontab", delete=False) as fh:
+        fh.write(content)
+        tmp_path = fh.name
+    result = run(["crontab", tmp_path])
+    Path(tmp_path).unlink(missing_ok=True)
+    return result.returncode == 0
+
+
+def install_cron_jobs() -> None:
+    """Add KAIROS-lite cron entries if not already present."""
+    existing = read_crontab()
+
+    if KAIROS_MARKER in existing:
+        info("Cron jobs already installed — skipping.")
+        return
+
+    separator = "\n" if existing and not existing.endswith("\n") else ""
+    new_crontab = existing + separator + CRON_BLOCK + "\n"
+
+    if write_crontab(new_crontab):
+        info("Cron jobs installed.")
+    else:
+        error("Failed to write crontab. Run `crontab -e` to add entries manually.")
+
+
+# ---------------------------------------------------------------------------
+# Log directory
+# ---------------------------------------------------------------------------
+
+
+def ensure_log_dir() -> None:
+    """Create ~/.claude/logs/ if it does not exist."""
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    info(f"Log directory: {LOG_DIR}")
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+
+def print_summary(owner: str, repo: str) -> None:
+    """Print post-setup instructions."""
+    print()
+    print("[kairos] Setup complete.")
+    print()
+    print(f"  Config:   {CONFIG_FILE}")
+    print(f"  Repo:     {owner}/{repo}")
+    print(f"  Logs:     /tmp/claude-kairos.log")
+    print()
+    print("  Cron schedule:")
+    print("    Every 4 h (08:00, 12:00, 16:00, 20:00 UTC)  — quick check")
+    print("    Daily at 02:30 UTC                           — deep scan")
+    print()
+    print("  Manual check:")
+    print(
+        "    cd /home/feedgen/claude-code-toolkit && "
+        'CLAUDE_KAIROS_ENABLED=true claude -p "$(cat skills/kairos-lite/monitor-prompt.md)" --model sonnet'
+    )
+    print()
+    print("  To disable:")
+    print("    Run `crontab -e` and remove the KAIROS-lite block, or")
+    print("    unset CLAUDE_KAIROS_ENABLED in your environment.")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Configure KAIROS-lite monitoring: config, prerequisites, cron.",
+    )
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Skip confirmation prompts; use auto-detected values.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run KAIROS-lite setup. Returns exit code."""
+    args = parse_args()
+
+    info("Starting KAIROS-lite setup...")
+    print()
+
+    # 1. Prerequisites
+    info("Checking prerequisites...")
+    if not validate_prerequisites():
+        return 1
+    print()
+
+    # 2. Monitoring targets
+    info("Determining monitoring targets...")
+    owner, repo = determine_targets(non_interactive=args.non_interactive)
+    print()
+
+    # 3. Config file
+    info("Writing config file...")
+    write_config(owner, repo)
+    print()
+
+    # 4. Log directory
+    info("Ensuring log directory...")
+    ensure_log_dir()
+    print()
+
+    # 5. Cron jobs
+    info("Installing cron jobs...")
+    install_cron_jobs()
+    print()
+
+    # 6. Summary
+    print_summary(owner, repo)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-04-01T03:23:29Z",
+  "generated": "2026-04-01T19:17:41Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
     "adr-consultation": {
@@ -812,6 +812,28 @@
         "voice-validator",
         "skill-creator"
       ]
+    },
+    "kairos-lite": {
+      "file": "skills/kairos-lite/SKILL.md",
+      "description": "Proactive monitoring \u2014 checks GitHub, CI, and toolkit health, produces briefings.",
+      "triggers": [
+        "morning briefing",
+        "what happened",
+        "check notifications",
+        "check CI",
+        "project status",
+        "what's new",
+        "monitoring",
+        "health check",
+        "kairos"
+      ],
+      "category": "meta-tooling",
+      "user_invocable": true,
+      "version": "1.0.0",
+      "pairs_with": [
+        "auto-dream"
+      ],
+      "model": "sonnet"
     },
     "kotlin-coroutines": {
       "file": "skills/kotlin-coroutines/SKILL.md",

--- a/skills/do/references/routing-tables.md
+++ b/skills/do/references/routing-tables.md
@@ -110,6 +110,7 @@ Route to these agents based on the user's task domain. Each entry describes what
 | **full-repo-review** | User wants a comprehensive 3-wave review of all source files in the entire repository. |
 | **repo-value-analysis** | User wants to systematically analyze an external repository to determine what ideas or patterns are worth adopting. |
 | **data-analysis** | User wants to analyze data: CSV files, metrics, A/B test results, cohort analysis, statistical distributions, KPIs, or funnel data. |
+| **kairos-lite** | User wants a project status briefing, health check, or to see what happened overnight — GitHub notifications, CI status, toolkit health. Common phrasings: "what happened", "morning briefing", "check notifications", "project status", "health check". NOT: specific PR status (use github-actions-check), specific CI debugging (use systematic-debugging). |
 | **pr-workflow** (miner mode) | User wants to extract review comments or learnings from past GitHub PRs, or coordinate batch mining. |
 | **skill-composer** | User wants to compose multiple skills into a multi-skill workflow. |
 | **routing-table-updater** | User wants to update routing tables after adding or changing agents/skills. |

--- a/skills/kairos-lite/SKILL.md
+++ b/skills/kairos-lite/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: kairos-lite
+description: Proactive monitoring — checks GitHub, CI, and toolkit health, produces briefings.
+version: 1.0.0
+user-invocable: true
+command: kairos
+context: fork
+model: sonnet
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - Grep
+  - WebFetch
+routing:
+  triggers:
+    - morning briefing
+    - what happened
+    - check notifications
+    - check CI
+    - project status
+    - what's new
+    - monitoring
+    - health check
+    - kairos
+  category: meta-tooling
+  pairs_with:
+    - auto-dream
+---
+
+Proactive monitoring and briefing agent. Runs between sessions via `cron + claude -p`, checks GitHub (PRs, CI, issues, dependabot), local repo state (stale branches, uncommitted changes), and toolkit health (hook errors, stale memories, state files). Produces structured briefings injected at session start.
+
+## When to invoke
+
+- User says "morning briefing", "what happened", "project status", "check notifications", "health check", "kairos"
+- Invoked automatically by cron every 4 hours during business hours (quick scan — Category A only)
+- Nightly deep scan at 2:30 AM (all categories)
+
+## Instructions
+
+When invoked interactively, read `skills/kairos-lite/monitor-prompt.md` and execute its phases directly. The prompt is self-contained — it describes the full monitoring cycle including check categories, output format, and file paths.
+
+For cron invocation: the monitor prompt is passed directly to `claude -p` and runs as a standalone headless session with no CLAUDE.md, no hooks, no project context. All instructions are embedded in the prompt.
+
+Requires `CLAUDE_KAIROS_ENABLED=true` environment variable. If not set, exit silently.
+
+## Monitoring Categories
+
+**Category A — Action Required** (quick and deep scans):
+- PRs assigned to @me with open state
+- Review requests pending for @me
+- CI failures on watched branches
+- Dependabot security alerts (critical and high severity)
+
+**Category B — FYI** (deep scan only):
+- New issues opened since last check
+- Dependency updates available (non-security)
+- Stale branches (> 7 days since last commit)
+- Uncommitted changes on feature branches
+
+**Category C — Toolkit Health** (deep scan only):
+- Hook error rate from learning.db
+- Stale memory files (> 14 days since last update)
+- ADR backlog count (local `adr/` directory)
+- State file accumulation in `~/.claude/state/`
+
+## Phases
+
+1. **LOAD CONFIG** — Read `~/.claude/config/kairos.json` for watched repos, branches, and thresholds. Determine scan mode from `KAIROS_MODE` env var.
+2. **GITHUB CHECKS** — Run `gh` queries in parallel. Category A always; Category B added for deep scans.
+3. **REPO CHECKS** — Check local repo state: stale branches, uncommitted changes. Deep scan only.
+4. **TOOLKIT HEALTH** — Query learning.db for hook error rates, scan memory file mtimes, count state directory files. Deep scan only.
+5. **COMPILE BRIEFING** — Aggregate findings into structured sections. Empty categories get explicit "all clear" entries.
+6. **WRITE OUTPUT** — Write briefing atomically (write to `.tmp`, then rename) to `~/.claude/state/briefing-{project-hash}-{date}.md`.
+
+## Output
+
+Briefing written to `~/.claude/state/briefing-{project-hash}-{date}.md`.
+
+The project hash uses the same encoding as `~/.claude/projects/` directory names (URL-encode the project path, replace `/` with `-`).
+
+## Config
+
+Read from `~/.claude/config/kairos.json`. Example structure:
+
+```json
+{
+  "repos": [
+    {"owner": "notque", "repo": "claude-code-toolkit", "branches": ["main"]}
+  ],
+  "thresholds": {
+    "stale_branch_days": 7,
+    "stale_memory_days": 14,
+    "state_file_warn_count": 50
+  }
+}
+```
+
+## Quick vs Deep scan
+
+| Mode | Trigger | Categories | Frequency |
+|------|---------|------------|-----------|
+| Quick | Default / every 4 hours business hours | A only | Every 4h (8 AM–6 PM) |
+| Deep | `KAIROS_MODE=deep` / nightly | A + B + C | 2:30 AM nightly |
+
+Set `KAIROS_MODE=deep` to force a deep scan interactively.
+
+## Opt-in requirement
+
+`CLAUDE_KAIROS_ENABLED=true` must be set in the environment. If absent, the skill exits 0 silently — no output, no error. This prevents accidental runs during toolkit development.
+
+## Cost estimate
+
+~$0.04 per quick run (Category A only, ~8-12K input tokens at Sonnet pricing).
+~$0.08 per deep run (all categories, ~18-25K input tokens).
+~$14/year for full automated operation (4h quick + nightly deep, 5-day business week).
+
+## Cron setup
+
+Use `crontab-manager.py` (not raw `crontab -e`) to install both schedules.
+
+```bash
+# Quick scan every 4 hours, 8 AM–6 PM business hours
+python3 ~/.claude/scripts/crontab-manager.py add \
+  --tag "kairos-quick" \
+  --schedule "0 8,12,16 * * 1-5" \
+  --command "CLAUDE_KAIROS_ENABLED=true /home/feedgen/claude-code-toolkit/scripts/kairos-cron.sh >> /home/feedgen/claude-code-toolkit/cron-logs/kairos/quick.log 2>&1"
+
+# Deep scan nightly at 2:30 AM
+python3 ~/.claude/scripts/crontab-manager.py add \
+  --tag "kairos-deep" \
+  --schedule "30 2 * * *" \
+  --command "CLAUDE_KAIROS_ENABLED=true KAIROS_MODE=deep /home/feedgen/claude-code-toolkit/scripts/kairos-cron.sh >> /home/feedgen/claude-code-toolkit/cron-logs/kairos/deep.log 2>&1"
+
+# Verify
+python3 ~/.claude/scripts/crontab-manager.py verify --tag kairos-quick
+python3 ~/.claude/scripts/crontab-manager.py verify --tag kairos-deep
+```
+
+## Testing
+
+```bash
+# Verify opt-in guard (should exit silently)
+./scripts/kairos-cron.sh
+echo "Exit: $?"
+
+# Quick scan dry-run
+CLAUDE_KAIROS_ENABLED=true ./scripts/kairos-cron.sh --dry-run
+
+# Deep scan dry-run
+CLAUDE_KAIROS_ENABLED=true KAIROS_MODE=deep ./scripts/kairos-cron.sh --dry-run
+
+# Check output
+ls ~/.claude/state/briefing-*.md | tail -1 | xargs cat
+
+# Interactive invocation (reads monitor-prompt.md and executes directly)
+# Just invoke this skill — it reads and runs the prompt inline
+```
+
+## Pairs with auto-dream
+
+kairos-lite and auto-dream are complementary. auto-dream runs nightly at 2:07 AM and consolidates memories. kairos-lite runs at 2:30 AM and checks external state. The nightly deep scan can incorporate the dream report into the toolkit health section.
+
+Session-start injection: if both `dream-injection-{project-hash}.md` and `briefing-{project-hash}-{date}.md` exist, load both. Briefing takes precedence for action items; dream injection takes precedence for memory context.

--- a/skills/kairos-lite/monitor-prompt.md
+++ b/skills/kairos-lite/monitor-prompt.md
@@ -1,0 +1,339 @@
+# KAIROS-lite Monitor — Headless Execution Prompt
+
+You are a monitoring agent running headless via `claude -p`. There is no CLAUDE.md, no hooks, no project context, and no interactive session. You must be completely self-contained.
+
+Do NOT ask clarifying questions. Do NOT produce conversational output. Your only output is the briefing file written to disk. If you have nothing to report, write a briefing that says so.
+
+---
+
+## PHASE 0: OPT-IN CHECK
+
+Check whether `CLAUDE_KAIROS_ENABLED` is set to `true`:
+
+```bash
+echo "${CLAUDE_KAIROS_ENABLED}"
+```
+
+If the value is not exactly `true`, exit 0 immediately with no output. This is not an error.
+
+---
+
+## PHASE 1: LOAD CONFIG
+
+Read monitoring configuration from `~/.claude/config/kairos.json`.
+
+If the file does not exist, use these defaults:
+```json
+{
+  "repos": [],
+  "thresholds": {
+    "stale_branch_days": 7,
+    "stale_memory_days": 14,
+    "state_file_warn_count": 50
+  }
+}
+```
+
+Determine scan mode:
+- If `KAIROS_MODE=deep` is set in the environment, run a **deep scan** (all categories: A + B + C).
+- Otherwise, run a **quick scan** (Category A only).
+
+Record the current date as `SCAN_DATE` in `YYYY-MM-DD` format and the current ISO timestamp as `SCAN_TIMESTAMP`.
+
+---
+
+## PHASE 2: GITHUB CHECKS (Category A — always)
+
+Run these `gh` commands. Where multiple commands are independent, run them in parallel (use background execution and collect results).
+
+### PR Assignments (Category A)
+```bash
+gh pr list --assignee @me --state open --json number,title,createdAt,repository 2>/dev/null
+```
+
+### Review Requests (Category A)
+```bash
+gh pr list --search "review-requested:@me" --state open --json number,title,createdAt,repository 2>/dev/null
+```
+
+### CI Status on Watched Branches (Category A)
+For each repo and branch in `config.repos`:
+```bash
+gh run list --repo {owner}/{repo} --branch {branch} --limit 5 --json conclusion,name,createdAt,headBranch 2>/dev/null
+```
+Flag any run where `conclusion` is `failure` or `cancelled`.
+
+### Dependabot Security Alerts — Critical/High (Category A)
+For each repo in `config.repos`:
+```bash
+gh api repos/{owner}/{repo}/dependabot/alerts \
+  --jq '[.[] | select(.state=="open") | select(.security_advisory.severity=="critical" or .security_advisory.severity=="high")] | length' \
+  2>/dev/null
+```
+
+---
+
+## PHASE 3: EXTENDED GITHUB CHECKS (Category B — deep scan only)
+
+Skip this phase entirely for quick scans.
+
+### New Issues (Category B)
+For each repo in `config.repos`:
+```bash
+gh issue list --repo {owner}/{repo} --state open --limit 20 \
+  --json number,title,createdAt,author 2>/dev/null
+```
+Report issues created within the last 24 hours.
+
+### Dependabot Updates — Medium/Low (Category B)
+For each repo in `config.repos`:
+```bash
+gh api repos/{owner}/{repo}/dependabot/alerts \
+  --jq '[.[] | select(.state=="open") | select(.security_advisory.severity=="medium" or .security_advisory.severity=="low")]' \
+  2>/dev/null
+```
+
+---
+
+## PHASE 4: REPO CHECKS (Category B — deep scan only)
+
+Skip this phase entirely for quick scans.
+
+### Stale Branches
+For each repo in `config.repos`, determine the local working directory (skip if not checked out locally).
+
+```bash
+git for-each-ref --format='%(refname:short) %(committerdate:iso8601)' refs/heads/ 2>/dev/null
+```
+
+Flag branches where the last commit is more than `config.thresholds.stale_branch_days` days ago. Exclude `main` and `master`.
+
+### Uncommitted Changes on Feature Branches
+```bash
+git status --porcelain 2>/dev/null | wc -l
+git stash list 2>/dev/null | wc -l
+```
+
+Report if there are uncommitted changes (non-zero porcelain output) or stashed changes.
+
+---
+
+## PHASE 5: TOOLKIT HEALTH (Category C — deep scan only)
+
+Skip this phase entirely for quick scans.
+
+### Hook Error Rate
+Query learning.db for governance events and error patterns from the last 7 days:
+
+```python
+import sqlite3
+from pathlib import Path
+from datetime import datetime, timedelta
+
+db_path = Path.home() / ".claude" / "state" / "learning.db"
+if db_path.exists():
+    conn = sqlite3.connect(str(db_path))
+    cutoff = (datetime.utcnow() - timedelta(days=7)).isoformat()
+    
+    # Hook error rate
+    cursor = conn.execute(
+        "SELECT COUNT(*) FROM governance_events WHERE blocked=1 AND created_at > ?",
+        (cutoff,)
+    )
+    blocked_count = cursor.fetchone()[0]
+    
+    cursor = conn.execute(
+        "SELECT COUNT(*) FROM governance_events WHERE created_at > ?",
+        (cutoff,)
+    )
+    total_count = cursor.fetchone()[0]
+    conn.close()
+    
+    error_rate = (blocked_count / total_count * 100) if total_count > 0 else 0
+    print(f"blocked={blocked_count} total={total_count} rate={error_rate:.1f}%")
+```
+
+Flag if error rate exceeds 20%.
+
+### Stale Memory Files
+```python
+import os
+from pathlib import Path
+from datetime import datetime, timedelta
+
+memory_dir = Path("/home/feedgen/claude-code-toolkit/.claude/agent-memory")
+stale_threshold = timedelta(days=14)  # from config.thresholds.stale_memory_days
+now = datetime.utcnow()
+
+stale_files = []
+for md_file in memory_dir.rglob("*.md"):
+    if md_file.name == "MEMORY.md":
+        continue
+    mtime = datetime.utcfromtimestamp(md_file.stat().st_mtime)
+    if now - mtime > stale_threshold:
+        stale_files.append((md_file.name, (now - mtime).days))
+
+for name, age_days in sorted(stale_files, key=lambda x: -x[1]):
+    print(f"{name}: {age_days} days old")
+```
+
+Flag if more than 5 stale memory files.
+
+### State File Accumulation
+```bash
+ls ~/.claude/state/ 2>/dev/null | wc -l
+```
+
+Flag if count exceeds `config.thresholds.state_file_warn_count` (default: 50).
+
+### ADR Backlog
+```bash
+ls /home/feedgen/claude-code-toolkit/adr/*.md 2>/dev/null | wc -l
+```
+
+Report the count. Flag if more than 20 ADRs are present (backlog may need attention).
+
+---
+
+## PHASE 6: COMPILE BRIEFING
+
+Aggregate all findings. Apply these rules:
+
+- **Action Required**: Items from Category A. If empty, write "No action items found."
+- **FYI**: Items from Category B. If empty (or quick scan), write "No informational items found."
+- **Toolkit Health**: Items from Category C. If empty (or quick scan), write "All systems nominal."
+- **Nothing Found**: For any section that is genuinely clear, add an explicit all-clear line.
+
+Format each finding as a bullet:
+- `[CRITICAL]` — dependabot critical, CI failure on main
+- `[HIGH]` — dependabot high, PR assigned > 3 days ago
+- `[INFO]` — new issues, stale branches, FYI items
+- `[HEALTH]` — toolkit health items
+
+---
+
+## PHASE 7: DETERMINE OUTPUT PATH
+
+Compute the project hash using the same encoding as `~/.claude/projects/` directory names.
+
+The `~/.claude/projects/` directories are named by URL-encoding the project path and replacing `/` with `-`. Replicate this:
+
+```python
+from urllib.parse import quote
+
+project_path = "/home/feedgen/claude-code-toolkit"
+# Claude Code uses the full path, URL-encoded, with / replaced by -
+encoded = quote(project_path, safe="")
+project_hash = encoded.replace("%2F", "-").replace("%", "%")
+# Actual directory name format observed in ~/.claude/projects/
+# Check: ls ~/.claude/projects/ to find the matching directory
+```
+
+Alternatively, find it directly:
+```bash
+ls ~/.claude/projects/ | grep -i feedgen | head -1
+```
+
+Output path: `~/.claude/state/briefing-{project_hash}-{SCAN_DATE}.md`
+
+---
+
+## PHASE 8: WRITE OUTPUT
+
+Write the briefing atomically:
+
+1. Write content to `{output_path}.tmp`
+2. Rename via `os.replace("{output_path}.tmp", "{output_path}")` (atomic on POSIX)
+
+```python
+import os
+from pathlib import Path
+
+output_path = Path.home() / ".claude" / "state" / f"briefing-{project_hash}-{scan_date}.md"
+tmp_path = Path(str(output_path) + ".tmp")
+
+briefing_content = """# KAIROS-lite Briefing — {date}
+
+Generated: {iso_timestamp}
+Project: claude-code-toolkit ({project_path})
+Scan type: {scan_type}
+
+## Action Required
+{action_items}
+
+## FYI
+{fyi_items}
+
+## Toolkit Health
+{health_items}
+
+## Nothing Found
+{nothing_found}
+"""
+
+tmp_path.write_text(briefing_content.format(
+    date=scan_date,
+    iso_timestamp=scan_timestamp,
+    project_path=project_path,
+    scan_type="deep" if deep_scan else "quick",
+    action_items=action_section,
+    fyi_items=fyi_section,
+    health_items=health_section,
+    nothing_found=nothing_found_section,
+))
+os.replace(str(tmp_path), str(output_path))
+```
+
+---
+
+## PHASE 9: EXIT
+
+- Exit 0 on success.
+- Exit 1 on any unrecoverable error; write error description to stderr.
+- Never leave `.tmp` files behind on failure — clean up in a finally block.
+
+---
+
+## Briefing Format Reference
+
+```markdown
+# KAIROS-lite Briefing — {date}
+
+Generated: {ISO timestamp}
+Project: {project name} ({project path})
+Scan type: quick | deep
+
+## Action Required
+- [CRITICAL] CI failure on main: "build" failed 2h ago (claude-code-toolkit)
+- [HIGH] PR #247 assigned to you for 4 days: "feat: add hook telemetry"
+- No action items found.
+
+## FYI
+- [INFO] 3 new issues opened in last 24h (claude-code-toolkit)
+- [INFO] Stale branch: feat/old-experiment (12 days, no commits)
+- No informational items found.
+
+## Toolkit Health
+- [HEALTH] Hook error rate: 23% (46/200 events blocked, last 7 days) — above 20% threshold
+- [HEALTH] 8 stale memory files (oldest: user_role.md, 31 days)
+- [HEALTH] State directory: 67 files (threshold: 50)
+- All systems nominal.
+
+## Nothing Found
+- PR assignments: all clear
+- Review requests: all clear
+- CI status: all clear
+- Dependabot alerts: all clear
+```
+
+---
+
+## Hard Constraints
+
+- Do NOT ask clarifying questions.
+- Do NOT produce conversational output.
+- Do NOT print progress messages or status updates.
+- Do NOT read or act on CLAUDE.md — it is not available in headless mode.
+- Do NOT access the internet except via `gh` CLI for GitHub API calls.
+- The briefing file is your only output. If you cannot write it, exit 1 with an error to stderr.
+- If `CLAUDE_KAIROS_ENABLED` is not `true`, exit 0 with no output.


### PR DESCRIPTION
## Summary

Implements ADR-148: KAIROS-lite proactive monitoring system — a lightweight adaptation of Claude Code's internal KAIROS pattern for background monitoring and session-start briefing injection.

- **`skills/kairos-lite/SKILL.md`** — Monitoring methodology skill with 6-phase pipeline (LOAD CONFIG → GITHUB CHECKS → REPO CHECKS → TOOLKIT HEALTH → COMPILE BRIEFING → WRITE OUTPUT)
- **`skills/kairos-lite/monitor-prompt.md`** — Self-contained headless prompt template for `claude -p` cron execution. Checks PRs, CI, dependabot, stale branches, and toolkit health
- **`hooks/kairos-briefing-injector.py`** — SessionStart hook that injects the most recent briefing into session context. Opt-in via `CLAUDE_KAIROS_ENABLED=true`, 24h staleness guard, truncation to Action Required section when >400 tokens
- **`scripts/kairos-setup.py`** — One-time setup: validates `gh auth`, creates `~/.claude/config/kairos.json`, installs idempotent cron jobs (quick every 4h, deep nightly at 2:30 AM)
- **`skills/INDEX.json`** + routing table updated with kairos-lite entry

### Design decisions
- **Opt-in only**: `CLAUDE_KAIROS_ENABLED=true` required; no impact on users who don't enable it
- **Monitoring between sessions, injection at session start**: Keeps monitoring cost off the session-open critical path
- **Atomic writes**: Briefing files written to `.tmp` then renamed, preventing partial reads
- **Graceful degradation**: Hook always exits 0, never blocks session start

## Test plan

- [x] Hook exits 0 with empty output when `CLAUDE_KAIROS_ENABLED` not set
- [x] Hook exits 0 with empty output when enabled but no briefing exists
- [x] Hook injects `<kairos-briefing>` block when fresh briefing present
- [x] Hook skips injection for briefings older than 24 hours
- [x] Large briefings truncated to Action Required section + file pointer
- [x] Sidecar `.meta.json` written with injection timestamp
- [x] Setup script has valid Python syntax (AST check)
- [x] All Python files pass ruff lint
- [x] Hook deployed to `~/.claude/hooks/` and registered in `settings.json`