### PR TITLE
fix(cron): increase budget caps from $5 to $15

### DIFF
--- a/scripts/reference-enrichment-cron.sh
+++ b/scripts/reference-enrichment-cron.sh
@@ -31,7 +31,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 LOG_DIR="$REPO_DIR/cron-logs/reference-enrichment"
 LOCKFILE="/tmp/reference-enrichment.lock"
-MAX_BUDGET="${MAX_BUDGET_USD:-5.00}"
+MAX_BUDGET="${MAX_BUDGET_USD:-15.00}"
 MAX_TARGETS="${MAX_TARGETS:-3}"
 EXECUTE=""
 

--- a/scripts/toolkit-evolution-cron.sh
+++ b/scripts/toolkit-evolution-cron.sh
@@ -31,7 +31,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 LOG_DIR="$REPO_DIR/cron-logs/toolkit-evolution"
 LOCKFILE="/tmp/toolkit-evolution.lock"
-MAX_BUDGET="${MAX_BUDGET_USD:-5.00}"
+MAX_BUDGET="${MAX_BUDGET_USD:-15.00}"
 EXECUTE=""
 
 # Cleanup function: release lock FD and remove lockfile on any exit


### PR DESCRIPTION
## Summary
- Bumps default budget from $5 to $15 for both `reference-enrichment-cron.sh` and `toolkit-evolution-cron.sh`
- $5 was too tight for full pipeline completion (generate references + create PR + review cycle)
- Still overridable via `MAX_BUDGET_USD` env var
- Dream cron stays at $3 (it does lightweight memory consolidation, not code generation)

## Test plan
- [ ] Verify `grep MAX_BUDGET scripts/*cron*.sh` shows 15.00 for enrichment/evolution, 3.00 for dream