### PR TITLE
feat(refs): nightly enrichment — threejs-builder, phaser-gamedev, pixijs-combat-renderer (Level 2→3)

### DIFF
--- a/agents/pixijs-combat-renderer.md
+++ b/agents/pixijs-combat-renderer.md
@@ -204,6 +204,8 @@ Individual `Texture.from()` calls per sprite are a hard block — batch them int
 | Normal maps, per-pixel lighting, light reactions to combat events | [pixi-2d-lighting.md](references/pixi-2d-lighting.md) |
 | GPU particles, wrestling presets, DOM particle replacement | [pixi-particle-systems.md](references/pixi-particle-systems.md) |
 | Bloom, vignette, chromatic aberration, color grading, mobile budgets | [pixi-post-processing.md](references/pixi-post-processing.md) |
+| Custom GLSL hit filters, glow chaining, shockwave displacement, Spine animation, z-ordering, UI masking | [combat-visual-effects.md](references/combat-visual-effects.md) |
+| Sprite batching, texture atlases, RenderTexture caching, object pooling, ParticleContainer vs Container | [pixi-performance.md](references/pixi-performance.md) |
 
 ---
 

--- a/agents/pixijs-combat-renderer/references/combat-visual-effects.md
+++ b/agents/pixijs-combat-renderer/references/combat-visual-effects.md
@@ -1,0 +1,430 @@
+---
+name: PixiJS Combat Visual Effects
+description: Custom GLSL filters for hit effects, glow chaining, DisplacementFilter shockwaves, Spine integration, particle emitter combat patterns, z-ordering, and alpha masking in PixiJS v8+
+agent: pixijs-combat-renderer
+category: visual-techniques
+version_range: "PixiJS v8+"
+---
+
+# Combat Visual Effects Reference
+
+> **Scope**: PixiJS v8-specific visual effects for combat rendering — custom filters, displacement ripples, Spine animation, particle combat presets, z-index control, and UI masking. Performance budget and batching lives in pixi-performance.md.
+> **Version range**: PixiJS v8+
+> **Generated**: 2026-04-08
+
+---
+
+## PIXI.Filter Custom GLSL for Hit Effects
+
+PixiJS v8 uses a shader-based Filter pipeline. Each Filter wraps a fragment shader applied to a RenderTexture copy of the container.
+
+```typescript
+import { Filter } from 'pixi.js';
+
+// Hit flash: brief white-to-transparent overlay
+const hitFlashVert = `
+  attribute vec2 aPosition;
+  varying vec2 vTextureCoord;
+  uniform vec4 inputSize;
+  uniform vec4 outputFrame;
+
+  vec4 filterVertexPosition() {
+    vec2 position = aPosition * max(outputFrame.zw, vec2(0.)) + outputFrame.xy;
+    return vec4((position / (inputSize.xy / inputSize.zw)) * 2.0 - 1.0, 0.0, 1.0);
+  }
+
+  void main() {
+    gl_Position = filterVertexPosition();
+    vTextureCoord = aPosition * (outputFrame.zw * inputSize.zw);
+  }
+`;
+
+const hitFlashFrag = `
+  varying vec2 vTextureCoord;
+  uniform sampler2D uSampler;
+  uniform float uFlash;  // 0.0 = normal, 1.0 = full white
+
+  void main() {
+    vec4 sample = texture2D(uSampler, vTextureCoord);
+    // Preserve alpha, push RGB toward white
+    gl_FragColor = vec4(mix(sample.rgb, vec3(1.0), uFlash * sample.a), sample.a);
+  }
+`;
+
+export class HitFlashFilter extends Filter {
+  constructor() {
+    super({ glProgram: { vertex: hitFlashVert, fragment: hitFlashFrag } });
+    this.resources.uniforms = { uFlash: 0.0 };
+  }
+
+  get flash(): number { return this.resources.uniforms.uFlash; }
+  set flash(v: number) { this.resources.uniforms.uFlash = v; }
+}
+
+// Usage on a combat sprite
+const hitFilter = new HitFlashFilter();
+characterSprite.filters = [hitFilter];
+
+// Animate the flash via GSAP or useTick
+gsap.to(hitFilter, {
+  flash: 1.0,
+  duration: 0.06,
+  yoyo: true,
+  repeat: 1,
+  onComplete: () => { characterSprite.filters = []; },
+});
+```
+
+---
+
+## BlurFilter Chaining for Glow Effects
+
+PixiJS v8's `pixi-filters` package (v6+) includes `AdvancedBloomFilter`. For a manual glow, chain blur on a duplicated sprite:
+
+```typescript
+import { BlurFilter, Container, Sprite } from 'pixi.js';
+import { AdvancedBloomFilter } from '@pixi/filter-advanced-bloom'; // pixi-filters v6+
+
+// Simple glow: add bloom to a character container
+const characterContainer = new Container();
+scene.addChild(characterContainer);
+
+const bloomFilter = new AdvancedBloomFilter({
+  threshold: 0.4,    // luminance required to bloom (0-1)
+  bloomScale: 0.8,
+  brightness: 1.2,
+  kernelSize: 5,     // 5 = medium quality, 15 = high (expensive on mobile)
+  quality: 4,
+});
+characterContainer.filters = [bloomFilter];
+
+// Pulse glow on power-up
+function pulseGlow(duration = 600): void {
+  const tween = { brightness: 1.2 };
+  gsap.to(tween, {
+    brightness: 2.0,
+    duration: duration / 1000,
+    ease: 'sine.inOut',
+    yoyo: true,
+    repeat: 3,
+    onUpdate: () => { bloomFilter.brightness = tween.brightness; },
+  });
+}
+
+// Manual two-pass glow (no external package needed)
+function addManualGlow(target: Sprite, glowColor: number, blur = 12): Container {
+  const wrapper = new Container();
+  const glow = Sprite.from(target.texture); // duplicate texture
+  glow.tint = glowColor;
+  glow.alpha = 0.7;
+  glow.filters = [new BlurFilter({ strength: blur })];
+  glow.anchor.set(target.anchor.x, target.anchor.y);
+
+  wrapper.addChild(glow); // glow behind
+  wrapper.addChild(target); // original on top
+  return wrapper;
+}
+```
+
+---
+
+## DisplacementFilter for Shockwave and Ripple
+
+```typescript
+import { Sprite, DisplacementFilter, Assets, Container } from 'pixi.js';
+
+// Shockwave: growing ring displacement
+export async function createShockwave(
+  stage: Container,
+  x: number,
+  y: number,
+): Promise<void> {
+  // Displacement maps are grayscale sprites; use a blurred circle
+  const dispTexture = await Assets.load('/textures/displacement_circle.png');
+  const dispSprite = new Sprite(dispTexture);
+  dispSprite.anchor.set(0.5);
+  dispSprite.position.set(x, y);
+  dispSprite.scale.set(0.1); // start small
+  stage.addChild(dispSprite);
+
+  const displacementFilter = new DisplacementFilter({
+    sprite: dispSprite,
+    scale: { x: 80, y: 80 },
+  });
+
+  stage.filters = stage.filters
+    ? [...stage.filters, displacementFilter]
+    : [displacementFilter];
+
+  // Expand the displacement sprite
+  gsap.to(dispSprite.scale, {
+    x: 3.0,
+    y: 3.0,
+    duration: 0.6,
+    ease: 'power2.out',
+  });
+  // Reduce intensity as it expands
+  gsap.to(displacementFilter.scale, {
+    x: 0,
+    y: 0,
+    duration: 0.6,
+    ease: 'power3.in',
+    onComplete: () => {
+      stage.filters = stage.filters!.filter(f => f !== displacementFilter);
+      dispSprite.destroy();
+    },
+  });
+}
+```
+
+---
+
+## Spine Animation Integration
+
+Spine v4 animations in PixiJS v8 via `@esotericsoftware/spine-pixi-v8`:
+
+```typescript
+import { Spine as PixiSpine } from '@esotericsoftware/spine-pixi-v8';
+import { Assets } from 'pixi.js';
+
+// Load Spine assets
+async function loadSpineCharacter(key: string): Promise<PixiSpine> {
+  await Assets.load([
+    { alias: `${key}-skel`, src: `/spine/${key}.skel` },
+    { alias: `${key}-atlas`, src: `/spine/${key}.atlas` },
+  ]);
+
+  return PixiSpine.from({ skeleton: `${key}-skel`, atlas: `${key}-atlas` });
+}
+
+// Animation state machine for combat
+class SpineCombatCharacter {
+  private spine: PixiSpine;
+  private state: string = 'idle';
+
+  constructor(spine: PixiSpine) {
+    this.spine = spine;
+    this.spine.state.setAnimation(0, 'idle', true); // track 0, loop
+  }
+
+  attack(): void {
+    if (this.state === 'hit') return;
+    this.state = 'attack';
+    this.spine.state.setAnimation(0, 'attack', false);
+    this.spine.state.addAnimation(0, 'idle', true, 0);
+    this.spine.state.addListener({
+      complete: (entry) => {
+        if (entry.animation?.name === 'attack') this.state = 'idle';
+      },
+    });
+  }
+
+  takeHit(): void {
+    this.state = 'hit';
+    // Track 1 for hit reaction — plays over top of attack/idle
+    this.spine.state.setAnimation(1, 'hit', false);
+    this.spine.state.addAnimation(1, null!, false, 0);
+    setTimeout(() => { this.state = 'idle'; }, 300);
+  }
+}
+```
+
+---
+
+## Particle Emitter Patterns for Combat
+
+```typescript
+import { Emitter } from '@spd789562/pixi-v8-particle-emitter';
+import { Container } from 'pixi.js';
+
+// Impact burst — one-shot, auto-destroys
+function burstImpact(stage: Container, x: number, y: number): void {
+  const particleContainer = new Container();
+  particleContainer.position.set(x, y);
+  stage.addChild(particleContainer);
+
+  const emitter = new Emitter(particleContainer, {
+    lifetime: { min: 0.2, max: 0.5 },
+    frequency: 0.001,
+    spawnChance: 1,
+    particlesPerWave: 12,
+    maxParticles: 12,
+    pos: { x: 0, y: 0 },
+    behaviors: [
+      { type: 'alpha', config: { alpha: { list: [{ value: 1, time: 0 }, { value: 0, time: 1 }] } } },
+      { type: 'scale', config: { scale: { list: [{ value: 0.6, time: 0 }, { value: 0.1, time: 1 }] } } },
+      { type: 'color', config: { color: { list: [
+        { value: 'ff6600', time: 0 },
+        { value: 'ff2200', time: 0.3 },
+        { value: '330000', time: 1 },
+      ] } } },
+      { type: 'moveSpeedStatic', config: { min: 150, max: 400 } },
+      { type: 'rotationStatic', config: { min: 0, max: 360 } },
+    ],
+  });
+
+  emitter.emit = true;
+  setTimeout(() => {
+    emitter.emit = false;
+    setTimeout(() => {
+      emitter.destroy();
+      particleContainer.destroy();
+    }, 600); // > max lifetime (500ms)
+  }, 50); // one burst wave
+}
+```
+
+---
+
+## Z-Index and Sorting in PixiJS
+
+```typescript
+import { Container, Sprite } from 'pixi.js';
+
+// Strategy 1: sortableChildren + zIndex (flexible, sort cost)
+const stage = new Container();
+stage.sortableChildren = true;
+
+const background = Sprite.from('bg');
+background.zIndex = 0;
+const player = Sprite.from('player');
+player.zIndex = 10;
+const hitEffect = Sprite.from('hit_flash');
+hitEffect.zIndex = 20; // above player
+const uiContainer = new Container();
+uiContainer.zIndex = 100; // always on top
+stage.addChild(background, player, hitEffect, uiContainer);
+
+// Strategy 2: explicit layer containers (faster, no sort)
+const bgLayer      = new Container();
+const entityLayer  = new Container();
+const effectLayer  = new Container();
+const uiLayer      = new Container();
+stage.addChild(bgLayer, entityLayer, effectLayer, uiLayer);
+entityLayer.addChild(player);
+effectLayer.addChild(hitEffect); // always above entities
+uiLayer.addChild(hpBar);
+```
+
+**Layer container strategy is faster** — no sort required. Use it when layers have clear separation (background / entities / effects / UI). Use `zIndex` only when entities need dynamic y-sorting (top-down RPG, characters in front of/behind each other).
+
+---
+
+## Alpha Masking for Health Bars
+
+```typescript
+import { Container, Graphics, Sprite } from 'pixi.js';
+
+export class HealthBar extends Container {
+  private fill: Sprite;
+  private fillMask: Graphics;
+  private maxWidth: number;
+
+  constructor(width = 200, height = 20) {
+    super();
+    this.maxWidth = width;
+
+    const bg = new Graphics()
+      .roundRect(0, 0, width, height, 4)
+      .fill({ color: 0x220000, alpha: 0.9 });
+    this.addChild(bg);
+
+    this.fill = Sprite.from('health_bar_fill');
+    this.fill.width = width;
+    this.fill.height = height;
+    this.addChild(this.fill);
+
+    this.fillMask = new Graphics();
+    this.addChild(this.fillMask);
+    this.fill.mask = this.fillMask;
+    this.setHealth(1.0);
+  }
+
+  setHealth(ratio: number): void {
+    const r = Math.max(0, Math.min(1, ratio));
+    this.fillMask.clear()
+      .rect(0, 0, this.maxWidth * r, this.fill.height)
+      .fill(0xffffff);
+
+    if (r > 0.6)      this.fill.tint = 0x44ff44;
+    else if (r > 0.3) this.fill.tint = 0xffcc00;
+    else               this.fill.tint = 0xff2222;
+  }
+}
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Creating New PIXI.Texture Per Frame
+
+**Detection**:
+```bash
+grep -rn "new PIXI\.Texture\|Texture\.from\|RenderTexture\.create" --include="*.ts" --include="*.js"
+rg "useTick|Ticker\.shared" --type ts -A 20 | grep "Texture"
+```
+
+**What it looks like**:
+```typescript
+app.ticker.add(() => {
+  const texture = Texture.from('spark_' + Math.floor(Math.random() * 4)); // BAD
+  const sprite = new Sprite(texture);
+  stage.addChild(sprite);
+});
+```
+
+**Why wrong**: Each frame adds a sprite with uncleaned GPU texture references. After 60 seconds at 60fps: 3600 leaked sprites, visible GC stutter.
+
+**Fix**: Pre-load textures array, pool sprites:
+```typescript
+const textures = ['spark_0', 'spark_1', 'spark_2', 'spark_3'].map(k => Texture.from(k));
+// Use object pool pattern — never create sprites in ticker
+```
+
+---
+
+### ❌ Applying Filters to Individual Sprites Instead of Containers
+
+**Detection**:
+```bash
+grep -rn "\.filters\s*=\s*\[" --include="*.ts" --include="*.js"
+rg "\.filters\s*=" --type ts
+```
+
+**What it looks like**:
+```typescript
+sprites.forEach(sprite => {
+  sprite.filters = [new BlurFilter({ strength: 4 })]; // BAD: N filter passes per frame
+});
+```
+
+**Why wrong**: Each filter on a Sprite triggers one render-to-texture pass. 20 sprites = 20 extra render passes per frame = 20fps drop on mid-range mobile.
+
+**Fix**: Apply filters to a parent Container:
+```typescript
+const entityContainer = new Container();
+entityContainer.filters = [new BlurFilter({ strength: 4 })]; // one pass for all
+sprites.forEach(sprite => entityContainer.addChild(sprite));
+stage.addChild(entityContainer);
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|-----------|-----|
+| `Filter vertex program undefined` | PixiJS v8 changed Filter constructor API | Use `new Filter({ glProgram: { vertex, fragment } })` not `new Filter(vert, frag, uniforms)` |
+| Displacement map not visible | `dispSprite` not added to the same container | `stage.addChild(dispSprite)` before setting `stage.filters` |
+| Spine character invisible | Atlas not loaded before `PixiSpine.from()` | `await Assets.load()` for both `.skel` and `.atlas` first |
+| `zIndex` sort not working | `sortableChildren` not `true` on parent | `parentContainer.sortableChildren = true` |
+| Health bar mask shows full bar | Mask `rect` width not clamped | `Math.max(0, Math.min(1, ratio))` before multiply |
+
+---
+
+## See Also
+
+- `references/pixi-performance.md` — Sprite batching, texture atlases, ParticleContainer
+- `references/pixi-particle-systems.md` — Full particle emitter config reference
+- `references/pixi-post-processing.md` — AdvancedBloomFilter, CRTFilter, filter chain ordering

--- a/agents/pixijs-combat-renderer/references/pixi-performance.md
+++ b/agents/pixijs-combat-renderer/references/pixi-performance.md
@@ -1,0 +1,393 @@
+---
+name: PixiJS Rendering Performance
+description: Sprite batching, texture atlases, RenderTexture caching, off-screen culling, object pooling, ParticleContainer vs Container, and anti-patterns that break GPU batching in PixiJS v8+
+agent: pixijs-combat-renderer
+category: performance
+version_range: "PixiJS v8+"
+---
+
+# PixiJS Performance Reference
+
+> **Scope**: PixiJS v8-specific rendering performance — what breaks batching, how to measure draw calls, when to use ParticleContainer, texture atlas format, RenderTexture caching, and object pooling patterns.
+> **Version range**: PixiJS v8+
+> **Generated**: 2026-04-08
+
+---
+
+## How PixiJS Batching Works and When It Breaks
+
+PixiJS v8 batches sprites sharing the same texture, blend mode, alpha, and no active filters into a single draw call. Understanding what breaks batching is the core performance skill.
+
+```typescript
+import { Application, Sprite, Texture } from 'pixi.js';
+
+// Batching diagnostic — check draw calls per frame
+const app = new Application();
+await app.init({ resizeTo: window });
+
+app.ticker.add(() => {
+  // Access renderer stats
+  const stats = (app.renderer as any).runners; // internal — use sparingly
+  // Better: use pixi-stats package for dev overlay
+  // import { addStats } from 'pixi-stats';
+  // const stats = addStats(document, app);
+});
+```
+
+### What Breaks Batching (Forces New Draw Call)
+
+| Cause | Triggers New Draw Call | Prevention |
+|-------|----------------------|------------|
+| Different texture | Each atlas break | Pack sprites into one atlas |
+| Filter on any ancestor | Yes — filter renders to RenderTexture | Use filters on container root only |
+| Different blend mode | Yes | Group by blend mode |
+| Per-sprite tint change per frame | Yes — tint changes trigger batch flush | Use one tint value per atlas batch |
+| Changing `alpha` on parent Container | Yes — alpha is baked per draw | Set alpha on sprites, not containers |
+| Mask on any ancestor | Yes | Pool masked containers, not per-sprite |
+
+---
+
+## Texture Atlases with TexturePacker Output
+
+Pack all combat sprites into one atlas to eliminate texture-switch draw calls.
+
+```typescript
+import { Assets, Spritesheet, Texture } from 'pixi.js';
+
+// Load TexturePacker JSON atlas
+await Assets.load('/atlases/combat.json'); // loads .json + .png together
+
+// Access individual frames
+const playerIdleTexture  = Texture.from('player_idle_000');
+const playerAttackTexture = Texture.from('player_attack_001');
+const hitSparkTexture    = Texture.from('hit_spark_000');
+
+// AnimatedSprite from atlas frames (character animation)
+const frames = [];
+for (let i = 0; i < 8; i++) {
+  frames.push(Texture.from(`player_idle_${String(i).padStart(3, '0')}`));
+}
+const animSprite = new AnimatedSprite(frames);
+animSprite.animationSpeed = 0.15;
+animSprite.play();
+
+// Verify all combat sprites use the same atlas
+// Detection: any Texture.from() that points to a DIFFERENT file breaks the batch
+```
+
+### TexturePacker Settings for PixiJS v8
+
+```
+Format: Pixi JS (JSON Hash or JSON Array)
+Algorithm: MaxRects
+Power of Two: YES (GPU texture requirement)
+Max texture: 2048x2048 (safe on all devices)
+Padding: 2 (prevents bleeding at atlas edges)
+Trim sprites: YES (reduces atlas size)
+Extrude: 1 (prevents seam artifacts when filtering)
+```
+
+---
+
+## RenderTexture for Cached Complex Composites
+
+When a composite (character + equipment + effects) is expensive to re-render and doesn't change every frame, bake it to a RenderTexture:
+
+```typescript
+import { RenderTexture, Sprite, Container, Application } from 'pixi.js';
+
+// Bake a character composite to a RenderTexture
+function bakeCharacterToTexture(
+  app: Application,
+  character: Container,
+  width: number,
+  height: number,
+): Sprite {
+  const renderTexture = RenderTexture.create({ width, height });
+
+  // Render the container once to the texture
+  app.renderer.render({ container: character, target: renderTexture });
+
+  // Use as a regular sprite — one draw call, no children
+  const baked = new Sprite(renderTexture);
+  return baked;
+}
+
+// Use case: character select screen — bake each character preview
+// Re-bake on state change (equip item, take damage), not every frame
+```
+
+---
+
+## Culling Off-Screen Objects
+
+PixiJS does not cull off-screen objects by default. For combat with many off-screen effects:
+
+```typescript
+import { Container, Sprite, Rectangle } from 'pixi.js';
+
+// Simple frustum cull — check bounds against screen rect
+const screenBounds = new Rectangle(0, 0, app.screen.width, app.screen.height);
+
+function cullChildren(container: Container): void {
+  for (const child of container.children) {
+    if (child instanceof Sprite) {
+      const bounds = child.getBounds();
+      // Add margin to prevent pop-in
+      child.visible = screenBounds.intersects(new Rectangle(
+        bounds.x - 50, bounds.y - 50,
+        bounds.width + 100, bounds.height + 100,
+      ));
+    }
+  }
+}
+
+// Call in ticker at a reduced rate (every 3 frames is sufficient)
+let cullFrame = 0;
+app.ticker.add(() => {
+  if (++cullFrame % 3 === 0) cullChildren(entityLayer);
+});
+```
+
+---
+
+## Object Pooling in PixiJS
+
+```typescript
+import { Sprite, Texture, Container } from 'pixi.js';
+
+// Generic sprite pool
+class SpritePool {
+  private pool: Sprite[] = [];
+  private texture: Texture;
+  private parent: Container;
+
+  constructor(texture: Texture, parent: Container, initialSize = 20) {
+    this.texture = texture;
+    this.parent = parent;
+    // Pre-warm pool
+    for (let i = 0; i < initialSize; i++) {
+      const sprite = new Sprite(texture);
+      sprite.visible = false;
+      parent.addChild(sprite);
+      this.pool.push(sprite);
+    }
+  }
+
+  get(): Sprite | null {
+    const sprite = this.pool.find(s => !s.visible);
+    if (!sprite) return null; // pool exhausted
+
+    sprite.visible = true;
+    sprite.alpha = 1;
+    sprite.rotation = 0;
+    sprite.scale.set(1);
+    return sprite;
+  }
+
+  release(sprite: Sprite): void {
+    sprite.visible = false;
+    // Reset to a safe position off-screen
+    sprite.position.set(-9999, -9999);
+  }
+}
+
+// Usage — projectiles
+const bulletPool = new SpritePool(Texture.from('bullet'), entityLayer, 30);
+
+function fireBullet(x: number, y: number, vx: number, vy: number): void {
+  const bullet = bulletPool.get();
+  if (!bullet) return; // pool exhausted — silent drop
+
+  bullet.position.set(x, y);
+  bullet.setData('vx', vx);
+  bullet.setData('vy', vy);
+}
+
+// In ticker — update and recycle
+app.ticker.add((ticker) => {
+  const dt = ticker.deltaTime;
+  for (const bullet of entityLayer.children) {
+    if (!bullet.visible) continue;
+    const sprite = bullet as Sprite;
+    sprite.x += sprite.getData('vx') * dt;
+    sprite.y += sprite.getData('vy') * dt;
+
+    if (sprite.x < -50 || sprite.x > app.screen.width + 50) {
+      bulletPool.release(sprite);
+    }
+  }
+});
+```
+
+---
+
+## ParticleContainer vs Container for Particles
+
+| Feature | ParticleContainer | Container |
+|---------|------------------|-----------|
+| Max sprites | 100,000+ | ~5,000 comfortable |
+| Tint per sprite | Yes | Yes |
+| Alpha per sprite | Yes | Yes |
+| Rotation per sprite | Yes (if enabled) | Yes |
+| Filters | No | Yes |
+| Children of children | No | Yes |
+| Blend mode per sprite | No | Yes |
+| Draw calls | 1 | 1 per texture |
+
+```typescript
+import { ParticleContainer, Sprite, Texture } from 'pixi.js';
+
+// ParticleContainer — all particles must use the SAME texture
+const particleContainer = new ParticleContainer(10000, {
+  position: true,   // enable per-particle position upload
+  rotation: true,   // enable per-particle rotation upload
+  scale: true,      // enable per-particle scale upload
+  alpha: true,      // enable per-particle alpha upload
+  uvs: false,       // disable if single texture (saves bandwidth)
+  tint: false,      // disable if no tint variation needed
+});
+
+// Only enable what you need — unused uploads waste GPU bandwidth
+const spark = Texture.from('spark');
+
+for (let i = 0; i < 5000; i++) {
+  const sprite = new Sprite(spark);
+  sprite.position.set(Math.random() * 800, Math.random() * 600);
+  sprite.alpha = Math.random();
+  particleContainer.addChild(sprite);
+}
+
+stage.addChild(particleContainer);
+```
+
+**When NOT to use ParticleContainer**:
+- Mixed textures (multiple atlas frames) — use regular Container with single atlas
+- Particles that need filters (glow, blur) — regular Container + filter on parent
+- Particles with children (labels, icons) — regular Container
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Changing Tint Per Frame on Many Sprites
+
+**Detection**:
+```bash
+grep -rn "\.tint\s*=" --include="*.ts" --include="*.js"
+rg "ticker\.add|useTick" --type ts -A 20 | grep "\.tint"
+```
+
+**What it looks like**:
+```typescript
+app.ticker.add(() => {
+  // BAD: tint change per frame flushes the batch for each sprite
+  sprites.forEach((sprite, i) => {
+    sprite.tint = hslToHex(i / sprites.length, 1, 0.5 + Math.sin(Date.now() * 0.001 + i) * 0.2);
+  });
+});
+```
+
+**Why wrong**: Setting `.tint` marks the sprite as dirty and flushes the current batch. 100 sprites with per-frame tint changes = 100 draw calls instead of 1.
+
+**Fix**: Use a custom shader uniform instead of per-sprite tint changes, or group sprites by tint value and update once per group:
+```typescript
+// Group by tint — batch-friendly
+const tintGroups = new Map<number, Sprite[]>();
+sprites.forEach(sprite => {
+  const tint = computeTint(sprite);
+  if (!tintGroups.has(tint)) tintGroups.set(tint, []);
+  tintGroups.get(tint)!.push(sprite);
+});
+tintGroups.forEach((group, tint) => {
+  group.forEach(s => { s.tint = tint; }); // same tint = batches together
+});
+```
+
+---
+
+### ❌ Using Container Instead of ParticleContainer for Hundreds of Uniform Particles
+
+**Detection**:
+```bash
+grep -rn "new Container\|new PIXI\.Container" --include="*.ts" --include="*.js"
+rg "addChild.*Sprite" --type ts | grep -v "ParticleContainer"
+```
+
+**What it looks like**:
+```typescript
+const particleLayer = new Container();
+for (let i = 0; i < 1000; i++) {
+  const p = new Sprite(sparkTexture);
+  particleLayer.addChild(p); // BAD: 1000 children in regular Container
+}
+```
+
+**Why wrong**: Regular Container renders each child individually during the batch flush. 1000 same-texture sprites in a Container use 1 draw call, but each child is inspected in JavaScript every frame — O(n) per-frame cost even with batching. Above ~500 children, the JS cost exceeds the GPU gain.
+
+**Fix**: Use `ParticleContainer` for homogeneous particle sets:
+```typescript
+const particleLayer = new ParticleContainer(1000, { position: true, alpha: true });
+for (let i = 0; i < 1000; i++) {
+  const p = new Sprite(sparkTexture);
+  particleLayer.addChild(p);
+}
+```
+
+---
+
+### ❌ Loading Individual Textures per Sprite (No Atlas)
+
+**Detection**:
+```bash
+grep -rn "Texture\.from\|Assets\.load.*\.png" --include="*.ts" --include="*.js"
+rg "\.load\(['\"].*\.png['\"]" --type ts
+```
+
+**What it looks like**:
+```typescript
+// BAD: each unique PNG = separate GPU texture = separate draw call
+const playerTexture = await Assets.load('/sprites/player.png');
+const enemyTexture  = await Assets.load('/sprites/enemy.png');
+const sparkTexture  = await Assets.load('/sprites/spark.png');
+```
+
+**Why wrong**: Each unique GPU texture creates a batch boundary. 10 unique textures in a scene = minimum 10 draw calls, regardless of how many sprites use them. On mobile, each texture switch has a measurable cost.
+
+**Fix**: Pack all sprites into one atlas. One `Assets.load('/atlases/combat.json')` loads everything:
+```typescript
+await Assets.load('/atlases/combat.json');
+// Now all frames share one GPU texture — single draw call for all sprites
+const playerTexture = Texture.from('player_idle_000');
+const sparkTexture  = Texture.from('hit_spark_000');
+```
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Find all per-frame tint mutations
+grep -rn "\.tint\s*=" --include="*.ts" --include="*.js"
+
+# Find non-ParticleContainer particle patterns
+grep -rn "addChild.*new Sprite" --include="*.ts" | grep -v "ParticleContainer"
+
+# Find individual texture loads (no atlas)
+grep -rn "Assets\.load.*\.png\|Texture\.from.*\.png" --include="*.ts"
+
+# Find RenderTexture usage — verify baking, not per-frame render
+grep -rn "RenderTexture\|renderer\.render" --include="*.ts"
+
+# Find filter application — check container vs sprite level
+grep -rn "\.filters\s*=" --include="*.ts"
+```
+
+---
+
+## See Also
+
+- `references/combat-visual-effects.md` — Hit filters, shockwave, glow, z-ordering
+- `references/pixi-particle-systems.md` — Full particle emitter config and presets
+- `references/pixi-post-processing.md` — Filter chain ordering and mobile budgets
+- `references/pixi-react-integration.md` — useTick animation, Vite bundle splitting

--- a/skills/phaser-gamedev/SKILL.md
+++ b/skills/phaser-gamedev/SKILL.md
@@ -83,6 +83,8 @@ Load these references based on the plan:
 - If sprites/animation: `references/spritesheets.md`
 - If Arcade physics: `references/arcade-physics.md`
 - If performance concern or many moving objects: `references/performance.md`
+- If polish / game feel / juice signal ("screen shake", "particles", "game feel", "hit feedback", "satisfying"): `references/game-feel-patterns.md`
+- If Matter.js, slopes, object layers, complex collision, or enemy spawning from Tiled: `references/tilemaps-and-physics.md`
 
 **Gate**: Scene plan documented. Physics system selected. References loaded. Proceed only when gate passes.
 
@@ -387,3 +389,5 @@ Fix: Pool bullets and enemies (see `references/performance.md`). Set emitters to
 | `references/tilemaps.md` | Tilemap / Tiled | Layer system, collision, animated tiles, object layers |
 | `references/spritesheets.md` | Sprites / animation | Frame measurement, loading, atlases, nine-slice |
 | `references/performance.md` | Performance concern | Object pooling, GC avoidance, texture atlases, mobile |
+| `references/game-feel-patterns.md` | Polish / juice signal | Screen shake, particle bursts, hit-stop, scale punch, tween chains, sound timing |
+| `references/tilemaps-and-physics.md` | Complex maps / Matter.js | Tiled integration pipeline, Matter.js vs Arcade decision table, collision categories, slopes, object layer spawning |

--- a/skills/phaser-gamedev/references/game-feel-patterns.md
+++ b/skills/phaser-gamedev/references/game-feel-patterns.md
@@ -1,0 +1,422 @@
+---
+name: Phaser Game Feel Patterns
+description: Screen shake, particle bursts, hit pause, scale punch, tween chaining, sound timing — techniques that make Phaser 3 games feel polished and responsive
+agent: phaser-gamedev
+category: visual-techniques
+version_range: "Phaser 3.60+"
+---
+
+# Game Feel Patterns Reference
+
+> **Scope**: "Juice" — the collection of micro-feedback effects that make a game feel satisfying. Camera shake, particles, time dilation, hit stop, scale punch, tween chains, and audio timing. Does NOT cover physics setup or tilemap config.
+> **Version range**: Phaser 3.60+
+> **Generated**: 2026-04-08
+
+---
+
+## Screen Shake
+
+Camera shake is the most visceral hit-feedback tool. Phaser 3.60+ has `camera.shake()` built in.
+
+```typescript
+// Basic shake on hit — parameters: duration (ms), intensity (0-1)
+this.cameras.main.shake(150, 0.008);
+
+// Directional shake via camera.pan() + tween
+// Use for knockback-directional feedback (e.g., hit from left = camera moves left then returns)
+hitFromLeft(): void {
+  this.tweens.add({
+    targets: this.cameras.main,
+    scrollX: this.cameras.main.scrollX - 12, // push camera left
+    duration: 60,
+    ease: 'Power2',
+    yoyo: true,   // return to original position
+    repeat: 2,    // 2 oscillations
+  });
+}
+
+// Strong boss hit: combined shake + flash
+onBossHit(): void {
+  this.cameras.main.shake(300, 0.02);
+  this.cameras.main.flash(100, 255, 200, 0, false); // flash: duration, r, g, b, force
+}
+```
+
+**Shake intensity guide**:
+| Event | Duration (ms) | Intensity |
+|-------|--------------|-----------|
+| Player takes damage | 120 | 0.006 |
+| Enemy dies | 200 | 0.012 |
+| Explosion | 350 | 0.025 |
+| Boss attack | 400 | 0.035 |
+
+---
+
+## Particle Burst Effects (Phaser 3.60+ API)
+
+Phaser 3.60 rewrote the particle system. The old `ParticleEmitterManager` API is removed.
+
+```typescript
+// Coin collect burst — Phaser 3.60+ API
+onCoinCollect(x: number, y: number): void {
+  const emitter = this.add.particles(x, y, 'spark', {
+    speed: { min: 80, max: 200 },
+    angle: { min: 0, max: 360 },
+    scale: { start: 0.6, end: 0 },
+    alpha: { start: 1, end: 0 },
+    lifespan: 500,
+    quantity: 12,
+    tint: [0xffdd00, 0xffaa00, 0xffffff],
+    gravityY: 300,
+    emitting: false, // don't emit continuously
+  });
+
+  emitter.explode(12, x, y); // fire burst, then auto-destroy after all particles die
+  // Emitter auto-destroys when all particles expire (Phaser 3.60+ default)
+}
+
+// Hit sparks (directional)
+onHit(x: number, y: number, directionX: number): void {
+  const emitter = this.add.particles(x, y, 'spark', {
+    speed: { min: 100, max: 250 },
+    angle: { min: -30, max: 30 },          // narrow cone forward
+    rotate: { min: 0, max: 360 },
+    scale: { start: 0.4, end: 0 },
+    lifespan: 300,
+    quantity: 6,
+    gravityY: 500,
+    emitting: false,
+  });
+
+  emitter.setParticleRotation(directionX > 0 ? 0 : 180); // face hit direction
+  emitter.explode(6, x, y);
+}
+
+// Continuous trail effect (stops when assigned sprite is recycled)
+attachTrail(sprite: Phaser.GameObjects.Sprite): Phaser.GameObjects.Particles.ParticleEmitter {
+  return this.add.particles(0, 0, 'trail', {
+    follow: sprite,           // emitter follows sprite
+    followOffset: { x: -sprite.width / 2, y: 0 },
+    speed: 20,
+    lifespan: 200,
+    scale: { start: 0.3, end: 0 },
+    alpha: { start: 0.6, end: 0 },
+    frequency: 16,            // emit every 16ms (~60fps)
+  });
+}
+```
+
+---
+
+## Hit Pause / Time Dilation
+
+Briefly stopping time on a heavy hit makes the impact feel weighty. Phaser uses `this.physics.world.timeScale` and scene's `this.time.timeScale`.
+
+```typescript
+// Hit stop: freeze game time for N ms then resume
+hitStop(duration: number = 80): void {
+  if (this.hitStopActive) return; // prevent stacking
+  this.hitStopActive = true;
+
+  this.physics.world.timeScale = 0.0001; // near-zero (can't be exactly 0)
+  this.tweens.timeScale = 0.0001;
+  this.time.timeScale = 0.0001;
+
+  this.time.delayedCall(duration, () => {
+    this.physics.world.timeScale = 1;
+    this.tweens.timeScale = 1;
+    this.time.timeScale = 1;
+    this.hitStopActive = false;
+  });
+}
+
+// Slow-motion mode (bullet time)
+enterSlowMo(duration: number = 2000): void {
+  this.physics.world.timeScale = 0.25;
+  this.tweens.timeScale = 0.25;
+  this.time.timeScale = 0.25;
+  this.sound.setRate(0.8); // Phaser 3.60+: slow audio pitch
+
+  this.time.delayedCall(duration, () => {
+    this.physics.world.timeScale = 1;
+    this.tweens.timeScale = 1;
+    this.time.timeScale = 1;
+    this.sound.setRate(1.0);
+  });
+}
+```
+
+---
+
+## Scale Punch (Squash and Stretch)
+
+Scale punch on hit makes sprites feel physical. Classic squash-and-stretch on impact:
+
+```typescript
+// Scale punch: fast enlarge → squash → return to normal
+scalePunch(target: Phaser.GameObjects.Sprite, punchX = 1.4, punchY = 0.7): void {
+  this.tweens.add({
+    targets: target,
+    scaleX: punchX,
+    scaleY: punchY,
+    duration: 60,
+    ease: 'Back.easeOut',
+    yoyo: true,                           // auto-return to original scale
+    onComplete: () => {
+      target.setScale(1);                 // ensure perfect reset
+    },
+  });
+}
+
+// Wobble: oscillating scale for collecting items
+wobble(target: Phaser.GameObjects.Sprite): void {
+  this.tweens.add({
+    targets: target,
+    scaleX: { from: 1, to: 1.2 },
+    scaleY: { from: 1, to: 0.85 },
+    duration: 80,
+    ease: 'Sine.easeInOut',
+    yoyo: true,
+    repeat: 2,
+    onComplete: () => target.setScale(1),
+  });
+}
+
+// Death spin: rotation + scale fade for enemies
+dieEffect(target: Phaser.GameObjects.Sprite): void {
+  this.tweens.add({
+    targets: target,
+    angle: 720,               // two full rotations
+    scaleX: 0,
+    scaleY: 0,
+    alpha: 0,
+    duration: 400,
+    ease: 'Power2.easeIn',
+    onComplete: () => target.destroy(),
+  });
+}
+```
+
+---
+
+## Tween Chaining
+
+Tween chains let you sequence effects without manual timers:
+
+```typescript
+// Chain: damage flash → shake → return to normal
+onPlayerHit(player: Phaser.GameObjects.Sprite): void {
+  // Prevent multiple chains running simultaneously
+  if (player.getData('invincible')) return;
+  player.setData('invincible', true);
+
+  this.tweens.chain({
+    targets: player,
+    tweens: [
+      {
+        alpha: 0.2,
+        duration: 60,
+        ease: 'Linear',
+        yoyo: true,
+        repeat: 5, // 6 flashes total = 720ms invincibility
+      },
+      {
+        alpha: 1,
+        duration: 1,
+        onComplete: () => player.setData('invincible', false),
+      },
+    ],
+  });
+
+  this.cameras.main.shake(100, 0.005);
+}
+
+// Score popup: rise + fade
+showScorePopup(x: number, y: number, points: number): void {
+  const text = this.add.text(x, y, `+${points}`, {
+    fontSize: '20px',
+    color: '#ffdd00',
+    stroke: '#000',
+    strokeThickness: 3,
+  }).setOrigin(0.5).setDepth(100);
+
+  this.tweens.chain({
+    targets: text,
+    tweens: [
+      { y: y - 40, scaleX: 1.2, scaleY: 1.2, duration: 200, ease: 'Back.easeOut' },
+      { y: y - 80, scaleX: 1, scaleY: 1, alpha: 0, duration: 400, ease: 'Power2.easeIn' },
+    ],
+    onComplete: () => text.destroy(),
+  });
+}
+```
+
+---
+
+## Sound Cue Timing Patterns
+
+Sound timing is critical for feeling responsive. Phaser 3.60+ Web Audio has predictable latency.
+
+```typescript
+// Play sound with attack on physics contact (not on timer)
+setupSoundCues(): void {
+  // Preload in BootScene.preload():
+  // this.load.audio('hit', ['assets/sounds/hit.ogg', 'assets/sounds/hit.mp3']);
+  // this.load.audio('pickup', ['assets/sounds/pickup.ogg']);
+
+  this.hitSound = this.sound.add('hit', { volume: 0.7 });
+  this.pickupSound = this.sound.add('pickup', { volume: 0.5 });
+
+  // Multiple hit sounds avoid "machine gun" repetition
+  this.hitSounds = [
+    this.sound.add('hit_1', { volume: 0.7 }),
+    this.sound.add('hit_2', { volume: 0.6 }),
+    this.sound.add('hit_3', { volume: 0.8 }),
+  ];
+}
+
+playHit(): void {
+  // Randomize pitch to avoid identical sounds feeling robotic
+  const sound = Phaser.Utils.Array.GetRandom(this.hitSounds) as Phaser.Sound.WebAudioSound;
+  sound.setRate(Phaser.Math.FloatBetween(0.9, 1.1));
+  sound.play();
+}
+
+// Sound with camera shake: start at same frame for synchronized feel
+onEnemyDeath(x: number, y: number): void {
+  this.sound.play('explosion', { volume: 0.9 });
+  this.cameras.main.shake(200, 0.015);    // same frame — synchronized impact
+  this.createDeathParticles(x, y);         // same frame
+}
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Using Alpha Tweens Instead of Particle Bursts for Hit Effects
+
+**Detection**:
+```bash
+grep -rn "tween.*alpha\|alpha.*tween" --include="*.ts" --include="*.js"
+rg "alpha.*0\b" --type ts -B 2 | grep "onHit\|takeDamage\|damage\|hit"
+```
+
+**What it looks like**:
+```typescript
+// BAD: alpha blink communicates "invisible" not "impact"
+onHit(): void {
+  this.tweens.add({
+    targets: this.player,
+    alpha: { from: 0, to: 1 },
+    repeat: 5,
+    duration: 80,
+  });
+}
+```
+
+**Why wrong**: Alpha blink is invisible feedback — it removes the visual, it doesn't add one. Players learn to "feel" hits through additive signals: particles appear, camera moves, sound plays. Removing the player sprite subtracts the signal.
+
+**Fix**: Use alpha blink for invincibility indication (secondary) and add a particle burst (primary hit feedback):
+```typescript
+onHit(): void {
+  // Primary: add particles at hit position
+  this.add.particles(this.player.x, this.player.y, 'spark', {
+    speed: { min: 60, max: 150 }, quantity: 8, lifespan: 250, emitting: false,
+  }).explode(8);
+  // Secondary: blink for invincibility window
+  this.tweens.add({ targets: this.player, alpha: { from: 0.3, to: 1 }, repeat: 4, duration: 80 });
+}
+```
+
+---
+
+### ❌ Creating Physics Bodies Inside update()
+
+**Detection**:
+```bash
+grep -rn "physics\.add\.\(sprite\|image\|existing\)\|add\.group" --include="*.ts" --include="*.js"
+rg "update\(.*delta\)" --type ts -A 30 | grep "physics\.add"
+```
+
+**What it looks like**:
+```typescript
+update(_time: number, _delta: number): void {
+  if (this.fireButton.isDown) {
+    // BAD: new physics sprite every frame the button is held
+    const bullet = this.physics.add.image(this.player.x, this.player.y, 'bullet');
+    bullet.setVelocityX(400);
+  }
+}
+```
+
+**Why wrong**: Creating physics bodies in `update()` allocates Box2D/Arcade body objects and THREE.js objects every frame. GC pressure causes visible stuttering at sustained fire rates. Frame rate drops from 60 to 30 after ~5 seconds of firing.
+
+**Fix**: Pool bullets in `create()`, recycle in `update()`:
+```typescript
+create(): void {
+  this.bullets = this.physics.add.group({
+    classType: Phaser.Physics.Arcade.Image,
+    maxSize: 20,
+    runChildUpdate: false,
+  });
+}
+
+fireBullet(): void {
+  const bullet = this.bullets.get(this.player.x, this.player.y, 'bullet');
+  if (!bullet) return;
+  bullet.setActive(true).setVisible(true);
+  bullet.body.setVelocityX(400);
+}
+```
+
+---
+
+### ❌ Camera Shake Without Bounds
+
+**Detection**:
+```bash
+grep -rn "camera\.shake\|cameras\.main\.shake" --include="*.ts" --include="*.js"
+rg "cameras\.main" --type ts | grep -v "bounds\|follow\|setZoom"
+```
+
+**What it looks like**:
+```typescript
+// BAD: camera shakes past world edge, revealing void outside the map
+this.cameras.main.shake(300, 0.05); // no world bounds set
+```
+
+**Why wrong**: Camera shake pans the camera. Without bounds, the camera reveals empty space outside the tilemap, breaking immersion.
+
+**Fix**:
+```typescript
+// Set bounds before any shake call
+this.cameras.main.setBounds(0, 0, map.widthInPixels, map.heightInPixels);
+this.cameras.main.shake(300, 0.02); // now shake is clamped to world edge
+```
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Find all shake calls — verify intensity is appropriate
+grep -rn "cameras\.main\.shake" --include="*.ts" --include="*.js"
+
+# Find particle emitters — verify using Phaser 3.60+ API (not old ParticleEmitterManager)
+grep -rn "ParticleEmitterManager\|createEmitter" --include="*.ts"
+
+# Find tween.add calls — check for yoyo/repeat patterns for polish
+grep -rn "tweens\.add\|tweens\.chain" --include="*.ts" --include="*.js"
+
+# Find timeScale usage — verify hit-stop cleanup resets all time scales
+grep -rn "timeScale" --include="*.ts" --include="*.js"
+```
+
+---
+
+## See Also
+
+- `references/tilemaps-and-physics.md` — Tilemap collision, Matter.js categories, slope terrain
+- `references/core-patterns.md` — Scene lifecycle, state machines, input
+- `references/performance.md` — Object pooling, GC avoidance

--- a/skills/phaser-gamedev/references/tilemaps-and-physics.md
+++ b/skills/phaser-gamedev/references/tilemaps-and-physics.md
@@ -1,0 +1,377 @@
+---
+name: Phaser Tilemaps and Physics
+description: Tiled map integration, Matter.js vs Arcade physics decision table, collision groups, slopes, object layers for enemy spawning, and physics performance patterns
+agent: phaser-gamedev
+category: patterns
+version_range: "Phaser 3.60+"
+---
+
+# Tilemaps and Physics Reference
+
+> **Scope**: Loading and configuring tilemaps from Tiled, choosing and configuring physics systems, collision categories in Matter.js, slopes, object layers for spawning. Extends core tilemaps.md and arcade-physics.md with advanced patterns.
+> **Version range**: Phaser 3.60+
+> **Generated**: 2026-04-08
+
+---
+
+## Tiled Map Integration
+
+### Complete Tilemap Loading Pipeline
+
+```typescript
+// BootScene.preload() — load all map assets
+preload(): void {
+  this.load.tilemapTiledJSON('level1', 'assets/maps/level1.json');
+  this.load.image('terrain', 'assets/tilesets/terrain.png');
+  this.load.image('decor',   'assets/tilesets/decor.png');
+  // For extruded tilesets (eliminates seam artifacts):
+  // this.load.image('terrain-extruded', 'assets/tilesets/terrain-extruded.png');
+}
+
+// GameScene.create() — build tilemap
+create(): void {
+  const map = this.make.tilemap({ key: 'level1' });
+
+  // Add each tileset — name must match what's in Tiled's JSON
+  const terrainTiles = map.addTilesetImage('terrain', 'terrain');
+  const decorTiles   = map.addTilesetImage('decor',   'decor');
+
+  // Create layers in draw order (background first)
+  const bgLayer       = map.createLayer('Background', decorTiles, 0, 0)!;
+  const groundLayer   = map.createLayer('Ground', terrainTiles, 0, 0)!;
+  const platformLayer = map.createLayer('Platforms', terrainTiles, 0, 0)!;
+  const fgLayer       = map.createLayer('Foreground', decorTiles, 0, 0)!;
+
+  // Enable collision by Tiled tile property 'collides: true'
+  groundLayer.setCollisionByProperty({ collides: true });
+  platformLayer.setCollisionByProperty({ collides: true });
+
+  // Camera bounds from map size
+  this.cameras.main.setBounds(0, 0, map.widthInPixels, map.heightInPixels);
+
+  // Store reference for physics setup
+  this.groundLayer = groundLayer;
+  this.map = map;
+}
+```
+
+### Tile Property Workflow (Tiled Editor)
+
+In Tiled: select tiles in the tileset editor → add boolean property `collides` = `true`. Check exact property name — Phaser's `setCollisionByProperty` is case-sensitive.
+
+```typescript
+// Verify which tiles have collision (dev debugging)
+groundLayer.forEachTile((tile) => {
+  if (tile.collides) {
+    console.log(`Colliding tile: ${tile.index} at (${tile.x}, ${tile.y})`);
+  }
+});
+```
+
+---
+
+## Matter.js vs Arcade Physics Decision Table
+
+| Criterion | Arcade | Matter.js |
+|-----------|--------|-----------|
+| Performance (100+ bodies) | Excellent | Degraded above 60 active bodies |
+| Rectangular collisions | Native AABB | Polygon support (heavier) |
+| Slopes / wedges | No native support | Via `MatterTilemapLayer` or custom bodies |
+| Rotating physics bodies | No | Yes |
+| One-way platforms | `checkCollision.up = false` | Via `collisionFilter` + callback |
+| Physics constraints / joints | No | Yes (chains, ragdolls) |
+| Setup complexity | Low | High |
+
+**Decision rule**: Arcade physics for platformers, shooters, and anything with rectangular hitboxes. Switch to Matter.js ONLY when you need rotating bodies, polygon shapes, or joints. Mixed engines (Arcade for player, Matter for specific objects) are possible but complex — avoid unless the feature requires it.
+
+---
+
+## Matter.js Setup and Collision Groups
+
+```typescript
+// Game config — use Matter.js
+const config: Phaser.Types.Core.GameConfig = {
+  physics: {
+    default: 'matter',
+    matter: {
+      gravity: { x: 0, y: 1 },
+      debug: false, // set true during development
+    },
+  },
+};
+
+// GameScene.create() — collision categories (bit flags, must be powers of 2)
+create(): void {
+  const CATEGORY_PLAYER  = this.matter.world.nextCategory(); // returns 1, 2, 4, 8...
+  const CATEGORY_ENEMY   = this.matter.world.nextCategory();
+  const CATEGORY_BULLET  = this.matter.world.nextCategory();
+  const CATEGORY_TERRAIN = this.matter.world.nextCategory();
+
+  // Player body — collides with terrain and enemies, not bullets
+  const player = this.matter.add.sprite(200, 100, 'player');
+  player.setCollisionCategory(CATEGORY_PLAYER);
+  player.setCollidesWith([CATEGORY_TERRAIN, CATEGORY_ENEMY]);
+
+  // Enemy body — collides with everything except other enemies
+  const enemy = this.matter.add.sprite(500, 100, 'enemy');
+  enemy.setCollisionCategory(CATEGORY_ENEMY);
+  enemy.setCollidesWith([CATEGORY_TERRAIN, CATEGORY_PLAYER, CATEGORY_BULLET]);
+
+  // Bullet — only collides with enemies and terrain
+  const bullet = this.matter.add.image(0, 0, 'bullet');
+  bullet.setCollisionCategory(CATEGORY_BULLET);
+  bullet.setCollidesWith([CATEGORY_TERRAIN, CATEGORY_ENEMY]);
+}
+```
+
+### Matter.js Collision Events
+
+```typescript
+// Use collisionstart/collisionend events instead of overlap callbacks
+this.matter.world.on('collisionstart', (event: Phaser.Physics.Matter.Events.CollisionStartEvent) => {
+  const pairs = event.pairs;
+  for (const pair of pairs) {
+    const { bodyA, bodyB } = pair;
+
+    // Bodies carry custom data via gameObject reference
+    const goA = bodyA.gameObject as Phaser.GameObjects.GameObject | null;
+    const goB = bodyB.gameObject as Phaser.GameObjects.GameObject | null;
+
+    if (!goA || !goB) continue;
+
+    if (goA.getData('type') === 'bullet' && goB.getData('type') === 'enemy') {
+      this.onBulletHitEnemy(goA as Phaser.Physics.Matter.Image, goB as Phaser.Physics.Matter.Sprite);
+    }
+  }
+});
+```
+
+---
+
+## Slopes and Complex Terrain
+
+### MatterTilemapLayer (Built-in Slope Support, Phaser 3.60+)
+
+```typescript
+// MatterTilemapLayer automatically creates concave polygon bodies for slopes
+import MatterTilemapLayer from 'phaser/src/physics/matter-js/MatterTilemapLayer';
+
+create(): void {
+  const map = this.make.tilemap({ key: 'level1' });
+  const tiles = map.addTilesetImage('terrain', 'terrain');
+  const groundLayer = map.createLayer('Ground', tiles, 0, 0)!;
+
+  // Convert ground layer to Matter.js compound body (handles slopes from Tiled shape data)
+  this.matter.add.tilemapLayer(groundLayer, {
+    isStatic: true,
+    friction: 0.2,        // reduces sliding on slopes
+    frictionStatic: 0.3,
+  });
+
+  // Note: tilemapLayer takes precedence over setCollisionByProperty
+  // Don't call both — use one or the other
+}
+```
+
+### Custom Slope Bodies (Manual)
+
+```typescript
+// Define slope hitbox manually when Tiled shapes aren't sufficient
+const slope = this.matter.add.fromVertices(x, y, [
+  { x: 0, y: 0 },        // left (top of slope)
+  { x: 100, y: 50 },     // right (bottom)
+  { x: 100, y: 0 },      // right top
+], {
+  isStatic: true,
+  friction: 0.3,
+  label: 'slope',
+});
+```
+
+---
+
+## Object Layers from Tiled (Enemy/Item Spawning)
+
+Tiled Object Layers let designers place spawn points without touching code. The standard pattern:
+
+```typescript
+// In Tiled: add Object Layer → place Point/Rectangle objects with name/type properties
+// Properties: type='enemy', enemyType='bat', patrolDistance=200
+
+create(): void {
+  const map = this.make.tilemap({ key: 'level1' });
+
+  // Read object layer — returns array of Tiled objects
+  const enemyObjects = map.getObjectLayer('Enemies')?.objects ?? [];
+
+  for (const obj of enemyObjects) {
+    const x = obj.x! + (obj.width ?? 0) / 2;  // center of object rectangle
+    const y = obj.y! + (obj.height ?? 0) / 2;
+
+    // Read custom properties from Tiled
+    const enemyType = this.getProperty<string>(obj, 'enemyType', 'basic');
+    const patrol    = this.getProperty<number>(obj, 'patrolDistance', 100);
+
+    this.spawnEnemy(x, y, enemyType, patrol);
+  }
+
+  // Item pickups
+  const itemObjects = map.getObjectLayer('Items')?.objects ?? [];
+  for (const obj of itemObjects) {
+    const itemType = this.getProperty<string>(obj, 'itemType', 'coin');
+    this.spawnItem(obj.x!, obj.y!, itemType);
+  }
+}
+
+// Helper — Tiled properties are typed as { name, type, value }[]
+private getProperty<T>(obj: Phaser.Types.Tilemaps.TiledObject, name: string, fallback: T): T {
+  const prop = obj.properties?.find(p => p.name === name);
+  return prop ? (prop.value as T) : fallback;
+}
+```
+
+---
+
+## Performance: Static Group vs Dynamic Group for Background Tiles
+
+| Group Type | Physics | Reposition Cost | Best For |
+|------------|---------|-----------------|----------|
+| `StaticGroup` | Static bodies (no gravity) | Must call `refresh()` after move | Platforms, walls — never move |
+| `DynamicGroup` | Full physics bodies | Normal velocity/force API | Enemies, projectiles — move via physics |
+| `Group` (no physics) | None | Just set x/y | Decorative objects, UI elements |
+
+```typescript
+// Static group for fixed platform tiles
+const platforms = this.physics.add.staticGroup();
+platforms.create(100, 500, 'platform');
+platforms.create(300, 400, 'platform');
+// After placing all platforms — refresh once, not per-frame
+platforms.refresh();
+
+// Player vs static group collision
+this.physics.add.collider(this.player, platforms);
+
+// Never call platforms.refresh() in update() — costs a full broadphase rebuild
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Calling setCollisionByProperty After Layer Already Has Colliders
+
+**Detection**:
+```bash
+grep -rn "setCollisionByProperty\|setCollision\b" --include="*.ts" --include="*.js"
+rg "setCollision" --type ts
+```
+
+**What it looks like**:
+```typescript
+// BAD: setting collision after a Matter tilemapLayer already generated bodies
+this.matter.add.tilemapLayer(groundLayer, { isStatic: true });
+groundLayer.setCollisionByProperty({ collides: true }); // no effect — Matter ignores this
+```
+
+**Why wrong**: `matter.add.tilemapLayer()` generates Matter.js body shapes from the layer's existing collision data. Calling `setCollisionByProperty` after has no effect — the bodies are already created and don't re-read tile properties.
+
+**Fix**: Set tile collision BEFORE creating the Matter layer body:
+```typescript
+groundLayer.setCollisionByProperty({ collides: true });  // first
+this.matter.add.tilemapLayer(groundLayer, { isStatic: true }); // then
+```
+
+---
+
+### ❌ Creating Physics Bodies Inside update()
+
+**Detection**:
+```bash
+grep -rn "matter\.add\.\(sprite\|image\|circle\|rectangle\)" --include="*.ts" --include="*.js"
+rg "update\b" --type ts -A 40 | grep "matter\.add\|physics\.add\.sprite"
+```
+
+**What it looks like**:
+```typescript
+update(_time: number, delta: number): void {
+  if (this.fireButton.isDown) {
+    // BAD: creates a new Matter body every frame
+    const bullet = this.matter.add.image(this.player.x, this.player.y, 'bullet');
+    bullet.setVelocity(8, 0);
+  }
+}
+```
+
+**Why wrong**: Matter.js body creation is expensive — it runs constraint solving, broadphase insertion, and event binding. Creating bodies in `update()` causes progressive frame time growth. At 60fps with rapid fire, frame time doubles within 3 seconds.
+
+**Fix**: Pool bullets, set active/inactive, reposition via `setPosition()`:
+```typescript
+create(): void {
+  this.bulletPool = this.matter.world.add; // use matter composite for pooling
+  // Pre-create bullet bodies, then toggle isSleeping to activate/deactivate
+}
+```
+
+---
+
+### ❌ Using `overlap()` Instead of `collider()` for Terrain
+
+**Detection**:
+```bash
+grep -rn "physics\.add\.overlap" --include="*.ts" --include="*.js"
+```
+
+**What it looks like**:
+```typescript
+// BAD: overlap doesn't apply physics resolution (no bounce, no stop)
+this.physics.add.overlap(this.player, this.groundLayer, () => {
+  this.player.setVelocityY(0);
+});
+```
+
+**Why wrong**: `overlap()` detects intersection but does NOT resolve physics. The player clips through the terrain; `setVelocityY(0)` is a manual patch that doesn't handle slope normals, one-way platforms, or edge cases. The player will jitter and occasionally fall through.
+
+**Fix**: Use `collider()` for terrain:
+```typescript
+this.physics.add.collider(this.player, this.groundLayer);
+// overlap() is correct for triggers (item pickups, damage zones) — not terrain
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|-----------|-----|
+| `Tilemap layer has no tileset` | `addTilesetImage()` name doesn't match Tiled export | Check Tiled File → Export → Tileset name exactly matches first arg to `addTilesetImage()` |
+| Player falls through floor | Missing `setCollisionByProperty` or property name typo | Verify `collides` boolean property exists on tiles in Tiled, check exact property name |
+| Matter.js slope physics jitter | Friction too low on terrain body | Set `friction: 0.2, frictionStatic: 0.3` on Matter tilemapLayer |
+| Object layer returns `null` | Layer name typo between Tiled and `getObjectLayer()` | `map.getObjectLayer('Enemies')` must match layer name in Tiled exactly |
+| `Cannot read 'objects' of null` | `getObjectLayer()` returns null when layer missing | Guard: `map.getObjectLayer('Enemies')?.objects ?? []` |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Find all tilemap creation calls — verify correct tileset name usage
+grep -rn "make\.tilemap\|createLayer\|addTilesetImage" --include="*.ts" --include="*.js"
+
+# Find Matter.js collision category setup — verify categories are powers of 2
+grep -rn "setCollisionCategory\|setCollidesWith\|nextCategory" --include="*.ts"
+
+# Find object layer reads — verify null-guard pattern
+grep -rn "getObjectLayer" --include="*.ts" --include="*.js"
+
+# Find physics.add.collider vs overlap usage
+grep -rn "physics\.add\.\(collider\|overlap\)" --include="*.ts" --include="*.js"
+```
+
+---
+
+## See Also
+
+- `references/arcade-physics.md` — Arcade physics groups, collider tuning, velocity patterns
+- `references/tilemaps.md` — Tilemap layer system basics, animated tiles
+- `references/game-feel-patterns.md` — Screen shake, particles, hit-stop timing
+- `references/performance.md` — Object pooling, GC avoidance for physics bodies

--- a/skills/threejs-builder/SKILL.md
+++ b/skills/threejs-builder/SKILL.md
@@ -91,6 +91,12 @@ Game and GLTF references load **alongside** the paradigm reference — they are 
 
 **Visual quality signal**: If the user's request implies high visual quality (portfolio, game, showcase, "make it look good", "impressive", "polished"), also load `references/visual-polish.md` alongside the paradigm reference. It contains specific material recipes, lighting setups, and post-processing configurations that bridge the gap between technically correct and visually impressive.
 
+**Custom shader signal**: If the user mentions custom shaders, GLSL, ShaderMaterial, vertex displacement, postprocessing effects (bloom, chromatic aberration, dissolve), or custom visual effects, load `references/shader-patterns.md`. It contains complete GLSL patterns with working code, anti-patterns with detection commands, and the postprocessing pipeline setup.
+
+**Performance signal**: If the user mentions many objects (particles, foliage, crowds), InstancedMesh, performance profiling, draw call reduction, texture compression, or memory issues, load `references/performance-patterns.md`.
+
+**Advanced animation signal**: If the user mentions AnimationMixer, morph targets, skeletal rigs, IK, spring physics, GSAP + Three.js, or GPU particle animation, load `references/advanced-animation.md`.
+
 **Step 1: Identify the core visual element**
 
 Determine from the user request:
@@ -296,3 +302,6 @@ Solution:
 | `references/gltf-loading.md` | GLTF/GLB model loading signal | Coordinate system contract, SkeletonUtils.clone, model caching, auto-centering, bone hierarchy, asset manifest |
 | `references/game-patterns.md` | Game project signal | Animation state machine, camera-relative movement, delta capping, mobile input, player controller |
 | `references/game-architecture.md` | Game project signal | EventBus, GameState singleton, Constants module, restart-safety, pre-ship checklist |
+| `references/shader-patterns.md` | Custom GLSL / visual effects | ShaderMaterial vs RawShaderMaterial, vertex displacement, fragment effects (holographic, dissolve, chromatic aberration), EffectComposer postprocessing pipeline |
+| `references/performance-patterns.md` | Performance / many objects | InstancedMesh, BufferGeometry typed arrays, draw call batching, LOD, KTX2 textures, dispose patterns |
+| `references/advanced-animation.md` | Animation systems / skeletal rigs | AnimationMixer morph targets, bone manipulation, procedural IK, spring physics, GSAP integration, particle animation |

--- a/skills/threejs-builder/references/advanced-animation.md
+++ b/skills/threejs-builder/references/advanced-animation.md
@@ -1,0 +1,432 @@
+---
+name: Three.js Advanced Animation
+description: AnimationMixer with morph targets, skeletal animation, procedural IK approximation, GSAP integration, particle system animation via BufferGeometry attributes
+agent: threejs-builder
+category: visual-techniques
+version_range: "Three.js r150+"
+---
+
+# Advanced Animation Reference
+
+> **Scope**: Three.js animation systems beyond basic rotation — AnimationMixer, morph targets, skeletal rigs, procedural IK, GSAP integration, and GPU-driven particle animation. GLTF model loading patterns live in gltf-loading.md.
+> **Version range**: Three.js r150+
+> **Generated**: 2026-04-08
+
+---
+
+## AnimationMixer with Morph Targets
+
+Morph targets (blend shapes) animate between pre-defined geometry states. Common for facial expressions and soft-body deformation.
+
+```javascript
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+
+const loader = new GLTFLoader();
+const gltf = await loader.loadAsync('/models/character.glb');
+scene.add(gltf.scene);
+
+// AnimationMixer drives both skeleton and morph targets from GLTF
+const mixer = new THREE.AnimationMixer(gltf.scene);
+
+// Morph targets are accessed via mesh.morphTargetInfluences[]
+// Three.js r150+: morphTargetDictionary maps names to indices
+const mesh = gltf.scene.getObjectByName('Face');
+if (mesh && mesh.morphTargetDictionary) {
+  const smileIndex = mesh.morphTargetDictionary['smile'];  // name from blender
+  const angryIndex = mesh.morphTargetDictionary['angry'];
+
+  // Animate morph weights directly (0.0 = neutral, 1.0 = full morph)
+  mesh.morphTargetInfluences[smileIndex] = 0.0;
+
+  // GSAP tween for smooth expression transition
+  gsap.to(mesh.morphTargetInfluences, {
+    [smileIndex]: 1.0,
+    duration: 0.3,
+    ease: 'power2.out',
+  });
+}
+
+// Play an AnimationClip from the GLTF (drives skeleton + morph via keyframes)
+const clip = gltf.animations.find(a => a.name === 'Idle');
+if (clip) {
+  const action = mixer.clipAction(clip);
+  action.play();
+}
+
+// Update mixer in animation loop
+const clock = new THREE.Clock();
+renderer.setAnimationLoop(() => {
+  const delta = clock.getDelta();
+  mixer.update(delta); // delta in seconds, not ms
+  renderer.render(scene, camera);
+});
+```
+
+### Crossfading Between Animations
+
+```javascript
+// Crossfade from current action to next
+function crossFadeTo(mixer, fromAction, toAction, duration = 0.3) {
+  toAction.enabled = true;
+  toAction.setEffectiveTimeScale(1);
+  toAction.setEffectiveWeight(1);
+  toAction.time = 0;
+
+  fromAction.crossFadeTo(toAction, duration, true);
+  toAction.play();
+}
+
+const idleAction = mixer.clipAction(gltf.animations.find(a => a.name === 'Idle'));
+const walkAction = mixer.clipAction(gltf.animations.find(a => a.name === 'Walk'));
+
+idleAction.play();
+// Later:
+crossFadeTo(mixer, idleAction, walkAction, 0.3);
+```
+
+---
+
+## Skeletal Animation and Bone Manipulation
+
+### Direct Bone Manipulation (Procedural Override)
+
+```javascript
+// Access skeleton from a SkinnedMesh
+const skinnedMesh = gltf.scene.getObjectByName('Body');
+const skeleton = skinnedMesh.skeleton;
+
+// List all bones
+skeleton.bones.forEach((bone, i) => {
+  console.log(i, bone.name);
+});
+
+// Get specific bone by name
+const headBone = skeleton.bones.find(b => b.name === 'Head');
+const spineBone = skeleton.bones.find(b => b.name === 'Spine');
+
+// Rotate bones procedurally (overrides AnimationMixer for those bones)
+renderer.setAnimationLoop(() => {
+  const t = clock.getElapsedTime();
+  // Head tracks mouse position
+  headBone.rotation.y = THREE.MathUtils.lerp(
+    headBone.rotation.y,
+    mouseTargetY,
+    0.1 // lerp factor — controls follow speed
+  );
+  headBone.rotation.x = THREE.MathUtils.clamp(
+    THREE.MathUtils.lerp(headBone.rotation.x, mouseTargetX, 0.1),
+    -0.4, 0.4
+  );
+
+  mixer.update(clock.getDelta());
+  renderer.render(scene, camera);
+});
+```
+
+### SkeletonHelper for Debug Visualization
+
+```javascript
+// Visualize bone positions during development
+const helper = new THREE.SkeletonHelper(gltf.scene);
+helper.visible = true; // set false in production
+scene.add(helper);
+
+// Remove before shipping:
+// scene.remove(helper);
+// helper.dispose();
+```
+
+---
+
+## Procedural Animation
+
+### IK Approximation (Cyclic Coordinate Descent)
+
+Full IK solvers are complex. For 2-3 bone chains (arms, legs), CCD gives good results without a library:
+
+```javascript
+// Two-bone IK: shoulder → elbow → wrist targeting a point
+function solveTwoBoneIK(root, mid, tip, target) {
+  const rootPos = new THREE.Vector3().setFromMatrixPosition(root.matrixWorld);
+  const midPos = new THREE.Vector3().setFromMatrixPosition(mid.matrixWorld);
+  const tipPos = new THREE.Vector3().setFromMatrixPosition(tip.matrixWorld);
+
+  const upperLen = rootPos.distanceTo(midPos);
+  const lowerLen = midPos.distanceTo(tipPos);
+  const totalLen = upperLen + lowerLen;
+  const targetDist = rootPos.distanceTo(target);
+
+  // Clamp target to reachable range
+  const reach = Math.min(targetDist, totalLen * 0.99);
+  const reachTarget = new THREE.Vector3()
+    .subVectors(target, rootPos)
+    .normalize()
+    .multiplyScalar(reach)
+    .add(rootPos);
+
+  // Law of cosines for elbow angle
+  const d = rootPos.distanceTo(reachTarget);
+  const cosAngle = (upperLen * upperLen + d * d - lowerLen * lowerLen)
+    / (2 * upperLen * d);
+  const angle = Math.acos(THREE.MathUtils.clamp(cosAngle, -1, 1));
+
+  // Apply rotation to root bone (simplified — assumes Y-up local space)
+  const dir = new THREE.Vector3().subVectors(reachTarget, rootPos).normalize();
+  root.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir);
+  root.rotateZ(angle);
+}
+```
+
+### Spring Physics (Secondary Animation)
+
+```javascript
+// Spring system for hair, tail, or accessory bounce
+class Spring {
+  constructor(stiffness = 100, damping = 15, mass = 1) {
+    this.stiffness = stiffness;
+    this.damping = damping;
+    this.mass = mass;
+    this.position = 0;
+    this.velocity = 0;
+    this.target = 0;
+  }
+
+  update(delta) {
+    const force = -this.stiffness * (this.position - this.target)
+                  - this.damping * this.velocity;
+    this.velocity += (force / this.mass) * delta;
+    this.position += this.velocity * delta;
+    return this.position;
+  }
+}
+
+const tailSpring = new Spring(80, 12, 1);
+
+renderer.setAnimationLoop(() => {
+  const delta = clock.getDelta();
+  tailSpring.target = characterVelocityX * 0.3; // tail lags behind movement
+  const tailAngle = tailSpring.update(delta);
+  tailBone.rotation.z = tailAngle;
+  renderer.render(scene, camera);
+});
+```
+
+---
+
+## GSAP Integration with Three.js Objects
+
+GSAP can tween any numeric property, including Three.js uniforms, positions, and quaternions:
+
+```javascript
+import gsap from 'gsap';
+
+// Basic position tween
+gsap.to(mesh.position, {
+  y: 2,
+  duration: 1.5,
+  ease: 'elastic.out(1, 0.4)',
+});
+
+// Rotation — use radians
+gsap.to(mesh.rotation, {
+  y: Math.PI * 2,
+  duration: 2,
+  ease: 'power2.inOut',
+});
+
+// Shader uniform tween
+gsap.to(material.uniforms.uProgress, {
+  value: 1.0,
+  duration: 1.2,
+  ease: 'power3.in',
+  onUpdate: () => {
+    material.needsUpdate = false; // uniforms don't need needsUpdate
+  },
+});
+
+// Camera animation with timeline
+const tl = gsap.timeline({ defaults: { ease: 'power2.inOut', duration: 1.5 } });
+tl.to(camera.position, { x: 5, y: 3, z: 8 })
+  .to(camera.position, { x: -5, y: 1, z: 5 }, '+=0.5') // 0.5s after previous
+  .to(camera.position, { x: 0, y: 2, z: 10 }, '<0.3'); // 0.3s before previous end
+
+// Quaternion tween via fromRotationMatrix (GSAP doesn't natively support quaternions)
+const targetQuat = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, Math.PI, 0));
+gsap.to({}, {
+  duration: 1,
+  ease: 'power2.inOut',
+  onUpdate: function() {
+    camera.quaternion.slerp(targetQuat, this.ratio);
+  },
+});
+```
+
+---
+
+## Particle System Animation via BufferGeometry
+
+GPU-friendly particle system using custom BufferGeometry attributes:
+
+```javascript
+const count = 10000;
+const positions = new Float32Array(count * 3);
+const velocities = new Float32Array(count * 3);
+const lifetimes = new Float32Array(count);
+const phases = new Float32Array(count); // random phase offset per particle
+
+// Initialize
+for (let i = 0; i < count; i++) {
+  const i3 = i * 3;
+  positions[i3]     = (Math.random() - 0.5) * 20;
+  positions[i3 + 1] = Math.random() * 10;
+  positions[i3 + 2] = (Math.random() - 0.5) * 20;
+
+  velocities[i3]     = (Math.random() - 0.5) * 0.02;
+  velocities[i3 + 1] = Math.random() * 0.05;
+  velocities[i3 + 2] = (Math.random() - 0.5) * 0.02;
+
+  lifetimes[i] = Math.random() * 3.0 + 1.0; // 1-4 second lifetime
+  phases[i] = Math.random() * Math.PI * 2;
+}
+
+const geometry = new THREE.BufferGeometry();
+geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+geometry.setAttribute('aVelocity', new THREE.BufferAttribute(velocities, 3));
+geometry.setAttribute('aPhase', new THREE.BufferAttribute(phases, 1));
+
+const material = new THREE.PointsMaterial({
+  size: 0.05,
+  sizeAttenuation: true,
+  transparent: true,
+  alphaTest: 0.001,
+  depthWrite: false,
+});
+
+const particles = new THREE.Points(geometry, material);
+scene.add(particles);
+
+// CPU-side animation (for < 10k particles)
+renderer.setAnimationLoop((time) => {
+  const t = time * 0.001;
+  const pos = geometry.attributes.position.array;
+  const vel = geometry.attributes.aVelocity.array;
+
+  for (let i = 0; i < count; i++) {
+    const i3 = i * 3;
+    pos[i3]     += vel[i3];
+    pos[i3 + 1] += vel[i3 + 1];
+    pos[i3 + 2] += vel[i3 + 2];
+
+    // Reset when off-screen
+    if (pos[i3 + 1] > 10) {
+      pos[i3 + 1] = 0;
+    }
+  }
+
+  geometry.attributes.position.needsUpdate = true;
+  renderer.render(scene, camera);
+});
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Calling mixer.update() with Raw Timestamp (Not Delta)
+
+**Detection**:
+```bash
+grep -rn "mixer\.update" --include="*.js" --include="*.ts"
+rg "mixer\.update\(time\)" --type js
+```
+
+**What it looks like**:
+```javascript
+renderer.setAnimationLoop((time) => {
+  mixer.update(time); // BAD: time is ms since page load (~120000ms after 2 minutes)
+});
+```
+
+**Why wrong**: `mixer.update()` expects elapsed seconds since last frame (delta), not absolute timestamp. Passing raw `time` makes animations play at 1000x speed because time is in milliseconds.
+
+**Fix**:
+```javascript
+const clock = new THREE.Clock();
+renderer.setAnimationLoop(() => {
+  const delta = clock.getDelta(); // seconds since last call, typically 0.016 at 60fps
+  mixer.update(delta);
+  renderer.render(scene, camera);
+});
+```
+
+---
+
+### ❌ Applying Bone Rotation After mixer.update()
+
+**Detection**:
+```bash
+grep -rn "bone\.rotation\|bone\.quaternion" --include="*.js" --include="*.ts"
+```
+
+**What it looks like**:
+```javascript
+renderer.setAnimationLoop(() => {
+  mixer.update(delta); // sets bone transforms from keyframe data
+  headBone.rotation.y = mouseTargetY; // immediately overwritten — no effect seen
+});
+```
+
+**Why wrong**: `mixer.update()` overwrites bone transforms from animation keyframes on the same frame tick. Manual bone changes set before or on the same tick are overwritten.
+
+**Fix**: Apply bone overrides AFTER `mixer.update()` in the same frame:
+```javascript
+renderer.setAnimationLoop(() => {
+  mixer.update(delta);
+  // Now override specific bones AFTER the mixer writes
+  headBone.rotation.y += (mouseTargetY - headBone.rotation.y) * 0.1;
+  renderer.render(scene, camera);
+});
+```
+
+---
+
+### ❌ Not Disposing Mixer on Component Unmount
+
+**Detection**:
+```bash
+grep -rn "AnimationMixer" --include="*.js" --include="*.ts"
+rg "mixer\." --type js | grep -v "dispose\|update\|stopAll"
+```
+
+**What it looks like**:
+```javascript
+// In a React Three Fiber component:
+useEffect(() => {
+  const mixer = new THREE.AnimationMixer(scene);
+  // No cleanup
+}, []);
+```
+
+**Why wrong**: `AnimationMixer` holds references to scene objects, preventing GC. Multiple mixers accumulate on route changes.
+
+**Fix**:
+```javascript
+useEffect(() => {
+  const mixer = new THREE.AnimationMixer(scene);
+  const action = mixer.clipAction(clip);
+  action.play();
+
+  return () => {
+    mixer.stopAllAction();
+    mixer.uncacheRoot(scene); // releases internal refs
+  };
+}, []);
+```
+
+---
+
+## See Also
+
+- `references/gltf-loading.md` — GLTF model loading, SkeletonUtils.clone, asset manifests
+- `references/performance-patterns.md` — InstancedMesh for particle systems at scale
+- `references/shader-patterns.md` — GPU-driven animation via vertex shaders

--- a/skills/threejs-builder/references/performance-patterns.md
+++ b/skills/threejs-builder/references/performance-patterns.md
@@ -1,0 +1,393 @@
+---
+name: Three.js Performance Patterns
+description: InstancedMesh, BufferGeometry manipulation, draw call batching, LOD, texture compression, and memory disposal for Three.js r150+
+agent: threejs-builder
+category: performance
+version_range: "Three.js r150+"
+---
+
+# Performance Patterns Reference
+
+> **Scope**: Three.js-specific performance patterns — instancing, buffer manipulation, draw call budgets, LOD, and memory management. Generic JavaScript optimization is out of scope.
+> **Version range**: Three.js r150+
+> **Generated**: 2026-04-08
+
+---
+
+## InstancedMesh for Thousands of Objects
+
+`InstancedMesh` renders N copies of the same geometry in a single draw call. Use it when you need more than ~50 identical objects (particles, foliage, crowds).
+
+```javascript
+const count = 5000;
+const geometry = new THREE.BoxGeometry(0.1, 0.1, 0.1);
+const material = new THREE.MeshStandardMaterial({ color: 0xffffff });
+
+const instancedMesh = new THREE.InstancedMesh(geometry, material, count);
+instancedMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage); // if positions change per frame
+
+const matrix = new THREE.Matrix4();
+const position = new THREE.Vector3();
+const quaternion = new THREE.Quaternion();
+const scale = new THREE.Vector3(1, 1, 1);
+
+// Set each instance's transform
+for (let i = 0; i < count; i++) {
+  position.set(
+    (Math.random() - 0.5) * 20,
+    (Math.random() - 0.5) * 20,
+    (Math.random() - 0.5) * 20,
+  );
+  matrix.compose(position, quaternion, scale);
+  instancedMesh.setMatrixAt(i, matrix);
+}
+instancedMesh.instanceMatrix.needsUpdate = true; // required after updates
+scene.add(instancedMesh);
+
+// Per-frame update (animating instances):
+renderer.setAnimationLoop((time) => {
+  for (let i = 0; i < count; i++) {
+    instancedMesh.getMatrixAt(i, matrix);
+    matrix.elements[13] += Math.sin(time * 0.001 + i) * 0.001; // move Y
+    instancedMesh.setMatrixAt(i, matrix);
+  }
+  instancedMesh.instanceMatrix.needsUpdate = true;
+  renderer.render(scene, camera);
+});
+```
+
+### Per-Instance Color (r150+)
+
+```javascript
+// InstancedMesh supports per-instance color without a custom shader
+const color = new THREE.Color();
+for (let i = 0; i < count; i++) {
+  color.setHSL(i / count, 0.8, 0.6);
+  instancedMesh.setColorAt(i, color);
+}
+instancedMesh.instanceColor.needsUpdate = true; // required after updates
+```
+
+---
+
+## BufferGeometry Manipulation
+
+### Typed Array Access for Maximum Speed
+
+```javascript
+// Reading existing geometry attributes
+const geometry = new THREE.PlaneGeometry(10, 10, 64, 64);
+const positions = geometry.attributes.position; // BufferAttribute
+const posArray = positions.array; // Float32Array — direct typed array access
+
+// Modify in place (fast — no GC pressure)
+for (let i = 0; i < posArray.length; i += 3) {
+  posArray[i + 1] = Math.sin(posArray[i] * 0.5) * 0.5; // modify Y
+}
+positions.needsUpdate = true; // signal GPU upload
+geometry.computeVertexNormals();  // recalculate after vertex changes
+```
+
+### Custom BufferGeometry from Scratch
+
+```javascript
+// Interleaved buffer — position + uv in one buffer (r150+ supports InterleavedBuffer)
+const vertexData = new Float32Array([
+  // x, y, z, u, v
+  -1, -1, 0,   0, 0,
+   1, -1, 0,   1, 0,
+   1,  1, 0,   1, 1,
+  -1,  1, 0,   0, 1,
+]);
+
+const interleavedBuffer = new THREE.InterleavedBuffer(vertexData, 5); // stride = 5 floats
+const geometry = new THREE.BufferGeometry();
+geometry.setAttribute('position', new THREE.InterleavedBufferAttribute(interleavedBuffer, 3, 0));
+geometry.setAttribute('uv',       new THREE.InterleavedBufferAttribute(interleavedBuffer, 2, 3));
+geometry.setIndex([0, 1, 2,  0, 2, 3]); // two triangles
+```
+
+---
+
+## Draw Call Batching
+
+A draw call is issued per unique material per object. Reducing draw calls is the highest-leverage optimization.
+
+| Strategy | Draw Calls Saved | Tradeoff |
+|----------|-----------------|----------|
+| `InstancedMesh` (N same-geometry objects) | N → 1 | All instances same geometry+material |
+| `BufferGeometryUtils.mergeGeometries()` | N → 1 | No individual transforms after merge |
+| Texture atlas (pack multiple textures) | Avoids material splits | Atlas creation cost, UV remapping |
+| `renderer.info.render.calls` | (monitoring) | Use to measure actual draw calls |
+
+```javascript
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+
+// Merge static scene geometry into one draw call
+const geometries = staticMeshes.map(m => {
+  m.geometry.applyMatrix4(m.matrixWorld); // bake transforms
+  return m.geometry;
+});
+const merged = mergeGeometries(geometries, true); // true = preserve groups for multi-material
+const mergedMesh = new THREE.Mesh(merged, materials);
+scene.add(mergedMesh);
+
+// Monitor draw calls (dev only)
+console.log('Draw calls:', renderer.info.render.calls);
+```
+
+---
+
+## LOD (Level of Detail)
+
+```javascript
+const lod = new THREE.LOD();
+
+// High detail: 0-10 units from camera
+const highGeom = new THREE.SphereGeometry(1, 64, 64);
+lod.addLevel(new THREE.Mesh(highGeom, material), 0);
+
+// Medium: 10-50 units
+const medGeom = new THREE.SphereGeometry(1, 16, 16);
+lod.addLevel(new THREE.Mesh(medGeom, material), 10);
+
+// Low: 50-100 units
+const lowGeom = new THREE.SphereGeometry(1, 4, 4);
+lod.addLevel(new THREE.Mesh(lowGeom, material), 50);
+
+// Nothing past 100
+lod.addLevel(new THREE.Object3D(), 100); // invisible placeholder
+
+scene.add(lod);
+
+// LOD.update() called automatically if autoUpdate is true (r155+)
+// For manual control: lod.update(camera) in animation loop
+```
+
+---
+
+## Frustum Culling
+
+Three.js enables frustum culling automatically (`object.frustumCulled = true` by default). For large scenes, verify nothing disables it accidentally.
+
+```javascript
+// Check frustum culling is enabled (it should be)
+console.log(mesh.frustumCulled); // should be true
+
+// Custom culling — manually skip rendering based on distance
+renderer.setAnimationLoop(() => {
+  const frustum = new THREE.Frustum();
+  frustum.setFromProjectionMatrix(
+    new THREE.Matrix4().multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse)
+  );
+
+  objects.forEach(obj => {
+    obj.visible = frustum.containsPoint(obj.position);
+  });
+
+  renderer.render(scene, camera);
+});
+```
+
+---
+
+## Texture Atlasing and Compression
+
+### KTX2 / Basis Texture Loading (r150+)
+
+KTX2 textures are GPU-native compressed formats. They reduce GPU memory by 4-8x vs PNG/JPEG and eliminate the CPU decode step.
+
+```javascript
+import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
+
+const ktx2Loader = new KTX2Loader()
+  .setTranscoderPath('https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/libs/basis/')
+  .detectSupport(renderer);
+
+// Load compressed texture
+const texture = await ktx2Loader.loadAsync('texture.ktx2');
+material.map = texture;
+
+// Convert PNGs to KTX2 via CLI (toktx from KTX-Software):
+// toktx --t2 --bcmp output.ktx2 input.png
+```
+
+### Texture Atlas Pattern
+
+```javascript
+// Single atlas texture, UV offsets per sprite
+const atlasTexture = new THREE.TextureLoader().load('/atlas.png');
+
+// Define UV regions (normalized 0-1)
+const spriteUVs = {
+  player: { x: 0, y: 0, w: 0.25, h: 0.5 },
+  enemy:  { x: 0.25, y: 0, w: 0.25, h: 0.5 },
+};
+
+function applyAtlasRegion(geometry, region) {
+  const uvs = geometry.attributes.uv.array;
+  for (let i = 0; i < uvs.length; i += 2) {
+    uvs[i]     = region.x + uvs[i] * region.w;
+    uvs[i + 1] = region.y + uvs[i + 1] * region.h;
+  }
+  geometry.attributes.uv.needsUpdate = true;
+}
+```
+
+---
+
+## Dispose Patterns (Prevent Memory Leaks)
+
+Three.js requires explicit disposal of GPU resources. Forgetting to dispose causes memory growth until tab crash.
+
+```javascript
+// Dispose a mesh and all its resources
+function disposeMesh(mesh) {
+  mesh.geometry.dispose();
+
+  // Material can be shared — only dispose if not reused
+  if (Array.isArray(mesh.material)) {
+    mesh.material.forEach(m => disposeMaterial(m));
+  } else {
+    disposeMaterial(mesh.material);
+  }
+
+  scene.remove(mesh);
+}
+
+function disposeMaterial(material) {
+  // Dispose all texture maps on the material
+  for (const key of Object.keys(material)) {
+    if (material[key] instanceof THREE.Texture) {
+      material[key].dispose();
+    }
+  }
+  material.dispose();
+}
+
+// Dispose EffectComposer when unmounting
+composer.dispose();
+renderer.dispose();
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Creating Geometry in the Animation Loop
+
+**Detection**:
+```bash
+grep -rn "new THREE\.\(Box\|Sphere\|Plane\|Cylinder\)Geometry" --include="*.js" --include="*.ts"
+rg "setAnimationLoop|useFrame" --type js -A 20 | grep "new THREE\."
+```
+
+**What it looks like**:
+```javascript
+renderer.setAnimationLoop((time) => {
+  // BAD: allocates new geometry every frame at 60fps
+  const geo = new THREE.SphereGeometry(Math.sin(time * 0.001), 32, 32);
+  mesh.geometry = geo;
+  renderer.render(scene, camera);
+});
+```
+
+**Why wrong**: Each new geometry allocates a GPU buffer. Old geometries are not freed without `dispose()`. At 60fps this creates 3,600 leaked GPU buffers per minute.
+
+**Fix**:
+```javascript
+// Morph the existing geometry's buffer in place
+const geo = new THREE.SphereGeometry(1, 32, 32);
+const mesh = new THREE.Mesh(geo, material);
+scene.add(mesh);
+
+renderer.setAnimationLoop((time) => {
+  mesh.scale.setScalar(Math.sin(time * 0.001) * 0.5 + 1.0); // transform, don't rebuild
+  renderer.render(scene, camera);
+});
+```
+
+---
+
+### ❌ `new THREE.Vector3()` Inside render Loop
+
+**Detection**:
+```bash
+grep -rn "new THREE\.Vector3\|new THREE\.Color\|new THREE\.Matrix4" --include="*.js" --include="*.ts"
+rg "setAnimationLoop|useFrame" --type js -A 30 | grep "new THREE\."
+```
+
+**What it looks like**:
+```javascript
+renderer.setAnimationLoop(() => {
+  // BAD: 3 allocations per frame = 10,800 objects/min of GC pressure
+  const pos = new THREE.Vector3(mesh.position);
+  const dir = new THREE.Vector3(0, 1, 0);
+  const target = new THREE.Vector3().addVectors(pos, dir);
+});
+```
+
+**Why wrong**: JavaScript GC pauses correlate directly with allocation rate. At 60fps, even small allocation storms cause visible frame stutters every few seconds.
+
+**Fix**:
+```javascript
+// Allocate once outside the loop, reuse as scratch
+const _pos = new THREE.Vector3();
+const _dir = new THREE.Vector3(0, 1, 0);
+const _target = new THREE.Vector3();
+
+renderer.setAnimationLoop(() => {
+  _pos.copy(mesh.position);
+  _target.addVectors(_pos, _dir);
+});
+```
+
+---
+
+### ❌ Using `renderer.render()` with EffectComposer
+
+**Detection**:
+```bash
+grep -rn "renderer\.render\|composer\.render" --include="*.js" --include="*.ts"
+```
+
+**What it looks like**:
+```javascript
+const composer = new EffectComposer(renderer);
+// ...
+
+renderer.setAnimationLoop(() => {
+  renderer.render(scene, camera); // BAD when composer is active — skips postprocessing
+});
+```
+
+**Why wrong**: `renderer.render()` writes directly to the canvas, bypassing the composer's pass chain. Postprocessing effects are invisible.
+
+**Fix**: Replace `renderer.render(scene, camera)` with `composer.render()` once EffectComposer is set up.
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Find geometry creation inside animation loops
+grep -rn "new THREE\." --include="*.js" --include="*.ts" | grep -v "//\|const \|let \|var "
+
+# Check if dispose() is called for materials
+grep -rn "\.dispose()" --include="*.js" --include="*.ts"
+
+# Monitor draw calls at runtime (add to dev mode)
+grep -rn "renderer.info.render.calls" --include="*.js" --include="*.ts"
+
+# Find InstancedMesh usage
+grep -rn "InstancedMesh\|instanceMatrix" --include="*.js" --include="*.ts"
+```
+
+---
+
+## See Also
+
+- `references/visual-polish.md` — Material recipes and HDR environments
+- `references/shader-patterns.md` — Custom GLSL shader patterns
+- `references/advanced-topics.md` — GLTF loading, TypeScript patterns

--- a/skills/threejs-builder/references/shader-patterns.md
+++ b/skills/threejs-builder/references/shader-patterns.md
@@ -1,0 +1,501 @@
+---
+name: Three.js Shader Patterns
+description: Custom GLSL shaders in Three.js — ShaderMaterial, vertex displacement, fragment effects, and EffectComposer postprocessing pipeline
+agent: threejs-builder
+category: visual-techniques
+version_range: "Three.js r150+"
+---
+
+# Shader Patterns Reference
+
+> **Scope**: Writing custom GLSL for Three.js — ShaderMaterial vs RawShaderMaterial, vertex displacement, fragment effects, postprocessing with EffectComposer. Does NOT cover TSL/WebGPU node materials (see webgpu.md).
+> **Version range**: Three.js r150+
+> **Generated**: 2026-04-08
+
+---
+
+## ShaderMaterial vs RawShaderMaterial
+
+| Class | Preprocessor Includes | Built-in Uniforms | Use When |
+|-------|----------------------|-------------------|----------|
+| `ShaderMaterial` | Yes — Three.js injects `#include <common>`, fog, lights | `projectionMatrix`, `modelViewMatrix`, `normalMatrix` auto-bound | Custom effects that still need Three.js lighting chunks |
+| `RawShaderMaterial` | None — full GLSL control | Must declare ALL uniforms manually, including matrices | Full shader control, when Three.js chunks cause conflicts |
+
+The most common mistake: using `RawShaderMaterial` and forgetting to declare `projectionMatrix` and `modelViewMatrix`, then wondering why geometry doesn't render.
+
+```javascript
+// ShaderMaterial — Three.js injects precision, matrices, and chunk definitions
+const mat = new THREE.ShaderMaterial({
+  uniforms: {
+    uTime: { value: 0.0 },
+    uColor: { value: new THREE.Color(0x00ffcc) },
+  },
+  vertexShader: /* glsl */`
+    uniform float uTime;
+    varying vec2 vUv;
+
+    void main() {
+      vUv = uv;
+      // projectionMatrix and modelViewMatrix are injected by Three.js
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: /* glsl */`
+    uniform vec3 uColor;
+    varying vec2 vUv;
+
+    void main() {
+      gl_FragColor = vec4(uColor * vUv.x, 1.0);
+    }
+  `,
+});
+
+// In animation loop:
+mat.uniforms.uTime.value = clock.getElapsedTime();
+```
+
+```javascript
+// RawShaderMaterial — must declare ALL uniforms and precision
+const mat = new THREE.RawShaderMaterial({
+  uniforms: {
+    uTime: { value: 0.0 },
+  },
+  vertexShader: /* glsl */`
+    precision mediump float;
+
+    uniform mat4 projectionMatrix;
+    uniform mat4 modelViewMatrix;
+    uniform float uTime;
+    attribute vec3 position;
+    attribute vec2 uv;
+    varying vec2 vUv;
+
+    void main() {
+      vUv = uv;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: /* glsl */`
+    precision mediump float;
+    varying vec2 vUv;
+
+    void main() {
+      gl_FragColor = vec4(vUv, 0.5, 1.0);
+    }
+  `,
+});
+```
+
+---
+
+## Vertex Displacement Shaders
+
+### Noise-Based Terrain
+
+```javascript
+// Simplex noise via glsl-noise (CDN) or inline implementation
+// Three.js r150+ includes ShaderChunk — use #include <common> for noise utilities
+
+const terrainMat = new THREE.ShaderMaterial({
+  uniforms: {
+    uTime: { value: 0 },
+    uStrength: { value: 2.0 },
+    uFrequency: { value: 0.5 },
+  },
+  vertexShader: /* glsl */`
+    #include <common>  // includes noise utilities in Three.js r150+
+
+    uniform float uTime;
+    uniform float uStrength;
+    uniform float uFrequency;
+    varying float vElevation;
+
+    // Classic Perlin noise — available after #include <common>
+    void main() {
+      vec4 modelPosition = modelMatrix * vec4(position, 1.0);
+
+      float elevation =
+        sin(modelPosition.x * uFrequency + uTime) *
+        sin(modelPosition.z * uFrequency + uTime) *
+        uStrength;
+
+      modelPosition.y += elevation;
+      vElevation = elevation;
+
+      gl_Position = projectionMatrix * viewMatrix * modelPosition;
+    }
+  `,
+  fragmentShader: /* glsl */`
+    varying float vElevation;
+
+    void main() {
+      // Map elevation to color gradient
+      float t = (vElevation + 2.0) / 4.0; // normalize to 0-1
+      vec3 low  = vec3(0.04, 0.08, 0.2);  // deep water
+      vec3 high = vec3(0.8, 0.95, 0.9);   // snow cap
+      gl_FragColor = vec4(mix(low, high, t), 1.0);
+    }
+  `,
+  side: THREE.DoubleSide,
+  wireframe: false,
+});
+```
+
+### Water Wave Displacement
+
+```javascript
+// Key pattern: multi-octave wave displacement with layered cnoise ripples
+const waterMat = new THREE.ShaderMaterial({
+  uniforms: {
+    uTime: { value: 0 },
+    uBigWavesElevation: { value: 0.2 },
+    uBigWavesFrequency: { value: new THREE.Vector2(4, 1.5) },
+    uSmallWavesElevation: { value: 0.15 },
+    uDepthColor: { value: new THREE.Color('#186691') },
+    uSurfaceColor: { value: new THREE.Color('#9bd8ff') },
+  },
+  vertexShader: /* glsl */`
+    #include <common>
+    uniform float uTime;
+    uniform vec2 uBigWavesFrequency;
+    uniform float uBigWavesElevation;
+    uniform float uSmallWavesElevation;
+    varying float vElevation;
+    void main() {
+      vec4 modelPosition = modelMatrix * vec4(position, 1.0);
+      float elevation =
+        sin(modelPosition.x * uBigWavesFrequency.x + uTime) *
+        sin(modelPosition.z * uBigWavesFrequency.y + uTime) *
+        uBigWavesElevation;
+      // Layer 3 octaves of cnoise for organic ripples
+      for(float i = 1.0; i <= 3.0; i++) {
+        elevation -= abs(cnoise(vec3(modelPosition.xz * 3.0 * i, uTime * 0.2))) * uSmallWavesElevation / i;
+      }
+      modelPosition.y += elevation;
+      vElevation = elevation;
+      gl_Position = projectionMatrix * viewMatrix * modelPosition;
+    }
+  `,
+  fragmentShader: /* glsl */`
+    uniform vec3 uDepthColor;
+    uniform vec3 uSurfaceColor;
+    varying float vElevation;
+    void main() {
+      gl_FragColor = vec4(mix(uDepthColor, uSurfaceColor, (vElevation + 0.1) * 5.0), 1.0);
+    }
+  `,
+});
+```
+
+---
+
+## Fragment Shader Effects
+
+### Holographic Effect
+
+```javascript
+const holoMat = new THREE.ShaderMaterial({
+  uniforms: {
+    uTime: { value: 0 },
+    uColor: { value: new THREE.Color(0x70c5e8) },
+  },
+  transparent: true,
+  side: THREE.DoubleSide,
+  depthWrite: false,
+  blending: THREE.AdditiveBlending,
+  vertexShader: /* glsl */`
+    varying vec2 vUv;
+    varying float vNormal;
+    void main() {
+      vUv = uv;
+      vec4 normalModelView = normalMatrix * vec4(normal, 0.0);
+      // Fresnel-like rim lighting
+      vNormal = abs(dot(normalize(normalModelView.xyz), vec3(0,0,1)));
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: /* glsl */`
+    uniform float uTime;
+    uniform vec3 uColor;
+    varying vec2 vUv;
+    varying float vNormal;
+
+    void main() {
+      // Horizontal scan lines
+      float scanLine = step(0.5, fract(vUv.y * 50.0 - uTime * 0.5));
+      // Rim glow (edges = bright)
+      float rim = 1.0 - vNormal;
+      float alpha = (scanLine * 0.1 + rim * 0.5) * 0.85;
+      gl_FragColor = vec4(uColor, alpha);
+    }
+  `,
+});
+```
+
+### Dissolve Shader
+
+```javascript
+const dissolveMat = new THREE.ShaderMaterial({
+  uniforms: {
+    uTime: { value: 0 },
+    uProgress: { value: 0 },   // 0 = solid, 1 = fully dissolved
+    uEdgeColor: { value: new THREE.Color(0xff6600) },
+    uNoiseScale: { value: 3.0 },
+  },
+  transparent: true,
+  side: THREE.DoubleSide,
+  vertexShader: /* glsl */`
+    varying vec2 vUv;
+    void main() {
+      vUv = uv;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: /* glsl */`
+    #include <common>
+    uniform float uProgress;
+    uniform vec3 uEdgeColor;
+    uniform float uNoiseScale;
+    varying vec2 vUv;
+
+    void main() {
+      float noise = cnoise(vec3(vUv * uNoiseScale, 0.0)) * 0.5 + 0.5;
+      float edge = 0.05; // edge band width
+
+      if (noise < uProgress) discard; // dissolve away
+
+      float edgeMix = smoothstep(uProgress, uProgress + edge, noise);
+      vec3 color = mix(uEdgeColor, vec3(1.0), edgeMix);
+      float alpha = step(uProgress + edge, noise) * 1.0 + (1.0 - edgeMix) * 0.8;
+
+      gl_FragColor = vec4(color, alpha);
+    }
+  `,
+});
+```
+
+### Chromatic Aberration (Postprocessing Shader)
+
+```javascript
+// Use as EffectComposer ShaderPass
+const ChromaticAberrationShader = {
+  uniforms: {
+    tDiffuse: { value: null },
+    uOffset: { value: new THREE.Vector2(0.003, 0.003) },
+  },
+  vertexShader: /* glsl */`
+    varying vec2 vUv;
+    void main() {
+      vUv = uv;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: /* glsl */`
+    uniform sampler2D tDiffuse;
+    uniform vec2 uOffset;
+    varying vec2 vUv;
+    void main() {
+      float r = texture2D(tDiffuse, vUv + uOffset).r;
+      float g = texture2D(tDiffuse, vUv).g;
+      float b = texture2D(tDiffuse, vUv - uOffset).b;
+      gl_FragColor = vec4(r, g, b, 1.0);
+    }
+  `,
+};
+```
+
+---
+
+## Postprocessing Pipeline with EffectComposer
+
+```javascript
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
+import { SSAOPass } from 'three/addons/postprocessing/SSAOPass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+
+const composer = new EffectComposer(renderer);
+
+// 1. Base render pass — always first
+composer.addPass(new RenderPass(scene, camera));
+
+// 2. SSAO — ambient occlusion adds depth (r150+)
+const ssaoPass = new SSAOPass(scene, camera, width, height);
+ssaoPass.kernelRadius = 16;
+ssaoPass.minDistance = 0.005;
+ssaoPass.maxDistance = 0.1;
+composer.addPass(ssaoPass);
+
+// 3. Bloom — selective bloom via layers (r150+)
+const bloomPass = new UnrealBloomPass(
+  new THREE.Vector2(width, height),
+  1.5,   // strength: 0-3, start at 1.5
+  0.4,   // radius: 0-1
+  0.85   // threshold: 0-1 (luminance required to bloom)
+);
+composer.addPass(bloomPass);
+
+// 4. Custom shader passes
+composer.addPass(new ShaderPass(ChromaticAberrationShader));
+
+// 5. Output — color space correction (required in r150+, replaces GammaCorrectionShader)
+composer.addPass(new OutputPass());
+
+// In animation loop — use composer.render() instead of renderer.render()
+renderer.setAnimationLoop((time) => {
+  controls.update();
+  composer.render();  // NOT renderer.render(scene, camera)
+});
+
+// Resize handler
+window.addEventListener('resize', () => {
+  composer.setSize(window.innerWidth, window.innerHeight);
+  bloomPass.resolution.set(window.innerWidth, window.innerHeight);
+});
+```
+
+---
+
+## Uniform Patterns and Texture Sampling
+
+### Passing Textures as Uniforms
+
+```javascript
+const textureLoader = new THREE.TextureLoader();
+const texture = textureLoader.load('/textures/diffuse.jpg');
+
+const mat = new THREE.ShaderMaterial({
+  uniforms: {
+    uTexture: { value: texture },       // sampler2D
+    uTime: { value: 0 },                // float
+    uResolution: { value: new THREE.Vector2(width, height) }, // vec2
+    uMouse: { value: new THREE.Vector2() },  // vec2
+  },
+  fragmentShader: /* glsl */`
+    uniform sampler2D uTexture;
+    uniform float uTime;
+    uniform vec2 uResolution;
+    varying vec2 vUv;
+
+    void main() {
+      // Animated UV distortion using texture
+      vec2 distortedUv = vUv + vec2(
+        sin(vUv.y * 10.0 + uTime) * 0.02,
+        cos(vUv.x * 10.0 + uTime) * 0.02
+      );
+      vec4 texColor = texture2D(uTexture, distortedUv);
+      gl_FragColor = texColor;
+    }
+  `,
+});
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Recreating ShaderMaterial in Animation Loop
+
+**Detection**:
+```bash
+grep -rn "new THREE.ShaderMaterial" --include="*.js" --include="*.ts"
+rg "new THREE\.ShaderMaterial" --type js
+```
+
+**What it looks like**:
+```javascript
+renderer.setAnimationLoop((time) => {
+  // BAD: creates new material every frame — leaks GPU memory
+  mesh.material = new THREE.ShaderMaterial({
+    uniforms: { uTime: { value: time } },
+    ...
+  });
+  renderer.render(scene, camera);
+});
+```
+
+**Why wrong**: GPU memory leak. Each new `ShaderMaterial` allocates shader programs on the GPU. After 60 seconds at 60fps, you've allocated 3600 programs that are never freed.
+
+**Fix**:
+```javascript
+// Create once, update uniform
+const mat = new THREE.ShaderMaterial({ uniforms: { uTime: { value: 0 } }, ... });
+mesh.material = mat;
+
+renderer.setAnimationLoop((time) => {
+  mat.uniforms.uTime.value = time * 0.001; // update, don't recreate
+  renderer.render(scene, camera);
+});
+```
+
+---
+
+### ❌ Forgetting OutputPass (Washed-Out Colors in r150+)
+
+**Detection**:
+```bash
+grep -rn "EffectComposer" --include="*.js" --include="*.ts" -l
+rg "GammaCorrectionShader" --type js
+```
+
+**What it looks like**:
+```javascript
+// r150+ — GammaCorrectionShader is deprecated, OutputPass is required
+import { GammaCorrectionShader } from 'three/addons/shaders/GammaCorrectionShader.js'; // deprecated r154+
+```
+
+**Why wrong**: In Three.js r150+, `renderer.outputColorSpace` defaults to `SRGBColorSpace`. Without `OutputPass` at the end of the composer chain, colors appear washed out or double-gamma-corrected.
+
+**Fix**:
+```javascript
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+composer.addPass(new OutputPass()); // always last pass
+```
+
+**Version note**: `OutputPass` introduced in r152. For r148-r151, use `ShaderPass(GammaCorrectionShader)` as last pass.
+
+---
+
+### ❌ Using ShaderChunk Injection Without Understanding Side Effects
+
+**Detection**:
+```bash
+grep -rn "onBeforeCompile" --include="*.js" --include="*.ts"
+rg "shader\.vertexShader\.replace" --type js
+```
+
+**What it looks like**:
+```javascript
+material.onBeforeCompile = (shader) => {
+  shader.vertexShader = shader.vertexShader.replace(
+    '#include <begin_vertex>',
+    `vec3 transformed = position + vec3(sin(uTime), 0.0, 0.0);`
+  );
+};
+```
+
+**Why wrong**: `#include` tokens change between Three.js versions. Replacing `<begin_vertex>` in r155 may not match the chunk in r160. The material silently renders incorrectly with no error.
+
+**Fix**: Use `ShaderMaterial` for custom vertex displacement instead of patching `onBeforeCompile`. Reserve `onBeforeCompile` only for lightweight additions to standard materials (fog, lights) where a custom `ShaderMaterial` would be too verbose.
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|-----------|-----|
+| `WebGL: INVALID_OPERATION: uniform not set` | Uniform declared in GLSL but not in `uniforms: {}` object | Add missing uniform key with initial value |
+| `THREE.WebGLProgram: Shader error — 'cnoise' undefined` | Using `cnoise` without `#include <common>` in ShaderMaterial | Add `#include <common>` at top of vertex shader |
+| Black screen with EffectComposer | Missing `OutputPass` or `GammaCorrectionShader` | Add `composer.addPass(new OutputPass())` as final pass |
+| `Cannot read 'value' of undefined` | Accessing `mat.uniforms.uTime` before material created | Create material before animation loop, guard `if (!mat.uniforms)` |
+| Bloom affecting UI elements | No bloom layer separation | Set emissive objects to `mesh.layers.enable(BLOOM_LAYER)`, use selective bloom technique |
+
+---
+
+## See Also
+
+- `references/visual-polish.md` — HDR environments, PBR material recipes, lighting setups
+- `references/webgpu.md` — TSL node materials for WebGPU renderer (different system)
+- `references/performance-patterns.md` — InstancedMesh, BufferGeometry optimization


### PR DESCRIPTION
## Summary

- **threejs-builder** (Level 3 → Level 3, +3 references): Adds `shader-patterns.md` (ShaderMaterial/GLSL vertex displacement/fragment effects/EffectComposer), `performance-patterns.md` (InstancedMesh/BufferGeometry/LOD/KTX2/dispose), and `advanced-animation.md` (AnimationMixer/morph targets/IK/spring physics/GSAP)
- **phaser-gamedev** (Level 2 → Level 3, +2 references): Adds `game-feel-patterns.md` (screen shake/particles/hit-stop/scale punch/tween chains) and `tilemaps-and-physics.md` (Tiled pipeline/Matter.js vs Arcade/collision categories/slopes/object layer spawning)
- **pixijs-combat-renderer** (Level 3 → Level 3, +2 references): Adds `combat-visual-effects.md` (custom GLSL filters/glow/shockwave/Spine v4/z-ordering) and `pixi-performance.md` (batching/texture atlases/RenderTexture/object pooling/ParticleContainer)

All reference files: max 500 lines, detection commands (grep/rg) present, code blocks throughout, anti-pattern sections with behavioral explanations and fixes. SKILL.md and agent body loading tables updated for all three targets.

## Test plan

- [ ] Audit passes: `python3 scripts/audit-reference-depth.py --verbose | grep -E "threejs|phaser|pixi"` — all three show Level 3
- [ ] Line counts within limit: `wc -l skills/threejs-builder/references/shader-patterns.md` ≤ 500
- [ ] No Python files modified — ruff not required
- [ ] CI lint passes