### PR TITLE
feat(evolution): deregister adr-context-injector stub + add hook stub audit to DIAGNOSE

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -83,12 +83,6 @@
           },
           {
             "type": "command",
-            "command": "python3 \"$HOME/.claude/hooks/adr-context-injector.py\"",
-            "description": "Inject active ADR session context when .adr-session.json present",
-            "timeout": 2000
-          },
-          {
-            "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/pipeline-context-detector.py\"",
             "description": "Detect pipeline creation requests and inject pipeline context",
             "timeout": 2000

--- a/skills/toolkit-evolution/SKILL.md
+++ b/skills/toolkit-evolution/SKILL.md
@@ -250,6 +250,52 @@ fi
 
 If an orphaned session is found, flag it as a cleanup opportunity in Step 6. Do not remove it automatically -- flag it so the user can confirm before deletion.
 
+**Step 4c: Scan for registered stub hooks**
+
+A stub hook is registered in settings.json but does nothing (body calls `empty_output()` or contains a `DISABLED` marker). Stubs waste a hook slot and fire on every matching event while returning empty output. They accumulate silently without this check.
+
+```bash
+python3 -c "
+import json, os, re
+from pathlib import Path
+
+settings_path = Path('.claude/settings.json')
+if not settings_path.exists():
+    print('No .claude/settings.json found -- skip hook stub audit')
+else:
+    with open(settings_path) as f:
+        settings = json.load(f)
+    hooks = settings.get('hooks', {})
+    stubs = []
+    for event, groups in hooks.items():
+        for group in (groups if isinstance(groups, list) else [groups]):
+            entries = group.get('hooks', [group]) if isinstance(group, dict) else [group]
+            for entry in entries:
+                cmd = entry.get('command', '') if isinstance(entry, dict) else str(entry)
+                m = re.search(r'python3 [\"\\x27]?([\\w/.\$~-]+\\.py)[\"\\x27]?', cmd)
+                if not m:
+                    continue
+                script = m.group(1).replace('\$HOME', str(Path.home()))
+                script = os.path.expandvars(script)
+                if not os.path.exists(script):
+                    continue
+                with open(script) as sf:
+                    body = sf.read()
+                if 'DISABLED' in body or 'empty_output()' in body:
+                    desc = entry.get('description', '(no description)') if isinstance(entry, dict) else ''
+                    stubs.append((event, os.path.basename(script), desc))
+    if stubs:
+        print(f'{len(stubs)} stub hook(s) registered in settings.json:')
+        for ev, name, desc in stubs:
+            print(f'  [{ev}] {name} -- {desc}')
+        print('  Add stub deregistration to the opportunity list.')
+    else:
+        print('No stub hooks found (OK)')
+"
+```
+
+Flag any stub hook as a cleanup opportunity in Step 6. Do not deregister automatically -- document the stub so the BUILD phase handles it deliberately.
+
 **Step 5: Narrow by focus area (if provided)**
 
 If the user specified a focus area (e.g., "routing", "hooks", "agents"), filter all findings to that domain. If no focus area, analyze broadly.


### PR DESCRIPTION
## Summary

- Evolution cycle proposal: Deregister adr-context-injector.py (DISABLED stub) from UserPromptSubmit hooks
- Evolution cycle proposal: Add Step 4c to toolkit-evolution DIAGNOSE — scans settings.json for registered hooks whose Python body is a stub (DISABLED or empty_output() markers)
- Consensus score: 15/15 (unanimous STRONG across Logician, Builder, Purist, User Advocate, Philosopher)
- A/B result: 10/10 PASS (5/5 per proposal)

## Changes

**`.claude/settings.json`**
- Removed adr-context-injector.py from UserPromptSubmit hooks
- Hook was DISABLED (body calls empty_output() — no ADR context injection was happening)
- Was firing on every user prompt with no effect

**`skills/toolkit-evolution/SKILL.md`**
- Added Step 4c between Step 4b (ADR session check) and Step 5 (focus area filter)
- Scans all registered hook commands for Python scripts containing DISABLED or empty_output() markers
- Flags stubs as cleanup opportunities in Phase 1 opportunity list
- Self-validates: running Step 4c against the cleaned settings immediately returns "No stub hooks found (OK)"

## Test Results

| Test Case | Proposal | Result |
|-----------|----------|--------|
| adr-context-injector removed from project settings | P1 | PASS |
| adr-context-injector removed from ~/.claude/settings | P1 | PASS |
| instruction-reminder still registered | P1 | PASS |
| pipeline-context-detector still registered | P1 | PASS |
| settings.json is valid JSON after edit | P1 | PASS |
| Step 4c header present in correct position | P2 | PASS |
| Step 4c between Step 4b and Step 5 | P2 | PASS |
| DISABLED pattern checked | P2 | PASS |
| empty_output() pattern checked | P2 | PASS |
| opportunity list action referenced | P2 | PASS |

## Evolution Cycle

This PR was generated and validated by the toolkit-evolution skill (2026-04-10 cycle).

**Evidence**: adr-context-injector confirmed DISABLED (empty_output() body); first stub confirmed via direct inspection; lost 2026-04-08 proposals had 15/15 consensus on both changes but were never merged.
**Why both together**: Proposal 1 removes the known stub; Proposal 2 prevents future stubs from accumulating silently. Sequencing matters: remove first, then add detection — otherwise the detector immediately re-flags the same stub.