### PR TITLE
feat(settings): set effortLevel to max

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,8 @@
 {
+  "effortLevel": "max",
   "env": {
-    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1"
+    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+    "CLAUDE_CODE_EFFORT_LEVEL": "max"
   },
   "attribution": {
     "commit": "",


### PR DESCRIPTION
## Summary
- Add `effortLevel: "max"` to project `.claude/settings.json` for maximum reasoning depth
- Add `CLAUDE_CODE_EFFORT_LEVEL=max` environment variable to the env block
- Ensures all Claude Code sessions in this repo use the highest reasoning effort

## Test plan
- [ ] Verify CI passes (lint + test)
- [ ] Confirm new sessions pick up `effortLevel: "max"` from project settings