### PR TITLE
Fix Codex install support and document /do vs $do

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -336,7 +336,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ~/.claude/hooks/sql-injection-detector.py",
+            "command": "python3 \"$HOME/.claude/hooks/sql-injection-detector.py\"",
             "timeout": 5000
           }
         ]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ It starts from the moment you type a request. You don't pick agents, configure w
 /do debug this Go test
 ```
 
+In Claude Code, the smart router command is `/do`. In Codex, use `$do`.
+
 A router reads your intent and selects a Go specialist agent paired with a systematic debugging methodology. The agent creates a branch, gathers evidence before guessing, runs through phased diagnosis, applies a fix, executes tests, reviews its own work, and presents a PR. You describe the problem. The system handles everything else.
 
 This works because the toolkit separates *what you know* from *what the system knows*. Agents carry domain expertise (Go idioms, Python conventions, Kubernetes patterns). Skills enforce process methodology (TDD cycles, debugging phases, review waves). Hooks automate quality gates that fire on lifecycle events. Scripts handle deterministic operations where you want predictable output, not LLM judgment. The router ties it all together, classifying requests, selecting the right combination, and dispatching.
@@ -47,11 +49,15 @@ python3 ~/.claude/scripts/install-doctor.py inventory
 
 If you update the repo later and want Codex to see newly added skills, rerun `./install.sh --symlink` from the repo root.
 
+Command entry points:
+- Claude Code: `/do`
+- Codex: `$do`
+
 **Detailed setup:** [docs/start-here.md](docs/start-here.md)
 
 ## The Core Workflow
 
-1. **Routing.** You type a request. The `/do` router classifies intent, selects a domain agent and a workflow skill, and dispatches. No menus, no configuration.
+1. **Routing.** You type a request. The router entry point is `/do` in Claude Code and `$do` in Codex. It classifies intent, selects a domain agent and a workflow skill, and dispatches. No menus, no configuration.
 
 2. **Planning.** For non-trivial work, the system creates a plan before touching code. Plans have phases, gates, and saved artifacts at each step.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A game built entirely by Claude Code using these agents, skills, and pipelines. 
 
 ## Installation
 
-Requires [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and working (`claude --version` should print a version number).
+Requires [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and working (`claude --version` should print a version number). Codex CLI is also supported: the installer mirrors toolkit skills into `~/.codex/skills` so Codex can use the same skill library (`codex --version` should print a version number if you want Codex support too).
 
 ```bash
 git clone https://github.com/notque/claude-code-toolkit.git ~/claude-code-toolkit
@@ -36,7 +36,16 @@ cd ~/claude-code-toolkit
 ./install.sh --symlink
 ```
 
-The installer links agents, skills, hooks, commands, and scripts into `~/.claude/`, where Claude Code loads extensions from. Use `--symlink` to get updates via `git pull`, or run without it for a stable copy.
+The installer links agents, skills, hooks, commands, and scripts into `~/.claude/`, where Claude Code loads extensions from. It also mirrors skills into `~/.codex/skills` for Codex. Use `--symlink` to get updates via `git pull`, or run without it for a stable copy.
+
+Verify the install with:
+
+```bash
+python3 ~/.claude/scripts/install-doctor.py check
+python3 ~/.claude/scripts/install-doctor.py inventory
+```
+
+If you update the repo later and want Codex to see newly added skills, rerun `./install.sh --symlink` from the repo root.
 
 **Detailed setup:** [docs/start-here.md](docs/start-here.md)
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -15,6 +15,10 @@ cd ~/claude-code-toolkit
 
 Claude Code is the primary runtime. If you also use Codex CLI, the same install mirrors toolkit skills into `~/.codex/skills`.
 
+Command entry points:
+- Claude Code: `/do`
+- Codex: `$do`
+
 **Alternative (bootstrap via Claude):** Start Claude Code in the claude-code-toolkit directory. The sync hook will automatically copy agents, skills, hooks, commands, and scripts to `~/.claude/`.
 
 ```bash
@@ -57,24 +61,28 @@ That's it. You can stop reading here.
 
 ## Want More Control?
 
-### Option A: Use `/do` (Smart Router)
+### Option A: Use the Smart Router
 
 ```
 /do [what you want in plain language]
+$do [what you want in plain language]
 ```
 
 Examples:
 - `/do Debug why authentication is broken`
 - `/do Extract coding patterns from this repo`
 - `/do Make this status update professional`
+- `$do Debug why authentication is broken`
+
+Use `/do` in Claude Code and `$do` in Codex.
 
 The system figures out which tools to use and tells you what it selected.
 
 ---
 
-### Option B: Use `/do` for Specific Workflows
+### Option B: Use the Router for Specific Workflows
 
-The `/do` command routes your request to the right agent and skill automatically:
+The router command routes your request to the right agent and skill automatically. Use `/do` in Claude Code and `$do` in Codex:
 
 | Want This? | Try This |
 |------------|----------|
@@ -124,8 +132,8 @@ These phrases automatically activate the right tools:
                           │
                           ▼
 ┌─────────────────────────────────────────────────────────┐
-│                  /do Smart Router                       │
-│         (or Claude's natural understanding)             │
+│         /do in Claude | $do in Codex                    │
+│         (or natural-language routing)                   │
 └─────────────────────────────────────────────────────────┘
                           │
           ┌───────────────┼───────────────┐

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,6 +13,8 @@ cd ~/claude-code-toolkit
 ./install.sh
 ```
 
+Claude Code is the primary runtime. If you also use Codex CLI, the same install mirrors toolkit skills into `~/.codex/skills`.
+
 **Alternative (bootstrap via Claude):** Start Claude Code in the claude-code-toolkit directory. The sync hook will automatically copy agents, skills, hooks, commands, and scripts to `~/.claude/`.
 
 ```bash
@@ -21,6 +23,15 @@ claude
 ```
 
 > **Note:** The initial sync must run from the claude-code-toolkit directory. After that, hooks work globally from any directory.
+
+Verify the install:
+
+```bash
+python3 ~/.claude/scripts/install-doctor.py check
+python3 ~/.claude/scripts/install-doctor.py inventory
+```
+
+If Codex should pick up newly added skills after a `git pull`, rerun `./install.sh --symlink`.
 
 ---
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -14,6 +14,10 @@ If that prints a version number, you're good. If not, install Claude Code first 
 
 Optional: if you also use Codex CLI, run `codex --version`. The toolkit mirrors its skills into `~/.codex/skills`, but Claude Code is still the full runtime for hooks, agents, commands, and scripts.
 
+Command entry points:
+- Claude Code: `/do`
+- Codex: `$do`
+
 ## Install
 
 Three commands. Copy-paste them.
@@ -61,7 +65,7 @@ Now try these.
 /do what can you do?
 ```
 
-The `/do` command is the front door. It reads your request, picks the right agent and skill, and runs it. This one shows you the full routing system -- every domain it handles, every workflow it knows.
+The router command is the front door. Use `/do` in Claude Code and `$do` in Codex. It reads your request, picks the right agent and skill, and runs it. This one shows you the full routing system -- every domain it handles, every workflow it knows.
 
 ### Explore a codebase
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -12,6 +12,8 @@ claude --version
 
 If that prints a version number, you're good. If not, install Claude Code first and come back.
 
+Optional: if you also use Codex CLI, run `codex --version`. The toolkit mirrors its skills into `~/.codex/skills`, but Claude Code is still the full runtime for hooks, agents, commands, and scripts.
+
 ## Install
 
 Three commands. Copy-paste them.
@@ -30,7 +32,18 @@ cd claude-code-toolkit
 
 The installer asks one question -- symlink or copy -- then sets everything up. Pick symlink if you want updates via `git pull`, copy if you want a stable snapshot. Either works fine.
 
-What just happened: the installer linked agents, skills, hooks, commands, and scripts into `~/.claude/`, which is where Claude Code looks for extensions. It also configured hooks in your settings so they activate automatically.
+What just happened: the installer linked agents, skills, hooks, commands, and scripts into `~/.claude/`, which is where Claude Code looks for extensions. It also mirrored skills into `~/.codex/skills` for Codex and configured hooks in your settings so they activate automatically.
+
+## Verify It
+
+Run:
+
+```bash
+python3 ~/.claude/scripts/install-doctor.py check
+python3 ~/.claude/scripts/install-doctor.py inventory
+```
+
+`check` verifies the install layout, settings, hook paths, learning DB access, and Codex skill mirror. `inventory` shows what Claude and Codex can currently see. If you pull new toolkit changes later and want Codex to pick up new skills, rerun `./install.sh`.
 
 ## Your First Commands
 

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,8 @@ NC='\033[0m' # No Color
 # Get the directory where this script lives
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLAUDE_DIR="${HOME}/.claude"
+CODEX_DIR="${HOME}/.codex"
+CODEX_SKILLS_DIR="${CODEX_DIR}/skills"
 
 echo -e "${BLUE}╔════════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${BLUE}║                Claude Code Toolkit - Installation Script               ║${NC}"
@@ -224,6 +226,62 @@ os.rename(tmp, dst)
         echo "  No settings.json found. Nothing to clean."
     fi
 
+    # Phase 3.5: Clean toolkit-owned Codex mirror entries
+    echo ""
+    echo -e "${YELLOW}Cleaning Codex skills mirror...${NC}"
+    if [ -d "$CODEX_SKILLS_DIR" ]; then
+        for item in "${SCRIPT_DIR}/skills/"*; do
+            [ -e "$item" ] || continue
+            target="${CODEX_SKILLS_DIR}/$(basename "$item")"
+            if [ -L "$target" ] || [ -e "$target" ]; then
+                if [ "$DRY_RUN" = true ]; then
+                    echo -e "${BLUE}  Would remove Codex entry: ${target}${NC}"
+                else
+                    rm -rf "$target"
+                    echo -e "${GREEN}  ✓ Removed Codex entry: ${target}${NC}"
+                fi
+                REMOVED+=("Codex skill $(basename "$item")")
+            fi
+        done
+
+        if [ -d "${SCRIPT_DIR}/private-voices" ]; then
+            for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
+                [ -d "$voice_dir" ] || continue
+                skill_src="${voice_dir}/skill"
+                [ -d "$skill_src" ] || continue
+                voice_name=$(basename "$voice_dir")
+                target="${CODEX_SKILLS_DIR}/voice-${voice_name}"
+                if [ -L "$target" ] || [ -e "$target" ]; then
+                    if [ "$DRY_RUN" = true ]; then
+                        echo -e "${BLUE}  Would remove Codex entry: ${target}${NC}"
+                    else
+                        rm -rf "$target"
+                        echo -e "${GREEN}  ✓ Removed Codex entry: ${target}${NC}"
+                    fi
+                    REMOVED+=("Codex skill voice-${voice_name}")
+                fi
+            done
+        fi
+
+        if [ -d "${SCRIPT_DIR}/private-skills" ]; then
+            for item in "${SCRIPT_DIR}/private-skills/"*; do
+                [ -e "$item" ] || continue
+                target="${CODEX_SKILLS_DIR}/$(basename "$item")"
+                if [ -L "$target" ] || [ -e "$target" ]; then
+                    if [ "$DRY_RUN" = true ]; then
+                        echo -e "${BLUE}  Would remove Codex entry: ${target}${NC}"
+                    else
+                        rm -rf "$target"
+                        echo -e "${GREEN}  ✓ Removed Codex entry: ${target}${NC}"
+                    fi
+                    REMOVED+=("Codex skill $(basename "$item")")
+                fi
+            done
+        fi
+    else
+        echo "  No ~/.codex/skills mirror found. Nothing to clean."
+    fi
+
     # Phase 4: Remove install manifest
     echo ""
     echo -e "${YELLOW}Cleaning up manifest...${NC}"
@@ -341,6 +399,15 @@ else
 fi
 echo -e "${GREEN}✓ ${CLAUDE_DIR} ready${NC}"
 
+echo ""
+echo -e "${YELLOW}Setting up ~/.codex skills directory...${NC}"
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}  Would create: ${CODEX_SKILLS_DIR}${NC}"
+else
+    mkdir -p "${CODEX_SKILLS_DIR}"
+fi
+echo -e "${GREEN}✓ ${CODEX_SKILLS_DIR} ready${NC}"
+
 # Install components
 echo ""
 echo -e "${YELLOW}Installing components (mode: ${MODE})...${NC}"
@@ -394,6 +461,41 @@ install_component() {
     fi
 }
 
+sync_codex_entry() {
+    local source=$1
+    local target=$2
+    local name
+    name=$(basename "$source")
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would replace Codex entry: ${target}${NC}"
+        else
+            rm -rf "$target"
+        fi
+    fi
+
+    if [ "$MODE" = "symlink" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would symlink Codex entry: ${source} -> ${target}${NC}"
+        else
+            ln -s "$source" "$target"
+            echo -e "${GREEN}  ✓ Codex symlinked ${name}${NC}"
+        fi
+    else
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would copy Codex entry: ${source} -> ${target}${NC}"
+        else
+            if [ -d "$source" ]; then
+                cp -r "$source" "$target"
+            else
+                cp "$source" "$target"
+            fi
+            echo -e "${GREEN}  ✓ Codex copied ${name}${NC}"
+        fi
+    fi
+}
+
 # Install main components
 for component in agents skills hooks commands scripts; do
     if [ -d "${SCRIPT_DIR}/${component}" ]; then
@@ -438,6 +540,37 @@ for private_dir in private-agents private-skills private-hooks; do
         fi
     fi
 done
+
+echo ""
+echo -e "${YELLOW}Syncing Codex skills mirror...${NC}"
+CODEX_ENTRY_COUNT=0
+for item in "${SCRIPT_DIR}/skills/"*; do
+    [ -e "$item" ] || continue
+    target="${CODEX_SKILLS_DIR}/$(basename "$item")"
+    sync_codex_entry "$item" "$target"
+    CODEX_ENTRY_COUNT=$((CODEX_ENTRY_COUNT + 1))
+done
+
+if [ -d "${SCRIPT_DIR}/private-voices" ]; then
+    for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
+        [ -d "$voice_dir" ] || continue
+        skill_src="${voice_dir}/skill"
+        [ -d "$skill_src" ] || continue
+        voice_name=$(basename "$voice_dir")
+        target="${CODEX_SKILLS_DIR}/voice-${voice_name}"
+        sync_codex_entry "$skill_src" "$target"
+        CODEX_ENTRY_COUNT=$((CODEX_ENTRY_COUNT + 1))
+    done
+fi
+
+if [ -d "${SCRIPT_DIR}/private-skills" ]; then
+    for item in "${SCRIPT_DIR}/private-skills/"*; do
+        [ -e "$item" ] || continue
+        target="${CODEX_SKILLS_DIR}/$(basename "$item")"
+        sync_codex_entry "$item" "$target"
+        CODEX_ENTRY_COUNT=$((CODEX_ENTRY_COUNT + 1))
+    done
+fi
 
 # Set up local overlay
 echo ""
@@ -577,8 +710,6 @@ fi
 if [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}  Would write: ${CLAUDE_DIR}/.install-manifest.json${NC}"
 else
-    SYMLINK_MODE="false"
-    [ "$MODE" = "symlink" ] && SYMLINK_MODE="true"
     $PYTHON_CMD -c "
 import json, datetime, subprocess, sys
 try:
@@ -589,7 +720,7 @@ manifest = {
     'installed_at': datetime.datetime.utcnow().isoformat() + 'Z',
     'toolkit_commit': commit,
     'toolkit_path': '${SCRIPT_DIR}',
-    'mode': 'symlink' if ${SYMLINK_MODE} else 'copy',
+    'mode': '${MODE}',
     'components': ['agents', 'skills', 'hooks', 'commands', 'scripts'],
 }
 json.dump(manifest, open('${CLAUDE_DIR}/.install-manifest.json', 'w'), indent=2)
@@ -619,6 +750,7 @@ echo ""
 echo "Installed components:"
 echo "  • Agents: ${AGENT_COUNT} specialized domain experts"
 echo "  • Skills: ${SKILL_COUNT} workflow methodologies (${INVOCABLE_COUNT} user-invocable)"
+echo "  • Codex skills: ${CODEX_ENTRY_COUNT} mirrored entries in ~/.codex/skills"
 echo "  • Hooks: ${HOOK_COUNT} automation hooks"
 echo "  • Commands: ${COMMAND_COUNT} slash commands"
 echo "  • Scripts: ${SCRIPT_COUNT} utility scripts"

--- a/scripts/install-doctor.py
+++ b/scripts/install-doctor.py
@@ -19,6 +19,7 @@ import importlib
 import importlib.util
 import json
 import os
+import shlex
 import sys
 from pathlib import Path
 
@@ -234,6 +235,21 @@ def check_hook_files() -> list[dict]:
     missing = []
     found = 0
 
+    def extract_python_paths(command: str) -> list[Path]:
+        """Extract Python script paths from a hook command."""
+        expanded = os.path.expandvars(command)
+        try:
+            parts = shlex.split(expanded)
+        except ValueError:
+            parts = expanded.replace('"', "").replace("'", "").split()
+
+        paths = []
+        for part in parts:
+            resolved = Path(os.path.expanduser(part))
+            if resolved.suffix.lower() == ".py":
+                paths.append(resolved)
+        return paths
+
     def extract_hook_commands(obj):
         """Recursively extract command strings from nested hook structures."""
         commands = []
@@ -250,18 +266,11 @@ def check_hook_files() -> list[dict]:
 
     for event, hook_list in hooks.items():
         for cmd in extract_hook_commands(hook_list):
-            # Expand $HOME and strip quotes
-            cmd_expanded = cmd.replace("$HOME", str(Path.home()))
-            cmd_expanded = cmd_expanded.replace('"', "").replace("'", "")
-            parts = cmd_expanded.split()
-            for part in parts:
-                if part.endswith(".py"):
-                    path = Path(part)
-                    if path.exists():
-                        found += 1
-                    else:
-                        missing.append(f"{event}: {path.name}")
-                    break
+            for path in extract_python_paths(cmd):
+                if path.exists():
+                    found += 1
+                else:
+                    missing.append(f"{event}: {path.name}")
 
     if missing:
         return [
@@ -332,27 +341,44 @@ def check_learning_db() -> dict:
     """Check learning.db existence and table accessibility. Absence is acceptable for fresh installs."""
     import sqlite3
 
-    db_path = CLAUDE_DIR / "learning.db"
+    env_learning_dir = os.environ.get("CLAUDE_LEARNING_DIR")
+    candidates = []
+    if env_learning_dir:
+        candidates.append(Path(env_learning_dir).expanduser() / "learning.db")
+    candidates.append(CLAUDE_DIR / "learning" / "learning.db")
+    candidates.append(CLAUDE_DIR / "learning.db")
+
+    db_path = next((path for path in candidates if path.exists()), candidates[0])
     if not db_path.exists():
         return {
             "name": "learning_db",
             "label": "learning.db exists",
             "passed": True,
-            "detail": "Not yet created (will be created on first use)",
+            "detail": f"Not yet created (expected at {db_path})",
         }
 
     try:
         conn = sqlite3.connect(str(db_path))
         try:
+            tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+            if "learnings" not in tables:
+                available = ", ".join(sorted(tables)[:5]) or "no tables"
+                return {
+                    "name": "learning_db",
+                    "label": "learning.db accessible",
+                    "passed": False,
+                    "detail": f"Unsupported schema at {db_path} (missing learnings table; found: {available})",
+                }
             cursor = conn.execute("SELECT count(*) FROM learnings")
             count = cursor.fetchone()[0]
+            schema_version = conn.execute("PRAGMA user_version").fetchone()[0]
         finally:
             conn.close()
         return {
             "name": "learning_db",
             "label": "learning.db accessible",
             "passed": True,
-            "detail": f"{count} entries",
+            "detail": f"{db_path} ({count} entries, schema v{schema_version})",
         }
     except sqlite3.OperationalError as e:
         return {

--- a/scripts/install-doctor.py
+++ b/scripts/install-doctor.py
@@ -23,7 +23,33 @@ import sys
 from pathlib import Path
 
 CLAUDE_DIR = Path.home() / ".claude"
+CODEX_DIR = Path.home() / ".codex"
 COMPONENTS = ["agents", "skills", "hooks", "commands", "scripts"]
+
+
+def _is_toolkit_repo(path: Path) -> bool:
+    """Return True when a path looks like the toolkit repo root."""
+    return (path / "skills").is_dir() and (path / "agents").is_dir() and (path / "hooks").is_dir()
+
+
+def get_toolkit_repo_root() -> Path | None:
+    """Locate the source repo root for comparisons against the Codex mirror."""
+    repo_candidate = Path(__file__).resolve().parent.parent
+    if _is_toolkit_repo(repo_candidate):
+        return repo_candidate
+
+    manifest_path = CLAUDE_DIR / ".install-manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    toolkit_path = manifest.get("toolkit_path")
+    if not toolkit_path:
+        return None
+
+    manifest_repo = Path(toolkit_path).expanduser()
+    return manifest_repo if _is_toolkit_repo(manifest_repo) else None
 
 
 def check_claude_dir() -> dict:
@@ -118,6 +144,61 @@ def check_settings_json() -> dict:
         "detail": f"Hook events configured: {', '.join(hook_events)}"
         if has_hooks
         else "No hooks configured. Run install.sh.",
+    }
+
+
+def check_codex_skills() -> dict:
+    """Check that toolkit skills are mirrored into ~/.codex/skills."""
+    codex_skills_dir = CODEX_DIR / "skills"
+    repo_root = get_toolkit_repo_root()
+
+    if repo_root is None:
+        return {
+            "name": "codex_skills",
+            "label": "~/.codex/skills mirror",
+            "passed": codex_skills_dir.is_dir(),
+            "detail": str(codex_skills_dir)
+            if codex_skills_dir.is_dir()
+            else "Codex skills mirror not found. Run install.sh from the toolkit repo.",
+        }
+
+    expected_entries = [item.name for item in sorted((repo_root / "skills").iterdir())]
+
+    private_skills_dir = repo_root / "private-skills"
+    if private_skills_dir.is_dir():
+        for skill_dir in sorted(private_skills_dir.iterdir()):
+            expected_entries.append(skill_dir.name)
+
+    private_voices_dir = repo_root / "private-voices"
+    if private_voices_dir.is_dir():
+        for voice_dir in sorted(private_voices_dir.iterdir()):
+            if (voice_dir / "skill").is_dir():
+                expected_entries.append(f"voice-{voice_dir.name}")
+
+    expected_entries = list(dict.fromkeys(expected_entries))
+
+    if not codex_skills_dir.is_dir():
+        return {
+            "name": "codex_skills",
+            "label": "~/.codex/skills mirror",
+            "passed": False,
+            "detail": "Directory not found. Run install.sh to mirror toolkit skills for Codex.",
+        }
+
+    missing = [entry for entry in expected_entries if not (codex_skills_dir / entry).exists()]
+    if missing:
+        return {
+            "name": "codex_skills",
+            "label": "~/.codex/skills mirror",
+            "passed": False,
+            "detail": f"{len(expected_entries) - len(missing)}/{len(expected_entries)} entries present; missing: {', '.join(missing[:5])}",
+        }
+
+    return {
+        "name": "codex_skills",
+        "label": "~/.codex/skills mirror",
+        "passed": True,
+        "detail": f"All {len(expected_entries)} toolkit entries mirrored",
     }
 
 
@@ -454,6 +535,12 @@ def inventory() -> dict:
         elif comp == "scripts":
             counts[comp] = len([f for f in real_dir.glob("*.py") if f.name != "__init__.py"])
 
+    codex_skills_dir = CODEX_DIR / "skills"
+    if codex_skills_dir.is_dir():
+        counts["codex_skills"] = len(list(codex_skills_dir.glob("*/SKILL.md")))
+    else:
+        counts["codex_skills"] = 0
+
     # Count MCP servers from registry
     mcp_results = check_mcp_servers()
     mcp_total = sum(1 for r in mcp_results if r["name"].startswith("mcp_") and r["name"] != "mcp_registry")
@@ -471,6 +558,7 @@ def run_all_checks() -> list[dict]:
     results = []
     results.append(check_claude_dir())
     results.extend(check_components_installed())
+    results.append(check_codex_skills())
     results.append(check_settings_json())
     results.extend(check_hook_files())
     results.append(check_python_version())
@@ -524,6 +612,7 @@ def main():
                 print("\n  Installed Components:\n")
                 print(f"  Agents:   {counts.get('agents', 0)}")
                 print(f"  Skills:   {counts.get('skills', 0)} ({counts.get('skills_invocable', 0)} user-invocable)")
+                print(f"  Codex:    {counts.get('codex_skills', 0)} skills available")
                 print(f"  Hooks:    {counts.get('hooks', 0)}")
                 print(f"  Commands: {counts.get('commands', 0)}")
                 print(f"  Scripts:  {counts.get('scripts', 0)}")

--- a/scripts/tests/test_install_doctor.py
+++ b/scripts/tests/test_install_doctor.py
@@ -1,0 +1,77 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "install-doctor.py"
+SPEC = importlib.util.spec_from_file_location("install_doctor", MODULE_PATH)
+install_doctor = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(install_doctor)
+
+
+def _make_repo(repo_root: Path) -> None:
+    for dirname in ("agents", "hooks"):
+        (repo_root / dirname).mkdir(parents=True, exist_ok=True)
+    skills_dir = repo_root / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    (skills_dir / "INDEX.json").write_text("{}\n", encoding="utf-8")
+    for name in ("install", "do"):
+        skill_dir = skills_dir / name
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+
+
+def test_get_toolkit_repo_root_uses_manifest_when_installed_copy(tmp_path, monkeypatch) -> None:
+    repo_root = tmp_path / "toolkit"
+    _make_repo(repo_root)
+
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    manifest = {"toolkit_path": str(repo_root)}
+    (claude_dir / ".install-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    fake_runtime_script = tmp_path / "runtime" / "scripts" / "install-doctor.py"
+    monkeypatch.setattr(install_doctor, "CLAUDE_DIR", claude_dir)
+    monkeypatch.setattr(install_doctor, "__file__", str(fake_runtime_script))
+
+    assert install_doctor.get_toolkit_repo_root() == repo_root
+
+
+def test_check_codex_skills_reports_missing_entries(tmp_path, monkeypatch) -> None:
+    repo_root = tmp_path / "toolkit"
+    _make_repo(repo_root)
+
+    codex_dir = tmp_path / ".codex"
+    mirrored_skill = codex_dir / "skills" / "install"
+    mirrored_skill.mkdir(parents=True)
+    (mirrored_skill / "SKILL.md").write_text("# install\n", encoding="utf-8")
+
+    monkeypatch.setattr(install_doctor, "CODEX_DIR", codex_dir)
+    monkeypatch.setattr(install_doctor, "get_toolkit_repo_root", lambda: repo_root)
+
+    result = install_doctor.check_codex_skills()
+
+    assert result["passed"] is False
+    assert result["name"] == "codex_skills"
+    assert "missing" in result["detail"]
+    assert "do" in result["detail"]
+
+
+def test_inventory_counts_codex_skills(tmp_path, monkeypatch) -> None:
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+
+    codex_dir = tmp_path / ".codex"
+    for name in ("install", "do"):
+        skill_dir = codex_dir / "skills" / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    monkeypatch.setattr(install_doctor, "CLAUDE_DIR", claude_dir)
+    monkeypatch.setattr(install_doctor, "CODEX_DIR", codex_dir)
+    monkeypatch.setattr(install_doctor, "check_mcp_servers", lambda: [])
+
+    counts = install_doctor.inventory()
+
+    assert counts["codex_skills"] == 2

--- a/scripts/tests/test_install_doctor.py
+++ b/scripts/tests/test_install_doctor.py
@@ -3,7 +3,6 @@ import json
 import sqlite3
 from pathlib import Path
 
-
 MODULE_PATH = Path(__file__).resolve().parent.parent / "install-doctor.py"
 SPEC = importlib.util.spec_from_file_location("install_doctor", MODULE_PATH)
 install_doctor = importlib.util.module_from_spec(SPEC)

--- a/scripts/tests/test_install_doctor.py
+++ b/scripts/tests/test_install_doctor.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import sqlite3
 from pathlib import Path
 
 
@@ -75,3 +76,61 @@ def test_inventory_counts_codex_skills(tmp_path, monkeypatch) -> None:
     counts = install_doctor.inventory()
 
     assert counts["codex_skills"] == 2
+
+
+def test_check_hook_files_expands_tilde_paths(tmp_path, monkeypatch) -> None:
+    claude_dir = tmp_path / ".claude"
+    hooks_dir = claude_dir / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "sql-injection-detector.py").write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    (claude_dir / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PostToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "command": "python3 ~/.claude/hooks/sql-injection-detector.py",
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(install_doctor, "CLAUDE_DIR", claude_dir)
+
+    results = install_doctor.check_hook_files()
+
+    assert results[0]["passed"] is True
+    assert "sql-injection-detector.py" not in results[0]["detail"]
+
+
+def test_check_learning_db_uses_learning_subdir_v2_schema(tmp_path, monkeypatch) -> None:
+    claude_dir = tmp_path / ".claude"
+    db_dir = claude_dir / "learning"
+    db_dir.mkdir(parents=True)
+    db_path = db_dir / "learning.db"
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("CREATE TABLE learnings (id INTEGER PRIMARY KEY, value TEXT)")
+        conn.execute("INSERT INTO learnings (value) VALUES ('entry')")
+        conn.execute("PRAGMA user_version = 3")
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.delenv("CLAUDE_LEARNING_DIR", raising=False)
+    monkeypatch.setattr(install_doctor, "CLAUDE_DIR", claude_dir)
+
+    result = install_doctor.check_learning_db()
+
+    assert result["passed"] is True
+    assert str(db_path) in result["detail"]
+    assert "1 entries" in result["detail"]


### PR DESCRIPTION
## Summary
- fix Codex install and install-doctor path handling
- document the router command difference between Claude Code and Codex
- keep Codex mirror/install verification documented

## Validation
- pytest -q scripts/tests/test_install_doctor.py hooks/tests/test_sql_injection_detector.py
- python3 -m py_compile scripts/install-doctor.py
- python3 scripts/install-doctor.py check
- ./install.sh --symlink --force
- python3 ~/.claude/scripts/install-doctor.py inventory