### PR TITLE
fix(enrichment): align prompt Level targets with audit --min-level 3

### DIFF
--- a/skills/reference-enrichment/enrichment-prompt.md
+++ b/skills/reference-enrichment/enrichment-prompt.md
@@ -10,7 +10,7 @@ You are running as an autonomous hourly process to improve the toolkit's domain 
 - **Max targets:** ${ENRICH_MAX_TARGETS}
 - **Dry-run mode:** ${ENRICH_DRY_RUN_MODE}
 
-These targets were identified by `scripts/audit-reference-depth.py` as having Level 0-1 reference depth (thin or missing domain knowledge). Your job is to enrich them to Level 2+ by generating concrete, domain-specific reference files.
+These targets were identified by `scripts/audit-reference-depth.py` as having Level 0-2 reference depth (missing, thin, or incomplete domain knowledge). Your job is to enrich them to Level 3+ by generating concrete, domain-specific reference files.
 
 ## If Dry-Run Mode is "yes"
 
@@ -89,7 +89,7 @@ This gate prevents reference bloat — only references that add concrete, signal
 - **Never modify existing code** — only create/modify files in `references/` directories and loading tables in agent/skill bodies
 - **Never modify agent/skill logic** — only add knowledge, not change behavior
 - **Maximum 500 lines per reference file** — progressive disclosure principle
-- **If a target already has Level 2+ references** when you actually check (audit data may be stale), skip it
+- **If a target already has Level 3+ references** when you actually check (audit data may be stale), skip it
 - **No force-push, no commits to main** — everything goes through a PR
 - **If anything fails, continue with the next target** — don't abort the whole run
 - **Validation gate is mandatory** — never skip Phase 2.5, even if the references "look good"
@@ -103,7 +103,7 @@ End your session with a summary:
 Date: {date}
 Targets processed: N/M
   - {name}: Level {before} → Level {after} ({new_files} new reference files)
-  - {name}: SKIPPED (already Level 2+)
+  - {name}: SKIPPED (already Level 3+)
   - ...
 PR: {url or "none (dry-run)"}
 ===


### PR DESCRIPTION
## Summary

The hourly reference-enrichment cron was effectively a no-op because of a threshold mismatch between two files that were supposed to move together:

- `scripts/reference-enrichment-cron.sh:98` runs the audit with `--min-level 3`, flagging anything below Level 3 as a gap.
- `skills/reference-enrichment/enrichment-prompt.md` still said "enrich them to Level 2+" and "skip if already Level 2+".

Commit `c5f89eb` (#299) upgraded the audit to Level 3 but never updated the prompt. Result: agents sitting at Level 2 were flagged by the audit every hour and skipped by the enrichment subagent every hour, with zero forward progress.

## Evidence

Observed live on 2026-04-11 at 09:31:21 during a manual cron run:

- Target selected: `react-native-engineer` (already has 7 Level-2 reference files)
- Subagent verdict: `SKIPPED (already Level 2+)`
- PR created: none
- Exit code: 0 (clean no-op, the worst kind — invisible to monitoring)

## Changes

Three substitutions in `skills/reference-enrichment/enrichment-prompt.md`:

- Line 13 target description: Level 0-1 → Level 0-2, Level 2+ → Level 3+
- Line 92 skip condition: Level 2+ → Level 3+
- Line 106 output template: Level 2+ → Level 3+

Lines 39 ("Level 3 depth" exemplar) and 79 ("Level 0→3" example) were already correct.

## Blast radius

Bounded by existing safety guards in `reference-enrichment-cron.sh`:
- `MAX_BUDGET_USD=5` per run
- `MAX_OPEN_PRS=5` accumulation cap (cron pauses itself if exceeded)
- Completion journal dedup per day
- Lockfile prevents concurrent runs

Worst case if the new threshold causes unexpected activity: at most 5 open enrichment PRs accumulate before the cron halts. Rollback: `git revert 5d2f19a` restores previous behavior.

## Test plan

- [x] Verified via grep that all Level references in the file are consistent
- [x] Verified the 164 unrelated working-tree files are NOT in this PR
- [ ] Post-merge: watch the 10:07 cron fire in `cron-logs/reference-enrichment/cron.log` — the run should process `react-portfolio-engineer` or next candidate and produce an enrichment PR (not a skip)