### PR TITLE
fix(enrichment): align SKILL.md threshold references with Level 3+ target

### DIFF
--- a/skills/reference-enrichment/SKILL.md
+++ b/skills/reference-enrichment/SKILL.md
@@ -27,7 +27,7 @@ routing:
 
 # Reference Enrichment Skill
 
-Enrich an agent or skill's reference files from Level 0-1 to Level 2-3. The pipeline runs five
+Enrich an agent or skill's reference files from Level 0-2 to Level 3+. The pipeline runs five
 phases with explicit gates because each phase feeds the next — starting Phase 3 without Phase 2
 research produces filler, not depth.
 
@@ -99,13 +99,13 @@ Write files to: `agents/{name}/references/` or `skills/{name}/references/`
 
 ### Phase 4: VALIDATE
 
-**Goal**: Confirm the reference files meet Level 2+ depth before integrating.
+**Goal**: Confirm the reference files meet Level 3+ depth before integrating.
 
 **Tier 1 (Deterministic):**
 ```bash
 python3 scripts/audit-reference-depth.py --agent {name} --json
 ```
-Verify the `level` field is 2 or 3 in the output. If still Level 1, the files are too
+Verify the `level` field is 3 in the output. If still below Level 3, the files are too
 generic — return to Phase 2 for the weak sub-domain.
 
 **Tier 2 (LLM self-assessment):**
@@ -162,7 +162,7 @@ Load when the task type matches:
 well-documented upstream. Flag and suggest manual enrichment with project-specific production
 incidents rather than generic docs research.
 
-**Phase 4 Tier 1 still Level 1 after compile**: The files are too short or too generic. Read one
+**Phase 4 Tier 1 still below Level 3 after compile**: The files are too short or too generic. Read one
 file, apply the rubric directly, identify the weakest section, and target Phase 2 research at
 that section specifically.
 


### PR DESCRIPTION
## Summary

Companion PR to #371. That PR fixed the runtime prompt text (`enrichment-prompt.md`) that the hourly cron reads. This PR fixes the four stale threshold references still in the skill's documentation file.

SKILL.md is the user-facing skill documentation and is not read by the cron at runtime, so the bug had no runtime impact. But leaving the SKILL.md description disagreeing with the actual audit threshold would confuse anyone trying to understand the skill from its docs.

## Changes

Four text substitutions in `skills/reference-enrichment/SKILL.md`:

| Line | Before | After |
|------|--------|-------|
| 30 | "Level 0-1 to Level 2-3" | "Level 0-2 to Level 3+" |
| 102 | "meet Level 2+ depth" | "meet Level 3+ depth" |
| 108 | "level field is 2 or 3 ... If still Level 1" | "level field is 3 ... If still below Level 3" |
| 165 | "Phase 4 Tier 1 still Level 1 after compile" | "Phase 4 Tier 1 still below Level 3 after compile" |

Lines 56, 66, 74, 91, 113, 151 already referenced Level 3 correctly and were left untouched.

## Context

Observed during a manual enrichment cron run on 2026-04-11 at 09:31:21. The subagent skipped `react-native-engineer` because its 7 reference files were already at Level 2, which the old prompt text treated as a valid stopping point. PR #371 fixed the runtime prompt. Then a broader grep found the same stale threshold in the skill documentation, which this PR addresses.

The underlying cause for both PRs is the same: commit c5f89eb (#299) upgraded `scripts/audit-reference-depth.py` to `--min-level 3` but did not propagate the threshold change to the two files that describe what the audit does.

## Test plan

- [x] Verified via `grep "Level [0-9]" skills/reference-enrichment/SKILL.md` that all ten Level references are now internally consistent with Level 3 as the target.
- [x] Verified the diff contains only SKILL.md, not the 164 unrelated working-tree files from the SessionStart sync hook.
- [x] No tests reference `SKILL.md` string content, so no test breakage expected.