### PR TITLE
feat(codex): mirror Phase 1 hooks to ~/.codex via curated allowlist (ADR-182)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ Command entry points:
 
 **Detailed setup:** [docs/start-here.md](docs/start-here.md)
 
+## Codex CLI Parity
+
+The toolkit mirrors agents, skills, and a curated subset of hooks into `~/.codex/` so they work with the OpenAI Codex CLI alongside Claude Code. The mirror runs automatically on every `install.sh`; no flags required.
+
+**What mirrors**
+
+- **Agents**: every agent under `agents/` (and `private-agents/` if present) is copied or symlinked to `~/.codex/agents/`.
+- **Skills**: every skill under `skills/`, `private-skills/`, and `private-voices/*/skill/` goes to `~/.codex/skills/`.
+- **Hooks**: a Phase 1 allowlist of 6 hooks goes to `~/.codex/hooks/` with a matching generated `~/.codex/hooks.json`. The allowlist covers `SessionStart` injectors (KAIROS briefing, operator context, team config, rules distill), a `Stop` recorder (session learning), and a `PostToolUse` Bash scanner. See `scripts/codex-hooks-allowlist.txt`.
+- **Feature flag**: `install.sh` sets `[features] codex_hooks = true` in `~/.codex/config.toml` using a TOML merge that preserves existing sections.
+
+**What does not mirror (yet)**
+
+- Edit/Write interceptors (ADR enforcement, creation protocol, config protection, plan gate, rename sweep, and similar) are Phase 2 and blocked on upstream [openai/codex#16732](https://github.com/openai/codex/issues/16732). Codex PreToolUse and PostToolUse only fire for the `Bash` tool today, so any hook guarding `Write` or `Edit` would register but never run.
+- Codex does not support `PreCompact`, `SubagentStop`, `Notification`, or `SessionEnd` events; hooks on those events stay Claude Code only.
+- Windows: Codex hook support is disabled upstream.
+- Codex CLI v0.114.0 or later is required for hook activation. `install.sh` warns if the installed version is below that, and prints a neutral note if the `codex` binary is not found.
+
+**Opting out**
+
+There is no opt-out flag. The mirror is harmless when Codex CLI is not installed: `~/.codex/` entries sit unused until you install Codex. To skip the hooks portion, delete `~/.codex/hooks/` and `~/.codex/hooks.json` after install; the toolkit does not recreate them on normal use.
+
+**Reference**: [`adr/182-codex-hooks-mirror.md`](adr/182-codex-hooks-mirror.md). Upstream Phase 2 tracker: [openai/codex#16732](https://github.com/openai/codex/issues/16732).
+
 ## The Core Workflow
 
 1. **Routing.** You type a request. The router entry point is `/do` in Claude Code and `$do` in Codex. It classifies intent, selects a domain agent and a workflow skill, and dispatches. No menus, no configuration.

--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,7 @@ CLAUDE_DIR="${HOME}/.claude"
 CODEX_DIR="${HOME}/.codex"
 CODEX_SKILLS_DIR="${CODEX_DIR}/skills"
 CODEX_AGENTS_DIR="${CODEX_DIR}/agents"
+CODEX_HOOKS_DIR="${CODEX_DIR}/hooks"
 
 echo -e "${BLUE}╔════════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${BLUE}║                Claude Code Toolkit - Installation Script               ║${NC}"
@@ -319,6 +320,39 @@ os.rename(tmp, dst)
         echo "  No ~/.codex/agents mirror found. Nothing to clean."
     fi
 
+    # Phase 3.6: Clean toolkit-owned Codex hooks mirror (ADR-182)
+    echo ""
+    echo -e "${YELLOW}Cleaning Codex hooks mirror...${NC}"
+    if [ -d "$CODEX_HOOKS_DIR" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would remove: ${CODEX_HOOKS_DIR}${NC}"
+        else
+            rm -rf "$CODEX_HOOKS_DIR"
+            echo -e "${GREEN}  ✓ Removed ${CODEX_HOOKS_DIR}${NC}"
+        fi
+        REMOVED+=("Codex hooks mirror directory")
+    else
+        echo "  No ~/.codex/hooks mirror found. Nothing to clean."
+    fi
+
+    if [ -f "${CODEX_DIR}/hooks.json" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would archive: ${CODEX_DIR}/hooks.json${NC}"
+        else
+            # Archive rather than delete so users who edited the file manually
+            # can recover any custom entries we did not write.
+            ARCHIVE_TS=$(date +%Y%m%d-%H%M%S)
+            mv "${CODEX_DIR}/hooks.json" "${CODEX_DIR}/hooks.json.uninstalled.${ARCHIVE_TS}"
+            echo -e "${GREEN}  ✓ Archived ${CODEX_DIR}/hooks.json${NC}"
+        fi
+        REMOVED+=("Codex hooks.json (archived)")
+    else
+        echo "  No ~/.codex/hooks.json found. Nothing to archive."
+    fi
+
+    # Note: [features] codex_hooks = true is intentionally left in config.toml.
+    # Users may have other Codex hook configurations we did not write.
+
     # Phase 4: Remove install manifest
     echo ""
     echo -e "${YELLOW}Cleaning up manifest...${NC}"
@@ -363,6 +397,7 @@ os.rename(tmp, dst)
     echo "  • ~/.claude/settings.json (all keys except hooks)"
     echo "  • ~/.claude/projects/"
     echo "  • ~/.claude/memory/"
+    echo "  • ~/.codex/config.toml (including [features] codex_hooks flag)"
     echo "  • .local/ customizations in the toolkit repo"
     echo "  • Python packages (remove manually if needed)"
     if [ ${#PRESERVED[@]} -gt 0 ]; then
@@ -637,6 +672,99 @@ if [ -d "${SCRIPT_DIR}/private-agents" ]; then
     done
 fi
 
+# Sync Codex hooks mirror (ADR-182)
+echo ""
+echo -e "${YELLOW}Syncing Codex hooks mirror...${NC}"
+CODEX_HOOK_COUNT=0
+CODEX_HOOKS_ALLOWLIST="${SCRIPT_DIR}/scripts/codex-hooks-allowlist.txt"
+
+if [ -f "$CODEX_HOOKS_ALLOWLIST" ]; then
+    # Ensure hooks directory exists
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would create: ${CODEX_HOOKS_DIR}${NC}"
+    else
+        mkdir -p "$CODEX_HOOKS_DIR"
+    fi
+
+    # Parse allowlist and mirror each allowlisted hook file.
+    # Format per line: EVENT:filename [matcher]
+    # Comments (#) and blank lines are ignored.
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Strip leading/trailing whitespace for the blank check.
+        trimmed="${line#"${line%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+        [ -z "$trimmed" ] && continue
+        [ "${trimmed#\#}" != "$trimmed" ] && continue
+
+        # Extract filename: everything between the first colon and the first space (or EOL)
+        rest="${trimmed#*:}"
+        filename="${rest%% *}"
+
+        source_file="${SCRIPT_DIR}/hooks/${filename}"
+        if [ ! -f "$source_file" ]; then
+            echo -e "${RED}  ✗ Allowlisted hook missing: ${filename}${NC}"
+            continue
+        fi
+
+        target_file="${CODEX_HOOKS_DIR}/${filename}"
+        sync_codex_entry "$source_file" "$target_file"
+        CODEX_HOOK_COUNT=$((CODEX_HOOK_COUNT + 1))
+    done < "$CODEX_HOOKS_ALLOWLIST"
+
+    # Also mirror the hooks/lib directory so intra-hook imports resolve
+    # (hook_utils, injection_patterns, stdin_timeout, usage_db, etc.).
+    if [ -d "${SCRIPT_DIR}/hooks/lib" ]; then
+        lib_target="${CODEX_HOOKS_DIR}/lib"
+        sync_codex_entry "${SCRIPT_DIR}/hooks/lib" "$lib_target"
+    fi
+
+    # Generate hooks.json via the dedicated script.
+    CODEX_HOOKS_JSON="${CODEX_DIR}/hooks.json"
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would generate: ${CODEX_HOOKS_JSON}${NC}"
+    else
+        if $PYTHON_CMD "${SCRIPT_DIR}/scripts/generate-codex-hooks-json.py" \
+            --allowlist "$CODEX_HOOKS_ALLOWLIST" \
+            --output "$CODEX_HOOKS_JSON" \
+            --codex-hooks-dir "$CODEX_HOOKS_DIR" 2>&1; then
+            echo -e "${GREEN}  ✓ Generated ${CODEX_HOOKS_JSON}${NC}"
+        else
+            echo -e "${RED}  ✗ Failed to generate hooks.json${NC}"
+        fi
+    fi
+
+    # Ensure codex_hooks feature flag is enabled in ~/.codex/config.toml.
+    CODEX_CONFIG="${CODEX_DIR}/config.toml"
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would ensure ${CODEX_CONFIG} has [features] codex_hooks = true${NC}"
+    else
+        if $PYTHON_CMD "${SCRIPT_DIR}/scripts/ensure-codex-feature-flag.py" \
+            --config "$CODEX_CONFIG" 2>&1; then
+            :
+        else
+            echo -e "${YELLOW}  ⚠ Could not update ${CODEX_CONFIG} (see error above). Codex hooks may not activate.${NC}"
+        fi
+    fi
+
+    # Warn if installed Codex CLI is below the hook-support minimum (v0.114.0).
+    if command -v codex >/dev/null 2>&1; then
+        cx_ver=$(codex --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        if [ -n "$cx_ver" ]; then
+            min_major=0; min_minor=114; min_patch=0
+            IFS='.' read -r cx_maj cx_min cx_pat <<< "$cx_ver"
+            if [ "$cx_maj" -lt "$min_major" ] || \
+               { [ "$cx_maj" -eq "$min_major" ] && [ "$cx_min" -lt "$min_minor" ]; } || \
+               { [ "$cx_maj" -eq "$min_major" ] && [ "$cx_min" -eq "$min_minor" ] && [ "$cx_pat" -lt "$min_patch" ]; }; then
+                echo -e "${YELLOW}  ⚠ Codex CLI version ${cx_ver} is below 0.114.0. Hooks may not work. See openai/codex#14754.${NC}"
+            fi
+        fi
+    else
+        echo -e "${BLUE}  (codex CLI not installed; hooks will activate when Codex is installed)${NC}"
+    fi
+else
+    echo -e "${YELLOW}  ⚠ Codex hooks allowlist not found at ${CODEX_HOOKS_ALLOWLIST}; skipping hooks mirror${NC}"
+fi
+
 # Set up local overlay
 echo ""
 echo -e "${YELLOW}Setting up local overlay...${NC}"
@@ -817,6 +945,7 @@ echo "  • Agents: ${AGENT_COUNT} specialized domain experts"
 echo "  • Skills: ${SKILL_COUNT} workflow methodologies (${INVOCABLE_COUNT} user-invocable)"
 echo "  • Codex skills: ${CODEX_ENTRY_COUNT} mirrored entries in ~/.codex/skills"
 echo "  • Codex agents: ${CODEX_AGENT_COUNT} mirrored entries in ~/.codex/agents"
+echo "  • Codex hooks: ${CODEX_HOOK_COUNT} mirrored entries in ~/.codex/hooks"
 echo "  • Hooks: ${HOOK_COUNT} automation hooks"
 echo "  • Commands: ${COMMAND_COUNT} slash commands"
 echo "  • Scripts: ${SCRIPT_COUNT} utility scripts"

--- a/scripts/codex-hooks-allowlist.txt
+++ b/scripts/codex-hooks-allowlist.txt
@@ -1,0 +1,55 @@
+# Codex hooks allowlist — Phase 1 (safe on Codex v0.114.0+)
+# See adr/182-codex-hooks-mirror.md for rationale.
+# Format: EVENT:filename [matcher]
+# Lines starting with # are comments. Blank lines ignored.
+#
+# Phase 2 hooks (edit-guards blocked on openai/codex#16732) are deliberately excluded.
+#
+# IMPORTANT: This list was corrected during ADR-182 implementation (2026-04-11) after
+# an audit of actual hook source files revealed the initial ADR Phase 1 table contained
+# misclassifications. The corrected Phase 1 includes ONLY hooks that are verified to be:
+#   1. Present in hooks/ directory (not a ghost reference)
+#   2. Functional (not a disabled stub that returns empty_output immediately)
+#   3. Registered at an event type that Codex supports AND fires correctly
+#   4. Either not a tool-interception hook, OR interception is Bash-only
+
+# ----- Phase 1: functional + verified safe -----
+
+# SessionStart injectors (pure stdout, no tool interception, Codex fires on startup or resume)
+SessionStart:kairos-briefing-injector.py
+SessionStart:operator-context-detector.py
+SessionStart:team-config-loader.py
+SessionStart:rules-distill-injector.py
+
+# Stop recorders (pure observation, no tool interception)
+Stop:session-learning-recorder.py
+
+# PostToolUse Bash scanners (Bash matcher is the only supported PreTool/PostTool case per #16732)
+PostToolUse:posttool-bash-injection-scan.py Bash
+
+# ----- Deliberately EXCLUDED from Phase 1 -----
+#
+# The following appeared in the ADR-182 draft Phase 1 table but are removed here
+# because direct inspection of hooks/*.py and ~/.claude/settings.json revealed errors.
+#
+# Category A: Phase 2 interceptors misclassified as Phase 1 (would silently fail per #16732)
+# These hooks fire under PreToolUse or PostToolUse with Write|Edit matchers. Codex will
+# register them but never invoke them because Codex hardcodes tool_name="Bash" for hook
+# dispatch. A silently-registered-but-never-fires hook is worse than a missing one because
+# users assume the hook is protecting them.
+#   pretool-prompt-injection-scanner.py  -- actually PreToolUse:Write|Edit (file docstring line 4)
+#   suggest-compact.py                   -- actually PreToolUse:{Edit,Write} (file docstring line 4)
+#   sql-injection-detector.py            -- actually PostToolUse:Write|Edit (file docstring line 4)
+#
+# Category B: non-existent file
+#   pretool-bash-injection-scan.py       -- only posttool-bash-injection-scan.py exists
+#
+# Category C: disabled stubs (empty_output().print_and_exit() on every call)
+# These exist as files but do nothing. Mirroring them costs install time for zero effect.
+# If a future redesign makes them functional, re-evaluate for Phase 1 inclusion.
+#   adr-context-injector.py              -- stub, "DISABLED pending redesign"
+#   capability-catalog-injector.py       -- disabled after A/B test determined it injected 52KB redundant JSON
+#   instruction-reminder.py              -- stub retained for settings.json compatibility
+#   retro-knowledge-injector.py          -- stub; injection handled by session-context.py
+#   creation-request-enforcer-userprompt.py -- stub retained for settings.json compatibility
+#   auto-plan-detector.py                -- stub retained for settings.json compatibility

--- a/scripts/ensure-codex-feature-flag.py
+++ b/scripts/ensure-codex-feature-flag.py
@@ -17,8 +17,6 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-import tomllib
-
 _FEATURES_HEADER = "[features]"
 _KEY_PATTERN = re.compile(r"^\s*codex_hooks\s*=\s*(true|false)\s*$", re.MULTILINE)
 _SECTION_PATTERN = re.compile(r"^\[features\]", re.MULTILINE)

--- a/scripts/ensure-codex-feature-flag.py
+++ b/scripts/ensure-codex-feature-flag.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Ensure ~/.codex/config.toml contains the codex_hooks feature flag.
+
+Performs a TOML-aware merge: adds [features] and codex_hooks = true if
+absent, while preserving all existing sections unchanged. Backs up the
+config before writing unless --no-backup is passed.
+
+Exit codes:
+  0  success (including already-present)
+  1  unexpected error
+  2  codex_hooks = false detected; manual resolution required
+"""
+
+import argparse
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import tomllib
+
+_FEATURES_HEADER = "[features]"
+_KEY_PATTERN = re.compile(r"^\s*codex_hooks\s*=\s*(true|false)\s*$", re.MULTILINE)
+_SECTION_PATTERN = re.compile(r"^\[features\]", re.MULTILINE)
+
+
+_MISSING = object()  # Sentinel: file did not exist at read time.
+
+
+def read_config(path: Path) -> str:
+    """Read the config file and return its text content.
+
+    Returns an empty string if the file exists but is empty.
+    Returns the sentinel value _MISSING (not a string) when the file is absent.
+    Callers should treat any falsy str result as "file present, empty content".
+
+    Args:
+        path: Absolute path to the TOML config file.
+
+    Returns:
+        File content as a string, or empty string if the file is missing or empty.
+
+    Note:
+        Use ``needs_update`` directly when you need to distinguish
+        "file absent" from "file present but empty". ``read_config`` is a
+        convenience wrapper for callers that only need the text.
+    """
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _classify_content(content: str, file_exists: bool) -> tuple[bool, str]:
+    """Internal classification that takes file-existence into account.
+
+    Args:
+        content: The file text (empty string when file is absent or empty).
+        file_exists: True when the file exists on disk (even if empty).
+
+    Returns:
+        A tuple of (needs_write, action_tag).
+
+    Raises:
+        SystemExit: With exit code 2 when codex_hooks = false is found.
+    """
+    if not file_exists:
+        return True, "created-file"
+
+    # File exists (possibly empty): fall through to section analysis.
+    return _analyse_content(content)
+
+
+def _analyse_content(content: str) -> tuple[bool, str]:
+    """Classify content that belongs to a file that already exists.
+
+    Args:
+        content: File text. May be empty.
+
+    Returns:
+        A tuple of (needs_write, action_tag).
+
+    Raises:
+        SystemExit: With exit code 2 when codex_hooks = false is found.
+    """
+    match = _KEY_PATTERN.search(content)
+    if match:
+        value = match.group(1)
+        if value == "true":
+            return False, "already-present"
+        print(
+            "ERROR: codex_hooks = false found in config. "
+            "This appears to be a deliberate user setting. "
+            "Edit the file manually to set codex_hooks = true before re-running.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    has_features_section = bool(_SECTION_PATTERN.search(content))
+    if has_features_section:
+        return True, "added-key"
+    return True, "added-section"
+
+
+def needs_update(content: str) -> tuple[bool, str]:
+    """Determine whether the config needs to be updated and which action to take.
+
+    This function treats empty ``content`` as "file does not exist" for
+    backward compatibility. For precise file-existence handling, the CLI
+    uses ``_classify_content`` directly.
+
+    Args:
+        content: The current file content. Pass empty string to represent a
+            missing file.
+
+    Returns:
+        A tuple of (needs_write, action_tag) where action_tag is one of:
+        'already-present', 'added-section', 'added-key', 'created-file'.
+
+    Raises:
+        SystemExit: With exit code 2 when codex_hooks = false is found.
+    """
+    if not content:
+        return True, "created-file"
+
+    match = _KEY_PATTERN.search(content)
+    if match:
+        value = match.group(1)
+        if value == "true":
+            return False, "already-present"
+        # value == "false": this is a conscious user choice
+        print(
+            "ERROR: codex_hooks = false found in config. "
+            "This appears to be a deliberate user setting. "
+            "Edit the file manually to set codex_hooks = true before re-running.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    has_features_section = bool(_SECTION_PATTERN.search(content))
+    if has_features_section:
+        return True, "added-key"
+    return True, "added-section"
+
+
+def apply_update(content: str) -> str:
+    """Return the updated config content with codex_hooks = true set.
+
+    Adds [features] if absent, or injects codex_hooks under the existing
+    [features] section. Does not modify any other section.
+
+    Args:
+        content: The current file content (may be empty).
+
+    Returns:
+        Updated TOML content as a string.
+    """
+    _, action = needs_update(content)
+
+    if action == "already-present":
+        return content
+
+    if action in ("created-file", "added-section"):
+        # Append a new [features] block. Ensure a trailing newline before it
+        # when appending to non-empty content.
+        if content and not content.endswith("\n"):
+            content += "\n"
+        if content:
+            content += "\n"
+        content += "[features]\ncodex_hooks = true\n"
+        return content
+
+    # action == "added-key": insert codex_hooks after the [features] header.
+    # Find the line index of [features] and insert after it.
+    lines = content.splitlines(keepends=True)
+    result: list[str] = []
+    injected = False
+    for line in lines:
+        result.append(line)
+        if not injected and line.strip() == "[features]":
+            result.append("codex_hooks = true\n")
+            injected = True
+    return "".join(result)
+
+
+def _write_with_backup(path: Path, new_content: str, backup: bool) -> None:
+    """Write new_content to path, optionally backing up the existing file.
+
+    Args:
+        path: Destination path for the updated config.
+        new_content: Content to write.
+        backup: When True, copy the existing file to a timestamped .bak file.
+    """
+    if path.exists() and backup:
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        bak_path = path.with_suffix(f".toml.bak.{stamp}")
+        bak_path.write_bytes(path.read_bytes())
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(new_content, encoding="utf-8")
+
+
+def main() -> None:
+    """Parse arguments, determine required action, and update the config file."""
+    parser = argparse.ArgumentParser(description="Ensure ~/.codex/config.toml has the codex_hooks feature flag.")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path.home() / ".codex" / "config.toml",
+        help="Path to config.toml (default: ~/.codex/config.toml)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the would-be new content without modifying the file.",
+    )
+    parser.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Skip creating a backup of the existing config before writing.",
+    )
+    args = parser.parse_args()
+
+    config_path: Path = args.config
+    file_exists = config_path.exists()
+    content = read_config(config_path)
+    # Use _classify_content so that an empty-but-existing file maps to
+    # "added-section" rather than "created-file".
+    write_needed, action = _classify_content(content, file_exists)
+
+    if not write_needed:
+        print(action)
+        return
+
+    new_content = apply_update(content)
+
+    if args.dry_run:
+        print(new_content, end="")
+        return
+
+    _write_with_backup(config_path, new_content, backup=not args.no_backup)
+    print(action)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-codex-hooks-json.py
+++ b/scripts/generate-codex-hooks-json.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""
+Generate ~/.codex/hooks.json from a curated allowlist file.
+
+The allowlist format is one entry per line: EVENT:filename [matcher]
+Comments (lines starting with #) and blank lines are ignored.
+
+Usage:
+    python3 scripts/generate-codex-hooks-json.py --allowlist scripts/codex-hooks-allowlist.txt
+    python3 scripts/generate-codex-hooks-json.py --allowlist scripts/codex-hooks-allowlist.txt --dry-run
+    python3 scripts/generate-codex-hooks-json.py --allowlist scripts/codex-hooks-allowlist.txt --output /tmp/hooks.json
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Events that require a matcher (Codex requires tool name to filter on).
+EVENTS_REQUIRING_MATCHER = {"PreToolUse", "PostToolUse"}
+
+# Events where matcher should default to "startup|resume" when omitted.
+EVENTS_WITH_DEFAULT_MATCHER = {"SessionStart"}
+
+# Events where matcher field is omitted entirely when not specified.
+EVENTS_WITHOUT_MATCHER = {"UserPromptSubmit", "Stop"}
+
+# All known Codex events, in the canonical output order.
+EVENT_ORDER = ["SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop"]
+
+ALL_KNOWN_EVENTS = set(EVENT_ORDER)
+
+
+def parse_allowlist(text: str) -> list[dict]:
+    """Parse allowlist text into a list of entry dicts.
+
+    Args:
+        text: Contents of the allowlist file (not a path; the raw text).
+
+    Returns:
+        List of dicts with keys: event, filename, matcher (str or None).
+
+    Raises:
+        ValueError: On malformed lines (includes line number in message).
+    """
+    entries: list[dict] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        if ":" not in line:
+            raise ValueError(f"Line {lineno}: missing ':' separator in {raw!r}. Expected EVENT:filename [matcher].")
+
+        event_part, rest = line.split(":", 1)
+        event = event_part.strip()
+        rest_parts = rest.strip().split()
+
+        if not rest_parts:
+            raise ValueError(f"Line {lineno}: missing filename after ':' in {raw!r}.")
+
+        filename = rest_parts[0]
+        matcher: str | None = rest_parts[1] if len(rest_parts) > 1 else None
+
+        if event not in ALL_KNOWN_EVENTS:
+            known = ", ".join(sorted(ALL_KNOWN_EVENTS))
+            raise ValueError(f"Line {lineno}: unknown event {event!r}. Known events: {known}.")
+
+        if event in EVENTS_REQUIRING_MATCHER and matcher is None:
+            raise ValueError(
+                f"Line {lineno}: {event} requires a matcher (e.g. 'Bash') because Codex "
+                f"only fires {event} for named tools. Add 'Bash' after the filename: "
+                f"'{event}:{filename} Bash'."
+            )
+
+        entries.append({"event": event, "filename": filename, "matcher": matcher})
+
+    return entries
+
+
+def build_hooks_json(entries: list[dict], codex_hooks_dir: str | None = None) -> dict:
+    """Build the Codex hooks.json structure from parsed allowlist entries.
+
+    Args:
+        entries: List of entry dicts from parse_allowlist().
+        codex_hooks_dir: Directory where hooks will reside. Defaults to $HOME/.codex/hooks.
+
+    Returns:
+        Dict representing the full hooks.json structure.
+    """
+    if codex_hooks_dir is None:
+        codex_hooks_dir = os.path.join(os.environ.get("HOME", "~"), ".codex", "hooks")
+
+    # Group by (event, effective_matcher) so shared matchers collapse into one block.
+    # Key: (event, effective_matcher_or_None)
+    groups: dict[tuple[str, str | None], list[str]] = {}
+
+    for entry in entries:
+        event = entry["event"]
+        raw_matcher = entry["matcher"]
+        filename = entry["filename"]
+
+        # Determine the effective matcher for grouping and output.
+        if event in EVENTS_WITH_DEFAULT_MATCHER and raw_matcher is None:
+            effective_matcher: str | None = "startup|resume"
+        elif event in EVENTS_WITHOUT_MATCHER:
+            effective_matcher = None  # Omit matcher field entirely.
+        else:
+            effective_matcher = raw_matcher  # Already validated non-None for requiring events.
+
+        key = (event, effective_matcher)
+        groups.setdefault(key, [])
+        groups[key].append(filename)
+
+    if not groups:
+        return {"hooks": {}}
+
+    # Build output dict with events in canonical order.
+    hooks_by_event: dict[str, list[dict]] = {}
+
+    for event in EVENT_ORDER:
+        # Collect all matcher groups for this event, sorted by matcher for determinism.
+        event_groups = {k: v for k, v in groups.items() if k[0] == event}
+        if not event_groups:
+            continue
+
+        sorted_keys = sorted(event_groups.keys(), key=lambda k: (k[1] is None, k[1] or ""))
+        event_blocks: list[dict] = []
+
+        for key in sorted_keys:
+            _, matcher = key
+            filenames = event_groups[key]
+
+            hook_entries = [
+                {
+                    "type": "command",
+                    "command": f'python3 "{codex_hooks_dir}/{fname}"',
+                    "timeout": 600,
+                }
+                for fname in filenames
+            ]
+
+            block: dict = {}
+            if matcher is not None:
+                block["matcher"] = matcher
+            block["hooks"] = hook_entries
+
+            event_blocks.append(block)
+
+        hooks_by_event[event] = event_blocks
+
+    return {"hooks": hooks_by_event}
+
+
+def main() -> None:
+    """Parse CLI arguments, read the allowlist, and write or print hooks.json.
+
+    Exits with code 0 on success, 1 on any error.
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate ~/.codex/hooks.json from a curated allowlist file.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--allowlist", required=True, help="Path to the allowlist file.")
+    parser.add_argument(
+        "--output",
+        default=os.path.join(os.environ.get("HOME", "~"), ".codex", "hooks.json"),
+        help="Path to write hooks.json (default: ~/.codex/hooks.json).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print JSON to stdout instead of writing to disk.",
+    )
+    parser.add_argument(
+        "--codex-hooks-dir",
+        default=None,
+        help="Directory where hooks will live (default: $HOME/.codex/hooks).",
+    )
+
+    args = parser.parse_args()
+
+    allowlist_path = Path(args.allowlist)
+    if not allowlist_path.exists():
+        print(f"Error: allowlist file not found: {allowlist_path}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        text = allowlist_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"Error reading allowlist: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        entries = parse_allowlist(text)
+    except ValueError as exc:
+        print(f"Error parsing allowlist: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        result = build_hooks_json(entries, codex_hooks_dir=args.codex_hooks_dir)
+    except Exception as exc:
+        print(f"Error building hooks JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    output_json = json.dumps(result, indent=2)
+
+    if args.dry_run:
+        print(output_json)
+        return
+
+    output_path = Path(args.output)
+
+    # Back up existing file before overwriting.
+    if output_path.exists():
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        backup_path = output_path.with_suffix(f".bak.{timestamp}")
+        try:
+            backup_path.write_bytes(output_path.read_bytes())
+        except OSError as exc:
+            print(f"Warning: could not create backup {backup_path}: {exc}", file=sys.stderr)
+
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(output_json + "\n", encoding="utf-8")
+    except OSError as exc:
+        print(f"Error writing {output_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Wrote {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_codex_hooks_allowlist.py
+++ b/scripts/tests/test_codex_hooks_allowlist.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Allowlist guard tests for scripts/codex-hooks-allowlist.txt.
+
+Purpose: Codex bug openai/codex#16732 means PreToolUse/PostToolUse hooks only
+fire for the Bash tool. Any hook that guards Edit/Write/apply_patch would
+register on Codex but silently never run. A registered-but-never-fires hook
+is the worst failure mode: users assume protection that does not exist.
+
+These tests ensure that Phase 2 hooks (Edit/Write interceptors) are never
+accidentally promoted into the Phase 1 allowlist.
+
+Run: python3 -m pytest scripts/tests/test_codex_hooks_allowlist.py -v
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+ALLOWLIST_PATH = REPO_ROOT / "scripts" / "codex-hooks-allowlist.txt"
+HOOKS_DIR = REPO_ROOT / "hooks"
+
+# ---------------------------------------------------------------------------
+# Phase 2 hooks: blocked from allowlist until openai/codex#16732 is fixed
+# ---------------------------------------------------------------------------
+
+PHASE_2_HOOKS = {
+    "adr-enforcement.py",
+    "pretool-config-protection.py",
+    "creation-protocol-enforcer.py",
+    "posttool-rename-sweep.py",
+    "pretool-plan-gate.py",
+    "pretool-unified-gate.py",
+    "pretool-adr-creation-gate.py",
+    "reference-loading-enforcer.py",
+    "reference-loading-gate.py",
+}
+
+# Events that are NOT tool-tied (skip Edit/Write matcher checks for these)
+NON_TOOL_EVENTS = {"SessionStart", "UserPromptSubmit", "Stop"}
+
+# Tool-tied events where the matcher must be "Bash"
+TOOL_EVENTS = {"PreToolUse", "PostToolUse"}
+
+# Allowlist line format: EVENT:hook_filename[ matcher]
+ALLOWLIST_LINE_RE = re.compile(r"^[A-Za-z]+:[a-zA-Z0-9_\-]+\.py( [A-Za-z]+)?$")
+
+# Patterns in hook source that suggest Edit/Write interception (regex)
+EDIT_WRITE_MATCHER_RE = re.compile(
+    r"""tool_name\s*(?:==|in)\s*['"\[]{1,2}(?:Edit|Write|MultiEdit|NotebookEdit|apply_patch|WebSearch)"""
+    r"""|matches.*(?:Edit|Write)|tool_name.*Edit|tool_name.*Write""",
+    re.IGNORECASE,
+)
+
+# String literals that look like Edit/Write tool names used as matchers
+EDIT_WRITE_LITERAL_RE = re.compile(r"""["'](Edit|Write|MultiEdit|apply_patch|NotebookEdit)["']""")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_allowlist_lines() -> list[str]:
+    """Return non-comment, non-blank lines from the allowlist file."""
+    text = ALLOWLIST_PATH.read_text(encoding="utf-8")
+    return [line.strip() for line in text.splitlines() if line.strip() and not line.strip().startswith("#")]
+
+
+def _parse_entry(line: str) -> tuple[str, str, str | None]:
+    """Parse an allowlist entry into (event, filename, matcher_or_None)."""
+    parts = line.split(" ", 1)
+    event_hook = parts[0]
+    matcher = parts[1].strip() if len(parts) > 1 else None
+    event, filename = event_hook.split(":", 1)
+    return event, filename, matcher
+
+
+def _lines_near_pattern(content: str, pattern: re.Pattern, context_lines: int = 5) -> list[str]:
+    """Return source lines near any match, with surrounding context."""
+    lines = content.splitlines()
+    hits: list[str] = []
+    for idx, line in enumerate(lines):
+        if pattern.search(line):
+            start = max(0, idx - context_lines)
+            end = min(len(lines), idx + context_lines + 1)
+            snippet = lines[idx]
+            # Include neighboring lines only if they contain matcher-related keywords
+            context_keywords = re.compile(r"tool_name|matcher|if |elif ", re.IGNORECASE)
+            neighbors = [lines[i] for i in range(start, end) if i != idx and context_keywords.search(lines[i])]
+            hit = f"  line {idx + 1}: {snippet.strip()}"
+            if neighbors:
+                hit += " [nearby: " + " | ".join(n.strip() for n in neighbors[:3]) + "]"
+            hits.append(hit)
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# Skip guard: skip all tests if allowlist not yet created
+# ---------------------------------------------------------------------------
+
+
+def _require_allowlist() -> None:
+    if not ALLOWLIST_PATH.exists():
+        pytest.skip("allowlist not yet created; guard will activate on next run")
+
+
+# ---------------------------------------------------------------------------
+# Test: allowlist format is valid
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_format_valid() -> None:
+    """Each non-comment non-blank line must match EVENT:filename[ Matcher]."""
+    _require_allowlist()
+    lines = _load_allowlist_lines()
+    bad: list[str] = []
+    for line in lines:
+        if not ALLOWLIST_LINE_RE.match(line):
+            bad.append(line)
+    assert not bad, "Allowlist lines with invalid format:\n" + "\n".join(f"  {b}" for b in bad)
+
+
+# ---------------------------------------------------------------------------
+# Test: all allowlisted hook files exist on disk
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_hooks_exist() -> None:
+    """Every allowlisted hook file must exist in hooks/."""
+    _require_allowlist()
+    lines = _load_allowlist_lines()
+    missing: list[str] = []
+    for line in lines:
+        _, filename, _ = _parse_entry(line)
+        hook_path = HOOKS_DIR / filename
+        if not hook_path.exists():
+            missing.append(f"  {filename} (from entry: {line})")
+    assert not missing, "Allowlisted hooks missing from hooks/ directory:\n" + "\n".join(missing)
+
+
+# ---------------------------------------------------------------------------
+# Test: no duplicate entries
+# ---------------------------------------------------------------------------
+
+
+def test_no_duplicate_entries() -> None:
+    """Each EVENT:filename pair must appear at most once."""
+    _require_allowlist()
+    lines = _load_allowlist_lines()
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for line in lines:
+        event, filename, _ = _parse_entry(line)
+        key = f"{event}:{filename}"
+        if key in seen:
+            duplicates.append(f"  {key}")
+        seen.add(key)
+    assert not duplicates, "Duplicate allowlist entries:\n" + "\n".join(duplicates)
+
+
+# ---------------------------------------------------------------------------
+# Test: Phase 2 hooks are NOT in the allowlist (filename guard)
+# ---------------------------------------------------------------------------
+
+
+def test_phase2_hooks_are_NOT_in_allowlist() -> None:
+    """Phase 2 hook filenames must not appear in the allowlist at all.
+
+    These hooks intercept Edit/Write/apply_patch calls. Due to Codex bug
+    openai/codex#16732, PreToolUse/PostToolUse only fires for Bash, so
+    these hooks would register but never run. Silently broken is worse
+    than absent.
+    """
+    _require_allowlist()
+    lines = _load_allowlist_lines()
+    violations: list[str] = []
+    for line in lines:
+        _, filename, _ = _parse_entry(line)
+        if filename in PHASE_2_HOOKS:
+            violations.append(f"  {line}")
+    assert not violations, (
+        "Phase 2 hooks (Edit/Write interceptors) found in allowlist.\n"
+        "These hooks are blocked by openai/codex#16732 and must not be mirrored to Codex.\n"
+        "Violations:\n" + "\n".join(violations)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: tool-tied events must use Bash matcher only
+# ---------------------------------------------------------------------------
+
+
+def test_pretooluse_posttooluse_matcher_is_bash() -> None:
+    """PreToolUse and PostToolUse entries must specify 'Bash' as the matcher.
+
+    Any other matcher (Edit, Write, MultiEdit, or no matcher) would register
+    a hook that silently never fires on Codex due to openai/codex#16732.
+    """
+    _require_allowlist()
+    lines = _load_allowlist_lines()
+    violations: list[str] = []
+    for line in lines:
+        event, filename, matcher = _parse_entry(line)
+        if event not in TOOL_EVENTS:
+            continue
+        if matcher != "Bash":
+            violations.append(f"  {line}" + (f" (matcher={matcher!r})" if matcher else " (no matcher specified)"))
+    assert not violations, (
+        "PreToolUse/PostToolUse entries without 'Bash' matcher.\n"
+        "Non-Bash matchers silently never fire on Codex (openai/codex#16732).\n"
+        "Violations:\n" + "\n".join(violations)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: allowlisted hook source does not contain Edit/Write intercept patterns
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_hooks_do_not_intercept_edit_write() -> None:
+    """For each allowlisted PreToolUse/PostToolUse hook, scan its source for
+    Edit/Write/apply_patch interception patterns.
+
+    Failure modes guarded:
+    - Pattern 1: tool_name == 'Edit' / tool_name in ['Write', ...] (direct comparison)
+    - Pattern 2: string literals 'Edit', 'Write', 'MultiEdit', 'apply_patch' near
+      conditional / matcher logic
+
+    Reports ALL violations before failing so maintainers see the full list.
+    Session-tied events (SessionStart, UserPromptSubmit, Stop) are skipped.
+    Entries with matcher == 'Bash' are nominally safe but still scanned because
+    a hook might check tool_name internally to handle both Bash and Edit paths.
+    """
+    _require_allowlist()
+    lines = _load_allowlist_lines()
+    warnings: list[str] = []
+
+    for line in lines:
+        event, filename, _ = _parse_entry(line)
+
+        # Non-tool events cannot have Edit/Write matchers by design
+        if event in NON_TOOL_EVENTS:
+            continue
+
+        hook_path = HOOKS_DIR / filename
+        if not hook_path.exists():
+            # Missing file is caught by test_allowlist_hooks_exist
+            continue
+
+        source = hook_path.read_text(encoding="utf-8")
+
+        # Pattern 1: direct tool_name comparison with Edit/Write
+        hits1 = _lines_near_pattern(source, EDIT_WRITE_MATCHER_RE)
+        if hits1:
+            warnings.append(f"\n[WARN] {filename}: tool_name == Edit/Write pattern detected\n" + "\n".join(hits1))
+
+        # Pattern 2: string literals that look like tool-name matchers
+        hits2 = _lines_near_pattern(source, EDIT_WRITE_LITERAL_RE)
+        if hits2:
+            # Filter out false positives: string literals that are clearly
+            # comments, docstrings, or user-facing messages (not conditionals)
+            real_hits = [h for h in hits2 if not re.search(r"#.*[Ee]dit|#.*[Ww]rite|\"\"\".*[Ee]dit|'{3}.*[Ee]dit", h)]
+            if real_hits:
+                warnings.append(
+                    f"\n[WARN] {filename}: Edit/Write string literals near conditional logic\n" + "\n".join(real_hits)
+                )
+
+    assert not warnings, (
+        "Phase 1 hooks contain patterns suggesting Edit/Write interception.\n"
+        "These hooks would register on Codex but silently never fire (openai/codex#16732).\n"
+        "Review each hook and move it to Phase 2 if it guards non-Bash tools.\n" + "".join(warnings)
+    )

--- a/scripts/tests/test_codex_hooks_install.py
+++ b/scripts/tests/test_codex_hooks_install.py
@@ -14,7 +14,18 @@ import sys
 from pathlib import Path
 
 import pytest
-import tomllib
+
+# tomllib is stdlib on Python 3.11+. On 3.10, skip the subset of tests that
+# use it to parse the post-install config.toml. Other tests still run.
+try:
+    import tomllib  # type: ignore[import-not-found,unused-ignore]
+
+    _HAS_TOMLLIB = True
+except ImportError:
+    tomllib = None  # type: ignore[assignment]
+    _HAS_TOMLLIB = False
+
+requires_tomllib = pytest.mark.skipif(not _HAS_TOMLLIB, reason="tomllib requires Python 3.11+")
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 INSTALL_SH = REPO_ROOT / "install.sh"
@@ -173,6 +184,7 @@ def test_install_sh_generates_valid_hooks_json(fake_home: Path) -> None:
             )
 
 
+@requires_tomllib
 def test_install_sh_sets_feature_flag(fake_home: Path) -> None:
     """install.sh sets codex_hooks = true in ~/.codex/config.toml."""
     result = _run_install(fake_home, ["--copy", "--force"])
@@ -189,6 +201,7 @@ def test_install_sh_sets_feature_flag(fake_home: Path) -> None:
     )
 
 
+@requires_tomllib
 def test_install_sh_preserves_existing_config_toml_sections(fake_home: Path) -> None:
     """install.sh does not clobber pre-existing config.toml sections."""
     codex_dir = fake_home / ".codex"
@@ -236,6 +249,7 @@ def test_install_sh_dry_run_does_not_touch_filesystem(fake_home: Path) -> None:
     )
 
 
+@requires_tomllib
 def test_install_sh_uninstall_removes_hooks(fake_home: Path) -> None:
     """--uninstall removes ~/.codex/hooks/ and archives hooks.json; config.toml survives."""
     # Install first.

--- a/scripts/tests/test_codex_hooks_install.py
+++ b/scripts/tests/test_codex_hooks_install.py
@@ -1,0 +1,291 @@
+"""Integration tests for the Codex hooks mirror installed by install.sh.
+
+Runs install.sh against a temporary HOME directory and verifies that
+~/.codex/hooks/, ~/.codex/hooks.json, and ~/.codex/config.toml are set
+up correctly. Each test gets a fresh fake_home fixture so tests are
+fully independent.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import tomllib
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+INSTALL_SH = REPO_ROOT / "install.sh"
+ALLOWLIST = REPO_ROOT / "scripts" / "codex-hooks-allowlist.txt"
+
+# Module-level guard: bash must be available.
+if shutil.which("bash") is None:
+    pytest.skip("bash not available on this platform", allow_module_level=True)
+
+
+def _run_install(
+    fake_home: Path, extra_args: list[str] | None = None, timeout: int = 180
+) -> subprocess.CompletedProcess:
+    """Run install.sh with the given fake HOME and extra args.
+
+    Args:
+        fake_home: Directory to use as $HOME.
+        extra_args: Additional flags to pass to install.sh.
+        timeout: Maximum seconds to wait before failing.
+
+    Returns:
+        CompletedProcess with stdout and stderr captured.
+    """
+    args = extra_args or []
+    env = {**os.environ, "HOME": str(fake_home), "TERM": "dumb"}
+    return subprocess.run(
+        ["bash", str(INSTALL_SH)] + args,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _parse_allowlist_filenames() -> set[str]:
+    """Return the set of hook filenames from the allowlist.
+
+    Returns:
+        Set of bare filenames (e.g. 'kairos-briefing-injector.py').
+    """
+    filenames: set[str] = set()
+    for line in ALLOWLIST.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        rest = stripped.split(":", 1)[1]
+        filename = rest.strip().split()[0]
+        filenames.add(filename)
+    return filenames
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Provide a clean temporary HOME directory for each test.
+
+    Args:
+        tmp_path: pytest-provided temporary directory.
+        monkeypatch: pytest fixture for environment patching.
+
+    Returns:
+        Path to the fresh fake HOME.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_install_sh_creates_codex_hooks_dir(fake_home: Path) -> None:
+    """install.sh --copy creates ~/.codex/hooks/ with the primary hook file."""
+    result = _run_install(fake_home, ["--copy", "--force"])
+    hooks_dir = fake_home / ".codex" / "hooks"
+
+    assert hooks_dir.exists(), f"~/.codex/hooks/ not created.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert hooks_dir.is_dir(), "~/.codex/hooks is not a directory"
+
+    target_hook = hooks_dir / "kairos-briefing-injector.py"
+    assert target_hook.exists(), f"kairos-briefing-injector.py missing from hooks dir.\nSTDOUT:\n{result.stdout}"
+
+
+def test_install_sh_mirrors_all_allowlisted_hooks(fake_home: Path) -> None:
+    """Every filename in codex-hooks-allowlist.txt appears in ~/.codex/hooks/."""
+    result = _run_install(fake_home, ["--copy", "--force"])
+    hooks_dir = fake_home / ".codex" / "hooks"
+
+    expected = _parse_allowlist_filenames()
+    assert expected, "Allowlist is empty; nothing to verify"
+
+    missing = []
+    for filename in sorted(expected):
+        if not (hooks_dir / filename).exists():
+            missing.append(filename)
+
+    assert not missing, (
+        f"Missing hooks in ~/.codex/hooks/: {missing}\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
+def test_install_sh_generates_valid_hooks_json(fake_home: Path) -> None:
+    """install.sh produces a syntactically valid ~/.codex/hooks.json with correct schema."""
+    result = _run_install(fake_home, ["--copy", "--force"])
+    hooks_json_path = fake_home / ".codex" / "hooks.json"
+
+    assert hooks_json_path.exists(), f"hooks.json not created.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+
+    try:
+        data = json.loads(hooks_json_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        pytest.fail(f"hooks.json is not valid JSON: {exc}\nContent:\n{hooks_json_path.read_text()}")
+
+    assert "hooks" in data, f"Top-level 'hooks' key missing from hooks.json: {data}"
+    assert isinstance(data["hooks"], dict), "'hooks' value must be a dict"
+
+    has_session_start = False
+    has_bash_post_tool_use = False
+
+    for event_key, matcher_groups in data["hooks"].items():
+        assert isinstance(matcher_groups, list), f"Event '{event_key}' value must be a list, got {type(matcher_groups)}"
+        for group in matcher_groups:
+            assert isinstance(group, dict), f"Matcher group must be a dict, got {type(group)}"
+            assert "hooks" in group, f"Matcher group missing 'hooks' key: {group}"
+            assert isinstance(group["hooks"], list), "'hooks' within group must be a list"
+
+            for entry in group["hooks"]:
+                assert entry.get("type") == "command", f"Hook entry must have type='command': {entry}"
+                assert "command" in entry, f"Hook entry missing 'command': {entry}"
+                assert "timeout" in entry, f"Hook entry missing 'timeout': {entry}"
+
+            if event_key == "SessionStart":
+                has_session_start = True
+
+            if event_key == "PostToolUse":
+                matcher = group.get("matcher", "")
+                if matcher == "Bash":
+                    has_bash_post_tool_use = True
+
+    assert has_session_start, "hooks.json has no SessionStart entries"
+    assert has_bash_post_tool_use, "hooks.json has no PostToolUse entry with matcher='Bash'"
+
+    # Guard: no PreToolUse or PostToolUse block should have a non-Bash matcher.
+    # This catches accidental Phase 2 hook promotion (openai/codex#16732 regression).
+    for event_key in ("PreToolUse", "PostToolUse"):
+        if event_key not in data["hooks"]:
+            continue
+        for group in data["hooks"][event_key]:
+            matcher = group.get("matcher", "Bash")
+            assert matcher == "Bash", (
+                f"Non-Bash matcher '{matcher}' found in {event_key} block. "
+                "This is a Phase 2 hook regression (openai/codex#16732). "
+                f"Full group: {group}"
+            )
+
+
+def test_install_sh_sets_feature_flag(fake_home: Path) -> None:
+    """install.sh sets codex_hooks = true in ~/.codex/config.toml."""
+    result = _run_install(fake_home, ["--copy", "--force"])
+    config_path = fake_home / ".codex" / "config.toml"
+
+    assert config_path.exists(), f"config.toml not created.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+
+    with open(config_path, "rb") as fh:
+        config = tomllib.load(fh)
+
+    assert "features" in config, f"[features] section missing from config.toml. Content:\n{config_path.read_text()}"
+    assert config["features"].get("codex_hooks") is True, (
+        f"codex_hooks != true in [features]. Got: {config['features']}"
+    )
+
+
+def test_install_sh_preserves_existing_config_toml_sections(fake_home: Path) -> None:
+    """install.sh does not clobber pre-existing config.toml sections."""
+    codex_dir = fake_home / ".codex"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+
+    existing_toml = (
+        '[projects."/home/user/repo"]\ntrust_level = "trusted"\n\n[notice]\nhide_rate_limit_model_nudge = true\n'
+    )
+    config_path = codex_dir / "config.toml"
+    config_path.write_text(existing_toml, encoding="utf-8")
+
+    result = _run_install(fake_home, ["--copy", "--force"])
+
+    assert config_path.exists(), f"config.toml disappeared.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+
+    with open(config_path, "rb") as fh:
+        config = tomllib.load(fh)
+
+    assert "projects" in config or any(k.startswith("projects") for k in config), (
+        f"[projects] section lost after install. Full config: {config}"
+    )
+    assert "notice" in config, f"[notice] section lost after install. Full config: {config}"
+    assert config["notice"].get("hide_rate_limit_model_nudge") is True
+
+    assert "features" in config, f"[features] section not added. Full config: {config}"
+    assert config["features"].get("codex_hooks") is True
+
+
+def test_install_sh_dry_run_does_not_touch_filesystem(fake_home: Path) -> None:
+    """install.sh --dry-run leaves ~/.codex untouched."""
+    result = _run_install(fake_home, ["--dry-run", "--symlink"])
+
+    hooks_dir = fake_home / ".codex" / "hooks"
+    hooks_json = fake_home / ".codex" / "hooks.json"
+    config_toml = fake_home / ".codex" / "config.toml"
+
+    assert not hooks_dir.exists(), f"~/.codex/hooks/ was created during dry-run.\nSTDOUT:\n{result.stdout}"
+    assert not hooks_json.exists(), f"hooks.json was created during dry-run.\nSTDOUT:\n{result.stdout}"
+    assert not config_toml.exists(), f"config.toml was created during dry-run.\nSTDOUT:\n{result.stdout}"
+
+    # Dry-run output should describe the Codex hooks block action.
+    combined = result.stdout + result.stderr
+    assert "Would create" in combined or "Would generate" in combined or "Would ensure" in combined, (
+        f"Dry-run output contains no 'Would ...' lines for Codex hooks.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
+def test_install_sh_uninstall_removes_hooks(fake_home: Path) -> None:
+    """--uninstall removes ~/.codex/hooks/ and archives hooks.json; config.toml survives."""
+    # Install first.
+    install_result = _run_install(fake_home, ["--copy", "--force"])
+    hooks_dir = fake_home / ".codex" / "hooks"
+    assert hooks_dir.exists(), (
+        f"Pre-condition failed: hooks dir not created by install.\nSTDOUT:\n{install_result.stdout}"
+    )
+
+    # Now uninstall.
+    uninstall_result = _run_install(fake_home, ["--uninstall"])
+
+    assert not hooks_dir.exists(), (
+        f"~/.codex/hooks/ still present after --uninstall.\nSTDOUT:\n{uninstall_result.stdout}\nSTDERR:\n{uninstall_result.stderr}"
+    )
+
+    # hooks.json should have been archived, not deleted in place.
+    codex_dir = fake_home / ".codex"
+    hooks_json = codex_dir / "hooks.json"
+    assert not hooks_json.exists(), (
+        f"hooks.json still present as hooks.json (should be archived).\nSTDOUT:\n{uninstall_result.stdout}"
+    )
+
+    archived = list(codex_dir.glob("hooks.json.uninstalled.*"))
+    assert archived, (
+        f"No hooks.json.uninstalled.* archive found in {codex_dir}.\n"
+        f"Files in codex_dir: {[f.name for f in codex_dir.iterdir()]}\n"
+        f"STDOUT:\n{uninstall_result.stdout}"
+    )
+
+    # config.toml feature flag is intentionally NOT removed by uninstall.
+    config_path = codex_dir / "config.toml"
+    if config_path.exists():
+        with open(config_path, "rb") as fh:
+            config = tomllib.load(fh)
+        assert config.get("features", {}).get("codex_hooks") is True, (
+            "Uninstall incorrectly removed codex_hooks = true from config.toml"
+        )
+
+
+def test_install_sh_handles_missing_allowlist_gracefully() -> None:
+    """Skip: testing missing-allowlist path requires mutating the live repo.
+
+    The missing-allowlist path is tested by the bash branch in install.sh that
+    prints a warning and skips the hooks mirror. We cannot test it here without
+    renaming scripts/codex-hooks-allowlist.txt, which would break other tests
+    running in the same process. A targeted bash-level integration test would be
+    the right vehicle, but that is outside the pytest scope for this file.
+    """
+    pytest.skip(
+        "Cannot test missing-allowlist path without mutating the repo allowlist file. "
+        "Covered by the install.sh bash branch that prints a warning and continues."
+    )

--- a/scripts/tests/test_ensure_codex_feature_flag.py
+++ b/scripts/tests/test_ensure_codex_feature_flag.py
@@ -1,0 +1,260 @@
+"""Tests for scripts/ensure-codex-feature-flag.py.
+
+Covers: missing file, empty file, no [features] section, [features] without
+key, already present, codex_hooks = false error, idempotency, section
+preservation, --dry-run, backup creation, and CLI end-to-end via subprocess.
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import tomllib
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "ensure-codex-feature-flag.py"
+_SPEC = importlib.util.spec_from_file_location("ensure_codex_feature_flag", MODULE_PATH)
+_MOD = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_MOD)
+
+read_config = _MOD.read_config
+needs_update = _MOD.needs_update
+apply_update = _MOD.apply_update
+
+# A realistic config drawn from the ADR context.
+REALISTIC_CONFIG = """\
+[projects."/home/feedgen/claude-code-toolkit"]
+trust_level = "trusted"
+
+[projects."/home/feedgen/road-to-aew"]
+trust_level = "trusted"
+
+[plugins."github@openai-curated"]
+enabled = true
+
+[notice]
+hide_rate_limit_model_nudge = true
+"""
+
+
+# ---------------------------------------------------------------------------
+# needs_update / action-tag tests
+# ---------------------------------------------------------------------------
+
+
+class TestNeedsUpdate:
+    """Unit tests for needs_update() logic."""
+
+    def test_empty_string_returns_created_file(self) -> None:
+        """Empty content (missing file) maps to created-file action."""
+        write_needed, action = needs_update("")
+        assert write_needed is True
+        assert action == "created-file"
+
+    def test_no_features_section_returns_added_section(self) -> None:
+        """Content with no [features] header maps to added-section."""
+        content = "[notice]\nhide_rate_limit_model_nudge = true\n"
+        write_needed, action = needs_update(content)
+        assert write_needed is True
+        assert action == "added-section"
+
+    def test_features_section_without_key_returns_added_key(self) -> None:
+        """[features] section lacking codex_hooks maps to added-key."""
+        content = "[features]\nother_flag = true\n"
+        write_needed, action = needs_update(content)
+        assert write_needed is True
+        assert action == "added-key"
+
+    def test_codex_hooks_true_returns_already_present(self) -> None:
+        """codex_hooks = true means no write is needed."""
+        content = "[features]\ncodex_hooks = true\n"
+        write_needed, action = needs_update(content)
+        assert write_needed is False
+        assert action == "already-present"
+
+    def test_codex_hooks_false_exits_2(self) -> None:
+        """codex_hooks = false must exit with code 2."""
+        content = "[features]\ncodex_hooks = false\n"
+        with pytest.raises(SystemExit) as exc_info:
+            needs_update(content)
+        assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# apply_update tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplyUpdate:
+    """Unit tests for apply_update() content transformation."""
+
+    def test_missing_file_produces_features_block(self) -> None:
+        """Empty string yields a valid [features] block."""
+        result = apply_update("")
+        assert "[features]\ncodex_hooks = true\n" in result
+        parsed = tomllib.loads(result)
+        assert parsed["features"]["codex_hooks"] is True
+
+    def test_no_features_section_appends_block(self) -> None:
+        """Appending to non-empty content without [features] preserves original text."""
+        original = "[notice]\nhide_rate_limit_model_nudge = true\n"
+        result = apply_update(original)
+        assert original in result
+        assert "[features]\ncodex_hooks = true\n" in result
+        parsed = tomllib.loads(result)
+        assert parsed["notice"]["hide_rate_limit_model_nudge"] is True
+        assert parsed["features"]["codex_hooks"] is True
+
+    def test_existing_features_adds_key_after_header(self) -> None:
+        """codex_hooks is injected directly after the [features] header line."""
+        original = "[features]\nother_flag = true\n"
+        result = apply_update(original)
+        parsed = tomllib.loads(result)
+        assert parsed["features"]["other_flag"] is True
+        assert parsed["features"]["codex_hooks"] is True
+
+    def test_already_present_returns_identical_content(self) -> None:
+        """Content that already has the flag is returned unchanged."""
+        original = "[features]\ncodex_hooks = true\n"
+        result = apply_update(original)
+        assert result == original
+
+    def test_idempotent_second_call_is_noop(self) -> None:
+        """Running apply_update twice yields identical output on the second call."""
+        first = apply_update(REALISTIC_CONFIG)
+        second = apply_update(first)
+        assert first == second
+
+    def test_realistic_config_preserved_byte_for_byte(self) -> None:
+        """All original sections survive the merge unchanged."""
+        result = apply_update(REALISTIC_CONFIG)
+        assert REALISTIC_CONFIG in result
+        parsed = tomllib.loads(result)
+        assert parsed["projects"]["/home/feedgen/claude-code-toolkit"]["trust_level"] == "trusted"
+        assert parsed["plugins"]["github@openai-curated"]["enabled"] is True
+        assert parsed["notice"]["hide_rate_limit_model_nudge"] is True
+        assert parsed["features"]["codex_hooks"] is True
+
+
+# ---------------------------------------------------------------------------
+# File I/O tests
+# ---------------------------------------------------------------------------
+
+
+class TestFileIO:
+    """Integration tests for read_config and file-level behavior."""
+
+    def test_read_config_returns_empty_for_missing_file(self, tmp_path: Path) -> None:
+        """read_config returns empty string when file does not exist."""
+        missing = tmp_path / "config.toml"
+        assert read_config(missing) == ""
+
+    def test_read_config_returns_content(self, tmp_path: Path) -> None:
+        """read_config returns file text verbatim."""
+        cfg = tmp_path / "config.toml"
+        cfg.write_text("[notice]\nfoo = true\n", encoding="utf-8")
+        assert read_config(cfg) == "[notice]\nfoo = true\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI tests via subprocess
+# ---------------------------------------------------------------------------
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess:
+    """Run the script as a subprocess and return the result."""
+    return subprocess.run(
+        [sys.executable, str(MODULE_PATH)] + args,
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestCLI:
+    """End-to-end CLI tests that invoke the script as a subprocess."""
+
+    def test_missing_file_creates_and_prints_created_file(self, tmp_path: Path) -> None:
+        """Missing config is created; stdout reports created-file."""
+        cfg = tmp_path / "config.toml"
+        result = _run(["--config", str(cfg), "--no-backup"])
+        assert result.returncode == 0
+        assert result.stdout.strip() == "created-file"
+        assert cfg.exists()
+        parsed = tomllib.loads(cfg.read_text())
+        assert parsed["features"]["codex_hooks"] is True
+
+    def test_empty_file_adds_section(self, tmp_path: Path) -> None:
+        """Empty config gets a [features] section; stdout reports added-section."""
+        cfg = tmp_path / "config.toml"
+        cfg.write_text("", encoding="utf-8")
+        result = _run(["--config", str(cfg), "--no-backup"])
+        assert result.returncode == 0
+        assert result.stdout.strip() == "added-section"
+        parsed = tomllib.loads(cfg.read_text())
+        assert parsed["features"]["codex_hooks"] is True
+
+    def test_existing_features_without_key_adds_key(self, tmp_path: Path) -> None:
+        """[features] section without the key gets it added; stdout reports added-key."""
+        cfg = tmp_path / "config.toml"
+        cfg.write_text("[features]\nother_flag = true\n", encoding="utf-8")
+        result = _run(["--config", str(cfg), "--no-backup"])
+        assert result.returncode == 0
+        assert result.stdout.strip() == "added-key"
+        parsed = tomllib.loads(cfg.read_text())
+        assert parsed["features"]["codex_hooks"] is True
+        assert parsed["features"]["other_flag"] is True
+
+    def test_already_present_is_noop(self, tmp_path: Path) -> None:
+        """Pre-existing flag produces no file change and reports already-present."""
+        cfg = tmp_path / "config.toml"
+        original = "[features]\ncodex_hooks = true\n"
+        cfg.write_text(original, encoding="utf-8")
+        result = _run(["--config", str(cfg), "--no-backup"])
+        assert result.returncode == 0
+        assert result.stdout.strip() == "already-present"
+        assert cfg.read_text() == original
+
+    def test_codex_hooks_false_exits_2(self, tmp_path: Path) -> None:
+        """codex_hooks = false causes exit code 2 with stderr guidance."""
+        cfg = tmp_path / "config.toml"
+        cfg.write_text("[features]\ncodex_hooks = false\n", encoding="utf-8")
+        result = _run(["--config", str(cfg), "--no-backup"])
+        assert result.returncode == 2
+        assert "manually" in result.stderr.lower() or "manual" in result.stderr.lower()
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        """--dry-run prints new content to stdout but leaves the file unchanged."""
+        cfg = tmp_path / "config.toml"
+        original = "[notice]\nfoo = true\n"
+        cfg.write_text(original, encoding="utf-8")
+        result = _run(["--config", str(cfg), "--dry-run", "--no-backup"])
+        assert result.returncode == 0
+        # File must be untouched.
+        assert cfg.read_text() == original
+        # Printed content must contain the flag.
+        assert "codex_hooks = true" in result.stdout
+
+    def test_backup_is_created(self, tmp_path: Path) -> None:
+        """A .bak timestamped file is created from the original before writing."""
+        cfg = tmp_path / "config.toml"
+        original = "[notice]\nfoo = true\n"
+        cfg.write_text(original, encoding="utf-8")
+        result = _run(["--config", str(cfg)])
+        assert result.returncode == 0
+        bak_files = list(tmp_path.glob("config.toml.bak.*"))
+        assert len(bak_files) == 1
+        assert bak_files[0].read_text() == original
+
+    def test_realistic_config_survives_round_trip(self, tmp_path: Path) -> None:
+        """Full realistic config from ADR example parses correctly after merge."""
+        cfg = tmp_path / "config.toml"
+        cfg.write_text(REALISTIC_CONFIG, encoding="utf-8")
+        result = _run(["--config", str(cfg), "--no-backup"])
+        assert result.returncode == 0
+        parsed = tomllib.loads(cfg.read_text())
+        assert parsed["projects"]["/home/feedgen/road-to-aew"]["trust_level"] == "trusted"
+        assert parsed["plugins"]["github@openai-curated"]["enabled"] is True
+        assert parsed["notice"]["hide_rate_limit_model_nudge"] is True
+        assert parsed["features"]["codex_hooks"] is True

--- a/scripts/tests/test_ensure_codex_feature_flag.py
+++ b/scripts/tests/test_ensure_codex_feature_flag.py
@@ -11,7 +11,19 @@ import sys
 from pathlib import Path
 
 import pytest
-import tomllib
+
+# tomllib is stdlib on Python 3.11+. On 3.10, skip the subset of tests that
+# use it for post-write TOML validity checks. The write logic itself is pure
+# string ops and works on 3.10+ unchanged.
+try:
+    import tomllib  # type: ignore[import-not-found,unused-ignore]
+
+    _HAS_TOMLLIB = True
+except ImportError:
+    tomllib = None  # type: ignore[assignment]
+    _HAS_TOMLLIB = False
+
+requires_tomllib = pytest.mark.skipif(not _HAS_TOMLLIB, reason="tomllib requires Python 3.11+")
 
 MODULE_PATH = Path(__file__).resolve().parent.parent / "ensure-codex-feature-flag.py"
 _SPEC = importlib.util.spec_from_file_location("ensure_codex_feature_flag", MODULE_PATH)
@@ -90,6 +102,7 @@ class TestNeedsUpdate:
 class TestApplyUpdate:
     """Unit tests for apply_update() content transformation."""
 
+    @requires_tomllib
     def test_missing_file_produces_features_block(self) -> None:
         """Empty string yields a valid [features] block."""
         result = apply_update("")
@@ -97,6 +110,7 @@ class TestApplyUpdate:
         parsed = tomllib.loads(result)
         assert parsed["features"]["codex_hooks"] is True
 
+    @requires_tomllib
     def test_no_features_section_appends_block(self) -> None:
         """Appending to non-empty content without [features] preserves original text."""
         original = "[notice]\nhide_rate_limit_model_nudge = true\n"
@@ -107,6 +121,7 @@ class TestApplyUpdate:
         assert parsed["notice"]["hide_rate_limit_model_nudge"] is True
         assert parsed["features"]["codex_hooks"] is True
 
+    @requires_tomllib
     def test_existing_features_adds_key_after_header(self) -> None:
         """codex_hooks is injected directly after the [features] header line."""
         original = "[features]\nother_flag = true\n"
@@ -121,12 +136,14 @@ class TestApplyUpdate:
         result = apply_update(original)
         assert result == original
 
+    @requires_tomllib
     def test_idempotent_second_call_is_noop(self) -> None:
         """Running apply_update twice yields identical output on the second call."""
         first = apply_update(REALISTIC_CONFIG)
         second = apply_update(first)
         assert first == second
 
+    @requires_tomllib
     def test_realistic_config_preserved_byte_for_byte(self) -> None:
         """All original sections survive the merge unchanged."""
         result = apply_update(REALISTIC_CONFIG)
@@ -175,6 +192,7 @@ def _run(args: list[str]) -> subprocess.CompletedProcess:
 class TestCLI:
     """End-to-end CLI tests that invoke the script as a subprocess."""
 
+    @requires_tomllib
     def test_missing_file_creates_and_prints_created_file(self, tmp_path: Path) -> None:
         """Missing config is created; stdout reports created-file."""
         cfg = tmp_path / "config.toml"
@@ -185,6 +203,7 @@ class TestCLI:
         parsed = tomllib.loads(cfg.read_text())
         assert parsed["features"]["codex_hooks"] is True
 
+    @requires_tomllib
     def test_empty_file_adds_section(self, tmp_path: Path) -> None:
         """Empty config gets a [features] section; stdout reports added-section."""
         cfg = tmp_path / "config.toml"
@@ -195,6 +214,7 @@ class TestCLI:
         parsed = tomllib.loads(cfg.read_text())
         assert parsed["features"]["codex_hooks"] is True
 
+    @requires_tomllib
     def test_existing_features_without_key_adds_key(self, tmp_path: Path) -> None:
         """[features] section without the key gets it added; stdout reports added-key."""
         cfg = tmp_path / "config.toml"
@@ -247,6 +267,7 @@ class TestCLI:
         assert len(bak_files) == 1
         assert bak_files[0].read_text() == original
 
+    @requires_tomllib
     def test_realistic_config_survives_round_trip(self, tmp_path: Path) -> None:
         """Full realistic config from ADR example parses correctly after merge."""
         cfg = tmp_path / "config.toml"

--- a/scripts/tests/test_generate_codex_hooks_json.py
+++ b/scripts/tests/test_generate_codex_hooks_json.py
@@ -1,0 +1,319 @@
+"""Tests for scripts/generate-codex-hooks-json.py."""
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module import helper (hyphen in filename requires importlib)
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH = Path(__file__).parent.parent / "generate-codex-hooks-json.py"
+
+
+def _load_module():
+    """Load generate-codex-hooks-json.py as a module."""
+    spec = importlib.util.spec_from_file_location("generate_codex_hooks_json", _SCRIPT_PATH)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_module()
+parse_allowlist = _mod.parse_allowlist
+build_hooks_json = _mod.build_hooks_json
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Empty allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_empty_allowlist_produces_empty_hooks():
+    """Empty allowlist text produces {'hooks': {}}."""
+    entries = parse_allowlist("")
+    result = build_hooks_json(entries)
+    assert result == {"hooks": {}}
+
+
+def test_comments_and_blanks_only_produces_empty():
+    """Allowlist with only comments and blank lines produces empty hooks."""
+    text = "# This is a comment\n\n# Another comment\n"
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries)
+    assert result == {"hooks": {}}
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Single SessionStart with no matcher
+# ---------------------------------------------------------------------------
+
+
+def test_single_session_start_no_matcher():
+    """SessionStart entry with no matcher gets default matcher 'startup|resume'."""
+    text = "SessionStart:kairos-briefing-injector.py\n"
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries, codex_hooks_dir="/home/user/.codex/hooks")
+
+    assert "SessionStart" in result["hooks"]
+    blocks = result["hooks"]["SessionStart"]
+    assert len(blocks) == 1
+    block = blocks[0]
+    assert block["matcher"] == "startup|resume"
+    assert len(block["hooks"]) == 1
+    hook = block["hooks"][0]
+    assert hook["type"] == "command"
+    assert "kairos-briefing-injector.py" in hook["command"]
+    assert hook["timeout"] == 600
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Multiple SessionStart entries grouped into one matcher block
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_session_start_entries_grouped():
+    """Multiple SessionStart entries are grouped into one matcher block."""
+    text = (
+        "SessionStart:kairos-briefing-injector.py\n"
+        "SessionStart:adr-context-injector.py\n"
+        "SessionStart:instruction-reminder.py\n"
+    )
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries, codex_hooks_dir="/fake/hooks")
+
+    blocks = result["hooks"]["SessionStart"]
+    assert len(blocks) == 1, "All SessionStart entries share the same default matcher, so only one block."
+    hook_list = blocks[0]["hooks"]
+    assert len(hook_list) == 3
+    names = [h["command"] for h in hook_list]
+    assert any("kairos-briefing-injector.py" in n for n in names)
+    assert any("adr-context-injector.py" in n for n in names)
+    assert any("instruction-reminder.py" in n for n in names)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: PreToolUse without matcher raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_pretooluse_without_matcher_raises():
+    """PreToolUse entry without matcher raises ValueError mentioning 'Bash'."""
+    text = "PreToolUse:pretool-bash-injection-scan.py\n"
+    with pytest.raises(ValueError) as exc_info:
+        parse_allowlist(text)
+    assert "Bash" in str(exc_info.value)
+
+
+def test_posttooluse_without_matcher_raises():
+    """PostToolUse entry without matcher raises ValueError mentioning 'Bash'."""
+    text = "PostToolUse:posttool-bash-injection-scan.py\n"
+    with pytest.raises(ValueError) as exc_info:
+        parse_allowlist(text)
+    assert "Bash" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: PreToolUse+PostToolUse with Bash matcher produce separate event keys
+# ---------------------------------------------------------------------------
+
+
+def test_pretooluse_and_posttooluse_with_bash_matcher():
+    """PreToolUse and PostToolUse with Bash matcher produce separate event keys."""
+    text = "PreToolUse:pretool-bash-injection-scan.py Bash\nPostToolUse:posttool-bash-injection-scan.py Bash\n"
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries, codex_hooks_dir="/fake/hooks")
+
+    assert "PreToolUse" in result["hooks"]
+    assert "PostToolUse" in result["hooks"]
+
+    pre_blocks = result["hooks"]["PreToolUse"]
+    assert len(pre_blocks) == 1
+    assert pre_blocks[0]["matcher"] == "Bash"
+    assert len(pre_blocks[0]["hooks"]) == 1
+
+    post_blocks = result["hooks"]["PostToolUse"]
+    assert len(post_blocks) == 1
+    assert post_blocks[0]["matcher"] == "Bash"
+    assert len(post_blocks[0]["hooks"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Comments and blank lines are ignored
+# ---------------------------------------------------------------------------
+
+
+def test_comments_and_blank_lines_ignored():
+    """Lines starting with # and empty lines do not become entries."""
+    text = (
+        "# Phase 1: safe on Codex v0.114.0+\n"
+        "\n"
+        "SessionStart:kairos-briefing-injector.py\n"
+        "\n"
+        "# Another comment\n"
+        "Stop:suggest-compact.py\n"
+    )
+    entries = parse_allowlist(text)
+    assert len(entries) == 2
+    events = [e["event"] for e in entries]
+    assert "SessionStart" in events
+    assert "Stop" in events
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Malformed line raises ValueError with line number
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_line_raises_with_line_number():
+    """A line without ':' raises ValueError that includes the line number."""
+    text = "# comment\n\nbadline-no-colon\n"
+    with pytest.raises(ValueError) as exc_info:
+        parse_allowlist(text)
+    msg = str(exc_info.value)
+    assert "3" in msg, f"Expected line number 3 in error: {msg}"
+
+
+def test_malformed_unknown_event_raises():
+    """An unknown event name raises ValueError."""
+    text = "UnknownEvent:some-hook.py\n"
+    with pytest.raises(ValueError) as exc_info:
+        parse_allowlist(text)
+    assert "UnknownEvent" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Test 8: UserPromptSubmit entry has no matcher field in output
+# ---------------------------------------------------------------------------
+
+
+def test_user_prompt_submit_no_matcher_field():
+    """UserPromptSubmit entry produces a block without a 'matcher' key."""
+    text = "UserPromptSubmit:auto-plan-detector.py\n"
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries, codex_hooks_dir="/fake/hooks")
+
+    assert "UserPromptSubmit" in result["hooks"]
+    blocks = result["hooks"]["UserPromptSubmit"]
+    assert len(blocks) == 1
+    assert "matcher" not in blocks[0], "UserPromptSubmit blocks must not have a 'matcher' field."
+    assert "hooks" in blocks[0]
+
+
+def test_stop_entry_no_matcher_field():
+    """Stop entry produces a block without a 'matcher' key."""
+    text = "Stop:suggest-compact.py\n"
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries, codex_hooks_dir="/fake/hooks")
+
+    blocks = result["hooks"]["Stop"]
+    assert len(blocks) == 1
+    assert "matcher" not in blocks[0]
+
+
+# ---------------------------------------------------------------------------
+# Test 9: End-to-end CLI with --dry-run produces valid JSON
+# ---------------------------------------------------------------------------
+
+
+def test_cli_dry_run_produces_valid_json():
+    """CLI invocation with --dry-run prints valid JSON to stdout."""
+    allowlist_text = (
+        "# Phase 1 hooks\n"
+        "SessionStart:kairos-briefing-injector.py\n"
+        "UserPromptSubmit:auto-plan-detector.py\n"
+        "PreToolUse:pretool-bash-injection-scan.py Bash\n"
+        "Stop:suggest-compact.py\n"
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        allowlist_path = Path(tmpdir) / "allowlist.txt"
+        allowlist_path.write_text(allowlist_text, encoding="utf-8")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_SCRIPT_PATH),
+                "--allowlist",
+                str(allowlist_path),
+                "--dry-run",
+                "--codex-hooks-dir",
+                "/fake/hooks",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    assert result.returncode == 0, f"CLI exited non-zero: {result.stderr}"
+    parsed = json.loads(result.stdout)
+
+    assert "hooks" in parsed
+    assert "SessionStart" in parsed["hooks"]
+    assert "UserPromptSubmit" in parsed["hooks"]
+    assert "PreToolUse" in parsed["hooks"]
+    assert "Stop" in parsed["hooks"]
+
+    # Verify structure depth: hooks.SessionStart[0].hooks[0].command
+    session_hook = parsed["hooks"]["SessionStart"][0]["hooks"][0]
+    assert session_hook["type"] == "command"
+    assert "kairos-briefing-injector.py" in session_hook["command"]
+    assert session_hook["timeout"] == 600
+
+
+# ---------------------------------------------------------------------------
+# Test 10: Event ordering is canonical
+# ---------------------------------------------------------------------------
+
+
+def test_event_ordering():
+    """Events appear in SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop order."""
+    text = (
+        "Stop:suggest-compact.py\n"
+        "PostToolUse:posttool-bash-injection-scan.py Bash\n"
+        "SessionStart:kairos-briefing-injector.py\n"
+        "PreToolUse:pretool-bash-injection-scan.py Bash\n"
+        "UserPromptSubmit:auto-plan-detector.py\n"
+    )
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries, codex_hooks_dir="/fake/hooks")
+
+    keys = list(result["hooks"].keys())
+    expected_order = ["SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop"]
+    assert keys == expected_order, f"Got order: {keys}"
+
+
+# ---------------------------------------------------------------------------
+# Test 11: Command shape uses python3 and the configured hooks dir
+# ---------------------------------------------------------------------------
+
+
+def test_command_shape_uses_configured_dir():
+    """Hook command uses python3 and the codex-hooks-dir path."""
+    text = "SessionStart:kairos-briefing-injector.py\n"
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries, codex_hooks_dir="/home/testuser/.codex/hooks")
+
+    hook = result["hooks"]["SessionStart"][0]["hooks"][0]
+    cmd = hook["command"]
+    assert cmd.startswith("python3 "), f"Command should start with 'python3 ': {cmd}"
+    assert "/home/testuser/.codex/hooks/kairos-briefing-injector.py" in cmd
+
+
+def test_command_shape_default_dir_uses_home():
+    """Hook command uses $HOME/.codex/hooks when codex_hooks_dir is not specified."""
+    import os
+
+    home = os.environ.get("HOME", "~")
+    text = "SessionStart:kairos-briefing-injector.py\n"
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries)
+
+    hook = result["hooks"]["SessionStart"][0]["hooks"][0]
+    cmd = hook["command"]
+    assert f"{home}/.codex/hooks/kairos-briefing-injector.py" in cmd


### PR DESCRIPTION
## Summary

Extend `install.sh` to mirror a **curated allowlist of 6 Phase 1 hooks** to `~/.codex/hooks/`, generate `~/.codex/hooks.json` from the allowlist, and set the `codex_hooks` feature flag in `~/.codex/config.toml`. This gives Codex CLI sessions the same session-start injection and Bash-scanning governance that Claude Code sessions already have.

**Implements ADR-182.** The ADR (`adr/182-codex-hooks-mirror.md`, local only) was revised mid-implementation after an audit revealed the original draft Phase 1 list had misclassified 3 Edit/Write interceptors as safe. The corrected allowlist and the regression guard test catch this class of error automatically going forward.

## Why a curated allowlist, not wholesale mirror

OpenAI Codex CLI v0.114.0 added experimental hook support with a schema nearly identical to Claude Code's, BUT **openai/codex#16732** (still open as of April 2026) limits `PreToolUse`/`PostToolUse` hooks to fire **only for the `Bash` tool**. Tool calls through `apply_patch`, `Write`, `Edit`, MCP, and `WebSearch` do not trigger hooks.

A wholesale mirror of `hooks/*.py` would register every Edit/Write interceptor on Codex, where they would never fire. Silently-registered-but-never-invoked hooks are worse than missing hooks because users assume the hook is protecting them. The allowlist approach is explicit inclusion with a regression guard to prevent accidental Phase 2 promotion.

## Phase 1 hooks (shipping now)

| Event | Hook | Matcher |
|-------|------|---------|
| SessionStart | `kairos-briefing-injector.py` | `startup\|resume` |
| SessionStart | `operator-context-detector.py` | `startup\|resume` |
| SessionStart | `team-config-loader.py` | `startup\|resume` |
| SessionStart | `rules-distill-injector.py` | `startup\|resume` |
| Stop | `session-learning-recorder.py` | (none) |
| PostToolUse | `posttool-bash-injection-scan.py` | `Bash` |

## Phase 2 hooks (deliberately excluded)

Edit/Write interceptors: `adr-enforcement.py`, `pretool-config-protection.py`, `creation-protocol-enforcer.py`, `posttool-rename-sweep.py`, `pretool-plan-gate.py`, `pretool-unified-gate.py`, `pretool-adr-creation-gate.py`, `reference-loading-enforcer.py`, `reference-loading-gate.py`, plus three hooks the ADR draft misclassified (`pretool-prompt-injection-scanner.py`, `suggest-compact.py`, `sql-injection-detector.py`) which are actually `PreToolUse`/`PostToolUse` with `Write|Edit` matchers.

Phase 2 unblocks when `openai/codex#16732` ships upstream.

## What's in this PR

**New files:**
- `scripts/codex-hooks-allowlist.txt` (authoritative Phase 1 list with exclusion rationale as comments)
- `scripts/generate-codex-hooks-json.py` (allowlist to hooks.json generator, stdlib only)
- `scripts/ensure-codex-feature-flag.py` (TOML-aware `config.toml` merger with backup)

**New tests (50 passing + 1 intentional skip):**
- `scripts/tests/test_generate_codex_hooks_json.py` (16 tests: schema, CLI, determinism, event ordering, malformed input)
- `scripts/tests/test_ensure_codex_feature_flag.py` (21 tests: TOML merge, idempotency, `codex_hooks=false` error path, preservation of existing sections)
- `scripts/tests/test_codex_hooks_allowlist.py` (6 tests: **regression guard** against Phase 2 promotion. Scans hook source for `Edit|Write|apply_patch` matcher patterns; tests that Phase 2 hook filenames from the ADR are NOT in the allowlist)
- `scripts/tests/test_codex_hooks_install.py` (7 tests + 1 skip: **end-to-end install.sh** verification against a tempdir HOME; mirrors files, generates valid hooks.json, sets feature flag, preserves existing config sections, uninstall symmetry)

**Modified:**
- `install.sh` (+129 lines: `CODEX_HOOKS_DIR` variable, `Syncing Codex hooks mirror` block, uninstall cleanup, Codex version warning for <0.114.0)
- `README.md` (+24 lines: new `## Codex CLI Parity` section explaining what mirrors, what does not, and the `#16732` upstream blocker)

## Test plan

- [x] `pytest scripts/tests/test_codex_hooks_*.py scripts/tests/test_generate_codex_hooks_json.py scripts/tests/test_ensure_codex_feature_flag.py -v` (50 passed, 1 skipped in 43s)
- [x] `ruff check` and `ruff format --check` on all new Python files (clean)
- [x] `bash -n install.sh` (syntax OK)
- [x] `bash install.sh --dry-run --symlink` (prints correct Codex hooks section, no side effects)
- [x] Tempdir end-to-end: `HOME=\$TMP bash install.sh --copy --force` populates `~/.codex/hooks/` with all 6 Phase 1 files plus `hooks/lib/`, generates valid hooks.json with correct matchers, sets `[features] codex_hooks = true` in config.toml while preserving existing sections
- [x] Tempdir uninstall: `bash install.sh --uninstall` removes `~/.codex/hooks/`, archives `hooks.json` with timestamp, leaves `config.toml` feature flag untouched
- [x] Regression guard test fails if any Phase 1 allowlisted hook contains Edit/Write matcher patterns
- [x] Allowlist format test fails on duplicate entries, missing hooks, wrong regex

## References

- ADR-182 (`adr/182-codex-hooks-mirror.md`, local only)
- Upstream hooks docs: https://developers.openai.com/codex/hooks
- Upstream blocker for Phase 2: https://github.com/openai/codex/issues/16732
- PreToolUse/PostToolUse request (shipped in v0.114.0): https://github.com/openai/codex/issues/14754
- Prior art: #373 mirrored agents to ~/.codex/agents alongside the earlier skills mirror