### PR TITLE
feat(frontend-design): intentionality rules for design skills and agents

### DIFF
--- a/agents/react-portfolio-engineer.md
+++ b/agents/react-portfolio-engineer.md
@@ -69,6 +69,19 @@ This agent operates as an operator for React portfolio development, configuring 
 - **Lazy Loading**: Load images below the fold lazily to optimize performance
 - **Touch-Friendly Interactions**: All gallery interactions must work on touch devices (swipe, tap)
 
+### Intentional Portfolio Design Constraints (Always Apply)
+
+Portfolios are the highest-risk surface for generic output. Without specific direction the model defaults to the most common template it saw during training: three-column grids, centered hero with a single CTA, safe pastel palettes, Inter body text. These constraints push every portfolio toward intentionality. Invoke the `distinctive-frontend-design` skill when deeper aesthetic exploration is warranted (unfamiliar genre, new artist voice, brand reset).
+
+- **The work is the hero.** Portfolios promote creative work, not the person explaining the work. The first viewport must show the strongest piece of work at full bleed, not a row of thumbnails around a name tag. No cards in the hero.
+- **One composition per section.** Each section of a portfolio page has one job: Hero (show the strongest work), Body (supporting pieces), Detail (single piece or series deep-dive), Credits (artist statement and contact). Do not mix "about the artist" with "gallery grid" in the same section.
+- **Real work, not Lorem Ipsum, not stock photos.** Work from the actual portfolio images from day one. Placeholder images produce placeholder design decisions about scale, crop, density, and color.
+- **Two typefaces maximum.** Display face for titles, body face for statements. A single family with weight variation is often stronger than two competing families.
+- **One accent color.** Portfolios already carry strong color from the artwork itself. Additional decorative color from the UI fights the work. Let the artwork be the color story.
+- **Motion discipline (2-3 slots).** (1) One hero entrance on load. (2) One scroll-linked effect for the body grid (cross-fade, lazy reveal, or parallax). (3) One interaction effect on image hover or lightbox open. Ambient decorative motion buries the work.
+- **Anti-cliche check.** Before implementing, check against `${CLAUDE_SKILL_DIR}/../../skills/distinctive-frontend-design/references/anti-patterns.json`. Avoid three-column feature grids, rounded cards with drop shadows, centered hero with single CTA, purple gradient on white, Inter + generic blue.
+- **Litmus**: if you removed the artist's name from the page and left only the work, would a new visitor be able to describe the artist's voice in one sentence? If not, the portfolio is not communicating yet.
+
 ### Default Behaviors (ON unless disabled)
 - **Communication Style**:
   - Fact-based progress: Report implementation without self-congratulation
@@ -121,6 +134,9 @@ When asked to perform unavailable actions, explain the limitation and suggest th
 This agent uses the **Implementation Schema**.
 
 **Phase 1: ANALYZE**
+- Confirm real artwork is available (not Lorem Ipsum, not stock photos)
+- Identify the strongest piece for the full-bleed hero
+- Write the narrative brief: visual thesis, content plan, interaction thesis
 - Identify gallery requirements (grid/masonry, filtering, lightbox)
 - Determine image optimization needs (formats, sizes, lazy loading)
 - Plan responsive breakpoints (mobile/tablet/desktop)
@@ -310,6 +326,11 @@ See [shared-patterns/anti-rationalization-core.md](../skills/shared-patterns/ant
 | "All images can be priority loaded" | Defeats lazy loading purpose | Only priority for above-the-fold images |
 | "JPEG is good enough" | WebP/AVIF save 30-50% file size | Serve modern formats with fallback |
 | "Fixed width is simpler than responsive" | Poor mobile experience | Use sizes prop for responsive images |
+| "I'll start with Lorem Ipsum and real images later" | Placeholder content produces placeholder layout decisions | Use the real artwork from day one, even if only a subset |
+| "A hero card with the artist name works fine" | Portfolios must show the work first, not metadata about the work | Full-bleed hero with the strongest piece, name goes elsewhere |
+| "Three-column grid is the standard for galleries" | It is a cliche that signals template output | Justify the layout from the work; grid is one option among many |
+| "Every image hover should have a zoom effect" | Decorative motion competes with the work | Ship one interaction effect for the whole gallery, not per-image flourishes |
+| "Two accent colors let me highlight different categories" | Accent colors compete with the artwork | One accent; use typography weight or position for category hierarchy |
 
 ## Blocker Criteria
 

--- a/agents/ui-design-engineer.md
+++ b/agents/ui-design-engineer.md
@@ -70,6 +70,40 @@ This agent operates as an operator for UI/UX design, configuring Claude's behavi
 - **Responsive by Default**: Mobile-first approach with proper breakpoints (sm: 640px, md: 768px, lg: 1024px, xl: 1280px)
 - **Reduced Motion Support**: Respect prefers-reduced-motion media query for users with vestibular disorders (hard requirement)
 
+### Intentional UI Constraints (Always Apply)
+
+The model defaults to generic output without specific direction: generic card grids, weak visual hierarchies, safe forgettable layouts. These constraints exist to push every UI decision toward intentionality. Apply them even when the user did not ask for them, and use the `distinctive-frontend-design` skill when deeper aesthetic exploration is warranted.
+
+- **Classify the surface type first.** Landing page or app/dashboard? Design rules diverge sharply. Never start implementation until this is decided because every downstream choice depends on it.
+- **Write the narrative brief before code.** Commit three sentences: (1) visual thesis (mood and energy), (2) content plan (named sections, each with one job), (3) interaction thesis (2-3 motion ideas, no more). If these three sentences are not resolved, stop and ask.
+- **Real content over placeholders.** Work from real copy, real product name, real imagery. Placeholder text produces placeholder thinking. If real content is not available, get at minimum the hero headline, product name, and single promise.
+- **Two typefaces maximum** on any page. A single family with weight variation often beats two families. Three families should never ship.
+- **One accent color**, not two. Functional colors (success/warning/error/info) do not count as accents.
+- **One job per section.** Every section answers "what is this section for" in one sentence. If a section is trying to do two things, split it or cut one.
+
+**Landing page rules** (when surface type is landing):
+- One composition in the first viewport, not a grid of parts
+- **No cards in the hero. Ever.** The hero is where the product speaks directly; wrapping it in a rounded card with a drop shadow instantly demotes it to a dashboard tile
+- Full-bleed hero by default, spanning the full viewport width
+- Brand-first: product name is set at hero scale in the display typeface
+- Narrative section sequence: Hero -> Supporting imagery -> Product detail -> Social proof -> Final CTA
+- Hero image litmus: if the page still works after mentally removing the hero image, the image is too weak
+
+**App and dashboard rules** (when surface type is app):
+- Default to Linear-style restraint: calm surface hierarchy, strong typography, tight spacing, few colors
+- Dense but readable information. Operators scan headings, labels, and numbers
+- **Cards only when the card IS the interaction** (a selectable item, sortable row, drag target). No cards for purely visual grouping
+- Avoid dashboard-card mosaics, thick borders on every region, decorative gradients, multiple competing accent colors
+- Motion is minimal and functional: a focus ring, a row expand, a drawer slide. Not ambient flourish
+- App litmus: if an operator scans only the headings, labels, and numbers, can they understand the page immediately?
+
+**Motion discipline (2-to-3 rule)**. Ship two or three intentional motions per page, not ten. Every motion fills one of three slots:
+1. **Entrance**: one hero entrance sequence on load
+2. **Scroll**: one scroll-linked or sticky effect
+3. **Interaction**: one hover, reveal, or layout transition
+
+Framer Motion is the recommended stack for React work, CSS transitions for simple hover/focus. Decorative-only motion litmus: remove the motion mentally. If the user understands the page the same way without it, cut it.
+
 ### Default Behaviors (ON unless disabled)
 - **Communication Style**:
   - Fact-based progress: Report design implementation without self-congratulation
@@ -122,6 +156,9 @@ When asked to perform unavailable actions, explain the limitation and suggest th
 This agent uses the **Implementation Schema**.
 
 **Phase 1: ANALYZE**
+- Classify surface type: landing page or app/dashboard
+- Write the narrative brief: visual thesis, content plan, interaction thesis
+- Confirm real content is available (hero headline, product name, single promise)
 - Identify design requirements (design system, components, responsiveness)
 - Determine accessibility needs (WCAG level, ARIA patterns)
 - Plan responsive breakpoints and mobile-first strategy
@@ -317,6 +354,13 @@ See [shared-patterns/anti-rationalization-core.md](../skills/shared-patterns/ant
 | "Focus outlines are ugly" | Required for keyboard navigation | Provide custom focus styles |
 | "Mobile layout can wait" | Mobile-first prevents issues | Design mobile layout first |
 | "Animations enhance every interaction" | Can trigger vestibular disorders | Respect prefers-reduced-motion |
+| "Placeholder text is fine for now" | Placeholder text produces placeholder thinking | Get real content before building |
+| "A card in the hero gives it structure" | Wrapping the hero in a card instantly demotes it to a dashboard tile | Remove the card, let the product speak directly |
+| "Three typefaces gives hierarchy" | Two typefaces max; three families fight each other | Cut to two families or use weight variation on one |
+| "Two accent colors create visual interest" | Two competing accents dilute hierarchy | Pick one accent, use functional colors separately |
+| "Animating everything feels alive" | Decorative motion is noise; hierarchy is lost | Ship 2-3 intentional motions only |
+| "This dashboard needs more gradients" | Decorative gradients belong on landing pages, not apps | Apply Linear-style restraint for apps |
+| "Cards everywhere in the dashboard" | Cards are only valid when the card IS the interaction | Strip cards unless the user interacts with the card itself |
 
 ## Blocker Criteria
 
@@ -324,12 +368,16 @@ STOP and ask the user (always get explicit approval) before proceeding when:
 
 | Situation | Why Stop | Ask This |
 |-----------|----------|----------|
+| Surface type unclear | Landing page vs app determines every downstream rule | "Is this a landing page or an app/dashboard?" |
+| Real content missing | Placeholder text produces placeholder thinking | "Can you share the real copy, product name, and hero imagery? At minimum the hero headline, product name, and the single promise." |
 | Brand colors unclear | Color choices affect entire design | "Do you have brand colors or should I suggest a palette?" |
 | Dark mode requested but no preference | Different implementation strategies | "System-based dark mode or toggle switch?" |
 | Animation complexity unclear | Simple vs complex animations | "Subtle micro-interactions or prominent animations?" |
 | Accessibility level unclear | AA vs AAA has different requirements | "WCAG 2.1 AA (standard) or AAA (stricter)?" |
 
 ### Never Guess On
+- Surface type (landing page vs app)
+- Real content for the hero section
 - Brand color palette choices
 - Dark mode implementation strategy
 - Animation intensity level

--- a/agents/ui-design-engineer.md
+++ b/agents/ui-design-engineer.md
@@ -360,11 +360,14 @@ See [shared-patterns/anti-rationalization-core.md](../skills/shared-patterns/ant
 | "Two accent colors create visual interest" | Two competing accents dilute hierarchy | Pick one accent, use functional colors separately |
 | "Animating everything feels alive" | Decorative motion is noise; hierarchy is lost | Ship 2-3 intentional motions only |
 | "This dashboard needs more gradients" | Decorative gradients belong on landing pages, not apps | Apply Linear-style restraint for apps |
-| "Cards everywhere in the dashboard" | Cards are only valid when the card IS the interaction | Strip cards unless the user interacts with the card itself |
+| "Cards everywhere in the dashboard" | In apps, cards are only valid when the card IS the interaction (selectable, sortable, drag target); decorative cards create dashboard-card mosaics | In apps, strip cards unless the user interacts with the card itself. On landing pages, the no-cards-in-hero rule applies separately to the first viewport. |
+| "Client brand guide says two accents, but the rule is one" | Defaults bend when the user supplies an explicit brand guide | Follow the brand guide and note the override in the specification document; defaults are defaults, not overrides of stated client identity |
 
 ## Blocker Criteria
 
 STOP and ask the user (always get explicit approval) before proceeding when:
+
+**Skip-if-answered rule**: If the user's original request already answers any of these questions, do not re-ask. The blocker table exists to close gaps, not to gate every request on ceremony. For example, if the request is "build a landing page for Acme with hero headline X", surface type and product name are already answered and the agent proceeds without re-asking.
 
 | Situation | Why Stop | Ask This |
 |-----------|----------|----------|

--- a/skills/distinctive-frontend-design/SKILL.md
+++ b/skills/distinctive-frontend-design/SKILL.md
@@ -30,6 +30,18 @@ Optional capabilities (off unless explicitly enabled by the user): design system
 
 ## Instructions
 
+### Vocabulary
+
+These terms appear throughout the phases as hard rules. Read them once before Phase 1 so the rules do not feel like jargon when they gate your work.
+
+- **Hero**: The first viewport section a visitor sees on page load. On landing pages it is the single largest decision in the design.
+- **Full-bleed**: Spanning the entire viewport width with no max-width container, sidebar, or padding. A full-bleed hero touches both edges of the browser.
+- **Narrative brief**: Three short sentences written before any code: visual thesis (mood and energy), content plan (named sections in order, one job each), interaction thesis (two or three motion ideas). See Phase 1 Step 4 for the full definition and examples.
+- **Surface type**: Whether the page is a landing page (marketing, promotion, portfolio intro) or an app/dashboard (operator tools, data consoles, admin surfaces). The two types take different rule sets and must never be mixed.
+- **Linear-style restraint**: A reference to the Linear project management tool's dashboard aesthetic. Calm surface hierarchy, strong typography, tight spacing, very few colors, no decorative ornament. The default posture for apps and dashboards.
+- **Decorative-only motion**: Motion that exists purely for visual interest. It does not communicate state, guide attention, or reveal hidden content. Decorative-only motion fails the Phase 4 litmus and should be cut.
+- **Brand override**: Any of these rules bend when the user supplies an explicit brand guide that contradicts the default (two accent colors, three typefaces, cards in hero for a specific identity reason). In that case, follow the brand guide and note the override in the specification document. Defaults are defaults, not overrides of stated client identity.
+
 ### Phase 1: Context Discovery
 
 **Goal**: Understand the project deeply before making any aesthetic decisions.
@@ -44,7 +56,7 @@ Optional capabilities (off unless explicitly enabled by the user): design system
 6. **Constraints**: Accessibility requirements, performance budgets, existing brand elements to preserve?
 7. **Tech stack**: React, Vue, vanilla HTML/CSS, Next.js, framework preferences?
 8. **Real content**: Gather the actual copy, real product name, real imagery, real product context. Placeholder text produces placeholder thinking. If final content is not yet available, secure at minimum the hero headline, product name, and the single promise you want the first viewport to convey.
-9. **Previous projects**: Any recent frontend work? (to avoid reusing the same aesthetic choices -- variety across projects is mandatory)
+9. **Previous projects**: Any recent frontend work? Variety across projects is mandatory, so check for choices that would overlap with recent work and avoid them.
 
 **Step 2: Define 3-5 distinct aesthetic directions** using `references/color-inspirations.json` and `references/font-catalog.json` as starting points. Providing multiple directions prevents anchoring on a first instinct, which is the primary source of generic "AI slop" output.
 
@@ -65,7 +77,9 @@ Example directions and what they mean:
 
 The narrative brief is the design brief. Every later phase is expected to be consistent with it. If a phase is producing choices that contradict the visual thesis or content plan, stop and revise the brief rather than drifting the design.
 
-**Gate**: Aesthetic direction defined with contextual justification linking project purpose, audience, and emotion to chosen direction. Narrative brief written with visual thesis, content plan, and interaction thesis. Do NOT proceed without both gate items passing.
+**Gate**: Aesthetic direction defined with contextual justification linking project purpose, audience, and emotion to chosen direction. Narrative brief from Step 4 written (visual thesis, content plan, interaction thesis). Do NOT proceed without both gate items passing.
+
+**Skip-if-answered**: If the user's original request already provides the surface type, the product name, and a clear promise for the hero, treat those answers as already gathered. Do not interrogate the user for information they have already supplied. The context-gathering questions exist to close gaps, not to gate every request on ceremony.
 
 ### Phase 2: Typography Selection
 

--- a/skills/distinctive-frontend-design/SKILL.md
+++ b/skills/distinctive-frontend-design/SKILL.md
@@ -37,12 +37,14 @@ Optional capabilities (off unless explicitly enabled by the user): design system
 **Step 1: Read and follow the repository CLAUDE.md**, then gather context by asking (adapt based on what is already known):
 
 1. **Purpose**: What is this frontend for? (portfolio, SaaS product, creative showcase, documentation, landing page)
-2. **Audience**: Who will use it? (developers, artists, enterprise users, general public, specific demographics)
-3. **Emotion**: What should users feel? (professional, playful, sophisticated, rebellious, calm, energetic)
-4. **Cultural context**: Any geographic, cultural, or thematic associations? (Japanese minimalism, industrial, retro, academic)
-5. **Constraints**: Accessibility requirements, performance budgets, existing brand elements to preserve?
-6. **Tech stack**: React, Vue, vanilla HTML/CSS, Next.js, framework preferences?
-7. **Previous projects**: Any recent frontend work? (to avoid reusing the same aesthetic choices -- variety across projects is mandatory)
+2. **Surface type**: Landing page or app/dashboard? Design rules diverge sharply. Landing pages lean on a full-bleed hero and narrative sequence. Apps and dashboards lean on Linear-style calm surfaces, strong typography, few colors, and dense readable information. Classify this up front because every downstream decision depends on it.
+3. **Audience**: Who will use it? (developers, artists, enterprise users, general public, specific demographics)
+4. **Emotion**: What should users feel? (professional, playful, sophisticated, rebellious, calm, energetic)
+5. **Cultural context**: Any geographic, cultural, or thematic associations? (Japanese minimalism, industrial, retro, academic)
+6. **Constraints**: Accessibility requirements, performance budgets, existing brand elements to preserve?
+7. **Tech stack**: React, Vue, vanilla HTML/CSS, Next.js, framework preferences?
+8. **Real content**: Gather the actual copy, real product name, real imagery, real product context. Placeholder text produces placeholder thinking. If final content is not yet available, secure at minimum the hero headline, product name, and the single promise you want the first viewport to convey.
+9. **Previous projects**: Any recent frontend work? (to avoid reusing the same aesthetic choices -- variety across projects is mandatory)
 
 **Step 2: Define 3-5 distinct aesthetic directions** using `references/color-inspirations.json` and `references/font-catalog.json` as starting points. Providing multiple directions prevents anchoring on a first instinct, which is the primary source of generic "AI slop" output.
 
@@ -55,7 +57,15 @@ Example directions and what they mean:
 
 **Step 3: Output** `aesthetic_direction.json` with chosen direction(s) and contextual justification. Every direction must link back to project purpose, audience, and emotion -- context-driven justification is what separates distinctive design from arbitrary choices. See `references/implementation-examples.md` for template.
 
-**Gate**: Aesthetic direction defined with contextual justification linking project purpose, audience, and emotion to chosen direction. Do NOT proceed without this gate passing.
+**Step 4: Write the narrative brief**. Before any code or visual exploration, commit three sentences to the page:
+
+1. **Visual thesis**: One sentence describing the mood and energy of the page. Example: "A calm, sun-warmed product page for a pottery studio where the ceramics themselves are the loudest element."
+2. **Content plan**: Name the sections in order. For landing pages use Hero, Supporting imagery, Product detail, Social proof, Final CTA. For apps use the top navigation targets and what lives under each. Assign one job to each section, not two.
+3. **Interaction thesis**: Two or three motion ideas. No more. Examples: "hero headline reveals on load with a 600ms stagger", "sticky product image follows the scroll through the detail section", "testimonials cross-fade on hover".
+
+The narrative brief is the design brief. Every later phase is expected to be consistent with it. If a phase is producing choices that contradict the visual thesis or content plan, stop and revise the brief rather than drifting the design.
+
+**Gate**: Aesthetic direction defined with contextual justification linking project purpose, audience, and emotion to chosen direction. Narrative brief written with visual thesis, content plan, and interaction thesis. Do NOT proceed without both gate items passing.
 
 ### Phase 2: Typography Selection
 
@@ -75,6 +85,8 @@ Selection criteria:
 - Creates clear hierarchy (Display/Heading + Body, or single font with weight variation)
 - Is unexpected -- avoid first instinct, explore deeper in the catalog
 - Has not been used in recent projects
+- **Two typefaces maximum**. If the pairing needs a third family to feel complete, something upstream is wrong. A single family with weight and size variation beats three families fighting each other.
+- **Brand first on branded pages**. When the page is promoting a named product or brand, the product name must be set at hero level in the display face. The product name is not a label, it is the loudest element in the first viewport.
 
 **Step 3: Validate**
 
@@ -111,6 +123,8 @@ Select an inspiration source that resonates with the project context from Phase 
 
 Colors distributed evenly without a clear dominant create visual chaos. The 60/30/10 ratio is non-negotiable because without it, no coherent aesthetic emerges.
 
+**One accent color, not two.** The accent slot is for a single hue. If a second accent seems necessary, it is almost always either (a) a functional color (error/success/warning/info, which belongs in the Functional group), or (b) a weight variation of the dominant or secondary. Two competing accents dilute the hierarchy and signal a page that does not know what it wants the user to look at.
+
 **Step 3: Check against anti-patterns** in `references/anti-patterns.json`:
 - No purple (#8B5CF6, #A855F7) as accent on white background -- the most cliched color scheme in modern web design, signaling generic SaaS template
 - No evenly distributed colors without clear dominance
@@ -133,17 +147,25 @@ Manually verify: no cliche patterns, clear 60/30/10 dominance ratio, sufficient 
 
 **Goal**: Design choreography for high-impact moments only. Restraint is a feature -- animating everything dilutes impact and signals lack of intentionality.
 
-**Step 1: Identify high-impact moments** worth investing animation effort:
-- Initial page load (hero section reveal)
-- Major state transitions (empty to filled, loading to success)
-- Feature showcases (pricing reveal, testimonial carousel)
-- User achievements (form submission success, milestone reached)
+**The 2-to-3 rule**. Ship two or three intentional motions per page, not ten. Motion creates presence and hierarchy. Too much motion creates noise. The interaction thesis from Phase 1 should already name the three slots; this phase choreographs them in detail.
 
-Moments NOT worth animating (resist the urge):
+**Step 1: Fill the three motion slots**. Pick one from each slot, not five from slot A:
+
+1. **Entrance slot**: One entrance sequence in the hero. The hero headline, the hero media, or a staggered reveal of both. Happens once, on load.
+2. **Scroll slot**: One scroll-linked or sticky effect. A sticky product image following the scroll, a parallax depth layer, a reveal-on-scroll sequence for the supporting sections.
+3. **Interaction slot**: One hover, reveal, or layout transition. A hover effect on the primary CTA, a card that expands on click, a tab that slides under the label.
+
+If a proposed motion does not fit into one of these three slots, it is extra noise and should be cut.
+
+**Moments NOT worth animating** (resist the urge):
 - Every hover state on every element
 - Every button click feedback
 - Low-importance UI elements (footers, metadata)
 - Background elements that distract from content
+
+**Decorative-only litmus**. For every motion in the design, ask: does removing this motion change what the user understands about the page? If the answer is no, the motion is decorative and should be cut. Motion is a tool for establishing hierarchy and presence, not a tool for making the page feel "alive".
+
+**Recommended stack**: Framer Motion for React, CSS transitions for simple hover/focus. Do not mix five animation libraries on one page.
 
 **Step 2: Design choreography** for each identified moment. Reference `references/animation-patterns.md` for battle-tested patterns:
 - Orchestrated page load with staggered reveal
@@ -169,9 +191,20 @@ Duration by scope:
 
 **Gate**: At least one high-impact moment has a fully defined choreography including element order, easing curves, and timing values. Do NOT proceed without this.
 
-### Phase 5: Background & Atmosphere
+### Phase 5: Hero Composition, Background & Atmosphere
 
-**Goal**: Create depth and mood through layered effects. Flat solid-color backgrounds fail this phase because they produce no atmospheric depth -- every surface needs at least two layers.
+**Goal**: Construct the first viewport as a single composition, then add depth and mood through layered effects. Flat solid-color backgrounds fail this phase because they produce no atmospheric depth -- every surface needs at least two layers.
+
+**Step 0: Hero composition rules** (landing pages). The first viewport must read as one composition, not a grid of parts. Apply these hard rules before any background work:
+
+- **One composition**. The first screen the user sees must read as a single unified image. If a new user cannot describe the hero in one sentence, it is not a composition yet.
+- **No cards in the hero. Ever.** The hero is where the product speaks directly. Putting the hero content inside a rounded card with a drop shadow instantly converts a landing page into a generic dashboard tile.
+- **Full-bleed hero by default**. The hero spans the full viewport width on landing pages. No content-width containers, no max-width wrapping, no sidebars stealing from the hero.
+- **Brand-first composition**. On branded pages, the product name must be set at hero scale in the display typeface from Phase 2. The product name is the loudest thing in the first viewport.
+- **One job per section**. The hero has one purpose, one takeaway, one CTA intent. If the hero is promising two things, cut one.
+- **Hero image litmus**. Remove the hero image mentally. Does the page still work without it? If yes, the image was too weak and needs to be replaced, not decorated.
+
+Apps and dashboards follow different rules; see "App vs Landing Page Rules" below.
 
 **Step 1: Choose technique** from `references/background-techniques.md` based on aesthetic direction:
 - **Layered radial gradients**: Atmospheric depth with soft colored glows (sophisticated, landing pages)
@@ -189,6 +222,30 @@ Duration by scope:
 
 **Gate**: Background uses at least 2 layers creating visual depth and atmospheric mood. Solid single-color backgrounds fail this gate.
 
+### App vs Landing Page Rules
+
+The surface type classified in Phase 1 determines which rule set governs layout. Mixing the two rule sets is the fastest way to produce a page that feels generic in one direction and cluttered in the other.
+
+**Landing page rules** (marketing, product promotion, portfolio intro):
+- Full-bleed hero, single composition, brand-first scale
+- Narrative section sequence: Hero → Supporting imagery → Product detail → Social proof → Final CTA
+- Each section does one job; cut the section if it cannot decide on one takeaway
+- Atmospheric backgrounds encouraged (gradients, textures, layered depth)
+- Motion used to reveal and orchestrate the narrative
+
+**App and dashboard rules** (operator tools, data consoles, admin surfaces):
+- Default to Linear-style restraint: calm surface hierarchy, strong typography, tight spacing
+- Few colors. Usually one accent, one or two functional hues, the rest is neutral
+- Dense but readable information. Operators scan headings, labels, and numbers
+- Cards only when the card is the interaction (a selectable item, a sortable row, a drag target). No cards for purely visual grouping
+- Avoid dashboard-card mosaics where every region is wrapped in a bordered box
+- Avoid decorative gradients, thick borders on every region, and multiple competing accent colors
+- Motion is minimal and functional: a focus ring, a row expand, a drawer slide. Not ambient flourish
+
+**App litmus test**. If an operator scans only the headings, labels, and numbers on the page, can they understand what the page is showing them immediately? If they need to read paragraphs of body copy or decode ornamental UI to figure out what they are looking at, the page is failing its job.
+
+**Landing litmus test**. If the user spends three seconds on the first viewport, can they name the product and describe the promise in one sentence? If not, the hero is failing its job regardless of how polished it looks.
+
 ### Phase 6: Validation & Scoring
 
 **Goal**: Objective quality assessment before any finalization. Validation must run before delivering specifications -- skipping it means flaws compound through every downstream implementation decision.
@@ -204,10 +261,18 @@ Duration by scope:
 - No banned fonts in selection or fallback stacks
 - No cliche color schemes detected
 - Font pairing uniqueness versus recent projects
+- Two typefaces maximum in the selected pairing
 - Color dominance ratio meets 60/30/10 target
+- Exactly one accent color in the accent slot (functional colors do not count)
 - Sufficient contrast ratios (WCAG AA minimum)
 - Animation strategy is defined (not missing)
+- Motion count fits the 2-to-3 slot rule (entrance, scroll, interaction)
+- Every motion passes the decorative-only litmus
 - Background atmosphere is present (not flat)
+- Narrative brief is present (visual thesis, content plan, interaction thesis)
+- Surface type classified as landing page or app, with matching rule set applied
+- For landing pages: hero reads as one composition, no cards in hero, full-bleed hero confirmed
+- For apps: Linear-style restraint applied, no decorative gradients or card mosaics
 
 **Step 3: Address issues** -- if overall score < 80:
 1. Review each failed check in the report

--- a/skills/distinctive-frontend-design/references/anti-patterns.json
+++ b/skills/distinctive-frontend-design/references/anti-patterns.json
@@ -39,6 +39,33 @@
     "Rounded card with drop shadow",
     "Pill-shaped buttons with gradient",
     "Floating action button (FAB)",
-    "Hamburger menu on desktop"
-  ]
+    "Hamburger menu on desktop",
+    "Cards in hero section on landing pages",
+    "Dashboard card mosaic with every region bordered",
+    "Decorative gradients on app/dashboard surfaces",
+    "Multiple competing accent colors on one page",
+    "More than two typefaces on one page",
+    "More than three distinct motion types on one page",
+    "Ambient decorative motion with no informational role"
+  ],
+  "hero_composition_rules": {
+    "description": "Landing page hero rules. Violations should be flagged and the hero reconstructed.",
+    "rules": [
+      "One composition: the first viewport reads as a single unified image, not a grid of parts",
+      "No cards in the hero: the hero is where the product speaks directly",
+      "Full-bleed hero: the hero spans the full viewport width on landing pages",
+      "Brand first: product name is set at hero scale in the display typeface",
+      "One job per section: hero has one purpose, one takeaway, one CTA intent",
+      "Hero image litmus: if the page still works with the hero image removed, the image is too weak"
+    ]
+  },
+  "motion_discipline": {
+    "description": "Ship 2-3 motions per page, not 10. Every motion fills one of three slots.",
+    "slots": [
+      "Entrance: one hero entrance sequence on page load",
+      "Scroll: one scroll-linked or sticky effect",
+      "Interaction: one hover, reveal, or layout transition"
+    ],
+    "litmus": "Remove the motion mentally. Does the user understand the page differently? If no, the motion is decorative and should be cut."
+  }
 }


### PR DESCRIPTION
## Summary

Integrates constraint-driven guidance from recent GPT-5.4 / Codex frontend design best practices into the three frontend-facing components of the toolkit. The core insight: every model defaults to generic output (card grids, weak hierarchies, safe layouts) when direction is thin; hard constraints push every decision toward intentionality.

**Files changed (4):**
- `skills/distinctive-frontend-design/SKILL.md` — main methodology update
- `skills/distinctive-frontend-design/references/anti-patterns.json` — new cliche entries + hero/motion data blocks
- `agents/ui-design-engineer.md` — new hardcoded behaviors block and tables
- `agents/react-portfolio-engineer.md` — new portfolio constraints block and tables

## Key rules introduced

**Pre-work (Phase 1 additions):**
- Classify surface type first: landing page or app/dashboard (rules diverge sharply)
- Write a narrative brief before code: visual thesis, content plan, interaction thesis
- Gather real content, not placeholders (at minimum: hero headline, product name, single promise)

**Typography & color:**
- Two typefaces maximum per page
- One accent color only (functional colors separate)
- Brand-first hero scale on branded pages

**Hero composition (landing pages):**
- One composition in the first viewport
- No cards in the hero, ever
- Full-bleed hero by default
- One job per section
- Hero image litmus: remove it mentally; if the page still works, the image was too weak

**Motion discipline:**
- Ship 2-to-3 motions per page, not 10
- Three slots: one entrance (hero), one scroll-linked, one interaction
- Decorative-only litmus: if removing the motion does not change comprehension, cut it

**Apps vs landing pages:**
- Apps default to Linear-style restraint: calm surface hierarchy, strong typography, few colors, dense readable info
- Cards only when the card IS the interaction
- Avoid dashboard-card mosaics, decorative gradients, multiple competing accents

## Test plan
- [x] \`python3 scripts/validate-references.py --agent ui-design-engineer\` passes (4/4 refs, 0 issues)
- [x] \`python3 scripts/validate-references.py --agent react-portfolio-engineer\` passes (3/3 refs, 0 issues)
- [x] anti-patterns.json is valid JSON
- [x] SKILL.md reads coherently phase-to-phase after edits
- [x] No em-dashes introduced in new content (per toolkit style rule)
- [ ] GitHub Actions \`Tests / lint\` passes
- [ ] GitHub Actions \`Tests / test\` passes