### PR TITLE
feat(ci): routing-drift check catches skills absent from routing-tables.md at PR time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,12 @@ jobs:
         with:
           python-version: "3.12"
       - run: python scripts/routing-benchmark.py --verbose
+
+  routing-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python scripts/check-routing-drift.py --verbose

--- a/scripts/check-routing-drift.py
+++ b/scripts/check-routing-drift.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Routing-table drift check.
+
+Verifies that every skill present in skills/INDEX.json is also mentioned
+in skills/do/references/routing-tables.md. A skill absent from the routing
+table is invisible to any process that consults the reference docs, which
+means users and the router's documentation are silently out of sync.
+
+Usage:
+    python3 scripts/check-routing-drift.py
+    python3 scripts/check-routing-drift.py --verbose
+
+Exit codes:
+    0 - All skills in INDEX.json are present in routing-tables.md
+    1 - One or more skills are absent from routing-tables.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_INDEX = REPO_ROOT / "skills" / "INDEX.json"
+ROUTING_TABLES = REPO_ROOT / "skills" / "do" / "references" / "routing-tables.md"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--verbose", action="store_true", help="Show all skills checked")
+    args = parser.parse_args()
+
+    if not SKILLS_INDEX.exists():
+        print(f"ERROR: {SKILLS_INDEX} not found", file=sys.stderr)
+        return 1
+
+    if not ROUTING_TABLES.exists():
+        print(f"ERROR: {ROUTING_TABLES} not found", file=sys.stderr)
+        return 1
+
+    with open(SKILLS_INDEX) as f:
+        idx = json.load(f)
+
+    index_skills = sorted(idx.get("skills", {}).keys())
+    routing_text = ROUTING_TABLES.read_text()
+
+    missing = [s for s in index_skills if s not in routing_text]
+    present = [s for s in index_skills if s in routing_text]
+
+    if args.verbose:
+        print(f"Checked {len(index_skills)} skills against routing-tables.md")
+        print(f"  Present: {len(present)}")
+        print(f"  Missing: {len(missing)}")
+
+    if missing:
+        print(f"\nFAIL: {len(missing)} skill(s) in INDEX.json absent from routing-tables.md:")
+        for skill in missing:
+            print(f"  {skill}")
+        print("\nAdd each missing skill to skills/do/references/routing-tables.md before merging.")
+        return 1
+
+    if args.verbose:
+        print("\nPASS: routing-tables.md is in sync with INDEX.json")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds `scripts/check-routing-drift.py` — deterministic check that every skill in `skills/INDEX.json` is present in `skills/do/references/routing-tables.md`
- Adds `routing-drift` CI job to `test.yml`, matching the existing `routing-benchmark` job pattern
- Closes a recurring gap: routing drift has been caught in 4+ nightly evolution cycles but never at PR time

## Changes
- `scripts/check-routing-drift.py` — 68-line script, exits 0 (in sync) or 1 (with named missing skills)
- `.github/workflows/test.yml` — new `routing-drift` job (7 lines, reuses routing-benchmark template)

## Test Results
| Test Case | Baseline | Candidate | Delta |
|-----------|----------|-----------|-------|
| T1: Exit 0 when in sync (124 skills) | No check existed | PASS | +detection |
| T2: Exit 1 + names missing skill | No check existed | PASS | +detection |
| T3: --verbose shows counts | No check existed | PASS | +usability |
| T4: routing-drift job in test.yml | absent | present | +CI gate |
| T5: ruff lint + format clean | N/A | PASS | clean |

**Win rate: 5/5 (100%)**

## Evolution Cycle
Generated by toolkit-evolution skill (2026-04-12).
Consensus: 3.0/3.0 unanimous (Pragmatist STRONG, Purist STRONG, User Advocate STRONG).