### PR TITLE
feat(settings): recommend CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,8 @@
   "effortLevel": "max",
   "env": {
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
-    "CLAUDE_CODE_EFFORT_LEVEL": "max"
+    "CLAUDE_CODE_EFFORT_LEVEL": "max",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000"
   },
   "attribution": {
     "commit": "",

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -276,6 +276,19 @@ docs/              ← This documentation
 
 ---
 
+## Recommended Settings
+
+Environment variables set in `.claude/settings.json` under `"env"`:
+
+| Variable | Recommended Value | Why |
+|----------|-------------------|-----|
+| `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | `400000` | Prompt cache TTL is 5 minutes (not 1 hour). Larger conversations miss cache frequently, making each turn reprocess the full context at full cost. Compacting at 400k keeps conversations in the cache-friendly zone. ([anthropics/claude-code#45756](https://github.com/anthropics/claude-code/issues/45756#issuecomment-4231739206)) |
+| `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` | `1` | Fixed thinking budget preferred over adaptive (A/B tested, see memory). |
+
+**Context on `AUTO_COMPACT_WINDOW`:** Anthropic's prompt caching currently uses a 5-minute TTL. When conversations grow large and cache entries expire between turns, each API call re-processes the full conversation at uncached token prices. Even though Claude supports a 1M token context window, using the full window without cache hits is prohibitively expensive. Setting `AUTO_COMPACT_WINDOW=400000` triggers compaction earlier, keeping the active context within a size that cache hits can cover. Anthropic is aware of this issue and exploring improvements. Credit: [@bcherny](https://github.com/bcherny).
+
+---
+
 ## Getting Help
 
 - **Don't know what to use?** → `/do [what you want]`

--- a/docs/compaction-reference.md
+++ b/docs/compaction-reference.md
@@ -67,3 +67,20 @@ session-keyed in `/tmp`).
 
 The counter tracks only Edit and Write calls. Bash-heavy sessions accumulate
 context faster than the counter reflects — use judgment in those cases.
+
+---
+
+## Prompt Cache TTL and Auto-Compact Window
+
+Anthropic's prompt cache has a **5-minute TTL** (not 1 hour as originally expected).
+When conversations grow large, cache entries expire between turns and each API call
+reprocesses the full context at uncached token prices. Even with a 1M token context
+window, using the full window without cache hits is prohibitively expensive.
+
+**Recommendation:** Set `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000` in settings to
+trigger compaction earlier, keeping active context within the cache-friendly zone.
+This is configured in `.claude/settings.json` under `env`.
+
+Anthropic is aware of the cache miss frequency issue and exploring improvements.
+See [anthropics/claude-code#45756](https://github.com/anthropics/claude-code/issues/45756#issuecomment-4231739206)
+for details. Credit: [@bcherny](https://github.com/bcherny).


### PR DESCRIPTION
## Summary

- Adds `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000` to project `.claude/settings.json`
- Documents the recommendation in `docs/REFERENCE.md` (new Recommended Settings section) and `docs/compaction-reference.md` (new Prompt Cache TTL section)
- Prompt cache TTL is 5 minutes, not 1 hour — large conversations miss cache frequently, making each turn reprocess at uncached prices. Compacting at 400k keeps context in the cache-friendly zone.

Ref: https://github.com/anthropics/claude-code/issues/45756#issuecomment-4231739206
Credit: @bcherny (Anthropic)

## Test plan

- [x] Setting added to `.claude/settings.json`
- [x] Documentation added to `docs/REFERENCE.md` with link to issue
- [x] Documentation added to `docs/compaction-reference.md` with technical context
- [ ] CI passes (lint + tests)