### PR TITLE
fix(refs): replace dangling synthesis-techniques.md link

### DIFF
--- a/agents/research-coordinator-engineer/references/query-classification.md
+++ b/agents/research-coordinator-engineer/references/query-classification.md
@@ -190,4 +190,4 @@ grep -il "compare\|vs\.\|versus\|difference between" research/*/plan.md
 ## See Also
 
 - `delegation-patterns.md` — How to write subagent instructions once query type is classified
-- `synthesis-techniques.md` — How synthesis approach differs by query type
+- `error-catalog.md` — Common failures when query type is misclassified


### PR DESCRIPTION
## Summary

- Replace nonexistent `synthesis-techniques.md` See Also link in `query-classification.md` with `error-catalog.md` (which exists and is relevant)
- Cleanup from PR #379 where this fix was pushed after the auto-merge

## Test plan

- [x] `python3 scripts/validate-references.py --agent research-coordinator-engineer` passes