### PR TITLE
fix(enrichment): per-run branch names prevent stacking

### DIFF
--- a/scripts/reference-enrichment-cron.sh
+++ b/scripts/reference-enrichment-cron.sh
@@ -134,6 +134,7 @@ echo "Audit found ${TARGETS_COUNT} gap(s). Processing up to ${MAX_TARGETS}: ${TA
 export ENRICH_REPO_DIR="$REPO_DIR"
 export ENRICH_TARGETS="$TARGETS_TRIMMED"
 export ENRICH_DATE="$(date +%Y-%m-%d)"
+export ENRICH_RUN_ID="$(date +%Y-%m-%d-%H%M)"
 export ENRICH_MAX_TARGETS="$MAX_TARGETS"
 export ENRICH_DRY_RUN_MODE="no"
 if [ -z "$EXECUTE" ]; then
@@ -148,7 +149,7 @@ if [ ! -f "$PROMPT_TEMPLATE" ]; then
     exit 1
 fi
 
-PROMPT=$(envsubst '${ENRICH_REPO_DIR} ${ENRICH_TARGETS} ${ENRICH_DATE} ${ENRICH_MAX_TARGETS} ${ENRICH_DRY_RUN_MODE}' < "$PROMPT_TEMPLATE")
+PROMPT=$(envsubst '${ENRICH_REPO_DIR} ${ENRICH_TARGETS} ${ENRICH_DATE} ${ENRICH_RUN_ID} ${ENRICH_MAX_TARGETS} ${ENRICH_DRY_RUN_MODE}' < "$PROMPT_TEMPLATE")
 
 cd "$REPO_DIR"
 

--- a/skills/reference-enrichment/enrichment-prompt.md
+++ b/skills/reference-enrichment/enrichment-prompt.md
@@ -5,6 +5,7 @@ You are running as an autonomous hourly process to improve the toolkit's domain 
 ## Context
 
 - **Date:** ${ENRICH_DATE}
+- **Run ID:** ${ENRICH_RUN_ID}
 - **Repository:** ${ENRICH_REPO_DIR}
 - **Targets:** ${ENRICH_TARGETS}
 - **Max targets:** ${ENRICH_MAX_TARGETS}
@@ -28,7 +29,7 @@ Print a summary and exit.
 
 1. Check for existing open enrichment PRs: `gh pr list --search "enrich/refs" --state open --json number | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d))"`
 2. If 5 or more enrichment PRs are already open, log "Too many open enrichment PRs (>=5), skipping to avoid accumulation" and exit
-3. Create a feature branch: `git checkout -b enrich/refs-${ENRICH_DATE}`
+3. Create a feature branch: `git checkout -b enrich/refs-${ENRICH_RUN_ID}`
 
 ### Phase 2: Enrich Each Target
 
@@ -77,7 +78,7 @@ This gate prevents reference bloat — only references that add concrete, signal
 1. Stage only the files you created/modified (reference files, agent/skill body updates)
 2. Commit with: `feat(refs): {agent-name} — {brief description of what was added} (Level {before}→{after})`
    - Example: `feat(refs): prometheus-grafana-engineer — PromQL patterns, alerting rules, cardinality management (Level 0→3)`
-3. Push: `git push -u origin enrich/refs-${ENRICH_DATE}`
+3. Push: `git push -u origin enrich/refs-${ENRICH_RUN_ID}`
 4. Create PR and auto-merge: `gh pr create --title "feat(refs): {agent-name} (Level {before}→{after})" --body "..."` then `gh pr merge --squash --auto --delete-branch`
    - PR title should describe WHAT was enriched, not just the date
    - PR body should include: targets processed, level before/after for each, list of new reference files


### PR DESCRIPTION
## Summary

- Branch names now include HHMM: `enrich/refs-2026-04-13-0407` instead of `enrich/refs-2026-04-13`
- Each hourly cron run gets its own branch and PR, preventing merge conflicts from commit stacking
- Existing guards (MAX_OPEN_PRS=5, completion journal, daily budget cap) naturally limit accumulation

## Root cause

The hourly enrichment cron used `date +%Y-%m-%d` for branch names. Multiple runs per day pushed to the same branch. When a PR was open and a new run pushed additional commits, subsequent merges to main created conflicts on the next run.

## Changes

| File | Change |
|------|--------|
| `scripts/reference-enrichment-cron.sh` | Add `ENRICH_RUN_ID` with HHMM precision, pass through envsubst |
| `skills/reference-enrichment/enrichment-prompt.md` | Use `ENRICH_RUN_ID` for branch name in checkout + push |

## Test plan

- [x] Shell syntax validates (`bash -n`)
- [x] `ruff check` passes
- [x] `envsubst` variable list includes `ENRICH_RUN_ID`
- [x] `enrich/refs` search pattern in open-PR guard still matches new naming
- [x] `enrich/*` glob in post-run cleanup still matches new naming