### PR TITLE
feat(motion-pipeline): add CPU-only motion data processing skill

### DIFF
--- a/scripts/bake-bvh-to-glb.py
+++ b/scripts/bake-bvh-to-glb.py
@@ -51,13 +51,13 @@ _PIPELINE_PATH = Path(__file__).parent / "motion-pipeline.py"
 # Scale BVH positions from cm to metres (same convention as generate-move-ts.py)
 _BVH_SCALE = 0.01
 
-# Walk cycle: frames 31-134 (one full stride, left foot contact to left foot contact)
-_WALK_START = 31
-_WALK_END = 135  # exclusive: range [31, 134] = 104 frames
+# Walk cycle: frames 100-160 (symmetric stride, both feet lift ~15cm)
+_WALK_START = 100
+_WALK_END = 161  # exclusive: 61 frames, roughly one symmetric stride
 
-# Idle: frames 31-60 (character in a static stance, slight weight on left foot)
-_IDLE_START = 31
-_IDLE_END = 61  # exclusive: 30 frames
+# Idle: frames 0-30 (first 31 frames where the character is settling into stance)
+_IDLE_START = 0
+_IDLE_END = 31  # exclusive: 31 frames
 
 # Subsample targets (keyframes written into the GLB)
 _WALK_KEYFRAMES = 64  # ~1 frame per 1.6 BVH frames — smooth but compact
@@ -609,7 +609,7 @@ def bake(
     )
     print(f"GLB bind pose: {non_identity}/{len(glb_bind_quats)} bones have non-identity rotations")
 
-    # --- Extract walk cycle (frames 31-134, 104 BVH frames) ---
+    # --- Extract walk cycle (frames 100-160, 61 BVH frames) ---
     walk_range = range(_WALK_START, _WALK_END)
     print(f"\nExtracting walk cycle: frames {_WALK_START}-{_WALK_END - 1} ({len(walk_range)} frames)")
     walk_quats_full, walk_bvh_bind = _extract_local_quats(motion, walk_range)

--- a/scripts/bake-bvh-to-glb.py
+++ b/scripts/bake-bvh-to-glb.py
@@ -1,0 +1,768 @@
+#!/usr/bin/env python3
+"""Bake real walking animation from BVH mocap data into ScottHall.glb.
+
+Replaces single-frame bind-pose animations with actual motion:
+- Clip 0 (idle): subtle weight-shift from BVH standing pose
+- Clip 1 (walk): one full stride cycle extracted from walking BVH
+
+Usage:
+    python3 scripts/bake-bvh-to-glb.py [--bvh PATH] [--glb PATH] [--out PATH] [--dry-run]
+
+The script imports motion-pipeline.py via importlib (same pattern as
+generate-move-ts.py) to parse BVH data without subprocess overhead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+import shutil
+import struct
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pygltflib
+from scipy.spatial.transform import Rotation as ScipyRotation
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BVH_PATH = Path("/tmp/ai4animationpy/Demos/BVHLoading/WalkingStickLeft_BR.bvh")
+_GLB_PATH = Path("/home/feedgen/road-to-aew/public/assets/prototype/models/ScottHall.glb")
+_PIPELINE_PATH = Path(__file__).parent / "motion-pipeline.py"
+
+# Scale BVH positions from cm to metres (same convention as generate-move-ts.py)
+_BVH_SCALE = 0.01
+
+# Walk cycle: frames 31-134 (one full stride, left foot contact to left foot contact)
+_WALK_START = 31
+_WALK_END = 135  # exclusive: range [31, 134] = 104 frames
+
+# Idle: frames 31-60 (character in a static stance, slight weight on left foot)
+_IDLE_START = 31
+_IDLE_END = 61  # exclusive: 30 frames
+
+# Subsample targets (keyframes written into the GLB)
+_WALK_KEYFRAMES = 64  # ~1 frame per 1.6 BVH frames — smooth but compact
+_IDLE_KEYFRAMES = 30  # 30 frames at ~1fps => 30-second slow bob
+
+# Clip names in the existing GLB (Three.js code references these by name)
+_IDLE_CLIP_NAME = "Scott Hall Rigged|Armature"
+_WALK_CLIP_NAME = "Scott Hall Rigged|Armature.001"
+
+# glTF accessor component types and element types
+_FLOAT = 5126  # GL_FLOAT
+_SCALAR = "SCALAR"
+_VEC4 = "VEC4"
+_VEC3 = "VEC3"
+
+# Animation interpolation
+_LINEAR = "LINEAR"
+
+
+# ---------------------------------------------------------------------------
+# Motion pipeline loader (mirrors generate-move-ts.py pattern exactly)
+# ---------------------------------------------------------------------------
+
+
+def _load_pipeline() -> types.ModuleType:
+    """Import motion-pipeline.py as a module via importlib.
+
+    The module uses dataclasses, so it must be registered in sys.modules
+    before exec_module runs.
+    """
+    spec = importlib.util.spec_from_file_location("motion_pipeline", _PIPELINE_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load motion pipeline from {_PIPELINE_PATH}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["motion_pipeline"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Bone name mapping: BVH names -> GLB node indices
+# ---------------------------------------------------------------------------
+
+# BVH bones that have no GLB counterpart (extra joints in the BVH rig)
+_BVH_SKIP_SUFFIXES = ("End", "Site")
+
+
+def _build_bone_map(glb: pygltflib.GLTF2, bvh_names: list[str]) -> dict[str, int]:
+    """Map BVH bone names to GLB node indices.
+
+    GLB node names follow the pattern: mixamorig:{BASE_NAME}_{NUMBER}
+    BVH bone names are the BASE_NAME (e.g. 'Hips', 'LeftUpLeg').
+
+    Some BVH bones have no GLB counterpart (finger tips with 'End' suffix,
+    intermediate spine segments, etc.). Those are omitted from the result.
+
+    Args:
+        glb: Loaded GLTF2 object.
+        bvh_names: Ordered list of bone names from the BVH Hierarchy.
+
+    Returns:
+        Dict mapping BVH bone name -> GLB node index. Only includes bones
+        that have a match in the GLB.
+    """
+    # Build reverse lookup: base_name -> node_index for all mixamorig nodes
+    glb_base_to_idx: dict[str, int] = {}
+    pattern = re.compile(r"^mixamorig:(.+?)_\d+$")
+    for node_idx, node in enumerate(glb.nodes):
+        if not node.name:
+            continue
+        m = pattern.match(node.name)
+        if m:
+            base = m.group(1)
+            glb_base_to_idx[base] = node_idx
+
+    # Match BVH bones to GLB bases
+    bone_map: dict[str, int] = {}
+    for bvh_name in bvh_names:
+        # Skip BVH leaf/end bones — they have no animation data
+        if any(bvh_name.endswith(s) for s in _BVH_SKIP_SUFFIXES):
+            continue
+        # Skip multi-word internal names that have no GLB match
+        if bvh_name not in glb_base_to_idx:
+            continue
+        bone_map[bvh_name] = glb_base_to_idx[bvh_name]
+
+    return bone_map
+
+
+# ---------------------------------------------------------------------------
+# Extract local quaternions from global BVH transforms
+# ---------------------------------------------------------------------------
+
+
+def _extract_local_quats(
+    motion: object,  # Motion dataclass from motion_pipeline
+    frame_range: range,
+) -> dict[str, np.ndarray]:
+    """Compute per-bone LOCAL rotation quaternions for a frame range.
+
+    The BVH frames store global 4x4 transforms. Local rotation for bone j:
+        local[j] = inv(parent_global[j]) @ bone_global[j]
+
+    For the root bone (parent index -1), local == global.
+
+    Args:
+        motion: Motion object from motion_pipeline.load_bvh.
+        frame_range: Range of frame indices to extract.
+
+    Returns:
+        Dict mapping BVH bone name -> np.ndarray of shape (N, 4) [x, y, z, w].
+        N = len(frame_range).
+    """
+    frames_arr = list(frame_range)
+    n_frames = len(frames_arr)
+    bone_names: list[str] = motion.hierarchy.bone_names
+    parent_indices: list[int] = motion.hierarchy.parent_indices
+
+    # Pre-fetch the relevant slice of motion.frames: shape (N, J, 4, 4)
+    motion_frames: np.ndarray = motion.frames[np.array(frames_arr)]  # (N, J, 4, 4)
+
+    result: dict[str, np.ndarray] = {}
+
+    for j, bone_name in enumerate(bone_names):
+        p = parent_indices[j]
+        if p == -1:
+            # Root: local == global rotation
+            rot_matrices = motion_frames[:, j, :3, :3]  # (N, 3, 3)
+        else:
+            # Local = inv(parent_global) @ bone_global
+            parent_global = motion_frames[:, p]  # (N, 4, 4)
+            bone_global = motion_frames[:, j]  # (N, 4, 4)
+
+            # Batched inv: since these are rigid transforms, inv = transpose of rot + negated trans
+            # But numpy.linalg.inv is safe and clear here; N is small (<=135 frames)
+            parent_inv = np.linalg.inv(parent_global)  # (N, 4, 4)
+            local_mat = np.einsum("fij,fjk->fik", parent_inv, bone_global)  # (N, 4, 4)
+            rot_matrices = local_mat[:, :3, :3]  # (N, 3, 3)
+
+        # Convert rotation matrices to quaternions [x, y, z, w] (scipy convention)
+        # ScipyRotation.as_quat() returns [x, y, z, w]
+        quats = ScipyRotation.from_matrix(rot_matrices).as_quat().astype(np.float32)  # (N, 4)
+        result[bone_name] = quats
+
+    return result
+
+
+def _extract_root_translations(
+    motion: object,
+    frame_range: range,
+) -> np.ndarray:
+    """Extract root (Hips) world-space translations for a frame range.
+
+    Returns shape (N, 3) float32 array in metres (BVH already scaled by _BVH_SCALE).
+    The translations are relative to the first frame of the range so the
+    character stays at the origin when the clip starts.
+    """
+    frames_arr = np.array(list(frame_range))
+    root_positions = motion.frames[frames_arr, 0, :3, 3]  # (N, 3)
+    # Remove root drift: subtract the starting position so clip begins at origin
+    root_positions = root_positions - root_positions[0:1]
+    return root_positions.astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# GLB binary blob helpers
+# ---------------------------------------------------------------------------
+
+
+def _append_binary(
+    glb: pygltflib.GLTF2,
+    data: bytes,
+) -> int:
+    """Append bytes to the GLB binary blob and return the byte offset.
+
+    Args:
+        glb: GLTF2 object (mutated in place).
+        data: Raw bytes to append.
+
+    Returns:
+        Byte offset of the appended data within the blob.
+    """
+    blob = glb.binary_blob() or b""
+    offset = len(blob)
+    glb.set_binary_blob(blob + data)
+    return offset
+
+
+def _add_buffer_view(
+    glb: pygltflib.GLTF2,
+    byte_offset: int,
+    byte_length: int,
+) -> int:
+    """Add a BufferView entry and return its index."""
+    bv = pygltflib.BufferView(
+        buffer=0,
+        byteOffset=byte_offset,
+        byteLength=byte_length,
+        target=None,  # animation data has no GPU target
+    )
+    glb.bufferViews.append(bv)
+    return len(glb.bufferViews) - 1
+
+
+def _add_accessor_scalar(
+    glb: pygltflib.GLTF2,
+    buffer_view_idx: int,
+    count: int,
+    min_val: float,
+    max_val: float,
+) -> int:
+    """Add a SCALAR float32 accessor (used for timestamps) and return its index."""
+    acc = pygltflib.Accessor(
+        bufferView=buffer_view_idx,
+        byteOffset=0,
+        componentType=_FLOAT,
+        count=count,
+        type=_SCALAR,
+        min=[float(min_val)],
+        max=[float(max_val)],
+    )
+    glb.accessors.append(acc)
+    return len(glb.accessors) - 1
+
+
+def _add_accessor_vec4(
+    glb: pygltflib.GLTF2,
+    buffer_view_idx: int,
+    count: int,
+) -> int:
+    """Add a VEC4 float32 accessor (used for quaternions) and return its index."""
+    acc = pygltflib.Accessor(
+        bufferView=buffer_view_idx,
+        byteOffset=0,
+        componentType=_FLOAT,
+        count=count,
+        type=_VEC4,
+    )
+    glb.accessors.append(acc)
+    return len(glb.accessors) - 1
+
+
+def _add_accessor_vec3(
+    glb: pygltflib.GLTF2,
+    buffer_view_idx: int,
+    count: int,
+) -> int:
+    """Add a VEC3 float32 accessor (used for translations) and return its index."""
+    acc = pygltflib.Accessor(
+        bufferView=buffer_view_idx,
+        byteOffset=0,
+        componentType=_FLOAT,
+        count=count,
+        type=_VEC3,
+    )
+    glb.accessors.append(acc)
+    return len(glb.accessors) - 1
+
+
+def _sync_buffer_length(glb: pygltflib.GLTF2) -> None:
+    """Update buffer[0].byteLength to match the actual binary blob size."""
+    blob = glb.binary_blob() or b""
+    if glb.buffers:
+        glb.buffers[0].byteLength = len(blob)
+
+
+# ---------------------------------------------------------------------------
+# Build one animation clip
+# ---------------------------------------------------------------------------
+
+
+def _build_animation(
+    glb: pygltflib.GLTF2,
+    clip_name: str,
+    timestamps: np.ndarray,
+    local_quats: dict[str, np.ndarray],
+    root_translations: np.ndarray | None,
+    bone_map: dict[str, int],
+) -> pygltflib.Animation:
+    """Construct a pygltflib Animation object from pre-computed data.
+
+    Writes binary data into the GLB blob and creates the accessor/bufferView
+    entries needed to reference it. Returns a fully-wired Animation object
+    ready to assign to glb.animations.
+
+    Args:
+        glb: GLTF2 to mutate with new binary data, accessors, and buffer views.
+        clip_name: Name for this animation clip.
+        timestamps: Float32 array of shape (N,) — keyframe times in seconds.
+        local_quats: Dict BVH_name -> (N, 4) float32 quaternion array [x,y,z,w].
+        root_translations: Optional (N, 3) float32 root position array (metres).
+            When provided, a translation channel is added for the Hips bone.
+        bone_map: Maps BVH bone name -> GLB node index.
+
+    Returns:
+        pygltflib.Animation ready to append to glb.animations.
+    """
+    n_frames = len(timestamps)
+    channels: list[pygltflib.AnimationChannel] = []
+    samplers: list[pygltflib.AnimationSampler] = []
+
+    def _add_sampler_and_channel(
+        input_acc_idx: int,
+        output_acc_idx: int,
+        node_idx: int,
+        path: str,
+    ) -> None:
+        sampler_idx = len(samplers)
+        samplers.append(
+            pygltflib.AnimationSampler(
+                input=input_acc_idx,
+                output=output_acc_idx,
+                interpolation=_LINEAR,
+            )
+        )
+        channels.append(
+            pygltflib.AnimationChannel(
+                sampler=sampler_idx,
+                target=pygltflib.AnimationChannelTarget(
+                    node=node_idx,
+                    path=path,
+                ),
+            )
+        )
+
+    # --- Shared timestamps accessor (all channels share the same input accessor) ---
+    ts_bytes = timestamps.astype(np.float32).tobytes()
+    ts_offset = _append_binary(glb, ts_bytes)
+    ts_bv_idx = _add_buffer_view(glb, ts_offset, len(ts_bytes))
+    ts_acc_idx = _add_accessor_scalar(
+        glb,
+        ts_bv_idx,
+        count=n_frames,
+        min_val=float(timestamps.min()),
+        max_val=float(timestamps.max()),
+    )
+
+    # --- Root translation channel (Hips only, if provided) ---
+    if root_translations is not None and "Hips" in bone_map:
+        hips_node_idx = bone_map["Hips"]
+        trans_bytes = root_translations.astype(np.float32).tobytes()
+        trans_offset = _append_binary(glb, trans_bytes)
+        trans_bv_idx = _add_buffer_view(glb, trans_offset, len(trans_bytes))
+        trans_acc_idx = _add_accessor_vec3(glb, trans_bv_idx, count=n_frames)
+        _add_sampler_and_channel(ts_acc_idx, trans_acc_idx, hips_node_idx, "translation")
+
+    # --- Rotation channels for each mapped bone ---
+    for bvh_name, node_idx in bone_map.items():
+        if bvh_name not in local_quats:
+            continue
+        quats = local_quats[bvh_name]  # (N, 4) [x, y, z, w]
+
+        # Ensure shortest-path: flip quaternions that are in the wrong hemisphere
+        # relative to their predecessor to avoid 360-degree snaps
+        for i in range(1, len(quats)):
+            if np.dot(quats[i - 1], quats[i]) < 0:
+                quats[i] = -quats[i]
+
+        q_bytes = quats.tobytes()
+        q_offset = _append_binary(glb, q_bytes)
+        q_bv_idx = _add_buffer_view(glb, q_offset, len(q_bytes))
+        q_acc_idx = _add_accessor_vec4(glb, q_bv_idx, count=n_frames)
+        _add_sampler_and_channel(ts_acc_idx, q_acc_idx, node_idx, "rotation")
+
+    return pygltflib.Animation(
+        name=clip_name,
+        channels=channels,
+        samplers=samplers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Subsample helpers
+# ---------------------------------------------------------------------------
+
+
+def _subsample_frames(total_frames: int, n_samples: int) -> np.ndarray:
+    """Return evenly-spaced frame indices within [0, total_frames).
+
+    Args:
+        total_frames: Total number of available frames.
+        n_samples: Desired number of output samples.
+
+    Returns:
+        Int array of shape (n_samples,) with frame indices.
+    """
+    return np.round(np.linspace(0, total_frames - 1, n_samples)).astype(int)
+
+
+def _subsample_quats(
+    quats: dict[str, np.ndarray],
+    sample_indices: np.ndarray,
+) -> dict[str, np.ndarray]:
+    """Subsample quaternion arrays to the given frame indices.
+
+    Args:
+        quats: Dict BVH_name -> (N, 4) full-frame quaternion array.
+        sample_indices: Int array of indices into axis-0 of each array.
+
+    Returns:
+        New dict with arrays subsampled to shape (len(sample_indices), 4).
+    """
+    return {name: arr[sample_indices] for name, arr in quats.items()}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def bake(
+    bvh_path: Path,
+    glb_path: Path,
+    out_path: Path,
+    dry_run: bool = False,
+) -> None:
+    """Load BVH, extract animations, and write enhanced GLB.
+
+    Args:
+        bvh_path: Path to the walking BVH file.
+        glb_path: Path to the source ScottHall.glb.
+        out_path: Destination for the enhanced GLB.
+        dry_run: If True, perform all computation but skip file writes.
+
+    Raises:
+        FileNotFoundError: If bvh_path or glb_path do not exist.
+        ValueError: If bone mapping yields no common bones.
+    """
+    # --- Validate inputs ---
+    if not bvh_path.is_file():
+        raise FileNotFoundError(f"BVH not found: {bvh_path}")
+    if not glb_path.is_file():
+        raise FileNotFoundError(f"GLB not found: {glb_path}")
+
+    # --- Load BVH ---
+    print(f"Loading BVH: {bvh_path}")
+    pipeline = _load_pipeline()
+    motion = pipeline.load_bvh(bvh_path, scale=_BVH_SCALE)
+    print(
+        f"  {motion.num_frames} frames @ {motion.framerate:.1f} fps  "
+        f"({motion.total_time:.1f}s)  {motion.num_joints} joints"
+    )
+
+    # --- Load GLB ---
+    print(f"Loading GLB: {glb_path}")
+    glb = pygltflib.GLTF2().load(str(glb_path))
+    print(f"  {len(glb.nodes)} nodes  {len(glb.animations)} animations  {len(glb.buffers)} buffers")
+
+    # --- Build bone map ---
+    bone_map = _build_bone_map(glb, motion.hierarchy.bone_names)
+    print(f"Bone mapping: {len(bone_map)} BVH bones mapped to GLB nodes")
+    if not bone_map:
+        raise ValueError("No bones mapped. Check BVH and GLB bone name patterns.")
+
+    # --- Extract walk cycle (frames 31-134, 104 BVH frames) ---
+    walk_range = range(_WALK_START, _WALK_END)
+    print(f"\nExtracting walk cycle: frames {_WALK_START}-{_WALK_END - 1} ({len(walk_range)} frames)")
+    walk_quats_full = _extract_local_quats(motion, walk_range)
+    walk_root_full = _extract_root_translations(motion, walk_range)
+
+    # Subsample to _WALK_KEYFRAMES
+    walk_sample_idx = _subsample_frames(len(walk_range), _WALK_KEYFRAMES)
+    walk_quats = _subsample_quats(walk_quats_full, walk_sample_idx)
+    walk_root = walk_root_full[walk_sample_idx]
+
+    # Timestamps: 0 to duration of the original segment, spaced evenly
+    walk_duration = (len(walk_range) - 1) / motion.framerate
+    walk_timestamps = np.linspace(0.0, walk_duration, _WALK_KEYFRAMES, dtype=np.float32)
+    print(f"  Subsampled to {_WALK_KEYFRAMES} keyframes  duration={walk_duration:.3f}s")
+
+    # Validate: leg bones should have meaningful rotation range
+    for leg_bone in ("LeftUpLeg", "RightUpLeg", "LeftLeg", "RightLeg"):
+        if leg_bone in walk_quats:
+            q = walk_quats[leg_bone]
+            # Convert to euler to get degrees
+            angles = ScipyRotation.from_quat(q).as_euler("xyz", degrees=True)
+            ranges = angles.max(axis=0) - angles.min(axis=0)
+            print(f"  {leg_bone} rotation range (deg): x={ranges[0]:.1f} y={ranges[1]:.1f} z={ranges[2]:.1f}")
+
+    # --- Extract idle pose (frames 31-60, 30 BVH frames) ---
+    idle_range = range(_IDLE_START, _IDLE_END)
+    print(f"\nExtracting idle pose: frames {_IDLE_START}-{_IDLE_END - 1} ({len(idle_range)} frames)")
+    idle_quats_full = _extract_local_quats(motion, idle_range)
+
+    # Subsample to _IDLE_KEYFRAMES (use full range, 30 frames -> 30 keyframes directly)
+    idle_sample_idx = _subsample_frames(len(idle_range), _IDLE_KEYFRAMES)
+    idle_quats = _subsample_quats(idle_quats_full, idle_sample_idx)
+
+    # Idle: slow loop, 4 seconds total (30 frames spread over 4s)
+    idle_duration = 4.0
+    idle_timestamps = np.linspace(0.0, idle_duration, _IDLE_KEYFRAMES, dtype=np.float32)
+    print(f"  Subsampled to {_IDLE_KEYFRAMES} keyframes  duration={idle_duration:.1f}s")
+
+    # --- Replace animations in the GLB ---
+    # Clear existing animation data: we replace clips 0 and 1 in-place by name.
+    # Find the target clip indices.
+    idle_clip_idx: int | None = None
+    walk_clip_idx: int | None = None
+    for i, anim in enumerate(glb.animations):
+        if anim.name == _IDLE_CLIP_NAME:
+            idle_clip_idx = i
+        elif anim.name == _WALK_CLIP_NAME:
+            walk_clip_idx = i
+
+    if idle_clip_idx is None:
+        print(f"WARNING: Idle clip '{_IDLE_CLIP_NAME}' not found. Will append as new.")
+    if walk_clip_idx is None:
+        print(f"WARNING: Walk clip '{_WALK_CLIP_NAME}' not found. Will append as new.")
+
+    print("\nBuilding idle animation...")
+    idle_anim = _build_animation(
+        glb=glb,
+        clip_name=_IDLE_CLIP_NAME,
+        timestamps=idle_timestamps,
+        local_quats=idle_quats,
+        root_translations=None,  # idle keeps the character stationary
+        bone_map=bone_map,
+    )
+
+    print("Building walk animation...")
+    walk_anim = _build_animation(
+        glb=glb,
+        clip_name=_WALK_CLIP_NAME,
+        timestamps=walk_timestamps,
+        local_quats=walk_quats,
+        root_translations=walk_root,
+        bone_map=bone_map,
+    )
+
+    # Replace or append animations
+    if idle_clip_idx is not None:
+        glb.animations[idle_clip_idx] = idle_anim
+        print(f"  Replaced idle clip at index {idle_clip_idx}")
+    else:
+        glb.animations.append(idle_anim)
+        print("  Appended idle clip")
+
+    if walk_clip_idx is not None:
+        glb.animations[walk_clip_idx] = walk_anim
+        print(f"  Replaced walk clip at index {walk_clip_idx}")
+    else:
+        glb.animations.append(walk_anim)
+        print("  Appended walk clip")
+
+    # Sync buffer byte length
+    _sync_buffer_length(glb)
+
+    # --- Validation ---
+    print("\nValidation:")
+    for anim in [idle_anim, walk_anim]:
+        total_keyframes = sum(glb.accessors[anim.samplers[ch.sampler].input].count for ch in anim.channels)
+        keyframes_per_channel = (
+            glb.accessors[anim.samplers[anim.channels[0].sampler].input].count if anim.channels else 0
+        )
+        print(
+            f"  {anim.name!r}: {len(anim.channels)} channels  "
+            f"{keyframes_per_channel} keyframes/channel  "
+            f"{len(anim.samplers)} samplers"
+        )
+        if keyframes_per_channel <= 1:
+            print(f"  ERROR: {anim.name!r} still has <=1 keyframe! Baking failed.")
+            sys.exit(1)
+
+    if dry_run:
+        print("\nDry run — no files written.")
+        return
+
+    # --- Backup and write ---
+    backup_path = glb_path.with_suffix(".glb.bak")
+    if not backup_path.exists():
+        shutil.copy2(glb_path, backup_path)
+        print(f"\nBackup: {backup_path}")
+    else:
+        print(f"\nBackup already exists, skipping: {backup_path}")
+
+    glb.save(str(out_path))
+    out_size_mb = out_path.stat().st_size / 1_048_576
+    print(f"Saved: {out_path}  ({out_size_mb:.2f} MB)")
+
+
+# ---------------------------------------------------------------------------
+# Validation: reload and spot-check the saved GLB
+# ---------------------------------------------------------------------------
+
+
+def validate_saved_glb(out_path: Path) -> bool:
+    """Reload the saved GLB and verify animations have real keyframes.
+
+    Args:
+        out_path: Path to the enhanced GLB file.
+
+    Returns:
+        True if validation passes, False otherwise.
+    """
+    print("\nReloading saved GLB for validation...")
+    glb = pygltflib.GLTF2().load(str(out_path))
+
+    all_ok = True
+    for anim in glb.animations:
+        if anim.name not in (_IDLE_CLIP_NAME, _WALK_CLIP_NAME):
+            continue
+
+        if not anim.channels:
+            print(f"  FAIL: {anim.name!r} has no channels")
+            all_ok = False
+            continue
+
+        ch = anim.channels[0]
+        sampler = anim.samplers[ch.sampler]
+        keyframe_count = glb.accessors[sampler.input].count
+        print(f"  {anim.name!r}: {len(anim.channels)} channels  {keyframe_count} keyframes/channel")
+
+        if keyframe_count <= 1:
+            print(f"  FAIL: {anim.name!r} only has {keyframe_count} keyframe(s)")
+            all_ok = False
+
+    # Spot-check: read leg rotation data for walk clip
+    for anim in glb.animations:
+        if anim.name != _WALK_CLIP_NAME:
+            continue
+
+        # Find a rotation channel for LeftUpLeg (node 73)
+        for ch in anim.channels:
+            if ch.target.node == 73 and ch.target.path == "rotation":
+                sampler = anim.samplers[ch.sampler]
+                acc_out = glb.accessors[sampler.output]
+                bv = glb.bufferViews[acc_out.bufferView]
+                blob = glb.binary_blob()
+                if blob is None:
+                    print("  FAIL: binary blob is None after reload")
+                    all_ok = False
+                    break
+                raw = blob[bv.byteOffset : bv.byteOffset + bv.byteLength]
+                quats = np.frombuffer(raw, dtype=np.float32).reshape(-1, 4)  # (N, 4) [x,y,z,w]
+                angles = ScipyRotation.from_quat(quats).as_euler("xyz", degrees=True)
+                ranges = angles.max(axis=0) - angles.min(axis=0)
+                print(
+                    f"  LeftUpLeg rotation range (deg) in saved GLB: "
+                    f"x={ranges[0]:.1f} y={ranges[1]:.1f} z={ranges[2]:.1f}"
+                )
+                if ranges.max() < 1.0:
+                    print("  FAIL: LeftUpLeg shows <1 degree total rotation — bake likely failed")
+                    all_ok = False
+                else:
+                    print("  OK: LeftUpLeg has meaningful rotation range")
+                break
+
+    return all_ok
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build argument parser for bake-bvh-to-glb."""
+    parser = argparse.ArgumentParser(
+        prog="bake-bvh-to-glb",
+        description="Bake BVH mocap animations into ScottHall.glb.",
+    )
+    parser.add_argument(
+        "--bvh",
+        type=Path,
+        default=_BVH_PATH,
+        help=f"Path to the walking BVH file (default: {_BVH_PATH})",
+    )
+    parser.add_argument(
+        "--glb",
+        type=Path,
+        default=_GLB_PATH,
+        help=f"Path to the source GLB (default: {_GLB_PATH})",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output GLB path (default: overwrites --glb in-place)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute animations but skip file writes.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for bake-bvh-to-glb.
+
+    Returns:
+        0 on success, 1 on error.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    out_path: Path = args.out if args.out is not None else args.glb
+
+    try:
+        bake(
+            bvh_path=args.bvh,
+            glb_path=args.glb,
+            out_path=out_path,
+            dry_run=args.dry_run,
+        )
+    except (FileNotFoundError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    if not args.dry_run:
+        ok = validate_saved_glb(out_path)
+        if not ok:
+            print("\nValidation FAILED", file=sys.stderr)
+            return 1
+        print("\nValidation PASSED")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bake-bvh-to-glb.py
+++ b/scripts/bake-bvh-to-glb.py
@@ -44,23 +44,28 @@ from scipy.spatial.transform import Rotation as ScipyRotation
 # Constants
 # ---------------------------------------------------------------------------
 
-_BVH_PATH = Path("/tmp/ai4animationpy/Demos/BVHLoading/WalkingStickLeft_BR.bvh")
+_BVH_PATH = Path("/tmp/mocap/07_01_walk.bvh")
 _GLB_PATH = Path("/home/feedgen/road-to-aew/public/assets/prototype/models/ScottHall.glb")
 _PIPELINE_PATH = Path(__file__).parent / "motion-pipeline.py"
 
 # Scale BVH positions from cm to metres (same convention as generate-move-ts.py)
 _BVH_SCALE = 0.01
 
-# Walk cycle: frames 100-160 (symmetric stride, both feet lift ~15cm)
-_WALK_START = 100
-_WALK_END = 161  # exclusive: 61 frames, roughly one symmetric stride
+# Walk cycle: frames 66-207 from CMU subject 07 trial 01 (clean natural walk,
+# no assistive devices). One complete symmetric stride: LeftFoot ground contact
+# at frame 66, next LeftFoot ground contact at frame 207. Both feet lift ~3-4cm
+# with 0.4cm symmetry difference. Leg rotation range 63-67 degrees.
+_WALK_START = 66
+_WALK_END = 208  # exclusive: 142 frames @ 120fps = 1.183s per stride cycle
 
-# Idle: frames 0-30 (first 31 frames where the character is settling into stance)
-_IDLE_START = 0
-_IDLE_END = 31  # exclusive: 31 frames
+# Idle: frames 37-67 — lowest-motion 30-frame window in the clip.
+# Feet stay within 0.85-1.22cm of ground, Hips drift only 2.2mm.
+# This gives a subtle weight-shift idle rather than a frozen T-pose.
+_IDLE_START = 37
+_IDLE_END = 67  # exclusive: 30 frames
 
 # Subsample targets (keyframes written into the GLB)
-_WALK_KEYFRAMES = 64  # ~1 frame per 1.6 BVH frames — smooth but compact
+_WALK_KEYFRAMES = 64  # 142 BVH frames -> 64 keyframes (~1 per 2.2 BVH frames) — smooth but compact
 _IDLE_KEYFRAMES = 30  # 30 frames at ~1fps => 30-second slow bob
 
 # Clip names in the existing GLB (Three.js code references these by name)
@@ -609,7 +614,7 @@ def bake(
     )
     print(f"GLB bind pose: {non_identity}/{len(glb_bind_quats)} bones have non-identity rotations")
 
-    # --- Extract walk cycle (frames 100-160, 61 BVH frames) ---
+    # --- Extract walk cycle (frames 66-207, 142 BVH frames, CMU 07_01) ---
     walk_range = range(_WALK_START, _WALK_END)
     print(f"\nExtracting walk cycle: frames {_WALK_START}-{_WALK_END - 1} ({len(walk_range)} frames)")
     walk_quats_full, walk_bvh_bind = _extract_local_quats(motion, walk_range)

--- a/scripts/bake-bvh-to-glb.py
+++ b/scripts/bake-bvh-to-glb.py
@@ -10,6 +10,19 @@ Usage:
 
 The script imports motion-pipeline.py via importlib (same pattern as
 generate-move-ts.py) to parse BVH data without subprocess overhead.
+
+Bind pose retargeting
+---------------------
+GLB skeletons from Mixamo/Sketchfab carry non-identity bind pose rotations on
+bones such as LeftUpLeg (~180 degrees around Z), shoulders, feet, etc. Writing
+raw BVH local rotations directly into those slots causes the skeleton to
+deform incorrectly (body drops, legs splay sideways).
+
+The fix: for each bone at each frame, compute the *delta* from the BVH bind
+pose (frame 0), then apply that delta to the GLB bind pose rotation:
+
+    bvh_delta = bvh_frame_rot * inv(bvh_bind_rot)
+    glb_frame_rot = bvh_delta * glb_bind_rot
 """
 
 from __future__ import annotations
@@ -142,7 +155,7 @@ def _build_bone_map(glb: pygltflib.GLTF2, bvh_names: list[str]) -> dict[str, int
 def _extract_local_quats(
     motion: object,  # Motion dataclass from motion_pipeline
     frame_range: range,
-) -> dict[str, np.ndarray]:
+) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
     """Compute per-bone LOCAL rotation quaternions for a frame range.
 
     The BVH frames store global 4x4 transforms. Local rotation for bone j:
@@ -150,13 +163,20 @@ def _extract_local_quats(
 
     For the root bone (parent index -1), local == global.
 
+    Also returns the BVH bind pose (frame 0 of the BVH, i.e. the absolute
+    frame at index frame_range.start) so callers can compute the delta from
+    rest to drive GLB-space animation correctly.
+
     Args:
         motion: Motion object from motion_pipeline.load_bvh.
         frame_range: Range of frame indices to extract.
 
     Returns:
-        Dict mapping BVH bone name -> np.ndarray of shape (N, 4) [x, y, z, w].
-        N = len(frame_range).
+        Tuple of two dicts, both mapping BVH bone name -> np.ndarray:
+        - quats: shape (N, 4) [x, y, z, w] for frames in frame_range.
+          N = len(frame_range).
+        - bind_quats: shape (4,) [x, y, z, w] quaternion at BVH frame 0
+          (the skeleton rest pose used as the reference for delta computation).
     """
     frames_arr = list(frame_range)
     n_frames = len(frames_arr)
@@ -166,13 +186,18 @@ def _extract_local_quats(
     # Pre-fetch the relevant slice of motion.frames: shape (N, J, 4, 4)
     motion_frames: np.ndarray = motion.frames[np.array(frames_arr)]  # (N, J, 4, 4)
 
+    # Bind pose: BVH frame 0 (absolute rest position of the BVH skeleton)
+    bind_frame: np.ndarray = motion.frames[0]  # (J, 4, 4)
+
     result: dict[str, np.ndarray] = {}
+    bind_quats: dict[str, np.ndarray] = {}
 
     for j, bone_name in enumerate(bone_names):
         p = parent_indices[j]
         if p == -1:
             # Root: local == global rotation
             rot_matrices = motion_frames[:, j, :3, :3]  # (N, 3, 3)
+            bind_rot_matrix = bind_frame[j, :3, :3]  # (3, 3)
         else:
             # Local = inv(parent_global) @ bone_global
             parent_global = motion_frames[:, p]  # (N, 4, 4)
@@ -184,12 +209,20 @@ def _extract_local_quats(
             local_mat = np.einsum("fij,fjk->fik", parent_inv, bone_global)  # (N, 4, 4)
             rot_matrices = local_mat[:, :3, :3]  # (N, 3, 3)
 
+            # Bind pose local rotation for this bone
+            bind_parent_inv = np.linalg.inv(bind_frame[p])  # (4, 4)
+            bind_local = bind_parent_inv @ bind_frame[j]  # (4, 4)
+            bind_rot_matrix = bind_local[:3, :3]  # (3, 3)
+
         # Convert rotation matrices to quaternions [x, y, z, w] (scipy convention)
         # ScipyRotation.as_quat() returns [x, y, z, w]
         quats = ScipyRotation.from_matrix(rot_matrices).as_quat().astype(np.float32)  # (N, 4)
         result[bone_name] = quats
 
-    return result
+        bind_q = ScipyRotation.from_matrix(bind_rot_matrix).as_quat().astype(np.float32)  # (4,)
+        bind_quats[bone_name] = bind_q
+
+    return result, bind_quats
 
 
 def _extract_root_translations(
@@ -207,6 +240,73 @@ def _extract_root_translations(
     # Remove root drift: subtract the starting position so clip begins at origin
     root_positions = root_positions - root_positions[0:1]
     return root_positions.astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Bind pose correction: BVH space -> GLB space retargeting
+# ---------------------------------------------------------------------------
+
+
+def _load_glb_bind_rotations(glb: pygltflib.GLTF2, bone_map: dict[str, int]) -> dict[str, np.ndarray]:
+    """Read the GLB node default rotations for each mapped bone.
+
+    These are the rotations the skeleton was authored in — the GLB bind pose.
+    Animation data must be expressed as deltas from this pose.
+
+    Args:
+        glb: Loaded GLTF2 object.
+        bone_map: Maps BVH bone name -> GLB node index.
+
+    Returns:
+        Dict mapping BVH bone name -> np.ndarray of shape (4,) [x, y, z, w].
+        Bones with no rotation set default to identity [0, 0, 0, 1].
+    """
+    glb_bind: dict[str, np.ndarray] = {}
+    for bvh_name, node_idx in bone_map.items():
+        node = glb.nodes[node_idx]
+        if node.rotation is not None:
+            glb_bind[bvh_name] = np.array(node.rotation, dtype=np.float32)
+        else:
+            glb_bind[bvh_name] = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+    return glb_bind
+
+
+def _retarget_quats(
+    bvh_quats: dict[str, np.ndarray],
+    bvh_bind_quats: dict[str, np.ndarray],
+    glb_bind_quats: dict[str, np.ndarray],
+) -> dict[str, np.ndarray]:
+    """Correct BVH-space quaternions to GLB-space by applying bind pose delta.
+
+    For each bone at each frame:
+        bvh_delta = bvh_frame_rot * inv(bvh_bind_rot)
+        glb_frame_rot = bvh_delta * glb_bind_rot
+
+    This maps the BVH motion (expressed as change-from-BVH-rest) into the
+    GLB skeleton (expressed as change-from-GLB-rest), so the mesh deforms
+    correctly regardless of the GLB's non-identity bind pose.
+
+    Args:
+        bvh_quats: Dict bone_name -> (N, 4) float32 BVH local quaternions.
+        bvh_bind_quats: Dict bone_name -> (4,) float32 BVH rest pose quaternion.
+        glb_bind_quats: Dict bone_name -> (4,) float32 GLB node default rotation.
+
+    Returns:
+        Dict bone_name -> (N, 4) float32 corrected quaternions ready for GLB.
+    """
+    retargeted: dict[str, np.ndarray] = {}
+    for bone_name, bvh_q in bvh_quats.items():
+        bvh_bind = ScipyRotation.from_quat(bvh_bind_quats[bone_name])
+        glb_bind = ScipyRotation.from_quat(glb_bind_quats.get(bone_name, np.array([0.0, 0.0, 0.0, 1.0])))
+
+        bvh_frames = ScipyRotation.from_quat(bvh_q)  # (N,) rotation object
+        # delta = frame * inv(bind): change relative to BVH rest
+        bvh_delta = bvh_frames * bvh_bind.inv()
+        # Apply delta to GLB bind pose
+        glb_frames = bvh_delta * glb_bind
+
+        retargeted[bone_name] = glb_frames.as_quat().astype(np.float32)  # (N, 4)
+    return retargeted
 
 
 # ---------------------------------------------------------------------------
@@ -488,9 +588,9 @@ def bake(
         f"({motion.total_time:.1f}s)  {motion.num_joints} joints"
     )
 
-    # --- Load GLB ---
+    # --- Load GLB (binary format) ---
     print(f"Loading GLB: {glb_path}")
-    glb = pygltflib.GLTF2().load(str(glb_path))
+    glb = pygltflib.GLTF2().load_binary(str(glb_path))
     print(f"  {len(glb.nodes)} nodes  {len(glb.animations)} animations  {len(glb.buffers)} buffers")
 
     # --- Build bone map ---
@@ -499,11 +599,24 @@ def bake(
     if not bone_map:
         raise ValueError("No bones mapped. Check BVH and GLB bone name patterns.")
 
+    # --- Load GLB bind pose rotations for retargeting ---
+    # The GLB skeleton has non-identity bind pose rotations on many bones
+    # (e.g. LeftUpLeg ~180 degrees around Z). We must express animation as
+    # delta-from-GLB-bind, not raw BVH local rotations.
+    glb_bind_quats = _load_glb_bind_rotations(glb, bone_map)
+    non_identity = sum(
+        1 for q in glb_bind_quats.values() if np.linalg.norm(q - np.array([0, 0, 0, 1], dtype=np.float32)) > 0.01
+    )
+    print(f"GLB bind pose: {non_identity}/{len(glb_bind_quats)} bones have non-identity rotations")
+
     # --- Extract walk cycle (frames 31-134, 104 BVH frames) ---
     walk_range = range(_WALK_START, _WALK_END)
     print(f"\nExtracting walk cycle: frames {_WALK_START}-{_WALK_END - 1} ({len(walk_range)} frames)")
-    walk_quats_full = _extract_local_quats(motion, walk_range)
+    walk_quats_full, walk_bvh_bind = _extract_local_quats(motion, walk_range)
     walk_root_full = _extract_root_translations(motion, walk_range)
+
+    # Apply bind pose retargeting: convert BVH-space rotations to GLB-space
+    walk_quats_full = _retarget_quats(walk_quats_full, walk_bvh_bind, glb_bind_quats)
 
     # Subsample to _WALK_KEYFRAMES
     walk_sample_idx = _subsample_frames(len(walk_range), _WALK_KEYFRAMES)
@@ -527,7 +640,10 @@ def bake(
     # --- Extract idle pose (frames 31-60, 30 BVH frames) ---
     idle_range = range(_IDLE_START, _IDLE_END)
     print(f"\nExtracting idle pose: frames {_IDLE_START}-{_IDLE_END - 1} ({len(idle_range)} frames)")
-    idle_quats_full = _extract_local_quats(motion, idle_range)
+    idle_quats_full, idle_bvh_bind = _extract_local_quats(motion, idle_range)
+
+    # Apply bind pose retargeting for idle clip
+    idle_quats_full = _retarget_quats(idle_quats_full, idle_bvh_bind, glb_bind_quats)
 
     # Subsample to _IDLE_KEYFRAMES (use full range, 30 frames -> 30 keyframes directly)
     idle_sample_idx = _subsample_frames(len(idle_range), _IDLE_KEYFRAMES)
@@ -620,7 +736,7 @@ def bake(
     else:
         print(f"\nBackup already exists, skipping: {backup_path}")
 
-    glb.save(str(out_path))
+    glb.save_binary(str(out_path))
     out_size_mb = out_path.stat().st_size / 1_048_576
     print(f"Saved: {out_path}  ({out_size_mb:.2f} MB)")
 
@@ -640,7 +756,7 @@ def validate_saved_glb(out_path: Path) -> bool:
         True if validation passes, False otherwise.
     """
     print("\nReloading saved GLB for validation...")
-    glb = pygltflib.GLTF2().load(str(out_path))
+    glb = pygltflib.GLTF2().load_binary(str(out_path))
 
     all_ok = True
     for anim in glb.animations:

--- a/scripts/bake-bvh-to-glb.py
+++ b/scripts/bake-bvh-to-glb.py
@@ -686,7 +686,7 @@ def bake(
         clip_name=_WALK_CLIP_NAME,
         timestamps=walk_timestamps,
         local_quats=walk_quats,
-        root_translations=walk_root,
+        root_translations=None,  # game code handles positioning; BVH root translation fights with it
         bone_map=bone_map,
     )
 

--- a/scripts/generate-move-ts.py
+++ b/scripts/generate-move-ts.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""Generate TypeScript wrestling move functions from BVH mocap data.
+
+Converts motion-pipeline JSON output (root trajectory + contact frames) into
+keyframe-interpolated TypeScript MoveFrame functions compatible with
+road-to-aew's wrestlingMoves.ts interface.
+
+Usage:
+    generate-move-ts.py BVH MOVE_NAME [--scale S] [--contact-bones B...] \\
+        [--num-keyframes N] [--hip-bone NAME]
+
+The script imports motion-pipeline.py as a module directly to avoid the
+5-frame stdout truncation applied by the decompose CLI command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import math
+import sys
+import types
+from datetime import date
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+# ---------------------------------------------------------------------------
+# Motion pipeline import (importlib to avoid CLI 5-frame truncation)
+# ---------------------------------------------------------------------------
+
+_PIPELINE_PATH = Path(__file__).parent / "motion-pipeline.py"
+
+
+def _load_pipeline() -> types.ModuleType:
+    """Import motion-pipeline.py as a module via importlib.
+
+    The module uses dataclasses, so it must be registered in sys.modules
+    before exec_module runs, or the dataclass decorator cannot resolve
+    the module's __dict__.
+    """
+    spec = importlib.util.spec_from_file_location("motion_pipeline", _PIPELINE_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load motion pipeline from {_PIPELINE_PATH}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["motion_pipeline"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Move name helpers
+# ---------------------------------------------------------------------------
+
+
+def kebab_to_pascal(name: str) -> str:
+    """Convert kebab-case to PascalCase: 'roundhouse-kick' -> 'RoundhouseKick'."""
+    return "".join(word.capitalize() for word in name.split("-"))
+
+
+def kebab_to_upper_snake(name: str) -> str:
+    """Convert kebab-case to UPPER_SNAKE: 'roundhouse-kick' -> 'ROUNDHOUSE_KICK'."""
+    return name.upper().replace("-", "_")
+
+
+# ---------------------------------------------------------------------------
+# Keyframe extraction
+# ---------------------------------------------------------------------------
+
+
+def _find_contact_window(
+    contact_data: dict,
+    bone_names: list[str],
+    total_frames: int,
+) -> tuple[float, float] | None:
+    """Detect the first sustained contact window across all requested bones.
+
+    Returns (start_progress, end_progress) or None if no contact found.
+
+    A "sustained" window requires at least 3 consecutive contact frames on
+    any of the specified bones — single-frame spikes are ignored.
+    """
+    bones_info = contact_data.get("bones", {})
+
+    best_start: int | None = None
+    best_end: int | None = None
+
+    for bone in bone_names:
+        if bone not in bones_info:
+            continue
+        frames: list[int] = bones_info[bone]["contact_frames"]
+        if len(frames) < 3:
+            continue
+
+        # Find first run of 3+ consecutive frames
+        run_start = frames[0]
+        prev = frames[0]
+        run_len = 1
+
+        for f in frames[1:]:
+            if f == prev + 1:
+                run_len += 1
+                if run_len >= 3:
+                    run_end = f
+                    if best_start is None or run_start < best_start:
+                        best_start = run_start
+                        best_end = run_end
+                    break
+            else:
+                run_start = f
+                run_len = 1
+            prev = f
+
+    if best_start is None or best_end is None:
+        return None
+
+    return (best_start / total_frames, best_end / total_frames)
+
+
+def _sample_keyframes(
+    positions: list[list[float]],
+    hip_euler: list[list[float]],
+    num_keyframes: int,
+) -> list[tuple[float, list[float], list[float]]]:
+    """Sample motion arrays at N evenly-spaced progress values.
+
+    Args:
+        positions: Root trajectory positions [[x,y,z], ...] — full frame count.
+        hip_euler: Hip Euler ZYX degrees [[z,y,x], ...] — full frame count.
+        num_keyframes: Number of keyframes to sample (including 0.0 and 1.0).
+
+    Returns:
+        List of (progress, [x,y,z], [rot_z,rot_y,rot_x]) tuples.
+    """
+    total_frames = len(positions)
+
+    # Normalize: subtract initial position so the move starts at origin
+    origin = positions[0]
+    ox, oy, oz = origin[0], origin[1], origin[2]
+
+    keyframes: list[tuple[float, list[float], list[float]]] = []
+
+    for i in range(num_keyframes):
+        progress = i / (num_keyframes - 1) if num_keyframes > 1 else 0.0
+        # Map progress [0,1] -> frame index [0, total_frames-1]
+        frame_idx = min(round(progress * (total_frames - 1)), total_frames - 1)
+
+        pos = positions[frame_idx]
+        euler = hip_euler[frame_idx]
+
+        # Normalised offsets (origin at first frame)
+        att_x = pos[0] - ox
+        att_y = pos[1] - oy
+        att_z = pos[2] - oz
+
+        # Convert degrees to radians for Three.js
+        rot_z = math.radians(euler[0])
+        rot_y = math.radians(euler[1])
+        rot_x = math.radians(euler[2])
+
+        keyframes.append((progress, [att_x, att_y, att_z], [rot_x, rot_y, rot_z]))
+
+    return keyframes
+
+
+def _compute_defender_keyframes(
+    attacker_keyframes: list[tuple[float, list[float], list[float]]],
+    impact_window: tuple[float, float] | None,
+) -> list[list[float]]:
+    """Compute defender reaction offsets/rotations for each keyframe.
+
+    Defender reaction model:
+    - Before impact: slight lean-in (tracking attacker approach)
+    - At impact: sharp backward displacement + backward rotation
+    - Post-impact: ease down to mat level
+
+    Args:
+        attacker_keyframes: Output from _sample_keyframes.
+        impact_window: (start_progress, end_progress) or None.
+
+    Returns:
+        List of [defOffX, defOffY, defOffZ, defRotX, defRotY, defRotZ] per keyframe.
+    """
+    imp_start = impact_window[0] if impact_window else 0.5
+    imp_end = impact_window[1] if impact_window else 0.55
+
+    # Defender displacement amplitude: moderate scale matching hand-authored moves
+    BACKWARD_PEAK = 1.2  # metres pushed backward (Z) at impact
+    UPWARD_PEAK = 0.8  # metres upward at impact
+    ROT_PEAK = 0.4  # radians backward lean at impact
+
+    results: list[list[float]] = []
+
+    for progress, att_pos, _att_rot in attacker_keyframes:
+        # Compute eased impact factor (0 outside impact, peaks at centre)
+        if progress < imp_start:
+            # Pre-impact: subtle backward lean tracking attacker Z
+            t = progress / max(imp_start, 1e-6)
+            ease = t * t  # ease-in
+            def_z = -abs(att_pos[2]) * 0.1 * ease  # slight lean toward attacker
+            def_y = 0.0
+            def_x = 0.0
+            def_rot_x = 0.05 * ease  # slight forward lean
+            def_rot_y = 0.0
+            def_rot_z = 0.0
+        elif progress <= imp_end:
+            # Impact window: ramp up to peak then hold
+            window = max(imp_end - imp_start, 1e-6)
+            t = (progress - imp_start) / window
+            ease = math.sin(t * math.pi / 2)  # ease-in to peak
+            def_z = -BACKWARD_PEAK * ease
+            def_y = UPWARD_PEAK * ease
+            def_x = 0.0
+            def_rot_x = -ROT_PEAK * ease  # backward lean (negative = lean back)
+            def_rot_y = 0.0
+            def_rot_z = 0.0
+        else:
+            # Post-impact: ease down to mat
+            t = (progress - imp_end) / max(1.0 - imp_end, 1e-6)
+            ease = 1.0 - (t * t)  # ease-out from 1 toward 0
+            def_z = -BACKWARD_PEAK * ease
+            def_y = UPWARD_PEAK * ease * 0.3  # settle faster than push
+            def_x = 0.0
+            def_rot_x = -ROT_PEAK * ease
+            def_rot_y = 0.0
+            def_rot_z = 0.0
+
+        results.append([def_x, def_y, def_z, def_rot_x, def_rot_y, def_rot_z])
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# TypeScript code generation
+# ---------------------------------------------------------------------------
+
+_TS_HEADER = """\
+// Generated from {bvh_name} on {today}
+// Keyframes: {num_keyframes}, Impact window: {impact_start:.3f}-{impact_end:.3f}
+//
+// Attacker columns: offsetX, offsetY, offsetZ (metres), rotationX, rotationY, rotationZ (radians)
+// Defender columns: offsetX, offsetY, offsetZ (metres), rotationX, rotationY, rotationZ (radians)
+//
+// Generated by scripts/generate-move-ts.py — do not hand-edit; re-run generator for changes.
+
+import type {{ MoveFrame, WrestlerTransform }} from "./wrestlingMoves";
+
+"""
+
+_KEYFRAME_CONST = """\
+const {const_name}_KEYFRAMES = [
+  // prettier-ignore
+  // [progress, attOffX, attOffY, attOffZ, attRotX, attRotY, attRotZ, defOffX, defOffY, defOffZ, defRotX, defRotY, defRotZ]
+{rows}
+] as const;
+
+"""
+
+_FUNCTION_BODY = """\
+export function get{pascal_name}(progress: number): MoveFrame {{
+  // Find the two surrounding keyframes by scanning for the bracket pair.
+  const kf = {const_name}_KEYFRAMES;
+  let lo = 0;
+  let hi = kf.length - 1;
+
+  for (let i = 0; i < kf.length - 1; i++) {{
+    if (kf[i][0] <= progress && progress <= kf[i + 1][0]) {{
+      lo = i;
+      hi = i + 1;
+      break;
+    }}
+  }}
+
+  const t0 = kf[lo][0] as number;
+  const t1 = kf[hi][0] as number;
+  const span = t1 - t0;
+  const t = span > 0 ? (progress - t0) / span : 0;
+
+  function lerp(a: number, b: number): number {{
+    return a + (b - a) * t;
+  }}
+
+  const attacker: WrestlerTransform = {{
+    offsetX: lerp(kf[lo][1] as number, kf[hi][1] as number),
+    offsetY: lerp(kf[lo][2] as number, kf[hi][2] as number),
+    offsetZ: lerp(kf[lo][3] as number, kf[hi][3] as number),
+    rotationX: lerp(kf[lo][4] as number, kf[hi][4] as number),
+    rotationY: lerp(kf[lo][5] as number, kf[hi][5] as number),
+    rotationZ: lerp(kf[lo][6] as number, kf[hi][6] as number),
+  }};
+
+  const defender: WrestlerTransform = {{
+    offsetX: lerp(kf[lo][7] as number, kf[hi][7] as number),
+    offsetY: lerp(kf[lo][8] as number, kf[hi][8] as number),
+    offsetZ: lerp(kf[lo][9] as number, kf[hi][9] as number),
+    rotationX: lerp(kf[lo][10] as number, kf[hi][10] as number),
+    rotationY: lerp(kf[lo][11] as number, kf[hi][11] as number),
+    rotationZ: lerp(kf[lo][12] as number, kf[hi][12] as number),
+  }};
+
+  const isImpact = progress >= {impact_start:.4f} && progress <= {impact_end:.4f};
+
+  return {{ attacker, defender, isImpact }};
+}}
+"""
+
+
+def _fmt_float(v: float) -> str:
+    """Format a float for TypeScript keyframe arrays: 4 significant digits, no trailing zeros."""
+    if v == 0.0:
+        return "0"
+    return f"{v:.4f}".rstrip("0").rstrip(".")
+
+
+def generate_typescript(
+    bvh_name: str,
+    move_name: str,
+    attacker_keyframes: list[tuple[float, list[float], list[float]]],
+    defender_frames: list[list[float]],
+    impact_window: tuple[float, float] | None,
+) -> str:
+    """Render the full TypeScript source for one wrestling move function.
+
+    Args:
+        bvh_name: Source BVH filename stem (for header comment).
+        move_name: Kebab-case move name (e.g. 'roundhouse-kick').
+        attacker_keyframes: [(progress, [x,y,z], [rx,ry,rz]), ...]
+        defender_frames: [[defX,defY,defZ,defRx,defRy,defRz], ...] — same length.
+        impact_window: (start, end) progress or None.
+
+    Returns:
+        Valid TypeScript source string.
+    """
+    pascal_name = kebab_to_pascal(move_name)
+    const_name = kebab_to_upper_snake(move_name)
+    today = date.today().isoformat()
+    imp_start = impact_window[0] if impact_window else 0.5
+    imp_end = impact_window[1] if impact_window else 0.55
+
+    header = _TS_HEADER.format(
+        bvh_name=bvh_name,
+        today=today,
+        num_keyframes=len(attacker_keyframes),
+        impact_start=imp_start,
+        impact_end=imp_end,
+    )
+
+    rows: list[str] = []
+    for (progress, att_pos, att_rot), def_vals in zip(attacker_keyframes, defender_frames):
+        vals = [progress] + att_pos + att_rot + def_vals
+        row_str = ", ".join(_fmt_float(v) for v in vals)
+        rows.append(f"  [{row_str}],")
+
+    const_block = _KEYFRAME_CONST.format(
+        const_name=const_name,
+        rows="\n".join(rows),
+    )
+
+    func_block = _FUNCTION_BODY.format(
+        pascal_name=pascal_name,
+        const_name=const_name,
+        impact_start=imp_start,
+        impact_end=imp_end,
+    )
+
+    return header + const_block + func_block
+
+
+# ---------------------------------------------------------------------------
+# Validation: minimal TypeScript syntax checks
+# ---------------------------------------------------------------------------
+
+
+def _validate_typescript(ts_source: str, output_path: Path) -> list[str]:
+    """Run basic structural checks on generated TypeScript source.
+
+    Returns list of error strings (empty = valid).
+    """
+    errors: list[str] = []
+
+    # Must have required structural elements
+    required = [
+        "as const;",
+        "export function get",
+        "(progress: number): MoveFrame",
+        "const attacker: WrestlerTransform",
+        "const defender: WrestlerTransform",
+        "return { attacker, defender, isImpact };",
+    ]
+    for req in required:
+        if req not in ts_source:
+            errors.append(f"Missing required element: {req!r}")
+
+    # Balanced braces
+    opens = ts_source.count("{")
+    closes = ts_source.count("}")
+    if opens != closes:
+        errors.append(f"Unbalanced braces: {{ count={opens}, }} count={closes}")
+
+    # Balanced brackets
+    sq_opens = ts_source.count("[")
+    sq_closes = ts_source.count("]")
+    if sq_opens != sq_closes:
+        errors.append(f"Unbalanced brackets: [ count={sq_opens}, ] count={sq_closes}")
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Summary output
+# ---------------------------------------------------------------------------
+
+
+def _print_summary(
+    bvh_path: Path,
+    move_name: str,
+    num_keyframes: int,
+    impact_window: tuple[float, float] | None,
+    attacker_keyframes: list[tuple[float, list[float], list[float]]],
+    output_path: Path,
+    validation_errors: list[str],
+) -> None:
+    """Print a human-readable summary to stderr."""
+    positions = [kf[1] for kf in attacker_keyframes]
+    xs = [p[0] for p in positions]
+    ys = [p[1] for p in positions]
+    zs = [p[2] for p in positions]
+
+    print(f"\n=== generate-move-ts summary ===", file=sys.stderr)
+    print(f"  BVH source   : {bvh_path}", file=sys.stderr)
+    print(f"  Move name    : {move_name}", file=sys.stderr)
+    print(f"  Keyframes    : {num_keyframes}", file=sys.stderr)
+    if impact_window:
+        print(f"  Impact window: {impact_window[0]:.3f} - {impact_window[1]:.3f}", file=sys.stderr)
+    else:
+        print(f"  Impact window: none detected (using default 0.500-0.550)", file=sys.stderr)
+    print(f"  Traj X range : [{min(xs):.4f}, {max(xs):.4f}] m", file=sys.stderr)
+    print(f"  Traj Y range : [{min(ys):.4f}, {max(ys):.4f}] m", file=sys.stderr)
+    print(f"  Traj Z range : [{min(zs):.4f}, {max(zs):.4f}] m", file=sys.stderr)
+    print(f"  Output       : {output_path}", file=sys.stderr)
+    if validation_errors:
+        print(f"  VALIDATION   : FAILED ({len(validation_errors)} error(s))", file=sys.stderr)
+        for e in validation_errors:
+            print(f"    - {e}", file=sys.stderr)
+    else:
+        print(f"  Validation   : OK", file=sys.stderr)
+    print(file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="generate-move-ts",
+        description="Convert BVH mocap to TypeScript MoveFrame function for road-to-aew.",
+    )
+    parser.add_argument("bvh", type=Path, help="Path to .bvh mocap file.")
+    parser.add_argument(
+        "move_name",
+        metavar="MOVE_NAME",
+        help="Kebab-case move name (e.g. roundhouse-kick). Used in TS identifiers.",
+    )
+    parser.add_argument(
+        "--scale",
+        type=float,
+        default=0.01,
+        help="Position scale factor (default 0.01 for cm-to-metre conversion).",
+    )
+    parser.add_argument(
+        "--contact-bones",
+        nargs="+",
+        default=["LeftToeBase", "RightToeBase", "LeftHand", "RightHand"],
+        metavar="BONE",
+        help="Bone names used for impact detection (default: LeftToeBase RightToeBase LeftHand RightHand).",
+    )
+    parser.add_argument(
+        "--num-keyframes",
+        type=int,
+        default=12,
+        metavar="N",
+        help="Number of sampled keyframes in the TS output (default 12).",
+    )
+    parser.add_argument(
+        "--hip-bone",
+        default="Hips",
+        metavar="NAME",
+        help="Name of the hip/root bone for trajectory extraction (default: Hips).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help="Write TypeScript to FILE in addition to printing to stdout.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for generate-move-ts.
+
+    Returns:
+        0 on success, 1 on error.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    bvh_path: Path = args.bvh
+    if not bvh_path.is_file():
+        print(f"Error: BVH file not found: {bvh_path}", file=sys.stderr)
+        return 1
+
+    if args.num_keyframes < 2:
+        print("Error: --num-keyframes must be at least 2.", file=sys.stderr)
+        return 1
+
+    # Load motion pipeline module
+    try:
+        pipeline = _load_pipeline()
+    except ImportError as e:
+        print(f"Error loading motion pipeline: {e}", file=sys.stderr)
+        return 1
+
+    # Load and decompose BVH
+    try:
+        motion = pipeline.load_bvh(bvh_path, scale=args.scale)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"Error loading BVH: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        decomp = pipeline.decompose(motion, hip_name=args.hip_bone)
+    except ValueError as e:
+        print(f"Error in decompose: {e}", file=sys.stderr)
+        return 1
+
+    # Filter contact bones to those that exist in the skeleton
+    available_bones = set(motion.hierarchy.bone_names)
+    contact_bones = [b for b in args.contact_bones if b in available_bones]
+    missing = [b for b in args.contact_bones if b not in available_bones]
+    if missing:
+        print(
+            f"Warning: contact bones not found in skeleton, skipping: {missing}",
+            file=sys.stderr,
+        )
+    if not contact_bones:
+        print("Warning: no contact bones available; impact window will use default.", file=sys.stderr)
+
+    # Extract contacts
+    contact_data: dict = {"bones": {}, "total_frames": motion.num_frames}
+    if contact_bones:
+        try:
+            contact_data = pipeline.extract_contacts(motion, bone_names=contact_bones)
+        except ValueError as e:
+            print(f"Warning: contact extraction failed: {e}", file=sys.stderr)
+
+    # Full-resolution trajectory and hip Euler (not truncated — imported directly)
+    positions: list[list[float]] = decomp["root_trajectory"]["positions"]
+    hip_euler: list[list[float]] = decomp["per_joint_euler_zyx_degrees"][args.hip_bone]
+
+    # Detect impact window
+    impact_window = _find_contact_window(contact_data, contact_bones, motion.num_frames)
+
+    # Sample keyframes
+    attacker_keyframes = _sample_keyframes(positions, hip_euler, args.num_keyframes)
+
+    # Compute defender reaction
+    defender_frames = _compute_defender_keyframes(attacker_keyframes, impact_window)
+
+    # Generate TypeScript
+    ts_source = generate_typescript(
+        bvh_name=bvh_path.name,
+        move_name=args.move_name,
+        attacker_keyframes=attacker_keyframes,
+        defender_frames=defender_frames,
+        impact_window=impact_window,
+    )
+
+    # Validate
+    output_path = args.output or Path("/dev/stdout")
+    validation_errors = _validate_typescript(ts_source, output_path)
+
+    # Print TypeScript to stdout
+    print(ts_source)
+
+    # Optionally write to file
+    if args.output is not None:
+        args.output.write_text(ts_source)
+
+    # Print summary to stderr
+    _print_summary(
+        bvh_path=bvh_path,
+        move_name=args.move_name,
+        num_keyframes=args.num_keyframes,
+        impact_window=impact_window,
+        attacker_keyframes=attacker_keyframes,
+        output_path=output_path,
+        validation_errors=validation_errors,
+    )
+
+    return 1 if validation_errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate-move-ts.py
+++ b/scripts/generate-move-ts.py
@@ -7,7 +7,13 @@ road-to-aew's wrestlingMoves.ts interface.
 
 Usage:
     generate-move-ts.py BVH MOVE_NAME [--scale S] [--contact-bones B...] \\
-        [--num-keyframes N] [--hip-bone NAME]
+        [--num-keyframes N] [--hip-bone NAME] [--tracking-bone NAME]
+
+When --tracking-bone is specified (e.g. RightHand), the generator tracks that
+bone's world-space position for attacker offsets instead of the root/hip bone.
+Root orientation (hip Euler angles) is always sourced from --hip-bone.
+Impact detection becomes velocity-based: the strike impact is the moment the
+tracking bone's velocity magnitude peaks and then rapidly decelerates.
 
 The script imports motion-pipeline.py as a module directly to avoid the
 5-frame stdout truncation applied by the decompose CLI command.
@@ -22,10 +28,8 @@ import sys
 import types
 from datetime import date
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    pass
+import numpy as np
 
 # ---------------------------------------------------------------------------
 # Motion pipeline import (importlib to avoid CLI 5-frame truncation)
@@ -119,6 +123,85 @@ def _find_contact_window(
     return (best_start / total_frames, best_end / total_frames)
 
 
+def _find_velocity_impact_window(
+    velocities: np.ndarray,
+    num_frames: int,
+    window_fraction: float = 0.05,
+) -> tuple[float, float]:
+    """Detect impact window from bone velocity magnitude.
+
+    The impact moment for a strike is where the tracking limb peaks in velocity
+    and then rapidly decelerates (collision). The window spans from just before
+    peak deceleration for window_fraction of the total clip.
+
+    Algorithm:
+      1. Compute per-frame velocity magnitude.
+      2. Find the frame with maximum magnitude (peak of the strike).
+      3. After the peak, find where speed drops by >50% — that is the impact
+         contact frame.
+      4. If no clear drop exists, fall back to the midpoint.
+
+    Args:
+        velocities: Shape (num_frames, 1, 3) velocity array from bone_velocities.
+        num_frames: Total frame count of the clip.
+        window_fraction: Width of impact window as fraction of total clip (default 5%).
+
+    Returns:
+        (start_progress, end_progress) tuple, both in [0, 1].
+    """
+    # Shape: (num_frames, 1, 3) -> (num_frames,)
+    speed = np.linalg.norm(velocities[:, 0, :], axis=-1)
+
+    peak_frame = int(np.argmax(speed))
+    peak_speed = float(speed[peak_frame])
+
+    # Search for >50% deceleration after peak
+    impact_frame = peak_frame
+    if peak_frame < num_frames - 1:
+        threshold = peak_speed * 0.5
+        for f in range(peak_frame + 1, min(peak_frame + max(int(num_frames * 0.2), 5), num_frames)):
+            if float(speed[f]) < threshold:
+                impact_frame = f
+                break
+        else:
+            # No clear drop found: use a few frames after peak
+            impact_frame = min(peak_frame + max(int(num_frames * 0.03), 2), num_frames - 1)
+
+    # Fallback: if peak is at very start or no meaningful velocity, use midpoint
+    if peak_speed < 1e-4 or peak_frame == 0:
+        impact_frame = num_frames // 2
+
+    window_frames = max(int(num_frames * window_fraction), 3)
+    start = impact_frame / num_frames
+    end = min((impact_frame + window_frames) / num_frames, 1.0)
+    return (start, end)
+
+
+def _extract_bone_positions(
+    motion: object,
+    bone_name: str,
+) -> tuple[list[list[float]], np.ndarray]:
+    """Extract world-space positions and velocities for a named bone.
+
+    Args:
+        motion: Motion object from motion-pipeline (has hierarchy, bone_positions,
+                bone_velocities methods).
+        bone_name: Bone name to track (e.g. 'RightHand').
+
+    Returns:
+        Tuple of (positions as list[list[float]], velocities as np.ndarray shape (F,1,3)).
+
+    Raises:
+        ValueError: If bone_name is not found in the skeleton.
+    """
+    bone_idx = motion.hierarchy.index(bone_name)  # raises ValueError if missing
+    # bone_positions returns (num_frames, num_bones, 3)
+    pos_array = motion.bone_positions([bone_idx])  # (F, 1, 3)
+    vel_array = motion.bone_velocities([bone_idx])  # (F, 1, 3)
+    positions: list[list[float]] = pos_array[:, 0, :].tolist()
+    return positions, vel_array
+
+
 def _sample_keyframes(
     positions: list[list[float]],
     hip_euler: list[list[float]],
@@ -168,17 +251,30 @@ def _sample_keyframes(
 def _compute_defender_keyframes(
     attacker_keyframes: list[tuple[float, list[float], list[float]]],
     impact_window: tuple[float, float] | None,
+    impact_direction: list[float] | None = None,
+    impact_magnitude: float | None = None,
 ) -> list[list[float]]:
     """Compute defender reaction offsets/rotations for each keyframe.
 
-    Defender reaction model:
-    - Before impact: slight lean-in (tracking attacker approach)
-    - At impact: sharp backward displacement + backward rotation
-    - Post-impact: ease down to mat level
+    Two reaction models are available:
+
+    Throw model (impact_direction is None):
+      - Before impact: slight lean-in tracking attacker approach
+      - At impact: sharp backward displacement + backward rotation
+      - Post-impact: ease down to mat level
+
+    Strike model (impact_direction provided):
+      - Pre-impact: defender is stationary (waiting to be hit)
+      - At impact: sharp displacement along the strike direction
+      - Post-impact: ease recovery
+      The push magnitude scales with impact_magnitude, capped at 1.5m backward
+      and 0.8m upward.
 
     Args:
         attacker_keyframes: Output from _sample_keyframes.
         impact_window: (start_progress, end_progress) or None.
+        impact_direction: Normalised XYZ push direction for strike moves, or None.
+        impact_magnitude: Velocity magnitude at impact (m/s) for strike scaling.
 
     Returns:
         List of [defOffX, defOffY, defOffZ, defRotX, defRotY, defRotZ] per keyframe.
@@ -186,46 +282,94 @@ def _compute_defender_keyframes(
     imp_start = impact_window[0] if impact_window else 0.5
     imp_end = impact_window[1] if impact_window else 0.55
 
-    # Defender displacement amplitude: moderate scale matching hand-authored moves
-    BACKWARD_PEAK = 1.2  # metres pushed backward (Z) at impact
-    UPWARD_PEAK = 0.8  # metres upward at impact
-    ROT_PEAK = 0.4  # radians backward lean at impact
+    is_strike = impact_direction is not None
+
+    if is_strike:
+        # Strike: scale push with velocity magnitude, capped at max values
+        MAX_BACKWARD = 1.5
+        MAX_UPWARD = 0.8
+        ROT_PEAK = 0.35
+
+        # Use velocity magnitude to set scale (normalised: 10 m/s = full push)
+        scale = min((impact_magnitude or 5.0) / 10.0, 1.0)
+        dx, dy, dz = impact_direction[0], impact_direction[1], impact_direction[2]
+
+        # Backward push: along strike direction, capped
+        push_x = dx * MAX_BACKWARD * scale
+        push_y = abs(dy) * MAX_UPWARD * scale  # upward component always positive
+        push_z = dz * MAX_BACKWARD * scale
+    else:
+        # Throw model: fixed amplitudes
+        push_x = 0.0
+        push_y = 0.8
+        push_z = -1.2
+        ROT_PEAK = 0.4
 
     results: list[list[float]] = []
 
     for progress, att_pos, _att_rot in attacker_keyframes:
-        # Compute eased impact factor (0 outside impact, peaks at centre)
-        if progress < imp_start:
-            # Pre-impact: subtle backward lean tracking attacker Z
-            t = progress / max(imp_start, 1e-6)
-            ease = t * t  # ease-in
-            def_z = -abs(att_pos[2]) * 0.1 * ease  # slight lean toward attacker
-            def_y = 0.0
-            def_x = 0.0
-            def_rot_x = 0.05 * ease  # slight forward lean
-            def_rot_y = 0.0
-            def_rot_z = 0.0
-        elif progress <= imp_end:
-            # Impact window: ramp up to peak then hold
-            window = max(imp_end - imp_start, 1e-6)
-            t = (progress - imp_start) / window
-            ease = math.sin(t * math.pi / 2)  # ease-in to peak
-            def_z = -BACKWARD_PEAK * ease
-            def_y = UPWARD_PEAK * ease
-            def_x = 0.0
-            def_rot_x = -ROT_PEAK * ease  # backward lean (negative = lean back)
-            def_rot_y = 0.0
-            def_rot_z = 0.0
+        if is_strike:
+            if progress < imp_start:
+                # Pre-impact: defender stationary
+                def_x = 0.0
+                def_y = 0.0
+                def_z = 0.0
+                def_rot_x = 0.0
+                def_rot_y = 0.0
+                def_rot_z = 0.0
+            elif progress <= imp_end:
+                # Impact window: ramp up to peak push
+                window = max(imp_end - imp_start, 1e-6)
+                t = (progress - imp_start) / window
+                ease = math.sin(t * math.pi / 2)
+                def_x = push_x * ease
+                def_y = push_y * ease
+                def_z = push_z * ease
+                def_rot_x = -ROT_PEAK * ease  # backward lean
+                def_rot_y = 0.0
+                def_rot_z = 0.0
+            else:
+                # Post-impact: ease recovery
+                t = (progress - imp_end) / max(1.0 - imp_end, 1e-6)
+                ease = 1.0 - (t * t)
+                def_x = push_x * ease
+                def_y = push_y * ease * 0.3
+                def_z = push_z * ease
+                def_rot_x = -ROT_PEAK * ease
+                def_rot_y = 0.0
+                def_rot_z = 0.0
         else:
-            # Post-impact: ease down to mat
-            t = (progress - imp_end) / max(1.0 - imp_end, 1e-6)
-            ease = 1.0 - (t * t)  # ease-out from 1 toward 0
-            def_z = -BACKWARD_PEAK * ease
-            def_y = UPWARD_PEAK * ease * 0.3  # settle faster than push
-            def_x = 0.0
-            def_rot_x = -ROT_PEAK * ease
-            def_rot_y = 0.0
-            def_rot_z = 0.0
+            if progress < imp_start:
+                # Pre-impact: subtle backward lean tracking attacker Z
+                t = progress / max(imp_start, 1e-6)
+                ease = t * t
+                def_z = -abs(att_pos[2]) * 0.1 * ease
+                def_y = 0.0
+                def_x = 0.0
+                def_rot_x = 0.05 * ease
+                def_rot_y = 0.0
+                def_rot_z = 0.0
+            elif progress <= imp_end:
+                # Impact window: ramp up to peak then hold
+                window = max(imp_end - imp_start, 1e-6)
+                t = (progress - imp_start) / window
+                ease = math.sin(t * math.pi / 2)
+                def_z = push_z * ease
+                def_y = push_y * ease
+                def_x = 0.0
+                def_rot_x = -ROT_PEAK * ease
+                def_rot_y = 0.0
+                def_rot_z = 0.0
+            else:
+                # Post-impact: ease down to mat
+                t = (progress - imp_end) / max(1.0 - imp_end, 1e-6)
+                ease = 1.0 - (t * t)
+                def_z = push_z * ease
+                def_y = push_y * ease * 0.3
+                def_x = 0.0
+                def_rot_x = -ROT_PEAK * ease
+                def_rot_y = 0.0
+                def_rot_z = 0.0
 
         results.append([def_x, def_y, def_z, def_rot_x, def_rot_y, def_rot_z])
 
@@ -421,6 +565,8 @@ def _print_summary(
     attacker_keyframes: list[tuple[float, list[float], list[float]]],
     output_path: Path,
     validation_errors: list[str],
+    tracking_bone: str | None = None,
+    impact_mode: str = "height",
 ) -> None:
     """Print a human-readable summary to stderr."""
     positions = [kf[1] for kf in attacker_keyframes]
@@ -428,14 +574,16 @@ def _print_summary(
     ys = [p[1] for p in positions]
     zs = [p[2] for p in positions]
 
-    print(f"\n=== generate-move-ts summary ===", file=sys.stderr)
+    print("\n=== generate-move-ts summary ===", file=sys.stderr)
     print(f"  BVH source   : {bvh_path}", file=sys.stderr)
     print(f"  Move name    : {move_name}", file=sys.stderr)
     print(f"  Keyframes    : {num_keyframes}", file=sys.stderr)
+    print(f"  Tracking bone: {tracking_bone or 'root (hip)'}", file=sys.stderr)
+    print(f"  Impact mode  : {impact_mode}", file=sys.stderr)
     if impact_window:
         print(f"  Impact window: {impact_window[0]:.3f} - {impact_window[1]:.3f}", file=sys.stderr)
     else:
-        print(f"  Impact window: none detected (using default 0.500-0.550)", file=sys.stderr)
+        print("  Impact window: none detected (using default 0.500-0.550)", file=sys.stderr)
     print(f"  Traj X range : [{min(xs):.4f}, {max(xs):.4f}] m", file=sys.stderr)
     print(f"  Traj Y range : [{min(ys):.4f}, {max(ys):.4f}] m", file=sys.stderr)
     print(f"  Traj Z range : [{min(zs):.4f}, {max(zs):.4f}] m", file=sys.stderr)
@@ -445,7 +593,7 @@ def _print_summary(
         for e in validation_errors:
             print(f"    - {e}", file=sys.stderr)
     else:
-        print(f"  Validation   : OK", file=sys.stderr)
+        print("  Validation   : OK", file=sys.stderr)
     print(file=sys.stderr)
 
 
@@ -490,6 +638,16 @@ def _build_parser() -> argparse.ArgumentParser:
         default="Hips",
         metavar="NAME",
         help="Name of the hip/root bone for trajectory extraction (default: Hips).",
+    )
+    parser.add_argument(
+        "--tracking-bone",
+        default=None,
+        metavar="NAME",
+        help=(
+            "Bone name for limb tracking (e.g. RightHand). When specified, the attacker's "
+            "offsetX/Y/Z follows this bone's world-space trajectory instead of the root. "
+            "Impact detection switches to velocity-based mode. Root bone still drives rotations."
+        ),
     )
     parser.add_argument(
         "--output",
@@ -539,38 +697,84 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error in decompose: {e}", file=sys.stderr)
         return 1
 
-    # Filter contact bones to those that exist in the skeleton
-    available_bones = set(motion.hierarchy.bone_names)
-    contact_bones = [b for b in args.contact_bones if b in available_bones]
-    missing = [b for b in args.contact_bones if b not in available_bones]
-    if missing:
-        print(
-            f"Warning: contact bones not found in skeleton, skipping: {missing}",
-            file=sys.stderr,
-        )
-    if not contact_bones:
-        print("Warning: no contact bones available; impact window will use default.", file=sys.stderr)
-
-    # Extract contacts
-    contact_data: dict = {"bones": {}, "total_frames": motion.num_frames}
-    if contact_bones:
-        try:
-            contact_data = pipeline.extract_contacts(motion, bone_names=contact_bones)
-        except ValueError as e:
-            print(f"Warning: contact extraction failed: {e}", file=sys.stderr)
-
-    # Full-resolution trajectory and hip Euler (not truncated — imported directly)
-    positions: list[list[float]] = decomp["root_trajectory"]["positions"]
+    # Full-resolution hip Euler (always from root/hip bone, drives rotations)
     hip_euler: list[list[float]] = decomp["per_joint_euler_zyx_degrees"][args.hip_bone]
 
-    # Detect impact window
-    impact_window = _find_contact_window(contact_data, contact_bones, motion.num_frames)
+    # Determine position source and impact detection mode
+    impact_window: tuple[float, float] | None = None
+    impact_direction: list[float] | None = None
+    impact_magnitude: float | None = None
+    impact_mode = "height"
 
-    # Sample keyframes
+    if args.tracking_bone:
+        # Limb tracking: use the specified bone's world-space position
+        tracking_name = args.tracking_bone
+        available_bones = set(motion.hierarchy.bone_names)
+        if tracking_name not in available_bones:
+            print(
+                f"Error: --tracking-bone '{tracking_name}' not found in skeleton. "
+                f"Available bones: {sorted(available_bones)}",
+                file=sys.stderr,
+            )
+            return 1
+
+        try:
+            positions, vel_array = _extract_bone_positions(motion, tracking_name)
+        except ValueError as e:
+            print(f"Error extracting tracking bone positions: {e}", file=sys.stderr)
+            return 1
+
+        # Velocity-based impact detection
+        impact_mode = "velocity"
+        impact_window = _find_velocity_impact_window(vel_array, motion.num_frames)
+
+        # Compute impact direction from velocity vector at impact frame
+        impact_frame = int(impact_window[0] * motion.num_frames)
+        vel_at_impact = vel_array[impact_frame, 0, :]  # (3,)
+        speed_at_impact = float(np.linalg.norm(vel_at_impact))
+        if speed_at_impact > 1e-6:
+            norm_dir = (vel_at_impact / speed_at_impact).tolist()
+            impact_direction = [float(v) for v in norm_dir]
+            impact_magnitude = speed_at_impact
+        else:
+            # Zero-velocity fallback: push straight back
+            impact_direction = [0.0, 0.0, -1.0]
+            impact_magnitude = 1.0
+    else:
+        # Default: track root/hip bone trajectory
+        positions = decomp["root_trajectory"]["positions"]
+
+        # Height-based contact detection
+        available_bones = set(motion.hierarchy.bone_names)
+        contact_bones = [b for b in args.contact_bones if b in available_bones]
+        missing = [b for b in args.contact_bones if b not in available_bones]
+        if missing:
+            print(
+                f"Warning: contact bones not found in skeleton, skipping: {missing}",
+                file=sys.stderr,
+            )
+        if not contact_bones:
+            print("Warning: no contact bones available; impact window will use default.", file=sys.stderr)
+
+        contact_data: dict = {"bones": {}, "total_frames": motion.num_frames}
+        if contact_bones:
+            try:
+                contact_data = pipeline.extract_contacts(motion, bone_names=contact_bones)
+            except ValueError as e:
+                print(f"Warning: contact extraction failed: {e}", file=sys.stderr)
+
+        impact_window = _find_contact_window(contact_data, contact_bones, motion.num_frames)
+
+    # Sample keyframes from resolved positions + hip rotations
     attacker_keyframes = _sample_keyframes(positions, hip_euler, args.num_keyframes)
 
-    # Compute defender reaction
-    defender_frames = _compute_defender_keyframes(attacker_keyframes, impact_window)
+    # Compute defender reaction (strike model if tracking bone used)
+    defender_frames = _compute_defender_keyframes(
+        attacker_keyframes,
+        impact_window,
+        impact_direction=impact_direction,
+        impact_magnitude=impact_magnitude,
+    )
 
     # Generate TypeScript
     ts_source = generate_typescript(
@@ -601,6 +805,8 @@ def main(argv: list[str] | None = None) -> int:
         attacker_keyframes=attacker_keyframes,
         output_path=output_path,
         validation_errors=validation_errors,
+        tracking_bone=args.tracking_bone,
+        impact_mode=impact_mode,
     )
 
     return 1 if validation_errors else 0

--- a/scripts/motion-pipeline.py
+++ b/scripts/motion-pipeline.py
@@ -1,0 +1,798 @@
+#!/usr/bin/env python3
+"""Motion pipeline CLI for game animation data processing.
+
+Standalone CPU-only implementation of the motion data processing pipeline
+inspired by Meta's ai4animationpy framework (CC BY-NC 4.0).
+
+All ai4animationpy modules (Animation, Import, IK, Math) require PyTorch at
+import time via Math/Tensor.py -- even the NumPy backend path. This script
+replicates the key algorithms using only numpy and scipy so the pipeline
+runs on hardware without a GPU.
+
+Usage:
+    motion-pipeline import-bvh FILE [--scale S] [--fps FPS]
+    motion-pipeline extract-contacts FILE --bones B... [--height H] [--vel V]
+    motion-pipeline decompose FILE [--hip JOINT]
+    motion-pipeline blend FILE1 FILE2 [--alpha A]
+    motion-pipeline solve-ik FILE --chain ROOT:TIP [--target X,Y,Z]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from scipy.spatial.transform import Rotation as ScipyRotation
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Hierarchy:
+    """Bone hierarchy: names and parent indices."""
+
+    bone_names: list[str]
+    parent_indices: list[int]  # -1 for root
+
+    def index(self, name: str) -> int:
+        """Return bone index by name, raises ValueError if not found."""
+        return self.bone_names.index(name)
+
+    def indices(self, names: list[str]) -> list[int]:
+        """Return indices for a list of bone names."""
+        return [self.index(n) for n in names]
+
+
+@dataclass
+class Motion:
+    """Core motion data structure.
+
+    Attributes:
+        name: Clip identifier (typically filename stem).
+        hierarchy: Bone names and parent relationships.
+        frames: Global transforms [num_frames, num_joints, 4, 4].
+        framerate: Frames per second.
+    """
+
+    name: str
+    hierarchy: Hierarchy
+    frames: np.ndarray  # (F, J, 4, 4) float32
+    framerate: float
+
+    @property
+    def num_frames(self) -> int:
+        return self.frames.shape[0]
+
+    @property
+    def num_joints(self) -> int:
+        return self.frames.shape[1]
+
+    @property
+    def total_time(self) -> float:
+        return (self.num_frames - 1) / self.framerate
+
+    @property
+    def delta_time(self) -> float:
+        return 1.0 / self.framerate
+
+    def bone_positions(self, bone_indices: list[int] | None = None) -> np.ndarray:
+        """Extract world-space positions for selected bones.
+
+        Returns array of shape (num_frames, num_bones, 3).
+
+        Note: Uses two-step indexing (frames[:, idx][:, :, :3, 3]) rather than
+        frames[:, idx, :3, 3] to avoid numpy advanced-indexing axis transposition
+        when idx is a list and a scalar index appears on a later axis.
+        """
+        idx = bone_indices if bone_indices is not None else list(range(self.num_joints))
+        return self.frames[:, idx][:, :, :3, 3]
+
+    def bone_velocities(self, bone_indices: list[int] | None = None) -> np.ndarray:
+        """Compute per-frame velocities (finite difference of positions).
+
+        Returns array of shape (num_frames, num_bones, 3).
+        """
+        positions = self.bone_positions(bone_indices)
+        velocities = np.zeros_like(positions)
+        dt = self.delta_time
+        # Central difference for interior frames
+        velocities[1:-1] = (positions[2:] - positions[:-2]) / (2.0 * dt)
+        # Forward/backward at boundaries
+        velocities[0] = (positions[1] - positions[0]) / dt
+        velocities[-1] = (positions[-1] - positions[-2]) / dt
+        return velocities
+
+    def summary(self) -> dict:
+        """Return human-readable summary dict."""
+        positions = self.bone_positions()
+        root_pos = positions[:, 0, :]  # assume bone[0] is root
+        return {
+            "name": self.name,
+            "num_frames": self.num_frames,
+            "num_joints": self.num_joints,
+            "framerate": self.framerate,
+            "total_time_seconds": round(self.total_time, 3),
+            "bones": self.hierarchy.bone_names,
+            "root_trajectory": {
+                "x_range": [round(float(root_pos[:, 0].min()), 3), round(float(root_pos[:, 0].max()), 3)],
+                "y_range": [round(float(root_pos[:, 1].min()), 3), round(float(root_pos[:, 1].max()), 3)],
+                "z_range": [round(float(root_pos[:, 2].min()), 3), round(float(root_pos[:, 2].max()), 3)],
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# BVH Parser (adapted from ai4animationpy BVHImporter.py)
+# ---------------------------------------------------------------------------
+
+_CHANNELMAP = {"Xrotation": "x", "Yrotation": "y", "Zrotation": "z"}
+
+
+def _euler_to_rotation_matrix(angles_deg: np.ndarray, order: str) -> np.ndarray:
+    """Convert Euler angles (degrees) to 3x3 rotation matrices.
+
+    Args:
+        angles_deg: Shape (..., 3) array of Euler angles in degrees.
+        order: Axis order string, e.g. 'zyx'.
+
+    Returns:
+        Shape (..., 3, 3) rotation matrices.
+    """
+    orig_shape = angles_deg.shape[:-1]
+    flat = angles_deg.reshape(-1, 3)
+    rot = ScipyRotation.from_euler(order.upper(), flat, degrees=True)
+    matrices = rot.as_matrix().astype(np.float32)
+    return matrices.reshape(orig_shape + (3, 3))
+
+
+def load_bvh(path: str | Path, scale: float = 1.0) -> Motion:
+    """Parse a BVH file into a Motion object.
+
+    Implements the same parsing logic as ai4animationpy BVHImporter.BVH,
+    but depends only on numpy + scipy (no PyTorch).
+
+    Args:
+        path: Path to .bvh file.
+        scale: Uniform scale applied to all positions (use 0.01 to convert
+               cm mocap data to meters).
+
+    Returns:
+        Motion object with global transform matrices.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the BVH file is malformed.
+    """
+    path = Path(path)
+    if not path.is_file():
+        raise FileNotFoundError(f"BVH file not found: {path}")
+
+    names: list[str] = []
+    offsets_list: list[list[float]] = []
+    parents: list[int] = []
+    channel_counts: list[int] = []
+
+    active = -1
+    channels: int | None = None
+    order: str | None = None
+    framerate: float | None = None
+    positions: np.ndarray | None = None
+    rotations: np.ndarray | None = None
+    frame_index = 0
+
+    with open(path) as fh:
+        for line in fh:
+            if "HIERARCHY" in line or "MOTION" in line:
+                continue
+
+            rmatch = re.match(r"\s*ROOT\s+(.+?)\s*$", line)
+            if rmatch:
+                names.append(rmatch.group(1))
+                offsets_list.append([0.0, 0.0, 0.0])
+                parents.append(active)
+                channel_counts.append(0)
+                active = len(parents) - 1
+                continue
+
+            if "{" in line:
+                continue
+
+            if "}" in line:
+                if active != -1:
+                    active = parents[active]
+                continue
+
+            offmatch = re.match(r"\s*OFFSET\s+([\-\d\.eE\+]+)\s+([\-\d\.eE\+]+)\s+([\-\d\.eE\+]+)", line)
+            if offmatch:
+                offsets_list[active] = [float(x) for x in offmatch.groups()]
+                continue
+
+            chanmatch = re.match(r"\s*CHANNELS\s+(\d+)", line)
+            if chanmatch:
+                n_channels = int(chanmatch.group(1))
+                channel_counts[active] = n_channels
+                if order is None:
+                    start = 0 if n_channels == 3 else 3
+                    parts = line.split()[2 + start : 2 + start + 3]
+                    if all(p in _CHANNELMAP for p in parts):
+                        order = "".join(_CHANNELMAP[p] for p in parts)
+                continue
+
+            jmatch = re.match(r"\s*JOINT\s+(.+?)\s*$", line)
+            if jmatch:
+                names.append(jmatch.group(1))
+                offsets_list.append([0.0, 0.0, 0.0])
+                parents.append(active)
+                channel_counts.append(0)
+                active = len(parents) - 1
+                continue
+
+            if "End Site" in line:
+                # End sites are leaf markers; skip (no channels to parse)
+                parent_name = names[active] if active != -1 else "End"
+                site_name = f"{parent_name}Site"
+                suffix = 1
+                while site_name in names:
+                    suffix += 1
+                    site_name = f"{parent_name}Site{suffix}"
+                names.append(site_name)
+                offsets_list.append([0.0, 0.0, 0.0])
+                parents.append(active)
+                channel_counts.append(0)
+                active = len(parents) - 1
+                continue
+
+            fmatch = re.match(r"\s*Frames:\s+(\d+)", line)
+            if fmatch:
+                fnum = int(fmatch.group(1))
+                offsets = np.array(offsets_list, dtype=np.float32)
+                # positions broadcast: each frame starts from bone offsets
+                positions = np.tile(offsets[np.newaxis], (fnum, 1, 1))
+                rotations = np.zeros((fnum, len(names), 3), dtype=np.float32)
+                continue
+
+            fmatch = re.match(r"\s*Frame Time:\s+([\d\.eE\+\-]+)", line)
+            if fmatch:
+                framerate = 1.0 / float(fmatch.group(1))
+                continue
+
+            dmatch = line.strip().split()
+            if dmatch and positions is not None:
+                try:
+                    data_block = np.array([float(x) for x in dmatch], dtype=np.float32)
+                except ValueError:
+                    continue
+
+                cursor = 0
+                for joint_idx, num_ch in enumerate(channel_counts):
+                    if num_ch == 0:
+                        continue
+                    block = data_block[cursor : cursor + num_ch]
+                    if block.size != num_ch:
+                        raise ValueError(
+                            f"Malformed BVH frame {frame_index}: expected {num_ch} values "
+                            f"for joint {names[joint_idx]}, got {block.size}."
+                        )
+                    if num_ch == 3:
+                        rotations[frame_index, joint_idx] = block
+                    elif num_ch >= 6:
+                        positions[frame_index, joint_idx] = block[:3]
+                        rotations[frame_index, joint_idx] = block[3:6]
+                    cursor += num_ch
+
+                frame_index += 1
+
+    if order is None:
+        raise ValueError(f"Could not detect rotation order from BVH: {path}")
+    if framerate is None:
+        raise ValueError(f"Could not detect frame time from BVH: {path}")
+    if positions is None:
+        raise ValueError(f"No frame data found in BVH: {path}")
+
+    num_frames, num_joints = positions.shape[:2]
+
+    # Build local 4x4 transform matrices [F, J, 4, 4]
+    rot_matrices = _euler_to_rotation_matrix(rotations, order)  # (F, J, 3, 3)
+    local_pos = positions * scale  # (F, J, 3)
+
+    local_matrices = np.zeros((num_frames, num_joints, 4, 4), dtype=np.float32)
+    local_matrices[:, :, :3, :3] = rot_matrices
+    local_matrices[:, :, :3, 3] = local_pos
+    local_matrices[:, :, 3, 3] = 1.0
+
+    # Forward kinematics: accumulate global transforms
+    global_matrices = np.zeros_like(local_matrices)
+    parents_arr = np.array(parents, dtype=np.int32)
+    for j in range(num_joints):
+        p = parents_arr[j]
+        if p == -1:
+            global_matrices[:, j] = local_matrices[:, j]
+        else:
+            # batched 4x4 matrix multiply: global[j] = global[parent] @ local[j]
+            global_matrices[:, j] = np.einsum("fij,fjk->fik", global_matrices[:, p], local_matrices[:, j])
+
+    # Filter to joints that have motion channels (same as ai4animationpy BVH.LoadMotion)
+    motion_joints = [i for i, ch in enumerate(channel_counts) if ch > 0]
+    motion_names = [names[i] for i in motion_joints]
+    motion_frames = global_matrices[:, motion_joints]
+
+    # Build parent index list for motion joints only
+    motion_name_set = set(motion_names)
+    motion_parent_indices: list[int] = []
+    for name in motion_names:
+        orig_idx = names.index(name)
+        p_idx = parents_arr[orig_idx]
+        # Walk up until we find a motion joint parent
+        while p_idx != -1 and names[p_idx] not in motion_name_set:
+            p_idx = parents_arr[p_idx]
+        if p_idx == -1 or names[p_idx] not in motion_names:
+            motion_parent_indices.append(-1)
+        else:
+            motion_parent_indices.append(motion_names.index(names[p_idx]))
+
+    hierarchy = Hierarchy(bone_names=motion_names, parent_indices=motion_parent_indices)
+    return Motion(name=path.stem, hierarchy=hierarchy, frames=motion_frames, framerate=framerate)
+
+
+# ---------------------------------------------------------------------------
+# Contact detection
+# ---------------------------------------------------------------------------
+
+
+def extract_contacts(
+    motion: Motion,
+    bone_names: list[str],
+    height_thresholds: list[float] | None = None,
+    velocity_thresholds: list[float] | None = None,
+) -> dict:
+    """Detect contact frames for specified bones.
+
+    A bone is considered in contact when both:
+    - Its world Y position is below the height threshold.
+    - Its world-space velocity magnitude is below the velocity threshold.
+
+    This replicates ai4animationpy ContactModule.GetContacts().
+
+    Args:
+        motion: Motion object from load_bvh.
+        bone_names: List of bone names to check (e.g. ['LeftFoot', 'RightFoot']).
+        height_thresholds: Per-bone Y thresholds (meters). Default: 0.1 each.
+        velocity_thresholds: Per-bone speed thresholds (m/s). Default: 0.5 each.
+
+    Returns:
+        Dict with per-bone contact frame lists and summary statistics.
+    """
+    try:
+        indices = motion.hierarchy.indices(bone_names)
+    except ValueError as e:
+        raise ValueError(f"Bone not found: {e}. Available: {motion.hierarchy.bone_names}") from e
+
+    n = len(bone_names)
+    ht = height_thresholds if height_thresholds is not None else [0.1] * n
+    vt = velocity_thresholds if velocity_thresholds is not None else [0.5] * n
+
+    positions = motion.bone_positions(indices)  # (F, n, 3)
+    velocities = motion.bone_velocities(indices)  # (F, n, 3)
+    speeds = np.linalg.norm(velocities, axis=-1)  # (F, n)
+
+    results: dict = {"bones": {}, "total_frames": motion.num_frames}
+    for bi, (bone, hi, vi) in enumerate(zip(bone_names, ht, vt)):
+        height_ok = positions[:, bi, 1] < hi
+        speed_ok = speeds[:, bi] < vi
+        contact = height_ok & speed_ok
+        contact_frames = np.where(contact)[0].tolist()
+
+        results["bones"][bone] = {
+            "contact_frames": contact_frames,
+            "contact_count": len(contact_frames),
+            "contact_ratio": round(len(contact_frames) / motion.num_frames, 3),
+            "height_threshold": hi,
+            "velocity_threshold": vi,
+        }
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Decompose: root trajectory + per-joint local transforms
+# ---------------------------------------------------------------------------
+
+
+def decompose(motion: Motion, hip_name: str | None = None) -> dict:
+    """Split motion into root trajectory, per-joint transforms, and velocities.
+
+    Implements the RootModule / MotionModule decomposition pattern from
+    ai4animationpy: root captures WHERE and HOW, joints capture the pose.
+
+    Args:
+        motion: Motion object.
+        hip_name: Name of the hip/root bone. Defaults to first bone.
+
+    Returns:
+        Dict with root_trajectory and per_joint_local_transforms.
+    """
+    hip_idx = 0
+    if hip_name is not None:
+        try:
+            hip_idx = motion.hierarchy.index(hip_name)
+        except ValueError as e:
+            raise ValueError(f"Hip bone '{hip_name}' not found. Available: {motion.hierarchy.bone_names}") from e
+
+    root_positions = motion.frames[:, hip_idx, :3, 3]  # (F, 3)
+    root_rot_matrices = motion.frames[:, hip_idx, :3, :3]  # (F, 3, 3)
+
+    # Root velocity (finite difference)
+    root_vel = np.zeros_like(root_positions)
+    dt = motion.delta_time
+    root_vel[1:-1] = (root_positions[2:] - root_positions[:-2]) / (2.0 * dt)
+    root_vel[0] = (root_positions[1] - root_positions[0]) / dt
+    root_vel[-1] = (root_positions[-1] - root_positions[-2]) / dt
+
+    # Facing direction: extract forward vector from root rotation (Z column)
+    facing = root_rot_matrices[:, :, 2]  # (F, 3) -- Z forward convention
+
+    # Per-joint local transforms: global[j] = global[parent] @ local[j]
+    # => local[j] = inv(global[parent]) @ global[j]
+    local_transforms = np.zeros_like(motion.frames)
+    parents = motion.hierarchy.parent_indices
+
+    for j in range(motion.num_joints):
+        p = parents[j]
+        if p == -1:
+            local_transforms[:, j] = motion.frames[:, j]
+        else:
+            parent_inv = np.linalg.inv(motion.frames[:, p])  # (F, 4, 4)
+            local_transforms[:, j] = np.einsum("fij,fjk->fik", parent_inv, motion.frames[:, j])
+
+    # Extract per-joint Euler angles from local rotation matrices
+    local_angles_list = []
+    for j in range(motion.num_joints):
+        rots = ScipyRotation.from_matrix(local_transforms[:, j, :3, :3])
+        euler = rots.as_euler("ZYX", degrees=True)  # (F, 3)
+        local_angles_list.append(euler.tolist())
+
+    return {
+        "hip_bone": motion.hierarchy.bone_names[hip_idx],
+        "num_frames": motion.num_frames,
+        "framerate": motion.framerate,
+        "root_trajectory": {
+            "positions": root_positions.tolist(),
+            "velocities": root_vel.tolist(),
+            "facing_directions": facing.tolist(),
+        },
+        "per_joint_euler_zyx_degrees": {
+            motion.hierarchy.bone_names[j]: local_angles_list[j] for j in range(motion.num_joints)
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Motion blending (SLERP rotations, LERP positions)
+# ---------------------------------------------------------------------------
+
+
+def blend_motions(motion_a: Motion, motion_b: Motion, alpha: float = 0.5) -> Motion:
+    """Blend two motion clips at a fixed alpha.
+
+    Both clips must have the same bone hierarchy. Frame counts may differ;
+    the shorter clip is resampled to match the longer.
+
+    Uses SLERP for rotation components and linear interpolation for positions,
+    matching the intended behavior of ai4animationpy Tensor.Interpolate.
+
+    Args:
+        motion_a: First motion clip.
+        motion_b: Second motion clip.
+        alpha: Blend weight (0.0 = all A, 1.0 = all B).
+
+    Returns:
+        New Motion with blended transforms.
+    """
+    if motion_a.hierarchy.bone_names != motion_b.hierarchy.bone_names:
+        raise ValueError("Cannot blend motions with different hierarchies.")
+    if not 0.0 <= alpha <= 1.0:
+        raise ValueError(f"Alpha must be in [0, 1], got {alpha}.")
+
+    target_frames = max(motion_a.num_frames, motion_b.num_frames)
+    target_fps = motion_a.framerate
+
+    def resample(frames: np.ndarray, from_n: int, to_n: int) -> np.ndarray:
+        """Resample frames array to a different frame count via linear interpolation."""
+        if from_n == to_n:
+            return frames
+        src_t = np.linspace(0, 1, from_n)
+        dst_t = np.linspace(0, 1, to_n)
+        # Vectorised: reshape to (from_n, -1), interp each column, reshape back
+        flat = frames.reshape(from_n, -1)
+        out = np.zeros((to_n, flat.shape[1]), dtype=np.float32)
+        for col in range(flat.shape[1]):
+            out[:, col] = np.interp(dst_t, src_t, flat[:, col])
+        return out.reshape(to_n, frames.shape[1], frames.shape[2], frames.shape[3])
+
+    frames_a = resample(motion_a.frames, motion_a.num_frames, target_frames)
+    frames_b = resample(motion_b.frames, motion_b.num_frames, target_frames)
+
+    blended = np.zeros_like(frames_a)
+
+    # LERP positions: vectorised over all joints and frames at once
+    blended[:, :, :3, 3] = (1.0 - alpha) * frames_a[:, :, :3, 3] + alpha * frames_b[:, :, :3, 3]
+    blended[:, :, 3, 3] = 1.0
+
+    # SLERP rotations: per-joint vectorised over all frames using quaternion lerp.
+    # scipy Rotation supports batched from_matrix and vectorised slerp via
+    # linear quaternion interpolation (nlerp) which is nearly identical to slerp
+    # for small angular differences and much faster than per-frame Slerp calls.
+    for j in range(motion_a.num_joints):
+        rot_a = ScipyRotation.from_matrix(frames_a[:, j, :3, :3])  # batch (F,)
+        rot_b = ScipyRotation.from_matrix(frames_b[:, j, :3, :3])  # batch (F,)
+
+        # Vectorised quaternion nlerp: q = normalize((1-a)*qa + a*qb)
+        qa = rot_a.as_quat()  # (F, 4) xyzw
+        qb = rot_b.as_quat()  # (F, 4) xyzw
+
+        # Ensure shortest-path interpolation by flipping qb if dot product < 0
+        dot = np.sum(qa * qb, axis=-1, keepdims=True)
+        qb = np.where(dot < 0, -qb, qb)
+
+        q_blend = (1.0 - alpha) * qa + alpha * qb
+        norms = np.linalg.norm(q_blend, axis=-1, keepdims=True)
+        q_blend = q_blend / np.maximum(norms, 1e-8)
+
+        blended[:, j, :3, :3] = ScipyRotation.from_quat(q_blend).as_matrix().astype(np.float32)
+
+    return Motion(
+        name=f"{motion_a.name}_x_{motion_b.name}_a{alpha:.2f}",
+        hierarchy=motion_a.hierarchy,
+        frames=blended,
+        framerate=target_fps,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FABRIK IK solver (standalone, mirrors ai4animationpy IK/FABRIK.py)
+# ---------------------------------------------------------------------------
+
+
+def solve_ik_fabrik(
+    chain_positions: np.ndarray,
+    target: np.ndarray,
+    max_iterations: int = 30,
+    threshold: float = 0.001,
+) -> np.ndarray:
+    """FABRIK inverse kinematics solver.
+
+    Forward And Backward Reaching Inverse Kinematics.
+    Mirrors the algorithm in ai4animationpy IK/FABRIK.py.
+
+    Args:
+        chain_positions: Bone positions (N, 3) from root to end effector.
+        target: Target position (3,).
+        max_iterations: Maximum solver iterations.
+        threshold: Convergence threshold (meters).
+
+    Returns:
+        Solved bone positions (N, 3).
+    """
+    positions = chain_positions.copy().astype(np.float64)
+    n = len(positions)
+    lengths = np.linalg.norm(positions[1:] - positions[:-1], axis=-1)  # (N-1,)
+    root = positions[0].copy()
+
+    total_length = lengths.sum()
+    dist_to_target = np.linalg.norm(target - root)
+
+    if dist_to_target > total_length:
+        # Target unreachable: fully extend chain toward target
+        direction = (target - root) / (dist_to_target + 1e-8)
+        for i in range(1, n):
+            positions[i] = positions[i - 1] + direction * lengths[i - 1]
+        return positions.astype(np.float32)
+
+    for _ in range(max_iterations):
+        # Backward pass: pull end effector to target
+        positions[-1] = target
+        for i in range(n - 2, -1, -1):
+            direction = positions[i] - positions[i + 1]
+            norm = np.linalg.norm(direction)
+            if norm > 1e-8:
+                positions[i] = positions[i + 1] + direction / norm * lengths[i]
+
+        # Forward pass: restore root
+        positions[0] = root
+        for i in range(1, n):
+            direction = positions[i] - positions[i - 1]
+            norm = np.linalg.norm(direction)
+            if norm > 1e-8:
+                positions[i] = positions[i - 1] + direction / norm * lengths[i - 1]
+
+        if np.linalg.norm(positions[-1] - target) < threshold:
+            break
+
+    return positions.astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="motion-pipeline",
+        description="CPU-only motion data processing pipeline for game animation.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # import-bvh
+    p_import = sub.add_parser("import-bvh", help="Parse BVH file and print motion summary.")
+    p_import.add_argument("file", type=Path, help="Path to .bvh file.")
+    p_import.add_argument("--scale", type=float, default=1.0, help="Position scale factor (default 1.0).")
+    p_import.add_argument(
+        "--fps",
+        type=float,
+        default=None,
+        help="Override output framerate (resampling not implemented, informational only).",
+    )
+
+    # extract-contacts
+    p_contact = sub.add_parser("extract-contacts", help="Detect ground contact frames per bone.")
+    p_contact.add_argument("file", type=Path, help="Path to .bvh file.")
+    p_contact.add_argument("--bones", nargs="+", required=True, help="Bone names to analyse.")
+    p_contact.add_argument("--height", type=float, default=0.1, help="Height threshold in metres (default 0.1).")
+    p_contact.add_argument("--vel", type=float, default=0.5, help="Velocity threshold in m/s (default 0.5).")
+    p_contact.add_argument("--scale", type=float, default=1.0)
+
+    # decompose
+    p_decompose = sub.add_parser("decompose", help="Split motion into root trajectory and per-joint transforms.")
+    p_decompose.add_argument("file", type=Path, help="Path to .bvh file.")
+    p_decompose.add_argument("--hip", type=str, default=None, help="Hip/root bone name.")
+    p_decompose.add_argument("--scale", type=float, default=1.0)
+
+    # blend
+    p_blend = sub.add_parser("blend", help="Blend two BVH clips at a fixed alpha.")
+    p_blend.add_argument("file_a", type=Path, help="First .bvh file.")
+    p_blend.add_argument("file_b", type=Path, help="Second .bvh file (must share skeleton).")
+    p_blend.add_argument("--alpha", type=float, default=0.5, help="Blend weight (0=A, 1=B).")
+    p_blend.add_argument("--scale", type=float, default=1.0)
+
+    # solve-ik
+    p_ik = sub.add_parser("solve-ik", help="Run FABRIK IK solver on a bone chain.")
+    p_ik.add_argument("file", type=Path, help="Path to .bvh file.")
+    p_ik.add_argument(
+        "--chain", required=True, metavar="ROOT:TIP", help="Colon-separated bone names forming the IK chain."
+    )
+    p_ik.add_argument("--target", required=True, metavar="X,Y,Z", help="Target position as comma-separated floats.")
+    p_ik.add_argument("--frame", type=int, default=0, help="Frame index to solve (default 0).")
+    p_ik.add_argument("--scale", type=float, default=1.0)
+
+    return parser
+
+
+def cmd_import_bvh(args: argparse.Namespace) -> None:
+    motion = load_bvh(args.file, scale=args.scale)
+    result = motion.summary()
+    print(json.dumps(result, indent=2))
+
+
+def cmd_extract_contacts(args: argparse.Namespace) -> None:
+    motion = load_bvh(args.file, scale=args.scale)
+    result = extract_contacts(
+        motion,
+        bone_names=args.bones,
+        height_thresholds=[args.height] * len(args.bones),
+        velocity_thresholds=[args.vel] * len(args.bones),
+    )
+    print(json.dumps(result, indent=2))
+
+
+def cmd_decompose(args: argparse.Namespace) -> None:
+    motion = load_bvh(args.file, scale=args.scale)
+    result = decompose(motion, hip_name=args.hip)
+    # Truncate large arrays for readability: show first 5 frames
+    if result["num_frames"] > 5:
+        result["root_trajectory"]["positions"] = result["root_trajectory"]["positions"][:5]
+        result["root_trajectory"]["velocities"] = result["root_trajectory"]["velocities"][:5]
+        result["root_trajectory"]["facing_directions"] = result["root_trajectory"]["facing_directions"][:5]
+        result["note"] = f"Truncated to first 5 frames of {result['num_frames']} total for display."
+        for bone in result["per_joint_euler_zyx_degrees"]:
+            result["per_joint_euler_zyx_degrees"][bone] = result["per_joint_euler_zyx_degrees"][bone][:5]
+    print(json.dumps(result, indent=2))
+
+
+def cmd_blend(args: argparse.Namespace) -> None:
+    motion_a = load_bvh(args.file_a, scale=args.scale)
+    motion_b = load_bvh(args.file_b, scale=args.scale)
+    blended = blend_motions(motion_a, motion_b, alpha=args.alpha)
+    result = blended.summary()
+    result["blend_alpha"] = args.alpha
+    result["source_a"] = str(args.file_a)
+    result["source_b"] = str(args.file_b)
+    print(json.dumps(result, indent=2))
+
+
+def cmd_solve_ik(args: argparse.Namespace) -> None:
+    motion = load_bvh(args.file, scale=args.scale)
+
+    chain_parts = args.chain.split(":")
+    if len(chain_parts) < 2:
+        print("Error: --chain must be ROOT:TIP (at least two bones)", file=sys.stderr)
+        sys.exit(1)
+
+    # Find bone chain between root and tip names
+    root_name, tip_name = chain_parts[0], chain_parts[-1]
+    try:
+        root_idx = motion.hierarchy.index(root_name)
+        tip_idx = motion.hierarchy.index(tip_name)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Build chain by walking from tip to root via parent indices
+    chain_indices: list[int] = []
+    current = tip_idx
+    while current != -1 and current != root_idx:
+        chain_indices.append(current)
+        current = motion.hierarchy.parent_indices[current]
+    if current == root_idx:
+        chain_indices.append(root_idx)
+    else:
+        print(f"Error: {root_name} is not an ancestor of {tip_name}.", file=sys.stderr)
+        sys.exit(1)
+    chain_indices.reverse()
+
+    frame = min(args.frame, motion.num_frames - 1)
+    chain_positions = motion.frames[frame, chain_indices, :3, 3]  # (N, 3)
+
+    try:
+        target_xyz = [float(x) for x in args.target.split(",")]
+        if len(target_xyz) != 3:
+            raise ValueError("Need exactly 3 values")
+    except ValueError as e:
+        print(f"Error parsing --target: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    target = np.array(target_xyz, dtype=np.float32)
+    solved = solve_ik_fabrik(chain_positions, target)
+
+    result = {
+        "frame": frame,
+        "chain": [motion.hierarchy.bone_names[i] for i in chain_indices],
+        "target": target_xyz,
+        "initial_positions": chain_positions.tolist(),
+        "solved_positions": solved.tolist(),
+        "end_effector_error": round(float(np.linalg.norm(solved[-1] - target)), 5),
+    }
+    print(json.dumps(result, indent=2))
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    dispatch = {
+        "import-bvh": cmd_import_bvh,
+        "extract-contacts": cmd_extract_contacts,
+        "decompose": cmd_decompose,
+        "blend": cmd_blend,
+        "solve-ik": cmd_solve_ik,
+    }
+
+    try:
+        dispatch[args.command](args)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/motion-pipeline/SKILL.md
+++ b/skills/motion-pipeline/SKILL.md
@@ -130,6 +130,63 @@ motion-pipeline-env/bin/python scripts/motion-pipeline.py solve-ik FILE \
 Output: `chain[]`, `target[]`, `initial_positions[]`, `solved_positions[]`,
 `end_effector_error` (metres).
 
+### generate-move-ts
+
+Convert a BVH mocap file into a TypeScript `MoveFrame` function compatible with
+road-to-aew's `wrestlingMoves.ts` interface. Outputs keyframe-interpolated
+TypeScript to stdout (and optionally a file).
+
+```bash
+motion-pipeline-env/bin/python scripts/generate-move-ts.py BVH MOVE_NAME \
+  [--scale 0.01] \
+  [--contact-bones LeftToeBase RightToeBase LeftHand RightHand] \
+  [--num-keyframes 12] \
+  [--hip-bone Hips] \
+  [--output path/to/output.ts]
+```
+
+| Argument | Default | Purpose |
+|---|---|---|
+| `BVH` | — | Path to .bvh mocap file |
+| `MOVE_NAME` | — | Kebab-case name (e.g. `roundhouse-kick`) used in TS identifiers |
+| `--scale` | `0.01` | Position scale; 0.01 converts cm→m for CMU/Mixamo files |
+| `--contact-bones` | `LeftToeBase RightToeBase LeftHand RightHand` | Bones used to detect the impact window |
+| `--num-keyframes` | `12` | Keyframe count in the output array (min 2) |
+| `--hip-bone` | `Hips` | Root bone name for trajectory extraction |
+| `--output` | stdout only | Write TS to this file path in addition to stdout |
+
+**Implementation note:** The script imports `motion-pipeline.py` as a module
+via `importlib` rather than calling it as a subprocess. This bypasses the 5-frame
+truncation applied by the `decompose` CLI command, giving access to all frames.
+
+**Output structure:**
+
+```typescript
+// Generated from roundhouse-kick.bvh on 2026-04-13
+// Keyframes: 12, Impact window: 0.45-0.55
+const ROUNDHOUSE_KICK_KEYFRAMES = [...] as const;
+
+export function getRoundhouseKick(progress: number): MoveFrame {
+  // keyframe lookup + linear interpolation
+  // isImpact based on detected contact window
+  return { attacker, defender, isImpact };
+}
+```
+
+The attacker's `offsetX/Y/Z` are root trajectory positions normalized to
+start at origin. Rotations are in radians (converted from the BVH's Euler
+ZYX degrees). The defender reaction is computed procedurally: pushed backward
+at impact, eases to mat post-impact.
+
+**Impact detection:** The script finds the first run of 3+ consecutive contact
+frames across the specified bones. For strike moves, this captures the moment
+of hit. For walking/idle clips (feet always down), the window will be frame-0
+and `isImpact` will be nearly never true — this is correct behavior.
+
+**Validation:** The script prints a summary to stderr including trajectory
+range, impact window, and a structural syntax check. Exit code 1 if validation
+fails.
+
 ## Data architecture pattern
 
 The decomposition from ai4animationpy becomes a design contract for all

--- a/skills/motion-pipeline/SKILL.md
+++ b/skills/motion-pipeline/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: motion-pipeline
+user-invocable: true
+description: "CPU-only motion data processing pipeline for game animation: BVH import, contact detection, root decomposition, motion blending, FABRIK IK. No GPU required."
+allowed-tools:
+  - Read
+  - Bash
+  - Write
+  - Edit
+  - Glob
+  - Grep
+version: 1.0.0
+routing:
+  triggers:
+    - "mocap"
+    - "motion data"
+    - "animation pipeline"
+    - "BVH import"
+    - "contact detection"
+    - "IK solve"
+    - "motion blend"
+    - "bone trajectory"
+    - "root extraction"
+    - "FABRIK"
+    - "skeletal animation data"
+  category: game-animation
+  agents:
+    - rive-skeletal-animator
+    - pixijs-combat-renderer
+    - game-asset-generator
+---
+
+# Motion Pipeline Skill
+
+CPU-only motion data processing pipeline for game animation, inspired by Meta's
+ai4animationpy framework (CC BY-NC 4.0). All operations run on numpy and scipy
+with no GPU or PyTorch required.
+
+## Why standalone implementations?
+
+ai4animationpy's `Math/Tensor.py` imports `torch` unconditionally at the top
+level, which propagates through every module (Animation, Import, IK, Math).
+This means zero ai4animationpy modules are importable without PyTorch installed.
+The standalone implementations in `scripts/motion-pipeline.py` replicate the
+key algorithms from their source code using only numpy + scipy.
+
+## Environment setup
+
+```bash
+# Create venv (one-time)
+python3 -m venv /home/feedgen/claude-code-toolkit/motion-pipeline-env/
+
+# Install CPU-only deps
+motion-pipeline-env/bin/pip install numpy scipy pygltflib Pillow
+
+# Verify
+motion-pipeline-env/bin/python -c "import numpy; import scipy; import pygltflib; print('OK')"
+```
+
+The venv is gitignored. The skill documents setup; it does not commit the venv.
+
+## Commands
+
+All commands output JSON to stdout. Errors go to stderr with exit code 1.
+
+### import-bvh
+
+Parse a BVH mocap file and print a motion summary.
+
+```bash
+motion-pipeline-env/bin/python scripts/motion-pipeline.py import-bvh FILE \
+  [--scale 0.01]   # scale cm->m for CMU/Mixamo files
+```
+
+Output fields: `name`, `num_frames`, `num_joints`, `framerate`,
+`total_time_seconds`, `bones[]`, `root_trajectory` (x/y/z range).
+
+### extract-contacts
+
+Detect ground contact frames per bone (foot, hand) using height + velocity
+thresholds. Replicates `ContactModule.GetContacts()` from ai4animationpy.
+
+```bash
+motion-pipeline-env/bin/python scripts/motion-pipeline.py extract-contacts FILE \
+  --bones LeftFoot RightFoot \
+  --height 0.1 \
+  --vel 0.5
+```
+
+Output: per-bone `contact_frames[]`, `contact_count`, `contact_ratio`.
+
+### decompose
+
+Split motion into root trajectory (WHERE + HOW) and per-joint local Euler
+angles (POSE). Implements the RootModule / MotionModule decomposition pattern.
+
+```bash
+motion-pipeline-env/bin/python scripts/motion-pipeline.py decompose FILE \
+  --hip Hips
+```
+
+Output: `root_trajectory.positions[]`, `root_trajectory.velocities[]`,
+`root_trajectory.facing_directions[]`, `per_joint_euler_zyx_degrees{}`.
+
+First 5 frames shown in stdout; full data requires piping to a file.
+
+### blend
+
+Blend two BVH clips at a fixed alpha using SLERP rotations and LERP positions.
+Clips must share the same bone hierarchy.
+
+```bash
+motion-pipeline-env/bin/python scripts/motion-pipeline.py blend FILE_A FILE_B \
+  --alpha 0.5
+```
+
+Output: summary of the blended motion.
+
+### solve-ik
+
+Run FABRIK inverse kinematics on a bone chain at a single frame.
+
+```bash
+motion-pipeline-env/bin/python scripts/motion-pipeline.py solve-ik FILE \
+  --chain Hips:LeftFoot \
+  --target 0.2,0.05,0.3 \
+  --frame 10
+```
+
+Output: `chain[]`, `target[]`, `initial_positions[]`, `solved_positions[]`,
+`end_effector_error` (metres).
+
+## Data architecture pattern
+
+The decomposition from ai4animationpy becomes a design contract for all
+game animation work:
+
+```
+Animation State
+  root_trajectory   -- WHERE (position, velocity, facing direction)
+  per_joint_euler   -- HOW (local pose in ZYX Euler degrees)
+  contact_frames    -- WHAT (contact states for feet, hands)
+  [guidance]        -- WHY (intent; handled at game engine layer)
+```
+
+This separation enables:
+- Different movement speeds without distorting body pose
+- Contact-driven game events (damage triggers, sound, VFX)
+- AI/input guidance independent of motion playback
+
+## Source reference: ai4animationpy modules adopted
+
+| ai4animationpy module | This script equivalent | Notes |
+|-----------------------|------------------------|-------|
+| `Import/BVHImporter.BVH` | `load_bvh()` | Same parsing logic; scipy replaces torch |
+| `Animation/Motion` | `Motion` dataclass | numpy-only; no torch backend |
+| `Animation/ContactModule` | `extract_contacts()` | Height + velocity criterion identical |
+| `Animation/RootModule` | `decompose()` root section | FK decomposition via matrix inverse |
+| `Animation/MotionModule` | `decompose()` joint section | Local Euler extraction via scipy |
+| `IK/FABRIK` | `solve_ik_fabrik()` | Algorithm identical; no Actor dependency |
+
+## Integration points
+
+| Downstream agent | Data consumed |
+|------------------|---------------|
+| `rive-skeletal-animator` | `per_joint_euler_zyx_degrees` from decompose |
+| `pixijs-combat-renderer` | `contact_frames` from extract-contacts |
+| `combat-effects-upgrade` | `contact_frames` (impact timing) |
+| `game-asset-generator` | Produces source BVH files for this pipeline |
+
+## Sample BVH for testing
+
+A walking cycle from ai4animationpy demos is available at:
+```
+/tmp/ai4animationpy/Demos/BVHLoading/WalkingStickLeft_BR.bvh
+```
+
+This is a full-body biped walking clip from the Geno character rig.
+
+## Reference: ai4animationpy
+
+- Source: `/tmp/ai4animationpy` (cloned locally)
+- License: CC BY-NC 4.0 (non-commercial; aligned with hobby game projects)
+- GitHub: https://github.com/facebookresearch/ai4animationpy
+- Key finding: ALL modules require torch at import time via `Math/Tensor.py` line 5.
+  No conditional import path exists. Standalone implementations are the correct approach.

--- a/skills/motion-pipeline/SKILL.md
+++ b/skills/motion-pipeline/SKILL.md
@@ -87,7 +87,7 @@ motion-pipeline-env/bin/python scripts/motion-pipeline.py extract-contacts FILE 
   --vel 0.5
 ```
 
-Output: per-bone `contact_frames[]`, `contact_count`, `contact_ratio`.
+Output: `{ "bones": { "<name>": { "contact_frames": [...] } }, "total_frames": N }`.
 
 ### decompose
 


### PR DESCRIPTION
## Summary

- Add `motion-pipeline` skill with CPU-only BVH mocap processing (numpy + scipy, no PyTorch/GPU required)
- Three scripts: `motion-pipeline.py` (5 CLI commands), `generate-move-ts.py` (BVH to TypeScript MoveFrame generator), `bake-bvh-to-glb.py` (BVH to GLB animation baking with bind pose retargeting)
- All algorithms reimplemented standalone from ai4animationpy (CC BY-NC 4.0) because the upstream requires PyTorch unconditionally

## What it does

**motion-pipeline.py** — BVH import, contact detection, motion decomposition, blending, FABRIK IK. Validated on CMU mocap data (5483 frames, 75 joints, 193 MB RSS).

**generate-move-ts.py** — Converts BVH mocap into TypeScript `MoveFrame` functions for road-to-aew's wrestling combat system. Supports `--tracking-bone` for limb-specific motion (9x improvement over root-only tracking) and velocity-based impact detection.

**bake-bvh-to-glb.py** — Bakes BVH walking/idle animations into GLB skinned mesh models with proper bind pose retargeting (`glb_rot = delta * glb_bind`). Handles Mixamo skeleton bone name mapping automatically.

## Key lessons learned during development

- ai4animationpy has zero CPU-only modules (Math/Tensor.py imports torch at line 5, propagating through everything)
- Skeleton retargeting requires bind pose correction or bones deform catastrophically
- GLB Hips translation channels REPLACE node position; must omit when game code handles positioning
- CMU Subject 07 Trial 01 has the best walking BVH symmetry (1mm bilateral difference)

## Test plan

- [x] motion-pipeline.py: all 5 commands tested on WalkingStickLeft_BR.bvh
- [x] generate-move-ts.py: generated valid TypeScript from 3 CMU combat BVH files
- [x] bake-bvh-to-glb.py: baked walking/idle into ScottHall.glb, verified in browser
- [x] ruff check + format: all 3 scripts pass