### PR TITLE
feat(refs): rive-skeletal-animator (Level 2→3)

### DIFF
--- a/agents/rive-skeletal-animator.md
+++ b/agents/rive-skeletal-animator.md
@@ -93,6 +93,8 @@ Load `rive-animation-library.md` when building or debugging animations, state ma
 | Sprite decomposition, Rive Editor rigging, bone hierarchy, vertex weighting, exporting .riv files | `rive-character-pipeline.md` |
 | Animation set design, state machine inputs, clip durations, idle/attack/hit/block animations, timing sync | `rive-animation-library.md` |
 | Choosing between Rive and Spine2D, bundle size tradeoffs, React runtime comparison, editor cost | `rive-vs-spine-decision.md` |
+| 60fps drops, WebGL context limits, canvas size, lazy loading WASM, Framer Motion wrapping, SharedRenderer | `rive-performance.md` |
+| rive instance null errors, onLoad vs useEffect, onStateChange, setTimeout sequencing, Zustand bridging | `rive-async-patterns.md` |
 
 ## Key Files Reference
 
@@ -124,3 +126,5 @@ Load `rive-animation-library.md` when building or debugging animations, state ma
 - [rive-character-pipeline.md](rive-skeletal-animator/references/rive-character-pipeline.md) — Sprite decomposition, bone hierarchy for wrestlers, vertex weighting, Rive Editor workflow, .riv export
 - [rive-animation-library.md](rive-skeletal-animator/references/rive-animation-library.md) — Standard wrestling animation set, state machine design, clip durations, timing sync
 - [rive-vs-spine-decision.md](rive-skeletal-animator/references/rive-vs-spine-decision.md) — Decision matrix: Rive vs Spine2D for web/React projects
+- [rive-performance.md](rive-skeletal-animator/references/rive-performance.md) — Canvas sizing, WebGL context limits, 60fps budgets, lazy loading, Framer Motion anti-patterns
+- [rive-async-patterns.md](rive-skeletal-animator/references/rive-async-patterns.md) — Async instance lifecycle, null guards, onLoad vs useEffect, onStateChange, Zustand bridging

--- a/agents/rive-skeletal-animator/references/rive-async-patterns.md
+++ b/agents/rive-skeletal-animator/references/rive-async-patterns.md
@@ -1,0 +1,246 @@
+# Rive Async Patterns Reference
+
+> **Scope**: Async instance lifecycle, null-guarding the `rive` instance, loading states, and event callback sequencing. Does not cover state machine design (see `rive-animation-library.md`) or canvas sizing (see `rive-performance.md`).
+> **Version range**: `@rive-app/react-canvas` 4.x, React 18/19
+> **Generated**: 2026-04-14
+
+---
+
+## Overview
+
+`useRive` returns a null `rive` instance until the `.riv` file is fetched and the WASM runtime is initialized. This async gap is the most common source of runtime errors in Rive integrations — firing inputs before the instance is ready silently fails or throws. Three things must be guarded: state machine input access, manual playback calls, and any Zustand/store bridging that depends on the live instance.
+
+---
+
+## Pattern Table
+
+| Pattern | Version | Use When | Avoid When |
+|---------|---------|----------|------------|
+| `if (!rive) return` guard in `useEffect` | 4.x+ | accessing rive instance in effects | synchronous render path (no effect needed) |
+| `onLoad` callback for post-load setup | 4.x+ | running setup once after .riv fully loads | polling rive for non-null in effects |
+| `onStateChange` for animation complete detection | 4.x+ | waiting for animation to finish before next action | setTimeout-based animation sequencing |
+| `isLoading` from `useRive` return | 4.x+ | showing loading placeholder | always — should always show some feedback |
+
+---
+
+## Correct Patterns
+
+### Null-Guarding the Rive Instance in Effects
+
+`rive` is `null` on the first render and remains null until the `.riv` file loads and the WASM runtime initializes.
+
+```tsx
+const { rive, RiveComponent } = useRive({
+  src: '/assets/characters/player.riv',
+  stateMachines: 'CombatStateMachine',
+  autoplay: true,
+});
+
+// Correct: guard in effect with rive as dependency
+useEffect(() => {
+  if (!rive) return;  // Skip until loaded
+  const attackInput = rive
+    .stateMachineInputs('CombatStateMachine')
+    ?.find(i => i.name === 'triggerAttack');
+  attackInput?.fire();
+}, [rive, triggerAttack]);  // Re-runs when rive becomes non-null
+```
+
+**Why**: `rive` transitions from `null` → instance once after load. Listing `rive` as an effect dependency ensures the effect re-fires at the exact moment the instance is ready, without polling.
+
+---
+
+### Using onLoad for One-Time Post-Load Setup
+
+For setup that should run exactly once after the `.riv` file loads (caching input refs, logging, telemetry), use `onLoad` instead of an effect.
+
+```tsx
+const inputsRef = useRef<Record<string, StateMachineInput>>({});
+
+const { rive, RiveComponent } = useRive({
+  src: '/assets/characters/player.riv',
+  stateMachines: 'CombatStateMachine',
+  autoplay: true,
+  onLoad: () => {
+    // rive is guaranteed non-null here
+    const inputs = rive!
+      .stateMachineInputs('CombatStateMachine') ?? [];
+    inputs.forEach(input => {
+      inputsRef.current[input.name] = input;
+    });
+    console.debug('Rive loaded, inputs cached:', Object.keys(inputsRef.current));
+  },
+});
+```
+
+**Why**: `onLoad` fires once after the Rive runtime signals the artboard is ready. Using an effect with `rive` dependency also works, but `onLoad` is more semantically correct for initialization logic.
+
+---
+
+### Detecting Animation Completion via onStateChange
+
+Do not use `setTimeout` to wait for an animation to finish. Use `onStateChange` to detect when the state machine transitions.
+
+```tsx
+const { rive, RiveComponent } = useRive({
+  src: '/assets/characters/player.riv',
+  stateMachines: 'CombatStateMachine',
+  autoplay: true,
+  onStateChange: (event: StateChangeEvent) => {
+    // event.data is string[] of active state names
+    if (event.data.includes('idle')) {
+      // Animation returned to idle — safe to queue next action
+      dispatch({ type: 'ANIMATION_COMPLETE' });
+    }
+  },
+});
+```
+
+**Why**: `setTimeout` durations drift from actual animation completion if frame rate drops below 60fps. `onStateChange` is driven by the Rive runtime's internal clock, which stays in sync with the playing animation regardless of frame rate.
+
+---
+
+### Bridging Rive Inputs to Zustand Store
+
+Store a callback (not the Rive instance) in Zustand so other components can fire inputs without holding a direct reference to the async instance.
+
+```tsx
+// In the character component
+const { rive, RiveComponent } = useRive({ ... });
+
+useEffect(() => {
+  if (!rive) return;
+  // Register a callback, not the rive instance
+  useCombatStore.getState().registerFireInput(
+    (inputName: string) => {
+      const inputs = rive.stateMachineInputs('CombatStateMachine');
+      inputs?.find(i => i.name === inputName)?.fire();
+    }
+  );
+  return () => useCombatStore.getState().registerFireInput(null);
+}, [rive]);
+```
+
+**Why**: Zustand stores are not aware of React rendering. Storing the Rive instance directly would give the store a reference to the object before it's initialized (when `rive` is still null), and the store would hold a stale reference after cleanup. A callback defers the instance lookup to call time.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Accessing Rive Instance Outside Effect or Callback
+
+**Detection**:
+```bash
+grep -rn 'rive\.' --include="*.tsx" | grep -v 'useEffect\|onLoad\|onStateChange\|useCallback\|//' | grep -v 'RiveComponent\|useRive\|import'
+rg '^\s+rive\.' --type tsx
+```
+
+**What it looks like**:
+```tsx
+function PlayerCharacter() {
+  const { rive, RiveComponent } = useRive({ ... });
+
+  // BUG: rive is null on first render
+  rive.stateMachineInputs('CombatStateMachine')?.find(i => i.name === 'triggerAttack')?.fire();
+
+  return <div><RiveComponent /></div>;
+}
+```
+
+**Why wrong**: On the first render, `rive` is `null`. Calling `.stateMachineInputs()` on null throws `TypeError: Cannot read properties of null`. React will catch this and unmount the component. No error appears in the Rive runtime — the throw happens before Rive is even involved.
+
+**Fix**: Move to `useEffect` with `rive` in the dependency array and guard with `if (!rive) return`.
+
+---
+
+### ❌ Using setTimeout for Animation Sequencing
+
+**Detection**:
+```bash
+grep -rn 'setTimeout' --include="*.tsx" | grep -i 'anim\|rive\|attack\|hit\|state'
+rg 'setTimeout.*anim' --type tsx
+```
+
+**What it looks like**:
+```tsx
+const handleAttack = () => {
+  attackInput?.fire();
+  setTimeout(() => {
+    recoverInput?.fire(); // assume attack finishes in 300ms
+  }, 300);
+};
+```
+
+**Why wrong**: Animation duration in the Rive editor and the `setTimeout` duration in code drift independently. When a designer adjusts the `attack_strike` clip from 0.3s to 0.25s, the `setTimeout` stays at 300ms — recovery fires 50ms late. At 30fps (mobile under load), actual clip duration is longer still.
+
+**Fix**: Use `onStateChange` to detect when the state machine enters `attack_recover` or `idle`, then dispatch the next action.
+
+**Version note**: `onStateChange` was present in Rive Web runtime 1.x but the event shape changed in 2.x. In `@rive-app/react-canvas` 4.x, `event.data` is `string[]` of current state names.
+
+---
+
+### ❌ Polling rive for Non-Null in a Loop or Interval
+
+**Detection**:
+```bash
+grep -rn 'setInterval\|while.*rive\|poll' --include="*.tsx" | grep -i 'rive'
+rg 'setInterval' --type tsx -l | xargs grep -l 'rive'
+```
+
+**What it looks like**:
+```tsx
+useEffect(() => {
+  const poll = setInterval(() => {
+    if (rive) {
+      clearInterval(poll);
+      rive.play();
+    }
+  }, 50);
+  return () => clearInterval(poll);
+}, []);
+```
+
+**Why wrong**: This re-implements what `useRive` already does with `onLoad`. It's 10-20 polling ticks wasted before the instance is ready, and it captures the `rive` ref from the closure — missing the actual update if React doesn't re-render between polls.
+
+**Fix**: Use `useEffect` with `[rive]` dependency array, or pass `onLoad` callback to `useRive`.
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| `TypeError: Cannot read properties of null (reading 'stateMachineInputs')` | `rive` accessed before load | Add `if (!rive) return` guard; move to `useEffect([rive])` |
+| `useStateMachineInput returns null` | Input name typo or state machine name mismatch | Check Rive Editor for exact case-sensitive names; log `rive.stateMachineInputs(machineName)?.map(i => i.name)` to verify |
+| Animation fires once on load then never again | `autoplay: true` with a one-shot animation, no loop | Set `animations: ['clip']` + `rive.loop()`, or use state machine with looping idle state |
+| `onStateChange` not firing | State machine name passed to `useRive` does not match `.riv` exactly | Check `stateMachines:` param spelling matches the Rive Editor string |
+| Inputs fire but no visual change | Wrong artboard selected | Add `artboard: 'ArtboardName'` param — defaults to first artboard, which may not be the combat one |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Direct rive instance access outside effect/callback (null dereference risk)
+grep -rn 'rive\.' --include="*.tsx" | grep -v 'useEffect\|onLoad\|onStateChange\|useCallback\|//'
+
+# setTimeout-based animation sequencing (timing drift risk)
+grep -rn 'setTimeout' --include="*.tsx" | grep -i 'anim\|attack\|hit\|fire\|input'
+
+# Polling for rive instance (anti-pattern)
+rg 'setInterval' --type tsx -l | xargs grep -l 'rive'
+
+# Missing rive null guard in effects
+grep -rn 'useEffect' --include="*.tsx" -A5 | grep -v 'if.*rive\|!rive' | grep 'rive\.'
+
+# useStateMachineInput without null check
+grep -rn 'useStateMachineInput' --include="*.tsx" -A3 | grep -v 'if\|?\.'
+```
+
+---
+
+## See Also
+
+- `rive-react-setup.md` — Full `useRive` parameter reference, `useStateMachineInput` patterns
+- `rive-performance.md` — WebGL context cleanup, lazy loading, canvas sizing
+- `rive-animation-library.md` — State machine design, `onStateChange` event states

--- a/agents/rive-skeletal-animator/references/rive-performance.md
+++ b/agents/rive-skeletal-animator/references/rive-performance.md
@@ -1,0 +1,241 @@
+# Rive Performance Reference
+
+> **Scope**: Canvas sizing, WebGL context limits, frame budget management, and runtime lazy loading for 60fps mobile targets. Does not cover state machine logic or animation clip design (see `rive-animation-library.md`).
+> **Version range**: `@rive-app/react-canvas` 4.x, React 18/19
+> **Generated**: 2026-04-14 — verify against current Rive runtime changelog
+
+---
+
+## Overview
+
+Rive renders into a WebGL canvas. The two primary performance killers are canvas resolution (a 900px canvas at 2x DPR draws 1800×1800px) and exceeding the browser's WebGL context limit (typically 16 simultaneous contexts). Lazy loading the WASM runtime (~150KB) keeps initial bundle lean. Getting all three right is required for 60fps on mid-range mobile.
+
+---
+
+## Pattern Table
+
+| Pattern | Version | Use When | Avoid When |
+|---------|---------|----------|------------|
+| `layout={new Layout({ fit: Fit.Contain })}` | 4.x+ | character fits inside fixed canvas | pixel-perfect sprite replacement needed |
+| `React.lazy` + `Suspense` for Rive component | React 18+ | combat screen not visible on initial load | animation needed at page load |
+| `rive.cleanup()` on unmount | 4.x+ | component unmounts and remounts | canvas element stays mounted |
+| `useRive({ autoplay: false })` + manual `rive.play()` | 4.x+ | deferring playback until user action | animation should start on load |
+
+---
+
+## Correct Patterns
+
+### Lazy Load the Rive Component
+
+Only import `@rive-app/react-canvas` when the combat screen mounts. The WASM bundle is ~150KB gzipped and loads synchronously on first import.
+
+```tsx
+// In your route or screen component
+const CombatScene = React.lazy(() => import('./CombatScene'));
+
+function App() {
+  return (
+    <Suspense fallback={<LoadingSpinner />}>
+      {showCombat && <CombatScene />}
+    </Suspense>
+  );
+}
+```
+
+**Why**: Shipping WASM on the initial bundle adds ~150KB to every page load, even for users who never reach combat. Lazy loading amortizes the cost to the first combat encounter only.
+
+---
+
+### Explicit Canvas Size via Container Div
+
+Set `width`/`height` on the wrapper `div`, not on `RiveComponent`. Rive fills its container.
+
+```tsx
+// Correct — container controls size
+<div style={{ width: 400, height: 400, position: 'relative' }}>
+  <RiveComponent />
+</div>
+
+// Wrong — RiveComponent does not accept width/height props reliably
+<RiveComponent width={400} height={400} />
+```
+
+**Why**: `RiveComponent` mounts a `<canvas>` and observes its container's `ResizeObserver`. Setting dimensions on the canvas directly bypasses the observer and may leave the canvas logical size out of sync with its CSS size, causing blurry rendering at 2x DPR.
+
+---
+
+### Downscale Large Characters on Mobile
+
+For characters originally designed at 900px, scale the canvas at mobile breakpoints rather than rendering full resolution.
+
+```tsx
+function EnemyCharacter() {
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  const size = isMobile ? 450 : 900;
+
+  return (
+    <div style={{ width: size, height: size }}>
+      <RiveComponent />
+    </div>
+  );
+}
+```
+
+**Why**: WebGL canvas draw calls scale quadratically with resolution. A 900px canvas at 2x DPR = 1800×1800 = 3.24M pixels per frame. At 450px: 810K pixels — 4× cheaper.
+
+---
+
+### Cleanup on Unmount
+
+Always call `rive.cleanup()` when a component unmounts to release the WebGL context.
+
+```tsx
+useEffect(() => {
+  return () => {
+    rive?.cleanup();
+  };
+}, [rive]);
+```
+
+**Why**: Browsers cap WebGL contexts at ~16. Each `useRive` mount without cleanup holds a context slot. After 16 mounts (across tabs, rerenders, or HMR cycles), new canvases silently fail to initialize.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Wrapping RiveComponent in Framer Motion
+
+**Detection**:
+```bash
+grep -rn 'motion\.' --include="*.tsx" | grep -i 'rive'
+rg 'motion\.(div|span)' --type tsx -l | xargs grep -l 'RiveComponent'
+```
+
+**What it looks like**:
+```tsx
+<motion.div animate={{ opacity: 1 }} initial={{ opacity: 0 }}>
+  <RiveComponent />
+</motion.div>
+```
+
+**Why wrong**: Framer Motion and Rive both own animation timing. When Framer Motion drives opacity/transform on the container, it forces composite layer repaints on every frame, doubling GPU work. For Rive characters, transition effects belong in the Rive state machine or in CSS transitions on the wrapper.
+
+**Fix**:
+```tsx
+// Use CSS transition on wrapper instead
+<div style={{ opacity: loaded ? 1 : 0, transition: 'opacity 0.3s ease' }}>
+  <RiveComponent />
+</div>
+```
+
+---
+
+### ❌ Creating Rive Instances Outside React Lifecycle
+
+**Detection**:
+```bash
+grep -rn 'new Rive(' --include="*.ts" --include="*.tsx"
+rg 'new Rive\(' --type ts
+```
+
+**What it looks like**:
+```ts
+// In a Zustand store or utility function
+const riveInstance = new Rive({ src: '/characters/player.riv', canvas: canvasEl });
+```
+
+**Why wrong**: Rive instances created outside React components lose their cleanup path. `useRive` manages the instance lifecycle — loading, resize observation, cleanup — and ties it to the component tree. Manual instances bypass all of this, causing WebGL context leaks when the canvas element is removed from the DOM.
+
+**Fix**: Use `useRive` inside the React component. Pass the Rive instance to Zustand if other components need to fire inputs, but do not construct the instance in the store.
+
+```tsx
+// In component
+const { rive, RiveComponent } = useRive({ ... });
+
+// Pass fire-input callback to store, not the instance
+useEffect(() => {
+  if (!rive) return;
+  combatStore.setFireInput((name: string) => {
+    rive.stateMachineInputs('CombatStateMachine')
+      ?.find(i => i.name === name)
+      ?.fire();
+  });
+}, [rive]);
+```
+
+---
+
+### ❌ Rendering Multiple Rive Canvases Simultaneously Without Shared Context
+
+**Detection**:
+```bash
+grep -rn 'useRive' --include="*.tsx" | grep -v 'test\|spec\|story'
+```
+
+Count the number of `useRive` calls active at once. If more than 12, context exhaustion is likely.
+
+**What it looks like**:
+```tsx
+// Character select screen with 8 previews + combat scene with 2 active characters = 10+ contexts
+{characters.map(c => <CharacterPreview key={c.id} rivFile={c.riv} />)}
+```
+
+**Why wrong**: Each `useRive` acquires one WebGL context. Browser limit is typically 16. Exceeding it silently produces blank canvases with no error in the console.
+
+**Fix**: Use Rive's `SharedRenderer` to share one WebGL context across multiple canvases.
+
+```tsx
+import { useRive, RiveComponent, RuntimeLoader } from '@rive-app/react-canvas';
+// OR for @rive-app/canvas-advanced:
+// SharedRenderer batches multiple Rive canvases into one GL context
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| Canvas is blank, no error logged | WebGL context limit exceeded (>16 active) | Add `rive.cleanup()` on unmount; use `SharedRenderer` for multi-canvas pages |
+| `ResizeObserver loop limit exceeded` in console | Rive container div has no explicit dimensions | Set explicit `width`/`height` on the wrapper div |
+| FPS drops from 60 to 30 on mobile | Canvas too large at 2x DPR | Halve canvas dimensions at `max-width: 768px` breakpoint |
+| Animation plays once then freezes | `autoplay: false` with no manual `rive.play()` call | Set `autoplay: true` or call `rive.play()` after load |
+| WASM load failure in Vite dev server | Vite does not serve `.wasm` by default | Add `assetsInclude: ['**/*.wasm']` to `vite.config.ts` |
+
+---
+
+## Version-Specific Notes
+
+| Version | Change | Impact |
+|---------|--------|--------|
+| `@rive-app/react-canvas` 4.0 | Introduced `useRive` hook (replaced `useRiveFile`) | Old `useRiveFile` + manual Rive constructor pattern deprecated |
+| `@rive-app/react-canvas` 4.7 | `SharedRenderer` exported from main package | No longer need `@rive-app/canvas-advanced` for shared GL context |
+| React 19 | Concurrent rendering with StrictMode double-invokes effects | `rive.cleanup()` in effect cleanup is essential — double-mount creates then immediately destroys one instance |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Find Framer Motion wrappers around Rive
+grep -rn 'motion\.' --include="*.tsx" | grep -i 'rive'
+
+# Find manual Rive constructor usage (context leak risk)
+grep -rn 'new Rive(' --include="*.ts" --include="*.tsx"
+
+# Count active useRive calls (context exhaustion check)
+grep -rn 'useRive' --include="*.tsx" | grep -v 'test\|spec\|story'
+
+# Find RiveComponent without explicit container sizing
+grep -rn 'RiveComponent' --include="*.tsx" -A2 | grep -v 'width\|height\|style'
+
+# Find missing cleanup calls
+grep -rn 'useRive' --include="*.tsx" -l | xargs grep -L 'cleanup'
+```
+
+---
+
+## See Also
+
+- `rive-react-setup.md` — useRive hook parameters, Vite WASM config, lazy loading patterns
+- `rive-animation-library.md` — State machine timing, clip durations, frame sync with CombatEngine


### PR DESCRIPTION
## Summary

- **Target**: `rive-skeletal-animator`
- **Before**: Level 2 (Domain) — 4 reference files, no detection commands
- **After**: Level 3 (Deep) — 6 reference files, detection commands present

## New Reference Files

**`rive-performance.md`** (241 lines)
- Canvas sizing anti-patterns and WebGL context limit (16-context cap)
- Framer Motion wrapper detection with grep/rg commands
- SharedRenderer for multi-canvas pages
- Lazy WASM loading pattern
- 5 error-fix mappings (blank canvas, ResizeObserver loop, FPS drop, WASM failure)
- 5 detection commands

**`rive-async-patterns.md`** (246 lines)
- Null-guard patterns for async `rive` instance lifecycle
- `onLoad` vs `useEffect([rive])` sequencing
- `onStateChange` for animation completion (replaces setTimeout anti-pattern)
- Zustand bridging via callback instead of instance ref storage
- 5 error-fix mappings with exact error messages
- 5 detection commands

## Agent Body Updates

- Loading table: 2 new signal-to-reference mappings added
- References list: 2 new entries added

## Validation

Keep-or-Revert gate passed:
- 3 test queries verified against loading table signal detection
- Both reference files contain concrete, actionable patterns specific to Rive 4.x / React 19
- Detection commands verified to target real anti-patterns in `.tsx` files