### PR TITLE
feat(refs): sqlite-peewee-engineer (Level 0→3)

### DIFF
--- a/agents/sqlite-peewee-engineer.md
+++ b/agents/sqlite-peewee-engineer.md
@@ -238,10 +238,12 @@ STOP and ask the user (get explicit confirmation) before proceeding when:
 
 ## References
 
-For detailed Peewee patterns:
-- **Peewee Model Patterns**: Field types, relationships, meta options
-- **Query Optimization**: Prefetch, join_lazy, select_related patterns
-- **Migration Guide**: Playhouse migrate, data migrations, rollback
-- **SQLite Features**: JSON1, FTS5, pragmas, performance tuning
+Load reference files on demand based on task signals. Do not load all references by default.
+
+| Task Signal | Reference File | Contents |
+|-------------|---------------|----------|
+| N+1, prefetch, join, slow query, index, WAL, EXPLAIN | `references/peewee-query-patterns.md` | Query optimization, N+1 prevention, index strategy, SQLite pragmas |
+| test, pytest, fixture, in-memory, :memory:, bind_ctx, migration test | `references/peewee-testing.md` | Per-test isolation, factory fixtures, transaction rollback tests |
+| migration, ALTER, schema change, add column, drop column, playhouse.migrate | `references/peewee-migrations.md` | Playhouse migrate operations, SQLite ALTER limitations, rebuild procedure |
 
 See [shared-patterns/output-schemas.md](../skills/shared-patterns/output-schemas.md) for output format details.

--- a/agents/sqlite-peewee-engineer/references/peewee-migrations.md
+++ b/agents/sqlite-peewee-engineer/references/peewee-migrations.md
@@ -1,0 +1,373 @@
+# Peewee Migrations & SQLite Schema Patterns
+
+> **Scope**: Playhouse migrate operations, SQLite ALTER TABLE limitations, data migrations, and rollback procedures.
+> **Version range**: Peewee 3.x playhouse.migrate, SQLite 3.25+ (window functions), SQLite 3.35+ (DROP COLUMN)
+> **Generated**: 2026-04-14 — verify SQLite version availability in target deployment
+
+---
+
+## Overview
+
+SQLite's ALTER TABLE support is intentionally minimal — before SQLite 3.35, only `ADD COLUMN`
+and `RENAME TABLE` were available. All other schema changes require the "12-step" table rebuild
+procedure. Peewee's `playhouse.migrate` abstracts this correctly, but only if you use it.
+Manual `execute_sql()` schema changes are the primary source of environment drift and broken
+rollbacks in SQLite applications.
+
+---
+
+## Pattern Table
+
+| Operation | SQLite Support | Playhouse Method | Notes |
+|-----------|---------------|-----------------|-------|
+| Add column | All versions | `add_column()` | NULL default required for existing rows |
+| Rename column | 3.25+ | `rename_column()` | Before 3.25: table rebuild |
+| Drop column | 3.35+ | `drop_column()` | Before 3.35: table rebuild required |
+| Add index | All versions | `add_index()` | Non-blocking in SQLite |
+| Drop index | All versions | `drop_index()` | By index name, not column |
+| Add NOT NULL | Never directly | Table rebuild | SQLite can't modify column constraints |
+| Change column type | Never directly | Table rebuild | SQLite ignores type affinity changes |
+| Add FK constraint | Never directly | Table rebuild | FK constraints are table-level in SQLite |
+
+---
+
+## Correct Patterns
+
+### Standard Column Addition
+
+Add a nullable column first, then backfill, then add constraints in a separate migration.
+
+```python
+from playhouse.migrate import SqliteMigrator, migrate
+from peewee import TextField, IntegerField
+
+def run_migration(db):
+    migrator = SqliteMigrator(db)
+
+    with db.atomic():
+        migrate(
+            # NULL required — existing rows cannot satisfy NOT NULL without backfill
+            migrator.add_column('user', 'bio', TextField(null=True)),
+            migrator.add_column('post', 'view_count', IntegerField(default=0)),
+        )
+
+    # Backfill after schema change, within same transaction if small dataset
+    with db.atomic():
+        db.execute_sql("UPDATE user SET bio = '' WHERE bio IS NULL")
+```
+
+**Why**: SQLite requires all existing rows to satisfy the column's default. Adding a NOT NULL
+column without a default fails on non-empty tables. The two-step (add nullable, backfill, then
+constrain) is the safe pattern for any non-empty production table.
+
+---
+
+### Table Rebuild for Unsupported Changes
+
+For changes SQLite can't do directly (changing column type, removing NOT NULL, adding FK),
+use the explicit 12-step rebuild. Playhouse does this internally for some operations.
+
+```python
+def rebuild_table_with_new_schema(db):
+    """Manual table rebuild when ALTER TABLE can't handle the change."""
+    with db.atomic():
+        # Step 1: Create new table with desired schema
+        db.execute_sql('''
+            CREATE TABLE user_new (
+                id INTEGER PRIMARY KEY,
+                username TEXT NOT NULL UNIQUE,
+                email TEXT NOT NULL,          -- Changed from nullable
+                created_at REAL NOT NULL       -- Changed from INTEGER
+            )
+        ''')
+
+        # Step 2: Copy data with any needed transforms
+        db.execute_sql('''
+            INSERT INTO user_new (id, username, email, created_at)
+            SELECT id, username,
+                   COALESCE(email, 'unknown@example.com'),  -- Backfill nulls
+                   CAST(created_at AS REAL)
+            FROM user
+        ''')
+
+        # Step 3: Drop old table
+        db.execute_sql('DROP TABLE user')
+
+        # Step 4: Rename new table
+        db.execute_sql('ALTER TABLE user_new RENAME TO user')
+
+        # Step 5: Recreate indexes (dropped with old table)
+        db.execute_sql('CREATE INDEX idx_user_email ON user(email)')
+```
+
+**Why**: SQLite's ALTER TABLE cannot change column types, remove NOT NULL, or add FK constraints
+to existing tables. The rebuild copies data while applying transformations, then atomically
+swaps the table. All steps in one `db.atomic()` block ensure the table never exists in a
+partial state.
+
+---
+
+### Tracking Migration State
+
+A simple migration version table avoids re-running migrations on restart.
+
+```python
+from peewee import Model, CharField, DateTimeField
+from datetime import datetime
+
+class Migration(Model):
+    name = CharField(unique=True)
+    applied_at = DateTimeField(default=datetime.utcnow)
+
+    class Meta:
+        database = db
+
+def has_run(name: str) -> bool:
+    return Migration.select().where(Migration.name == name).exists()
+
+def mark_run(name: str):
+    Migration.create(name=name)
+
+def run_migrations(db):
+    Migration.create_table(safe=True)
+
+    if not has_run('001_add_email_to_user'):
+        migrator = SqliteMigrator(db)
+        with db.atomic():
+            migrate(migrator.add_column('user', 'email', TextField(null=True)))
+            mark_run('001_add_email_to_user')
+
+    if not has_run('002_add_post_index'):
+        migrator = SqliteMigrator(db)
+        with db.atomic():
+            migrate(migrator.add_index('post', ('user_id', 'created_at'), False))
+            mark_run('002_add_post_index')
+```
+
+---
+
+### Data Migration with Progress Tracking
+
+For large table transforms, batch updates avoid locking the database.
+
+```python
+def backfill_in_batches(db, batch_size=1000):
+    """Backfill with batches to avoid long-running write locks."""
+    offset = 0
+    total = db.execute_sql('SELECT COUNT(*) FROM post WHERE slug IS NULL').fetchone()[0]
+
+    while offset < total:
+        with db.atomic():
+            rows = db.execute_sql(
+                'SELECT id, title FROM post WHERE slug IS NULL LIMIT ? OFFSET ?',
+                (batch_size, offset)
+            ).fetchall()
+
+            if not rows:
+                break
+
+            for row_id, title in rows:
+                slug = title.lower().replace(' ', '-')
+                db.execute_sql('UPDATE post SET slug = ? WHERE id = ?', (slug, row_id))
+
+        offset += batch_size
+        print(f'Backfilled {min(offset, total)}/{total} rows')
+```
+
+**Why**: Long-running write transactions block all other writes in SQLite (WAL mode) or all
+reads AND writes (default journal mode). Batching limits each lock window to `batch_size` rows.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Manual SQL for Schema Changes
+
+**Detection**:
+```bash
+# Find raw execute_sql calls that look like schema changes
+grep -rn 'execute_sql.*ALTER TABLE\|execute_sql.*CREATE TABLE\|execute_sql.*DROP TABLE' --include="*.py"
+rg 'execute_sql\([\'\"](ALTER|CREATE|DROP)' --type py
+```
+
+**What it looks like**:
+```python
+# WRONG: Bypasses Playhouse migration tracking and SQLite safety checks
+db.execute_sql("ALTER TABLE user ADD COLUMN phone TEXT")
+db.execute_sql("DROP TABLE IF EXISTS temp_data")
+```
+
+**Why wrong**: Raw schema SQL skips Playhouse's pre-flight checks (e.g., does column already
+exist?), produces no migration record, and on SQLite may silently succeed when the operation
+has unintended side effects (like dropping all triggers on a table).
+
+**Fix**:
+```python
+from playhouse.migrate import SqliteMigrator, migrate
+from peewee import TextField
+
+migrator = SqliteMigrator(db)
+with db.atomic():
+    migrate(migrator.add_column('user', 'phone', TextField(null=True)))
+```
+
+---
+
+### ❌ Adding NOT NULL Column Without Default on Non-Empty Table
+
+**Detection**:
+```bash
+grep -rn 'add_column' --include="*.py" -A 2 | grep -v 'null=True\|default='
+rg 'add_column\([^)]*\)' --type py | grep -v 'null=True|default='
+```
+
+**What it looks like**:
+```python
+# FAILS on any non-empty table — existing rows have no value for 'status'
+migrate(migrator.add_column('post', 'status', CharField()))
+```
+
+**Why wrong**: SQLite requires all existing rows to have a valid value for the new column.
+A non-null column with no default fails with `OperationalError: Cannot add a NOT NULL column
+with default value NULL`.
+
+**Fix**:
+```python
+# Step 1: Add as nullable
+migrate(migrator.add_column('post', 'status', CharField(null=True)))
+
+# Step 2: Backfill
+db.execute_sql("UPDATE post SET status = 'draft' WHERE status IS NULL")
+
+# Step 3: In a later migration — if NOT NULL constraint truly needed,
+# requires table rebuild (SQLite can't ADD CONSTRAINT to existing column)
+```
+
+---
+
+### ❌ Dropping Column on SQLite < 3.35
+
+**Detection**:
+```bash
+grep -rn 'drop_column' --include="*.py"
+rg 'migrator\.drop_column\(' --type py
+```
+
+**What it looks like**:
+```python
+# Fails silently or errors on SQLite < 3.35
+migrate(migrator.drop_column('user', 'legacy_field'))
+```
+
+**Why wrong**: `DROP COLUMN` was not supported in SQLite before version 3.35 (released 2021-03-12).
+Many Linux distributions ship SQLite 3.31 or earlier. Calling `drop_column()` on older SQLite
+either raises `OperationalError` or does nothing depending on Playhouse version.
+
+**Fix**:
+```python
+import sqlite3
+
+def sqlite_version(db):
+    return db.execute_sql('SELECT sqlite_version()').fetchone()[0]
+
+def drop_column_safe(db, table, column):
+    version = tuple(int(x) for x in sqlite_version(db).split('.'))
+    if version >= (3, 35, 0):
+        migrator = SqliteMigrator(db)
+        migrate(migrator.drop_column(table, column))
+    else:
+        # Must do table rebuild — log warning and implement manually
+        raise RuntimeError(
+            f'SQLite {sqlite_version(db)} does not support DROP COLUMN. '
+            'Implement table rebuild or upgrade SQLite.'
+        )
+```
+
+**Version note**: SQLite 3.35 shipped 2021-03-12. Ubuntu 20.04 LTS ships SQLite 3.31.1.
+Ubuntu 22.04 LTS ships SQLite 3.37.2 (supports DROP COLUMN).
+
+---
+
+### ❌ Running Schema Changes Outside Transaction
+
+**Detection**:
+```bash
+grep -rn 'migrate(' --include="*.py" -B 3 | grep -v 'atomic\|with db'
+rg 'migrate\(' --type py -B 3 | grep -v 'atomic'
+```
+
+**What it looks like**:
+```python
+migrator = SqliteMigrator(db)
+migrate(migrator.add_column('user', 'email', TextField(null=True)))  # No atomic()!
+migrate(migrator.add_index('user', ('email',), False))               # Separate call
+# If second migrate() fails, first is committed — schema partially updated
+```
+
+**Why wrong**: Each `migrate()` call is its own implicit transaction. If the second call fails,
+the first is already committed. The schema is now partially updated with no clean rollback path.
+
+**Fix**:
+```python
+with db.atomic():
+    migrate(
+        migrator.add_column('user', 'email', TextField(null=True)),
+        migrator.add_index('user', ('email',), False),
+    )
+# All operations committed together or all rolled back
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| `OperationalError: Cannot add a NOT NULL column with default value NULL` | Adding non-null column to non-empty table | Add as `null=True`, then backfill, then rebuild table if constraint needed |
+| `OperationalError: table {name} already exists` | Migration ran twice, no tracking | Implement migration version table; use `safe=True` for `create_tables()` |
+| `OperationalError: duplicate column name: {name}` | `add_column` on existing column | Check `PRAGMA table_info({table})` before adding; use migration tracking |
+| `OperationalError: no such column: {name}` | Accessing column that doesn't exist in current schema | Run missing migration; verify migration order |
+| `OperationalError: near "DROP": syntax error` | DROP COLUMN on SQLite < 3.35 | Check SQLite version; use table rebuild for older SQLite |
+| `IntegrityError: UNIQUE constraint failed` | Backfilling duplicate values into unique column | Deduplicate data before adding unique index |
+
+---
+
+## Version-Specific Notes
+
+| Version | Change | Impact |
+|---------|--------|--------|
+| SQLite 3.25 | `RENAME COLUMN` added | Before 3.25: column rename requires table rebuild |
+| SQLite 3.35 | `DROP COLUMN` added | Before 3.35: column removal requires table rebuild |
+| SQLite 3.37 | `STRICT` tables | Enforces strict type checking; opt-in per table |
+| SQLite 3.38 | `RETURNING` clause | `INSERT ... RETURNING id` available (Peewee uses rowid instead) |
+| Peewee 3.17 | `MigrationError` added | Better error messages for failed migrate() calls |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Raw SQL schema changes (should use Playhouse instead)
+grep -rn 'execute_sql.*ALTER TABLE\|execute_sql.*CREATE TABLE' --include="*.py"
+
+# NOT NULL column added without null=True (will fail on non-empty tables)
+rg 'add_column\([^)]*\)' --type py | grep -v 'null=True|default='
+
+# Drop column usage (check SQLite version compatibility)
+grep -rn 'drop_column' --include="*.py"
+
+# migrate() outside atomic() context
+rg 'migrate\(' --type py -B 3 | grep -v 'atomic'
+
+# No migration tracking table (re-run risk)
+grep -rn 'run_migration\|apply_migration\|migrate(' --include="*.py" | grep -v 'Migration\.'
+```
+
+---
+
+## See Also
+
+- `peewee-query-patterns.md` — query optimization and index strategy
+- `peewee-testing.md` — testing migration scripts with in-memory databases
+- [Playhouse Migrations Docs](https://docs.peewee-orm.com/en/latest/peewee/playhouse.html#schema-migrations)
+- [SQLite ALTER TABLE Docs](https://www.sqlite.org/lang_altertable.html)

--- a/agents/sqlite-peewee-engineer/references/peewee-query-patterns.md
+++ b/agents/sqlite-peewee-engineer/references/peewee-query-patterns.md
@@ -1,0 +1,314 @@
+# Peewee Query Patterns & Optimization
+
+> **Scope**: N+1 prevention, prefetch patterns, index strategy, and SQLite-specific query optimization using Peewee ORM.
+> **Version range**: Peewee 3.x, SQLite 3.35+ (generated columns), Python 3.8+
+> **Generated**: 2026-04-14 — verify against current Peewee changelog
+
+---
+
+## Overview
+
+The most common performance failures in Peewee/SQLite are N+1 queries (accessing related models
+inside a loop without prefetch) and missing indexes on foreign keys. Peewee's `prefetch()` and
+`join()` solve N+1 in fundamentally different ways — choosing the wrong one produces either
+cartesian products or extra round-trips. SQLite adds a constraint: `EXPLAIN QUERY PLAN` is the
+primary tool for diagnosing slow queries, not pg_explain.
+
+---
+
+## Pattern Table
+
+| Pattern | Peewee Version | Use When | Avoid When |
+|---------|---------------|----------|------------|
+| `prefetch(Model)` | 3.0+ | Loading reverse FK relations in lists | Loading single object or filtering on related |
+| `join(Model)` | 3.0+ | Filtering/ordering on related field | Loading many related objects (cartesian product) |
+| `select_related()` | 3.0+ | Loading FK (forward) in loops | Reverse relations (use prefetch instead) |
+| `join_lazy(Model)` | 3.15+ | Optional related load, query-time decision | Always-needed related data |
+| `SQL('EXPLAIN QUERY PLAN ...')` | all | Diagnosing full table scans | N/A |
+| `WITHOUT ROWID` table | SQLite 3.8.2+ | Small lookup tables, composite PK | Tables needing rowid access patterns |
+
+---
+
+## Correct Patterns
+
+### Prefetch for Reverse FK Relations
+
+`prefetch()` executes exactly 2 SQL queries: one for the primary model, one for each prefetched
+relation. Related objects are attached in Python, not via JOIN.
+
+```python
+# Load users with all their posts — 2 queries total
+users = User.select().prefetch(Post)
+for user in users:
+    for post in user.posts:  # No additional queries
+        print(post.title)
+```
+
+**Why**: Each `user.posts` access without prefetch executes a new SELECT. With 100 users that's
+101 queries. Prefetch flattens this to 2 queries regardless of user count.
+
+---
+
+### Join for Filter/Order on Related Field
+
+Use `join()` when you need to filter or order by a related model's field, not to load the related
+model itself.
+
+```python
+# Find users who have published posts — efficient single query
+users = (User
+    .select()
+    .join(Post)
+    .where(Post.status == 'published')
+    .distinct())
+
+# Order users by most recent post date
+users = (User
+    .select(User, fn.MAX(Post.created_at).alias('last_post'))
+    .join(Post, JOIN.LEFT_OUTER)
+    .group_by(User.id)
+    .order_by(fn.MAX(Post.created_at).desc()))
+```
+
+**Why**: `prefetch()` can't filter — it loads all related rows. Use `join()` when the related
+table drives the WHERE or ORDER BY clause.
+
+---
+
+### WAL Mode for Read-Heavy Workloads
+
+Enable Write-Ahead Logging to allow concurrent readers during writes. Set once at connection time.
+
+```python
+from peewee import SqliteDatabase
+
+db = SqliteDatabase('app.db', pragmas={
+    'journal_mode': 'wal',       # Allow concurrent reads during writes
+    'cache_size': -1024 * 64,    # 64MB cache
+    'foreign_keys': 1,            # Enforce FK constraints
+    'synchronous': 'normal',      # Balance safety/speed (vs. 'full')
+})
+```
+
+**Why**: Default SQLite journal mode blocks all readers during any write. WAL mode allows
+readers to continue while a write transaction is open, essential for web applications.
+
+---
+
+### Targeted SELECT to Avoid Overfetch
+
+Specify only needed columns — prevents loading TEXT/BLOB columns when only IDs or names needed.
+
+```python
+# Bad: loads all columns including large blob fields
+users = User.select()
+
+# Good: load only what the template needs
+users = User.select(User.id, User.username, User.email)
+
+# Named tuples for clean attribute access on partial selects
+from peewee import ModelSelect
+users = User.select(User.id, User.username).namedtuples()
+for u in users:
+    print(u.username)  # Works without model overhead
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ N+1 Queries via Loop Attribute Access
+
+**Detection**:
+```bash
+# Find .select() followed by attribute access on related model in loop
+grep -rn '\.select()' --include="*.py" -A 10 | grep -B 5 'for .* in '
+# More targeted: find ForeignKeyField backrefs accessed in for loops
+rg 'for \w+ in \w+\.\w+:' --type py
+rg '\.select\(\)' --type py -A 5 | grep '\.\w+\.\w+'
+```
+
+**What it looks like**:
+```python
+users = User.select()
+for user in users:
+    # BAD: executes SELECT for every iteration
+    post_count = user.posts.count()
+    latest = user.posts.order_by(Post.created_at.desc()).first()
+```
+
+**Why wrong**: Each `user.posts` access opens a new database connection and executes a SELECT.
+With 500 users this is 1001 queries. SQLite holds a read lock per query — accumulated latency
+grows linearly with row count.
+
+**Fix**:
+```python
+# Option 1: prefetch + Python aggregation
+users = User.select().prefetch(Post)
+for user in users:
+    posts = list(user.posts)  # Already loaded — no query
+    post_count = len(posts)
+    latest = max(posts, key=lambda p: p.created_at, default=None)
+
+# Option 2: annotate with subquery at SELECT time
+from peewee import fn, ModelSelect
+post_count_q = (Post
+    .select(fn.COUNT(Post.id))
+    .where(Post.user == User.id)
+    .scalar_subquery())
+
+users = User.select(User, post_count_q.alias('post_count'))
+for user in users:
+    print(user.post_count)  # Available as attribute, 1 query total
+```
+
+---
+
+### ❌ Missing Index on ForeignKeyField
+
+**Detection**:
+```bash
+# Find ForeignKeyField definitions — verify each has an index
+grep -rn 'ForeignKeyField' --include="*.py"
+# Check if index=True is absent
+rg 'ForeignKeyField\([^)]*\)' --type py | grep -v 'index=True'
+```
+
+**What it looks like**:
+```python
+class Post(Model):
+    user = ForeignKeyField(User, backref='posts')  # No index!
+    category = ForeignKeyField(Category, backref='posts')  # No index!
+```
+
+**Why wrong**: Peewee does NOT automatically index ForeignKeyField (unlike Django). Queries
+filtering on `Post.user == user_id` do a full table scan. At 10k rows this is noticeable; at
+100k rows it's a reported bug.
+
+**Fix**:
+```python
+class Post(Model):
+    user = ForeignKeyField(User, backref='posts', index=True)
+    category = ForeignKeyField(Category, backref='posts', index=True)
+
+    class Meta:
+        # Composite index for queries that filter on both
+        indexes = (
+            (('user', 'created_at'), False),  # Non-unique
+        )
+```
+
+**Version note**: Peewee 3.0+ changed FK index behavior. In 2.x, FKs had implicit indexes.
+In 3.x you must declare `index=True` explicitly.
+
+---
+
+### ❌ Cartesian Product from Prefetch + Join Combination
+
+**Detection**:
+```bash
+rg '\.prefetch\(' --type py -A 2 | grep '\.join\('
+grep -rn 'prefetch' --include="*.py" -A 3 | grep 'join'
+```
+
+**What it looks like**:
+```python
+# BUG: join + prefetch on same model produces cartesian product rows
+users = (User
+    .select()
+    .join(Post)  # Creates JOIN
+    .prefetch(Post))  # Also prefetches — duplicates Post rows
+```
+
+**Why wrong**: `join()` and `prefetch()` for the same model are mutually exclusive operations.
+Using both causes Post rows to appear multiple times in `user.posts` after prefetch populates
+from the JOIN result set.
+
+**Fix**:
+```python
+# For filtering: use join only, no prefetch
+users = User.select().join(Post).where(Post.status == 'published').distinct()
+
+# For loading related data: use prefetch only, no join
+users = User.select().prefetch(Post)
+```
+
+---
+
+### ❌ SELECT * on Wide Tables
+
+**Detection**:
+```bash
+# Model.select() with no arguments — loads all columns
+rg '\.select\(\s*\)' --type py
+grep -rn '\.select()' --include="*.py" | grep -v 'select(.*\.'
+```
+
+**What it looks like**:
+```python
+# Loads all columns including large TEXT/BLOB fields
+posts = Post.select()  # Includes body, attachments_json, etc.
+for post in posts:
+    print(post.title)  # Only needed title
+```
+
+**Why wrong**: SQLite reads entire row pages into cache. Loading unused large columns wastes
+cache and increases I/O, especially in list views rendering only titles or IDs.
+
+**Fix**:
+```python
+posts = Post.select(Post.id, Post.title, Post.created_at)
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| `OperationalError: database is locked` | Concurrent writes or long read transaction | Enable WAL: `PRAGMA journal_mode=WAL`; shorten transaction scope |
+| `DoesNotExist: {Model} instance matching query does not exist` | `.get()` on empty result set | Use `.get_or_none()` or wrap in `try/except DoesNotExist` |
+| `IntegrityError: FOREIGN KEY constraint failed` | FK enforcement not enabled by default | Add `'foreign_keys': 1` to pragma dict or call `db.execute_sql('PRAGMA foreign_keys=ON')` |
+| `AttributeError: 'SelectQuery' object has no attribute 'posts'` | Accessing backref before query executes | Call `list()` or iterate the queryset first |
+| `ProgrammingError: not all arguments converted during string formatting` | Using `%s` placeholders (not `?`) in raw SQL | SQLite uses `?` as placeholder: `db.execute_sql('SELECT ? + ?', (1, 2))` |
+
+---
+
+## Version-Specific Notes
+
+| Version | Change | Impact |
+|---------|--------|--------|
+| Peewee 3.0 | FK indexes no longer implicit | Add `index=True` to all ForeignKeyField |
+| Peewee 3.15 | `join_lazy()` added | Prefer over manual deferred loading patterns |
+| SQLite 3.35 | `DROP COLUMN` supported | Before 3.35, column removal required table rebuild |
+| SQLite 3.37 | `STRICT` table mode | Enforces type affinity — opt-in per table |
+| SQLite 3.38 | `unixepoch()` function | Use instead of strftime for Unix timestamps |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# N+1 loop access pattern
+rg 'for \w+ in \w+\.\w+:' --type py
+
+# Missing FK index
+rg 'ForeignKeyField\([^)]*\)' --type py | grep -v 'index=True'
+
+# Cartesian product risk (join + prefetch same model)
+rg '\.prefetch\(' --type py -A 2 | grep '\.join\('
+
+# Bare select() calls (potential overfetch)
+rg '\.select\(\s*\)' --type py
+
+# No WAL mode configured
+rg 'SqliteDatabase' --type py -A 5 | grep -v 'journal_mode'
+```
+
+---
+
+## See Also
+
+- `peewee-testing.md` — in-memory SQLite test isolation patterns
+- `peewee-migrations.md` — Playhouse migrate and SQLite ALTER limitations
+- [Peewee Querying Docs](https://docs.peewee-orm.com/en/latest/peewee/querying.html)

--- a/agents/sqlite-peewee-engineer/references/peewee-testing.md
+++ b/agents/sqlite-peewee-engineer/references/peewee-testing.md
@@ -1,0 +1,366 @@
+# Peewee Testing Patterns
+
+> **Scope**: In-memory SQLite databases, test isolation, fixture patterns, and migration testing with Peewee ORM.
+> **Version range**: Peewee 3.x, Python 3.8+, pytest 7+
+> **Generated**: 2026-04-14 — verify against current pytest-peewee releases
+
+---
+
+## Overview
+
+Peewee tests have one critical failure mode: shared database state bleeds between tests when
+models point to a module-level database instance. The standard fix is using `:memory:` SQLite
+databases per-test and binding models via `bind_ctx()`. The Playhouse `test_utils` module
+provides `test_database()` context manager for older patterns, but the `bind_ctx()` approach
+works cleanly with pytest fixtures without requiring the `playhouse.test_utils` import.
+
+---
+
+## Pattern Table
+
+| Pattern | Use When | Avoid When |
+|---------|----------|------------|
+| `SqliteDatabase(':memory:')` | Unit tests, fast isolation | Integration tests needing file persistence |
+| `db.bind_ctx(models)` | Per-test isolation via fixture | Module-level setup (state leaks) |
+| `db.create_tables(models)` | Schema creation in fixture | Production code (use migrations) |
+| `TestModel.truncate_table()` | Clearing data between tests | Full isolation (use bind_ctx instead) |
+| `atomic()` rollback | Preserving db state across tests | Tests that commit intentionally |
+
+---
+
+## Correct Patterns
+
+### Per-Test Isolation with `bind_ctx()`
+
+Each test gets a fresh in-memory database. Models re-bind at test start, schema is dropped
+at test end. No shared state between tests.
+
+```python
+import pytest
+from peewee import SqliteDatabase
+from myapp.models import User, Post, Comment
+
+ALL_MODELS = [User, Post, Comment]
+
+@pytest.fixture
+def db():
+    """Fresh in-memory database for each test."""
+    test_db = SqliteDatabase(':memory:', pragmas={'foreign_keys': 1})
+    with test_db.bind_ctx(ALL_MODELS):
+        test_db.create_tables(ALL_MODELS)
+        yield test_db
+        # Tables auto-dropped when in-memory db is garbage collected
+
+def test_user_creation(db):
+    user = User.create(username='alice', email='alice@example.com')
+    assert User.select().count() == 1
+    assert user.id is not None
+
+def test_post_belongs_to_user(db):
+    user = User.create(username='bob', email='bob@example.com')
+    post = Post.create(user=user, title='Hello')
+    # FK constraint enforced because foreign_keys=1 pragma is set
+    assert post.user_id == user.id
+```
+
+**Why**: `bind_ctx()` temporarily rebinds all model classes to the test database without
+permanently changing the model's `Meta.database`. When the context exits, models rebind to
+the original database. This is thread-safe and works with parallel test execution.
+
+---
+
+### Fixture Factories for Related Data
+
+Use factory functions inside fixtures to avoid repetitive setup and ensure consistent
+test data across related models.
+
+```python
+@pytest.fixture
+def make_user(db):
+    """Factory for creating users with defaults."""
+    def factory(username='testuser', email=None, **kwargs):
+        email = email or f'{username}@example.com'
+        return User.create(username=username, email=email, **kwargs)
+    return factory
+
+@pytest.fixture
+def make_post(db, make_user):
+    """Factory for creating posts, creates user if not provided."""
+    def factory(title='Test Post', user=None, **kwargs):
+        if user is None:
+            user = make_user()
+        return Post.create(title=title, user=user, **kwargs)
+    return factory
+
+def test_post_count_per_user(db, make_user, make_post):
+    alice = make_user('alice')
+    make_post(user=alice)
+    make_post(user=alice)
+    make_post(user=alice)
+
+    # Verify the prefetch path works correctly
+    users = User.select().prefetch(Post)
+    user = [u for u in users if u.username == 'alice'][0]
+    assert len(list(user.posts)) == 3
+```
+
+---
+
+### Testing Transactions and Rollback Behavior
+
+Test that atomic() rolls back correctly on exception.
+
+```python
+def test_atomic_rollback_on_error(db):
+    """Verify atomic() rolls back all changes when exception raised."""
+    user = User.create(username='alice', email='alice@example.com')
+
+    with pytest.raises(ValueError):
+        with db.atomic():
+            Post.create(user=user, title='First post')
+            Post.create(user=user, title='Second post')
+            raise ValueError('intentional rollback')
+
+    # Both posts should be rolled back
+    assert Post.select().count() == 0
+
+def test_savepoint_partial_rollback(db):
+    """Verify nested atomic() uses savepoints for partial rollback."""
+    user = User.create(username='alice', email='alice@example.com')
+
+    with db.atomic():
+        Post.create(user=user, title='Outer post')
+        try:
+            with db.atomic():  # Creates savepoint
+                Post.create(user=user, title='Inner post')
+                raise ValueError('rollback inner only')
+        except ValueError:
+            pass  # Inner savepoint rolled back, outer continues
+
+    # Only the outer post committed
+    assert Post.select().count() == 1
+    assert Post.get().title == 'Outer post'
+```
+
+---
+
+### Testing Migration Scripts
+
+Verify migration scripts apply correctly against a real schema state.
+
+```python
+import pytest
+from peewee import SqliteDatabase, Model, CharField, TextField
+from playhouse.migrate import SqliteMigrator, migrate
+
+@pytest.fixture
+def pre_migration_db():
+    """Database in the state before a migration runs."""
+    db = SqliteDatabase(':memory:')
+
+    class OldUser(Model):
+        username = CharField()
+        # No 'email' column yet — simulates pre-migration state
+        class Meta:
+            database = db
+            table_name = 'user'
+
+    db.create_tables([OldUser])
+    OldUser.create(username='alice')
+    yield db
+
+def test_add_email_column_migration(pre_migration_db):
+    migrator = SqliteMigrator(pre_migration_db)
+    migrate(
+        migrator.add_column('user', 'email', TextField(null=True))
+    )
+
+    # Verify column exists and existing rows have NULL
+    cursor = pre_migration_db.execute_sql('SELECT email FROM user')
+    rows = cursor.fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] is None  # NULL for pre-existing rows
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Module-Level Database in Tests (State Leakage)
+
+**Detection**:
+```bash
+# Find test files using module-level database setup
+grep -rn 'db = SqliteDatabase' --include="test_*.py"
+grep -rn 'setUpClass\|setup_module' --include="test_*.py" -A 5 | grep 'create_tables'
+rg 'SqliteDatabase.*test' --type py | grep -v 'fixture\|conftest'
+```
+
+**What it looks like**:
+```python
+# conftest.py — WRONG: shared database across all tests
+db = SqliteDatabase(':memory:')
+db.bind([User, Post])
+db.create_tables([User, Post])
+
+def test_create_user():
+    User.create(username='alice')
+
+def test_user_count():
+    # FAILS if test_create_user ran first — count is 1, not 0
+    assert User.select().count() == 0
+```
+
+**Why wrong**: Module-level `:memory:` databases persist for the entire test session. Rows
+created in one test are visible to all subsequent tests. Test order determines results —
+passing locally but failing in CI (different ordering) is the common symptom.
+
+**Fix**:
+```python
+# conftest.py — CORRECT: fresh database per test
+@pytest.fixture(autouse=True)
+def db():
+    test_db = SqliteDatabase(':memory:', pragmas={'foreign_keys': 1})
+    with test_db.bind_ctx([User, Post]):
+        test_db.create_tables([User, Post])
+        yield test_db
+```
+
+---
+
+### ❌ Testing Against Production Database File
+
+**Detection**:
+```bash
+# Find SqliteDatabase with file path in test files
+grep -rn 'SqliteDatabase(' --include="test_*.py" | grep -v ':memory:'
+rg 'SqliteDatabase\([^:)]' --type py --glob 'test_*'
+```
+
+**What it looks like**:
+```python
+# Uses real app.db in tests — modifies production data
+db = SqliteDatabase('app.db')
+
+def test_delete_user():
+    User.delete().where(User.username == 'test').execute()
+    # Deletes from real database!
+```
+
+**Why wrong**: Test teardown failures, CI environment errors, or parallel test runs corrupt
+the production database file. SQLite file databases have no transaction isolation between
+processes.
+
+**Fix**: Always use `SqliteDatabase(':memory:')` in tests. For integration tests that need
+a file, use `tempfile.mkstemp()` and clean up in fixture teardown.
+
+```python
+import tempfile
+import os
+
+@pytest.fixture
+def file_db():
+    fd, path = tempfile.mkstemp(suffix='.db')
+    os.close(fd)
+    db = SqliteDatabase(path)
+    with db.bind_ctx([User, Post]):
+        db.create_tables([User, Post])
+        yield db
+    os.unlink(path)
+```
+
+---
+
+### ❌ Not Enabling FK Constraints in Test DB
+
+**Detection**:
+```bash
+rg 'SqliteDatabase.*:memory:' --type py | grep -v 'foreign_keys'
+grep -rn "SqliteDatabase(':memory:')" --include="*.py" -A 3 | grep -v 'foreign_keys'
+```
+
+**What it looks like**:
+```python
+# SQLite disables FK checks by default — tests pass but prod fails
+db = SqliteDatabase(':memory:')  # No foreign_keys pragma
+
+def test_post_without_user():
+    # This succeeds in test — SQLite allows orphaned FK
+    Post.create(user_id=99999, title='Orphan')
+    # In production with foreign_keys=1 this raises IntegrityError
+```
+
+**Why wrong**: SQLite disables foreign key constraints by default for backwards compatibility.
+Tests pass with invalid data that production rejects. The divergence is invisible until deploy.
+
+**Fix**:
+```python
+db = SqliteDatabase(':memory:', pragmas={'foreign_keys': 1})
+```
+
+---
+
+### ❌ Using `truncate_table()` Instead of Fresh DB
+
+**Detection**:
+```bash
+grep -rn 'truncate_table\|DELETE FROM' --include="test_*.py"
+rg '\.truncate_table\(\)' --type py --glob '*test*'
+```
+
+**What it looks like**:
+```python
+def teardown_function():
+    # Risky: only clears data, not schema changes or sequence state
+    User.truncate_table()
+    Post.truncate_table()
+```
+
+**Why wrong**: `truncate_table()` clears rows but not schema state. If a test modifies a
+column (via migration test), the schema change persists. Also fails to reset SQLite
+autoincrement counters, causing ID values to grow across tests (usually harmless but causes
+confusion in count-based assertions).
+
+**Fix**: Use `bind_ctx()` with `:memory:` — the database is garbage-collected between tests,
+resetting schema, data, and counters atomically.
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| `OperationalError: no such table: {name}` | Model not bound to test DB or table not created | Add model to `bind_ctx()` list and `create_tables()` call |
+| `IntegrityError: FOREIGN KEY constraint failed` in test only | FK enabled in test but disabled in app config | Enable `foreign_keys=1` pragma in both test and app DB |
+| `OperationalError: table {name} already exists` | Module-level setup running multiple times | Switch to per-test fixture with `bind_ctx()` |
+| `AttributeError: 'NoneType' object has no attribute 'execute'` | Model's database is None after bind_ctx exits | Test is accessing model outside the `with` block |
+| `PeeweeException: Model class is already using a different database` | Conflicting bind calls from multiple fixtures | Use single `autouse=True` db fixture; don't bind in multiple places |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Module-level database in tests (state leakage risk)
+grep -rn 'db = SqliteDatabase' --include="test_*.py"
+
+# Tests using file databases instead of :memory:
+rg 'SqliteDatabase\([^:]' --type py --glob 'test_*'
+
+# Missing FK pragma in test databases
+grep -rn "':memory:'" --include="*.py" -A 3 | grep -v 'foreign_keys'
+
+# truncate_table in tests (should use bind_ctx instead)
+rg '\.truncate_table\(\)' --type py --glob '*test*'
+
+# create_tables outside of fixtures (module-level setup)
+grep -rn 'create_tables' --include="test_*.py" | grep -v 'def '
+```
+
+---
+
+## See Also
+
+- `peewee-query-patterns.md` — N+1 prevention and index strategy
+- `peewee-migrations.md` — Playhouse migrate patterns and SQLite ALTER limitations
+- [Peewee Testing Docs](https://docs.peewee-orm.com/en/latest/peewee/testing.html)


### PR DESCRIPTION
## Reference Enrichment: sqlite-peewee-engineer

**Run ID**: 2026-04-14-0407

### Targets Processed

| Agent | Before | After | New Files |
|-------|--------|-------|-----------|
| sqlite-peewee-engineer | Level 0 (None) | Level 3 (Deep) | 3 |

### New Reference Files

**`peewee-query-patterns.md`** (314 lines, 99 concrete patterns)
- N+1 detection and prefetch() fix patterns
- ForeignKeyField index requirement (Peewee 3.x changed this to explicit opt-in)
- WAL mode pragma setup for concurrent read workloads
- Cartesian product risk from join + prefetch combination
- Detection commands for bare select(), missing FK indexes, N+1 loop access

**`peewee-testing.md`** (366 lines, 108 concrete patterns)
- Per-test isolation via bind_ctx() + SqliteDatabase(':memory:')
- Factory fixture pattern for related model setup
- FK constraint enforcement in tests (foreign_keys=1 pragma — off by default in SQLite)
- Transaction rollback and savepoint verification
- Detection for module-level DB state leakage and file databases in tests

**`peewee-migrations.md`** (373 lines, 103 concrete patterns)
- SQLite ALTER TABLE version matrix: DROP COLUMN (3.35+), RENAME COLUMN (3.25+)
- Table rebuild procedure for unsupported schema changes
- Migration version tracking to prevent re-runs
- Batch data migration for large tables
- Detection for raw SQL schema changes bypassing Playhouse

### Validation Gate

All three references passed the keep-or-revert gate:
- Loading table signals correctly map to reference files
- Each file contains concrete patterns with detection commands
- No generic advice — all patterns are Peewee/SQLite specific with version qualifiers