### PR TITLE
feat(refs): sqlite-peewee-engineer (Level 0→3)

### DIFF
--- a/agents/sqlite-peewee-engineer.md
+++ b/agents/sqlite-peewee-engineer.md
@@ -238,10 +238,12 @@ STOP and ask the user (get explicit confirmation) before proceeding when:
 
 ## References
 
-For detailed Peewee patterns:
-- **Peewee Model Patterns**: Field types, relationships, meta options
-- **Query Optimization**: Prefetch, join_lazy, select_related patterns
-- **Migration Guide**: Playhouse migrate, data migrations, rollback
-- **SQLite Features**: JSON1, FTS5, pragmas, performance tuning
+Load the appropriate reference file when the task matches:
+
+| Task Type | Reference File | When to Load |
+|-----------|---------------|--------------|
+| N+1 queries, prefetch, joins, indexes | [references/query-optimization.md](references/query-optimization.md) | Any query performance work, loop + related access, `prefetch()` usage |
+| Schema changes, migrations, playhouse | [references/migrations.md](references/migrations.md) | Adding/removing/renaming columns, `playhouse.migrate`, data backfills |
+| WAL mode, FTS5, JSON1, pragmas, locks | [references/sqlite-features.md](references/sqlite-features.md) | Concurrency errors, full-text search, JSON storage, SQLite version checks |
 
 See [shared-patterns/output-schemas.md](../skills/shared-patterns/output-schemas.md) for output format details.

--- a/agents/sqlite-peewee-engineer/references/migrations.md
+++ b/agents/sqlite-peewee-engineer/references/migrations.md
@@ -1,0 +1,294 @@
+# Migrations Reference
+
+> **Scope**: Schema changes via `playhouse.migrate`, data migrations, SQLite ALTER TABLE limitations, and rollback procedures.
+> **Version range**: Peewee 3.x playhouse, SQLite 3.25+ (for RENAME COLUMN support)
+> **Generated**: 2026-04-15 — verify against Peewee playhouse changelog
+
+---
+
+## Overview
+
+SQLite's ALTER TABLE is severely limited compared to other databases: before SQLite 3.35, you could not drop columns; before 3.25, you could not rename them. `playhouse.migrate` wraps these limitations by recreating tables when needed. Always use `playhouse.migrate` for schema changes — raw SQL migrations are untracked, unrollable, and may silently corrupt data on SQLite.
+
+---
+
+## Pattern Table
+
+| Operation | SQLite version | playhouse approach | Notes |
+|-----------|---------------|-------------------|-------|
+| Add nullable column | all | `add_column` | Safe, no table rewrite |
+| Add NOT NULL column | all | `add_column` with default | Must supply default |
+| Drop column | 3.35+ | `drop_column` | Older: recreate table manually |
+| Rename column | 3.25+ | `rename_column` | Older: recreate table |
+| Add index | all | `add_index` | Non-destructive |
+| Drop index | all | `drop_index` | Non-destructive |
+| Rename table | all | `rename_table` | Updates FK references |
+| Change column type | all | No direct support | Recreate table, migrate data |
+
+---
+
+## Correct Patterns
+
+### Standard Schema Migration
+
+All migrations should follow the setup → migrate → verify sequence.
+
+```python
+from playhouse.migrate import SqliteMigrator, migrate
+
+# Setup — reuse the same db instance
+migrator = SqliteMigrator(db)
+
+# Run migrations in a single atomic block
+with db.atomic():
+    migrate(
+        migrator.add_column('user', 'email', CharField(null=True)),
+        migrator.add_index('user', ('email',), unique=True),
+    )
+```
+
+**Why**: Wrapping in `db.atomic()` ensures all operations succeed or none do. SQLite doesn't support transactional DDL for all operations, but `atomic()` protects the data migration steps.
+
+---
+
+### Adding NOT NULL Column to Existing Table
+
+NOT NULL columns require a default so existing rows aren't violated.
+
+```python
+from peewee import CharField, IntegerField
+
+with db.atomic():
+    migrate(
+        # Approach 1: Add with default (safe for all row counts)
+        migrator.add_column(
+            'product',
+            'quantity',
+            IntegerField(default=0)
+        ),
+    )
+
+# After migration: update rows if default is a placeholder
+Product.update(quantity=0).where(Product.quantity.is_null(True)).execute()
+```
+
+**Why**: SQLite fills existing rows with the column default at migration time. Without a default, the migration fails with `NOT NULL constraint failed`.
+
+---
+
+### Data Migration Pattern
+
+When migrating data (not just schema), do schema change first, then backfill.
+
+```python
+def migrate_add_full_name():
+    """Add full_name column derived from first + last name."""
+
+    with db.atomic():
+        # Phase 1: schema change
+        migrate(
+            migrator.add_column('user', 'full_name', CharField(null=True)),
+        )
+
+    # Phase 2: backfill in batches (avoids locking DB for long time)
+    batch_size = 500
+    total = User.select().count()
+
+    for offset in range(0, total, batch_size):
+        with db.atomic():
+            users = User.select().offset(offset).limit(batch_size)
+            for user in users:
+                User.update(
+                    full_name=f"{user.first_name} {user.last_name}"
+                ).where(User.id == user.id).execute()
+
+    # Phase 3: add NOT NULL constraint (requires table recreate in SQLite)
+    # — done in a follow-up migration after verifying backfill completed
+```
+
+**Why**: Large single-transaction backfills hold an exclusive lock on SQLite. Batching with separate `atomic()` blocks releases locks between batches.
+
+---
+
+### Rollback Script Pattern
+
+Generate a rollback script before running any destructive migration.
+
+```python
+def migration_add_status_field():
+    """Add status field to Order. Rollback: drop_column."""
+    with db.atomic():
+        migrate(
+            migrator.add_column('order', 'status', CharField(default='pending')),
+            migrator.add_index('order', ('status',), unique=False),
+        )
+
+def rollback_add_status_field():
+    """Undo migration_add_status_field."""
+    with db.atomic():
+        migrate(
+            migrator.drop_index('order', 'order_status'),
+            migrator.drop_column('order', 'status'),
+        )
+```
+
+**Why**: Having explicit rollback functions paired with each migration makes recovery deterministic. Comment at the top of the migration naming its inverse.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Raw SQL for Schema Changes
+
+**Detection**:
+```bash
+grep -rn "execute_sql.*ALTER\|execute_sql.*CREATE\|execute_sql.*DROP" --include="*.py"
+rg "db\.execute_sql\(" --type py -A 1 | grep -i "alter\|create table\|drop"
+```
+
+**What it looks like**:
+```python
+db.execute_sql("ALTER TABLE user ADD COLUMN phone TEXT")
+db.execute_sql("CREATE INDEX idx_user_email ON user(email)")
+```
+
+**Why wrong**: Raw DDL bypasses playhouse tracking. No rollback path. On SQLite, `ALTER TABLE` silently ignores constraints that work on PostgreSQL. Leads to schema drift across environments.
+
+**Fix**:
+```python
+from playhouse.migrate import SqliteMigrator, migrate
+
+migrator = SqliteMigrator(db)
+with db.atomic():
+    migrate(
+        migrator.add_column('user', 'phone', CharField(null=True)),
+        migrator.add_index('user', ('phone',), unique=False),
+    )
+```
+
+---
+
+### ❌ Running Migrations Outside of atomic()
+
+**Detection**:
+```bash
+grep -rn "^migrate(" --include="*.py"
+grep -rn "migrator\." --include="*.py" -B 2 | grep -v "atomic\|with db"
+```
+
+**What it looks like**:
+```python
+migrator = SqliteMigrator(db)
+migrate(
+    migrator.add_column('user', 'email', CharField(null=True)),
+    migrator.add_column('user', 'phone', CharField(null=True)),
+)
+# If second add_column fails, first is already committed — schema is half-migrated
+```
+
+**Why wrong**: Multiple DDL operations without `atomic()` can partially apply. On SQLite, DDL is implicitly committed after each statement. A failed second operation leaves a corrupted schema state.
+
+**Fix**:
+```python
+with db.atomic():
+    migrate(
+        migrator.add_column('user', 'email', CharField(null=True)),
+        migrator.add_column('user', 'phone', CharField(null=True)),
+    )
+```
+
+**Version note**: SQLite does not support transactional DDL for all statement types. For table recreations (e.g., drop column on SQLite < 3.35), playhouse falls back to CREATE + INSERT + DROP, which `atomic()` protects.
+
+---
+
+### ❌ Skipping Migration for "Simple" Changes
+
+**Detection**:
+```bash
+# Find schema changes in model files that aren't in a migration function
+grep -rn "class Meta" --include="*.py" -A 10 | grep "indexes\|constraints"
+# Compare against migration files
+grep -rn "add_column\|add_index\|drop_column" --include="*.py"
+```
+
+**What it looks like**:
+```python
+class User(Model):
+    username = CharField()
+    # "I'll just add this directly, it's a test DB"
+    phone = CharField(null=True)  # Added to model but no migration
+```
+
+**Why wrong**: Model changes without migrations cause `OperationalError: no such column: user.phone` in any environment where the DB was created before the change. This is always discovered at the worst time.
+
+**Fix**: Every model field addition must have a corresponding migration. Verify schema matches model on startup with:
+```python
+# Check column exists on startup
+db.execute_sql("SELECT phone FROM user LIMIT 1")
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| `OperationalError: no such column: table.column` | Migration not run in this environment | Run migration, or check migration version tracking |
+| `IntegrityError: NOT NULL constraint failed` | Added NOT NULL column without default | Add `default=value` to field definition in migration |
+| `OperationalError: duplicate column name: column` | Migration ran twice | Add migration version tracking (see below) |
+| `OperationalError: no such table: old_table` | rename_table migration partially applied | Check if atomic() was used; recreate if corrupted |
+| `OperationalError: Cannot add a NOT NULL column with default value NULL` | SQLite strict NULL check | Always provide a non-None default for NOT NULL additions |
+
+---
+
+## Migration Version Tracking
+
+Peewee does not ship a migrations table by default. Implement a simple one:
+
+```python
+class MigrationHistory(Model):
+    name = CharField(unique=True)
+    applied_at = DateTimeField(default=datetime.datetime.now)
+
+    class Meta:
+        database = db
+
+def run_migration(name: str, fn):
+    """Run migration only if not previously applied."""
+    db.create_tables([MigrationHistory], safe=True)
+
+    if MigrationHistory.select().where(MigrationHistory.name == name).exists():
+        print(f"[skip] {name} already applied")
+        return
+
+    fn()
+    MigrationHistory.create(name=name)
+    print(f"[done] {name}")
+
+# Usage
+run_migration("2026-01-01_add_user_email", migration_add_email)
+```
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Raw DDL bypassing playhouse
+grep -rn "execute_sql.*ALTER\|execute_sql.*CREATE\|execute_sql.*DROP" --include="*.py"
+
+# Migrations outside atomic()
+grep -rn "^migrate(" --include="*.py"
+
+# Model fields without corresponding migrations
+grep -rn "ForeignKeyField\|CharField\|IntegerField" --include="*.py" models/
+grep -rn "add_column\|drop_column" --include="*.py" migrations/
+```
+
+---
+
+## See Also
+
+- `query-optimization.md` — Adding indexes to improve query performance
+- `sqlite-features.md` — SQLite ALTER TABLE limitations by version
+- [Peewee Migrations docs](https://docs.peewee-orm.com/en/latest/peewee/playhouse.html#schema-migrations)

--- a/agents/sqlite-peewee-engineer/references/query-optimization.md
+++ b/agents/sqlite-peewee-engineer/references/query-optimization.md
@@ -1,0 +1,281 @@
+# Query Optimization Reference
+
+> **Scope**: N+1 prevention, prefetch patterns, join strategies, and index usage for Peewee ORM with SQLite.
+> **Version range**: Peewee 3.x (3.14+), SQLite 3.35+
+> **Generated**: 2026-04-15 — verify against current Peewee changelog
+
+---
+
+## Overview
+
+The most common performance failure in Peewee is the N+1 query problem: loading a parent list then accessing related data per item, each triggering a separate SELECT. Peewee provides `prefetch()` and `join()` to collapse this into 1-2 queries. SQLite amplifies N+1 pain more than server databases because each query carries file I/O overhead.
+
+---
+
+## Pattern Table
+
+| Pattern | Peewee Version | Use When | Avoid When |
+|---------|---------------|----------|------------|
+| `prefetch()` | 3.x+ | Loading reverse FK collections (posts per user) | Single item lookup |
+| `join().switch()` | 3.x+ | Filtering on related fields | Pulling full related objects (use prefetch) |
+| `select_related()` | via `playhouse.shortcuts` | Forward FK traversal, single depth | Deep nested relationships |
+| `join_lazy()` | deprecated 3.17+ | — | Use `join()` instead |
+| `.tuples()` | 3.x+ | High-volume reads where model overhead matters | When you need model methods |
+| `.dicts()` | 3.x+ | JSON serialization of large result sets | — |
+| `Model.index()` in Meta | 3.x+ | Compound index on frequently queried pairs | Single-column FK (auto-indexed) |
+
+---
+
+## Correct Patterns
+
+### prefetch() for Reverse FK Collections
+
+Use `prefetch()` when loading a list of parents and accessing their children. Executes exactly 2 queries regardless of parent count.
+
+```python
+from peewee import prefetch
+
+# 2 queries total — one for users, one for all their posts
+users = User.select().prefetch(Post)
+
+for user in users:
+    # user.posts is already populated, no extra queries
+    for post in user.posts:
+        print(post.title)
+```
+
+**Why**: Without `prefetch()`, `user.posts` triggers a SELECT per user. 100 users = 101 queries. With prefetch: always 2.
+
+---
+
+### join() for Filter-and-Return
+
+Use `join()` when filtering parent records by related field values, but returning only parent data.
+
+```python
+# Find users who have posts with > 10 comments — one query
+users = (User
+    .select()
+    .join(Post)
+    .where(Post.comment_count > 10)
+    .distinct())
+
+# join().switch() for multiple joins
+posts = (Post
+    .select(Post, User, Category)
+    .join(User)
+    .switch(Post)
+    .join(Category)
+    .where(Category.name == 'tech'))
+```
+
+**Why**: `join()` generates a single SQL JOIN. The `.switch(Post)` resets the join point to `Post` for the second join.
+
+---
+
+### select() with Specific Columns
+
+Avoid selecting all columns when only a subset is needed — Peewee fetches all by default.
+
+```python
+# Only fetch what you need
+users = User.select(User.id, User.username, User.email)
+
+# Count without loading rows
+count = User.select().where(User.active == True).count()
+
+# Exists check — more efficient than count
+exists = User.select().where(User.username == 'alice').exists()
+```
+
+**Why**: SQLite reads full rows from disk even for narrow queries unless you project. Selecting 2 columns from a 20-column table is measurably faster at scale.
+
+---
+
+### Index Definition in Meta
+
+```python
+class EventLog(Model):
+    user = ForeignKeyField(User, backref='events')
+    action = CharField(max_length=50)
+    created_at = DateTimeField()
+
+    class Meta:
+        database = db
+        indexes = (
+            # Compound index for user+time range queries
+            (('user', 'created_at'), False),  # False = not unique
+            # Single unique index
+            (('user', 'action'), True),  # True = unique
+        )
+```
+
+**Why**: ForeignKeyField auto-creates a single-column index. For queries like `WHERE user_id = ? AND created_at > ?`, the compound index is used; the single-column index is not.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Accessing Related Data in Loop Without prefetch
+
+**Detection**:
+```bash
+# Find .select() loops that access related via dot notation
+grep -rn "for.*in.*\.select()" --include="*.py" -A 3 | grep -E "\.(posts|comments|items|children)\b"
+
+# Broader: any attribute access on select() results inside loop
+rg "for \w+ in \w+\.select\(" --type py -A 5
+```
+
+**What it looks like**:
+```python
+users = User.select()
+for user in users:
+    print(f"{user.username}: {user.posts.count()}")  # SELECT per user!
+```
+
+**Why wrong**: `user.posts` on a `ModelSelect` result triggers a fresh `SELECT * FROM post WHERE user_id=?` on every iteration. 1000 users = 1001 queries. Undetectable in development with small datasets; catastrophic in production.
+
+**Fix**:
+```python
+users = User.select().prefetch(Post)
+for user in users:
+    print(f"{user.username}: {len(user.posts)}")  # No extra queries
+```
+
+---
+
+### ❌ Using count() Inside Loop
+
+**Detection**:
+```bash
+grep -rn "\.count()" --include="*.py" | grep -v "test_"
+rg "in.*loop|for.*\n.*\.count\(\)" --type py --multiline
+```
+
+**What it looks like**:
+```python
+for user in User.select():
+    active_posts = user.posts.where(Post.active == True).count()
+```
+
+**Why wrong**: Each `.count()` call is a subquery. This is N+1 with aggregation overhead.
+
+**Fix**:
+```python
+from peewee import fn, Case
+
+# Single query with conditional aggregation
+query = (User
+    .select(User, fn.COUNT(Post.id).alias('active_post_count'))
+    .join(Post, JOIN.LEFT_OUTER)
+    .where(Post.active == True)
+    .group_by(User.id))
+
+for user in query:
+    print(user.active_post_count)
+```
+
+---
+
+### ❌ Missing Index on Filter Fields
+
+**Detection**:
+```bash
+# Find where() calls on non-FK, non-primary-key fields
+grep -rn "\.where(" --include="*.py" -A 1 | grep -v "\.id\b\|_id\b"
+
+# Check model definitions for missing indexes
+grep -rn "class Meta" --include="*.py" -A 5 | grep -v "indexes\|index_together"
+```
+
+**What it looks like**:
+```python
+class Order(Model):
+    user = ForeignKeyField(User, backref='orders')
+    status = CharField()  # No index, but queried constantly
+    created_at = DateTimeField()
+
+# This does a full table scan
+recent = Order.select().where(Order.status == 'pending')
+```
+
+**Why wrong**: SQLite performs a full table scan on unindexed columns. At 100k rows, this takes milliseconds; at 1M rows, seconds.
+
+**Fix**:
+```python
+class Order(Model):
+    user = ForeignKeyField(User, backref='orders')
+    status = CharField(index=True)  # Single column index
+    created_at = DateTimeField()
+
+    class Meta:
+        indexes = (
+            (('status', 'created_at'), False),  # Compound for status + time range
+        )
+```
+
+---
+
+### ❌ Calling .execute() Prematurely
+
+**Detection**:
+```bash
+grep -rn "\.execute()" --include="*.py" | grep -v "db\.execute\|execute_sql"
+```
+
+**What it looks like**:
+```python
+query = User.select().where(User.active == True).execute()
+for user in query:  # Re-iterates cached result
+    ...
+
+# Then later someone passes the query object expecting lazy eval
+paginate(query, page=2)  # Already executed, pagination broken
+```
+
+**Why wrong**: Peewee queries are lazy by default. Calling `.execute()` immediately materializes the full result set. This prevents further chaining, breaks pagination, and loads all rows into memory.
+
+**Fix**: Iterate directly — Peewee auto-executes on first iteration.
+```python
+query = User.select().where(User.active == True)
+for user in query:  # Executes lazily on first iteration
+    ...
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| `AttributeError: 'SelectBase' has no attribute 'username'` | Accessing field on query object instead of iterating | Add `for user in query:` wrapper |
+| `peewee.ProgrammingError: no such column: t2.id` | join() without matching ForeignKeyField | Verify FK points to correct model |
+| `OperationalError: too many SQL variables` | `Model.id << [...]` with >999 items | Batch into chunks of 900: `[ids[i:i+900] for i in range(0, len(ids), 900)]` |
+| `AttributeError: 'NoneType' object has no attribute 'posts'` | `.get()` returned None, FK traverse failed | Use `.get_or_none()` and check before accessing |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# N+1: related access in loop without prefetch
+grep -rn "for.*in.*\.select()" --include="*.py" -A 3
+
+# .count() inside loops
+rg "\.count\(\)" --type py
+
+# Missing indexes on queried fields
+grep -rn "\.where(" --include="*.py" -A 1
+
+# Premature .execute() calls
+grep -rn "\.execute()" --include="*.py" | grep -v "db\.\|execute_sql"
+```
+
+---
+
+## See Also
+
+- `sqlite-features.md` — WAL mode, EXPLAIN QUERY PLAN, PRAGMA analysis
+- `migrations.md` — Adding indexes to existing tables via playhouse.migrate
+- [Peewee Querying docs](https://docs.peewee-orm.com/en/latest/peewee/querying.html)

--- a/agents/sqlite-peewee-engineer/references/sqlite-features.md
+++ b/agents/sqlite-peewee-engineer/references/sqlite-features.md
@@ -1,0 +1,325 @@
+# SQLite Features Reference
+
+> **Scope**: SQLite-specific capabilities and constraints relevant to Peewee apps: WAL mode, pragmas, JSON1, FTS5, concurrency limits, and EXPLAIN QUERY PLAN usage.
+> **Version range**: SQLite 3.35+ (3.38+ for JSON functions), all Peewee 3.x
+> **Generated**: 2026-04-15 — SQLite version bundled with Python can lag behind; check `sqlite3.sqlite_version`
+
+---
+
+## Overview
+
+SQLite is a file-based database with no separate server process. Its main constraints are: one writer at a time (in WAL mode: one writer plus multiple concurrent readers), no user management, and limited ALTER TABLE support. Its strengths are zero-config setup, embedded JSON1 and FTS5 extensions, and excellent read concurrency with WAL enabled.
+
+---
+
+## Pattern Table
+
+| Feature | SQLite Version | Peewee Access | Notes |
+|---------|---------------|--------------|-------|
+| WAL mode | 3.7.0+ | `PRAGMA journal_mode=WAL` | Enables concurrent readers during writes |
+| JSON1 extension | 3.38+ (built-in), 3.9+ (loadable) | `JSONField` from playhouse | Bundled in Python 3.12+ SQLite |
+| FTS5 full-text search | 3.9+ | `FTSModel` from playhouse | Replaces FTS4 |
+| Generated columns | 3.31+ | Raw SQL only | Not exposed in Peewee ORM |
+| WITHOUT ROWID | 3.8.2+ | Raw SQL only | For wide tables with natural PKs |
+| RENAME COLUMN | 3.25+ | `migrator.rename_column` | |
+| DROP COLUMN | 3.35+ | `migrator.drop_column` | |
+| RETURNING clause | 3.35+ | `Model.insert().returning()` | Peewee 3.15+ |
+
+---
+
+## Correct Patterns
+
+### WAL Mode Pragma (Always Set)
+
+Enable WAL and key performance pragmas on database initialization.
+
+```python
+from peewee import SqliteDatabase
+
+db = SqliteDatabase(
+    'app.db',
+    pragmas={
+        'journal_mode': 'wal',        # WAL enables concurrent reads
+        'cache_size': -1 * 64 * 1000, # 64MB page cache
+        'foreign_keys': 1,            # Enforce FK constraints
+        'ignore_check_constraints': 0,
+        'synchronous': 1,             # NORMAL — safe and faster than FULL
+    }
+)
+```
+
+**Why**: Default journal mode is DELETE (rollback journal), which blocks all reads during writes. WAL allows readers to continue while a write is in progress. `foreign_keys=1` is OFF by default in SQLite — required for ON DELETE CASCADE to work.
+
+---
+
+### EXPLAIN QUERY PLAN for Index Verification
+
+Verify that queries actually use indexes before claiming they're optimized.
+
+```python
+# Check if a query uses the index you added
+cursor = db.execute_sql(
+    "EXPLAIN QUERY PLAN SELECT * FROM post WHERE user_id=? AND created_at>?",
+    (1, '2026-01-01')
+)
+for row in cursor.fetchall():
+    print(row)
+# Output showing SEARCH post USING INDEX ... means index hit
+# Output showing SCAN post means full table scan
+```
+
+```bash
+# From command line
+sqlite3 app.db "EXPLAIN QUERY PLAN SELECT * FROM post WHERE user_id=1 AND created_at>'2026-01-01'"
+```
+
+**Why**: Adding an index to a model doesn't guarantee SQLite uses it. Query planner uses indexes only when the leading column of a compound index matches the WHERE clause. EXPLAIN QUERY PLAN catches this before it hits production.
+
+---
+
+### JSON1 Extension with Peewee
+
+```python
+from playhouse.sqlite_ext import JSONField, SqliteExtDatabase
+
+db = SqliteExtDatabase('app.db', pragmas={'foreign_keys': 1})
+
+class Config(Model):
+    key = CharField(unique=True)
+    value = JSONField()  # Stored as TEXT, queried with JSON functions
+
+    class Meta:
+        database = db
+
+# Store arbitrary JSON
+Config.create(key='feature_flags', value={'beta': True, 'max_items': 100})
+
+# Query into JSON — Peewee exposes JSON_EXTRACT via fn
+from peewee import fn
+result = Config.select().where(
+    fn.JSON_EXTRACT(Config.value, '$.beta') == True
+)
+```
+
+**Version note**: `JSON_EXTRACT()` available since SQLite 3.9. If using Python's bundled SQLite on older systems, check `import sqlite3; sqlite3.sqlite_version` before relying on JSON1.
+
+---
+
+### FTS5 Full-Text Search
+
+```python
+from playhouse.sqlite_ext import FTS5Model, SearchField, RowIDField
+
+class DocumentIndex(FTS5Model):
+    rowid = RowIDField()
+    title = SearchField()
+    body = SearchField()
+
+    class Meta:
+        database = db
+        options = {
+            'tokenize': 'porter unicode61',  # Stemming + Unicode support
+        }
+
+# Create virtual table
+db.create_tables([DocumentIndex])
+
+# Populate from main table
+for doc in Document.select():
+    DocumentIndex.create(rowid=doc.id, title=doc.title, body=doc.body)
+
+# Search — BM25 ranking built in
+results = (DocumentIndex
+    .search_bm25('python database patterns', weights={'title': 2.0, 'body': 1.0})
+    .limit(10))
+
+for result in results:
+    doc = Document.get_by_id(result.rowid)
+    print(doc.title, result.bm25())
+```
+
+**Why**: FTS5 uses BM25 ranking by default (vs FTS4's TF-IDF). Always use `unicode61` tokenizer for non-ASCII content. FTS virtual tables can't use foreign keys or indexes.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Missing foreign_keys Pragma
+
+**Detection**:
+```bash
+grep -rn "SqliteDatabase\|pragmas" --include="*.py" | grep -v "foreign_keys"
+grep -rn "SqliteDatabase(" --include="*.py" -A 5 | grep -v "foreign_keys"
+```
+
+**What it looks like**:
+```python
+db = SqliteDatabase('app.db')
+# No pragmas — foreign keys OFF by default
+```
+
+**Why wrong**: SQLite ships with foreign key enforcement disabled for backwards compatibility. `ON DELETE CASCADE`, `ON UPDATE CASCADE`, and FK constraint violations are silently ignored without `PRAGMA foreign_keys=1`. You discover this when production data has orphaned rows.
+
+**Fix**:
+```python
+db = SqliteDatabase('app.db', pragmas={'foreign_keys': 1})
+```
+
+---
+
+### ❌ Concurrent Writes Without WAL
+
+**Detection**:
+```bash
+grep -rn "SqliteDatabase(" --include="*.py" -A 5 | grep -v "journal_mode\|wal"
+grep -rn "threading\|concurrent\|ThreadPool\|asyncio" --include="*.py"
+```
+
+**What it looks like**:
+```python
+db = SqliteDatabase('app.db')  # Default: DELETE journal mode
+
+# In a Flask/FastAPI app with multiple workers or threads
+# → OperationalError: database is locked
+```
+
+**Why wrong**: Default DELETE mode uses an exclusive lock for the entire write duration. Any concurrent reader blocks. In web servers with thread workers, this causes frequent `database is locked` errors under load.
+
+**Fix**:
+```python
+db = SqliteDatabase('app.db', pragmas={
+    'journal_mode': 'wal',
+    'busy_timeout': 5000,  # Wait up to 5s before raising "database is locked"
+})
+```
+
+**Version note**: WAL mode is available since SQLite 3.7.0 (2010). Safe to use universally.
+
+---
+
+### ❌ Using FTS4 Instead of FTS5
+
+**Detection**:
+```bash
+grep -rn "FTS4Model\|fts4" --include="*.py"
+grep -rn "using fts4\|create virtual.*fts4" --include="*.py" -i
+```
+
+**What it looks like**:
+```python
+from playhouse.sqlite_ext import FTS4Model, SearchField
+
+class SearchIndex(FTS4Model):
+    content = SearchField()
+```
+
+**Why wrong**: FTS4 is deprecated since SQLite 3.9 (2015). FTS5 has better ranking (BM25), better Unicode support, and active development. FTS4 will not receive bug fixes.
+
+**Fix**:
+```python
+from playhouse.sqlite_ext import FTS5Model, SearchField
+
+class SearchIndex(FTS5Model):
+    content = SearchField()
+
+    class Meta:
+        options = {'tokenize': 'porter unicode61'}
+```
+
+---
+
+### ❌ Long-Running Transactions on SQLite
+
+**Detection**:
+```bash
+grep -rn "with db.atomic()" --include="*.py" -A 20 | grep -E "sleep|time\.sleep|\.all()\b|len\("
+```
+
+**What it looks like**:
+```python
+with db.atomic():
+    # Process 50,000 records
+    for record in LargeTable.select():
+        process_and_update(record)  # Holds write lock entire time
+```
+
+**Why wrong**: SQLite write lock is held for the entire transaction duration. Other processes (web workers, cron jobs) can't write during this time. `busy_timeout` eventually raises `OperationalError`.
+
+**Fix**: Batch into chunks, committing each batch separately.
+```python
+batch_size = 500
+query = LargeTable.select()
+total = query.count()
+
+for offset in range(0, total, batch_size):
+    with db.atomic():  # Lock held only for batch duration
+        batch = list(query.offset(offset).limit(batch_size))
+        for record in batch:
+            process_and_update(record)
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| `OperationalError: database is locked` | Concurrent write in non-WAL mode, or long transaction | Enable WAL mode; set `busy_timeout`; batch long transactions |
+| `OperationalError: unable to open database file` | Path doesn't exist or permissions issue | Verify directory exists; check filesystem permissions |
+| `OperationalError: no such function: json_extract` | SQLite < 3.9 or JSON1 not compiled in | Check `sqlite3.sqlite_version`; upgrade Python/SQLite |
+| `OperationalError: no such module: fts5` | SQLite compiled without FTS5 (rare on modern systems) | Check `sqlite3.sqlite_version_info >= (3, 9, 0)` |
+| `IntegrityError: FOREIGN KEY constraint failed` | FK enforcement is OFF — this means you added `foreign_keys=1` and found a bug | Audit orphaned rows; add pragma permanently |
+| `OperationalError: table user has no column named email` | Migration not run; model and DB out of sync | Run pending migrations; check migration version table |
+
+---
+
+## SQLite Version Check
+
+```python
+import sqlite3
+
+version = sqlite3.sqlite_version_info
+print(f"SQLite {sqlite3.sqlite_version}")
+
+# Feature availability
+features = {
+    'WAL mode': version >= (3, 7, 0),
+    'FTS5': version >= (3, 9, 0),
+    'JSON1': version >= (3, 9, 0),
+    'RENAME COLUMN': version >= (3, 25, 0),
+    'DROP COLUMN': version >= (3, 35, 0),
+    'RETURNING': version >= (3, 35, 0),
+    'JSON built-in (no ext)': version >= (3, 38, 0),
+}
+
+for feature, available in features.items():
+    status = "✓" if available else "✗"
+    print(f"  {status} {feature}")
+```
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Missing foreign_keys pragma
+grep -rn "SqliteDatabase(" --include="*.py" -A 5 | grep -v "foreign_keys"
+
+# Missing WAL mode
+grep -rn "SqliteDatabase(" --include="*.py" -A 5 | grep -v "journal_mode\|wal"
+
+# FTS4 usage (deprecated)
+grep -rn "FTS4Model\|fts4" --include="*.py"
+
+# Long transactions (heuristic — large selects inside atomic)
+grep -rn "with db.atomic()" --include="*.py" -A 10 | grep "\.select()"
+```
+
+---
+
+## See Also
+
+- `query-optimization.md` — EXPLAIN QUERY PLAN usage and index strategies
+- `migrations.md` — SQLite ALTER TABLE version constraints
+- [SQLite pragma documentation](https://www.sqlite.org/pragma.html)
+- [Peewee SQLite Extensions](https://docs.peewee-orm.com/en/latest/peewee/sqlite_ext.html)


### PR DESCRIPTION
## Reference Enrichment: sqlite-peewee-engineer

### Targets processed: 1/1

| Agent | Level Before | Level After | New Files |
|-------|-------------|------------|-----------|
| sqlite-peewee-engineer | 0 (None) | 3 (Deep) | 3 |

### New Reference Files

**`references/query-optimization.md`** (281 lines)
- N+1 detection grep commands
- `prefetch()` vs `join()` pattern table with Peewee version context
- Anti-patterns: related access in loop, `.count()` in loop, missing indexes, premature `.execute()`
- Error-fix mappings for common query errors

**`references/migrations.md`** (294 lines)
- `SqliteMigrator` + `playhouse.migrate` patterns
- `db.atomic()` wrapping requirement with why it matters on SQLite
- Data backfill batching pattern (avoids long exclusive locks)
- Migration version tracking model
- Anti-patterns: raw SQL DDL, migrations outside atomic(), skipped migrations

**`references/sqlite-features.md`** (325 lines)
- WAL mode + pragma setup (foreign_keys, cache_size, synchronous)
- FTS5 `search_bm25()` with BM25 weights
- JSON1 version notes (3.9+ loadable, 3.38+ built-in)
- EXPLAIN QUERY PLAN usage for index verification
- SQLite version feature table (WAL, FTS5, DROP COLUMN, RETURNING)
- Long-transaction anti-pattern with batch fix

### Validation Gate: KEEP
- Loading table maps all 3 signal sets to correct files
- All files score concrete=77+ generic=0 in audit
- 6 reference loading tests pass, 3 XFAIL (expected for ❌ headings)
- validate-references: 3 declared, 3 present, 0 issues