### PR TITLE
fix(do): correct invalid routing-decision category — unblocks learning DB diagnosis

### DIFF
--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -541,7 +541,7 @@ def cmd_roi(args: argparse.Namespace) -> None:
 def cmd_route_stats(args: argparse.Namespace) -> None:
     """Display routing decision statistics."""
     init_db()
-    results = query_learnings(topic="routing", category="routing-decision", limit=10000, exclude_graduated=False)
+    results = query_learnings(topic="routing", category="effectiveness", limit=10000, exclude_graduated=False)
 
     if not results:
         print("No routing data found. Run sessions with /do to capture routing decisions.")

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -202,12 +202,13 @@ For Trivial: show `Classification: Trivial - [reason]` and `Handling directly (n
 ```bash
 python3 ~/.claude/scripts/learning-db.py record \
     routing "{selected_agent}:{selected_skill}" \
-    "request: {first_200_chars} | complexity: {complexity} | enhancements: {comma_separated_list}" \
-    --category routing-decision \
+    "routing-decision: agent={selected_agent} skill={selected_skill} request: {first_200_chars} complexity: {complexity} enhancements: {comma_separated_list}" \
+    --category effectiveness \
     --tags "{applicable_flags}"
 ```
 
 Tags: `auto-pipeline` (as applicable). This call is advisory — if it fails, continue.
+Valid categories: `error, pivot, review, design, debug, gotcha, effectiveness, misroute`. Use `effectiveness` for successful routing, `misroute` for reroutes.
 
 **Gate**: Agent and skill selected. Banner displayed. Routing decision recorded. Proceed to Phase 3.
 
@@ -313,8 +314,8 @@ When uncertain which route: **ROUTE ANYWAY.** Add verification-before-completion
 ```bash
 python3 ~/.claude/scripts/learning-db.py record \
     routing "{selected_agent}:{selected_skill}" \
-    "{existing_value} | tool_errors: {0|1} | user_rerouted: {0|1}" \
-    --category routing-decision
+    "routing-decision: agent={selected_agent} skill={selected_skill} tool_errors: {0|1} user_rerouted: {0|1}" \
+    --category effectiveness
 ```
 
 Record only observable facts (tool_errors, user_rerouted) — routing outcome quality is measured by user reroutes, not self-assessment.

--- a/skills/do/references/progressive-depth.md
+++ b/skills/do/references/progressive-depth.md
@@ -76,7 +76,7 @@ Users can override depth at any time during routing or execution:
 | "full pipeline" | Escalate to Level 3 (Pipeline) |
 | "start over deeper" | Abandon current work, restart at specified level |
 
-The escape hatch exists because the user has context the router lacks. When a user overrides, record the override in `learning.db` via `routing-decision` category with tag `user-depth-override` — this feeds future routing accuracy.
+The escape hatch exists because the user has context the router lacks. When a user overrides, record the override in `learning.db` via `effectiveness` category with tag `user-depth-override` — this feeds future routing accuracy.
 
 ---
 

--- a/skills/toolkit-evolution/SKILL.md
+++ b/skills/toolkit-evolution/SKILL.md
@@ -112,7 +112,7 @@ Each agent receives the briefing data from Step 1 and evaluates from a different
 
 | Agent | Perspective | What it looks for |
 |-------|------------|-------------------|
-| **The User** | Analyzes learning.db for unmatched routing requests (`python3 scripts/learning-db.py search "routing-decision" --limit 20`), error patterns, and requests that had no agent match. "What did users ask for that we couldn't handle?" |
+| **The User** | Analyzes learning.db for unmatched routing requests (`python3 scripts/learning-db.py search "routing decision" --limit 20`), error patterns, and requests that had no agent match. "What did users ask for that we couldn't handle?" |
 | **The Operator** | Examines the active projects (check git repos in `~/`) for repeated manual workflows that could be skills. "What am I doing by hand that should be automated?" |
 | **The Strategist** | Uses the csuite skill's EVALUATION mode thinking: what decision-support, content, or process skills would make the owner more effective? Reads `skills/csuite/SKILL.md` for framework. "What high-leverage skills are we missing?" |
 | **The Community** | Web-searches for what people are building and requesting in AI coding communities (Claude Code GitHub issues, Reddit, X/Twitter). "What does the market want?" |
@@ -168,12 +168,13 @@ mkdir -p evolution-reports
 **Step 1: Query the learning database for recent failures and routing mismatches**
 
 ```bash
-python3 ~/.claude/scripts/learning-db.py search "routing decision mismatch reroute" --min-confidence 0.3 --limit 20
+python3 ~/.claude/scripts/learning-db.py search "routing decision" --min-confidence 0.0 --limit 20
+python3 ~/.claude/scripts/learning-db.py search "routing gap mismatch reroute" --min-confidence 0.3 --limit 20
 python3 ~/.claude/scripts/learning-db.py search "error pattern failure bug" --min-confidence 0.3 --limit 20
 python3 ~/.claude/scripts/learning-db.py search "skill gap missing improvement" --min-confidence 0.3 --limit 20
 ```
 
-Look for: recurring failures, routing mismatches where the user had to reroute, skills that consistently underperform, error patterns without automated fixes.
+Look for: routing decision patterns (first query, low threshold since effectiveness entries start at 0.5-0.6 confidence), recurring routing failures and mismatches, skills that consistently underperform, error patterns without automated fixes.
 
 **Step 2: Scan recent git history for patterns**
 

--- a/skills/toolkit-evolution/SKILL.md
+++ b/skills/toolkit-evolution/SKILL.md
@@ -112,7 +112,7 @@ Each agent receives the briefing data from Step 1 and evaluates from a different
 
 | Agent | Perspective | What it looks for |
 |-------|------------|-------------------|
-| **The User** | Analyzes learning.db for unmatched routing requests (`python3 scripts/learning-db.py query --category routing-decision`), error patterns, and requests that had no agent match. "What did users ask for that we couldn't handle?" |
+| **The User** | Analyzes learning.db for unmatched routing requests (`python3 scripts/learning-db.py search "routing-decision" --limit 20`), error patterns, and requests that had no agent match. "What did users ask for that we couldn't handle?" |
 | **The Operator** | Examines the active projects (check git repos in `~/`) for repeated manual workflows that could be skills. "What am I doing by hand that should be automated?" |
 | **The Strategist** | Uses the csuite skill's EVALUATION mode thinking: what decision-support, content, or process skills would make the owner more effective? Reads `skills/csuite/SKILL.md` for framework. "What high-leverage skills are we missing?" |
 | **The Community** | Web-searches for what people are building and requesting in AI coding communities (Claude Code GitHub issues, Reddit, X/Twitter). "What does the market want?" |


### PR DESCRIPTION
## Summary

- **Root cause**: Every `/do` routing decision recording attempt has silently failed since the skill was written. `--category routing-decision` is not a valid category in `learning-db.py` (valid: `error, pivot, review, design, debug, gotcha, effectiveness, misroute`). The command exits with code 2 (argparse validation error), leaving the learning DB blind to all routing decisions.
- **Impact**: The DIAGNOSE phase of toolkit-evolution returned empty for all three routing queries across every evolution cycle — no routing data, no evidence-backed proposals from that source.
- **Detection**: 2026-04-15 evolution cycle; confirmed by running the record command directly and observing exit code 2.

## Changes

- `skills/do/SKILL.md`: Fix Phase 2 Step 4 and Phase 5 LEARN — change `--category routing-decision` to `--category effectiveness`; update value format to include `routing-decision:` prefix for FTS discoverability; document valid categories inline
- `scripts/learning-db.py`: Fix `cmd_route_stats` to query `category="effectiveness"` matching the corrected storage format
- `skills/do/references/progressive-depth.md`: Correct category reference in escape-hatch docs
- `skills/toolkit-evolution/SKILL.md`: Fix DIAGNOSE phase queries to use correct FTS syntax (`routing decision` with space, not hyphen); split into separate success/failure queries; fix DISCOVER phase query

## Test Results

| Test | Baseline | Candidate | Result |
|------|----------|-----------|--------|
| Old category `routing-decision` exits with code 2 | ✓ | - | PASS |
| New category `effectiveness` exits with code 0 | - | ✓ | PASS |
| FTS search `routing decision` finds recorded entries | 0 results | finds entries | PASS |
| `route-stats --by agent` works with new category | - | ✓ | PASS |
| Full test suite (1869 pytest) | 0 failures | 0 failures | PASS |

**5/5 tests PASS — WIN**

## Evolution Cycle

Generated by toolkit-evolution cycle 2026-04-15. Proposal: P1 (routing-gap success recording). Consensus: 3.0/3.0 STRONG (unanimous). A/B result: 5/5 100% win rate.