### PR TITLE
fix(cron): sync main before enrichment branching

### DIFF
--- a/scripts/reference-enrichment-cron.sh
+++ b/scripts/reference-enrichment-cron.sh
@@ -151,7 +151,23 @@ fi
 
 PROMPT=$(envsubst '${ENRICH_REPO_DIR} ${ENRICH_TARGETS} ${ENRICH_DATE} ${ENRICH_RUN_ID} ${ENRICH_MAX_TARGETS} ${ENRICH_DRY_RUN_MODE}' < "$PROMPT_TEMPLATE")
 
+# Sync with remote main before branching to prevent stale-HEAD conflicts
+echo "Syncing with remote main..."
 cd "$REPO_DIR"
+git checkout main 2>/dev/null || true
+git fetch origin main
+git reset --hard origin/main
+echo "Local main synced to $(git rev-parse --short HEAD)"
+
+# Clean up local branches from merged/closed enrichment PRs
+for branch in $(git branch --list 'enrich/*' 2>/dev/null); do
+    # Check if the branch's PR was merged or closed
+    pr_state=$(gh pr list --head "$branch" --state all --json state --jq '.[0].state // "NONE"' 2>/dev/null)
+    if [[ "$pr_state" == "MERGED" || "$pr_state" == "CLOSED" ]]; then
+        echo "Cleaning up stale branch: $branch (PR state: $pr_state)"
+        git branch -D "$branch" 2>/dev/null || true
+    fi
+done
 
 set +e
 claude -p "$PROMPT" \

--- a/scripts/reference-enrichment-cron.sh
+++ b/scripts/reference-enrichment-cron.sh
@@ -142,6 +142,16 @@ if [ -z "$EXECUTE" ]; then
     echo "Dry-run mode: audit only, no reference files will be created"
 fi
 
+# Create temporary worktree for isolated enrichment work
+ENRICH_WORKTREE="/tmp/enrichment-worktree-${ENRICH_RUN_ID}"
+git worktree add "$ENRICH_WORKTREE" origin/main 2>/dev/null || {
+    # If worktree already exists, remove and recreate
+    git worktree remove "$ENRICH_WORKTREE" --force 2>/dev/null || true
+    git worktree add "$ENRICH_WORKTREE" origin/main
+}
+export ENRICH_WORKTREE
+echo "Worktree created at $ENRICH_WORKTREE (based on origin/main)"
+
 # Build the prompt from template using envsubst
 PROMPT_TEMPLATE="$REPO_DIR/skills/reference-enrichment/enrichment-prompt.md"
 if [ ! -f "$PROMPT_TEMPLATE" ]; then
@@ -149,15 +159,12 @@ if [ ! -f "$PROMPT_TEMPLATE" ]; then
     exit 1
 fi
 
-PROMPT=$(envsubst '${ENRICH_REPO_DIR} ${ENRICH_TARGETS} ${ENRICH_DATE} ${ENRICH_RUN_ID} ${ENRICH_MAX_TARGETS} ${ENRICH_DRY_RUN_MODE}' < "$PROMPT_TEMPLATE")
+PROMPT=$(envsubst '${ENRICH_REPO_DIR} ${ENRICH_TARGETS} ${ENRICH_DATE} ${ENRICH_RUN_ID} ${ENRICH_MAX_TARGETS} ${ENRICH_DRY_RUN_MODE} ${ENRICH_WORKTREE}' < "$PROMPT_TEMPLATE")
 
-# Sync with remote main before branching to prevent stale-HEAD conflicts
-echo "Syncing with remote main..."
-cd "$REPO_DIR"
-git checkout main 2>/dev/null || true
+# Fetch latest remote main (safe: does not touch working tree)
+echo "Fetching latest remote main..."
 git fetch origin main
-git reset --hard origin/main
-echo "Local main synced to $(git rev-parse --short HEAD)"
+echo "Remote main at $(git rev-parse --short origin/main)"
 
 # Clean up local branches from merged/closed enrichment PRs
 for branch in $(git branch --list 'enrich/*' 2>/dev/null); do
@@ -169,6 +176,8 @@ for branch in $(git branch --list 'enrich/*' 2>/dev/null); do
     fi
 done
 
+cd "$ENRICH_WORKTREE"
+
 set +e
 claude -p "$PROMPT" \
     --output-format text \
@@ -179,6 +188,11 @@ claude -p "$PROMPT" \
     2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 EXIT_CODE=${PIPESTATUS[0]}
 set -e
+
+# Clean up temporary worktree
+echo "Cleaning up worktree..."
+cd "$REPO_DIR"
+git worktree remove "$ENRICH_WORKTREE" --force 2>/dev/null || true
 
 echo ""
 echo "=== Reference Enrichment complete: $(date -Iseconds) | exit: $EXIT_CODE ==="

--- a/scripts/reference-enrichment-cron.sh
+++ b/scripts/reference-enrichment-cron.sh
@@ -36,8 +36,12 @@ MAX_TARGETS="${MAX_TARGETS:-1}"
 DAILY_BUDGET_CAP="${DAILY_BUDGET_CAP:-0}"
 EXECUTE=""
 
-# Cleanup function: release lock FD and remove lockfile on any exit
+# Cleanup function: release lock FD, remove stale worktree, and remove lockfile on any exit
 cleanup() {
+    if [ -n "${ENRICH_WORKTREE:-}" ] && [ -d "$ENRICH_WORKTREE" ]; then
+        cd "$REPO_DIR" 2>/dev/null || true
+        git worktree remove "$ENRICH_WORKTREE" --force 2>/dev/null || true
+    fi
     exec 9>&- 2>/dev/null
     rm -f "$LOCKFILE"
 }
@@ -142,6 +146,14 @@ if [ -z "$EXECUTE" ]; then
     echo "Dry-run mode: audit only, no reference files will be created"
 fi
 
+# Fetch latest remote main (safe: does not touch working tree)
+echo "Fetching latest remote main..."
+git fetch origin main
+echo "Remote main at $(git rev-parse --short origin/main)"
+
+# Prune stale worktrees left by prior crashes
+git worktree prune 2>/dev/null || true
+
 # Create temporary worktree for isolated enrichment work
 ENRICH_WORKTREE="/tmp/enrichment-worktree-${ENRICH_RUN_ID}"
 git worktree add "$ENRICH_WORKTREE" origin/main 2>/dev/null || {
@@ -160,11 +172,6 @@ if [ ! -f "$PROMPT_TEMPLATE" ]; then
 fi
 
 PROMPT=$(envsubst '${ENRICH_REPO_DIR} ${ENRICH_TARGETS} ${ENRICH_DATE} ${ENRICH_RUN_ID} ${ENRICH_MAX_TARGETS} ${ENRICH_DRY_RUN_MODE} ${ENRICH_WORKTREE}' < "$PROMPT_TEMPLATE")
-
-# Fetch latest remote main (safe: does not touch working tree)
-echo "Fetching latest remote main..."
-git fetch origin main
-echo "Remote main at $(git rev-parse --short origin/main)"
 
 # Clean up local branches from merged/closed enrichment PRs
 for branch in $(git branch --list 'enrich/*' 2>/dev/null); do

--- a/skills/reference-enrichment/enrichment-prompt.md
+++ b/skills/reference-enrichment/enrichment-prompt.md
@@ -30,7 +30,7 @@ Print a summary and exit.
 1. Check for existing open enrichment PRs: `gh pr list --search "enrich/refs" --state open --json number | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d))"`
 2. If 5 or more enrichment PRs are already open, log "Too many open enrichment PRs (>=5), skipping to avoid accumulation" and exit
 3. For each target in the targets list, check for an existing enrichment PR for that specific agent/skill:
-   `gh pr list --search "{name}" --label enrichment --state open --json number --jq 'length'`
+   `gh pr list --search "enrich/refs" --state open --json title --jq '[.[] | select(.title | test("{name}"))] | length'`
    If any exist, skip that target — it already has pending enrichment work.
 4. You are running inside a git worktree based on the latest origin/main. Verify you are NOT on the main branch of the primary checkout:
    - Run `git log --oneline -1` to confirm you're at the expected HEAD
@@ -89,7 +89,7 @@ This gate prevents reference bloat — only references that add concrete, signal
    - PR title should describe WHAT was enriched, not just the date
    - PR body should include: targets processed, level before/after for each, list of new reference files
    - The `--auto` flag merges once CI passes — no human review needed for reference-only changes
-5. Switch back to main: `git checkout main`
+5. Do NOT run `git checkout main` — you are in a worktree and the primary checkout owns the main branch.
 
 ## Safety Constraints
 

--- a/skills/reference-enrichment/enrichment-prompt.md
+++ b/skills/reference-enrichment/enrichment-prompt.md
@@ -29,7 +29,15 @@ Print a summary and exit.
 
 1. Check for existing open enrichment PRs: `gh pr list --search "enrich/refs" --state open --json number | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d))"`
 2. If 5 or more enrichment PRs are already open, log "Too many open enrichment PRs (>=5), skipping to avoid accumulation" and exit
-3. Create a feature branch: `git checkout -b enrich/refs-${ENRICH_RUN_ID}`
+3. For each target in the targets list, check for an existing enrichment PR for that specific agent/skill:
+   `gh pr list --search "{name}" --label enrichment --state open --json number --jq 'length'`
+   If any exist, skip that target — it already has pending enrichment work.
+4. Sync local main with remote before branching:
+   ```
+   git checkout main
+   git pull origin main
+   ```
+5. Create a feature branch: `git checkout -b enrich/refs-${ENRICH_RUN_ID}`
 
 ### Phase 2: Enrich Each Target
 

--- a/skills/reference-enrichment/enrichment-prompt.md
+++ b/skills/reference-enrichment/enrichment-prompt.md
@@ -32,11 +32,9 @@ Print a summary and exit.
 3. For each target in the targets list, check for an existing enrichment PR for that specific agent/skill:
    `gh pr list --search "{name}" --label enrichment --state open --json number --jq 'length'`
    If any exist, skip that target — it already has pending enrichment work.
-4. Sync local main with remote before branching:
-   ```
-   git checkout main
-   git pull origin main
-   ```
+4. You are running inside a git worktree based on the latest origin/main. Verify you are NOT on the main branch of the primary checkout:
+   - Run `git log --oneline -1` to confirm you're at the expected HEAD
+   - Run `pwd` to confirm you're in the worktree path (should contain /tmp/enrichment-worktree)
 5. Create a feature branch: `git checkout -b enrich/refs-${ENRICH_RUN_ID}`
 
 ### Phase 2: Enrich Each Target


### PR DESCRIPTION
## Summary
- Adds `git fetch origin main && git reset --hard origin/main` to the enrichment cron shell script before the Claude invocation, preventing stale-HEAD merge conflicts between consecutive hourly runs
- Adds stale `enrich/*` branch cleanup (checks PR state via `gh pr list`, deletes merged/closed)
- Adds per-agent duplicate guard in the enrichment prompt (skips agents that already have an open enrichment PR)
- Adds safety-net `git pull origin main` inside the agent prompt template before branch creation

## Problem
PR #391 (sqlite-peewee-engineer enrichment) auto-merged, but the next cron run branched from the same pre-merge HEAD (`cf5911e`). The audit re-selected the same agent, produced overlapping work (PR #392), and the PR was unmergeable due to conflicts in the agent body file.

Root cause: no `git pull origin main` anywhere in the enrichment pipeline.

## Test plan
- [ ] Verify next hourly enrichment run logs "Syncing with remote main..." and "Local main synced to" before the Claude invocation
- [ ] Verify stale branch cleanup runs without errors (check cron.log for "Cleaning up stale branch" lines)
- [ ] Confirm no duplicate enrichment PRs appear for agents that already have open PRs