### PR TITLE
fix(cron): remove completion journal from enrichment

### DIFF
--- a/scripts/reference-enrichment-cron.sh
+++ b/scripts/reference-enrichment-cron.sh
@@ -110,28 +110,6 @@ if [ "$TARGETS_COUNT" -eq 0 ]; then
     exit 0
 fi
 
-# Completion journal: skip targets already enriched today
-COMPLETION_JOURNAL="$LOG_DIR/.completions-$(date +%Y%m%d)"
-touch "$COMPLETION_JOURNAL"
-TARGETS_TRIMMED=$(echo "$TARGETS_TRIMMED" | python3 -c "
-import json, sys
-targets = json.load(sys.stdin)
-journal = set()
-try:
-    with open('$COMPLETION_JOURNAL') as f:
-        journal = {line.strip() for line in f if line.strip()}
-except FileNotFoundError:
-    pass
-filtered = [t for t in targets if t not in journal]
-print(json.dumps(filtered))
-")
-TARGETS_COUNT=$(echo "$TARGETS_TRIMMED" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
-
-if [ "$TARGETS_COUNT" -eq 0 ]; then
-    echo "$(date -Iseconds) All targets already completed today (see $COMPLETION_JOURNAL). Exiting cleanly."
-    exit 0
-fi
-
 echo "Audit found ${TARGETS_COUNT} gap(s). Processing up to ${MAX_TARGETS}: ${TARGETS_TRIMMED}"
 
 # Build envsubst variables
@@ -206,11 +184,7 @@ echo "=== Reference Enrichment complete: $(date -Iseconds) | exit: $EXIT_CODE ==
 
 # Record completed targets in journal (only on success)
 if [ "$EXIT_CODE" -eq 0 ]; then
-    echo "$TARGETS_TRIMMED" | python3 -c "
-import json, sys
-for name in json.load(sys.stdin):
-    print(name)
-" >> "$COMPLETION_JOURNAL"
+    echo "Enrichment completed successfully for: $TARGETS_TRIMMED"
 fi
 
 # Increment daily run counter


### PR DESCRIPTION
## Summary
- Removes the daily completion journal that filtered out agents already enriched today
- The audit's Level 3 check is the sole gatekeeper: if an agent has references, the audit skips it naturally
- The per-agent open-PR dedup guard (in enrichment-prompt.md) remains as the correct duplicate prevention

## Why
The journal prevented re-evaluation of agents after their PRs merged. If an agent's enrichment PR merges and new gaps appear (e.g., from a code change that adds new reference signals), the journal blocked re-enrichment until the next day. The audit itself already handles this correctly: Level 3 agents are skipped, sub-Level-3 agents are selected.

## Change
- Removed: `.completions-YYYYMMDD` journal creation, filter logic, and post-run append (27 lines)
- Kept: per-agent open-PR dedup guard, dollar budget cap (already unlimited), audit-based Level check

## Test plan
- [ ] Verify next cron run does not reference completion journal in logs
- [ ] Verify agents at Level 3 are still correctly skipped by the audit (not the journal)
- [ ] Verify agents with open enrichment PRs are still skipped by the prompt-level dedup guard