### PR TITLE
feat(refs): technical-journalist-writer (Level 0→3)

### DIFF
--- a/agents/technical-journalist-writer.md
+++ b/agents/technical-journalist-writer.md
@@ -360,8 +360,20 @@ STOP and ask the user when:
 
 ## References
 
-This agent pairs well with:
-- **voice-writer**: Unified voice content generation pipeline
-- **technical-documentation-engineer**: For technical accuracy validation
+### Loading Table
 
-See [voice-patterns.md](references/voice-patterns.md) for complete voice analysis with extensive examples.
+Load reference files on demand based on task signals:
+
+| Signal | Load | Why |
+|--------|------|-----|
+| Banned pattern present (`amazing`, `seamlessly`, persuasive framing) | `references/voice-patterns.md` | Detection commands and replacement patterns for banned voice violations |
+| Reviewing or auditing generated article tone | `references/voice-patterns.md` | Grep commands to find enthusiasm markers, vague abstractions, condescension |
+| Writing explainer, opinion, or analysis article | `references/article-structure-patterns.md` | Structure templates per article type, header and topic-sentence patterns |
+| Clickbait headers or missing topic sentences detected | `references/article-structure-patterns.md` | Anti-pattern detection and structural fixes |
+| Article contains statistics, version claims, or historical facts | `references/sourcing-and-claims.md` | Claim classification, inline citation patterns, inference-marking cheat sheet |
+| Verifying claims before article delivery | `references/sourcing-and-claims.md` | Detection commands for unsourced percentages, fake certainty, comparative claims |
+
+### Companion Agents and Skills
+
+- **voice-writer**: Unified voice content generation pipeline
+- **technical-documentation-engineer**: Technical accuracy validation

--- a/agents/technical-journalist-writer/references/article-structure-patterns.md
+++ b/agents/technical-journalist-writer/references/article-structure-patterns.md
@@ -1,0 +1,244 @@
+# Article Structure Patterns
+
+> **Scope**: Structure templates and anti-patterns for the three article types this agent produces: explainer, opinion, and analysis. Covers header patterns, topic sentences, and structural detection commands.
+> **Version range**: All versions — applies to markdown article output.
+> **Generated**: 2026-04-15
+
+---
+
+## Overview
+
+The journalist voice produces three distinct article types, each with a specific structure. Explainers build from mechanism to implication. Opinion pieces follow principle-application-example. Analysis pieces state findings first, then evidence. The most common failure is applying the wrong structure to the wrong article type, or using clickbait headers that describe drama instead of content.
+
+---
+
+## Article Type Pattern Table
+
+| Article Type | Opening | Body Structure | Closing |
+|--------------|---------|----------------|---------|
+| Explainer | State what changed or how it works | Mechanism → consequence → implication | What this means for the reader's context |
+| Opinion | State the core claim directly | Principle → application → concrete example | Restate claim with evidence accumulated |
+| Analysis | State the finding | Evidence → why it matters → what's missing | What question remains open |
+
+---
+
+## Explainer Structure
+
+Explainers answer "how does this work" or "what changed." The structure builds from the mechanism to its implications.
+
+```markdown
+## [Descriptive Header: What the System Does]
+
+[Opening: One sentence stating what the system does or what changed.]
+
+[Mechanism paragraph: How it works, specifically.]
+
+[Consequence paragraph: What this means operationally.]
+
+### [Sub-component or Edge Case]
+
+[Topic sentence stating this section's specific focus.]
+
+[Detail with concrete example — a real scenario, not "for example, imagine you..."]
+
+### [Comparison or Context, if relevant]
+
+[How this differs from the previous approach, if applicable.]
+```
+
+**Structural rule**: Each section adds one new piece of information. No section exists to create suspense or withhold information for impact.
+
+---
+
+## Opinion Structure: Principle-Application-Example
+
+Opinion pieces make an argument. The journalist voice makes arguments through logic and evidence, not through appeals to authority or enthusiasm.
+
+```markdown
+## [Descriptive Header: The Claim]
+
+[Opening: State the core claim directly. One sentence.]
+
+### [Why This Claim Holds]
+
+[Principle: The underlying mechanism that makes the claim true.]
+
+[Application: Apply that principle to the specific context under discussion.]
+
+[Example: A concrete, specific scenario — real system, real behavior, real outcome.]
+
+### [Where This Breaks Down]
+
+[The edge case or counter-argument — acknowledge it directly.]
+
+[Why the main claim still holds despite this.]
+```
+
+**Detection** — missing principle-application-example structure:
+```bash
+# Check if opinion article has concrete example (a date or system name is a strong signal)
+grep -i '\b(last month\|last year\|in [0-9]\{4\}\|[A-Z][a-z]* [Ss]ystem\|[A-Z][a-z]* [Ss]ervice)\b' article.md
+
+# Check for specific numbers or metrics (makes it concrete)
+grep -E '\b[0-9]+(%|ms|MB|GB|req|rpm|RPS)\b' article.md
+```
+
+---
+
+## Analysis Structure
+
+Analysis pieces examine existing data, behavior, or systems. The finding comes first.
+
+```markdown
+## [Descriptive Header: The Finding]
+
+[Opening: State the finding. What the analysis shows.]
+
+### [Evidence]
+
+[Topic sentence: This section presents the specific evidence.]
+
+[The data, behavior, or system characteristic that supports the finding.]
+
+### [Why It Matters]
+
+[Operational or architectural consequence of this finding.]
+
+### [What's Not Known]
+
+[The open question — what the analysis can't answer from available data.]
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Clickbait Headers
+
+**Detection**:
+```bash
+# Clickbait patterns in headers
+rg '^#{1,3} .*(Nobody|Everything|Changes Everything|Will Surprise|You Won.t Believe|Shocking|Secret|Hidden)' --type md -i
+
+# Vague dramatic headers
+rg '^#{1,3} (The Problem|The Solution|Why This Matters|What Comes Next|The Future)$' --type md
+```
+
+**What it looks like**:
+```markdown
+### The Problem Nobody Saw Coming
+### The Solution That Changes Everything
+### What Happens Next Will Surprise You
+```
+
+**Why wrong**: Clickbait headers delay information by making the reader read the section to find out what it covers. Descriptive headers function as navigation — the reader scans headers to find relevant sections.
+
+**Fix**:
+```markdown
+### Why Schema Files Failed at Scale
+### How Migration Scripts Fix Deployment Ordering
+### Rollback Strategy for Failed Migrations
+```
+
+**Rule**: Headers state the section's content. "The Problem" is not content — "Why the Mutex Implementation Is Wrong" is.
+
+---
+
+### ❌ Missing Topic Sentences
+
+**Detection**:
+```bash
+# Paragraphs starting with "This" or "It" (often indicate missing topic setup)
+grep -n '^This \|^It ' article.md | head -10
+
+# Paragraphs starting with transition words without a preceding claim
+grep -n '^However,\|^Additionally,\|^Furthermore,\|^Also,' article.md
+```
+
+**What it looks like**:
+```
+Rollback strategies are an important consideration when thinking about
+migrations. There are several things to keep in mind when approaching
+this problem...
+```
+
+**Why wrong**: The first sentence doesn't state what the paragraph covers. "Important consideration" is a label, not information. The reader can't tell from the first sentence whether to keep reading this paragraph.
+
+**Fix**:
+```
+The rollback strategy handles three failure modes. Syntax errors abort before
+any rows change. Partial constraint violations require row-level rollback.
+Lock timeout failures leave the schema unchanged but require manual state verification.
+```
+
+---
+
+### ❌ Burying the Lead
+
+**Detection**:
+```bash
+# Articles where the main claim appears late (after paragraph 3)
+# Count paragraphs before the first concrete claim sentence
+awk '/^$/{para++} para>=3 && /[0-9]%|[0-9]ms|[A-Z][a-z]+ (changed|failed|broke)/{print NR": first concrete claim at paragraph "para; exit}' article.md
+```
+
+**What it looks like**:
+```
+[3 paragraphs of context and background]
+[Paragraph 4: "The system failed because the lock timeout was 30 seconds."]
+```
+
+**Why wrong**: The reader has to read through context to find the information they came for. Technical readers skim; burying the lead means many readers miss the core point.
+
+**Fix**: State the core finding in the first paragraph. Use subsequent paragraphs to support, not to build up to.
+
+---
+
+### ❌ Unsupported Section Length
+
+**Detection**:
+```bash
+# Sections with only one paragraph (possible padding or incomplete treatment)
+awk '/^#{1,3}/{section=$0} /^$/{if(para==1) print "Single-para section: "section; para=0} /^[^#]/{para++}' article.md
+```
+
+**What it looks like**:
+```
+### Why This Matters
+
+This is important because it affects system reliability.
+
+### What To Do
+```
+
+**Why wrong**: A section with one short paragraph is either padding (can be deleted) or incomplete (the idea wasn't developed). The journalist voice covers each point thoroughly or cuts it.
+
+**Fix**: Either develop the section with specific examples, data, or mechanisms — or remove the section header and fold the content into an adjacent paragraph.
+
+---
+
+## Structure Detection Commands Reference
+
+```bash
+# Clickbait headers
+rg '^#{1,3} .*(Nobody|Changes Everything|Will Surprise|Shocking|Secret)' --type md -i
+
+# Vague dramatic headers
+rg '^#{1,3} (The Problem|The Solution|Why This Matters|What Comes Next)$' --type md
+
+# Missing topic sentences (paragraphs starting with weak openers)
+grep -n '^This \|^It \|^There ' article.md | head -10
+
+# No concrete numbers in article (signals vague/abstract content)
+grep -cE '\b[0-9]+(%|ms|MB|GB|req)\b' article.md
+
+# Clickbait question openers in paragraph bodies
+rg '^(How can|What if|Why do|Can we)' --type md -m 5
+```
+
+---
+
+## See Also
+
+- `voice-patterns.md` — banned phrases and tone anti-patterns with detection
+- `sourcing-and-claims.md` — claim verification and citation patterns

--- a/agents/technical-journalist-writer/references/sourcing-and-claims.md
+++ b/agents/technical-journalist-writer/references/sourcing-and-claims.md
@@ -1,0 +1,256 @@
+# Sourcing and Claims Patterns
+
+> **Scope**: How to handle factual claims, mark inferences, cite sources, and avoid unsupported assertions in technical journalism. Covers claim classification and detection commands for validation.
+> **Version range**: All versions — applies to any technical article output.
+> **Generated**: 2026-04-15
+
+---
+
+## Overview
+
+The journalist voice requires a verifiable basis for every factual claim. The agent body includes a hard STOP rule: before delivering any article, verify every factual claim against its source. This reference operationalizes that rule — covering claim classification, inline citation patterns, how to mark inferences, and how to detect unsupported assertions.
+
+---
+
+## Claim Classification
+
+| Claim Type | Source Required | How to Handle |
+|------------|----------------|---------------|
+| Statistical claim | Yes — specific source | Cite inline: "X% of Y, per [Source Year]" |
+| Version-specific behavior | Yes — release notes or docs | Cite inline: "as of [Framework vX.Y]" |
+| Historical event | Yes — dated reference | Cite with date: "in [Month Year], [Organization]..." |
+| Architectural observation | If specific — docs or codebase | Mark as inference if derived from reading code |
+| General mechanism | No — established knowledge | State directly without citation |
+| Reader-facing inference | No source exists — reasoning only | Mark explicitly: "this suggests..." or "the implication is..." |
+
+---
+
+## Correct Sourcing Patterns
+
+### Statistical Claims
+
+State the source inline, not in a footnote. Technical readers verify claims immediately.
+
+```markdown
+PostgreSQL handles approximately 10,000 concurrent connections on typical hardware,
+per the 2023 PostgreSQL benchmark suite. The limit is configurable via max_connections.
+```
+
+```markdown
+The study found 73% of production incidents traced to configuration drift,
+not code bugs (Puppet State of DevOps Report, 2022).
+```
+
+**Why inline**: Footnotes require the reader to interrupt reading to verify. Inline sourcing integrates verification into reading.
+
+---
+
+### Version-Specific Behavior
+
+State the version where behavior applies or changed.
+
+```markdown
+Go 1.21 introduced built-in min/max functions. Prior versions required
+manual comparison or a third-party package.
+```
+
+```markdown
+React 18 changed rendering to concurrent by default. Strict Mode behavior
+changed as a result — effects run twice in development.
+```
+
+**Detection** — version claims without version number:
+```bash
+# Claims about framework behavior without version qualifier
+rg '\b(changed|introduced|deprecated|removed|added)\b' article.md | grep -v '\b[0-9]\+\.[0-9]\+\b'
+```
+
+---
+
+### Marking Inferences
+
+When a claim derives from reasoning rather than a direct source, mark it explicitly.
+
+**Marked inference patterns** (acceptable):
+```markdown
+The latency increase suggests the bottleneck is in the serialization layer,
+not the network hop.
+
+This implies that the migration runs before the application starts — otherwise
+the schema version check would fail on startup.
+
+The configuration suggests the team chose consistency over availability
+in the CAP tradeoff.
+```
+
+**Unmarked inference patterns** (wrong — these sound like facts):
+```markdown
+The bottleneck is in the serialization layer.  # stated as fact, is inference
+The migration runs before the application starts.  # stated as fact, is inference
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Statistical Claims Without Source
+
+**Detection**:
+```bash
+# Percentage claims without citation signal
+rg '\b[0-9]+%\b' article.md | grep -v 'per\|according\|source\|report\|survey\|study\|2[0-9][0-9][0-9]'
+
+# Numeric comparative claims ("X times faster", "X% improvement")
+rg '\b[0-9]+ times (faster|slower|larger|smaller)\b' article.md
+```
+
+**What it looks like**:
+```
+Studies show that 80% of developers prefer this approach. It's 3x faster
+than the alternative in most workloads.
+```
+
+**Why wrong**: "Studies show" without a specific study is not a source — it's a rhetorical move. "3x faster" without a benchmark methodology is marketing language. Both patterns erode credibility when readers verify them and find nothing.
+
+**Fix**:
+```
+The Redis Labs 2023 benchmark showed 3.2x throughput improvement over
+Memcached for workloads with key sizes under 1KB. Results vary with
+key distribution and value size.
+```
+
+---
+
+### ❌ Fake Certainty for Inferences
+
+**Detection**:
+```bash
+# Definitive statements about system internals that would require source code to verify
+rg '\b(definitely|certainly|always|never|guaranteed|impossible)\b' article.md
+
+# "The reason is..." patterns (often inference stated as fact)
+rg '\b(the reason (is|was|for)\b|this is because\b|this happens because\b)' article.md -i
+```
+
+**What it looks like**:
+```
+The reason the system is slow is definitely the database. The query
+always takes 200ms because of missing indexes.
+```
+
+**Why wrong**: Without profiling data or execution plans, this is inference stated as fact. If the reader checks and the database isn't the bottleneck, the article loses all credibility.
+
+**Fix**:
+```
+Profiling showed the database at 73% of request time. The slow_query_log
+identified three queries averaging 200ms — all on the users table without
+an index on created_at.
+```
+
+Or, if no profiling data is available:
+```
+The symptoms suggest database contention — high response time with low CPU
+usage typically indicates waiting on I/O or locks, not compute.
+```
+
+---
+
+### ❌ Historical Claims Without Date
+
+**Detection**:
+```bash
+# Historical claims without a year
+rg '\b(originally|previously|historically|in the early days|back when|used to)\b' article.md | grep -v '\b(19|20)[0-9][0-9]\b'
+
+# "When X was released/launched/introduced" without year
+rg 'when .* (was released|launched|introduced|shipped)' article.md -i | grep -v '\b(19|20)[0-9][0-9]\b'
+```
+
+**What it looks like**:
+```
+When Kubernetes was first released, the networking model was much simpler.
+Originally, services used flat networks without namespace isolation.
+```
+
+**Why wrong**: "When Kubernetes was first released" is vague — Kubernetes 1.0 shipped July 2015. Without the date, the reader can't evaluate how much the ecosystem has changed since then.
+
+**Fix**:
+```
+Kubernetes 1.0 shipped in July 2015 with a flat networking model.
+NetworkPolicy resources, which enable namespace isolation, arrived in
+Kubernetes 1.3 (July 2016).
+```
+
+---
+
+### ❌ Unsourced Comparative Claims
+
+**Detection**:
+```bash
+# Comparative claims that require a baseline to be meaningful
+rg '\b(better than|worse than|faster than|more reliable than|superior to|more popular than)\b' article.md -i
+
+# "Widely adopted", "commonly used", "most teams" — popularity claims need data
+rg '\b(widely|commonly|most teams|most developers|industry standard|best practice)\b' article.md -i
+```
+
+**What it looks like**:
+```
+PostgreSQL is more reliable than MySQL for write-heavy workloads.
+Most teams have moved away from monolithic architectures.
+```
+
+**Why wrong**: "More reliable" requires a specific reliability metric and measured workload. "Most teams" requires a survey. Without these, the claims are opinions presented as facts.
+
+**Fix**:
+```
+In TPC-C benchmarks on write-heavy workloads, PostgreSQL's MVCC implementation
+shows lower lock contention than MySQL's row-level locking under high concurrency
+(PostgreSQL vs MySQL Benchmark, 2023).
+
+The CNCF 2023 Annual Survey found 44% of respondents running microservices
+in production, up from 38% in 2022.
+```
+
+---
+
+## Inference Marking Cheat Sheet
+
+Use these phrasings to mark inferences explicitly:
+
+| Inference Strength | Phrasing |
+|-------------------|----------|
+| Strong (high confidence) | "This suggests..." / "The data implies..." |
+| Medium | "One explanation is..." / "This may indicate..." |
+| Weak (speculative) | "It's possible that..." / "If [assumption] holds, then..." |
+| Acknowledged gap | "Without profiling data, the root cause is unclear." |
+
+**Rule**: When you can't point to a source for a claim, either mark it as inference using the above phrasings, or remove it. The third option — stating inference as fact — is not available in this voice.
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Unsourced percentage claims
+rg '\b[0-9]+%\b' --type md | grep -v 'per\|according\|source\|report\|survey\|study\|2[0-9][0-9][0-9]'
+
+# Version claims without version numbers
+rg '\b(changed|introduced|deprecated|removed|added)\b' --type md | grep -v '\b[0-9]\+\.[0-9]\+\b'
+
+# Certainty words on inference statements
+rg '\b(definitely|certainly|always|never|guaranteed|impossible)\b' --type md
+
+# Historical claims without year
+rg '\b(originally|previously|historically|back when|used to)\b' --type md | grep -v '\b(19|20)[0-9][0-9]\b'
+
+# Comparative claims without baseline
+rg '\b(better than|faster than|more reliable than|superior to)\b' --type md -i
+```
+
+---
+
+## See Also
+
+- `voice-patterns.md` — banned phrases and tone anti-patterns
+- `article-structure-patterns.md` — structural patterns for explainer/opinion/analysis

--- a/agents/technical-journalist-writer/references/voice-patterns.md
+++ b/agents/technical-journalist-writer/references/voice-patterns.md
@@ -1,0 +1,226 @@
+# Technical Journalist Voice Patterns
+
+> **Scope**: Banned phrases, tone anti-patterns, and structural violations for the matter-of-fact journalism voice. Covers detection commands for auditing generated article content.
+> **Version range**: All versions — applies to any technical article output in markdown.
+> **Generated**: 2026-04-15
+
+---
+
+## Overview
+
+The technical journalist voice informs without editorial coloring. The most common failure mode is enthusiasm contamination — single words like "amazing" or "seamlessly" break the matter-of-fact register. A second failure mode is persuasive framing ("you should", "you must") that substitutes the author's judgment for evidence. Detection is straightforward because both failure modes are specific lexical items.
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Enthusiasm markers — superlatives and hype words
+rg -i '\b(amazing|incredible|revolutionary|game-changing|cutting-edge|next-generation|elegant|brilliant|exciting|seamlessly|beautifully|effortlessly|powerful)\b' --type md
+
+# Persuasive language
+rg -i '\b(you should definitely|you must|trust me|you will love|you will thank)\b' --type md
+
+# Exclamation points used for enthusiasm (not imperative)
+grep -n '!' article.md | grep -v "Don't\|do not\|never\|warning\|STOP\|NOTE"
+
+# Throat-clearing openers
+rg -i '^(Have you ever|Did you know|In today|In this article|Welcome to|As we all know|It is worth noting)' --type md -m 5
+
+# Condescending framing
+rg -i "\b(don't worry|as you probably know|let me explain|i'll break it down|for those who don't know|in simple terms)\b" --type md
+
+# Vague abstractions — no concrete specification
+rg -i '\b(appropriate(ly)?|proper(ly)?|graceful(ly)?|careful(ly)?|thorough(ly)?|effective(ly)?)\b' --type md
+
+# Listicle format (5+ numbered items = likely listicle)
+grep -c '^[0-9]\+\.' article.md
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Enthusiasm Markers
+
+**Detection**:
+```bash
+rg -i '\b(amazing|incredible|revolutionary|powerful|elegant|game-changing|cutting-edge)\b' --type md
+```
+
+**What it looks like**:
+```
+The system is amazing! It elegantly leverages PostgreSQL's powerful MVCC capabilities
+to beautifully solve concurrency without compromising performance.
+```
+
+**Why wrong**: Enthusiasm adjectives make claims that can't be verified. "Powerful" compared to what? "Elegantly" by whose standard? These words add editorializing without adding information. Readers tracking the matter-of-fact register notice immediately and discount subsequent factual claims.
+
+**Fix**:
+```
+The system uses PostgreSQL. PostgreSQL handles concurrent writes through MVCC.
+Readers don't block writers. The tradeoff is storage overhead for old row versions.
+```
+
+**Replacement rule**: Replace every enthusiasm adjective with a measurement or delete it.
+- "powerful" → specific throughput/scale numbers, or delete
+- "elegant" → describe the mechanism, not the aesthetic
+- "seamlessly" → describe what actually happens at the integration point
+
+---
+
+### ❌ Persuasive Framing
+
+**Detection**:
+```bash
+rg -i '\b(you should|you must|you need to|you will want to|trust me|make sure to|I recommend)\b' --type md
+```
+
+**What it looks like**:
+```
+You absolutely must write documentation! It's the single most important thing
+you can do. Trust me, you'll thank yourself later.
+```
+
+**Why wrong**: The journalist voice informs, it doesn't prescribe. "You must" assumes authority over the reader's situation — which the author doesn't have. "Trust me" substitutes author credibility for evidence, which is the opposite of journalism.
+
+**Fix**:
+```
+Teams write documentation for integration contracts. This prevents breaking
+changes by recording what each service guarantees.
+```
+
+**Pattern**: Replace "you should X" with an observation about what teams/systems do, and state the consequence.
+
+---
+
+### ❌ Throat-Clearing Openers
+
+**Detection**:
+```bash
+rg -i '^(Have you ever|Did you know|In today|In this article|Welcome to|As we all know)' --type md
+rg '^[A-Z][^.!?]{10,60}\?$' --type md -m 3  # Rhetorical question openers
+```
+
+**What it looks like**:
+```
+Have you ever wondered about the best way to handle database migrations?
+It's a fascinating problem that many developers face! Let me share an
+exciting new approach...
+```
+
+**Why wrong**: The first sentence is the highest-value real estate in any article. Rhetorical questions and scene-setting delay the information the reader came for. Technical readers opened the article knowing the topic — delay signals filler.
+
+**Fix**: First sentence states the topic directly.
+```
+The database migration system changed. The old approach used schema files;
+the new one uses versioned migration scripts.
+```
+
+---
+
+### ❌ Condescending Explanations
+
+**Detection**:
+```bash
+rg -i "\b(as you (probably )?know|don't worry|let me explain|i'll break|for those who don't|in simple terms|step by step)\b" --type md
+```
+
+**What it looks like**:
+```
+As you probably know, JWT stands for JSON Web Token. Don't worry if this
+sounds complicated — I'll break it down step by step!
+```
+
+**Why wrong**: The knowledgeable reader assumption means this audience knows JWT basics. Explaining them signals the author misjudged the audience, eroding trust in the technical claims that follow.
+
+**Fix**:
+```
+The system uses JWT. The token includes user_id and role claims. Expiry is 1 hour.
+```
+
+**Rule**: Skip any explanation the target reader already has. If in doubt about audience level, write for the more experienced reader.
+
+---
+
+### ❌ Vague Abstractions
+
+**Detection**:
+```bash
+rg -i '\b(appropriate(ly)?|proper(ly)?|correct(ly)?|graceful(ly)?|careful(ly)?|thorough(ly)?)\b' --type md
+```
+
+**What it looks like**:
+```
+The API has rate limiting. It returns an error when you make too many requests.
+You should implement appropriate backoff strategies to handle this gracefully.
+```
+
+**Why wrong**: "Appropriate" and "gracefully" are placeholders for specific knowledge the author didn't provide. The reader needs the specific behavior: what HTTP status code, which response header, how many seconds.
+
+**Fix**:
+```
+The API returns HTTP 429 when you exceed 100 requests per minute. The response
+includes a Retry-After header specifying seconds to wait.
+```
+
+---
+
+### ❌ Listicle Format
+
+**Detection**:
+```bash
+# Count numbered list items in article
+grep -c '^[0-9]\+\.' article.md
+
+# Find consecutive numbered items (listicle blocks)
+grep -n '^[0-9]\+\.' article.md | awk -F: 'prev && $1-prev==1{count++} {prev=$1} count>=4{print "Listicle block at line "$1; count=0}'
+```
+
+**What it looks like**:
+```
+### Top 5 Reasons Schema Files Failed
+
+1. Synchronization issues across environments
+2. Merge conflicts in large teams
+3. No deployment history
+4. Difficult rollbacks
+5. State drift over time
+```
+
+**Why wrong**: Numbered lists atomize related ideas and hide logical relationships. The journalist voice builds arguments in prose where causation is explicit ("X caused Y because Z"), not implied by list adjacency.
+
+**Fix**:
+```
+### Why Schema Files Failed
+
+Schema files represented a static snapshot of database state. Each environment
+maintained one file. Deployment became a synchronization problem: staging and
+production diverged because teams edited them independently. Merge conflicts
+were frequent. When a migration failed, there was no history of what had been
+applied where.
+```
+
+---
+
+## Replacement Map
+
+| Banned Pattern | Replacement Strategy |
+|----------------|---------------------|
+| `amazing`, `incredible` | Delete — if the fact is notable, state it specifically |
+| `powerful` | Specific metric: throughput, latency, scale ceiling |
+| `seamlessly` | Describe what actually happens at the integration point |
+| `elegantly` | Describe the mechanism, not the aesthetic |
+| `appropriately` | State the specific required behavior |
+| `gracefully` | Describe what the error path does concretely |
+| `as you know` | Delete — just state the fact |
+| `you should` | "Teams that X find Y" or state the consequence directly |
+| `next-generation` | State specifically what changed from the previous approach |
+| `cutting-edge` | State the publication date and what was new then |
+
+---
+
+## See Also
+
+- `article-structure-patterns.md` — explainer/opinion/analysis article type structures
+- `sourcing-and-claims.md` — claim verification and citation patterns


### PR DESCRIPTION
## Summary

Enriches `technical-journalist-writer` from Level 0 (no references) to Level 3 (deep references with detection commands).

## Targets Processed

| Agent | Before | After | New Files |
|-------|--------|-------|-----------|
| technical-journalist-writer | Level 0 | Level 3 | 3 |

## New Reference Files

**`agents/technical-journalist-writer/references/voice-patterns.md`** (226 lines)
- grep/rg detection commands for all 5 banned patterns: enthusiasm markers, persuasive framing, throat-clearing openers, condescending explanations, listicle format
- Replacement map table mapping banned phrases to concrete replacements
- Code examples showing bad/good patterns for each anti-pattern

**`agents/technical-journalist-writer/references/article-structure-patterns.md`** (244 lines)
- Structure templates for three article types: explainer, opinion, analysis
- Detection commands for clickbait headers, missing topic sentences, buried leads
- Principle-application-example structure for opinion pieces with grep signals

**`agents/technical-journalist-writer/references/sourcing-and-claims.md`** (256 lines)
- Claim classification table (statistical, version-specific, historical, inference)
- Detection commands for unsourced percentages, fake certainty, comparative claims without baselines
- Inference-marking cheat sheet with phrasing by confidence level

## Agent Body Update

Added a loading table mapping 6 task signals to the appropriate reference files. The agent body previously referenced `voice-patterns.md` but the file didn't exist — this closes that gap.

## Validation

- `audit-reference-depth.py`: Level 3 confirmed (concrete=62-85, detection commands present, code blocks present)
- `test_reference_loading.py`: 6 passed, 3 xfailed (expected joy-check xfails)
- Keep-or-revert gate: KEEP — all 3 files contain domain-specific patterns with detection commands