### PR TITLE
fix(cron): cd to repo dir before git operations

### DIFF
--- a/scripts/reference-enrichment-cron.sh
+++ b/scripts/reference-enrichment-cron.sh
@@ -66,6 +66,9 @@ fi
 # Now that we hold the lock, register cleanup for any exit path
 trap cleanup EXIT
 
+# All git operations need to run from inside the repo
+cd "$REPO_DIR"
+
 TIMESTAMP="$(date -Iseconds)"
 echo "=== Reference Enrichment run: $TIMESTAMP ==="
 


### PR DESCRIPTION
## Summary
Adds `cd "$REPO_DIR"` before the first git operation in the enrichment cron script.

## Problem
The script resolved `REPO_DIR` at line 31 but never `cd`'d there. When cron executes from an arbitrary CWD, `git fetch` fails with `fatal: not a git repository`. This was observed in the 11:07 scheduled run today.

## Verification
- Ran dry-run from `/tmp` (simulating cron's arbitrary CWD) — passes
- Previous run from repo dir — passes
- This is a 1-line fix (plus comment)

## Test plan
- [x] Dry-run from /tmp: `cd /tmp && bash /path/to/script` — no git errors
- [ ] Wait for next :07 cron run and verify cron.log shows no `fatal` errors