### PR TITLE
feat(refs): testing-automation-engineer (Level 0→3)

### DIFF
--- a/agents/testing-automation-engineer.md
+++ b/agents/testing-automation-engineer.md
@@ -343,13 +343,24 @@ STOP and ask the user (get explicit confirmation) before proceeding when:
 - Whether to test implementation details (always no, but confirm)
 - Mock vs real external service (depends on test environment)
 
+## Reference Loading Table
+
+Load on demand based on task signals. Do not load all at once — load only what the current task requires.
+
+| Signal in Request | Load This Reference |
+|-------------------|---------------------|
+| "vitest", "vi.fn", "vi.mock", "coverage config", "spy", "jest to vitest", "fake timers" | `references/vitest-patterns.md` |
+| "async", "waitFor", "findBy", "MSW", "flaky test", "setTimeout in test", "userEvent" | `references/async-testing.md` |
+| "mock", "over-mocking", "what to mock", "MSW vs mock", "spyOn", "mock boundary" | `references/mocking-patterns.md` |
+| anti-patterns, "testing implementation details", "shared state", "assertion-free" | `testing-automation-engineer/anti-patterns.md` |
+
 ## References
 
 For detailed testing patterns and implementation examples:
-- **Vitest Configuration**: [testing-automation/vitest-config.md](testing-automation-engineer/vitest-config.md)
-- **Component Testing**: [testing-automation/component-testing.md](testing-automation-engineer/component-testing.md)
-- **E2E Testing**: [testing-automation/e2e-testing.md](testing-automation-engineer/e2e-testing.md)
-- **Pattern Guide**: [testing-automation/anti-patterns.md](testing-automation-engineer/anti-patterns.md)
+- **Vitest Patterns**: [references/vitest-patterns.md](testing-automation-engineer/references/vitest-patterns.md) — Vitest 1.x/2.x config, spy lifecycle, coverage thresholds, anti-patterns
+- **Async Testing**: [references/async-testing.md](testing-automation-engineer/references/async-testing.md) — waitFor, findBy*, MSW, Playwright auto-wait patterns
+- **Mocking Patterns**: [references/mocking-patterns.md](testing-automation-engineer/references/mocking-patterns.md) — mock boundary decisions, over-mocking detection, MSW vs vi.mock
+- **Anti-Patterns**: [testing-automation/anti-patterns.md](testing-automation-engineer/anti-patterns.md)
 - **Testing Anti-Rationalization**: [shared-patterns/anti-rationalization-testing.md](../skills/shared-patterns/anti-rationalization-testing.md)
 
 See [shared-patterns/output-schemas.md](../skills/shared-patterns/output-schemas.md) for Implementation Schema details.

--- a/agents/testing-automation-engineer/references/async-testing.md
+++ b/agents/testing-automation-engineer/references/async-testing.md
@@ -1,0 +1,305 @@
+# Async Testing Reference
+
+> **Scope**: Async test patterns for React Testing Library, Vitest, and Playwright. Covers waitFor, act(), MSW request interception, and async error handling. Does NOT cover Vitest configuration (see vitest-patterns.md).
+> **Version range**: React Testing Library 14+, Vitest 1.0+, Playwright 1.40+
+> **Generated**: 2026-04-15
+
+---
+
+## Overview
+
+Async testing is the primary source of flaky tests. The two failure modes are (1) not waiting for async state updates before asserting, and (2) adding arbitrary `setTimeout` delays instead of waiting for a deterministic condition. RTL's `waitFor` and Playwright's auto-waiting locators eliminate both — when used correctly.
+
+---
+
+## Pattern Table
+
+| Pattern | Version | Use When | Avoid When |
+|---------|---------|----------|------------|
+| `waitFor(() => expect(...))` | RTL 9+ | DOM state changes after async event | Synchronous state changes |
+| `findBy*` queries | RTL 9+ | Element appears asynchronously | Element already in DOM at render |
+| `getBy*` queries | RTL 9+ | Element is in DOM at time of assertion | Element appears asynchronously |
+| `act()` | React 16.8+ | Wrapping state-triggering code in unit tests | RTL renders (auto-wrapped) |
+| `page.getByRole()` | Playwright 1.27+ | Auto-waiting for element to be ready | Assertions on hidden elements |
+| `await expect(locator).toBeVisible()` | Playwright 1.27+ | Playwright async assertions | Synchronous `expect(value).toBe()` |
+
+---
+
+## Correct Patterns
+
+### React Testing Library — waitFor for Async State
+
+```typescript
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+it('shows success message after form submission', async () => {
+  const user = userEvent.setup()
+  render(<ContactForm />)
+
+  await user.type(screen.getByLabelText(/email/i), 'test@example.com')
+  await user.click(screen.getByRole('button', { name: /submit/i }))
+
+  // waitFor polls until assertion passes or timeout (default 1000ms)
+  await waitFor(() => {
+    expect(screen.getByText(/message sent/i)).toBeInTheDocument()
+  })
+})
+```
+
+**Why**: `userEvent.click` triggers the event but the state update (API call → response → re-render) happens asynchronously. Without `waitFor`, the assertion runs before the component re-renders.
+
+---
+
+### findBy* for Elements That Appear Asynchronously
+
+```typescript
+it('loads and displays user data', async () => {
+  render(<UserProfile userId={1} />)
+
+  // findBy* = getBy* + waitFor built in. Throws if not found within timeout.
+  const heading = await screen.findByRole('heading', { name: /alice/i })
+  expect(heading).toBeInTheDocument()
+
+  // After findBy* resolves, use synchronous getBy* for further assertions
+  expect(screen.getByText(/alice@example.com/i)).toBeInTheDocument()
+})
+```
+
+**Why**: `findBy*` is shorthand for `waitFor(() => getBy*(...))`. Use it when an element is absent at render and appears after a data fetch. After the first `findBy*` resolves, subsequent assertions can use `getBy*` synchronously.
+
+---
+
+### MSW (Mock Service Worker) for API Mocking
+
+```typescript
+// src/test/server.ts
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+
+export const server = setupServer(
+  http.get('/api/users/:id', ({ params }) => {
+    return HttpResponse.json({ id: params.id, name: 'Alice', email: 'alice@example.com' })
+  }),
+)
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())   // reset per-test overrides
+afterAll(() => server.close())
+```
+
+```typescript
+// Override default handler in one test
+import { http, HttpResponse } from 'msw'
+import { server } from '../test/server'
+
+it('shows error when user not found', async () => {
+  server.use(
+    http.get('/api/users/:id', () => HttpResponse.json({ error: 'Not found' }, { status: 404 }))
+  )
+
+  render(<UserProfile userId={999} />)
+  await screen.findByText(/user not found/i)
+})
+```
+
+**Why**: MSW intercepts at the network layer, not the module layer. The component's actual `fetch` call runs, so error handling, response parsing, and timeout logic are all exercised. `onUnhandledRequest: 'error'` catches unexpected API calls that would otherwise silently return `undefined`.
+
+---
+
+### Playwright — Async Assertions
+
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test'
+export default defineConfig({
+  use: { baseURL: 'http://localhost:3000' },
+  expect: { timeout: 5000 },   // per-assertion timeout
+  timeout: 30_000,              // per-test timeout
+})
+```
+
+```typescript
+import { test, expect } from '@playwright/test'
+
+test('submits form and shows confirmation', async ({ page }) => {
+  await page.goto('/contact')
+
+  await page.getByLabel('Email').fill('test@example.com')
+  await page.getByRole('button', { name: 'Submit' }).click()
+
+  // Auto-waits up to expect.timeout for element to be visible
+  await expect(page.getByText('Message sent')).toBeVisible()
+
+  // Playwright locators re-query on each assertion — no stale element refs
+  await expect(page.getByRole('heading', { name: 'Thank you' })).toBeVisible()
+})
+```
+
+**Why**: Playwright's `expect(locator).toBeVisible()` auto-waits. Using `page.waitForSelector()` manually or `page.waitForTimeout(2000)` is an anti-pattern — fixed delays are slow on fast machines and flaky on slow ones.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ setTimeout / sleep Delays in Tests
+
+**Detection**:
+```bash
+grep -rn 'setTimeout\|waitForTimeout\|new Promise.*sleep' --include="*.test.ts" --include="*.test.tsx" --include="*.spec.ts"
+rg 'waitForTimeout|page\.waitFor\b' --type ts
+```
+
+**What it looks like**:
+```typescript
+// BAD: arbitrary delay in RTL
+it('shows result after fetch', async () => {
+  render(<DataLoader />)
+  await new Promise(resolve => setTimeout(resolve, 500))  // hope it loaded
+  expect(screen.getByText(/result/i)).toBeInTheDocument()
+})
+
+// BAD: Playwright explicit wait
+await page.waitForTimeout(2000)
+expect(await page.textContent('.result')).toBe('Done')
+```
+
+**Why wrong**: Arbitrary delays make tests slow on fast machines and flaky on slow ones. If the operation takes 600ms instead of 500ms (CI under load), the test fails. These tests hide timing bugs rather than revealing them.
+
+**Fix**:
+```typescript
+// RTL — wait for actual DOM change
+await screen.findByText(/result/i)
+// or
+await waitFor(() => expect(screen.getByText(/result/i)).toBeInTheDocument())
+
+// Playwright — assert on locator (auto-waits)
+await expect(page.getByText('Done')).toBeVisible()
+```
+
+---
+
+### ❌ Un-awaited userEvent Actions (RTL 14+)
+
+**Detection**:
+```bash
+grep -rn 'user\.' --include="*.test.ts" --include="*.test.tsx" | grep -v 'await user\.\|const user\|let user'
+rg 'userEvent\.(click|type|clear|selectOptions)\(' --type tsx | grep -v 'await '
+```
+
+**What it looks like**:
+```typescript
+// BAD: missing await on user actions (RTL 14+ requires await)
+const user = userEvent.setup()
+user.click(button)         // fire-and-forget
+user.type(input, 'hello')
+expect(screen.getByText(/hello/i)).toBeInTheDocument()
+```
+
+**Why wrong**: `userEvent.setup()` returns async methods in RTL 14+. Without `await`, the events fire but React state updates haven't processed before assertions run. Test passes inconsistently depending on microtask scheduling.
+
+**Fix**:
+```typescript
+const user = userEvent.setup()
+await user.click(button)
+await user.type(input, 'hello')
+await screen.findByText(/hello/i)
+```
+
+**Version note**: RTL 13 and earlier used synchronous `userEvent`. RTL 14+ switched to async. Un-awaited calls produce flaky tests, not immediate errors — the breakage is subtle.
+
+---
+
+### ❌ getBy* After Async Operations
+
+**Detection**:
+```bash
+rg 'await user\.(click|submit|type)' --type ts -A1 | grep 'getBy'
+```
+
+**What it looks like**:
+```typescript
+await user.click(screen.getByRole('button', { name: /save/i }))
+expect(screen.getByText(/saved/i)).toBeInTheDocument()  // may not exist yet
+```
+
+**Why wrong**: `user.click` resolves after the event dispatches, not after React re-renders from async work (API calls, state transitions). The `getByText` assertion runs synchronously and finds the element absent.
+
+**Fix**:
+```typescript
+await user.click(screen.getByRole('button', { name: /save/i }))
+await screen.findByText(/saved/i)   // waits up to 1000ms by default
+```
+
+---
+
+### ❌ MSW Without onUnhandledRequest: 'error'
+
+**Detection**:
+```bash
+grep -rn 'server\.listen' --include="*.ts" --include="*.tsx" | grep -v 'onUnhandledRequest'
+rg 'setupServer' --type ts -l | xargs rg -L 'onUnhandledRequest'
+```
+
+**What it looks like**:
+```typescript
+server.listen()  // no onUnhandledRequest — silent network failures
+```
+
+**Why wrong**: When a component makes an unexpected API call (wrong path, URL typo), MSW passes it through or returns undefined without failing the test. The component renders broken UI, tests assert on something unrelated, and the bug is hidden until production.
+
+**Fix**:
+```typescript
+server.listen({ onUnhandledRequest: 'error' })
+// Unexpected requests now throw: "Error: No handler for GET /api/typo"
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| `Unable to find an element with the text: X` | Assertion runs before async render | Replace `getBy*` with `await findBy*` |
+| `Found multiple elements with the role "button"` | Query too broad | Add `name` option: `getByRole('button', { name: /submit/i })` |
+| `Warning: An update to X inside a test was not wrapped in act(...)` | State update after test cleanup | Return the async operation or use `waitFor` |
+| `Error: connect ECONNREFUSED` in Playwright | App not running on expected port | Run dev server before test; check `baseURL` in config |
+| `Timeout 5000ms exceeded` in Playwright | Element never appeared | Check selector; inspect for race condition; increase `expect.timeout` only as last resort |
+| `Error: No handler for GET /api/X` (MSW) | `onUnhandledRequest: 'error'` + missing handler | Add handler to `setupServer` or to the specific test |
+| `act(...)` warning on unmounted component | Test doesn't await component cleanup | Add `await waitFor(() => {})` at end, or fix component cleanup |
+
+---
+
+## Version-Specific Notes
+
+| Version | Change | Impact |
+|---------|--------|--------|
+| RTL 13 → 14 | `userEvent` methods became async | Must `await` all user interactions |
+| MSW 1 → 2 | `rest.get` replaced by `http.get`; `ctx.json` by `HttpResponse.json` | Update handler syntax on MSW 2 upgrade |
+| Playwright 1.27 | Locator API stable; `page.$()` deprecated | Use `page.getByRole()` / `page.locator()` exclusively |
+| Playwright 1.40 | `expect.soft()` added for non-fatal assertions | Use for collecting multiple failures in one test run |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Arbitrary delays (should use waitFor or findBy* instead)
+grep -rn 'setTimeout\|waitForTimeout' --include="*.test.ts" --include="*.test.tsx"
+
+# Un-awaited userEvent calls (RTL 14+)
+grep -rn 'user\.' --include="*.test.tsx" | grep -v 'await user\.\|const user\|let user'
+
+# MSW listeners without onUnhandledRequest guard
+grep -rn 'server\.listen' --include="*.ts" | grep -v 'onUnhandledRequest'
+
+# Synchronous getBy* immediately after async click
+rg 'await user\.(click|submit)' --type ts -A1 | grep 'getBy'
+```
+
+---
+
+## See Also
+
+- `vitest-patterns.md` — Vitest configuration, spy lifecycle, fake timers
+- `mocking-patterns.md` — when to use MSW vs vi.mock, test doubles taxonomy

--- a/agents/testing-automation-engineer/references/mocking-patterns.md
+++ b/agents/testing-automation-engineer/references/mocking-patterns.md
@@ -1,0 +1,286 @@
+# Mocking Patterns Reference
+
+> **Scope**: What to mock and what not to mock, MSW vs vi.mock decision tree, test double taxonomy, and over-mocking detection. Does NOT cover Vitest spy APIs (see vitest-patterns.md) or MSW server setup (see async-testing.md).
+> **Version range**: Vitest 1.0+, MSW 2.0+, all versions for taxonomy
+> **Generated**: 2026-04-15
+
+---
+
+## Overview
+
+Over-mocking is the primary cause of tests that pass but fail in production. When every dependency is mocked, the test verifies that mocks behave like mocks, not that the real system works. The rule: mock at boundaries (network, file system, time, external services), not inside the application layer.
+
+---
+
+## Mock Boundary Decision Table
+
+| Layer | Mock? | Why | How |
+|-------|-------|-----|-----|
+| External HTTP APIs | YES | Non-deterministic, slow, costs money | MSW (`http.get`) |
+| Browser `fetch` / `XMLHttpRequest` | YES (via MSW) | Network layer isolation | MSW intercepts at network level |
+| `Date.now()` / system time | YES | Tests require deterministic time | `vi.setSystemTime()` |
+| File system (unit test) | YES | Side effects, path portability | `vi.mock('node:fs')` |
+| File system (integration test) | NO | Use temp dir (`fs.mkdtempSync`) | — |
+| Database (unit test) | YES | Side effects, speed | Repository interface mock |
+| Database (integration test) | NO | Use test DB or in-memory SQLite | — |
+| Internal module functions | NO | Tests become brittle, miss integration bugs | Test the public API |
+| React context providers | NO | Wrap component in real provider in tests | `renderWithProviders` helper |
+| Third-party UI libraries | NO | Use real components | Render in test; assert on output |
+| `console.error` | SOMETIMES | Suppress expected React warnings | `vi.spyOn(console, 'error')` |
+
+---
+
+## Correct Patterns
+
+### MSW for HTTP — Preferred Over vi.stubGlobal('fetch')
+
+```typescript
+// GOOD: MSW intercepts the real fetch call
+import { http, HttpResponse } from 'msw'
+import { server } from '../test/server'
+
+it('displays product name from API', async () => {
+  server.use(
+    http.get('/api/products/1', () =>
+      HttpResponse.json({ id: 1, name: 'Widget Pro', price: 29.99 })
+    )
+  )
+
+  render(<ProductPage productId={1} />)
+  await screen.findByText('Widget Pro')
+})
+```
+
+```typescript
+// BAD: vi.stubGlobal skips network layer, tests the mock
+vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+  json: () => Promise.resolve({ id: 1, name: 'Widget Pro' })
+}))
+```
+
+**Why prefer MSW**: MSW intercepts at the network level via `@mswjs/interceptors` (Node). The component's `fetch` call is real — error handling, response parsing, and retry logic are all exercised. `vi.stubGlobal('fetch')` replaces the function, bypassing all of that.
+
+---
+
+### Repository Pattern for Database Mocking
+
+```typescript
+// Define the interface
+interface UserRepository {
+  findById(id: number): Promise<User | null>
+  save(user: User): Promise<User>
+}
+
+// In-memory mock implements the same interface
+class MockUserRepository implements UserRepository {
+  private users = new Map<number, User>()
+
+  findById(id: number): Promise<User | null> {
+    return Promise.resolve(this.users.get(id) ?? null)
+  }
+
+  save(user: User): Promise<User> {
+    this.users.set(user.id, user)
+    return Promise.resolve(user)
+  }
+}
+
+// Test — no vi.mock needed
+const repo = new MockUserRepository()
+const service = new UserService(repo)
+
+it('returns null for unknown user', async () => {
+  const result = await service.getUser(999)
+  expect(result).toBeNull()
+})
+```
+
+**Why**: TypeScript enforces that `MockUserRepository` stays in sync with the real interface contract. `vi.mock` on a database module bypasses type checking and can silently drift from the real implementation.
+
+---
+
+### Partial Spy — Mock One Method, Keep the Rest Real
+
+```typescript
+import { vi, afterEach } from 'vitest'
+import * as emailService from '../services/email'
+
+afterEach(() => vi.restoreAllMocks())
+
+it('sends welcome email on registration', async () => {
+  const sendSpy = vi.spyOn(emailService, 'sendEmail').mockResolvedValue(undefined)
+
+  await registerUser({ email: 'new@example.com', name: 'Alice' })
+
+  expect(sendSpy).toHaveBeenCalledWith({
+    to: 'new@example.com',
+    subject: 'Welcome!',
+    template: 'welcome',
+  })
+})
+```
+
+**Why**: `vi.spyOn` replaces only one function. All other `emailService` exports remain real. This tests that `registerUser` calls `sendEmail` with the right arguments without disabling the rest of the email module.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Over-Mocking — Mocking Internal Application Logic
+
+**Detection**:
+```bash
+# vi.mock calls targeting src/ (internal modules)
+grep -rn "vi\.mock('\.\." --include="*.test.ts" --include="*.test.tsx" | grep "src/"
+rg "vi\.mock\('\./|vi\.mock\('\.\." --type ts | grep -v "node_modules\|__mocks__"
+```
+
+**What it looks like**:
+```typescript
+// BAD: mocking internal business logic
+vi.mock('../services/orderCalculator')
+vi.mock('../utils/priceFormatter')
+vi.mock('../hooks/useCart')
+
+it('displays total', () => {
+  (calculateTotal as Mock).mockReturnValue(99.99)
+  render(<OrderSummary />)
+  expect(screen.getByText('$99.99')).toBeInTheDocument()
+})
+```
+
+**Why wrong**: This test verifies that when `calculateTotal` returns `99.99`, the component displays it. It does NOT test whether `calculateTotal` returns the right value. A bug in the calculation is invisible to this test. Over-mocked tests pass while the real system is broken.
+
+**Fix**: Mock only the network boundary, let real internal logic run:
+```typescript
+server.use(
+  http.get('/api/cart', () => HttpResponse.json({ items: [{ price: 99.99, qty: 1 }] }))
+)
+render(<OrderSummary />)
+await screen.findByText('$99.99')
+```
+
+---
+
+### ❌ Mocking What You Don't Own (Third-Party Libraries)
+
+**Detection**:
+```bash
+# vi.mock on node_modules (not starting with ./ or ../)
+grep -rn "vi\.mock('" --include="*.test.ts" | grep -v "vi\.mock('\." | grep -v "msw\|vitest\|node:"
+rg "vi\.mock\('(?!\.)" --type ts | grep -v msw
+```
+
+**What it looks like**:
+```typescript
+// BAD: mocking React Router internals
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useParams: () => ({ id: '1' }),
+}))
+```
+
+**Why wrong**: When `react-router-dom` updates its API, the mock silently diverges. The test passes but the real component breaks in production. You're testing against a fake contract you wrote yourself.
+
+**Fix**: Use real providers in tests. For React Router v6+:
+```typescript
+import { MemoryRouter } from 'react-router-dom'
+
+function renderWithRouter(ui: React.ReactElement, { route = '/' } = {}) {
+  return render(<MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>)
+}
+
+it('navigates to product page', async () => {
+  const { user } = renderWithRouter(<ProductList />, { route: '/products' })
+  await user.click(screen.getByText('Widget Pro'))
+  expect(screen.getByRole('heading', { name: 'Widget Pro' })).toBeInTheDocument()
+})
+```
+
+---
+
+### ❌ Asserting Only on Mock Calls, Not Behavior
+
+**Detection**:
+```bash
+# Test files with toHaveBeenCalledWith but no toBeInTheDocument/toBe
+rg 'toHaveBeenCalledWith' --type ts -l | xargs rg -L 'toBeInTheDocument\|toBe\b\|toEqual'
+grep -rn 'expect.*toHaveBeenCalled' --include="*.test.ts" | wc -l
+```
+
+**What it looks like**:
+```typescript
+// BAD: asserting implementation, not behavior
+it('saves user preferences', async () => {
+  const saveSpy = vi.spyOn(userService, 'savePreferences')
+  await user.click(screen.getByRole('button', { name: /save/i }))
+  expect(saveSpy).toHaveBeenCalledWith({ theme: 'dark', locale: 'en' })
+  // Never checks that the UI updated to reflect the saved state
+})
+```
+
+**Why wrong**: This test passes even if `savePreferences` is called but returns an error the component silently swallows. Or if the UI shows a stale state. It verifies that a function was invoked, not that the user got the right outcome.
+
+**Fix**: Assert on user-visible result first; use call assertions as secondary verification:
+```typescript
+it('saves user preferences', async () => {
+  server.use(http.post('/api/preferences', () => new HttpResponse(null, { status: 204 })))
+
+  await user.click(screen.getByRole('button', { name: /save/i }))
+
+  // Primary: user sees confirmation
+  await screen.findByText(/preferences saved/i)
+  // Secondary: correct payload was sent (via MSW request inspection)
+})
+```
+
+---
+
+### ❌ Mocking console.error to Suppress All Warnings
+
+**Detection**:
+```bash
+grep -rn 'spyOn.*console.*error\|mock.*console\.error' --include="*.test.ts" --include="*.test.tsx"
+rg 'console\.error.*mockImplementation\(\s*\)' --type ts
+```
+
+**What it looks like**:
+```typescript
+// BAD: blanket suppression hides real problems
+beforeAll(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+```
+
+**Why wrong**: This suppresses all React prop-type warnings, act() warnings, and real errors. A broken component renders silently. Errors that should fail the test pass unnoticed.
+
+**Fix**: Suppress only the specific known warning; assert others still fire:
+```typescript
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation((msg) => {
+    if (typeof msg === 'string' && msg.includes('act(...)')) return
+    // Let all other errors through (still logged, test may still fail)
+    console.warn('[console.error suppressed in test]:', msg)
+  })
+})
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| `The module ... has already been mocked` | `vi.mock` called twice for same path | Remove duplicate mock; use `server.use()` for per-test override |
+| `TypeError: X is not a function` after `vi.mock` | Module mock returns wrong shape | Add `vi.importActual` to preserve real exports |
+| `Mock function called 0 times` | Wrong spy target (default vs named export) | Default exports need `{ default: vi.fn() }` in factory |
+| `No handler for POST /api/X` (MSW error mode) | Test exercises API call not in default handlers | Add handler to `setupServer` defaults or to the specific test |
+| `Cannot spy on a primitive value` | Trying to spy on a string/number | Only spy on object methods; wrap primitive in an object |
+| `mockResolvedValue is not a function` | `vi.fn()` not called before `.mockResolvedValue` | Create spy with `vi.fn()` first, then chain `.mockResolvedValue()` |
+
+---
+
+## See Also
+
+- `vitest-patterns.md` — `vi.mock`, `vi.spyOn`, `vi.fn` API details and lifecycle
+- `async-testing.md` — MSW server setup, `waitFor`, async assertion patterns

--- a/agents/testing-automation-engineer/references/vitest-patterns.md
+++ b/agents/testing-automation-engineer/references/vitest-patterns.md
@@ -1,0 +1,303 @@
+# Vitest Patterns Reference
+
+> **Scope**: Vitest 1.x/2.x configuration, test lifecycle, spy/mock APIs, and coverage setup. Does NOT cover React component rendering (see async-testing.md) or Playwright E2E.
+> **Version range**: Vitest 1.0+ (stable API); Vitest 2.0+ notes flagged inline
+> **Generated**: 2026-04-15 — verify against current vitest.dev release notes
+
+---
+
+## Overview
+
+Vitest is the primary test framework for this agent. Its Jest-compatible API allows migration but introduces breaking differences around fake timers, module mocking, and snapshot serializers. The most common failure mode is treating Vitest as if it were Jest: `jest.mock()` calls silently fail, `jest.fn()` is missing, and `beforeAll` ordering differs in concurrent mode.
+
+---
+
+## Pattern Table
+
+| Pattern | Version | Use When | Avoid When |
+|---------|---------|----------|------------|
+| `vi.fn()` | 1.0+ | Creating a spy / mock function | `jest.fn()` (not available) |
+| `vi.mock('module')` | 1.0+ | Auto-mocking an entire module | Mocking only one export (use `vi.spyOn`) |
+| `vi.spyOn(obj, 'method')` | 1.0+ | Spying on an existing method | Creating a standalone mock function |
+| `vi.useFakeTimers()` | 1.0+ | Testing `setTimeout`, `setInterval`, `Date` | Tests with real network/async I/O |
+| `vi.importActual()` | 1.0+ | Partial module mock preserving real implementations | Full module replacement |
+| `pool: 'forks'` | 1.1+ | Node APIs needing true process isolation | Browser-mode tests |
+| `browser: true` mode | 2.0+ | Running tests in real browser (Chromium/Firefox) | Unit tests (use jsdom) |
+
+---
+
+## Correct Patterns
+
+### Vitest Configuration — vitest.config.ts
+
+Required coverage provider and threshold setup. Missing `provider: 'v8'` causes silent 0% branch coverage.
+
+```typescript
+// vitest.config.ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',         // or 'node' for backend tests
+    coverage: {
+      provider: 'v8',             // 'istanbul' also valid; v8 is faster
+      reporter: ['text', 'html', 'json'],
+      thresholds: {
+        lines: 80,
+        branches: 80,             // REQUIRED — do not omit
+        functions: 80,
+        statements: 80,
+      },
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.d.ts', 'src/**/*.stories.*'],
+    },
+    globals: false,               // explicit imports preferred over globals
+    setupFiles: ['./src/test/setup.ts'],
+  },
+})
+```
+
+**Why**: Without `thresholds.branches`, Vitest reports lines only. A function with `if/else` and only the happy path tested reads 100% lines but 50% branches — the threshold won't catch it.
+
+---
+
+### Spy Setup and Teardown
+
+```typescript
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as api from '../api/users'
+
+describe('UserService', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(api, 'fetchUser').mockResolvedValue({ id: 1, name: 'Alice' })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()  // REQUIRED — restores original implementations
+  })
+
+  it('calls fetchUser with the correct id', async () => {
+    await getUserById(1)
+    expect(fetchSpy).toHaveBeenCalledWith(1)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+**Why**: `vi.restoreAllMocks()` in `afterEach` prevents spy state leaking between tests. `vi.clearAllMocks()` resets call counts only; `vi.restoreAllMocks()` also removes mock implementations.
+
+---
+
+### Partial Module Mock with vi.importActual
+
+```typescript
+vi.mock('../services/email', async () => {
+  const actual = await vi.importActual<typeof import('../services/email')>('../services/email')
+  return {
+    ...actual,
+    sendEmail: vi.fn().mockResolvedValue({ success: true }),  // only mock sendEmail
+  }
+})
+```
+
+**Why**: Without `vi.importActual`, all exports become `undefined`. This is the correct pattern when you want to mock one function but keep the rest of the module real.
+
+---
+
+### Fake Timers for setTimeout/setInterval
+
+```typescript
+import { vi, it, expect, beforeEach, afterEach } from 'vitest'
+
+beforeEach(() => { vi.useFakeTimers() })
+afterEach(() => { vi.useRealTimers() })  // always restore
+
+it('fires callback after 1 second delay', () => {
+  const cb = vi.fn()
+  scheduleCallback(cb, 1000)
+
+  expect(cb).not.toHaveBeenCalled()
+  vi.advanceTimersByTime(1000)
+  expect(cb).toHaveBeenCalledTimes(1)
+})
+
+it('tests a Date.now() timestamp', () => {
+  vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+  const result = getTimestamp()
+  expect(result).toBe('2026-01-01')
+})
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Using jest.mock() or jest.fn() in Vitest files
+
+**Detection**:
+```bash
+grep -rn 'jest\.mock\|jest\.fn\|jest\.spyOn' --include="*.test.ts" --include="*.test.tsx" --include="*.spec.ts"
+rg 'jest\.(mock|fn|spyOn|clearAllMocks|resetAllMocks)' --type ts
+```
+
+**What it looks like**:
+```typescript
+// BAD: jest.fn() is undefined in Vitest
+const mockFn = jest.fn()
+jest.mock('../utils')
+jest.spyOn(console, 'error')
+```
+
+**Why wrong**: Vitest does not polyfill the `jest` global by default. These calls throw `ReferenceError: jest is not defined` at runtime or produce silent `undefined` if `globals: true` is configured with a partial shim.
+
+**Fix**:
+```typescript
+import { vi } from 'vitest'
+const mockFn = vi.fn()
+vi.mock('../utils')
+vi.spyOn(console, 'error')
+```
+
+**Version note**: Vitest 1.0+ provides a `jest` compatibility shim via `globals: true` + `@vitest/compat`, but this is opt-in and not recommended for new code.
+
+---
+
+### ❌ Missing vi.restoreAllMocks() — Spy Leak Between Tests
+
+**Detection**:
+```bash
+grep -rn 'vi\.spyOn' --include="*.test.ts" --include="*.test.tsx" -l | xargs grep -L 'restoreAllMocks\|resetAllMocks'
+rg 'vi\.spyOn' --type ts -l | xargs rg -l 'restoreAllMocks' --files-without-match
+```
+
+**What it looks like**:
+```typescript
+describe('Suite A', () => {
+  it('mocks fetch', () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))
+    // NO afterEach/vi.restoreAllMocks()
+  })
+})
+
+describe('Suite B', () => {
+  it('uses real fetch — but it is still mocked!', async () => {
+    // fetch is still the spy from Suite A
+  })
+})
+```
+
+**Why wrong**: Spy state persists across test files in the same worker thread. Tests in unrelated files fail with unexpected mock behavior. Produces order-dependent failures that are hard to reproduce.
+
+**Fix**: Always pair `vi.spyOn` with `afterEach(() => vi.restoreAllMocks())`. Or configure globally:
+```typescript
+test: { restoreMocks: true }  // auto-restore after each test in vitest.config.ts
+```
+
+---
+
+### ❌ No Branch Coverage Threshold
+
+**Detection**:
+```bash
+grep -rn 'thresholds' vitest.config.ts vitest.config.js
+rg 'thresholds' vitest.config.ts | grep -v branches
+```
+
+**What it looks like**:
+```typescript
+coverage: {
+  thresholds: {
+    lines: 80,
+    functions: 80,
+    // branches MISSING — silently passes with 0% branch coverage
+  }
+}
+```
+
+**Why wrong**: A function with `if (user.isAdmin)` tested only with admin users shows 100% line coverage but 0% branch coverage. The non-admin code path is completely untested. CI passes, bugs ship.
+
+**Fix**: Always include `branches: 80` in thresholds (see Correct Patterns section above).
+
+---
+
+### ❌ External Snapshot Files Instead of Inline
+
+**Detection**:
+```bash
+find . -name "*.snap" | grep -v node_modules | wc -l
+rg 'toMatchSnapshot\(\)' --type ts
+```
+
+**What it looks like**:
+```typescript
+it('renders correctly', () => {
+  const { container } = render(<Button label="Click me" />)
+  expect(container).toMatchSnapshot()  // creates external .snap file
+})
+```
+
+**Why wrong**: External `.snap` files are updated with `--updateSnapshot` without review. Developers mindlessly accept them in CI, converting regression detectors into rubber stamps.
+
+**Fix**: Use inline snapshots or explicit behavioral assertions:
+```typescript
+// Inline snapshot — diff visible in the PR
+expect(button).toMatchInlineSnapshot(`<button class="btn">Click me</button>`)
+
+// Better — test the behavior
+expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument()
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| `ReferenceError: jest is not defined` | `jest.fn()` called instead of `vi.fn()` | Replace `jest.` with `vi.` throughout |
+| `Error: Cannot mock a module that has no exports` | `vi.mock()` path is wrong | Verify import path matches exactly |
+| `Your test suite must contain at least one test` | Only `describe` blocks, no `it`/`test` | Add at least one `it()` call |
+| `Coverage threshold not met: branches (X% < 80%)` | Conditional paths not tested | Add tests for `else`/`catch` branches |
+| `Cannot access 'X' before initialization` in mock | Hoisting issue with `vi.mock` factory accessing outer variable | Move variable inside the factory function |
+| `TypeError: Cannot redefine property: default` | Mocking ES module default export | Use `vi.spyOn` on the object or `vi.importActual` pattern |
+
+---
+
+## Version-Specific Notes
+
+| Version | Change | Impact |
+|---------|--------|--------|
+| Vitest 1.0 | Stable `vi` API replaces `jest` compat shim | All new code should use `vi.*` |
+| Vitest 1.1 | `pool: 'forks'` option added for process isolation | Use for tests requiring `process.env` mutation |
+| Vitest 1.3 | `vi.waitFor()` added | Replaces custom polling loops in unit tests |
+| Vitest 2.0 | Browser mode stable; `jsdom` no longer default environment | Set `environment: 'jsdom'` explicitly in config |
+| Vitest 2.0 | `coverage.provider` defaults to `'v8'`; `'c8'` removed | Remove deprecated `provider: 'c8'` references |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# jest.* calls that should be vi.*
+grep -rn 'jest\.' --include="*.test.ts" --include="*.test.tsx" --include="*.spec.ts"
+
+# Spy files missing restoreAllMocks
+grep -rn 'vi\.spyOn' --include="*.test.ts" -l | xargs grep -L 'restoreAllMocks'
+
+# Missing branch threshold in vitest config
+grep -A5 'thresholds' vitest.config.ts | grep -v branches
+
+# External snapshot files (prefer inline)
+find . -name "*.snap" | grep -v node_modules
+
+# Test files with no assertions
+rg 'it\(' --type ts -l | xargs rg -L 'expect\('
+```
+
+---
+
+## See Also
+
+- `async-testing.md` — waitFor, async component testing, MSW setup
+- `mocking-patterns.md` — what to mock, MSW vs vi.mock, test doubles taxonomy


### PR DESCRIPTION
## Reference Enrichment — testing-automation-engineer

**Run ID**: 2026-04-15-1123
**ADR**: ADR-173 (Reference Enrichment)

### Targets Processed

| Agent | Before | After | New Files |
|-------|--------|-------|-----------|
| testing-automation-engineer | Level 0 (no refs/) | Level 3 (Deep) | 3 |

### New Reference Files

**`references/vitest-patterns.md`** (303 lines, 88 concrete patterns)
- Vitest 1.x/2.x configuration with required `branches` coverage threshold
- `vi.fn`/`vi.spyOn`/`vi.mock` lifecycle and teardown patterns
- 4 anti-patterns with `grep`/`rg` detection commands: `jest.*` calls, spy leaks, missing branch threshold, external snapshots
- Version table: Vitest 1.0 → 2.0 breaking changes

**`references/async-testing.md`** (305 lines, 96 concrete patterns)
- RTL 14+ `waitFor`/`findBy*` patterns vs synchronous `getBy*`
- MSW 2.x server setup with `onUnhandledRequest: 'error'`
- Playwright auto-wait assertions vs `waitForTimeout`
- 4 anti-patterns: `setTimeout` delays, un-awaited `userEvent`, sync `getBy*` after async click, missing MSW guard

**`references/mocking-patterns.md`** (286 lines, 72 concrete patterns)
- Mock boundary decision table (what to mock and what not to)
- MSW vs `vi.stubGlobal('fetch')` — why MSW is preferred
- Repository pattern for database mocking
- 4 anti-patterns: over-mocking internals, mocking third-party libs, call-only assertions, blanket `console.error` suppression

### Agent Body Update

Added reference loading table mapping 4 signal groups (vitest/spy, async/waitFor/MSW, mock/boundary, anti-patterns) to the correct reference files.

### Validation

- `validate-references.py`: 3/3 references present, 0 issues
- Audit: Level 0 → Level 3 (256 total concrete patterns, 0 generic phrases, detection commands in all 3 files)
- Keep-or-Revert gate: KEEP — loading table signals correctly map to domain-specific content