### PR TITLE
feat(refs): toolkit-governance-engineer (Level 0→3)

### DIFF
--- a/agents/toolkit-governance-engineer.md
+++ b/agents/toolkit-governance-engineer.md
@@ -103,6 +103,22 @@ This agent operates as the toolkit's internal maintainer — the agent that gove
 
 When asked to perform unavailable actions, explain the limitation and suggest the appropriate agent.
 
+## Reference Loading
+
+Load the relevant reference file before starting any governance task:
+
+| Task Type | Load This Reference | Key Content |
+|-----------|--------------------|-|
+| Frontmatter audit, `allowed-tools` review, YAML parse errors | `agents/toolkit-governance-engineer/references/frontmatter-compliance.md` | Required fields, ADR-063 tool restrictions, detection commands |
+| Routing table add/update/delete, `pairs_with` validation, INDEX.json | `agents/toolkit-governance-engineer/references/routing-table-patterns.md` | Phantom route detection, trigger conflict checks, index validation |
+| Cross-component consistency sweep | Load both references | Full detection command set |
+
+**Signals that trigger reference loading**:
+- Any mention of `allowed-tools`, `frontmatter`, `YAML`, or field compliance → load `frontmatter-compliance.md`
+- Any mention of `routing`, `triggers`, `pairs_with`, `INDEX.json`, or phantom routes → load `routing-table-patterns.md`
+
+---
+
 ## Workflow
 
 ### Single-File Edit

--- a/agents/toolkit-governance-engineer/references/frontmatter-compliance.md
+++ b/agents/toolkit-governance-engineer/references/frontmatter-compliance.md
@@ -1,0 +1,249 @@
+# Frontmatter Compliance Reference
+
+> **Scope**: YAML frontmatter validation for agents and skills — required fields, tool restrictions, type rules, and detection commands. Does not cover skill phase/gate structure.
+> **Version range**: v2.0 template (current standard)
+> **Generated**: 2026-04-15
+
+---
+
+## Overview
+
+Agent and skill frontmatter is the contract between a component and the routing system. Broken frontmatter silently removes a component from discovery — the router never finds it, and the component disappears from all coverage reports. The most common failure modes are missing required fields, overly permissive `allowed-tools`, and YAML parse errors from unquoted special characters.
+
+---
+
+## Required Fields (v2.0 Template)
+
+| Field | Type | Required In | Example |
+|-------|------|-------------|---------|
+| `name` | string | agents, skills | `name: golang-general-engineer` |
+| `version` | string (semver) | agents, skills | `version: 1.0.0` |
+| `description` | string (quoted if special chars) | agents, skills | `description: "Go dev: features, debugging"` |
+| `routing.triggers` | list of strings | agents, skills | `triggers: [edit skill, update routing]` |
+| `routing.complexity` | enum | agents, skills | `complexity: Medium` |
+| `routing.category` | string | agents, skills | `category: meta` |
+| `allowed-tools` | list of strings | agents only | `allowed-tools: [Read, Glob, Grep]` |
+| `color` | string | agents | `color: blue` |
+| `model` | string | agents | `model: sonnet` |
+
+---
+
+## Tool Restrictions by Agent Type (ADR-063)
+
+| Agent Role | Permitted Tools | Rationale |
+|------------|-----------------|-----------|
+| Reviewer / auditor | `Read`, `Glob`, `Grep` | Read-only prevents unauthorized changes |
+| Code modifier / engineer | `Read`, `Edit`, `Write`, `Bash`, `Glob`, `Grep` | Full access for implementation work |
+| Orchestrator / coordinator | `Read`, `Agent`, `Bash` | Dispatches agents; no direct file edits |
+| Skill-invoker | `Read`, `Bash`, `Glob`, `Grep` | Executes skills but doesn't write files |
+
+**Rule**: `allowed-tools` must match the agent's actual role. Granting `Edit` to a reviewer or `Agent` to a non-orchestrator violates ADR-063.
+
+---
+
+## Correct Patterns
+
+### Quoting Descriptions with Special Characters
+
+Descriptions containing colons, commas, or markdown are YAML special characters and must be quoted.
+
+```yaml
+# Correct — colon inside quotes
+description: "Toolkit governance: edit skills, update routing tables"
+
+# Correct — simple description, no quotes needed
+description: Go development and debugging
+```
+
+**Why**: Unquoted colons in YAML values cause parse errors — the YAML parser interprets the colon as a key-value separator, silently truncating the description.
+
+---
+
+### Complexity Tier Values
+
+```yaml
+routing:
+  complexity: Low     # Single-file edits, read-only audits
+  complexity: Medium  # Multi-file edits, routing table updates
+  complexity: High    # Full compliance sweeps, ADR consultations
+```
+
+**Why**: Complexity matching is case-sensitive. Values outside `Low/Medium/High` are silently ignored — the router defaults to Medium.
+
+---
+
+### Tool List Format
+
+```yaml
+# Correct — block list
+allowed-tools:
+  - Read
+  - Edit
+  - Glob
+  - Grep
+
+# Also correct — inline list
+allowed-tools: [Read, Edit, Glob, Grep]
+```
+
+**Why**: Mixed formats cause parse errors in strict YAML parsers. Pick one and be consistent within a file.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Missing `allowed-tools` in Agent Frontmatter
+
+**Detection**:
+```bash
+grep -rL "allowed-tools" agents/*.md
+rg -L 'allowed-tools' --glob 'agents/*.md'
+```
+
+**What it looks like**:
+```yaml
+---
+name: my-agent
+model: sonnet
+version: 1.0.0
+description: "Does something"
+routing:
+  triggers: [do thing]
+  complexity: Medium
+  category: engineering
+# allowed-tools: missing entirely
+---
+```
+
+**Why wrong**: Without `allowed-tools`, the agent inherits an undefined tool set. Behavior varies by runtime — some runtimes grant all tools (dangerous), others grant none (agent cannot function).
+
+**Fix**: Add `allowed-tools` matching the agent's role type per the Tool Restrictions table above.
+
+---
+
+### ❌ Unquoted Description with Colon
+
+**Detection**:
+```bash
+grep -n "^description: [^\"'].*:" agents/*.md
+grep -n "^description: [^\"'].*:" skills/*/SKILL.md
+```
+
+**What it looks like**:
+```yaml
+description: Toolkit governance: edit skills, update routing  # YAML parse error
+```
+
+**Why wrong**: The YAML parser sees `Toolkit governance` as the value and `edit skills` as an unknown key, producing a parse error. The component becomes invisible to the routing system.
+
+**Fix**:
+```yaml
+description: "Toolkit governance: edit skills, update routing"
+```
+
+---
+
+### ❌ Wrong Complexity Casing
+
+**Detection**:
+```bash
+grep -rn "complexity:" agents/*.md skills/*/SKILL.md | grep -vE "complexity: (Low|Medium|High)"
+```
+
+**What it looks like**:
+```yaml
+routing:
+  complexity: moderate  # wrong casing
+  complexity: medium    # wrong casing — must be capitalized
+```
+
+**Why wrong**: Complexity matching is case-sensitive. `medium` does not match `Medium` — the router silently assigns a default.
+
+**Fix**: Use exactly `Low`, `Medium`, or `High`.
+
+---
+
+### ❌ Reviewer Agent with Write/Edit Tools (ADR-063 Violation)
+
+**Detection**:
+```bash
+grep -l "reviewer" agents/*.md | xargs grep -l "Edit\|Write"
+```
+
+**What it looks like**:
+```yaml
+name: reviewer-code-quality
+allowed-tools:
+  - Read
+  - Edit    # violation: reviewers should not modify files
+  - Grep
+```
+
+**Why wrong**: Reviewer agents with write access can modify files during review passes, creating unintended side-effects. ADR-063 requires reviewers to be read-only.
+
+**Fix**: Remove `Edit` and `Write` from reviewer `allowed-tools`. Reviewers use `Read`, `Glob`, `Grep` only.
+
+---
+
+### ❌ Pre-Production Version on Stable Agent
+
+**Detection**:
+```bash
+grep -rn "^version: 0\." agents/*.md
+```
+
+**What it looks like**:
+```yaml
+version: 0.1.0  # signals "not production-ready"
+```
+
+**Why wrong**: Agents in active production use should be at `1.x.x` or higher. `0.x.x` affects coverage reporting confidence scores.
+
+**Fix**: Bump to `version: 1.0.0` once the agent is in stable use.
+
+---
+
+## Error-Fix Mappings
+
+| Symptom | Root Cause | Fix |
+|---------|------------|-----|
+| Agent missing from routing coverage report | Broken YAML frontmatter (parse error) | `python3 -c "import yaml; yaml.safe_load(open('agents/name.md').read().split('---')[1])"` |
+| Agent in INDEX.json but not routed | Missing `routing.triggers` | Add `routing.triggers` list with at least one trigger string |
+| `allowed-tools` grants unexpected access | Field absent from frontmatter | Add `allowed-tools` explicitly; never rely on runtime defaults |
+| Description truncated in INDEX.json | Unquoted colon in description | Wrap description in double quotes |
+| Agent routes but hits wrong complexity tier | `complexity` casing mismatch | Verify exact: `Low`, `Medium`, `High` |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Find agents missing allowed-tools
+grep -rL "allowed-tools" agents/*.md
+
+# Find unquoted descriptions with colons
+grep -n "^description: [^\"'].*:" agents/*.md
+
+# Find wrong complexity casing
+grep -rn "complexity:" agents/*.md | grep -vE "complexity: (Low|Medium|High)"
+
+# Find reviewer agents with write tools (ADR-063)
+grep -l "reviewer" agents/*.md | xargs grep -l "Edit\|Write"
+
+# Find pre-production versions on deployed agents
+grep -rn "^version: 0\." agents/*.md
+
+# Validate frontmatter YAML for a single agent
+python3 -c "import yaml; yaml.safe_load(open('agents/AGENTNAME.md').read().split('---')[1])"
+
+# Scan all agents for required fields
+python3 scripts/validate-frontmatter.py --all 2>/dev/null || grep -c "^name:" agents/*.md
+```
+
+---
+
+## See Also
+
+- `routing-table-patterns.md` — routing entry structure, trigger conflicts, phantom route prevention
+- `agents/INDEX.json` — coverage index; regenerate after frontmatter changes
+- `docs/PHILOSOPHY.md` — progressive disclosure and specialist separation principles

--- a/agents/toolkit-governance-engineer/references/routing-table-patterns.md
+++ b/agents/toolkit-governance-engineer/references/routing-table-patterns.md
@@ -1,0 +1,310 @@
+# Routing Table Patterns Reference
+
+> **Scope**: Routing table entry structure, intent-based descriptions, trigger conflicts, phantom route prevention, and index validation. Does not cover frontmatter field compliance (see frontmatter-compliance.md).
+> **Version range**: all routing table versions
+> **Generated**: 2026-04-15
+
+---
+
+## Overview
+
+The routing system maps user intent to agents and skills via trigger phrases and metadata. Phantom routes (entries pointing to nonexistent components) and ambiguous triggers (two components claiming the same phrase) are the most common failure modes — both cause silent routing failures where the router selects a component that doesn't exist or picks the wrong one without warning.
+
+---
+
+## Routing Entry Structure
+
+A complete routing entry in an agent's frontmatter:
+
+```yaml
+routing:
+  triggers:
+    - edit skill          # primary trigger phrase
+    - update routing      # secondary trigger phrase
+    - ADR management      # domain-specific trigger
+  pairs_with:
+    - adr-consultation    # agents commonly invoked together
+    - routing-table-updater
+  complexity: Medium
+  category: meta
+```
+
+| Field | Required | Type | Purpose |
+|-------|----------|------|---------|
+| `triggers` | yes | list of strings | Intent phrases that route to this component |
+| `pairs_with` | no | list of agent names | Agents frequently co-dispatched with this one |
+| `complexity` | yes | `Low`/`Medium`/`High` | Selects execution strategy |
+| `category` | yes | string | Groups components in coverage reports |
+
+---
+
+## Intent-Based Description Format
+
+Routing table descriptions must answer three questions: **what**, **when to use**, **when NOT to use**.
+
+```yaml
+# Correct — answers what, when, and when-not
+description: >
+  Toolkit governance: edit skills, update routing tables, manage ADR lifecycle,
+  enforce cross-component standards. Use for toolkit maintenance and internal
+  consistency checks. NOT for application code review or new component creation.
+
+# Wrong — only states what, no routing signal
+description: Manages toolkit components
+```
+
+**Why**: The routing system uses the description for fuzzy intent matching. Explicit negative examples (`NOT for...`) prevent the router from selecting this agent for unrelated requests.
+
+---
+
+## Correct Patterns
+
+### Filesystem Verification Before Adding Entry
+
+Always verify the component file exists before adding or updating a routing entry.
+
+```bash
+# Verify agent exists
+ls agents/toolkit-governance-engineer.md
+ls agents/toolkit-governance-engineer/
+
+# Verify skill exists
+ls skills/routing-table-updater/SKILL.md
+
+# Verify all pairs_with entries exist
+for name in adr-consultation routing-table-updater docs-sync-checker; do
+  ls agents/${name}.md 2>/dev/null || ls skills/${name}/SKILL.md 2>/dev/null || echo "MISSING: ${name}"
+done
+```
+
+**Why**: Adding a routing entry for a nonexistent component creates a phantom route. The router selects it, the component lookup fails, and the request falls through to a generic handler — often silently.
+
+---
+
+### Trigger Phrase Specificity
+
+```yaml
+# Correct — specific phrases that uniquely identify this agent's domain
+triggers:
+  - edit skill
+  - update routing tables
+  - ADR status transition
+  - frontmatter compliance audit
+
+# Wrong — generic phrases that match too many agents
+triggers:
+  - update
+  - fix
+  - check
+  - manage
+```
+
+**Why**: Generic triggers cause ambiguous routing — the router must break ties arbitrarily, often selecting the wrong agent. Triggers should be specific enough that they wouldn't match any other agent.
+
+---
+
+### Category Values and Routing Coverage
+
+```yaml
+# Valid categories used in the toolkit
+category: meta          # toolkit-internal maintenance agents
+category: engineering   # code generation and modification agents
+category: review        # analysis and review agents
+category: operations    # infrastructure, deployment, monitoring agents
+category: content       # writing, documentation, content agents
+```
+
+**Why**: Category drives coverage grouping in `agents/INDEX.json`. Components with unknown categories appear in an "uncategorized" bucket and are harder to discover.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Phantom Route — Entry References Nonexistent Component
+
+**Detection**:
+```bash
+# Check all pairs_with entries exist
+python3 -c "
+import yaml, glob, os
+for f in glob.glob('agents/*.md'):
+    txt = open(f).read()
+    if '---' not in txt: continue
+    try:
+        fm = yaml.safe_load(txt.split('---')[1])
+        pairs = fm.get('routing', {}).get('pairs_with', [])
+        for p in pairs:
+            if not os.path.exists(f'agents/{p}.md') and not os.path.exists(f'skills/{p}/SKILL.md'):
+                print(f'PHANTOM: {f} -> pairs_with: {p}')
+    except: pass
+"
+
+# Quick grep for a specific missing component
+grep -rn "pairs_with" agents/*.md | grep "deleted-agent-name"
+```
+
+**What it looks like**:
+```yaml
+routing:
+  pairs_with:
+    - old-reviewer-agent    # renamed or deleted 3 months ago
+    - legacy-skill-name     # skill was removed in a cleanup
+```
+
+**Why wrong**: The router follows `pairs_with` hints when orchestrating multi-agent workflows. A phantom entry either causes a lookup failure or triggers a fallback to a generic agent, breaking the intended workflow.
+
+**Fix**: Run the detection script above. For each phantom entry, either update to the current component name or remove the entry.
+
+---
+
+### ❌ Trigger Phrase Conflicts Between Two Agents
+
+**Detection**:
+```bash
+# Find duplicate trigger phrases across all agents
+python3 -c "
+import yaml, glob
+from collections import defaultdict
+triggers = defaultdict(list)
+for f in glob.glob('agents/*.md'):
+    txt = open(f).read()
+    if '---' not in txt: continue
+    try:
+        fm = yaml.safe_load(txt.split('---')[1])
+        for t in fm.get('routing', {}).get('triggers', []):
+            triggers[t.lower()].append(f)
+    except: pass
+for t, files in triggers.items():
+    if len(files) > 1:
+        print(f'CONFLICT: \"{t}\" claimed by: {files}')
+"
+```
+
+**What it looks like**:
+```
+CONFLICT: "update routing" claimed by: agents/toolkit-governance-engineer.md, agents/routing-table-updater.md
+```
+
+**Why wrong**: The router cannot deterministically select between two agents claiming the same trigger. Resolution depends on ordering or scoring, which is non-obvious and changes silently when the index regenerates.
+
+**Fix**: Differentiate the triggers. One agent keeps the general phrase; the other uses a more specific variant. Or consolidate the two agents if their domains truly overlap.
+
+---
+
+### ❌ Stale INDEX.json After Component Changes
+
+**Detection**:
+```bash
+# Count registered agents vs filesystem agents
+registered=$(python3 -c "import json; d=json.load(open('agents/INDEX.json')); print(len(d.get('agents', [])))" 2>/dev/null)
+on_disk=$(ls agents/*.md | grep -v README | wc -l)
+echo "Registered: $registered, On disk: $on_disk"
+
+# List agents on disk but not in index
+python3 -c "
+import json, glob, os
+idx = json.load(open('agents/INDEX.json'))
+registered = {a['name'] for a in idx.get('agents', [])}
+for f in glob.glob('agents/*.md'):
+    name = os.path.basename(f).replace('.md','')
+    if name not in registered and name != 'README':
+        print(f'UNREGISTERED: {name}')
+"
+```
+
+**Why wrong**: An unregistered component exists on disk but is invisible to the routing system. It can never be selected, even if its triggers perfectly match a user's intent.
+
+**Fix**: Regenerate `INDEX.json` after any agent/skill add, rename, or delete. The regeneration script rebuilds from filesystem state.
+
+---
+
+### ❌ `pairs_with` Circular Reference
+
+**Detection**:
+```bash
+# Find pairs_with that reference the agent itself
+python3 -c "
+import yaml, glob, os
+for f in glob.glob('agents/*.md'):
+    name = os.path.basename(f).replace('.md','')
+    txt = open(f).read()
+    if '---' not in txt: continue
+    try:
+        fm = yaml.safe_load(txt.split('---')[1])
+        pairs = fm.get('routing', {}).get('pairs_with', [])
+        if name in pairs:
+            print(f'CIRCULAR: {name} pairs_with itself')
+    except: pass
+"
+```
+
+**Why wrong**: An agent that lists itself in `pairs_with` causes a routing loop when the orchestrator resolves co-dispatch recommendations.
+
+**Fix**: Remove the self-reference from `pairs_with`.
+
+---
+
+## Error-Fix Mappings
+
+| Symptom | Root Cause | Fix |
+|---------|------------|-----|
+| Router selects generic handler for specific request | Phantom route in `pairs_with` | Run phantom detection script; remove or update stale entries |
+| Two agents both invoked for same trigger phrase | Duplicate triggers | Run conflict detection script; differentiate trigger phrases |
+| Agent on disk but never routed | Not in INDEX.json | Regenerate INDEX.json from filesystem |
+| `pairs_with` agent lookup fails at runtime | Component renamed or deleted | Glob for current name; update pairs_with or remove entry |
+| INDEX.json count mismatch after cleanup | Stale entries after agent deletion | Regenerate INDEX.json; verify `registered == on_disk` |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Find phantom pairs_with references
+python3 -c "
+import yaml, glob, os
+for f in glob.glob('agents/*.md'):
+    txt = open(f).read()
+    if '---' not in txt: continue
+    try:
+        fm = yaml.safe_load(txt.split('---')[1])
+        for p in fm.get('routing', {}).get('pairs_with', []):
+            if not os.path.exists(f'agents/{p}.md') and not os.path.exists(f'skills/{p}/SKILL.md'):
+                print(f'PHANTOM: {f} -> {p}')
+    except: pass
+"
+
+# Find duplicate trigger phrases
+python3 -c "
+import yaml, glob
+from collections import defaultdict
+triggers = defaultdict(list)
+for f in glob.glob('agents/*.md'):
+    txt = open(f).read()
+    if '---' not in txt: continue
+    try:
+        fm = yaml.safe_load(txt.split('---')[1])
+        for t in fm.get('routing', {}).get('triggers', []):
+            triggers[t.lower()].append(f)
+    except: pass
+for t, files in triggers.items():
+    if len(files) > 1: print(f'CONFLICT: \"{t}\" in {files}')
+"
+
+# Find unregistered agents
+python3 -c "
+import json, glob, os
+idx = json.load(open('agents/INDEX.json'))
+registered = {a['name'] for a in idx.get('agents', [])}
+for f in glob.glob('agents/*.md'):
+    name = os.path.basename(f).replace('.md','')
+    if name not in registered and name != 'README': print(f'UNREGISTERED: {name}')
+"
+```
+
+---
+
+## See Also
+
+- `frontmatter-compliance.md` — required fields, tool restrictions, YAML parse error fixes
+- `agents/INDEX.json` — coverage index; source of truth for registered components
+- `docs/PHILOSOPHY.md` — specialist selection and deterministic execution principles


### PR DESCRIPTION
## Reference Enrichment

**Run ID**: 2026-04-15-1307
**Target**: toolkit-governance-engineer

### Results

| Agent | Level Before | Level After | New Reference Files |
|-------|-------------|-------------|---------------------|
| toolkit-governance-engineer | 0 (None) | 3 (Deep) | 2 |

### New Reference Files

**`frontmatter-compliance.md`** (249 lines, 77 concrete patterns)
- Required fields table (v2.0 template): name, version, description, routing, allowed-tools
- Tool restriction rules by agent type (ADR-063): reviewers read-only, engineers full access, orchestrators dispatch-only
- Anti-pattern catalog with detection commands: missing allowed-tools, unquoted description colons, wrong complexity casing, reviewer agents with write tools, pre-production version strings
- Error-fix mappings for 5 common frontmatter failure symptoms

**`routing-table-patterns.md`** (310 lines, 49 concrete patterns)
- Routing entry structure and required fields
- Intent-based description format (what + when + when-NOT)
- Phantom route detection via Python script scanning all pairs_with entries
- Trigger conflict detection across all agents
- Stale INDEX.json detection (registered vs on-disk count)
- Circular pairs_with self-reference detection

### Loading Table Added

Agent body updated with signal-based loading table:
- `frontmatter`, `allowed-tools`, `YAML` → load `frontmatter-compliance.md`
- `routing`, `pairs_with`, `INDEX.json`, `phantom` → load `routing-table-patterns.md`

### Validation Gate (Phase 2.5)

- [x] Loading table file paths verified to exist on disk
- [x] Signal keywords cover all 3 test query domains
- [x] Both reference files contain detection commands (Level 3 requirement)
- [x] No generic advice — all patterns are toolkit-specific with concrete grep commands
- Decision: **KEEP** — concrete, signal-matched, domain-specific knowledge