### PR TITLE
feat(refs): ui-design-engineer (Level 2→3)

### DIFF
--- a/agents/ui-design-engineer.md
+++ b/agents/ui-design-engineer.md
@@ -388,11 +388,16 @@ STOP and ask the user (always get explicit approval) before proceeding when:
 
 ## References
 
-For detailed information:
-- **Accessibility Patterns**: [references/accessibility-patterns.md](references/accessibility-patterns.md) - WCAG 2.1 AA compliance guide
-- **Design Tokens**: [references/design-tokens.md](references/design-tokens.md) - Tailwind theme configuration
-- **Component Library (Interactive)**: [references/component-library-interactive.md](references/component-library-interactive.md) - Buttons, inputs, modals, dropdowns, tabs, accordions, toasts, form controls
-- **Component Library (Display)**: [references/component-library-display.md](references/component-library-display.md) - Cards, tables, badges, avatars, progress indicators, alerts
+Load on demand — fetch only the file(s) relevant to the current task:
+
+| Task Type | Signal Keywords | Reference File |
+|-----------|----------------|----------------|
+| WCAG compliance, ARIA, keyboard nav, screen readers, focus management | accessibility, contrast, ARIA, keyboard, screen reader | [references/accessibility-patterns.md](references/accessibility-patterns.md) |
+| Design system, Tailwind theme, CSS variables, color scales, typography, dark mode | design tokens, theme, CSS variables, color palette, font scale | [references/design-tokens.md](references/design-tokens.md) |
+| Buttons, inputs, modals, dropdowns, tabs, accordions, toasts, form controls | button, input, modal, dropdown, tab, accordion, toast | [references/component-library-interactive.md](references/component-library-interactive.md) |
+| Cards, tables, badges, avatars, progress indicators, alerts | card, table, badge, avatar, progress, alert | [references/component-library-display.md](references/component-library-display.md) |
+| Tailwind configuration, class composition, purge issues, `@apply`, responsive prefixes, arbitrary values | Tailwind config, @apply, responsive, purge, JIT, arbitrary | [references/tailwind-anti-patterns.md](references/tailwind-anti-patterns.md) |
+| Framer Motion, CSS transitions, prefers-reduced-motion, exit animations, AnimatePresence, micro-interactions | animation, Framer Motion, transition, reduced motion, exit, AnimatePresence | [references/animation-patterns.md](references/animation-patterns.md) |
 
 **Shared Patterns**:
 - [anti-rationalization-core.md](../skills/shared-patterns/anti-rationalization-core.md) - Universal rationalization patterns

--- a/agents/ui-design-engineer/references/animation-patterns.md
+++ b/agents/ui-design-engineer/references/animation-patterns.md
@@ -1,0 +1,349 @@
+# Animation Patterns Reference
+<!-- Loaded by ui-design-engineer when task involves Framer Motion, CSS transitions, micro-interactions, loading states, or prefers-reduced-motion -->
+
+> **Scope**: Framer Motion and CSS animation patterns for accessible, intentional UI motion. Covers reduced-motion, exit animations, and the 2-to-3 motion discipline rule.
+> **Version range**: Framer Motion 10+ (React 18+)
+> **Generated**: 2026-04-15
+
+The most common animation failures are: ignoring `prefers-reduced-motion` (triggers vestibular disorders), shipping more than 3 animations per page (destroys hierarchy), and missing `AnimatePresence` for exit animations (element vanishes without transition).
+
+---
+
+## Pattern Table
+
+| Pattern | Version | Use When | Avoid When |
+|---------|---------|----------|------------|
+| `useReducedMotion()` hook | Framer Motion 4+ | Detecting user preference inside a component | Checking media query directly with `window.matchMedia` |
+| `AnimatePresence` wrapper | Framer Motion 1+ | Any element that conditionally mounts/unmounts | Element is always visible; adds unnecessary overhead |
+| `layout` prop on `motion.div` | Framer Motion 2+ | Animating list reorders, dynamic height changes | Static layouts; triggers expensive layout recalculations |
+| CSS `transition` | all | Simple hover/focus state changes (color, opacity, border) | Complex keyframe sequences or coordinated multi-element animations |
+
+---
+
+## Correct Patterns
+
+### Respecting `prefers-reduced-motion` with Framer Motion
+
+Use the `useReducedMotion()` hook to build a variants object that conditionally disables motion. Never skip this — WCAG 2.3.3 Success Criterion (AAA) and best practice for AA.
+
+```tsx
+import { motion, useReducedMotion } from 'framer-motion'
+
+function FadeInCard({ children }: { children: React.ReactNode }) {
+  const shouldReduceMotion = useReducedMotion()
+
+  const variants = {
+    hidden: { opacity: 0, y: shouldReduceMotion ? 0 : 20 },
+    visible: { opacity: 1, y: 0 },
+  }
+
+  return (
+    <motion.div
+      variants={variants}
+      initial="hidden"
+      animate="visible"
+      transition={{ duration: shouldReduceMotion ? 0 : 0.3 }}
+    >
+      {children}
+    </motion.div>
+  )
+}
+```
+
+**Why**: `useReducedMotion()` subscribes to `prefers-reduced-motion: reduce` media query reactively. Setting `duration: 0` and `y: 0` means the element appears instantly without jarring users with vestibular disorders.
+
+---
+
+### Exit Animations with `AnimatePresence`
+
+`AnimatePresence` is required for exit animations to run. Without it, the component unmounts before Framer Motion can animate the exit.
+
+```tsx
+import { AnimatePresence, motion } from 'framer-motion'
+
+function Toast({ message, visible }: { message: string; visible: boolean }) {
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          key="toast"
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}  // requires AnimatePresence parent
+          transition={{ duration: 0.2 }}
+          role="status"
+          aria-live="polite"
+        >
+          {message}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}
+```
+
+**Why**: When `visible` flips to `false`, React would normally unmount immediately. `AnimatePresence` delays the unmount until the `exit` animation completes.
+
+---
+
+### The 2-to-3 Motion Rule (Three Slots Per Page)
+
+Ship exactly two or three intentional motions per page. Each motion fills one slot:
+
+```tsx
+// Slot 1: ENTRANCE — one hero entrance on load
+const heroVariants = {
+  hidden: { opacity: 0, y: 30 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.5 } },
+}
+
+// Slot 2: SCROLL — one scroll-linked effect (use Framer Motion's useScroll)
+import { useScroll, useTransform } from 'framer-motion'
+function ParallaxSection() {
+  const { scrollY } = useScroll()
+  const y = useTransform(scrollY, [0, 500], [0, -80])
+  return <motion.div style={{ y }}>...</motion.div>
+}
+
+// Slot 3: INTERACTION — one hover/focus/layout transition
+<motion.button whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+  Submit
+</motion.button>
+```
+
+**Why**: More than three motions compete for attention. Each additional animation dilutes the signal value of all others. The page feels "jumpy" rather than intentional.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Missing `prefers-reduced-motion` Support
+
+**Detection**:
+```bash
+# Find motion components without reduced-motion handling
+grep -rn "motion\." --include="*.tsx" | grep -v "useReducedMotion\|prefers-reduced"
+# Find CSS transitions without reduced-motion media query
+grep -rn "transition:" --include="*.css" --include="*.tsx" | grep -v "prefers-reduced"
+# Check for CSS @media prefers-reduced-motion
+grep -rn "prefers-reduced-motion" --include="*.css"
+```
+
+**What it looks like**:
+```tsx
+// WRONG: No check for user preference
+<motion.div
+  initial={{ opacity: 0, y: 40 }}
+  animate={{ opacity: 1, y: 0 }}
+  transition={{ duration: 0.6 }}
+>
+```
+```css
+/* WRONG: No reduced-motion override */
+.card {
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+.card:hover {
+  transform: translateY(-4px);
+}
+```
+
+**Why wrong**: Users with vestibular disorders (motion sickness, Meniere's disease) can experience nausea or disorientation from unnecessary motion. `prefers-reduced-motion: reduce` is a system-level accessibility setting.
+
+**Fix**:
+```tsx
+// Framer Motion: use hook
+const shouldReduceMotion = useReducedMotion()
+<motion.div
+  initial={{ opacity: 0, y: shouldReduceMotion ? 0 : 40 }}
+  animate={{ opacity: 1, y: 0 }}
+  transition={{ duration: shouldReduceMotion ? 0 : 0.6 }}
+>
+```
+```css
+/* CSS: add @media override */
+.card {
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+.card:hover {
+  transform: translateY(-4px);
+}
+@media (prefers-reduced-motion: reduce) {
+  .card { transition: none; }
+  .card:hover { transform: none; }
+}
+```
+
+---
+
+### ❌ Exit Animation Not Running (Missing `AnimatePresence`)
+
+**Detection**:
+```bash
+# Find conditional motion elements without AnimatePresence wrapping
+grep -rn "exit={{" --include="*.tsx"
+# If exit prop exists but no AnimatePresence in the same file, that's the bug
+grep -rn "exit={{" --include="*.tsx" | xargs grep -L "AnimatePresence"
+```
+
+**What it looks like**:
+```tsx
+// WRONG: exit prop present but AnimatePresence is absent — exit never runs
+{isOpen && (
+  <motion.div
+    initial={{ opacity: 0 }}
+    animate={{ opacity: 1 }}
+    exit={{ opacity: 0 }}  // silently ignored
+  >
+    Modal content
+  </motion.div>
+)}
+```
+
+**Why wrong**: React unmounts the component synchronously when `isOpen` becomes `false`. By the time Framer Motion would start the exit animation, the element is already gone from the DOM.
+
+**Fix**:
+```tsx
+import { AnimatePresence, motion } from 'framer-motion'
+
+<AnimatePresence>
+  {isOpen && (
+    <motion.div
+      key="modal"  // key is required for AnimatePresence to track the element
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      Modal content
+    </motion.div>
+  )}
+</AnimatePresence>
+```
+
+**Version note**: `AnimatePresence` requires a `key` prop on direct children to track mount/unmount identity correctly. Without `key`, re-renders may not trigger exit animations.
+
+---
+
+### ❌ Animating Everything (Motion Overload)
+
+**Detection**:
+```bash
+# Count motion. components per file — flag files with more than 6
+grep -c "motion\." --include="*.tsx" $(find . -name "*.tsx") 2>/dev/null | awk -F: '$2 > 6 {print $1": "$2" motion components"}'
+# Or with rg
+rg "motion\." --type tsx -c | awk -F: '$2 > 6'
+```
+
+**What it looks like**:
+```tsx
+// WRONG: Every element has entrance animation — hierarchy collapses into noise
+<motion.nav initial={{ y: -20 }} animate={{ y: 0 }}>
+  <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+    <motion.ul initial={{ x: -10 }} animate={{ x: 0 }}>
+      {items.map(item => (
+        <motion.li key={item.id} whileHover={{ scale: 1.05 }}>
+          <motion.span initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+            {item.label}
+          </motion.span>
+        </motion.li>
+      ))}
+    </motion.ul>
+  </motion.div>
+</motion.nav>
+```
+
+**Why wrong**: When everything animates, nothing communicates. The brain uses motion as a signal for hierarchy and importance. Saturating the page with motion degrades every motion's signal value to zero.
+
+**Fix**: Apply the 2-to-3 rule. Audit existing motion and remove any that aren't filling one of the three slots (entrance, scroll, interaction). Use `variants` with `staggerChildren` to coordinate list animations as a single entrance slot:
+
+```tsx
+// CORRECT: One entrance slot using stagger — nav entrance counts as one motion
+const containerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.05 } },
+}
+const itemVariants = {
+  hidden: { opacity: 0, y: 8 },
+  visible: { opacity: 1, y: 0 },
+}
+
+<motion.ul variants={containerVariants} initial="hidden" animate="visible">
+  {items.map(item => (
+    <motion.li key={item.id} variants={itemVariants}>
+      {item.label}
+    </motion.li>
+  ))}
+</motion.ul>
+```
+
+---
+
+### ❌ Using `whileHover` on Non-Interactive Elements
+
+**Detection**:
+```bash
+# Find whileHover on non-interactive elements (div, span, p)
+grep -rn "whileHover" --include="*.tsx" | grep "motion\.div\|motion\.span\|motion\.p"
+```
+
+**What it looks like**:
+```tsx
+// WRONG: hover animation on non-interactive element confuses keyboard users
+<motion.div whileHover={{ scale: 1.02 }} className="card">
+  {content}
+</motion.div>
+```
+
+**Why wrong**: `whileHover` triggers on CSS `:hover`, not on keyboard focus. A card with hover animation but no `tabIndex` and no focus animation is inaccessible — keyboard users get no feedback and may not know the element is interactive.
+
+**Fix**:
+```tsx
+// CORRECT: Use interactive element with both hover and focus states
+<motion.button
+  whileHover={{ scale: 1.02 }}
+  whileFocus={{ scale: 1.02 }}   // match hover behavior for keyboard users
+  className="card focus:outline-none focus:ring-2 focus:ring-blue-500"
+>
+  {content}
+</motion.button>
+```
+
+---
+
+## Error-Fix Mappings
+
+| Symptom | Root Cause | Fix |
+|---------|------------|-----|
+| Exit animation doesn't run — element disappears instantly | `AnimatePresence` missing as ancestor | Wrap conditional `motion.*` element with `<AnimatePresence>` and add `key` prop |
+| Animation runs in dev but skipped for some users | `prefers-reduced-motion: reduce` active | Add `useReducedMotion()` hook and set `duration: 0` / zero offsets when true |
+| `staggerChildren` has no effect | Variants not propagated — child elements lack `variants` prop | Add matching `variants` prop to all child `motion.*` elements |
+| Layout animation causes "jump" | `layout` prop on element with `position: absolute` children | Wrap absolute children in `motion.div` with `layout` or use `layoutId` instead |
+| Animation works once, breaks on re-render | `key` not stable — component remounts every render | Ensure `key` on `AnimatePresence` children is stable (id, not array index) |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Missing prefers-reduced-motion in motion components
+grep -rn "motion\." --include="*.tsx" | grep -v "useReducedMotion"
+
+# Exit animations without AnimatePresence
+grep -rn "exit={{" --include="*.tsx" | xargs grep -L "AnimatePresence" 2>/dev/null
+
+# Motion overload (>6 motion components per file)
+rg "motion\." --type tsx -c | awk -F: '$2 > 6'
+
+# whileHover on non-interactive elements
+grep -rn "whileHover" --include="*.tsx" | grep "motion\.div\|motion\.span\|motion\.p"
+
+# CSS animations missing reduced-motion override
+grep -rn "transition:" --include="*.css" | xargs grep -L "prefers-reduced-motion" 2>/dev/null
+```
+
+---
+
+## See Also
+
+- `accessibility-patterns.md` — WCAG compliance patterns including focus management
+- `component-library-interactive.md` — Button/modal interaction patterns with accessible focus handling

--- a/agents/ui-design-engineer/references/tailwind-anti-patterns.md
+++ b/agents/ui-design-engineer/references/tailwind-anti-patterns.md
@@ -1,0 +1,218 @@
+# Tailwind CSS Anti-Patterns Reference
+<!-- Loaded by ui-design-engineer when task involves Tailwind configuration, class composition, theme customization, or build-time CSS issues -->
+
+> **Scope**: Tailwind-specific pitfalls that cause style breakage, build bloat, or maintenance debt. Does not cover general CSS anti-patterns.
+> **Version range**: Tailwind CSS v3.0+
+> **Generated**: 2026-04-15 — verify against current Tailwind v3/v4 release notes
+
+Tailwind's utility-first model creates a specific class of bugs that don't appear in traditional CSS: dynamic class construction that gets purged, specificity fights from `@apply`, and responsive prefix ordering that silently does nothing.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Dynamic Class Construction (Purge Trap)
+
+**Detection**:
+```bash
+# Find string-concatenated Tailwind classes
+grep -rn "text-\${" --include="*.tsx" --include="*.ts" --include="*.jsx"
+grep -rn "\`bg-\${" --include="*.tsx" --include="*.jsx"
+rg 'className=\{.*\$\{.*\}' --type tsx
+```
+
+**What it looks like**:
+```tsx
+// WRONG: Tailwind cannot statically detect these classes at build time
+const color = 'red'
+<div className={`text-${color}-500`}>Error</div>
+
+// Also wrong: computed key lookups
+const variantClasses = { primary: 'blue', danger: 'red' }
+<button className={`bg-${variantClasses[variant]}-600`}>Click</button>
+```
+
+**Why wrong**: Tailwind's content scanner extracts class names at build time by looking for complete strings. Partial strings like `` `text-${'red'}-500` `` are never seen as `text-red-500` — the final class does not exist in the generated CSS and renders as unstyled.
+
+**Fix**:
+```tsx
+// CORRECT: Map to complete class strings
+const variantClasses = {
+  primary: 'bg-blue-600 hover:bg-blue-700 text-white',
+  danger:  'bg-red-700  hover:bg-red-800  text-white',
+}
+<button className={variantClasses[variant]}>Click</button>
+
+// Or use cn() with full class names
+<div className={cn(
+  isError && 'text-red-500',
+  isSuccess && 'text-green-600',
+)}>
+```
+
+**Version note**: Tailwind v3 uses `content` config to scan files for class names. v4 uses a Vite plugin with automatic detection, but dynamic construction still fails in both versions.
+
+---
+
+### ❌ Overusing `@apply` for Component Styles
+
+**Detection**:
+```bash
+grep -rn "@apply" --include="*.css" --include="*.scss"
+# Count @apply lines per file — flag files with >8 occurrences
+grep -c "@apply" src/**/*.css 2>/dev/null | awk -F: '$2 > 8 {print $1": "$2" @apply lines"}'
+```
+
+**What it looks like**:
+```css
+/* WRONG: Recreating component abstractions in CSS using @apply */
+.card {
+  @apply bg-white rounded-lg shadow-md p-6 border border-gray-200
+         hover:shadow-lg transition-shadow duration-200
+         dark:bg-gray-800 dark:border-gray-700;
+}
+```
+
+**Why wrong**: `@apply` re-couples design to CSS files, defeats the utility model, and loses the ability to conditionally compose classes in JSX. Each `@apply` expands to the full property set rather than sharing utility classes, increasing final CSS bundle size.
+
+**Fix**:
+```tsx
+// CORRECT: Extract to React component with class strings
+function Card({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div className={cn(
+      'bg-white rounded-lg shadow-md p-6 border border-gray-200',
+      'hover:shadow-lg transition-shadow duration-200',
+      'dark:bg-gray-800 dark:border-gray-700',
+      className,
+    )}>
+      {children}
+    </div>
+  )
+}
+```
+
+**Acceptable `@apply` uses**: Base element resets in global CSS, third-party component overrides where JSX access is unavailable.
+
+---
+
+### ❌ Wrong Responsive Prefix Order (Mobile-Last)
+
+**Detection**:
+```bash
+# Find lines where xl: or lg: appears but sm: or md: does not — likely desktop-first
+grep -rn "xl:text-\|xl:w-\|xl:flex" --include="*.tsx" | grep -v "sm:\|md:"
+# Lines with larger breakpoint before smaller on the same property
+rg 'lg:\S+\s+sm:\S+' --type tsx
+```
+
+**What it looks like**:
+```tsx
+// WRONG: Starting with desktop size, patching down to mobile
+<h1 className="text-4xl sm:text-2xl md:text-xl">
+  {/* mobile gets text-4xl (the bare class), sm gets text-2xl — opposite of intent */}
+</h1>
+
+// Also wrong: bare class after responsive prefix (bare always applies at all widths)
+<div className="sm:flex block">
+  {/* block applies at ALL widths, sm:flex applies at sm+ — but block wins at sm+ too
+      because both have equal specificity and source order determines winner */}
+</div>
+```
+
+**Why wrong**: Tailwind breakpoints are `min-width` media queries. `sm:` means "at sm and above". A bare class has no breakpoint and applies at every width. When you write `text-4xl sm:text-2xl`, mobile gets `text-4xl` (the bare class) and sm+ gets `text-2xl` — the opposite of mobile-first intent.
+
+**Fix**:
+```tsx
+// CORRECT: Bare class = mobile default, breakpoints scale up
+<h1 className="text-xl sm:text-2xl lg:text-4xl">
+  {/* mobile: xl, sm+: 2xl, lg+: 4xl */}
+</h1>
+
+// Responsive show/hide
+<div className="hidden sm:block">Only visible sm+</div>
+<div className="block sm:hidden">Only visible below sm</div>
+```
+
+---
+
+### ❌ Hardcoded Arbitrary Values Instead of Theme Extension
+
+**Detection**:
+```bash
+# Find arbitrary hex colors — should be in Tailwind theme
+grep -rn "\[#[0-9a-fA-F]\{3,6\}\]" --include="*.tsx" --include="*.jsx"
+# Find arbitrary px values (except standard touch target sizes)
+grep -rn "\[[0-9]\+px\]" --include="*.tsx" | grep -v "44px\|48px"
+```
+
+**What it looks like**:
+```tsx
+// WRONG: Brand color repeated as arbitrary value across multiple files
+<header className="bg-[#1a237e]">
+<button className="bg-[#1a237e] hover:bg-[#283593]">
+<div className="border-[#1a237e]">
+```
+
+**Why wrong**: Arbitrary values scatter magic numbers across files. A brand color change requires finding every `[#1a237e]` instance. Tailwind's JIT cannot deduplicate arbitrary values with different syntax for the same color.
+
+**Fix**:
+```javascript
+// tailwind.config.js — extend with named tokens
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: '#1a237e',
+          hover:   '#283593',
+        },
+      },
+    },
+  },
+}
+```
+```tsx
+// CORRECT: Named token, single source of truth
+<header className="bg-brand">
+<button className="bg-brand hover:bg-brand-hover">
+```
+
+**Acceptable arbitrary values**: One-off layout values for unusual compositions, third-party integration styles that appear exactly once.
+
+---
+
+## Error-Fix Mappings
+
+| Symptom | Root Cause | Fix |
+|---------|------------|-----|
+| Class present in dev, missing in production build | Dynamic class construction purged at build time | Use complete class strings, never interpolate Tailwind class segments |
+| Responsive breakpoint class has no effect | Mobile-last ordering — bare class overrides the breakpoint prefix at all widths | Reorder: bare class = mobile default, breakpoints scale up |
+| `@apply` rule not found | Class not in Tailwind's generated output (purged or non-existent) | Ensure class is in `safelist` or in a content-scanned file as a complete string |
+| Dark mode background stays light | Missing `dark:` variant on colored element | Add `dark:bg-*` and `dark:text-*` counterparts |
+| CSS bundle unexpectedly large | `@apply` expanding full property sets per selector | Replace `@apply`-heavy CSS with React component abstractions |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Dynamic class construction (purge trap)
+grep -rn "\`[a-z]*-\${" --include="*.tsx" --include="*.jsx"
+
+# @apply overuse
+grep -rn "@apply" --include="*.css"
+
+# Responsive ordering issues
+rg 'lg:\S+\s+sm:\S+' --type tsx
+
+# Arbitrary color values that should be theme tokens
+grep -rn "\[#[0-9a-fA-F]\{3,6\}\]" --include="*.tsx"
+```
+
+---
+
+## See Also
+
+- `design-tokens.md` — Tailwind theme configuration and CSS custom properties
+- `component-library-interactive.md` — Button/input class composition patterns


### PR DESCRIPTION
## Reference Enrichment: ui-design-engineer

**Targets processed:** 1/1
**Level before:** 2 (Domain)
**Level after:** 3 (Deep)

## New Reference Files

### `agents/ui-design-engineer/references/tailwind-anti-patterns.md` (218 lines)
Tailwind CSS pitfalls with grep/rg detection commands:
- Dynamic class construction (purge trap) — interpolated class segments silently stripped from production CSS
- `@apply` overuse — re-couples design to CSS files, bloats bundle size
- Mobile-last responsive ordering — `xl:text-foo sm:text-bar` pattern where bare class overrides breakpoint prefix
- Hardcoded arbitrary values — magic hex colors that should be theme tokens

### `agents/ui-design-engineer/references/animation-patterns.md` (349 lines)
Framer Motion and CSS animation patterns with detection commands:
- `useReducedMotion()` hook patterns for WCAG 2.3.3 compliance
- `AnimatePresence` required for exit animations — detection command finds `exit={{` without `AnimatePresence` in same file
- 2-to-3 motion discipline rule with `staggerChildren` pattern for entrance slots
- `whileHover` accessibility trap on non-interactive elements

## Agent Loading Table
Updated `agents/ui-design-engineer.md` References section from a flat list to a signal-keyed loading table mapping task types and signal keywords to specific reference files.

## Validation
- Phase 2.5 gate passed: all 3 test queries correctly route to new references
- `audit-reference-depth.py` confirms Level 3 (cmds=Y on both new files)
- No Python files created — lint check skipped