### PR TITLE
fix(commands): repair create-pipeline frontmatter

### DIFF
--- a/commands/create-pipeline.md
+++ b/commands/create-pipeline.md
@@ -14,15 +14,16 @@ trigger:
   hook: pipeline-context-detector
   event: UserPromptSubmit
 parameters:
-  required:
-    - name: task
-      description: What the pipeline should accomplish (e.g., "blog post publishing workflow")
-  optional:
-    - name: context
-      description: Additional constraints, domain knowledge, or reference pipelines
-    - name: components
-      description: Override which components to scaffold (default: agent,skill,hook)
-      default: "agent,skill,hook"
+  - name: task
+    required: true
+    description: "What the pipeline should accomplish (e.g., blog post publishing workflow)"
+  - name: context
+    required: false
+    description: "Additional constraints, domain knowledge, or reference pipelines"
+  - name: components
+    required: false
+    description: "Override which components to scaffold (default: agent,skill,hook)"
+    default: "agent,skill,hook"
 ---
 
 # create-pipeline


### PR DESCRIPTION
## Summary
- replace the nested `parameters.required` / `parameters.optional` structure in `commands/create-pipeline.md`
- switch the command frontmatter to a flat parameter list with explicit `required` flags
- resolve the YAML frontmatter parse failure triggered by the `components` description field

## Verification
- parsed the updated frontmatter with `yaml.safe_load`
- verified all files in `commands/*.md` still parse as YAML frontmatter
- ran `git diff --cached --check` before commit
