### PR TITLE
fix: expand gitignore for all private component patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,8 +87,11 @@ private-skills/
 private-agents/
 private-hooks/
 private-voices/
-agents/wrestlejoy-amy-writer*
-agents/wrestlejoy-news-*
+agents/wrestlejoy-*
+skills/wrestlejoy-*
+skills/voice-amy-*
+skills/voice-andy-*
+skills/gemini-wrestlejoy-*
 
 # Local-only index targets, not committed
 skills/INDEX.local.json


### PR DESCRIPTION
## Summary

Follow-up to #409. Expands gitignore to cover all private component patterns:

- `agents/wrestlejoy-*` (was only `wrestlejoy-amy-writer*` and `wrestlejoy-news-*`)
- `skills/wrestlejoy-*`
- `skills/voice-amy-*`
- `skills/voice-andy-*`
- `skills/gemini-wrestlejoy-*`

These exist as untracked local files and were being picked up by the repo-directory scan in the enrichment audit.

## Test plan

- [ ] `git check-ignore` confirms all private patterns are blocked
- [ ] CI passes