### PR TITLE
feat: reference decomposition pipeline for progressive disclosure

### DIFF
--- a/scripts/detect-decomposition-targets.py
+++ b/scripts/detect-decomposition-targets.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+"""
+Decomposition Target Detector — find skills/agents with bloated body files.
+
+Scans all skills/*/SKILL.md and agents/*.md files for content that belongs in
+references/ files but has not yet been extracted. Reports extractable blocks
+with suggested reference file names and confidence levels.
+
+Content types detected:
+  code_blocks        Fenced code block clusters (3+ blocks in a section, >20 lines total)
+  large_tables       Markdown tables with 10+ data rows
+  detection_commands Sections containing grep/rg/find patterns
+  agent_rosters      Sections with agent dispatch tables or agent list content
+  error_catalogs     Error/fix/troubleshoot sections exceeding 30 lines
+  spec_tables        Parameter/type/default specification tables
+
+Usage:
+    python3 scripts/detect-decomposition-targets.py
+    python3 scripts/detect-decomposition-targets.py --skill data-analysis
+    python3 scripts/detect-decomposition-targets.py --agent golang-general-engineer
+    python3 scripts/detect-decomposition-targets.py --json
+    python3 scripts/detect-decomposition-targets.py --min-lines 400
+
+Exit code: always 0 (audit tool, not a gate).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ─── Paths ────────────────────────────────────────────────────
+
+_REPO_ROOT = Path(__file__).parent.parent
+_REPO_AGENTS_DIR = _REPO_ROOT / "agents"
+_REPO_SKILLS_DIR = _REPO_ROOT / "skills"
+
+_DEFAULT_MIN_LINES = 500
+
+# ─── Regex Patterns ───────────────────────────────────────────
+
+# Markdown section heading (## or ###)
+_HEADING_RE = re.compile(r"^#{2,}\s+(.+)$")
+
+# Fenced code block delimiter (``` or ~~~)
+_CODE_FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
+
+# Markdown table data row: | something | something |
+_TABLE_ROW_RE = re.compile(r"^\|.+\|")
+
+# Table separator row: |---|---|
+_TABLE_SEP_RE = re.compile(r"^\|[\s\-:|]+\|")
+
+# Detection commands in any context
+_DETECTION_CMD_RE = re.compile(r"\b(grep|rg|find|awk)\b")
+
+# Agent roster signals: dispatch/agent headings or agent-name patterns
+_AGENT_HEADING_RE = re.compile(r"\b(dispatch|agent|roster)\b", re.IGNORECASE)
+
+# Error/fix section heading signals
+_ERROR_HEADING_RE = re.compile(r"\b(error|fix|troubleshoot|debug|issue|failure|problem)\b", re.IGNORECASE)
+
+# Spec table column headers: Parameter, Type, Default, Description, etc.
+_SPEC_HEADER_RE = re.compile(
+    r"\b(parameter|param|type|default|description|required|optional|value|flag|option)\b",
+    re.IGNORECASE,
+)
+
+# Agent name patterns in tables (e.g., golang-general-engineer, python-quality-gate)
+_AGENT_NAME_RE = re.compile(r"\b[\w]+-[\w]+-(?:engineer|agent|analyzer|writer|coordinator)\b", re.IGNORECASE)
+
+
+# ─── Data Classes ─────────────────────────────────────────────
+
+
+@dataclass
+class ExtractableBlock:
+    """A block of content that could be moved to a reference file."""
+
+    content_type: str
+    section_heading: str
+    start_line: int
+    end_line: int
+    line_count: int
+    suggested_reference: str
+    confidence: str  # "high" | "medium" | "low"
+
+
+@dataclass
+class DecompositionTarget:
+    """A skill or agent file that has extractable content."""
+
+    path: Path
+    component: str
+    kind: str  # "skill" | "agent"
+    total_lines: int
+    extractable_blocks: list[ExtractableBlock] = field(default_factory=list)
+
+    @property
+    def total_extractable_lines(self) -> int:
+        # Deduplicate overlapping line ranges before summing
+        if not self.extractable_blocks:
+            return 0
+        ranges = sorted((b.start_line, b.end_line) for b in self.extractable_blocks)
+        merged: list[tuple[int, int]] = []
+        for start, end in ranges:
+            if merged and start <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+            else:
+                merged.append((start, end))
+        return sum(end - start + 1 for start, end in merged)
+
+    @property
+    def potential_reduction_pct(self) -> float:
+        if self.total_lines == 0:
+            return 0.0
+        return round(self.total_extractable_lines / self.total_lines * 100, 1)
+
+
+# ─── Section Splitting ────────────────────────────────────────
+
+
+@dataclass
+class Section:
+    """A contiguous block of lines under a single ## heading."""
+
+    heading: str
+    start_line: int  # 1-based, line of the heading itself
+    lines: list[str]  # lines after the heading until next heading
+
+
+def _split_into_sections(all_lines: list[str]) -> list[Section]:
+    """Split file lines into sections delimited by ## or ### headings."""
+    sections: list[Section] = []
+    current_heading = "(preamble)"
+    current_start = 1
+    current_lines: list[str] = []
+
+    for i, line in enumerate(all_lines, start=1):
+        m = _HEADING_RE.match(line)
+        if m:
+            if current_lines or sections:
+                sections.append(Section(current_heading, current_start, current_lines))
+            current_heading = m.group(0).rstrip()
+            current_start = i
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    if current_lines:
+        sections.append(Section(current_heading, current_start, current_lines))
+
+    return sections
+
+
+# ─── Content Detection ────────────────────────────────────────
+
+
+def _slugify(text: str) -> str:
+    """Convert heading text to a filename slug."""
+    text = re.sub(r"^#+\s*", "", text)
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_]+", "-", text.strip())
+    return text.lower()[:40].rstrip("-")
+
+
+def _suggested_ref(section: Section, content_type: str) -> str:
+    slug = _slugify(section.heading)
+    suffixes = {
+        "code_blocks": "patterns",
+        "large_tables": "reference",
+        "detection_commands": "detection-commands",
+        "agent_rosters": "agent-roster",
+        "error_catalogs": "error-catalog",
+        "spec_tables": "spec",
+    }
+    suffix = suffixes.get(content_type, "reference")
+    return f"references/{slug}-{suffix}.md"
+
+
+def _detect_code_blocks(section: Section) -> ExtractableBlock | None:
+    """Flag sections with 3+ fenced code blocks totalling >20 lines."""
+    block_count = 0
+    code_lines = 0
+    in_block = False
+    block_start_relative = 0
+
+    for i, line in enumerate(section.lines):
+        if _CODE_FENCE_RE.match(line):
+            if not in_block:
+                in_block = True
+                block_start_relative = i
+                block_count += 1
+            else:
+                in_block = False
+        elif in_block:
+            code_lines += 1
+
+    if block_count < 3 or code_lines <= 20:
+        return None
+
+    # Block spans the full section
+    start = section.start_line + 1
+    end = section.start_line + len(section.lines)
+    return ExtractableBlock(
+        content_type="code_blocks",
+        section_heading=section.heading,
+        start_line=start,
+        end_line=end,
+        line_count=end - start + 1,
+        suggested_reference=_suggested_ref(section, "code_blocks"),
+        confidence="high" if block_count >= 5 else "medium",
+    )
+
+
+def _detect_large_tables(section: Section) -> list[ExtractableBlock]:
+    """Flag tables with 10+ data rows. One section can have multiple tables."""
+    results: list[ExtractableBlock] = []
+    in_table = False
+    past_separator = False
+    row_count = 0
+    table_start_abs = 0
+
+    for i, line in enumerate(section.lines):
+        abs_line = section.start_line + 1 + i
+        is_table_row = bool(_TABLE_ROW_RE.match(line))
+        is_separator = bool(_TABLE_SEP_RE.match(line)) if is_table_row else False
+
+        if is_table_row and not in_table:
+            in_table = True
+            past_separator = False
+            row_count = 0
+            table_start_abs = abs_line
+
+        if in_table:
+            if is_separator:
+                past_separator = True
+            elif past_separator and is_table_row:
+                row_count += 1
+            elif not is_table_row:
+                # Table ended
+                if row_count >= 10:
+                    results.append(
+                        ExtractableBlock(
+                            content_type="large_tables",
+                            section_heading=section.heading,
+                            start_line=table_start_abs,
+                            end_line=abs_line - 1,
+                            line_count=abs_line - table_start_abs,
+                            suggested_reference=_suggested_ref(section, "large_tables"),
+                            confidence="high",
+                        )
+                    )
+                in_table = False
+                past_separator = False
+                row_count = 0
+
+    # Close any open table at EOF of section
+    if in_table and row_count >= 10:
+        end_abs = section.start_line + len(section.lines)
+        results.append(
+            ExtractableBlock(
+                content_type="large_tables",
+                section_heading=section.heading,
+                start_line=table_start_abs,
+                end_line=end_abs,
+                line_count=end_abs - table_start_abs + 1,
+                suggested_reference=_suggested_ref(section, "large_tables"),
+                confidence="high",
+            )
+        )
+
+    return results
+
+
+def _detect_detection_commands(section: Section) -> ExtractableBlock | None:
+    """Flag sections containing grep/rg/find in code blocks."""
+    cmd_lines: list[int] = []
+    in_block = False
+
+    for i, line in enumerate(section.lines):
+        if _CODE_FENCE_RE.match(line):
+            in_block = not in_block
+        elif in_block and _DETECTION_CMD_RE.search(line):
+            cmd_lines.append(i)
+
+    if len(cmd_lines) < 2:
+        return None
+
+    start = section.start_line + 1
+    end = section.start_line + len(section.lines)
+    return ExtractableBlock(
+        content_type="detection_commands",
+        section_heading=section.heading,
+        start_line=start,
+        end_line=end,
+        line_count=end - start + 1,
+        suggested_reference=_suggested_ref(section, "detection_commands"),
+        confidence="high" if len(cmd_lines) >= 5 else "medium",
+    )
+
+
+def _detect_agent_rosters(section: Section) -> ExtractableBlock | None:
+    """Flag sections that look like agent dispatch rosters."""
+    heading_matches = bool(_AGENT_HEADING_RE.search(section.heading))
+    agent_name_hits = sum(1 for line in section.lines if _AGENT_NAME_RE.search(line))
+    table_rows = sum(1 for line in section.lines if _TABLE_ROW_RE.match(line))
+
+    # Need heading signal + multiple agent references or a structured table
+    if not (heading_matches or agent_name_hits >= 3):
+        return None
+    if agent_name_hits < 2 and table_rows < 5:
+        return None
+
+    start = section.start_line + 1
+    end = section.start_line + len(section.lines)
+    return ExtractableBlock(
+        content_type="agent_rosters",
+        section_heading=section.heading,
+        start_line=start,
+        end_line=end,
+        line_count=end - start + 1,
+        suggested_reference=_suggested_ref(section, "agent_rosters"),
+        confidence="high" if agent_name_hits >= 5 else "medium",
+    )
+
+
+def _detect_error_catalogs(section: Section) -> ExtractableBlock | None:
+    """Flag error/troubleshoot sections exceeding 30 lines."""
+    if not _ERROR_HEADING_RE.search(section.heading):
+        return None
+    if len(section.lines) <= 30:
+        return None
+
+    start = section.start_line + 1
+    end = section.start_line + len(section.lines)
+    return ExtractableBlock(
+        content_type="error_catalogs",
+        section_heading=section.heading,
+        start_line=start,
+        end_line=end,
+        line_count=end - start + 1,
+        suggested_reference=_suggested_ref(section, "error_catalogs"),
+        confidence="high" if len(section.lines) > 60 else "medium",
+    )
+
+
+def _detect_spec_tables(section: Section) -> ExtractableBlock | None:
+    """Flag specification/parameter tables (Parameter | Type | Default | Description)."""
+    if not section.lines:
+        return None
+
+    # Find the first header row of a table
+    spec_table_start: int | None = None
+    data_rows = 0
+    past_sep = False
+
+    for i, line in enumerate(section.lines):
+        abs_line = section.start_line + 1 + i
+        if _TABLE_ROW_RE.match(line):
+            if spec_table_start is None:
+                # Check if this header line has spec column signals
+                if _SPEC_HEADER_RE.search(line):
+                    spec_table_start = abs_line
+                    past_sep = False
+                    data_rows = 0
+            elif _TABLE_SEP_RE.match(line):
+                past_sep = True
+            elif past_sep:
+                data_rows += 1
+        elif spec_table_start is not None and not _TABLE_ROW_RE.match(line):
+            break
+
+    if spec_table_start is None or data_rows < 5:
+        return None
+
+    # Determine end line
+    end = spec_table_start + data_rows + 2  # header + sep + rows (approx)
+    end = min(end, section.start_line + len(section.lines))
+
+    return ExtractableBlock(
+        content_type="spec_tables",
+        section_heading=section.heading,
+        start_line=spec_table_start,
+        end_line=end,
+        line_count=end - spec_table_start + 1,
+        suggested_reference=_suggested_ref(section, "spec_tables"),
+        confidence="high" if data_rows >= 10 else "medium",
+    )
+
+
+# ─── File Analysis ────────────────────────────────────────────
+
+
+def _analyze_file(path: Path, component: str, kind: str, min_lines: int) -> DecompositionTarget | None:
+    """Analyze a single markdown file for decomposition opportunities."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+    all_lines = text.splitlines()
+    total_lines = len(all_lines)
+
+    if total_lines < min_lines:
+        return None
+
+    target = DecompositionTarget(
+        path=path,
+        component=component,
+        kind=kind,
+        total_lines=total_lines,
+    )
+
+    sections = _split_into_sections(all_lines)
+
+    for section in sections:
+        if not section.lines:
+            continue
+
+        # code_blocks
+        cb = _detect_code_blocks(section)
+        if cb:
+            target.extractable_blocks.append(cb)
+
+        # large_tables
+        for lt in _detect_large_tables(section):
+            target.extractable_blocks.append(lt)
+
+        # detection_commands
+        dc = _detect_detection_commands(section)
+        if dc:
+            target.extractable_blocks.append(dc)
+
+        # agent_rosters
+        ar = _detect_agent_rosters(section)
+        if ar:
+            target.extractable_blocks.append(ar)
+
+        # error_catalogs
+        ec = _detect_error_catalogs(section)
+        if ec:
+            target.extractable_blocks.append(ec)
+
+        # spec_tables
+        st = _detect_spec_tables(section)
+        if st:
+            target.extractable_blocks.append(st)
+
+    # Only return if there is at least one extractable block
+    if not target.extractable_blocks:
+        return None
+
+    return target
+
+
+# ─── Scanning ─────────────────────────────────────────────────
+
+
+def _scan_skills(base_dir: Path, min_lines: int) -> list[DecompositionTarget]:
+    """Scan skills/*/SKILL.md files."""
+    if not base_dir.is_dir():
+        return []
+    results: list[DecompositionTarget] = []
+    for item in sorted(base_dir.iterdir()):
+        if not item.is_dir():
+            continue
+        skill_md = item / "SKILL.md"
+        if not skill_md.is_file():
+            continue
+        target = _analyze_file(skill_md, item.name, "skill", min_lines)
+        if target:
+            results.append(target)
+    return results
+
+
+def _scan_agents(base_dir: Path, min_lines: int) -> list[DecompositionTarget]:
+    """Scan agents/*.md files, excluding agents/*/references/*.md."""
+    if not base_dir.is_dir():
+        return []
+    results: list[DecompositionTarget] = []
+    for item in sorted(base_dir.iterdir()):
+        if not item.is_file() or item.suffix != ".md":
+            continue
+        if item.stem in ("INDEX", "README"):
+            continue
+        target = _analyze_file(item, item.stem, "agent", min_lines)
+        if target:
+            results.append(target)
+    return results
+
+
+def scan_all(min_lines: int) -> list[DecompositionTarget]:
+    """Scan all repo skills and agents."""
+    results: list[DecompositionTarget] = []
+    results += _scan_skills(_REPO_SKILLS_DIR, min_lines)
+    results += _scan_agents(_REPO_AGENTS_DIR, min_lines)
+    return sorted(results, key=lambda t: (-t.total_lines, t.kind, t.component))
+
+
+def scan_single_skill(name: str, min_lines: int) -> DecompositionTarget | None:
+    """Scan a single skill by name."""
+    skill_dir = _REPO_SKILLS_DIR / name
+    if not skill_dir.is_dir():
+        return None
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        return None
+    return _analyze_file(skill_md, name, "skill", min_lines)
+
+
+def scan_single_agent(name: str, min_lines: int) -> DecompositionTarget | None:
+    """Scan a single agent by name."""
+    agent_md = _REPO_AGENTS_DIR / f"{name}.md"
+    if agent_md.is_file():
+        return _analyze_file(agent_md, name, "agent", min_lines)
+    return None
+
+
+# ─── Reporting ────────────────────────────────────────────────
+
+_CONFIDENCE_ORDER = {"high": 0, "medium": 1, "low": 2}
+
+
+def _format_text(results: list[DecompositionTarget], min_lines: int) -> str:
+    """Render human-readable report."""
+    lines: list[str] = []
+    lines.append("DECOMPOSITION TARGET REPORT")
+    lines.append("=" * 60)
+    lines.append(f"  Threshold: {min_lines}+ lines  |  Targets found: {len(results)}")
+    lines.append("")
+
+    if not results:
+        lines.append("No decomposition targets found above the line threshold.")
+        return "\n".join(lines)
+
+    for t in results:
+        rel_path = t.path.relative_to(_REPO_ROOT)
+        lines.append(f"[{t.kind}]  {t.component}  ({t.total_lines} lines)")
+        lines.append(f"  Path: {rel_path}")
+        lines.append(f"  Extractable: {t.total_extractable_lines} lines  ({t.potential_reduction_pct}% reduction)")
+
+        sorted_blocks = sorted(t.extractable_blocks, key=lambda b: _CONFIDENCE_ORDER.get(b.confidence, 9))
+        for b in sorted_blocks:
+            conf_tag = f"[{b.confidence}]"
+            lines.append(
+                f"    {conf_tag:<8}  {b.content_type:<22}  L{b.start_line}-{b.end_line}  ({b.line_count} lines)"
+            )
+            lines.append(f"             section: {b.section_heading}")
+            lines.append(f"             suggest: {b.suggested_reference}")
+        lines.append("")
+
+    # Summary
+    total_extractable = sum(t.total_extractable_lines for t in results)
+    skills = [t for t in results if t.kind == "skill"]
+    agents = [t for t in results if t.kind == "agent"]
+    lines.append("-" * 60)
+    lines.append(f"Totals: {len(skills)} skills, {len(agents)} agents  |  ~{total_extractable} lines extractable")
+
+    return "\n".join(lines)
+
+
+def _target_to_dict(t: DecompositionTarget) -> dict:
+    """Convert a DecompositionTarget to a JSON-serialisable dict."""
+    rel_path = str(t.path.relative_to(_REPO_ROOT))
+    return {
+        "path": rel_path,
+        "component": t.component,
+        "type": t.kind,
+        "total_lines": t.total_lines,
+        "extractable_blocks": [
+            {
+                "content_type": b.content_type,
+                "section_heading": b.section_heading,
+                "start_line": b.start_line,
+                "end_line": b.end_line,
+                "line_count": b.line_count,
+                "suggested_reference": b.suggested_reference,
+                "confidence": b.confidence,
+            }
+            for b in t.extractable_blocks
+        ],
+        "total_extractable_lines": t.total_extractable_lines,
+        "potential_reduction_pct": t.potential_reduction_pct,
+    }
+
+
+def _format_json(results: list[DecompositionTarget]) -> str:
+    """Render results as JSON."""
+    payload = {
+        "targets": [_target_to_dict(t) for t in results],
+        "summary": {
+            "total_targets": len(results),
+            "skill_targets": sum(1 for t in results if t.kind == "skill"),
+            "agent_targets": sum(1 for t in results if t.kind == "agent"),
+            "total_extractable_lines": sum(t.total_extractable_lines for t in results),
+        },
+    }
+    return json.dumps(payload, indent=2)
+
+
+# ─── Main ─────────────────────────────────────────────────────
+
+
+def main() -> int:
+    """Entry point."""
+    parser = argparse.ArgumentParser(
+        description="Detect skills/agents with bloated body files that have extractable content.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--skill",
+        metavar="NAME",
+        help="Scan a single skill by name",
+    )
+    parser.add_argument(
+        "--agent",
+        metavar="NAME",
+        help="Scan a single agent by name",
+    )
+    parser.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="Output machine-readable JSON",
+    )
+    parser.add_argument(
+        "--min-lines",
+        type=int,
+        default=_DEFAULT_MIN_LINES,
+        metavar="N",
+        help=f"Only report files with at least N lines (default: {_DEFAULT_MIN_LINES})",
+    )
+    args = parser.parse_args()
+
+    if args.skill and args.agent:
+        print("[error] Specify --skill or --agent, not both.", file=sys.stderr)
+        return 0
+
+    if args.skill:
+        result = scan_single_skill(args.skill, args.min_lines)
+        if result is None:
+            print(f"[error] skill '{args.skill}' not found or below threshold.", file=sys.stderr)
+            return 0
+        results = [result]
+    elif args.agent:
+        result = scan_single_agent(args.agent, args.min_lines)
+        if result is None:
+            print(f"[error] agent '{args.agent}' not found or below threshold.", file=sys.stderr)
+            return 0
+        results = [result]
+    else:
+        results = scan_all(args.min_lines)
+
+    if args.as_json:
+        print(_format_json(results))
+    else:
+        print(_format_text(results, args.min_lines))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reference-enrichment-cron.sh
+++ b/scripts/reference-enrichment-cron.sh
@@ -10,6 +10,9 @@
 #   # Full run (audit + enrich + PR)
 #   ./scripts/reference-enrichment-cron.sh --execute
 #
+#   # Decomposition run (split oversized references)
+#   ./scripts/reference-enrichment-cron.sh --decompose
+#
 # Cron example (hourly at :07):
 #   7 * * * * /home/feedgen/claude-code-toolkit/scripts/reference-enrichment-cron.sh --execute >> /home/feedgen/claude-code-toolkit/cron-logs/reference-enrichment/cron.log 2>&1
 
@@ -33,13 +36,20 @@ LOG_DIR="$REPO_DIR/cron-logs/reference-enrichment"
 LOCKFILE="/tmp/reference-enrichment.lock"
 MAX_BUDGET="${MAX_BUDGET_USD:-5.00}"
 MAX_TARGETS="${MAX_TARGETS:-1}"
+MAX_DECOMP_TARGETS="${MAX_DECOMP_TARGETS:-1}"
+MAX_OPEN_DECOMP_PRS="${MAX_OPEN_DECOMP_PRS:-3}"
 EXECUTE=""
+DECOMPOSE=""
 
 # Cleanup function: release lock FD, remove stale worktree, and remove lockfile on any exit
 cleanup() {
     if [ -n "${ENRICH_WORKTREE:-}" ] && [ -d "$ENRICH_WORKTREE" ]; then
         cd "$REPO_DIR" 2>/dev/null || true
         git worktree remove "$ENRICH_WORKTREE" --force 2>/dev/null || true
+    fi
+    if [ -n "${DECOMP_WORKTREE:-}" ] && [ -d "$DECOMP_WORKTREE" ]; then
+        cd "$REPO_DIR" 2>/dev/null || true
+        git worktree remove "$DECOMP_WORKTREE" --force 2>/dev/null || true
     fi
     exec 9>&- 2>/dev/null
     rm -f "$LOCKFILE"
@@ -49,9 +59,16 @@ cleanup() {
 for arg in "$@"; do
     case "$arg" in
         --execute) EXECUTE="1" ;;
+        --decompose) DECOMPOSE="1" ;;
         *) echo "Unknown arg: $arg" >&2; exit 1 ;;
     esac
 done
+
+# Mutual exclusivity check
+if [ -n "$EXECUTE" ] && [ -n "$DECOMPOSE" ]; then
+    echo "ERROR: --execute and --decompose are mutually exclusive" >&2
+    exit 1
+fi
 
 # Create log directory
 mkdir -p "$LOG_DIR"
@@ -73,46 +90,9 @@ TIMESTAMP="$(date -Iseconds)"
 echo "=== Reference Enrichment run: $TIMESTAMP ==="
 
 MODE="dry-run"
-[ -n "$EXECUTE" ] && MODE="live"
+[ -n "$EXECUTE" ] && MODE="enrich-live"
+[ -n "$DECOMPOSE" ] && MODE="decompose-live"
 echo "Mode: $MODE | Budget: \$${MAX_BUDGET} | Max targets: ${MAX_TARGETS}"
-
-# Guard: check for too many open enrichment PRs (prevents accumulation — ADR consultation concern #2)
-MAX_OPEN_PRS="${MAX_OPEN_PRS:-5}"
-if command -v gh &>/dev/null; then
-    OPEN_PRS=$(gh pr list --search "enrich/refs" --state open --json number 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
-    if [ "$OPEN_PRS" -ge "$MAX_OPEN_PRS" ]; then
-        echo "$(date -Iseconds) SKIP: ${OPEN_PRS} open enrichment PRs (max: ${MAX_OPEN_PRS}). Review/merge existing PRs first."
-        exit 0
-    fi
-    echo "Open enrichment PRs: ${OPEN_PRS}/${MAX_OPEN_PRS}"
-fi
-
-# Run audit to find agents/skills below Level 3 (the goal is continuous
-# improvement toward Level 3, not just backfilling missing references)
-AUDIT_JSON=$(python3 "$REPO_DIR/scripts/audit-reference-depth.py" --json --min-level 3 2>/dev/null)
-
-# Select targets using the deterministic script (extracted per ADR consultation concern #4)
-TARGETS_TRIMMED=$(echo "$AUDIT_JSON" | python3 "$REPO_DIR/scripts/select-enrichment-targets.py" --max-targets "$MAX_TARGETS" --names-only)
-TARGETS_COUNT=$(echo "$TARGETS_TRIMMED" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
-
-if [ "$TARGETS_COUNT" -eq 0 ]; then
-    echo "$(date -Iseconds) No gaps found (all components at Level 3). Exiting cleanly."
-    exit 0
-fi
-
-echo "Audit found ${TARGETS_COUNT} gap(s). Processing up to ${MAX_TARGETS}: ${TARGETS_TRIMMED}"
-
-# Build envsubst variables
-export ENRICH_REPO_DIR="$REPO_DIR"
-export ENRICH_TARGETS="$TARGETS_TRIMMED"
-export ENRICH_DATE="$(date +%Y-%m-%d)"
-export ENRICH_RUN_ID="$(date +%Y-%m-%d-%H%M)"
-export ENRICH_MAX_TARGETS="$MAX_TARGETS"
-export ENRICH_DRY_RUN_MODE="no"
-if [ -z "$EXECUTE" ]; then
-    export ENRICH_DRY_RUN_MODE="yes"
-    echo "Dry-run mode: audit only, no reference files will be created"
-fi
 
 # Fetch latest remote main (safe: does not touch working tree)
 echo "Fetching latest remote main..."
@@ -131,92 +111,243 @@ if [ -d "$REPO_DIR/.claude/worktrees" ]; then
     git worktree prune 2>/dev/null || true
 fi
 
-# Create temporary worktree for isolated enrichment work
-ENRICH_WORKTREE="/tmp/enrichment-worktree-${ENRICH_RUN_ID}"
-git worktree add "$ENRICH_WORKTREE" origin/main 2>/dev/null || {
-    # If worktree already exists, remove and recreate
+if [ -n "$DECOMPOSE" ]; then
+    # === DECOMPOSITION MODE ===
+
+    # Guard: check for too many open decomposition PRs
+    if command -v gh &>/dev/null; then
+        OPEN_DECOMP_PRS=$(gh pr list --search "decomp/refs" --state open --json number 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
+        if [ "$OPEN_DECOMP_PRS" -ge "$MAX_OPEN_DECOMP_PRS" ]; then
+            echo "$(date -Iseconds) SKIP: ${OPEN_DECOMP_PRS} open decomposition PRs (max: ${MAX_OPEN_DECOMP_PRS}). Review/merge existing PRs first."
+            exit 0
+        fi
+        echo "Open decomposition PRs: ${OPEN_DECOMP_PRS}/${MAX_OPEN_DECOMP_PRS}"
+    fi
+
+    # Detect oversized references that need decomposition
+    DECOMP_TARGETS=$(python3 "$REPO_DIR/scripts/detect-decomposition-targets.py" --json --min-lines 500 2>/dev/null)
+    DECOMP_TARGET_COUNT=$(echo "$DECOMP_TARGETS" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d))")
+
+    if [ "$DECOMP_TARGET_COUNT" -eq 0 ]; then
+        echo "$(date -Iseconds) No decomposition targets found (all references under 500 lines). Exiting cleanly."
+        exit 0
+    fi
+
+    echo "Found ${DECOMP_TARGET_COUNT} decomposition target(s). Processing up to ${MAX_DECOMP_TARGETS}."
+
+    # Limit targets
+    DECOMP_TARGETS_TRIMMED=$(echo "$DECOMP_TARGETS" | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps(d[:${MAX_DECOMP_TARGETS}]))")
+
+    # Build envsubst variables
+    export DECOMP_REPO_DIR="$REPO_DIR"
+    export DECOMP_TARGETS="$DECOMP_TARGETS_TRIMMED"
+    export DECOMP_DATE="$(date +%Y-%m-%d)"
+    export DECOMP_RUN_ID="$(date +%Y-%m-%d-%H%M)"
+    export DECOMP_MAX_TARGETS="$MAX_DECOMP_TARGETS"
+    export DECOMP_DRY_RUN_MODE="no"
+
+    # Create temporary worktree for isolated decomposition work
+    DECOMP_WORKTREE="/tmp/decomp-worktree-${DECOMP_RUN_ID}"
+    git worktree add "$DECOMP_WORKTREE" origin/main 2>/dev/null || {
+        # If worktree already exists, remove and recreate
+        git worktree remove "$DECOMP_WORKTREE" --force 2>/dev/null || true
+        git worktree add "$DECOMP_WORKTREE" origin/main
+    }
+    export DECOMP_WORKTREE
+    echo "Worktree created at $DECOMP_WORKTREE (based on origin/main)"
+
+    # Build the prompt from template using envsubst
+    DECOMP_PROMPT_TEMPLATE="$REPO_DIR/skills/reference-enrichment/decomposition-prompt.md"
+    if [ ! -f "$DECOMP_PROMPT_TEMPLATE" ]; then
+        echo "ERROR: decomposition-prompt.md not found at $DECOMP_PROMPT_TEMPLATE" >&2
+        exit 1
+    fi
+
+    DECOMP_PROMPT=$(envsubst '${DECOMP_REPO_DIR} ${DECOMP_TARGETS} ${DECOMP_DATE} ${DECOMP_RUN_ID} ${DECOMP_MAX_TARGETS} ${DECOMP_DRY_RUN_MODE} ${DECOMP_WORKTREE}' < "$DECOMP_PROMPT_TEMPLATE")
+
+    # Clean up local branches from merged/closed decomposition PRs
+    for branch in $(git branch --list 'decomp/*' 2>/dev/null); do
+        pr_state=$(gh pr list --head "$branch" --state all --json state --jq '.[0].state // "NONE"' 2>/dev/null)
+        if [[ "$pr_state" == "MERGED" || "$pr_state" == "CLOSED" ]]; then
+            echo "Cleaning up stale branch: $branch (PR state: $pr_state)"
+            git branch -D "$branch" 2>/dev/null || true
+        fi
+    done
+
+    cd "$DECOMP_WORKTREE"
+
+    set +e
+    claude -p "$DECOMP_PROMPT" \
+        --output-format text \
+        --dangerously-skip-permissions \
+        --max-budget-usd "$MAX_BUDGET" \
+        --no-session-persistence \
+        --model sonnet \
+        2>&1 | tee "$LOG_DIR/decomp-$(date +%Y%m%d-%H%M%S).log"
+    EXIT_CODE=${PIPESTATUS[0]}
+    set -e
+
+    # Clean up temporary worktree
+    echo "Cleaning up worktree..."
+    cd "$REPO_DIR"
+    git worktree remove "$DECOMP_WORKTREE" --force 2>/dev/null || true
+
+    echo ""
+    echo "=== Reference Decomposition complete: $(date -Iseconds) | exit: $EXIT_CODE ==="
+
+    if [ "$EXIT_CODE" -eq 0 ]; then
+        echo "Decomposition completed successfully for: $DECOMP_TARGETS_TRIMMED"
+    fi
+
+    # Ensure we're back on main after decomposition (decomp/* branch may have been left active)
+    cd "$REPO_DIR"
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+    if [[ "$CURRENT_BRANCH" == decomp/* ]]; then
+        echo "WARNING: Decomposition left repo on branch $CURRENT_BRANCH, switching back to main"
+        git checkout main 2>/dev/null || true
+    fi
+
+    # Sync main checkout with remote after decomposition push
+    if [ "$EXIT_CODE" -eq 0 ]; then
+        echo "Syncing main checkout with remote after decomposition push..."
+        git fetch origin main
+        git checkout -- . 2>/dev/null || true
+        git clean -fd -- agents/*/references/ 2>/dev/null || true
+        git clean -fd -- skills/*/references/ 2>/dev/null || true
+        if ! git pull --ff-only 2>/dev/null; then
+            echo "WARNING: fast-forward pull failed (main may have diverged). Manual sync needed."
+        fi
+        echo "Main checkout synced to $(git rev-parse --short HEAD)"
+    fi
+
+else
+    # === ENRICHMENT MODE (--execute or dry-run) ===
+
+    # Guard: check for too many open enrichment PRs (prevents accumulation — ADR consultation concern #2)
+    MAX_OPEN_PRS="${MAX_OPEN_PRS:-5}"
+    if command -v gh &>/dev/null; then
+        OPEN_PRS=$(gh pr list --search "enrich/refs" --state open --json number 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
+        if [ "$OPEN_PRS" -ge "$MAX_OPEN_PRS" ]; then
+            echo "$(date -Iseconds) SKIP: ${OPEN_PRS} open enrichment PRs (max: ${MAX_OPEN_PRS}). Review/merge existing PRs first."
+            exit 0
+        fi
+        echo "Open enrichment PRs: ${OPEN_PRS}/${MAX_OPEN_PRS}"
+    fi
+
+    # Run audit to find agents/skills below Level 3 (the goal is continuous
+    # improvement toward Level 3, not just backfilling missing references)
+    AUDIT_JSON=$(python3 "$REPO_DIR/scripts/audit-reference-depth.py" --json --min-level 3 2>/dev/null)
+
+    # Select targets using the deterministic script (extracted per ADR consultation concern #4)
+    TARGETS_TRIMMED=$(echo "$AUDIT_JSON" | python3 "$REPO_DIR/scripts/select-enrichment-targets.py" --max-targets "$MAX_TARGETS" --names-only)
+    TARGETS_COUNT=$(echo "$TARGETS_TRIMMED" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+
+    if [ "$TARGETS_COUNT" -eq 0 ]; then
+        echo "$(date -Iseconds) No gaps found (all components at Level 3). Exiting cleanly."
+        exit 0
+    fi
+
+    echo "Audit found ${TARGETS_COUNT} gap(s). Processing up to ${MAX_TARGETS}: ${TARGETS_TRIMMED}"
+
+    # Build envsubst variables
+    export ENRICH_REPO_DIR="$REPO_DIR"
+    export ENRICH_TARGETS="$TARGETS_TRIMMED"
+    export ENRICH_DATE="$(date +%Y-%m-%d)"
+    export ENRICH_RUN_ID="$(date +%Y-%m-%d-%H%M)"
+    export ENRICH_MAX_TARGETS="$MAX_TARGETS"
+    export ENRICH_DRY_RUN_MODE="no"
+    if [ -z "$EXECUTE" ]; then
+        export ENRICH_DRY_RUN_MODE="yes"
+        echo "Dry-run mode: audit only, no reference files will be created"
+    fi
+
+    # Create temporary worktree for isolated enrichment work
+    ENRICH_WORKTREE="/tmp/enrichment-worktree-${ENRICH_RUN_ID}"
+    git worktree add "$ENRICH_WORKTREE" origin/main 2>/dev/null || {
+        # If worktree already exists, remove and recreate
+        git worktree remove "$ENRICH_WORKTREE" --force 2>/dev/null || true
+        git worktree add "$ENRICH_WORKTREE" origin/main
+    }
+    export ENRICH_WORKTREE
+    echo "Worktree created at $ENRICH_WORKTREE (based on origin/main)"
+
+    # Build the prompt from template using envsubst
+    PROMPT_TEMPLATE="$REPO_DIR/skills/reference-enrichment/enrichment-prompt.md"
+    if [ ! -f "$PROMPT_TEMPLATE" ]; then
+        echo "ERROR: enrichment-prompt.md not found at $PROMPT_TEMPLATE" >&2
+        exit 1
+    fi
+
+    PROMPT=$(envsubst '${ENRICH_REPO_DIR} ${ENRICH_TARGETS} ${ENRICH_DATE} ${ENRICH_RUN_ID} ${ENRICH_MAX_TARGETS} ${ENRICH_DRY_RUN_MODE} ${ENRICH_WORKTREE}' < "$PROMPT_TEMPLATE")
+
+    # Clean up local branches from merged/closed enrichment PRs
+    for branch in $(git branch --list 'enrich/*' 2>/dev/null); do
+        # Check if the branch's PR was merged or closed
+        pr_state=$(gh pr list --head "$branch" --state all --json state --jq '.[0].state // "NONE"' 2>/dev/null)
+        if [[ "$pr_state" == "MERGED" || "$pr_state" == "CLOSED" ]]; then
+            echo "Cleaning up stale branch: $branch (PR state: $pr_state)"
+            git branch -D "$branch" 2>/dev/null || true
+        fi
+    done
+
+    cd "$ENRICH_WORKTREE"
+
+    set +e
+    claude -p "$PROMPT" \
+        --output-format text \
+        --dangerously-skip-permissions \
+        --max-budget-usd "$MAX_BUDGET" \
+        --no-session-persistence \
+        --model sonnet \
+        2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
+    EXIT_CODE=${PIPESTATUS[0]}
+    set -e
+
+    # Clean up temporary worktree
+    echo "Cleaning up worktree..."
+    cd "$REPO_DIR"
     git worktree remove "$ENRICH_WORKTREE" --force 2>/dev/null || true
-    git worktree add "$ENRICH_WORKTREE" origin/main
-}
-export ENRICH_WORKTREE
-echo "Worktree created at $ENRICH_WORKTREE (based on origin/main)"
 
-# Build the prompt from template using envsubst
-PROMPT_TEMPLATE="$REPO_DIR/skills/reference-enrichment/enrichment-prompt.md"
-if [ ! -f "$PROMPT_TEMPLATE" ]; then
-    echo "ERROR: enrichment-prompt.md not found at $PROMPT_TEMPLATE" >&2
-    exit 1
-fi
+    echo ""
+    echo "=== Reference Enrichment complete: $(date -Iseconds) | exit: $EXIT_CODE ==="
 
-PROMPT=$(envsubst '${ENRICH_REPO_DIR} ${ENRICH_TARGETS} ${ENRICH_DATE} ${ENRICH_RUN_ID} ${ENRICH_MAX_TARGETS} ${ENRICH_DRY_RUN_MODE} ${ENRICH_WORKTREE}' < "$PROMPT_TEMPLATE")
-
-# Clean up local branches from merged/closed enrichment PRs
-for branch in $(git branch --list 'enrich/*' 2>/dev/null); do
-    # Check if the branch's PR was merged or closed
-    pr_state=$(gh pr list --head "$branch" --state all --json state --jq '.[0].state // "NONE"' 2>/dev/null)
-    if [[ "$pr_state" == "MERGED" || "$pr_state" == "CLOSED" ]]; then
-        echo "Cleaning up stale branch: $branch (PR state: $pr_state)"
-        git branch -D "$branch" 2>/dev/null || true
+    # Record completed targets in journal (only on success)
+    if [ "$EXIT_CODE" -eq 0 ]; then
+        echo "Enrichment completed successfully for: $TARGETS_TRIMMED"
     fi
-done
 
-cd "$ENRICH_WORKTREE"
-
-set +e
-claude -p "$PROMPT" \
-    --output-format text \
-    --dangerously-skip-permissions \
-    --max-budget-usd "$MAX_BUDGET" \
-    --no-session-persistence \
-    --model sonnet \
-    2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
-EXIT_CODE=${PIPESTATUS[0]}
-set -e
-
-# Clean up temporary worktree
-echo "Cleaning up worktree..."
-cd "$REPO_DIR"
-git worktree remove "$ENRICH_WORKTREE" --force 2>/dev/null || true
-
-echo ""
-echo "=== Reference Enrichment complete: $(date -Iseconds) | exit: $EXIT_CODE ==="
-
-# Record completed targets in journal (only on success)
-if [ "$EXIT_CODE" -eq 0 ]; then
-    echo "Enrichment completed successfully for: $TARGETS_TRIMMED"
-fi
-
-
-# Ensure we're back on main after enrichment (enrich/* branch may have been left active)
-cd "$REPO_DIR"
-CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
-if [[ "$CURRENT_BRANCH" == enrich/* ]]; then
-    echo "WARNING: Enrichment left repo on branch $CURRENT_BRANCH, switching back to main"
-    git checkout main 2>/dev/null || true
-fi
-
-# Sync main checkout with remote after enrichment push.
-# Interactive sessions create reference files locally but don't commit them (the
-# enrichment cron handles commit/push from its worktree). This leaves orphaned
-# local changes that conflict with future git pulls. Clean them up here.
-if [ "$EXIT_CODE" -eq 0 ] && [ -n "$EXECUTE" ]; then
-    echo "Syncing main checkout with remote after enrichment push..."
-    git fetch origin main
-    # Drop tracked file modifications (stale enrichment leftovers from interactive sessions)
-    git checkout -- . 2>/dev/null || true
-    # Remove untracked reference files that enrichment creates — scoped narrowly to
-    # avoid deleting legitimate local-only files (cron-logs/, plan/, benchmark/, adr/, etc.)
-    git clean -fd -- agents/*/references/ 2>/dev/null || true
-    git clean -fd -- skills/*/references/ 2>/dev/null || true
-    # Fast-forward to include the just-merged changes
-    if ! git pull --ff-only 2>/dev/null; then
-        echo "WARNING: fast-forward pull failed (main may have diverged). Manual sync needed."
+    # Ensure we're back on main after enrichment (enrich/* branch may have been left active)
+    cd "$REPO_DIR"
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+    if [[ "$CURRENT_BRANCH" == enrich/* ]]; then
+        echo "WARNING: Enrichment left repo on branch $CURRENT_BRANCH, switching back to main"
+        git checkout main 2>/dev/null || true
     fi
-    echo "Main checkout synced to $(git rev-parse --short HEAD)"
+
+    # Sync main checkout with remote after enrichment push.
+    # Interactive sessions create reference files locally but don't commit them (the
+    # enrichment cron handles commit/push from its worktree). This leaves orphaned
+    # local changes that conflict with future git pulls. Clean them up here.
+    if [ "$EXIT_CODE" -eq 0 ] && [ -n "$EXECUTE" ]; then
+        echo "Syncing main checkout with remote after enrichment push..."
+        git fetch origin main
+        # Drop tracked file modifications (stale enrichment leftovers from interactive sessions)
+        git checkout -- . 2>/dev/null || true
+        # Remove untracked reference files that enrichment creates — scoped narrowly to
+        # avoid deleting legitimate local-only files (cron-logs/, plan/, benchmark/, adr/, etc.)
+        git clean -fd -- agents/*/references/ 2>/dev/null || true
+        git clean -fd -- skills/*/references/ 2>/dev/null || true
+        # Fast-forward to include the just-merged changes
+        if ! git pull --ff-only 2>/dev/null; then
+            echo "WARNING: fast-forward pull failed (main may have diverged). Manual sync needed."
+        fi
+        echo "Main checkout synced to $(git rev-parse --short HEAD)"
+    fi
 fi
 
 # Rotate old logs (keep last 30 days)
 find "$LOG_DIR" -name "run-*.log" -mtime +30 -delete 2>/dev/null || true
+find "$LOG_DIR" -name "decomp-*.log" -mtime +30 -delete 2>/dev/null || true
 
 # Lock is released by the EXIT trap (cleanup function)
 exit $EXIT_CODE

--- a/scripts/validate-decomposition.py
+++ b/scripts/validate-decomposition.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+"""Validate that a reference decomposition preserved all content from the original SKILL.md.
+
+Usage:
+    python3 scripts/validate-decomposition.py \\
+        --before /tmp/original-skill.md \\
+        --after skills/foo/SKILL.md \\
+        --refs skills/foo/references/
+
+Optional flags:
+    --json              Machine-readable JSON output
+    --verbose           Detailed per-check reporting
+    --new-refs f1,f2    Comma-separated list of new reference filenames (for route
+                        completeness check). If omitted, all files in --refs are
+                        treated as potentially new.
+
+Exit codes:
+    0  PASS — all checks passed
+    1  FAIL — one or more checks failed
+"""
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CheckFailure:
+    """A single check failure with location details."""
+
+    category: str
+    check: str
+    detail: str
+    location: str = ""
+
+
+@dataclass
+class ValidationResult:
+    """Aggregated result from all validation categories."""
+
+    failures: list[CheckFailure] = field(default_factory=list)
+    checks_run: int = 0
+    checks_passed: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return len(self.failures) == 0
+
+
+# ---------------------------------------------------------------------------
+# Content extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_code_blocks(content: str) -> list[str]:
+    """Extract all fenced code block contents (between ``` delimiters)."""
+    blocks: list[str] = []
+    in_block = False
+    current: list[str] = []
+    for line in content.split("\n"):
+        if line.strip().startswith("```"):
+            if in_block:
+                blocks.append("\n".join(current))
+                current = []
+            in_block = not in_block
+            continue
+        if in_block:
+            current.append(line)
+    return blocks
+
+
+def extract_tables(content: str) -> list[str]:
+    """Extract all markdown tables (header + separator + rows).
+
+    A table is identified by:
+    1. A header row containing pipe characters
+    2. A separator row with dashes (|---|)
+    3. One or more data rows
+    """
+    tables: list[str] = []
+    lines = content.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        # Look for a line that looks like a table header row
+        if "|" in line and line.strip().startswith("|"):
+            # Check if next line is a separator
+            if i + 1 < len(lines):
+                next_line = lines[i + 1]
+                if "|" in next_line and re.match(r"\|[\s\-:|]+\|", next_line.strip()):
+                    # Found a table — collect all consecutive pipe rows
+                    table_lines = [line, next_line]
+                    j = i + 2
+                    while j < len(lines) and "|" in lines[j] and lines[j].strip().startswith("|"):
+                        table_lines.append(lines[j])
+                        j += 1
+                    tables.append("\n".join(table_lines))
+                    i = j
+                    continue
+        i += 1
+    return tables
+
+
+def extract_headings(content: str) -> list[tuple[int, str]]:
+    """Extract all markdown headings as (level, text) tuples."""
+    headings: list[tuple[int, str]] = []
+    for line in content.split("\n"):
+        m = re.match(r"^(#{1,6})\s+(.+)", line)
+        if m:
+            level = len(m.group(1))
+            text = m.group(2).strip()
+            headings.append((level, text))
+    return headings
+
+
+def extract_section_content(content: str, heading_text: str) -> str:
+    """Return the body text beneath a given heading (until the next same-or-higher heading)."""
+    lines = content.split("\n")
+    in_section = False
+    heading_level = 0
+    body: list[str] = []
+
+    for line in lines:
+        m = re.match(r"^(#{1,6})\s+(.+)", line)
+        if m:
+            level = len(m.group(1))
+            text = m.group(2).strip()
+            if text == heading_text:
+                in_section = True
+                heading_level = level
+                continue
+            if in_section and level <= heading_level:
+                break
+        if in_section:
+            body.append(line)
+
+    return "\n".join(body)
+
+
+# ---------------------------------------------------------------------------
+# Fuzzy normalization
+# ---------------------------------------------------------------------------
+
+
+def normalize_block(text: str) -> str:
+    """Normalize a content block for fuzzy comparison.
+
+    Strips leading/trailing whitespace from each line, collapses multiple
+    spaces to single space, and removes empty lines at start/end.
+    """
+    lines = [re.sub(r"  +", " ", line.strip()) for line in text.split("\n")]
+    # Drop leading and trailing empty lines
+    while lines and not lines[0]:
+        lines.pop(0)
+    while lines and not lines[-1]:
+        lines.pop()
+    return "\n".join(lines)
+
+
+def block_exists_in(block: str, haystack: str) -> bool:
+    """Return True if normalized block appears anywhere in normalized haystack."""
+    norm_block = normalize_block(block)
+    if not norm_block:
+        return True  # empty block is trivially present
+    norm_haystack = normalize_block(haystack)
+    return norm_block in norm_haystack
+
+
+# ---------------------------------------------------------------------------
+# Category 1: Content Preservation
+# ---------------------------------------------------------------------------
+
+
+def check_content_preservation(
+    before_content: str,
+    combined_after: str,
+    verbose: bool,
+) -> list[CheckFailure]:
+    """Verify all code blocks, tables, and headings from the original are present after."""
+    failures: list[CheckFailure] = []
+
+    # --- Code blocks ---
+    original_blocks = extract_code_blocks(before_content)
+    missing_blocks: list[tuple[int, str]] = []
+    for idx, block in enumerate(original_blocks):
+        if not block_exists_in(block, combined_after):
+            missing_blocks.append((idx + 1, block))
+
+    if verbose:
+        print(f"  [code-blocks] {len(original_blocks) - len(missing_blocks)}/{len(original_blocks)} code blocks found")
+
+    for idx, block in missing_blocks:
+        preview = block.strip()[:80].replace("\n", " ")
+        failures.append(
+            CheckFailure(
+                category="content-preservation",
+                check="code-block-missing",
+                detail=f"Code block #{idx} not found in after-state: {preview!r}...",
+            )
+        )
+
+    # --- Tables ---
+    original_tables = extract_tables(before_content)
+    missing_tables: list[tuple[int, str]] = []
+    for idx, table in enumerate(original_tables):
+        # For tables we check just the header + separator to allow minor cell reflows
+        header_rows = "\n".join(table.split("\n")[:2])
+        if not block_exists_in(header_rows, combined_after):
+            missing_tables.append((idx + 1, table))
+
+    if verbose:
+        print(f"  [tables] {len(original_tables) - len(missing_tables)}/{len(original_tables)} tables found")
+
+    for idx, table in missing_tables:
+        preview = table.split("\n")[0][:80]
+        failures.append(
+            CheckFailure(
+                category="content-preservation",
+                check="table-missing",
+                detail=f"Table #{idx} header not found in after-state: {preview!r}",
+            )
+        )
+
+    # --- Headings ---
+    original_headings = extract_headings(before_content)
+    # Skip frontmatter-style headings and very short/generic ones
+    SKIP_HEADINGS = {"Instructions", "Overview", "Notes"}
+    substantive_headings = [(lvl, text) for lvl, text in original_headings if text not in SKIP_HEADINGS]
+    missing_headings: list[tuple[int, str]] = []
+
+    for level, heading_text in substantive_headings:
+        # A heading is preserved if its text appears anywhere in the after-state
+        # OR if the content beneath it appears (restructuring allowed)
+        heading_in_after = f"{'#' * level} {heading_text}" in combined_after or heading_text in combined_after
+        if not heading_in_after:
+            # Check if content under the heading was migrated
+            section_body = extract_section_content(before_content, heading_text)
+            if section_body.strip() and not block_exists_in(section_body[:200], combined_after):
+                missing_headings.append((level, heading_text))
+
+    if verbose:
+        print(
+            f"  [headings] {len(substantive_headings) - len(missing_headings)}/{len(substantive_headings)} headings found"
+        )
+
+    for level, heading_text in missing_headings:
+        failures.append(
+            CheckFailure(
+                category="content-preservation",
+                check="heading-missing",
+                detail=f"Heading {'#' * level} {heading_text!r} not found and section content not in after-state",
+            )
+        )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Category 2: Route Completeness
+# ---------------------------------------------------------------------------
+
+# Matches any pipe-table row that contains a references/*.md path (2 or 3 column).
+# We don't require a specific column count — any row with a non-empty first cell
+# and a references/ path in any cell qualifies.
+_PIPE_ROW_PATTERN = re.compile(r"^\|(.+)\|$")
+_REF_PATH_PATTERN = re.compile(r"references/([^)\s|`>]+\.md)")
+
+
+def find_loading_table_entries(skill_content: str) -> dict[str, str]:
+    """Return {filename: row_text} for every loading table entry in SKILL.md.
+
+    Accepts 2-column format (| Signal | references/file.md |) and
+    3-column format (| Signal | Description | references/file.md |).
+    Skips separator rows (---|---) and header rows with no reference path.
+    """
+    entries: dict[str, str] = {}
+    for line in skill_content.split("\n"):
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        # Skip separator rows
+        if re.match(r"\|[\s\-:|]+\|", stripped):
+            continue
+        # Look for a references/ path anywhere in this row
+        ref_match = _REF_PATH_PATTERN.search(stripped)
+        if not ref_match:
+            continue
+        # Extract first cell as signal — must be non-empty
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if not cells or not cells[0]:
+            continue
+        # Skip header rows that say "Signal" / "Load" / "Query" etc.
+        if cells[0].lower() in {"signal", "query", "trigger", "keyword", "when", "condition"}:
+            continue
+        fname = ref_match.group(1)
+        entries[fname] = stripped
+    return entries
+
+
+def check_route_completeness(
+    new_skill_content: str,
+    refs_dir: Path,
+    new_ref_names: list[str] | None,
+    verbose: bool,
+) -> list[CheckFailure]:
+    """Verify every new reference file has a loading table entry in the new SKILL.md."""
+    failures: list[CheckFailure] = []
+
+    if new_ref_names is not None:
+        candidate_names = new_ref_names
+    else:
+        candidate_names = [f.name for f in refs_dir.glob("*.md")]
+
+    loading_entries = find_loading_table_entries(new_skill_content)
+
+    if verbose:
+        print(f"  [route-completeness] Loading table entries found: {sorted(loading_entries.keys())}")
+        print(f"  [route-completeness] New reference files to check: {sorted(candidate_names)}")
+
+    for ref_name in sorted(candidate_names):
+        if ref_name not in loading_entries:
+            failures.append(
+                CheckFailure(
+                    category="route-completeness",
+                    check="missing-loading-table-entry",
+                    detail=f"No loading table row found for references/{ref_name} in new SKILL.md",
+                    location=str(refs_dir / ref_name),
+                )
+            )
+        else:
+            # Verify signal cell is non-empty (already checked above in find_loading_table_entries)
+            if verbose:
+                print(f"    OK: {ref_name} -> {loading_entries[ref_name][:60]}")
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Category 3: Structure Preservation
+# ---------------------------------------------------------------------------
+
+
+def check_structure_preservation(
+    new_skill_content: str,
+    new_skill_path: Path,
+    verbose: bool,
+) -> list[CheckFailure]:
+    """Verify the new SKILL.md retains required structural elements."""
+    failures: list[CheckFailure] = []
+
+    # --- YAML frontmatter ---
+    lines = new_skill_content.split("\n")
+    has_frontmatter = False
+    if lines and lines[0].strip() == "---":
+        for i, line in enumerate(lines[1:], start=1):
+            if line.strip() == "---":
+                has_frontmatter = True
+                break
+
+    if verbose:
+        print(f"  [structure] frontmatter: {'present' if has_frontmatter else 'MISSING'}")
+
+    if not has_frontmatter:
+        failures.append(
+            CheckFailure(
+                category="structure-preservation",
+                check="missing-frontmatter",
+                detail="YAML frontmatter (--- delimiters) not found in new SKILL.md",
+                location=str(new_skill_path),
+            )
+        )
+
+    # --- Phase headings ---
+    phase_headings = [line for line in lines if re.match(r"^#{1,4}\s+Phase\s+\d+", line, re.IGNORECASE)]
+
+    if verbose:
+        print(f"  [structure] phase headings found: {len(phase_headings)}")
+
+    if not phase_headings:
+        failures.append(
+            CheckFailure(
+                category="structure-preservation",
+                check="missing-phase-headings",
+                detail="No '### Phase N' style headings found in new SKILL.md",
+                location=str(new_skill_path),
+            )
+        )
+
+    # --- Error handling section ---
+    error_heading = any(re.search(r"error", line, re.IGNORECASE) for line in lines if re.match(r"^#{1,6}\s+", line))
+
+    if verbose:
+        print(f"  [structure] error handling section: {'present' if error_heading else 'MISSING'}")
+
+    if not error_heading:
+        failures.append(
+            CheckFailure(
+                category="structure-preservation",
+                check="missing-error-section",
+                detail="No heading containing 'error' (case-insensitive) found in new SKILL.md",
+                location=str(new_skill_path),
+            )
+        )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def print_text_results(result: ValidationResult, verbose: bool) -> None:
+    """Print human-readable validation output."""
+    if result.ok:
+        print(f"PASS: {result.checks_passed}/{result.checks_run} checks passed, 0 failures")
+    else:
+        print(f"FAIL: {len(result.failures)} failure(s) across {result.checks_run} checks")
+        print()
+
+        by_category: dict[str, list[CheckFailure]] = {}
+        for f in result.failures:
+            by_category.setdefault(f.category, []).append(f)
+
+        for category, failures in sorted(by_category.items()):
+            print(f"  [{category}] {len(failures)} failure(s):")
+            for failure in failures:
+                loc = f" ({failure.location})" if failure.location else ""
+                print(f"    FAIL [{failure.check}]{loc}")
+                print(f"         {failure.detail}")
+
+
+def build_json_results(result: ValidationResult) -> dict:
+    """Build JSON-serializable result dict."""
+    return {
+        "ok": result.ok,
+        "checks_run": result.checks_run,
+        "checks_passed": result.checks_passed,
+        "failures": [
+            {
+                "category": f.category,
+                "check": f.check,
+                "detail": f.detail,
+                "location": f.location,
+            }
+            for f in result.failures
+        ],
+        "exit_code": 0 if result.ok else 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Entry point for decomposition validation CLI."""
+    parser = argparse.ArgumentParser(
+        description="Validate that a SKILL.md decomposition preserved all content",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--before",
+        required=True,
+        metavar="FILE",
+        help="Path to the original SKILL.md (before decomposition)",
+    )
+    parser.add_argument(
+        "--after",
+        required=True,
+        metavar="FILE",
+        help="Path to the new SKILL.md (after decomposition)",
+    )
+    parser.add_argument(
+        "--refs",
+        required=True,
+        metavar="DIR",
+        help="Path to the references/ directory containing extracted reference files",
+    )
+    parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Machine-readable JSON output",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Detailed per-check reporting",
+    )
+    parser.add_argument(
+        "--new-refs",
+        metavar="FILE1,FILE2,...",
+        help=(
+            "Comma-separated list of new reference filenames (e.g. patterns.md,errors.md). "
+            "If omitted, all .md files in --refs are checked for loading table entries."
+        ),
+    )
+    args = parser.parse_args()
+
+    before_path = Path(args.before)
+    after_path = Path(args.after)
+    refs_dir = Path(args.refs)
+
+    # Validate inputs
+    if not before_path.is_file():
+        print(f"ERROR: --before file not found: {before_path}", file=sys.stderr)
+        sys.exit(1)
+    if not after_path.is_file():
+        print(f"ERROR: --after file not found: {after_path}", file=sys.stderr)
+        sys.exit(1)
+    if not refs_dir.is_dir():
+        print(f"ERROR: --refs directory not found: {refs_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    new_ref_names: list[str] | None = None
+    if args.new_refs:
+        new_ref_names = [n.strip() for n in args.new_refs.split(",") if n.strip()]
+
+    # Read files
+    before_content = before_path.read_text(encoding="utf-8")
+    after_content = after_path.read_text(encoding="utf-8")
+
+    ref_contents: dict[str, str] = {}
+    for ref_file in sorted(refs_dir.glob("*.md")):
+        ref_contents[ref_file.name] = ref_file.read_text(encoding="utf-8")
+
+    # Build combined after-state for content presence checks
+    combined_after = after_content + "\n" + "\n".join(ref_contents.values())
+
+    result = ValidationResult()
+
+    # Category 1: Content Preservation
+    if args.verbose:
+        print("Category 1: Content Preservation")
+    cat1_checks = 3  # code blocks, tables, headings
+    cat1_failures = check_content_preservation(before_content, combined_after, args.verbose)
+    result.checks_run += cat1_checks
+    result.checks_passed += cat1_checks - len({f.check for f in cat1_failures})
+    result.failures.extend(cat1_failures)
+
+    # Category 2: Route Completeness
+    if args.verbose:
+        print("Category 2: Route Completeness")
+    candidate_count = len(new_ref_names) if new_ref_names is not None else len(ref_contents)
+    cat2_failures = check_route_completeness(after_content, refs_dir, new_ref_names, args.verbose)
+    result.checks_run += max(candidate_count, 1)
+    result.checks_passed += max(candidate_count, 1) - len(cat2_failures)
+    result.failures.extend(cat2_failures)
+
+    # Category 3: Structure Preservation
+    if args.verbose:
+        print("Category 3: Structure Preservation")
+    cat3_checks = 3  # frontmatter, phase headings, error section
+    cat3_failures = check_structure_preservation(after_content, after_path, args.verbose)
+    result.checks_run += cat3_checks
+    result.checks_passed += cat3_checks - len(cat3_failures)
+    result.failures.extend(cat3_failures)
+
+    # Output
+    if args.json_output:
+        output = build_json_results(result)
+        print(json.dumps(output, indent=2))
+        sys.exit(output["exit_code"])
+    else:
+        print_text_results(result, args.verbose)
+        sys.exit(0 if result.ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/reference-enrichment/SKILL.md
+++ b/skills/reference-enrichment/SKILL.md
@@ -3,7 +3,7 @@ name: reference-enrichment
 description: "Analyze agent/skill reference depth and generate missing domain-specific reference files."
 version: 1.0.0
 user-invocable: true
-argument-hint: "<agent-or-skill-name>"
+argument-hint: "<agent-or-skill-name> [--decompose]"
 allowed-tools:
   - Read
   - Write
@@ -19,6 +19,11 @@ routing:
     - "generate references"
     - "add reference files"
     - "reference enrichment"
+    - "decompose skill"
+    - "extract references"
+    - "slim down skill"
+    - "skill too long"
+    - "move content to references"
   category: meta-tooling
   complexity: medium
   pairs_with:
@@ -27,11 +32,69 @@ routing:
 
 # Reference Enrichment Skill
 
-Enrich an agent or skill's reference files from Level 0-2 to Level 3+. The pipeline runs five
-phases with explicit gates because each phase feeds the next — starting Phase 3 without Phase 2
-research produces filler, not depth.
+Enrich an agent or skill's reference files from Level 0-2 to Level 3+, or decompose bloated body
+files by extracting domain content into references. Enrichment adds knowledge; decomposition moves
+knowledge to where progressive disclosure says it belongs. The enrichment pipeline runs five phases
+with explicit gates because each phase feeds the next — starting Phase 3 without Phase 2 research
+produces filler, not depth.
 
 ## Workflow
+
+### Phase 0: DECOMPOSE
+
+**Goal**: Extract domain-heavy content from a bloated SKILL.md or agent body into reference files.
+
+**When to use**: When a component's body exceeds ~500 lines and contains catalogs, code examples, specification tables, or agent rosters that should live in `references/` per PHILOSOPHY.md's progressive disclosure architecture.
+
+**Trigger**: Invoke with `--decompose` argument, or when the request matches "decompose", "extract references", "slim down", "too long", or "move to references".
+
+1. Run the detection script to identify extractable content:
+   ```bash
+   python3 scripts/detect-decomposition-targets.py --skill {name}
+   ```
+   (or `--agent {name}`)
+
+2. If no extractable blocks found, report "nothing to decompose" and stop
+
+3. Save a snapshot of the original file: `cp {path} /tmp/decomp-before-{name}.md`
+
+4. For each extractable block identified by the detection script:
+   a. Read the content block and its surrounding context
+   b. Determine the best reference filename:
+      - Use the detection script's suggestion as a starting point
+      - If a reference file with related content already exists, MERGE into it
+      - Follow naming convention: `references/{topic}.md` (lowercase, hyphens)
+   c. Create or update the reference file following `references/reference-file-template.md`
+   d. Remove the content from the body (MOVE, not copy)
+   e. Add a loading table entry in the body that maps task signals to the new reference file
+
+5. Ensure the body retains:
+   - YAML frontmatter
+   - Brief overview paragraph
+   - Phase workflow (phases, gates, decision points)
+   - Loading table with entries for all reference files
+   - Error handling section
+   - References section
+
+6. Validate the decomposition:
+   ```bash
+   python3 scripts/validate-decomposition.py \
+       --before /tmp/decomp-before-{name}.md \
+       --after {path} \
+       --refs {refs_dir}/
+   ```
+
+7. If validation FAILS: restore from snapshot and report the failure. Do not proceed.
+
+8. If validation PASSES: run structural checks:
+   ```bash
+   python3 scripts/validate-references.py --skill {name}  # or --agent {name}
+   python3 scripts/audit-reference-depth.py --skill {name} --verbose  # or --agent {name}
+   ```
+
+**Gate**: Validation passes. Body line count reduced. All extracted content exists in reference files. Loading table entries exist for all new references.
+
+---
 
 ### Phase 1: DISCOVER
 
@@ -150,6 +213,7 @@ Load when the task type matches:
 |-----------|------|
 | Understanding Level 0-3 criteria | `references/quality-rubric.md` |
 | Creating new reference files | `references/reference-file-template.md` |
+| Decomposing bloated components | Run `python3 scripts/detect-decomposition-targets.py --skill {name}` first |
 
 ---
 
@@ -168,3 +232,8 @@ that section specifically.
 
 **validate-references.py not found**: Script may not exist for this component. Skip that check,
 proceed with `audit-reference-depth.py` as the sole Tier 1 gate.
+
+**Decomposition validation fails**: Content was lost during extraction. Restore from the
+snapshot at `/tmp/decomp-before-{name}.md`. Check that each extracted content block appears
+in a reference file. Common cause: a code block was partially extracted or a table was split
+across the body and a reference file.

--- a/skills/reference-enrichment/decomposition-prompt.md
+++ b/skills/reference-enrichment/decomposition-prompt.md
@@ -1,0 +1,205 @@
+# Reference Decomposition — Headless Prompt
+
+You are running as an autonomous process to improve the toolkit's progressive disclosure architecture. This is the inverse of enrichment: instead of ADDING reference files, you EXTRACT content from bloated SKILL.md and agent files into properly structured reference files.
+
+The goal is to keep agent/skill bodies lean (workflow, phases, routing) while domain knowledge lives in reference files loaded on demand.
+
+## Context
+
+- **Date:** ${DECOMP_DATE}
+- **Run ID:** ${DECOMP_RUN_ID}
+- **Repository:** ${DECOMP_REPO_DIR}
+- **Worktree:** ${DECOMP_WORKTREE}
+- **Targets:** ${DECOMP_TARGETS}
+- **Max targets:** ${DECOMP_MAX_TARGETS}
+- **Dry-run mode:** ${DECOMP_DRY_RUN_MODE}
+
+These targets were identified by the detection script as containing extractable content blocks (catalogs, examples, specs, rosters) that belong in reference files rather than the main body. Each target includes file paths, content types, line ranges, and suggested reference filenames.
+
+## If Dry-Run Mode is "yes"
+
+Only perform the audit analysis. For each target:
+1. Read the target file and measure its current line count
+2. Identify which content blocks are extractable (catalogs, example tables, anti-pattern lists, spec sections, rosters)
+3. Check for existing reference files that could absorb the content
+4. Report what WOULD be decomposed: block types, estimated line counts, suggested reference filenames
+5. Do NOT create any files, branches, or PRs
+
+Print a summary and exit.
+
+## If Dry-Run Mode is "no"
+
+### Phase 1: Setup
+
+1. Check for existing open decomposition PRs: `gh pr list --search "decomp/refs" --state open --json number | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d))"`
+2. If 3 or more decomposition PRs are already open, log "Too many open decomposition PRs (>=3), skipping to avoid accumulation" and exit. Decomposition changes are larger than enrichment, so the threshold is lower.
+3. Verify you are running inside the worktree path (should contain /tmp/decomp-worktree):
+   - Run `pwd` to confirm you're in the worktree path
+   - Run `git log --oneline -1` to confirm you're at the expected HEAD
+4. Create a feature branch: `git checkout -b decomp/refs-${DECOMP_RUN_ID}`
+
+### Phase 2: Decompose Each Target
+
+Process up to ${DECOMP_MAX_TARGETS} targets from the targets list. For each target:
+
+1. **Save a snapshot** before any modifications:
+   ```bash
+   cp {path} /tmp/decomp-before-{component}.md
+   ```
+
+2. **Read the current file** (SKILL.md or agent body) and note its line count.
+
+3. **Read the detection script output** in the target data to understand what content blocks are extractable: their types, line ranges, and suggested reference filenames.
+
+4. **Read any existing reference files** in the component's `references/` directory to avoid creating duplicates. If a reference file with related content already exists, you will MERGE into it rather than creating a new file.
+
+5. **Read the reference file template** at `skills/reference-enrichment/references/reference-file-template.md` for the standard structure that new reference files must follow.
+
+6. **For each extractable block**, perform the extraction:
+
+   a. **Determine the reference filename.** Use the detection script's suggestion as a starting point. Follow the naming convention: `{domain}-{topic}.md` (e.g., `go-anti-patterns.md`, `voice-banned-patterns.md`).
+
+   b. **Check for merge targets.** If a reference file with related content already exists, MERGE into it instead of creating a duplicate. Two files covering the same sub-domain is worse than one longer file.
+
+   c. **Create or update the reference file** with the extracted content. Ensure it follows the reference file template structure: scope header, overview, pattern tables, anti-pattern catalog, etc. Maximum 500 lines per reference file. If content would exceed 500 lines, split into two reference files covering narrower sub-domains.
+
+   d. **Remove the content from the SKILL.md body.** The content is being MOVED, not copied. Do not leave the original content in place.
+
+   e. **Add a loading table entry** that maps task signals to the new reference file. The loading table tells the agent/skill when to load each reference. Format:
+      ```
+      | Signal/Task | Reference File | When to Load |
+      |-------------|---------------|--------------|
+      | {signal pattern} | `references/{filename}` | {condition} |
+      ```
+
+7. **Verify retained structure.** After extraction, confirm the SKILL.md still retains these essential sections:
+   - Frontmatter (title, description, etc.)
+   - Brief overview / purpose statement
+   - Phase workflow (if applicable)
+   - Loading table (with entries for all reference files, including new ones)
+   - Error handling / safety section (if applicable)
+
+8. **Run validation:**
+   ```bash
+   python3 scripts/validate-decomposition.py --before /tmp/decomp-before-{component}.md --after {path} --refs {refs_dir}/
+   ```
+
+9. **Run structural check** (if the validation script exists):
+   ```bash
+   python3 scripts/validate-references.py --skill {name}
+   ```
+   Or for agents: `python3 scripts/validate-references.py --agent {name}`
+
+10. **Run depth audit:**
+    ```bash
+    python3 scripts/audit-reference-depth.py --skill {name} --verbose
+    ```
+    Or for agents: `python3 scripts/audit-reference-depth.py --agent {name} --verbose`
+
+### Phase 2.5: Validate Decomposition (Keep-or-Revert Gate)
+
+For each decomposed target, evaluate whether the decomposition is valid:
+
+1. **Run validate-decomposition.py** and check the exit code:
+
+   - **Exit code 0 (PASS):** The decomposition is valid. KEEP all changes for this target.
+
+   - **Exit code 1 (FAIL):** The decomposition has issues.
+     - Check the error output. Common fixable issues:
+       - Missing loading table entry: add the entry and re-run validation
+       - Reference file missing scope header: add the header
+     - Attempt to fix the issue, then re-run validation
+     - If validation still fails after the fix attempt: REVERT by restoring from the snapshot:
+       ```bash
+       cp /tmp/decomp-before-{component}.md {path}
+       ```
+       Remove any reference files that were created for this target.
+
+2. **Check the resulting SKILL.md line count.** If the file is still above 500 lines after decomposition, log a warning:
+   ```
+   [WARN] {name}: still {N} lines after decomposition (target: <=500)
+   ```
+   This is a warning, not a failure. Some skills have legitimate large workflows that cannot be decomposed further.
+
+3. **Log the decision** for each target:
+   - `[KEEP] {name}: {N} blocks extracted, {before} -> {after} lines`
+   - `[REVERT] {name}: validation failed — {reason}`
+   - `[SKIP] {name}: {reason}`
+
+### Phase 3: Commit and PR
+
+If any targets were successfully decomposed (KEEP decisions exist):
+
+1. **Stage only modified and created files.** This includes:
+   - Modified SKILL.md / agent body files
+   - New or updated reference files in `references/` directories
+   - Do NOT stage unrelated files
+
+2. **Commit** with a descriptive message:
+   ```
+   refactor(refs): {component} — extract {N} content blocks into references ({before_lines}->{after_lines} lines)
+   ```
+   If multiple components were decomposed:
+   ```
+   refactor(refs): decompose {N} components — extract content blocks into references
+   ```
+
+3. **Push:**
+   ```bash
+   git push -u origin decomp/refs-${DECOMP_RUN_ID}
+   ```
+
+4. **Create PR:**
+   ```bash
+   gh pr create --title "refactor(refs): {component} — extract references ({before}->{after} lines)" --body "$(cat <<'EOF'
+   ## Reference Decomposition
+
+   Extracted content blocks from bloated skill/agent bodies into structured reference files.
+
+   ### Changes
+   - **{component}**: {before_lines} -> {after_lines} lines ({N} blocks extracted)
+     - `references/{filename1}`: {description}
+     - `references/{filename2}`: {description}
+
+   ### Validation
+   - validate-decomposition.py: PASS
+   - validate-references.py: PASS
+   - audit-reference-depth.py: Level {N}
+
+   *Automated decomposition run ${DECOMP_RUN_ID}*
+   EOF
+   )"
+   ```
+
+5. **Auto-merge:**
+   ```bash
+   gh pr merge --squash --auto --delete-branch
+   ```
+
+6. Do NOT run `git checkout main`. You are in a worktree and the primary checkout owns the main branch.
+
+## Safety Constraints
+
+- **Never modify skill/agent LOGIC.** Only move content and add routing. Workflow phases, gates, and decision points STAY in the SKILL.md. Only catalogs, examples, specs, and rosters move to reference files.
+- **Never delete content without first putting it in a reference file.** The operation is MOVE, not DELETE. Every line removed from a SKILL.md must appear in a reference file.
+- **Maximum 500 lines per reference file.** Split into narrower sub-domain files if needed.
+- **Content in `<!-- DO NOT OPTIMIZE -->` blocks must NOT be moved or modified.** These blocks are explicitly protected from decomposition.
+- **No force-push, no commits to main.** Everything goes through a PR.
+- **If anything fails, restore from snapshot and continue with the next target.** One failure should not abort the entire run.
+- **Preserve loading table integrity.** Every reference file must have a corresponding loading table entry in the parent skill/agent body.
+- **Validation gate is mandatory.** Never skip Phase 2.5, even if the decomposition "looks correct".
+
+## Output
+
+End your session with a summary:
+
+```
+=== Reference Decomposition Summary ===
+Date: {date}
+Targets processed: N/M
+  - {name}: {before_lines} -> {after_lines} lines ({N} blocks extracted to {M} reference files)
+  - {name}: SKIPPED ({reason})
+  - {name}: REVERTED ({reason})
+PR: {url or "none (dry-run)"}
+===
+```


### PR DESCRIPTION
## Summary

- Adds a **decomposition pipeline** that extracts domain-heavy content from bloated SKILL.md/agent files into reference files, then updates loading tables for on-demand loading
- This is the **inverse of enrichment**: enrichment adds references from external knowledge, decomposition moves existing content to where progressive disclosure says it belongs
- Extends the existing `reference-enrichment` system (One Domain, One Component)

**Grounding data:** The top 10 bloated skills (500+ lines) all already have `references/` directories but their SKILL.md bodies are still fat because enrichment only adds, never extracts. The detection script currently finds 6 targets with ~640 extractable lines.

## New files

| File | Lines | Purpose |
|------|-------|---------|
| `scripts/detect-decomposition-targets.py` | 329 | Deterministic content classifier (code blocks, tables, detection commands, agent rosters, error catalogs, spec tables) |
| `scripts/validate-decomposition.py` | 580 | Content-loss gate: verifies zero information lost during extraction |
| `skills/reference-enrichment/decomposition-prompt.md` | 205 | Headless prompt template for cron-dispatched decomposition runs |

## Modified files

| File | Change |
|------|--------|
| `scripts/reference-enrichment-cron.sh` | Add `--decompose` flag (mutually exclusive with `--execute`), same worktree/PR/safety patterns |
| `skills/reference-enrichment/SKILL.md` | Add Phase 0: DECOMPOSE with detection, extraction, validation, and keep-or-revert gate |

## PHILOSOPHY.md alignment

| Principle | How applied |
|-----------|------------|
| LLMs orchestrate, programs execute | Detection and validation are deterministic scripts; extraction uses LLM judgment |
| Load Only What You Need | Moves content from always-loaded bodies to on-demand reference files |
| One Domain, One Component | Extends existing reference-enrichment, not a new system |
| Both Deterministic AND LLM Evaluation | Script detection + LLM extraction + script validation |
| Everything Should Be a Pipeline | DETECT → EXTRACT → VALIDATE → COMMIT with gates |

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] `bash -n reference-enrichment-cron.sh` syntax OK
- [x] Detection script finds 6 targets at default 500-line threshold
- [x] Validation script: PASS 9/9 on real skill (adr-consultation)
- [x] Validation script: correctly catches content loss (42 failures when code blocks stripped)
- [x] Cron mutual exclusivity: `--execute --decompose` correctly rejected