### PR TITLE
feat(refs): auto-dream — testing + logging references (Level 3→3+)

### DIFF
--- a/skills/auto-dream/SKILL.md
+++ b/skills/auto-dream/SKILL.md
@@ -143,3 +143,8 @@ Load these references when the task matches the signal:
 | Updating `MEMORY.md` index, atomic write, `.tmp` rename | `references/memory-file-operations.md` |
 | Staleness detection, duplicate merging, conflict flagging | `references/memory-file-operations.md` |
 | YAML frontmatter structure, `merged_from`, memory file format | `references/memory-file-operations.md` |
+| Testing the dream cycle safely, dry-run validation, output file verification | `references/dream-cycle-testing.md` |
+| Inspecting graduation candidates, snapshot testing, PIPESTATUS in test wrappers | `references/dream-cycle-testing.md` |
+| Reading and interpreting cron run logs, detecting silent failures | `references/logging-patterns.md` |
+| Log rotation, log directory structure, phase completion markers in logs | `references/logging-patterns.md` |
+| `last-dream.md` stale, missing injection payload, cron log empty | `references/logging-patterns.md` |

--- a/skills/auto-dream/references/dream-cycle-testing.md
+++ b/skills/auto-dream/references/dream-cycle-testing.md
@@ -1,0 +1,257 @@
+# Dream Cycle Testing Reference
+
+> **Scope**: Patterns for safely testing the auto-dream cycle — dry-run validation, output verification, phase isolation, and graduation candidate inspection. Does NOT cover production execution or memory file authoring.
+> **Version range**: All toolkit versions with `scripts/auto-dream-cron.sh` and the 7-phase dream prompt
+> **Generated**: 2026-04-16 — verify script flags against `./scripts/auto-dream-cron.sh --help`
+
+---
+
+## Overview
+
+Testing the dream cycle is high-stakes: a mis-run writes to real memory files, archives active memories, and commits graduation branches. The safe testing model is dry-run first, inspect outputs in `~/.claude/state/`, then run a live cycle against a snapshot copy of your memory directory. Never run `--execute` against your live memory directory without reading the dry-run report first.
+
+---
+
+## Pattern Table
+
+| Test Goal | Command | Safe? |
+|-----------|---------|-------|
+| Full dry-run (no mutations) | `./scripts/auto-dream-cron.sh` | Yes — default mode |
+| Read what would be consolidated | `cat ~/.claude/state/last-dream.md` | Yes |
+| Inspect graduation candidates without graduating | SQLite query (see below) | Yes |
+| Live cycle against a snapshot | `DREAM_MEMORY_DIR=/tmp/test-memory ./scripts/auto-dream-cron.sh --execute` | Yes, safe |
+| Live cycle against real memory | `./scripts/auto-dream-cron.sh --execute` | Use with caution |
+| Check cron registration | `python3 ~/.claude/scripts/crontab-manager.py verify --tag auto-dream` | Yes |
+
+---
+
+## Correct Patterns
+
+### Dry-run validation — verifying scan and analysis
+
+The default invocation is always read-only:
+
+```bash
+# Run dry-run (no --execute = no filesystem mutations to memory files)
+./scripts/auto-dream-cron.sh
+
+# Verify the scan document was written
+ls -la ~/.claude/state/dream-scan-*.md | tail -1
+
+# Verify the analysis document was written
+ls -la ~/.claude/state/dream-analysis-*.md | tail -1
+
+# Read the consolidated report (written in all modes)
+cat ~/.claude/state/last-dream.md
+```
+
+**Why**: Dry-run still executes SCAN and ANALYZE phases fully — reading memory files, querying SQLite, reading git log — but CONSOLIDATE and SYNTHESIZE only describe proposed changes without writing them. The report file (`last-dream.md`) is always written, so you see exactly what a live run would do.
+
+---
+
+### Inspecting graduation candidates before GRADUATE runs
+
+```bash
+# Query graduation candidates directly — no dream cycle needed
+python3 -c "
+import sys; sys.path.insert(0, 'hooks/lib')
+from learning_db_v2 import query_graduation_candidates
+import json
+candidates = query_graduation_candidates()
+print(json.dumps(candidates, indent=2))
+"
+
+# Count graduation-ready entries (confidence >= 0.9, 3+ observations)
+sqlite3 ~/.claude/learning.db "
+  SELECT pattern_key, confidence, observation_count
+  FROM patterns
+  WHERE confidence >= 0.9 AND observation_count >= 3
+  ORDER BY confidence DESC LIMIT 10;
+"
+
+# Check if any graduation branches already exist from a prior run
+git branch --list 'dream/graduate-*'
+```
+
+**Why**: The GRADUATE phase only runs when entries meet both thresholds (confidence >= 0.9 AND 3+ observations). Checking first prevents surprises and lets you inspect what would be promoted before the dream cycle touches agent files. If a graduation branch already exists, the new cycle skips GRADUATE to avoid duplicate branches.
+
+---
+
+### Safe live testing with a memory snapshot
+
+To test CONSOLIDATE and SYNTHESIZE without risk to real memories:
+
+```bash
+# 1. Copy your real memory directory to a temp location
+SNAP="/tmp/test-dream-memory-$(date +%Y%m%d)"
+cp -r ~/.claude/projects/-home-feedgen-claude-code-toolkit/memory/ "${SNAP}/"
+
+# 2. Run a live cycle against the snapshot only
+DREAM_MEMORY_DIR="${SNAP}" ./scripts/auto-dream-cron.sh --execute
+
+# 3. Inspect what changed in the snapshot
+diff -r ~/.claude/projects/-home-feedgen-claude-code-toolkit/memory/ "${SNAP}/"
+
+# 4. Read the report (always written to ~/.claude/state/)
+cat ~/.claude/state/last-dream.md
+```
+
+**Why**: `DREAM_MEMORY_DIR` overrides the default memory path set by the wrapper script via `envsubst`. All CONSOLIDATE and SYNTHESIZE operations happen in the snapshot, leaving real memories untouched. The state directory (`~/.claude/state/`) still receives report files — this is expected and safe.
+
+---
+
+### Verifying output file structure after a run
+
+```bash
+DATE=$(date +%Y-%m-%d)
+STATE_DIR="${HOME}/.claude/state"
+
+# Scan document (SCAN phase, all modes)
+[ -f "${STATE_DIR}/dream-scan-${DATE}.md" ] && echo "PASS: scan doc" || echo "FAIL: scan doc missing"
+
+# Analysis document (ANALYZE phase, all modes)
+[ -f "${STATE_DIR}/dream-analysis-${DATE}.md" ] && echo "PASS: analysis doc" || echo "FAIL: analysis doc missing"
+
+# Report (REPORT phase, all modes)
+[ -f "${STATE_DIR}/last-dream.md" ] && echo "PASS: report" || echo "FAIL: report missing"
+
+# Injection payload (SELECT phase, all modes — read-only)
+HASH=$(echo "/home/feedgen/claude-code-toolkit" | md5sum | cut -c1-8)
+[ -f "${STATE_DIR}/dream-injection-${HASH}.md" ] && echo "PASS: injection payload" || echo "FAIL: injection payload missing"
+```
+
+**Why**: A dry-run that produces no output files means something failed silently. SCAN and ANALYZE always produce their dated documents. A missing `last-dream.md` means REPORT did not complete — check the cron log for the error. A missing injection payload means SELECT failed, and the next session will start without memory context.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Running `--execute` without reading the dry-run report first
+
+**Detection**:
+```bash
+# Look for --execute runs in cron logs without a preceding dry-run same day
+grep -l 'execute' cron-logs/auto-dream/run-*.log | while read f; do
+  date=$(basename "$f" | grep -oP '\d{4}-\d{2}-\d{2}')
+  grep -l "dry" cron-logs/auto-dream/run-*${date}*.log 2>/dev/null || echo "No dry-run: $f"
+done
+```
+
+**What it looks like**:
+```bash
+./scripts/auto-dream-cron.sh --execute  # What will it consolidate? Unknown.
+```
+
+**Why wrong**: The dream cycle can archive active memories if it mis-classifies them as stale. Without reading the dry-run report, you don't know which memories are flagged for archiving until they're already moved. New memory files that haven't appeared in recent sessions yet may have all three staleness signals trip at once.
+
+**Fix**:
+```bash
+./scripts/auto-dream-cron.sh              # Step 1: dry run
+cat ~/.claude/state/last-dream.md         # Step 2: read what would happen
+./scripts/auto-dream-cron.sh --execute    # Step 3: proceed if report looks correct
+```
+
+---
+
+### ❌ Testing with learning.db missing
+
+**Detection**:
+```bash
+ls -la ~/.claude/learning.db 2>/dev/null || echo "MISSING: learning.db"
+
+# Check if the last dream report noted a SQLite failure
+grep -i 'sqlite\|database\|learning.db\|failed' ~/.claude/state/last-dream.md | head -5
+```
+
+**What it looks like**:
+```
+## Dream Report: 2026-04-16
+
+SCAN: Read 28 memory files.
+SQLite query failed: unable to open database file
+ANALYZE: Cross-session patterns: none (no session data available)
+```
+
+**Why wrong**: When learning.db is missing, SCAN notes the failure and continues — the cycle does not abort. But ANALYZE then lacks session data, so SYNTHESIZE produces low-quality or no cross-session insights. A silent SQLite failure looks like a successful run when it's actually missing half its input.
+
+**Fix**:
+```bash
+# Verify learning.db exists before testing
+[ -f ~/.claude/learning.db ] || echo "Run at least one Claude Code session with hooks enabled"
+
+# Count sessions available to dream
+sqlite3 ~/.claude/learning.db \
+  "SELECT COUNT(*) FROM sessions WHERE start_time > datetime('now', '-7 days');"
+```
+
+---
+
+### ❌ Wrapping cron script output and losing the exit code
+
+**Detection**:
+```bash
+# In any custom test scripts that pipe auto-dream-cron.sh output:
+grep -n '\$?' test*.sh 2>/dev/null | grep -v 'PIPESTATUS'
+```
+
+**What it looks like**:
+```bash
+./scripts/auto-dream-cron.sh --execute | tee test-output.log
+echo "Exit: $?"  # Always 0 — tee's exit code, not claude's
+```
+
+**Why wrong**: The wrapper script handles `PIPESTATUS[0]` internally, but a custom test wrapper that pipes the cron script inherits the same problem. `$?` after a pipe reflects the last command (`tee`), not the cron script. A Claude session that errors mid-run silently appears as success.
+
+**Fix**:
+```bash
+./scripts/auto-dream-cron.sh --execute 2>&1 | tee test-output.log
+CRON_EXIT="${PIPESTATUS[0]}"
+echo "Dream exit code: ${CRON_EXIT}"
+[ "${CRON_EXIT}" -eq 0 ] && echo "PASS" || echo "FAIL"
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error / Symptom | Root Cause | Fix |
+|-----------------|------------|-----|
+| No scan document after dry-run | SCAN phase failed; check cron log | `ls -t cron-logs/auto-dream/run-*.log \| head -1 \| xargs tail -50` |
+| No injection payload file | SELECT phase skipped or DREAM_PROJECT_HASH wrong | Verify `DREAM_PROJECT_HASH`; check state dir path |
+| `last-dream.md` unchanged from prior run | Lockfile blocked the run (prior run still active) | `rm /tmp/auto-dream.lock` then retry |
+| Dry-run shows 0 memories scanned | `DREAM_MEMORY_DIR` path wrong | Check envsubst output; verify memory dir exists with `ls` |
+| `query_graduation_candidates` ImportError | `hooks/lib` not on `sys.path` | Add `sys.path.insert(0, 'hooks/lib')` before import |
+| Graduation branch already exists | Prior GRADUATE phase left the branch | Review branch then `git branch -d dream/graduate-YYYY-MM-DD` |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Check all expected output files exist after a run
+ls ~/.claude/state/dream-{scan,analysis}-$(date +%Y-%m-%d).md 2>/dev/null
+
+# Read the last dream report
+cat ~/.claude/state/last-dream.md
+
+# Count active graduation candidates
+sqlite3 ~/.claude/learning.db \
+  "SELECT COUNT(*) FROM patterns WHERE confidence >= 0.9 AND observation_count >= 3;"
+
+# Check for graduation branches
+git branch --list 'dream/graduate-*'
+
+# Read the most recent cron run log
+ls -t cron-logs/auto-dream/run-*.log | head -1 | xargs tail -50
+
+# Verify cron is registered
+python3 ~/.claude/scripts/crontab-manager.py verify --tag auto-dream
+```
+
+---
+
+## See Also
+
+- `skills/auto-dream/references/headless-cron-patterns.md` — wrapper script, lockfile, budget cap, dry-run toggle
+- `skills/auto-dream/references/memory-file-operations.md` — what CONSOLIDATE and SYNTHESIZE write
+- `skills/auto-dream/dream-prompt.md` — the full 7-phase prompt with safety constraints

--- a/skills/auto-dream/references/logging-patterns.md
+++ b/skills/auto-dream/references/logging-patterns.md
@@ -1,0 +1,251 @@
+# Dream Logging Patterns Reference
+
+> **Scope**: Log structure, output interpretation, and rotation patterns for the auto-dream cron process. Covers `cron-logs/auto-dream/`, the `~/.claude/state/` report files, and common failure signatures in log output. Does NOT cover the memory file format or wrapper script invocation.
+> **Version range**: All toolkit versions using `scripts/auto-dream-cron.sh` with `tee` dual-logging
+> **Generated**: 2026-04-16 — verify log paths against `scripts/auto-dream-cron.sh`
+
+---
+
+## Overview
+
+The dream cycle writes to two places: timestamped per-run logs in `cron-logs/auto-dream/` (raw Claude output via `tee`) and structured state files in `~/.claude/state/` (scan, analysis, report, injection payload). Diagnosing a failed dream run requires reading both: the cron log shows what Claude said; the state files show what it wrote. Silent failures — where the cron log is empty but the cycle shows success — are the most common and most dangerous failure mode.
+
+---
+
+## Log Directory Structure
+
+```
+cron-logs/auto-dream/
+  run-2026-04-16-020712.log   # timestamped per-run (tee output)
+  run-2026-04-15-020708.log
+  ...
+
+~/.claude/state/
+  dream-scan-2026-04-16.md        # SCAN phase output (all modes)
+  dream-analysis-2026-04-16.md    # ANALYZE phase output (all modes)
+  last-dream.md                   # REPORT phase — most recent run (overwritten each cycle)
+  dream-injection-{hash}.md       # SELECT phase — session-start payload
+```
+
+The `run-*.log` files are the raw Claude output stream. The `~/.claude/state/` files are structured artifacts written by the dream prompt itself. Both must exist for a run to be considered successful.
+
+---
+
+## Pattern Table
+
+| Log Scenario | What it means | Where to look |
+|-------------|---------------|---------------|
+| Log file exists, has content, exit 0 | Normal successful run | Check `last-dream.md` for summary |
+| Log file exists, empty, exit 0 | Silent failure — Claude did not emit output | `cron-logs/auto-dream/` + check lockfile |
+| Log file exists, has content, exit non-zero | Claude ran but errored | Check log for "error" or "budget exceeded" |
+| Log file missing entirely | Cron job did not fire or PATH issue | `crontab -l` + `crontab-manager.py verify` |
+| `last-dream.md` is stale (old date) | Cycle did not complete REPORT phase | Check run log for interruption |
+
+---
+
+## Correct Patterns
+
+### Reading the most recent run log
+
+```bash
+# Find and tail the most recent per-run log
+ls -t cron-logs/auto-dream/run-*.log | head -1 | xargs tail -100
+
+# Or stream it interactively during a manual run
+./scripts/auto-dream-cron.sh 2>&1 | tee /tmp/dream-watch.log
+tail -f /tmp/dream-watch.log
+```
+
+**Why**: The `run-*.log` files are sorted by filename timestamp. The most recent is always `ls -t ... | head -1`. During manual testing, piping to both `/tmp` and the screen lets you read output in real-time without waiting for the full cycle.
+
+---
+
+### Reading the structured dream report
+
+```bash
+# The report is always written to the same path (overwritten each cycle)
+cat ~/.claude/state/last-dream.md
+
+# Check the date in the report header to confirm it's from today
+head -3 ~/.claude/state/last-dream.md
+
+# Count memories processed vs deferred
+grep -E 'consolidated|archived|deferred|synthesized|graduated' ~/.claude/state/last-dream.md
+```
+
+**Why**: `last-dream.md` is overwritten each cycle, not versioned. It's the authoritative summary of what the most recent cycle did. The dated `dream-scan-` and `dream-analysis-` files preserve the per-cycle audit trail but require matching by date.
+
+---
+
+### Detecting a silent failure (empty log)
+
+```bash
+# Check the most recent log file size
+LAST_LOG=$(ls -t cron-logs/auto-dream/run-*.log | head -1)
+LOG_SIZE=$(wc -c < "${LAST_LOG}")
+echo "Log size: ${LOG_SIZE} bytes"
+[ "${LOG_SIZE}" -lt 100 ] && echo "WARNING: log is suspiciously small — possible silent failure"
+
+# Check the lockfile — is a prior run still holding it?
+flock -n /tmp/auto-dream.lock echo "Lock is free" 2>/dev/null || echo "LOCKED — prior run may still be active"
+
+# Verify the exit code was recorded in the log (some wrappers log it)
+grep -i 'exit\|budget\|error\|fail' "${LAST_LOG}" | tail -10
+```
+
+**Why**: A silent failure occurs when the lockfile blocks the run (exits immediately with code 0), when the Claude session is killed by the OS before emitting output, or when `--max-budget-usd` is hit before SCAN completes. An empty log with exit 0 is always suspicious — budget cap exits non-zero, but lockfile skip exits 0.
+
+---
+
+### Log rotation to prevent unbounded growth
+
+The cron job creates one log file per run. At nightly frequency, this is ~365 files/year. Without rotation, the directory grows indefinitely.
+
+```bash
+# Check current log count and disk usage
+ls cron-logs/auto-dream/run-*.log | wc -l
+du -sh cron-logs/auto-dream/
+
+# Manual cleanup: keep last 30 days of logs
+find cron-logs/auto-dream/ -name 'run-*.log' -mtime +30 -delete
+
+# Add to crontab-manager.py as a separate weekly cleanup job, or add to the wrapper:
+# At the end of scripts/auto-dream-cron.sh:
+find "${LOG_DIR}" -name 'run-*.log' -mtime +30 -delete
+```
+
+**Why**: Each log file is typically 5-50KB (one Claude session's output). At 365 files, this is 2-18MB — not critical but untidy. The `find -mtime +30 -delete` pattern keeps the last 30 days, which is sufficient for debugging any recurring issue. Run this as part of the wrapper script after the dream cycle exits.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Using `last-dream.md` date to confirm the cycle ran today
+
+**Detection**:
+```bash
+# Check if last-dream.md date matches today's cron log
+grep '^# Dream Report' ~/.claude/state/last-dream.md
+ls -t cron-logs/auto-dream/run-*.log | head -1
+```
+
+**What it looks like**:
+```bash
+head -1 ~/.claude/state/last-dream.md
+# Dream Report: 2026-04-15   ← yesterday's date, today's cron supposedly ran
+```
+
+**Why wrong**: `last-dream.md` is written by the REPORT phase. If today's run was blocked by the lockfile (prior run still active) or crashed before REPORT, the file retains yesterday's content. The file date confirms the *last successful* cycle, not whether *today's* cycle ran.
+
+**Fix**:
+```bash
+# Cross-check the cron log timestamp with the report date
+echo "Cron log: $(ls -t cron-logs/auto-dream/run-*.log | head -1)"
+echo "Report date: $(head -1 ~/.claude/state/last-dream.md)"
+```
+
+---
+
+### ❌ Grepping raw cron log for success without checking report
+
+**Detection**:
+```bash
+# Scanning run log for "success" when the report might tell a different story
+grep 'success\|complete\|done' "$(ls -t cron-logs/auto-dream/run-*.log | head -1)"
+```
+
+**What it looks like**:
+```bash
+# Cron log says "SCAN complete" but CONSOLIDATE crashed halfway through
+grep 'complete' run-2026-04-16-020712.log
+# → "SCAN complete: 28 files read"
+# → "ANALYZE complete: 3 consolidation candidates"
+# (CONSOLIDATE then crashed — but grep found "complete" so we thought it worked)
+```
+
+**Why wrong**: The dream cycle writes "phase X complete" at the end of each phase. If CONSOLIDATE crashes mid-write, the log contains "ANALYZE complete" but no "CONSOLIDATE complete". Grepping for any "complete" produces a false positive.
+
+**Fix**:
+```bash
+# Check for ALL phase completions, not just any
+for phase in SCAN ANALYZE CONSOLIDATE SYNTHESIZE SELECT REPORT; do
+  grep -q "${phase}" "${LAST_LOG}" && echo "PASS: ${phase}" || echo "MISSING: ${phase}"
+done
+# Or simply read last-dream.md which only gets written if REPORT runs
+cat ~/.claude/state/last-dream.md | head -20
+```
+
+---
+
+### ❌ Logging dream output to a path that changes each run without cleanup
+
+**Detection**:
+```bash
+# Log directory growing without bounds
+ls cron-logs/auto-dream/run-*.log | wc -l
+# > 100 files suggests no rotation policy
+```
+
+**What it looks like**:
+```bash
+# Wrapper script creates new log each run but never deletes old ones
+RUN_LOG="${LOG_DIR}/run-$(date +%Y-%m-%d-%H%M%S).log"
+claude ... | tee "${RUN_LOG}"
+# No cleanup step — files accumulate forever
+```
+
+**Why wrong**: At nightly frequency, 365 log files/year is manageable, but after a few years the directory becomes hard to navigate and the disk usage is non-trivial. More importantly, missing a rotation policy means the first time you actually need to debug a failure, you have to scroll through hundreds of files to find the relevant one.
+
+**Fix**: Add to the end of the wrapper script:
+```bash
+# Rotate: keep last 30 days of logs
+find "${LOG_DIR}" -name 'run-*.log' -mtime +30 -delete
+```
+
+---
+
+## Error-Fix Mappings
+
+| Log Symptom | Root Cause | Fix |
+|-------------|------------|-----|
+| Log file empty, exit 0 | Lockfile skip (prior run active) | `flock -n /tmp/auto-dream.lock echo ok` — if locked, wait or remove stale lock |
+| Log file empty, exit non-zero | Claude failed to start (bad PATH, missing claude binary) | `which claude` in cron environment; add PATH to wrapper |
+| `last-dream.md` not updated today | REPORT phase did not run (cycle crashed earlier) | Read the dated cron log; look for last phase completion marker |
+| Log shows budget cap hit | `--max-budget-usd` reached before cycle completed | Check memory directory size; reduce scope or increase cap |
+| `dream-scan-YYYY-MM-DD.md` missing | SCAN phase failed or state dir doesn't exist | Verify `mkdir -p ${DREAM_STATE_DIR}` runs before SCAN |
+| Injection payload stale (old hash) | Repo path changed; `DREAM_PROJECT_HASH` changed | Re-run to regenerate; old payload is ignored after hash changes |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Most recent run log
+ls -t cron-logs/auto-dream/run-*.log | head -1 | xargs tail -100
+
+# Last dream report
+cat ~/.claude/state/last-dream.md
+
+# Check all phase markers in the last run
+LAST=$(ls -t cron-logs/auto-dream/run-*.log | head -1)
+for p in SCAN ANALYZE CONSOLIDATE SYNTHESIZE SELECT REPORT; do
+  grep -q "$p" "$LAST" && echo "OK: $p" || echo "MISSING: $p"
+done
+
+# Log directory size and count
+ls cron-logs/auto-dream/run-*.log | wc -l && du -sh cron-logs/auto-dream/
+
+# Lockfile state
+flock -n /tmp/auto-dream.lock echo "Lock free" 2>/dev/null || echo "LOCKED"
+
+# State files for today
+ls ~/.claude/state/dream-*-$(date +%Y-%m-%d).md 2>/dev/null
+```
+
+---
+
+## See Also
+
+- `skills/auto-dream/references/headless-cron-patterns.md` — PIPESTATUS capture, tee dual-logging, budget cap
+- `skills/auto-dream/references/dream-cycle-testing.md` — test patterns, dry-run validation
+- `scripts/auto-dream-cron.sh` — the wrapper script that produces the `run-*.log` files


### PR DESCRIPTION
## Summary

Enriches `skills/auto-dream` with two new Level 3 reference files covering testing and logging gaps identified by the gap analyzer.

## Targets processed

| Skill | Before | After | New reference files |
|-------|--------|-------|---------------------|
| auto-dream | Level 3 (2 refs) | Level 3+ (4 refs) | 2 |

## New reference files

**`references/dream-cycle-testing.md`** (257 lines)
- Dry-run validation patterns — safe defaults before `--execute`
- Snapshot testing — live cycle against a memory directory copy
- Graduation candidate inspection via SQLite without triggering GRADUATE phase
- Output file verification checklist (scan doc, analysis doc, report, injection payload)
- Anti-patterns: skipping dry-run, missing learning.db, losing exit code in test wrappers
- Error-fix mappings for 6 common test failure symptoms

**`references/logging-patterns.md`** (251 lines)
- Log directory structure (`cron-logs/auto-dream/` vs `~/.claude/state/`)
- Silent failure detection — empty log with exit 0 diagnosis
- Phase completion marker checking in raw cron logs
- Log rotation pattern (keep 30 days, delete older)
- Anti-patterns: trusting `last-dream.md` date as proof of today's run, grepping for any "complete"
- Error-fix mappings for 6 common log symptoms

**`SKILL.md` loading table** — 5 new signal entries mapping test and logging queries to the appropriate new references.

## Validation (Phase 2.5)

- [x] 3 domain-specific test queries verified against loading table signals
- [x] Both files contain concrete shell commands, detection commands, and error-fix tables
- [x] Neither file duplicates content already in `headless-cron-patterns.md` or `memory-file-operations.md`
- [x] All files under 500-line limit (257 and 251 lines)
- Decision: **[KEEP] auto-dream** — loading table correctly maps all gaps; references add concrete domain knowledge not in existing files