### PR TITLE
feat(refs): bluesky-reader AT Protocol references (Level 0→3)

### DIFF
--- a/skills/bluesky-reader/SKILL.md
+++ b/skills/bluesky-reader/SKILL.md
@@ -50,6 +50,15 @@ python3 ~/.claude/scripts/bluesky_reader.py feed --handle HANDLE --cursor CURSOR
 - Searching a profile's posts for mentions of a topic
 - Feeding Bluesky content into a news or content pipeline
 
+## Reference Loading
+
+| Task type | Load this reference |
+|-----------|-------------------|
+| Endpoint details, data shapes, pagination | `references/at-protocol-api.md` |
+| Debugging fetch errors, wrong output, missing posts | `references/at-protocol-anti-patterns.md` |
+| Extending the script with new endpoints or search | `references/at-protocol-api.md` |
+| Code review of AT Protocol Python code | `references/at-protocol-anti-patterns.md` |
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/bluesky-reader/references/at-protocol-anti-patterns.md
+++ b/skills/bluesky-reader/references/at-protocol-anti-patterns.md
@@ -1,0 +1,290 @@
+# AT Protocol Anti-Patterns
+
+> **Scope**: Common mistakes when reading Bluesky/AT Protocol data with Python and the public XRPC API
+> **Version range**: AT Protocol v1, all versions
+> **Generated**: 2026-04-16
+
+---
+
+## Overview
+
+The AT Protocol has several non-obvious gotchas: opaque cursor pagination (not offset-based),
+a `feed` key in author feeds vs `posts` in search results, DID vs handle disambiguation, and
+feed items that wrap posts inside `post` and `reason` sub-keys. Missing any of these silently
+returns incomplete or wrong data.
+
+---
+
+## Anti-Pattern Catalog
+
+### Using bsky.social for Public Reads
+
+**Detection**:
+```bash
+rg 'bsky\.social/xrpc' --type py
+grep -rn 'https://bsky.social/xrpc' --include="*.py"
+```
+
+**What it looks like**:
+```python
+# Wrong — bsky.social requires auth for most endpoints
+url = f"https://bsky.social/xrpc/app.bsky.feed.getAuthorFeed?actor={handle}"
+```
+
+**Why wrong**: `bsky.social` is a PDS (Personal Data Server) that requires JWT authentication
+for most endpoints. Unauthenticated requests return `HTTP 401: AuthRequired`. The public app
+view (`public.api.bsky.app`) is purpose-built for unauthenticated reads.
+
+**Fix**:
+```python
+# Correct — public app view, no auth needed
+url = f"https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor={handle}"
+```
+
+---
+
+### Offset-Based Pagination Instead of Cursor
+
+**Detection**:
+```bash
+grep -rn '\boffset\b' --include="*.py" | grep -i 'bsky\|atproto\|feed'
+grep -rn 'page\s*\*\s*limit\|skip=' --include="*.py"
+```
+
+**What it looks like**:
+```python
+# Wrong — AT Protocol has no offset parameter
+for page in range(10):
+    url = f"{BASE}/app.bsky.feed.getAuthorFeed?actor={handle}&limit=100&offset={page * 100}"
+    data = fetch_json(url)
+```
+
+**Why wrong**: The AT Protocol lexicon has no `offset` parameter — the API ignores it silently.
+All pagination is cursor-based. Passing `offset` fetches the same first page on every iteration.
+
+**Fix**:
+```python
+# Correct — use cursor from each response
+cursor = ""
+while True:
+    params = {"actor": handle, "limit": 100}
+    if cursor:
+        params["cursor"] = cursor
+    data = fetch_json(build_url("app.bsky.feed.getAuthorFeed", **params))
+    posts = data.get("feed", [])
+    if not posts:
+        break
+    cursor = data.get("cursor", "")
+    if not cursor:
+        break  # Final page
+```
+
+---
+
+### Using "posts" Key on Author Feed Response
+
+**Detection**:
+```bash
+grep -rn '\.get("posts"' --include="*.py" | grep -i 'author\|feed'
+grep -rn '\["posts"\]' --include="*.py"
+```
+
+**What it looks like**:
+```python
+# Wrong — getAuthorFeed uses "feed" key, not "posts"
+data = fetch_json(url)
+posts = data["posts"]  # KeyError or empty list
+```
+
+**Why wrong**: `getAuthorFeed` returns `{"feed": [...], "cursor": "..."}`. The `posts` key
+is only used by `searchPosts`. Confusing the two silently returns nothing.
+
+**Fix**:
+```python
+# getAuthorFeed
+data = fetch_json(url)
+items = data.get("feed", [])   # Each item is a FeedViewPost wrapper
+
+# searchPosts
+data = fetch_json(search_url)
+items = data.get("posts", [])  # Each item is a PostView directly
+```
+
+---
+
+### Accessing post.text Directly on a Feed Item
+
+**Detection**:
+```bash
+grep -rn 'item\["text"\]\|item\.get("text"' --include="*.py"
+grep -rn 'feed_item\["text"\]' --include="*.py"
+```
+
+**What it looks like**:
+```python
+# Wrong — feed items wrap the post data, text is nested
+for item in data["feed"]:
+    text = item["text"]  # KeyError — text lives at item["post"]["record"]["text"]
+```
+
+**Why wrong**: `getAuthorFeed` returns `FeedViewPost` objects, not raw posts. The actual post
+record is nested at `item["post"]["record"]`. The outer `item` holds `post`, `reason`, and
+`reply` sub-keys.
+
+**Fix**:
+```python
+for item in data.get("feed", []):
+    post_data = item.get("post", {})
+    record = post_data.get("record", {})
+    text = record.get("text", "")
+    author = post_data.get("author", {}).get("handle", "")
+    like_count = post_data.get("likeCount", 0)
+```
+
+---
+
+### Missing Repost Detection
+
+**Detection**:
+```bash
+grep -rn '"reason"' --include="*.py" | grep -v '#\|reason='
+# Should find code handling the reason key; absence means reposts are silently misattributed
+```
+
+**What it looks like**:
+```python
+# Wrong — treats reposts as original posts by the feed owner
+for item in data["feed"]:
+    handle = item["post"]["author"]["handle"]  # This is the ORIGINAL author, not reposter
+    print(f"@{handle}: {item['post']['record']['text']}")
+```
+
+**Why wrong**: When a user reposts, `item["reason"]["$type"]` is
+`"app.bsky.feed.defs#reasonRepost"` and `item["reason"]["by"]` holds the reposter's info.
+The `item["post"]["author"]` is always the original author. Without checking `reason`, every
+repost is presented as if the profile owner wrote it.
+
+**Fix**:
+```python
+for item in data.get("feed", []):
+    reason = item.get("reason", {})
+    is_repost = reason.get("$type", "") == "app.bsky.feed.defs#reasonRepost"
+    reposted_by = reason.get("by", {}).get("handle", "") if is_repost else ""
+
+    post = item.get("post", {})
+    author = post.get("author", {}).get("handle", "")
+    text = post.get("record", {}).get("text", "")
+
+    if is_repost:
+        print(f"[repost by @{reposted_by}] @{author}: {text}")
+    else:
+        print(f"@{author}: {text}")
+```
+
+---
+
+### Not URL-Encoding Handle Parameter
+
+**Detection**:
+```bash
+grep -rn 'actor={handle}\|actor={actor}\|f".*actor=' --include="*.py"
+# Check if urllib.parse.quote or urllib.request.quote is missing around the handle
+rg 'actor=\{' --type py
+```
+
+**What it looks like**:
+```python
+# Wrong — handle not encoded, will break for DID-based actors
+handle = "did:plc:abc123def456"
+url = f"{BASE}/app.bsky.feed.getAuthorFeed?actor={handle}&limit=30"
+# -> ...?actor=did:plc:abc123def456&limit=30
+# Colon in DID may be misinterpreted by proxies/CDNs
+```
+
+**Why wrong**: While most handles (`user.bsky.social`) survive unencoded, DID identifiers
+(`did:plc:...`, `did:web:...`) contain colons that some HTTP proxies interpret as port
+separators, producing corrupted requests. Always encode `actor` consistently.
+
+**Fix**:
+```python
+import urllib.request
+
+handle = "did:plc:abc123def456"
+encoded = urllib.request.quote(handle, safe="")
+url = f"{BASE}/app.bsky.feed.getAuthorFeed?actor={encoded}&limit=30"
+```
+
+---
+
+### Ignoring Timeout on urllib.request.urlopen
+
+**Detection**:
+```bash
+grep -rn 'urlopen(' --include="*.py" | grep -v 'timeout'
+```
+
+**What it looks like**:
+```python
+# Wrong — no timeout, hangs indefinitely on network stall
+with urllib.request.urlopen(req) as resp:
+    return json.loads(resp.read())
+```
+
+**Why wrong**: The Bluesky public API can stall under load. Without a timeout, the script
+hangs until the OS TCP timeout (often 2+ minutes), making the tool appear frozen.
+
+**Fix**:
+```python
+# Correct — 15 second timeout matches expected API response time
+with urllib.request.urlopen(req, timeout=15) as resp:
+    return json.loads(resp.read())
+```
+
+**Version note**: `timeout` parameter available in `urllib.request.urlopen` since Python 2.6.
+No version concern for Python 3.x.
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|---|---|---|
+| `KeyError: 'feed'` | Using `data["feed"]` without `.get()`, or response is an error dict | Use `data.get("feed", [])` and check for `data.get("error")` first |
+| `KeyError: 'text'` | Accessing text at wrong nesting level | Navigate `item["post"]["record"]["text"]` not `item["text"]` |
+| `HTTP 401: AuthRequired` | Using `bsky.social` base URL without auth | Switch to `public.api.bsky.app` |
+| `TimeoutError` | No timeout on `urlopen` | Add `timeout=15` to `urlopen` call |
+| `UnicodeDecodeError` | Emoji/non-ASCII in post text decoded with wrong charset | Use `resp.read().decode("utf-8")`, not `"ascii"` |
+| Infinite loop on pagination | Cursor not advancing (always passing empty cursor) | Ensure cursor is extracted from `data.get("cursor", "")` and passed to next request |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Wrong base URL
+rg 'bsky\.social/xrpc' --type py
+
+# Offset-based pagination
+grep -rn '\boffset\b' --include="*.py" | grep -i 'bsky\|atproto'
+
+# Wrong response key for author feed
+grep -rn '\.get("posts"' --include="*.py" | grep -i 'author\|feed'
+
+# Direct text access on feed item (wrong nesting)
+grep -rn 'item\["text"\]\|item\.get("text"' --include="*.py"
+
+# Missing repost detection
+grep -rn 'reason' --include="*.py"  # Expect at least one hit per fetch function
+
+# Unencoded actor parameter
+rg 'actor=\{(?!.*quote)' --type py
+
+# urlopen without timeout
+grep -rn 'urlopen(' --include="*.py" | grep -v 'timeout'
+```
+
+---
+
+## See Also
+
+- `at-protocol-api.md` — Endpoint reference, pagination patterns, data shapes

--- a/skills/bluesky-reader/references/at-protocol-api.md
+++ b/skills/bluesky-reader/references/at-protocol-api.md
@@ -1,0 +1,237 @@
+# AT Protocol API Reference
+
+> **Scope**: Bluesky/AT Protocol XRPC endpoint patterns, data shapes, pagination, and rate limits for public read-only access
+> **Version range**: AT Protocol v1 (lexicon `app.bsky.*`, `com.atproto.*`)
+> **Generated**: 2026-04-16 — verify endpoint behavior against current Bluesky API docs
+
+---
+
+## Overview
+
+The AT Protocol exposes XRPC (cross-resolver procedure call) endpoints under two base URLs:
+- **Public app view** (`public.api.bsky.app`): No auth, read-only, Bluesky-specific lexicons
+- **Personal data server** (`bsky.social`): Auth required, full read/write access
+
+For read-only content retrieval, prefer the public app view — it bypasses authentication and is
+more permissive with rate limits for unauthenticated clients.
+
+---
+
+## Endpoint Table
+
+| Endpoint | Auth | Limit param | Returns |
+|----------|------|-------------|---------|
+| `app.bsky.feed.getAuthorFeed` | No | `limit` (1-100) | Posts by a specific actor |
+| `app.bsky.feed.searchPosts` | No | `limit` (1-100) | Global full-text search results |
+| `app.bsky.actor.getProfile` | No | — | Profile metadata for one handle/DID |
+| `app.bsky.actor.searchActors` | No | `limit` (1-100) | Actor search by keyword |
+| `app.bsky.feed.getPostThread` | No | `depth` (0-1000) | Thread containing a post |
+| `com.atproto.identity.resolveHandle` | No | — | Resolve handle to DID |
+| `app.bsky.feed.getTimeline` | **Yes** | `limit` (1-100) | Authenticated user's home timeline |
+
+---
+
+## Correct Patterns
+
+### Building XRPC URLs
+
+XRPC endpoints map directly to URL paths. Always URL-encode the `actor` param — handles
+containing dots and colons will be misrouted without encoding.
+
+```python
+import urllib.request
+
+BASE = "https://public.api.bsky.app/xrpc"
+
+def build_url(lexicon: str, **params: str | int) -> str:
+    """Build a public XRPC request URL."""
+    encoded = "&".join(
+        f"{k}={urllib.request.quote(str(v))}" for k, v in params.items() if v
+    )
+    return f"{BASE}/{lexicon}?{encoded}" if encoded else f"{BASE}/{lexicon}"
+
+# Correct
+url = build_url("app.bsky.feed.getAuthorFeed", actor="user.bsky.social", limit=30)
+# -> https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=user.bsky.social&limit=30
+```
+
+**Why**: Handles like `did:plc:abc123` contain colons — without quoting, some HTTP clients
+split on the colon and corrupt the parameter.
+
+---
+
+### Cursor-Based Pagination
+
+The API uses opaque cursor strings, not page numbers. Store the cursor from each response
+and pass it in the next request.
+
+```python
+def fetch_all_posts(handle: str, max_posts: int = 500) -> list[dict]:
+    """Fetch posts across multiple pages using cursor pagination."""
+    posts: list[dict] = []
+    cursor = ""
+
+    while len(posts) < max_posts:
+        url = build_url(
+            "app.bsky.feed.getAuthorFeed",
+            actor=handle,
+            limit=100,
+            cursor=cursor,
+        )
+        data = fetch_json(url)
+        batch = data.get("feed", [])
+        if not batch:
+            break  # No more posts
+
+        posts.extend(batch)
+        cursor = data.get("cursor", "")
+        if not cursor:
+            break  # Last page
+
+    return posts[:max_posts]
+```
+
+**Why**: The cursor encodes server state. Reconstructing it from local data or using offset
+integers will return wrong results or raise `InvalidRequest`.
+
+---
+
+### Feed Filter for Posts-Only
+
+`getAuthorFeed` returns posts, replies, AND reposts by default. Use `filter` to narrow:
+
+```python
+url = build_url(
+    "app.bsky.feed.getAuthorFeed",
+    actor=handle,
+    limit=50,
+    filter="posts_no_replies",  # Only original posts
+)
+```
+
+| Filter value | Returns |
+|---|---|
+| `posts_with_replies` | Posts + replies (default) |
+| `posts_no_replies` | Only top-level posts, no replies |
+| `posts_with_media` | Posts containing images/video |
+| `posts_and_author_threads` | Posts + self-reply threads |
+
+---
+
+### AT URI to Web URL Conversion
+
+AT URIs (`at://did:plc:xxx/app.bsky.feed.post/rkey`) must be rewritten to `bsky.app` URLs
+for human-readable links. The rkey (record key) is the final path segment.
+
+```python
+def at_uri_to_url(uri: str, handle: str) -> str:
+    """Convert AT URI to bsky.app web URL.
+
+    at://did:plc:abc/app.bsky.feed.post/3kg7abc -> https://bsky.app/profile/handle/post/3kg7abc
+    """
+    parts = uri.split("/")
+    if len(parts) < 5:
+        return uri  # Malformed URI, return as-is
+    rkey = parts[-1]
+    return f"https://bsky.app/profile/{handle}/post/{rkey}"
+```
+
+**Why**: AT URIs use DIDs, not handles. Using the DID directly in the URL works but produces
+opaque links — handle-based URLs are stable and human-readable.
+
+---
+
+### Global Full-Text Search vs Local Filter
+
+The basic `search` command fetches all posts then filters locally. For keyword search
+across a profile's full history or across all of Bluesky, use `app.bsky.feed.searchPosts`:
+
+```python
+url = build_url(
+    "app.bsky.feed.searchPosts",
+    q="search terms here",
+    author="user.bsky.social",  # Scope to one author
+    limit=25,
+)
+data = fetch_json(url)
+posts = data.get("posts", [])  # Note: "posts" key, not "feed"
+```
+
+**Why**: Local filtering caps at the fetch limit (100 posts). `searchPosts` indexes the full
+post history and returns ranked results. Use it when you need historical coverage beyond 100 posts.
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---|---|---|
+| `HTTP 400: InvalidRequest` | Bad param value or missing required param | Check `actor` is URL-encoded; verify param names match lexicon |
+| `HTTP 400: UnknownActor` | Handle does not resolve or account is deleted | Verify handle spelling; try resolving with `resolveHandle` first |
+| `HTTP 429: RateLimitExceeded` | Too many requests from this IP | Add `time.sleep(1)` between pages; stay under ~100 req/min |
+| `HTTP 500: InternalServerError` | Transient server error | Retry after 5-15 seconds with exponential backoff |
+| `JSONDecodeError` on response | Server returned HTML error page instead of JSON | Check `Content-Type` header before parsing |
+
+---
+
+## Data Shape: FeedViewPost
+
+Each item in the `feed` array is a `FeedViewPost`. Key fields:
+
+```python
+# feed item structure (simplified)
+{
+    "post": {
+        "uri": "at://did:plc:xxx/app.bsky.feed.post/rkey",
+        "cid": "bafy...",
+        "author": {
+            "did": "did:plc:xxx",
+            "handle": "user.bsky.social",
+            "displayName": "User Name",
+        },
+        "record": {
+            "$type": "app.bsky.feed.post",
+            "text": "post content",
+            "createdAt": "2024-01-15T12:00:00.000Z",
+            "reply": {},   # Present if this is a reply
+            "embed": {},   # Present if post has images/links/quotes
+        },
+        "likeCount": 42,
+        "repostCount": 7,
+        "replyCount": 3,
+    },
+    "reason": {  # Only present for reposts
+        "$type": "app.bsky.feed.defs#reasonRepost",
+        "by": {"handle": "reposter.bsky.social"},
+    },
+    "reply": {  # Only present for replies
+        "root": {},
+        "parent": {},
+    }
+}
+```
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Find calls that use numeric offset instead of cursor (wrong pagination)
+grep -rn 'offset=' --include="*.py" | grep -i 'bsky\|bluesky\|atproto'
+
+# Find hardcoded bsky.social base URL (should use public.api.bsky.app for public reads)
+rg 'bsky\.social/xrpc' --type py
+
+# Find feed parsing that skips the 'reason' key (misses repost detection)
+grep -n 'feed_item\[.post.\]' --include="*.py" -r
+
+# Find missing cursor handling in fetch loops
+grep -B2 -A10 'getAuthorFeed' --include="*.py" -r | grep -c 'cursor'
+```
+
+---
+
+## See Also
+
+- `at-protocol-anti-patterns.md` — Common mistakes using the AT Protocol API
+- AT Protocol Lexicon browser: https://atproto.com/lexicons/app-bsky-feed


### PR DESCRIPTION
## Reference Enrichment — bluesky-reader

**Run:** 2026-04-16-0407 (automated hourly enrichment)

### Targets Processed

| Skill | Before | After | New Files |
|-------|--------|-------|-----------|
| bluesky-reader | Level 0 | Level 3 | 2 |

### New Reference Files

**`skills/bluesky-reader/references/at-protocol-api.md`**
- XRPC endpoint table (7 endpoints with auth requirements and limit ranges)
- Cursor-based pagination pattern with full code example
- Feed filter values (`posts_no_replies`, `posts_with_media`, etc.)
- AT URI to bsky.app URL conversion
- Global `searchPosts` vs local keyword filter comparison
- `FeedViewPost` data shape (post, reason, reply nesting)
- Error-fix mappings for HTTP 400/429/500 and JSONDecodeError

**`skills/bluesky-reader/references/at-protocol-anti-patterns.md`**
- Six anti-pattern entries, each with grep/rg detection commands:
  - Using `bsky.social` for public reads (needs auth, use `public.api.bsky.app`)
  - Offset-based pagination (AT Protocol is cursor-only)
  - Using `posts` key on author feed response (correct key is `feed`)
  - Accessing `item["text"]` directly (text is at `item["post"]["record"]["text"]`)
  - Missing repost detection (must check `item["reason"].$type`)
  - Unencoded `actor` parameter (breaks DID-based actors with colons)
  - Missing `timeout` on `urlopen` (hangs on network stall)
- Error-fix mappings for KeyError, HTTP 401, TimeoutError, UnicodeDecodeError

### Audit Results

- avg_line_count: 263.5 (threshold: 80)
- total_concrete_hits: 142 (threshold: 10)
- has_detection_commands: true
- specificity_score: 1.0 (both files)

### Validation Gate: KEEP

All three test queries correctly route through the loading table to concrete,
actionable patterns. No generic advice — every entry has a detection command,
code example, and behavioral explanation.