### PR TITLE
feat(refs): cobalt-core — concurrency and testing patterns (Level 2→3)

### DIFF
--- a/skills/cobalt-core/SKILL.md
+++ b/skills/cobalt-core/SKILL.md
@@ -37,6 +37,8 @@ Domain skill for the [cobaltcore-dev](https://github.com/cobaltcore-dev) project
 | Signal | Reference | Size |
 |--------|-----------|------|
 | kvm-exporter, metrics, prometheus, libvirt, hypervisor, collector, scrape, steal time, NUMA, cgroups, cloud hypervisor | `references/kvm-exporter.md` | ~800 lines |
+| goroutine, concurrency, semaphore, TryLock, sync.Map, race condition, socket exhaustion, scrape overlap, ClearScrapeCache | `references/concurrency-patterns.md` | ~200 lines |
+| test, mock, moq, unit test, E2E, Kind cluster, race detector, interface_mock_gen, test-metrics.sh | `references/testing-patterns.md` | ~200 lines |
 
 **Load greedily.** If the user's question touches any signal keyword, load the matching reference before responding. Multiple signals matching = load all matching references.
 

--- a/skills/cobalt-core/references/concurrency-patterns.md
+++ b/skills/cobalt-core/references/concurrency-patterns.md
@@ -1,0 +1,268 @@
+# Cobalt Core — Concurrency Patterns
+
+> **Scope**: Goroutine management, synchronization primitives, and scrape-safe concurrency as used in kvm-exporter. Does not cover general Go concurrency theory.
+> **Version range**: Go 1.21+ (uses `sync.Mutex.TryLock`, generics-ready patterns)
+> **Generated**: 2026-04-16 — verify against `internal/libvirt/` source
+
+---
+
+## Overview
+
+kvm-exporter collects metrics from 50–500+ KVM domains per scrape, each requiring libvirt RPC calls, /proc reads, and cgroup stat lookups. The concurrency model is built around: (1) goroutine-per-domain with a semaphore cap to prevent socket exhaustion, (2) `TryLock` to serialize overlapping Prometheus scrapes, and (3) tiered caching with `sync.Map` for cross-scrape state. Violating these patterns causes libvirt socket exhaustion, metric duplication, or stale data.
+
+---
+
+## Pattern Table
+
+| Pattern | Version | Use When | Avoid When |
+|---------|---------|----------|------------|
+| `sync.Mutex.TryLock()` | Go 1.18+ | Scrape serialization — skip if already collecting | Long-held business locks |
+| Buffered channel semaphore | All | Cap goroutines to protect shared resource (libvirt socket) | Global rate limits (use `golang.org/x/sync/semaphore`) |
+| `sync.Map` | Go 1.9+ | Per-domain delta state that survives scrapes | Simple per-request scratch space (use plain map + mutex) |
+| `atomic.Value` | All | Single-value timestamp for readiness probe | Multi-field structs (use mutex instead) |
+| `context.WithTimeout` | All | Bound collection to 40s scrape deadline | Calling `context.Background()` directly in collection |
+
+---
+
+## Correct Patterns
+
+### Semaphore-Limited Goroutines (the kvm-exporter pattern)
+
+Cap concurrent domain collections to prevent libvirt socket exhaustion. The semaphore is a buffered channel of empty structs.
+
+```go
+sem := make(chan struct{}, 50) // max 50 concurrent domain goroutines
+
+var wg sync.WaitGroup
+for _, domain := range domains {
+    wg.Add(1) // Add BEFORE go func to avoid race with wg.Wait()
+    go func(d libvirt.Domain) {
+        defer wg.Done()
+        sem <- struct{}{}         // acquire slot
+        defer func() { <-sem }() // release slot
+        collectDomain(ctx, d, ch)
+    }(domain)
+}
+wg.Wait()
+```
+
+**Why**: libvirt's Unix socket is a single RPC endpoint. Sending 500 simultaneous calls causes libvirt to drop connections. The semaphore keeps in-flight calls bounded without serializing all collection.
+
+---
+
+### TryLock for Scrape Serialization
+
+Use `TryLock` to skip a scrape when the previous one is still running, rather than blocking Prometheus.
+
+```go
+type ServiceImpl struct {
+    mu sync.Mutex
+}
+
+func (s *ServiceImpl) Collect(ch chan<- prometheus.Metric) {
+    if !s.mu.TryLock() {
+        // Previous scrape still running — emit nothing, Prometheus retries
+        return
+    }
+    defer s.mu.Unlock()
+    s.retrieveMetrics(ctx, ch)
+}
+```
+
+**Why**: If collection takes 35s and Prometheus scrapes every 30s, blocking stacks goroutines until OOM. `TryLock` sacrifices one scrape rather than accumulating blocked callers.
+
+**Version note**: `sync.Mutex.TryLock()` added in Go 1.18.
+
+---
+
+### sync.Map for Cross-Scrape Delta State
+
+Steal time requires comparing current CPU time to the previous scrape's value. `sync.Map` provides concurrent-safe access without a mutex wrapping the domain loop.
+
+```go
+// Key: "domainName-PID"
+var stealTimeHistory sync.Map
+
+func calculateStealTime(domain, pid string, current uint64) float64 {
+    key := domain + "-" + pid
+    if prev, ok := stealTimeHistory.Load(key); ok {
+        delta := current - prev.(uint64)
+        stealTimeHistory.Store(key, current)
+        return float64(delta)
+    }
+    stealTimeHistory.Store(key, current)
+    return 0 // first scrape — no delta available
+}
+```
+
+**Why**: The domain loop runs concurrently. A plain `map[string]uint64` requires a global mutex serializing all delta lookups. `sync.Map` is optimized for read-heavy workloads with stable key sets (domain IDs don't churn rapidly).
+
+---
+
+### Context Cancellation in Collection Loops
+
+Check `ctx.Err()` before queuing each domain to exit early when the scrape timeout fires.
+
+```go
+for _, domain := range domains {
+    if ctx.Err() != nil {
+        return // timeout fired before we could queue this domain
+    }
+    wg.Add(1)
+    go func(d libvirt.Domain) {
+        defer wg.Done()
+        sem <- struct{}{}
+        defer func() { <-sem }()
+        if ctx.Err() != nil {
+            return // re-check inside goroutine before doing any work
+        }
+        collectDomain(ctx, d, ch)
+    }(domain)
+}
+```
+
+**Why**: Without the pre-queue check, all 500 domains could be queued before the timeout fires, then all goroutines start and run over deadline together.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Unbounded Goroutine-Per-Domain
+
+**Detection**:
+```bash
+# Find goroutine launches — review each for semaphore acquire
+rg 'go func\(' --type go internal/
+grep -rn 'go func(' --include="*.go" internal/
+```
+
+**What it looks like**:
+```go
+for _, domain := range domains {
+    go func(d libvirt.Domain) {
+        collectDomain(ctx, d, ch) // no semaphore
+    }(domain)
+}
+```
+
+**Why wrong**: On a hypervisor with 500 VMs, this launches 500 goroutines simultaneously. Each goroutine makes libvirt RPC calls over the same Unix socket. libvirt queues drop, connections time out, and the exporter logs hundreds of "connection refused" per scrape.
+
+**Fix**: Add buffered channel semaphore with cap ≤ 50 as shown in Correct Patterns above.
+
+---
+
+### ❌ Blocking Lock in Prometheus Collect Path
+
+**Detection**:
+```bash
+rg '\.Lock\(\)' --type go internal/libvirt/
+grep -n "\.Lock()" internal/libvirt/*.go
+```
+Review if `Lock()` appears in any `Collect()` or `Describe()` method.
+
+**What it looks like**:
+```go
+func (s *ServiceImpl) Collect(ch chan<- prometheus.Metric) {
+    s.mu.Lock()         // blocks if previous scrape running
+    defer s.mu.Unlock()
+    s.retrieveMetrics(ctx, ch)
+}
+```
+
+**Why wrong**: Prometheus's default scrape timeout is 10s. If collection takes 35s and Prometheus fires every 30s, the second `Collect()` call blocks, then the third — goroutines stack until the scrape target appears hung and alerts fire.
+
+**Fix**: Replace `s.mu.Lock()` with `if !s.mu.TryLock() { return }`.
+
+**Version note**: `TryLock` added in Go 1.18. For earlier versions, use `sync/atomic` swap-based implementation.
+
+---
+
+### ❌ Skipping ClearScrapeCache() on Error Exit
+
+**Detection**:
+```bash
+rg 'ClearScrapeCache' --type go
+grep -rn 'ClearScrapeCache' --include="*.go" .
+```
+Confirm it is called in `defer` or in all exit paths of `retrieveMetrics`.
+
+**What it looks like**:
+```go
+func (s *ServiceImpl) retrieveMetrics(ctx context.Context, ch chan<- prometheus.Metric) {
+    if err := s.connectLibvirt(); err != nil {
+        log.Errorf("connect: %v", err)
+        return // scrape cache NOT cleared — stale data persists
+    }
+    // ...
+    s.ch.ClearScrapeCache() // only reached on success
+}
+```
+
+**Why wrong**: Per-scrape caches (PID lookup, VM counters) accumulate stale entries. On the next successful scrape, the exporter reads stale PIDs for domains restarted since last scrape, emitting metrics for dead processes.
+
+**Fix**: `defer s.ch.ClearScrapeCache()` at the top of `retrieveMetrics`, before any error paths.
+
+---
+
+### ❌ Plain map for Concurrent Domain State
+
+**Detection**:
+```bash
+rg 'map\[string\]' --type go internal/libvirt/
+grep -n "map\[string\]" internal/libvirt/*.go
+```
+Any `map[string]` accessed from goroutines without a wrapping mutex is a data race.
+
+**What it looks like**:
+```go
+var history = map[string]uint64{} // shared, no mutex
+
+func updateHistory(key string, val uint64) uint64 {
+    prev := history[key]  // concurrent read — data race
+    history[key] = val    // concurrent write — data race
+    return val - prev
+}
+```
+
+**Why wrong**: Go's race detector (`go test -race`) catches this. In production without `-race`, it causes silent map corruption or `panic: concurrent map read and map write`.
+
+**Fix**: Use `sync.Map` for stable read-heavy key sets (domain IDs), or a `sync.RWMutex`-protected map if you need `range` iteration.
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|-----------|-----|
+| `panic: concurrent map read and map write` | Goroutine-per-domain accessing plain `map` | Replace with `sync.Map` or add `sync.RWMutex` |
+| `libvirt: connection refused` (mass, same scrape) | Too many concurrent goroutines saturating libvirt socket | Verify semaphore is applied; reduce cap if needed |
+| `context deadline exceeded` every scrape | Collection regularly exceeds 40s timeout | Enable pprof (`ENABLE_PPROF=true`); common culprit is blocked libvirt RPC without per-call timeout |
+| Metrics missing for some domains each scrape | `wg.Add(1)` called inside goroutine rather than before launch | Move `wg.Add(1)` to before `go func(...)` |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Find unbounded goroutine launches (check each for semaphore)
+rg 'go func\(' --type go internal/
+
+# Find blocking Lock() in Prometheus Collect path
+rg '\.Lock\(\)' --type go internal/libvirt/
+
+# Find plain map in concurrent code
+rg 'map\[string\]' --type go internal/libvirt/
+
+# Find missing or misplaced ClearScrapeCache calls
+rg 'ClearScrapeCache' --type go
+
+# Run race detector across all packages
+go test -race ./internal/...
+```
+
+---
+
+## See Also
+
+- `references/kvm-exporter.md` — Concurrency Model and Cache Tiers sections for architecture overview
+- `references/testing-patterns.md` — How to write race-detector-clean tests with moq

--- a/skills/cobalt-core/references/testing-patterns.md
+++ b/skills/cobalt-core/references/testing-patterns.md
@@ -1,0 +1,271 @@
+# Cobalt Core — Testing Patterns
+
+> **Scope**: Unit testing with moq-generated mocks and E2E testing with Kind clusters, as used in kvm-exporter. Does not cover general Go testing theory.
+> **Version range**: Go 1.21+, moq 0.5.0, Kind 0.23+
+> **Generated**: 2026-04-16 — verify against `test/` and `internal/libvirt/*_test.go`
+
+---
+
+## Overview
+
+kvm-exporter has two test layers: unit tests using `moq`-generated interface mocks (fast, no libvirt), and E2E tests using a custom Kind cluster image with actual libvirt + Cloud Hypervisor running (slow, requires Docker). The unit test pattern is interface injection — `ServiceImpl` accepts mock `LibVirt` and `Cloudhypervisor` dependencies. The E2E layer validates that expected metrics actually appear in the HTTP response. Skipping the race detector on unit tests is the most common error that lets concurrency bugs through.
+
+---
+
+## Pattern Table
+
+| Tool | Version | Use When | Avoid When |
+|------|---------|----------|------------|
+| `moq` | 0.5.0 | Generate mocks for `LibVirt`, `Cloudhypervisor` interfaces | Hand-rolling mocks (use `moq` for regeneration) |
+| `testify/assert` | All | Readable assertion failures | `t.Fatalf` for non-fatal checks |
+| `go test -race` | All | All concurrent code; CI always | Benchmarks (adds overhead) |
+| Kind E2E | 0.23+ | Validating actual metric output end-to-end | Unit-testable logic (too slow) |
+| `test/test-metrics.sh` | — | HTTP response metric validation in E2E | Go test for HTTP parsing |
+
+---
+
+## Correct Patterns
+
+### Unit Test: Interface Injection with moq
+
+Create `ServiceImpl` with mocked interfaces, inject a metric channel, call the collector, verify emitted metrics.
+
+```go
+func TestVcpuCollector(t *testing.T) {
+    virt := &LibVirtMock{
+        ConnectGetAllDomainStatsFunc: func(...) ([]libvirt.DomainStats, error) {
+            return []libvirt.DomainStats{
+                {
+                    Domain: libvirt.Domain{Name: "test-domain"},
+                    Vcpu:   []libvirt.DomainStatsVcpu{{State: 1, Time: 1000}},
+                },
+            }, nil
+        },
+    }
+
+    svc := &ServiceImpl{virt: virt}
+    ch := make(chan prometheus.Metric, 10)
+
+    svc.collectVcpu(context.Background(), ch)
+    close(ch)
+
+    var metrics []prometheus.Metric
+    for m := range ch {
+        metrics = append(metrics, m)
+    }
+    assert.NotEmpty(t, metrics, "expected at least one vcpu metric")
+}
+```
+
+**Why**: No libvirt socket required. The mock records call arguments so you can assert the RPC was called with correct parameters. Regenerate with `make generate` after interface changes.
+
+---
+
+### Regenerating Mocks After Interface Change
+
+After modifying `LibVirt` or `Cloudhypervisor` interfaces, regenerate mocks:
+
+```bash
+# In repo root
+make generate
+# or directly:
+moq -out internal/libvirt/interface_mock_gen.go \
+    internal/libvirt LibVirt Cloudhypervisor
+```
+
+The generated file is committed — never edit `interface_mock_gen.go` by hand.
+
+**Why**: Hand-edited mocks drift from the interface. `moq` regeneration guarantees the mock matches the interface exactly, and CI will fail if the generated file is out of sync.
+
+---
+
+### E2E Test: Kind Cluster + metric validation
+
+The E2E setup creates a Kind cluster with a custom node image containing libvirt and Cloud Hypervisor. VMs are created on worker nodes, the exporter DaemonSet is deployed, and metrics are validated via HTTP.
+
+```bash
+# Full E2E (QEMU + CH paths):
+make test-all
+
+# QEMU path only:
+make test-qemu
+
+# CH path only:
+make test-ch
+
+# Manual metric check against running exporter:
+curl -s http://NODE_IP:8080/metrics | grep 'kvm_domain_libvirt_vcpu'
+```
+
+Metric validation script (`test/test-metrics.sh`) uses grep patterns against the HTTP response — add expected metrics there when adding new collectors.
+
+```bash
+# Add to test/test-metrics.sh for a new metric:
+check_metric "kvm_domain_libvirt_new_metric_name"
+```
+
+**Why**: The unit tests mock libvirt responses. The E2E layer validates that the actual libvirt RPC, cgroup reads, and /proc parsing produce real metrics. It's the only layer that catches libvirt version incompatibilities.
+
+---
+
+### Race-Detector-Clean Tests
+
+Always run the race detector in CI. For local development, add `-race` to catch issues before push.
+
+```bash
+# Run with race detector
+go test -race ./internal/...
+
+# Run specific test with race detector
+go test -race -run TestCollectVcpu ./internal/libvirt/
+
+# Run with verbose output and race detector
+go test -race -v ./internal/libvirt/
+```
+
+When using `sync.Map` or channels in tests, the race detector validates the access patterns are safe.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Hand-Editing interface_mock_gen.go
+
+**Detection**:
+```bash
+git log --oneline internal/libvirt/interface_mock_gen.go
+grep -n "hand" internal/libvirt/interface_mock_gen.go
+rg 'interface_mock_gen' --type go
+```
+Check if the file has commits that don't come from `make generate`.
+
+**What it looks like**:
+```go
+// In interface_mock_gen.go — manually added method:
+func (m *LibVirtMock) NewMethod(ctx context.Context) error {
+    // hand-written — not from moq
+    return nil
+}
+```
+
+**Why wrong**: The next `make generate` overwrites the file. The hand-written method disappears silently. Tests that relied on it compile but the mock no longer has the behavior.
+
+**Fix**: Extend the actual `LibVirt` interface, then run `make generate`. The mock is always derived from the interface.
+
+---
+
+### ❌ Skipping Race Detector in Tests with Goroutines
+
+**Detection**:
+```bash
+rg 'go test' Makefile
+grep -n "go test" Makefile
+```
+Check that all `go test` invocations in Makefile include `-race`.
+
+**What it looks like**:
+```makefile
+test:
+    go test ./internal/...   # no -race
+```
+
+**Why wrong**: kvm-exporter's domain collection is concurrent. Tests that exercise collection without `-race` can pass even with data races — the race detector is not enabled by default. Race conditions surface only under load in production.
+
+**Fix**:
+```makefile
+test:
+    go test -race ./internal/...
+```
+
+**Version note**: `-race` requires CGO on Linux. Since kvm-exporter already requires `CGO_ENABLED=1` for libvirt, this is always available.
+
+---
+
+### ❌ Asserting Exact Metric Count Instead of Presence
+
+**Detection**:
+```bash
+rg 'assert\.Len\(t, metrics' --type go internal/
+grep -n "assert.Len" internal/libvirt/*_test.go
+```
+
+**What it looks like**:
+```go
+assert.Len(t, metrics, 3, "expected exactly 3 metrics")
+```
+
+**Why wrong**: Adding a label to an existing metric (e.g., adding `numa_node` label to steal time) changes the cardinality. The exact-count assertion breaks, but the metric is still correct. Tests become a maintenance burden.
+
+**Fix**: Assert metric presence and specific label values rather than total count:
+```go
+assert.NotEmpty(t, metrics)
+// Find the specific metric you care about:
+found := false
+for _, m := range metrics {
+    if strings.Contains(m.Desc().String(), "kvm_domain_libvirt_steal_time") {
+        found = true
+    }
+}
+assert.True(t, found, "steal time metric must be present")
+```
+
+---
+
+### ❌ E2E Tests Without test-metrics.sh Coverage for New Collectors
+
+**Detection**:
+```bash
+grep -n "check_metric" test/test-metrics.sh
+# Compare against collector list in DISABLED_COLLECTORS docs
+```
+If a new collector name does not appear in `test-metrics.sh`, its E2E coverage is missing.
+
+**What it looks like**:
+New collector `hugepages` is added to `internal/libvirt/hugepages.go` but `test/test-metrics.sh` has no `check_metric "kvm_domain_hugepages_bytes"` line.
+
+**Why wrong**: Unit tests cover the mock path. The E2E cluster deploys the exporter against real VMs. If hugepages collection silently returns no metrics (e.g., smaps not readable), no test catches it.
+
+**Fix**: For every new collector, add at minimum one `check_metric "kvm_..."` line to `test/test-metrics.sh` targeting the primary metric the collector emits.
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|-----------|-----|
+| `undefined: LibVirtMock` | `interface_mock_gen.go` not regenerated after interface change | Run `make generate` |
+| `DATA RACE` in `go test -race` | Goroutine-per-domain accessing shared state without sync | Check `sync.Map` usage; add mutex if using plain map |
+| `no such file or directory: /run/libvirt/libvirt-sock-ro` (unit test) | Test code directly instantiating real libvirt connection | Inject mock via interface; never connect to real libvirt in unit tests |
+| E2E `make test-all` fails at Kind node image build | Custom Kind Dockerfile outdated after Ubuntu/libvirt version bump | Rebuild base image: `make build-test-image` |
+| `check_metric` fails in `test-metrics.sh` | New collector not returning metrics in E2E cluster | Check collector enabled/disabled status; add debug logging; validate cgroup paths on Kind node |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Check if race detector is in Makefile test targets
+grep -n "go test" Makefile
+
+# Find any test that skips -race
+rg 'go test [^-]' Makefile
+
+# Find hand-edits to generated mock file
+git log --oneline internal/libvirt/interface_mock_gen.go
+
+# Find exact-count metric assertions (fragile)
+rg 'assert\.Len\(t, metrics' --type go internal/
+
+# Find uncovered collectors in E2E script
+grep "check_metric" test/test-metrics.sh
+
+# Run unit tests with race detector
+go test -race -v ./internal/...
+```
+
+---
+
+## See Also
+
+- `references/kvm-exporter.md` — Testing section for E2E infrastructure setup and `make test-all` targets
+- `references/concurrency-patterns.md` — Concurrency patterns that need race-detector-clean tests


### PR DESCRIPTION
## Reference Enrichment — cobalt-core

**Run ID**: 2026-04-16-0607
**Target**: cobalt-core (skill)

### Results

| Target | Before | After | New Files |
|--------|--------|-------|-----------|
| cobalt-core | Level 2 | Level 3 | 2 |

### New Reference Files

**`references/concurrency-patterns.md`** (~200 lines)
- Semaphore-limited goroutine pattern (cap 50) for libvirt socket protection
- TryLock scrape serialization vs blocking Lock anti-pattern
- sync.Map for cross-scrape delta state (steal time history)
- Context cancellation in collection loops
- 4 anti-patterns with rg/grep detection commands each
- Error-fix mappings: concurrent map panic, connection refused, deadline exceeded
- Version note: TryLock added Go 1.18

**`references/testing-patterns.md`** (~200 lines)
- moq interface injection pattern for LibVirt/Cloudhypervisor mocks
- make generate workflow (never hand-edit interface_mock_gen.go)
- go test -race usage — required for all concurrent code
- Kind E2E cluster setup (make test-all, make test-qemu, make test-ch)
- test-metrics.sh coverage pattern for new collectors
- 4 anti-patterns with detection commands each
- Error-fix mappings: undefined LibVirtMock, DATA RACE, missing metrics

### Loading Table Update

Added signal rows for both new references to SKILL.md:
- goroutine, concurrency, semaphore, TryLock, sync.Map, race condition → concurrency-patterns.md
- test, mock, moq, unit test, E2E, Kind cluster, race detector → testing-patterns.md

### Validation Gate

[KEEP] cobalt-core: All 3 test queries correctly routed to new references via signal matching. References contain concrete patterns with detection commands, version qualifiers (Go 1.18+), and error-fix mappings — not generic advice.