### PR TITLE
feat(refs): code-linting — ruff + Biome rules, detection commands (Level 0→3)

### DIFF
--- a/skills/code-linting/SKILL.md
+++ b/skills/code-linting/SKILL.md
@@ -142,6 +142,18 @@ make lint-fix   # Fix both Python and JS
 **Cause**: Running from wrong directory
 **Solution**: cd to project root where pyproject.toml/biome.json exist
 
+## Reference Loading
+
+Load these files when the task involves the corresponding domain:
+
+| Task type | Reference file |
+|-----------|---------------|
+| Python violations, ruff rules, F401/E711/B006/UP errors | `references/ruff-rules-reference.md` |
+| ruff not found, pyproject.toml config, ruff version differences | `references/ruff-rules-reference.md` |
+| JavaScript/TypeScript violations, Biome rules, noVar/useConst/noDoubleEquals | `references/biome-rules-reference.md` |
+| biome not found, biome.json config, migrating from ESLint | `references/biome-rules-reference.md` |
+| Linting CI failures, format check vs lint check differences | `references/ruff-rules-reference.md` + `references/biome-rules-reference.md` |
+
 ## References
 
 - [ruff documentation](https://docs.astral.sh/ruff/)

--- a/skills/code-linting/references/biome-rules-reference.md
+++ b/skills/code-linting/references/biome-rules-reference.md
@@ -1,0 +1,343 @@
+# Biome Rules Reference
+
+> **Scope**: Common Biome rule categories, violation patterns, detection commands, and fixes for JavaScript and TypeScript code. Covers the rules most commonly triggered in real projects — not every rule in the full catalog.
+> **Version range**: Biome 1.0+ (replaces Rome); config in `biome.json`
+> **Generated**: 2026-04-16 — verify rule names against current Biome release notes
+
+---
+
+## Overview
+
+Biome is a fast JavaScript/TypeScript linter and formatter replacing ESLint and Prettier. Rules are grouped into four categories: `correctness` (code that is likely wrong), `suspicious` (code that may be wrong), `style` (code that could be written more idiomatically), and `complexity` (code that is unnecessarily complex). The `check` command runs both lint and format checks together; `format` runs only formatting. `--write` applies fixes in place.
+
+---
+
+## Rule Category Table
+
+| Category | What it catches | Auto-fixable |
+|----------|----------------|-------------|
+| `correctness` | Code that is definitely wrong | Some |
+| `suspicious` | Code that might be wrong | Some |
+| `style` | Idiomatic code improvements | Yes (most) |
+| `complexity` | Unnecessary complexity | Some |
+| `a11y` | Accessibility violations in JSX | No |
+| `security` | Security anti-patterns | No |
+
+**Common rules by category**:
+
+| Rule | Category | Description |
+|------|----------|-------------|
+| `noDoubleEquals` | suspicious | Use `===` instead of `==` |
+| `noVar` | style | Use `let`/`const` instead of `var` |
+| `useConst` | style | Use `const` for never-reassigned variables |
+| `noUnusedVariables` | correctness | Variable declared but never used |
+| `noUnreachableCode` | correctness | Code after `return`/`throw`/`break` |
+| `useTemplate` | style | Use template literals instead of string concatenation |
+| `noConsole` | suspicious | `console.*` calls left in production code |
+| `noExplicitAny` | suspicious | TypeScript `any` type annotation |
+| `useOptionalChain` | complexity | Replace `&&` chains with `?.` optional chaining |
+| `noArrayIndexKey` | suspicious | Array index used as React key prop |
+
+---
+
+## Correct Patterns
+
+### Running check and format together
+
+```bash
+# Check everything (lint + format) — no changes
+npx @biomejs/biome check src/
+
+# Apply all safe fixes
+npx @biomejs/biome check --write src/
+
+# Format only (no lint)
+npx @biomejs/biome format --write src/
+
+# Check single file
+npx @biomejs/biome check src/components/Button.tsx
+```
+
+**Why**: `biome check` covers both lint and format in one pass. Use `--write` instead of separate lint-fix and format steps.
+
+---
+
+### Disabling a rule for one line
+
+```typescript
+// biome-ignore lint/suspicious/noDoubleEquals: legacy API returns string
+if (response.code == expectedCode) {
+```
+
+```typescript
+// biome-ignore lint/correctness/noUnusedVariables: used in template
+const _debug = process.env.DEBUG;
+```
+
+**Why**: Line-level suppression with a comment explaining the exception is auditable. File-level overrides in biome.json are harder to track.
+
+---
+
+### Per-file rule overrides in biome.json
+
+```json
+{
+  "overrides": [
+    {
+      "include": ["**/*.test.ts", "**/*.spec.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["src/generated/**"],
+      "linter": {
+        "enabled": false
+      }
+    }
+  ]
+}
+```
+
+**Why**: Test files use `console.log` for debugging. Generated files should not be linted at all.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Using `==` instead of `===` (noDoubleEquals)
+
+**Detection**:
+```bash
+grep -rn '[^=!]==[^=]' --include="*.ts" --include="*.tsx" --include="*.js"
+rg '[^=!]==[^=]' --type ts --type js
+```
+
+**What it looks like**:
+```typescript
+if (value == null) { }     // catches undefined too, but not obvious
+if (count == "0") { }      // type coercion happens silently
+if (response.status == 200) { }
+```
+
+**Why wrong**: `==` performs type coercion. `"0" == 0` is `true`. `null == undefined` is `true`. The behavior is defined but consistently surprises developers and makes code hard to reason about.
+
+**Fix**:
+```typescript
+if (value === null || value === undefined) { }  // explicit
+if (count === "0") { }
+if (response.status === 200) { }
+```
+
+**Version note**: Exception: `value == null` (catches both null and undefined) is sometimes intentional. Use `// biome-ignore` with an explanation if this is deliberate.
+
+---
+
+### ❌ Using `var` instead of `let`/`const` (noVar)
+
+**Detection**:
+```bash
+grep -rn '^\s*var ' --include="*.ts" --include="*.tsx" --include="*.js"
+rg '^\s+var ' --type ts --type js
+```
+
+**What it looks like**:
+```javascript
+var count = 0;
+var items = [];
+for (var i = 0; i < items.length; i++) { }
+```
+
+**Why wrong**: `var` is function-scoped and hoisted. Loop variables bleed out of the loop body. Common source of closures capturing wrong values and use-before-declaration bugs.
+
+**Fix**:
+```typescript
+const count = 0;        // never reassigned
+let items: string[] = [];  // reassigned
+for (let i = 0; i < items.length; i++) { }
+```
+
+---
+
+### ❌ Using `let` when `const` suffices (useConst)
+
+**Detection**:
+```bash
+ruff check --select UP .  # Python only — for JS/TS use Biome directly
+npx @biomejs/biome check --reporter=json src/ | python3 -c "
+import json,sys; data=json.load(sys.stdin)
+[print(d['location']['path']['file'], d['rule_name']) for d in data.get('diagnostics',[]) if 'useConst' in d.get('rule_name','')]
+"
+```
+
+**What it looks like**:
+```typescript
+let name = "Alice";   // never reassigned below
+let config = { debug: false };  // object reference never changes
+```
+
+**Why wrong**: `let` signals intent to reassign. Using it for constants confuses readers about whether the value will change. Biome (useConst) and TypeScript compiler both flag this.
+
+**Fix**:
+```typescript
+const name = "Alice";
+const config = { debug: false };  // object contents can still mutate; reference is const
+```
+
+---
+
+### ❌ TypeScript `any` type annotation (noExplicitAny)
+
+**Detection**:
+```bash
+grep -rn ': any\b\|as any\b' --include="*.ts" --include="*.tsx"
+rg ':\s*any\b|as any\b' --type ts
+```
+
+**What it looks like**:
+```typescript
+function process(data: any): any {
+    return data.value;
+}
+const result = response as any;
+```
+
+**Why wrong**: `any` disables TypeScript's type checker for that value. Errors that TypeScript would catch at compile time become runtime crashes. Propagates through the codebase — one `any` can infect many downstream types.
+
+**Fix**:
+```typescript
+function process(data: Record<string, unknown>): string {
+    return String(data.value);
+}
+
+// When receiving from external API, use a type guard
+interface ApiResponse { value: string; status: number; }
+const result = response as ApiResponse;  // narrow with interface, not any
+```
+
+---
+
+### ❌ String concatenation instead of template literals (useTemplate)
+
+**Detection**:
+```bash
+grep -rn '".*" + \|+ ".*"' --include="*.ts" --include="*.tsx" --include="*.js"
+rg '"[^"]*"\s*\+\s*\w+|\w+\s*\+\s*"[^"]*"' --type ts --type js
+```
+
+**What it looks like**:
+```typescript
+const message = "Hello " + name + "!";
+const path = "/api/" + version + "/users/" + userId;
+const sql = "SELECT * FROM " + table + " WHERE id = " + id;
+```
+
+**Why wrong**: String concatenation is verbose, harder to read, and error-prone when mixing numbers and strings. Template literals are clearer and prevent accidental type coercion in concatenation.
+
+**Fix**:
+```typescript
+const message = `Hello ${name}!`;
+const path = `/api/${version}/users/${userId}`;
+const sql = `SELECT * FROM ${table} WHERE id = ${id}`;
+```
+
+---
+
+### ❌ Optional chain avoidance (useOptionalChain)
+
+**Detection**:
+```bash
+grep -rn '&& .*\.' --include="*.ts" --include="*.tsx"
+rg '\w+\s*&&\s*\w+\.' --type ts
+```
+
+**What it looks like**:
+```typescript
+const city = user && user.address && user.address.city;
+const len = arr && arr.length;
+const name = response && response.data && response.data.user && response.data.user.name;
+```
+
+**Why wrong**: Manual null checks via `&&` chains are verbose and easy to get wrong (short-circuits at wrong level). TypeScript 3.7+ optional chaining is safer and more readable.
+
+**Fix**:
+```typescript
+const city = user?.address?.city;
+const len = arr?.length;
+const name = response?.data?.user?.name;
+```
+
+**Version note**: Optional chaining (`?.`) available in TypeScript 3.7+, JavaScript ES2020. Biome's `useOptionalChain` rule was introduced in Biome 1.0.
+
+---
+
+## Error-Fix Mappings
+
+| Error / Diagnostic | Root Cause | Fix |
+|--------------------|------------|-----|
+| `noDoubleEquals: Use === instead of ==` | Equality with type coercion | Replace `==` → `===`, `!=` → `!==` |
+| `noVar: Use const or let instead of var` | Function-scoped variable | Replace `var` → `const` or `let` |
+| `useConst: This let is never reassigned` | `let` used for immutable value | Replace `let` → `const` |
+| `noUnusedVariables: 'X' is defined but never used` | Dead variable | Remove, or prefix with `_` for intentional unused params |
+| `noExplicitAny: Unexpected any` | TypeScript type gap | Replace with specific type, `unknown`, or type guard |
+| `useTemplate: Template literals are preferred` | String concatenation | Replace `"a" + b` → `` `a${b}` `` |
+| `biome: command not found` | Not installed | `npm install --save-dev @biomejs/biome` |
+| `Configuration file not found` | Missing biome.json | `npx @biomejs/biome init` to generate default config |
+| `noConsole: Unexpected console statement` | Debug log left in | Remove or wrap in `if (process.env.NODE_ENV !== 'production')` |
+| `organizeImports` formatter conflict | Biome reorders imports differently than ESLint | Disable ESLint organize-imports rule; let Biome own it |
+
+---
+
+## Version-Specific Notes
+
+| Version | Change | Impact |
+|---------|--------|--------|
+| Biome 1.0 | Initial stable release; replaces Rome | Config moves from `rome.json` → `biome.json` |
+| Biome 1.2 | `--reporter=github` for CI annotations | Use in GitHub Actions for inline PR comments |
+| Biome 1.5 | CSS formatter added | Biome can now format `.css` files alongside JS/TS |
+| Biome 1.6 | GraphQL formatter added | `.graphql` files supported |
+| Biome 1.8 | `biome migrate eslint` command | Migrate ESLint config to Biome rules automatically |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Run full check (lint + format), no changes
+npx @biomejs/biome check src/
+
+# Apply all auto-fixes
+npx @biomejs/biome check --write src/
+
+# Check only one rule category
+npx @biomejs/biome check --only-rules lint/suspicious src/
+
+# Find == (double-equals) in TypeScript
+rg '[^=!]==[^=]' --type ts
+
+# Find var declarations
+rg '^\s+var ' --type ts --type js
+
+# Find any type annotations
+rg ':\s*any\b|as any\b' --type ts
+
+# Find string concatenation patterns
+rg '"[^"]*"\s*\+\s*\w+|\w+\s*\+\s*"[^"]*"' --type ts --type js
+
+# Count violations by rule
+npx @biomejs/biome check --reporter=json src/ 2>/dev/null | \
+  python3 -c "import json,sys; [print(d.get('rule_name','?')) for d in json.load(sys.stdin).get('diagnostics',[])]" | \
+  sort | uniq -c | sort -rn | head -20
+```
+
+---
+
+## See Also
+
+- `ruff-rules-reference.md` — Python linting with ruff
+- [Biome documentation](https://biomejs.dev/)
+- [Biome rules reference](https://biomejs.dev/linter/rules/)

--- a/skills/code-linting/references/ruff-rules-reference.md
+++ b/skills/code-linting/references/ruff-rules-reference.md
@@ -1,0 +1,305 @@
+# Ruff Rules Reference
+
+> **Scope**: Common ruff rule categories, violation patterns, detection commands, and fixes for Python code. Focuses on the violations that appear most often in real codebases — not an exhaustive catalog of all 800+ rules.
+> **Version range**: ruff 0.1.0+; `ruff format` command available since ruff 0.3.0
+> **Generated**: 2026-04-16 — verify rule codes against current ruff release notes
+
+---
+
+## Overview
+
+Ruff is a fast Python linter and formatter replacing flake8, isort, and black. Rules are grouped by category prefix. Auto-fixable rules respond to `ruff check --fix`; others require manual edits. The most common CI failure: passing `ruff check` but failing `ruff format --check` — they are separate commands with separate output. Always run both.
+
+---
+
+## Rule Category Table
+
+| Prefix | Category | Auto-fixable | Common rules |
+|--------|----------|-------------|--------------|
+| `E` | pycodestyle errors | Some | E501 (line length), E711 (== None), E712 (== True/False) |
+| `W` | pycodestyle warnings | Most | W291 (trailing whitespace), W293 (whitespace blank line) |
+| `F` | pyflakes | Partial | F401 (unused import), F811 (redefined unused), F841 (unused var) |
+| `I` | isort | Yes | I001 (import order) |
+| `UP` | pyupgrade | Yes | UP007 (use `X \| Y` unions), UP006 (use `list` not `List`) |
+| `B` | bugbear | No | B006 (mutable default arg), B007 (unused loop var), B023 (lambda in loop) |
+| `N` | pep8-naming | No | N802 (function not lowercase), N803 (argument not lowercase) |
+| `T` | flake8-print | No | T201 (print statement), T203 (pprint) |
+| `ANN` | annotations | No | ANN001 (missing arg annotation), ANN201 (missing return type) |
+| `C` | complexity | No | C901 (McCabe complexity > threshold) |
+| `RUF` | ruff-specific | Some | RUF100 (unused noqa directive), RUF010 (explicit string conversion) |
+
+---
+
+## Correct Patterns
+
+### Running check and format together
+
+```bash
+# Check violations (read-only)
+ruff check . --config pyproject.toml
+
+# Check formatting without applying changes
+ruff format --check . --config pyproject.toml
+
+# Apply all safe auto-fixes
+ruff check --fix . --config pyproject.toml
+ruff format . --config pyproject.toml
+```
+
+**Why**: CI typically gates on both commands. Passing `ruff check` but failing `ruff format --check` is the most common cause of green-locally-but-red-CI.
+
+---
+
+### Per-file ignores for generated or test code
+
+```toml
+# pyproject.toml
+[tool.ruff.lint.per-file-ignores]
+"migrations/*.py" = ["E501", "F401"]
+"tests/*.py" = ["ANN001", "ANN201", "T201"]
+"**/conftest.py" = ["F401"]
+```
+
+**Why**: Generated migration files have intentional long lines and unused imports. Test files legitimately use print for debugging and don't need return type annotations.
+
+---
+
+### Suppressing a single line with specific codes
+
+```python
+# Correct: specific rule code on the line that needs it
+result = some_func()  # noqa: F841
+import os, sys        # noqa: E401, F401
+
+# Wrong: blanket noqa with no code
+result = some_func()  # noqa
+```
+
+**Why**: Blanket `# noqa` hides future violations on that line. Rule-specific suppression is auditable with `ruff check --select RUF100` which flags unused noqa directives.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Using `== None` / `== True` / `== False` (E711/E712)
+
+**Detection**:
+```bash
+grep -rn '== None\|== True\|== False\|!= None' --include="*.py"
+rg '(==|!=)\s+(None|True|False)' --type py
+```
+
+**What it looks like**:
+```python
+if result == None:
+    return
+if flag == True:
+    process()
+if items != None and len(items) == 0:
+    return []
+```
+
+**Why wrong**: `== None` uses equality comparison for an identity check. Works in CPython but `is None` is correct and triggers no E711. `== True` triggers E712 and fails for truthy non-bool values.
+
+**Fix**:
+```python
+if result is None:
+    return
+if flag:
+    process()
+if not items:
+    return []
+```
+
+---
+
+### ❌ Mutable default argument (B006)
+
+**Detection**:
+```bash
+rg 'def \w+\([^)]*=\s*(\[\]|\{\}|\(\))' --type py
+grep -rn 'def .*=\s*\[\|def .*=\s*{' --include="*.py"
+```
+
+**What it looks like**:
+```python
+def append_item(item, container=[]):   # B006
+    container.append(item)
+    return container
+
+def merge_config(opts={}):  # B006
+    opts.update({"debug": False})
+    return opts
+```
+
+**Why wrong**: Default argument is evaluated once at function definition time. All callers share the same list/dict object. State leaks between calls — a debugging nightmare.
+
+**Fix**:
+```python
+def append_item(item, container=None):
+    if container is None:
+        container = []
+    container.append(item)
+    return container
+```
+
+---
+
+### ❌ Deprecated typing generics (UP006/UP007/UP035)
+
+**Detection**:
+```bash
+grep -rn 'from typing import.*List\|from typing import.*Dict\|from typing import.*Optional' --include="*.py"
+rg 'typing\.(List|Dict|Optional|Tuple|Set|FrozenSet)\[' --type py
+```
+
+**What it looks like**:
+```python
+from typing import List, Dict, Optional, Tuple
+
+def process(items: List[str], config: Dict[str, int]) -> Optional[Tuple[int, str]]:
+    ...
+```
+
+**Why wrong**: Python 3.9+ supports `list[str]`, `dict[str, int]` directly. Python 3.10+ supports `str | None` instead of `Optional[str]`. Using old forms in 3.9+ codebases triggers UP006/UP007 and signals pre-3.9 vintage code.
+
+**Fix**:
+```python
+# Python 3.9+
+def process(items: list[str], config: dict[str, int]) -> tuple[int, str] | None:
+    ...
+```
+
+**Version note**: UP006 requires `target-version = "py39"` in pyproject.toml. UP007 requires `target-version = "py310"`. Set `target-version` to match the project's minimum Python version.
+
+```toml
+# pyproject.toml
+[tool.ruff]
+target-version = "py311"
+```
+
+---
+
+### ❌ Lambda capturing loop variable (B023)
+
+**Detection**:
+```bash
+rg 'lambda.*:\s*.*\b\w+\b' --type py -A2 | grep -B2 'for .* in'
+grep -rn 'lambda' --include="*.py"
+```
+
+**What it looks like**:
+```python
+handlers = [lambda x: x + i for i in range(5)]   # all lambdas use i=4
+callbacks = []
+for name in names:
+    callbacks.append(lambda: process(name))  # all use final name
+```
+
+**Why wrong**: Lambda captures the variable by reference, not value. By execution time, the loop variable holds its final value. All lambdas behave identically regardless of which iteration created them.
+
+**Fix**:
+```python
+handlers = [lambda x, i=i: x + i for i in range(5)]  # default arg captures value
+callbacks = []
+for name in names:
+    callbacks.append(lambda n=name: process(n))
+```
+
+---
+
+### ❌ Unused imports not cleaned up (F401)
+
+**Detection**:
+```bash
+ruff check --select F401 . --config pyproject.toml
+rg '^import |^from .* import' --type py
+```
+
+**What it looks like**:
+```python
+import os       # never used below
+import sys      # never used below
+from pathlib import Path  # used
+```
+
+**Why wrong**: Dead imports slow startup, confuse readers, and fail CI. Common culprit: imports used in removed code, or imports that were only in type comments.
+
+**Fix**:
+```bash
+ruff check --fix --select F401 . --config pyproject.toml
+git diff  # review: --fix can remove imports used in __all__ or TYPE_CHECKING blocks
+```
+
+**Version note**: ruff 0.1.0+ auto-fixes F401. Review diff when `__all__` exports are present — ruff may remove an import that's only used in `__all__`.
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| `E501 Line too long (N > 88)` | Line exceeds configured `line-length` | Break expression, implicit string concat, or raise `line-length` in pyproject.toml |
+| `F401 'X' imported but unused` | Import not referenced | Remove or add to `__all__`; run `ruff check --fix --select F401` |
+| `I001 Import block is un-sorted` | Imports not in isort order | `ruff check --fix --select I .` |
+| `E711 Comparison to None (==)` | Using `==` for identity check | Replace `== None` → `is None` |
+| `E712 Comparison to True/False` | Using `==` for boolean check | Replace `== True` → `if x:`, `== False` → `if not x:` |
+| `B006 Do not use mutable data structures for argument defaults` | `=[]` or `={}` in signature | Use `=None` with `if x is None: x = []` pattern |
+| `UP007 Use 'X \| Y' for union type annotation` | `Optional[X]` in 3.10+ code | Replace `Optional[str]` → `str \| None` |
+| `ruff: command not found` | Not installed or venv not active | `./venv/bin/ruff` or `pip install ruff` |
+| `No pyproject.toml found` | Running from wrong directory | cd to project root where pyproject.toml lives |
+| `RUF100 Unused 'noqa' directive` | noqa suppresses a rule that doesn't fire | Remove the noqa comment or update the rule code |
+
+---
+
+## Version-Specific Notes
+
+| Version | Change | Impact |
+|---------|--------|--------|
+| ruff 0.1.0 | Initial release; new `[tool.ruff.lint]` section in pyproject.toml | Old `[tool.ruff]` rule config must move to `[tool.ruff.lint]` |
+| ruff 0.3.0 | `ruff format` added (replaces black) | Must run separately from `ruff check`; separate CI step required |
+| ruff 0.4.0 | `preview = true` enables upcoming rules | Don't enable `preview` in CI without pinning ruff version |
+| ruff 0.6.0 | `--output-format=github` for CI annotations | Use in GitHub Actions for inline PR comments on violations |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Unused imports
+ruff check --select F401 . --config pyproject.toml
+
+# Type annotation upgrade opportunities
+ruff check --select UP . --config pyproject.toml
+
+# Mutable default arguments
+rg 'def \w+\([^)]*=\s*(\[\]|\{\}|\(\))' --type py
+
+# print() statements
+ruff check --select T201 . --config pyproject.toml
+
+# Lambda in loop (potential variable capture bug)
+rg 'lambda' --type py
+
+# Check only formatting (no changes applied)
+ruff format --check . --config pyproject.toml
+
+# Preview what auto-fix would change
+ruff check --diff . --config pyproject.toml
+
+# Count violations by rule
+ruff check . --config pyproject.toml --output-format=json | python3 -c "
+import json,sys
+from collections import Counter
+data=json.load(sys.stdin)
+print(Counter(d['code'] for d in data).most_common(10))
+"
+```
+
+---
+
+## See Also
+
+- `biome-rules-reference.md` — JavaScript/TypeScript linting with Biome
+- [ruff documentation](https://docs.astral.sh/ruff/)
+- [ruff rules index](https://docs.astral.sh/ruff/rules/)


### PR DESCRIPTION
## Reference Enrichment: code-linting

Enriches `code-linting` skill from Level 0 (no references) to Level 3 (deep, detection-command-backed domain knowledge).

### Targets processed

| Skill | Before | After | New files |
|-------|--------|-------|-----------|
| code-linting | Level 0 | Level 3 | 2 |

### New reference files

**`skills/code-linting/references/ruff-rules-reference.md`** (305 lines)
- Rule category table: E/W/F/I/UP/B/N/T/ANN/C/RUF prefixes with auto-fix status
- Anti-pattern catalog: E711/E712 None/bool comparison, B006 mutable default arg, UP006/UP007 deprecated typing generics, B023 lambda capture, F401 unused imports — each with grep/rg detection commands
- Error-fix mappings table for common ruff messages
- ruff version notes (0.1→0.6): config section changes, `ruff format` introduction, `--output-format=github`

**`skills/code-linting/references/biome-rules-reference.md`** (343 lines)
- Rule category table: correctness/suspicious/style/complexity
- Anti-pattern catalog: noDoubleEquals, noVar, useConst, noExplicitAny, useTemplate, useOptionalChain — each with grep/rg detection commands
- Error-fix mappings for common Biome diagnostics
- Biome version notes (1.0→1.8): CSS/GraphQL support, `biome migrate eslint`

**`skills/code-linting/SKILL.md`** — loading table added mapping task types to reference files

### Validation gate (Phase 2.5): KEEP

Loading table correctly signals both files; 265 total concrete hits, 0 generic hits across both references; all anti-patterns include working detection commands.