### PR TITLE
fix: remove stale TODO comments for implemented scripts

### DIFF
--- a/skills/agent-comparison/SKILL.md
+++ b/skills/agent-comparison/SKILL.md
@@ -218,9 +218,7 @@ Generate a side-by-side comparison report with a clear verdict.
 **Step 2: Run comparison analysis**
 
 ```bash
-# TODO: scripts/compare.py not yet implemented
-# Manual alternative: compare benchmark outputs side-by-side
-diff benchmark/{task-name}/full/ benchmark/{task-name}/compact/
+python3 ${CLAUDE_SKILL_DIR}/scripts/compare.py benchmark/{task-name}/
 ```
 
 **Step 3: Analyze token economics**

--- a/skills/codebase-analyzer/SKILL.md
+++ b/skills/codebase-analyzer/SKILL.md
@@ -44,8 +44,8 @@ Read and follow the repository's CLAUDE.md before doing anything else -- project
 
 | Variant | Script | Metrics | Use When |
 |---------|--------|---------|----------|
-| Omni (recommended) | `cartographer_omni.py` (not yet implemented) | 100 across 25 categories | Full codebase profiling |
-| Basic | `cartographer.py` (not yet implemented) | ~15 categories | Quick pattern overview |
+| Omni (recommended) | `cartographer_omni.py` | 100 across 25 categories | Full codebase profiling |
+| Basic | `cartographer.py` | ~15 categories | Quick pattern overview |
 | Ultimate | `cartographer_ultimate.py` | 6 focused categories | Performance pattern detection |
 
 **Step 3: Verify environment**
@@ -89,12 +89,8 @@ Automatically filter vendor/, testdata/, and generated code (files with "Code ge
 **Step 1: Execute the cartographer**
 
 ```bash
-# TODO: scripts/cartographer_omni.py not yet implemented
-# Manual alternative: use grep/find to count patterns across Go files
-# Example: count error wrapping patterns
-grep -rn 'fmt.Errorf.*%w' ~/repos/my-project --include="*.go" | wc -l
-# Example: count constructor patterns
-grep -rn 'func New' ~/repos/my-project --include="*.go" | wc -l
+python3 ${CLAUDE_SKILL_DIR}/scripts/cartographer_omni.py /path/to/go/repo
+# Or for quick overview: python3 ${CLAUDE_SKILL_DIR}/scripts/cartographer.py /path/to/go/repo
 ```
 
 Always run the cartographer scripts for measurement; reserve LLM interpretation for Phase 3. When an LLM sees `return err` it may report "not wrapping errors properly" even if that IS the local standard. The scripts produce deterministic, reproducible counts; the LLM's role begins at interpretation in Phase 3.
@@ -115,7 +111,7 @@ Always run the cartographer scripts for measurement; reserve LLM interpretation 
  PHASE 2: MEASURE
 ===============================================================
 
- Script Executed: [cartographer_omni.py (not yet implemented — use manual pattern counting)]
+ Script Executed: [cartographer_omni.py]
  Target: [/path/to/repo]
 
  Results:

--- a/skills/distinctive-frontend-design/SKILL.md
+++ b/skills/distinctive-frontend-design/SKILL.md
@@ -267,8 +267,7 @@ The surface type classified in Phase 1 determines which rule set governs layout.
 **Step 1: Run comprehensive validation**
 
 ```bash
-# TODO: scripts/validate_design.py not yet implemented
-# Manual alternative: review each validation check listed below against design choices
+python3 ${CLAUDE_SKILL_DIR}/scripts/validate_design.py design-spec.json
 ```
 
 **Step 2: Review** validation report. The report checks:

--- a/skills/git-commit-flow/SKILL.md
+++ b/skills/git-commit-flow/SKILL.md
@@ -174,9 +174,7 @@ Either accept user-provided message or generate one from staged changes. Show th
 Validate now, not later, because git history is permanent and "I'll fix the message later" rarely happens in practice.
 
 ```bash
-# TODO: scripts/validate_message.py not yet implemented
-# Manual alternative: validate commit message format
-# Check: type prefix exists, no banned patterns, subject line <= 72 chars
+python3 ${CLAUDE_SKILL_DIR}/scripts/validate_message.py "feat(scope): description"
 ```
 
 Check:

--- a/skills/link-auditor/SKILL.md
+++ b/skills/link-auditor/SKILL.md
@@ -37,9 +37,8 @@ Read and follow the repository CLAUDE.md before starting any audit.
 Scan all markdown files in `content/` because even small sites with 10 posts can have orphan pages, and partial scans miss graph-level issues. Locate the Hugo content directory and enumerate all markdown files:
 
 ```bash
-# TODO: scripts/link_scanner.py not yet implemented
-# Manual alternative: extract links from markdown files
-grep -rn '\[.*\](.*' ~/your-blog/content/ --include="*.md"
+python3 ${CLAUDE_SKILL_DIR}/scripts/link_scanner.py ~/your-blog/content/
+# Options: --check-external, --min-inbound 3, --json
 ```
 
 **Step 2: Extract links by type**

--- a/skills/skill-composer/SKILL.md
+++ b/skills/skill-composer/SKILL.md
@@ -49,9 +49,7 @@ Identify:
 Before building any DAG, scan skills/*/SKILL.md for available skills:
 
 ```bash
-# TODO: scripts/discover_skills.py not yet implemented
-# Manual alternative: scan skills directory for SKILL.md files
-find ./skills -name "SKILL.md" -exec grep -l "^name:" {} \; | sort
+python3 ${CLAUDE_SKILL_DIR}/scripts/discover_skills.py ./skills
 ```
 
 Review the discovered skills. Categorize by type (workflow, testing, quality, documentation, code-analysis, debugging) with dependency metadata.
@@ -77,8 +75,7 @@ Cross-reference selections against `references/compatibility-matrix.md` to confi
 Construct the execution DAG as a JSON structure with nodes (skills) and edges (dependencies) based on the task analysis:
 
 ```bash
-# TODO: scripts/build_dag.py not yet implemented
-# Manual alternative: structure the DAG in your reasoning before presenting it
+python3 ${CLAUDE_SKILL_DIR}/scripts/build_dag.py skill-index.json task-description.json
 ```
 
 **Step 2: Validate the DAG (MANDATORY before execution)**


### PR DESCRIPTION
## Summary
- Fix 6 SKILL.md files that claimed scripts were "not yet implemented" when they actually exist
- link-auditor's link_scanner.py (649 lines) and codebase-analyzer's cartographer_omni.py (2,259 lines) were the primary targets
- Also fixed stale references in git-commit-flow, agent-comparison, distinctive-frontend-design, and skill-composer
- 3 genuinely missing scripts left with their TODO comments intact

## Test plan
- [ ] Verify link-auditor SKILL.md references link_scanner.py correctly
- [ ] Verify codebase-analyzer SKILL.md references cartographer_omni.py correctly
- [ ] Ruff lint passes