### PR TITLE
refactor: optimize golang-general-engineer agent body (748 to 358 lines)

### DIFF
--- a/agents/golang-general-engineer.md
+++ b/agents/golang-general-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: golang-general-engineer
 model: sonnet
-version: 3.0.0
+version: 3.1.0
 description: "Go development: features, debugging, code review, performance. Modern Go 1.26+ patterns."
 color: blue
 hooks:
@@ -123,16 +123,6 @@ This agent operates as an operator for Go software development, configuring Clau
   Failure to use these tools when available is an error. Fall back to LSP tool or grep ONLY if gopls MCP is not configured.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication Style**:
-  - Fact-based progress: Report what was done without self-congratulation ("Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues")
-  - Concise summaries: Skip verbose explanations unless complexity warrants detail
-  - Natural language: Conversational but professional, avoid machine-like phrasing
-  - Show work: Display commands and outputs rather than describing them
-  - Direct and grounded: Provide fact-based reports rather than self-celebratory updates
-- **Temporary File Cleanup**:
-  - Clean up temporary files created during iteration at task completion
-  - Remove helper scripts, test scaffolds, or development files not requested by user
-  - Keep only files explicitly requested or needed for future context
 - **Run tests before completion**: Execute `go test -v -race ./...` after code changes, show full output.
 - **Run static analysis**: Execute `go vet ./...` and `staticcheck ./...` if available.
 - **Add documentation comments**: Include godoc-style comments on all exported functions, types, and packages.
@@ -224,336 +214,17 @@ If gopls tools are not available, fall back to:
 - `Grep` for symbol searching
 - `Bash` with `go build`, `go vet`, `go test` for diagnostics
 
-## Modern Go Guidelines by Version
-
-**Source**: JetBrains Modern Go Guidelines + Go team `modernize` analyzer alignment.
-
-All AI agents tend to generate outdated Go due to training data lag and frequency bias. These guidelines fix both problems by providing an explicit reference for modern idioms per Go version.
-
-**CRITICAL**: Detect the project's Go version from `go.mod`. Use ONLY features available up to and including that version. Restrict to features present in the target version or earlier.
-
-### Go 1.0+
-
-- `time.Since`: Use `time.Since(start)` instead of `time.Now().Sub(start)`
-
-### Go 1.8+
-
-- `time.Until`: Use `time.Until(deadline)` instead of `deadline.Sub(time.Now())`
-
-### Go 1.13+
-
-- `errors.Is`: Use `errors.Is(err, target)` instead of `err == target` (works with wrapped errors)
-
-### Go 1.18+
-
-- `any`: Use `any` instead of `interface{}`
-- `bytes.Cut`: `before, after, found := bytes.Cut(b, sep)` instead of Index+slice
-- `strings.Cut`: `before, after, found := strings.Cut(s, sep)`
-
-### Go 1.19+
-
-- `fmt.Appendf`: `buf = fmt.Appendf(buf, "x=%d", x)` instead of `[]byte(fmt.Sprintf(...))`
-- `atomic.Bool`/`atomic.Int64`/`atomic.Pointer[T]`: Type-safe atomics instead of `atomic.StoreInt32`
-
-```go
-var flag atomic.Bool
-flag.Store(true)
-if flag.Load() { ... }
-
-var ptr atomic.Pointer[Config]
-ptr.Store(cfg)
-```
-
-### Go 1.20+
-
-- `strings.Clone`: `strings.Clone(s)` to copy string without sharing memory
-- `bytes.Clone`: `bytes.Clone(b)` to copy byte slice
-- `strings.CutPrefix/CutSuffix`: `if rest, ok := strings.CutPrefix(s, "pre:"); ok { ... }`
-- `errors.Join`: `errors.Join(err1, err2)` to combine multiple errors
-- `context.WithCancelCause`: `ctx, cancel := context.WithCancelCause(parent)` then `cancel(err)`
-- `context.Cause`: `context.Cause(ctx)` to get the error that caused cancellation
-
-### Go 1.21+
-
-**Built-ins:**
-- `min`/`max`: `max(a, b)` instead of if/else comparisons
-- `clear`: `clear(m)` to delete all map entries, `clear(s)` to zero slice elements
-
-**slices package:**
-- `slices.Contains`: `slices.Contains(items, x)` instead of manual loops
-- `slices.Index`: `slices.Index(items, x)` returns index (-1 if not found)
-- `slices.IndexFunc`: `slices.IndexFunc(items, func(item T) bool { return item.ID == id })`
-- `slices.SortFunc`: `slices.SortFunc(items, func(a, b T) int { return cmp.Compare(a.X, b.X) })`
-- `slices.Sort`: `slices.Sort(items)` for ordered types
-- `slices.Max`/`slices.Min`: `slices.Max(items)` instead of manual loop
-- `slices.Reverse`: `slices.Reverse(items)` instead of manual swap loop
-- `slices.Compact`: `slices.Compact(items)` removes consecutive duplicates in-place
-- `slices.Clip`: `slices.Clip(s)` removes unused capacity
-- `slices.Clone`: `slices.Clone(s)` creates a copy
-
-**maps package:**
-- `maps.Clone`: `maps.Clone(m)` instead of manual map iteration
-- `maps.Copy`: `maps.Copy(dst, src)` copies entries from src to dst
-- `maps.DeleteFunc`: `maps.DeleteFunc(m, func(k K, v V) bool { return condition })`
-
-**sync package:**
-- `sync.OnceFunc`: `f := sync.OnceFunc(func() { ... })` instead of `sync.Once` + wrapper
-- `sync.OnceValue`: `getter := sync.OnceValue(func() T { return computeValue() })`
-
-**context package:**
-- `context.AfterFunc`: `stop := context.AfterFunc(ctx, cleanup)` runs cleanup on cancellation
-- `context.WithTimeoutCause`: `ctx, cancel := context.WithTimeoutCause(parent, d, err)`
-- `context.WithDeadlineCause`: Similar with deadline instead of duration
-
-### Go 1.22+
-
-**Loops:**
-- `for i := range n`: `for i := range len(items)` instead of `for i := 0; i < len(items); i++`
-- Loop variables are now safe to capture in goroutines (each iteration has its own copy)
-
-**cmp package:**
-- `cmp.Or`: `cmp.Or(flag, env, config, "default")` returns first non-zero value
-
-```go
-// Instead of:
-name := os.Getenv("NAME")
-if name == "" {
-    name = "default"
-}
-// Use:
-name := cmp.Or(os.Getenv("NAME"), "default")
-```
-
-**reflect package:**
-- `reflect.TypeFor`: `reflect.TypeFor[T]()` instead of `reflect.TypeOf((*T)(nil)).Elem()`
-
-**net/http:**
-- Enhanced `http.ServeMux` patterns: `mux.HandleFunc("GET /api/{id}", handler)` with method and path params
-- `r.PathValue("id")` to get path parameters
-
-### Go 1.23+
-
-- `maps.Keys(m)` / `maps.Values(m)` return iterators
-- `slices.Collect(iter)` to build slice from iterator (not manual loop)
-- `slices.Sorted(iter)` to collect and sort in one step
-
-```go
-keys := slices.Collect(maps.Keys(m))       // not: for k := range m { keys = append(keys, k) }
-sortedKeys := slices.Sorted(maps.Keys(m))  // collect + sort
-for k := range maps.Keys(m) { process(k) } // iterate directly
-```
-
-**time package:**
-- `time.Tick`: Use freely — as of Go 1.23, GC can recover unreferenced tickers even if not stopped. No longer any reason to prefer `NewTicker` when `Tick` will do.
-
-### Go 1.24+
-
-- **`t.Context()`** not `context.WithCancel(context.Background())` in tests.
-  ALWAYS use `t.Context()` when a test function needs a context.
-
-```go
-// Before:
-func TestFoo(t *testing.T) {
-    ctx, cancel := context.WithCancel(context.Background())
-    defer cancel()
-    result := doSomething(ctx)
-}
-// After:
-func TestFoo(t *testing.T) {
-    ctx := t.Context()
-    result := doSomething(ctx)
-}
-```
-
-- **`omitzero`** not `omitempty` in JSON struct tags.
-  ALWAYS use `omitzero` for `time.Duration`, `time.Time`, structs, slices, maps.
-
-```go
-// Before:
-type Config struct {
-    Timeout time.Duration `json:"timeout,omitempty"` // doesn't work for Duration!
-}
-// After:
-type Config struct {
-    Timeout time.Duration `json:"timeout,omitzero"`
-}
-```
-
-- **`b.Loop()`** not `for i := 0; i < b.N; i++` in benchmarks.
-  ALWAYS use `b.Loop()` for the main loop in benchmark functions.
-
-```go
-// Before:
-func BenchmarkFoo(b *testing.B) {
-    for i := 0; i < b.N; i++ {
-        doWork()
-    }
-}
-// After:
-func BenchmarkFoo(b *testing.B) {
-    for b.Loop() {
-        doWork()
-    }
-}
-```
-
-- **`strings.SplitSeq`** not `strings.Split` when iterating.
-  ALWAYS use `SplitSeq`/`FieldsSeq` when iterating over split results in a for-range loop.
-
-```go
-// Before:
-for _, part := range strings.Split(s, ",") {
-    process(part)
-}
-// After:
-for part := range strings.SplitSeq(s, ",") {
-    process(part)
-}
-```
-Also: `strings.FieldsSeq`, `bytes.SplitSeq`, `bytes.FieldsSeq`.
-
-### Go 1.25+
-
-- **`wg.Go(fn)`** not `wg.Add(1)` + `go func() { defer wg.Done(); ... }()`.
-  ALWAYS use `wg.Go()` when spawning goroutines with `sync.WaitGroup`.
-
-```go
-// Before:
-var wg sync.WaitGroup
-for _, item := range items {
-    wg.Add(1)
-    go func() {
-        defer wg.Done()
-        process(item)
-    }()
-}
-wg.Wait()
-
-// After:
-var wg sync.WaitGroup
-for _, item := range items {
-    wg.Go(func() {
-        process(item)
-    })
-}
-wg.Wait()
-```
-
-### Go 1.26+
-
-- **`new(val)`** not `x := val; &x` — returns pointer to any value.
-  Go 1.26 extends `new()` to accept expressions, not just types.
-  Type is inferred: `new(0)` → `*int`, `new("s")` → `*string`, `new(T{})` → `*T`.
-  DO NOT use `x := val; &x` pattern — always use `new(val)` directly.
-  DO NOT use redundant casts like `new(int(0))` — just write `new(0)`.
-
-```go
-// Before:
-timeout := 30
-debug := true
-cfg := Config{
-    Timeout: &timeout,
-    Debug:   &debug,
-}
-// After:
-cfg := Config{
-    Timeout: new(30),   // *int
-    Debug:   new(true), // *bool
-}
-```
-
-- **`errors.AsType[T](err)`** not `errors.As(err, &target)`.
-  ALWAYS use `errors.AsType` when checking if error matches a specific type.
-
-```go
-// Before:
-var pathErr *os.PathError
-if errors.As(err, &pathErr) {
-    handle(pathErr)
-}
-// After:
-if pathErr, ok := errors.AsType[*os.PathError](err); ok {
-    handle(pathErr)
-}
-```
-
-## Capabilities & Limitations
-
-### What This Agent CAN Do
-- Design type-safe Go applications with modern generics and interfaces
-- Implement concurrent systems using goroutines, channels, and sync primitives
-- Write comprehensive test suites with table-driven tests, fuzzing, and benchmarks
-- Debug concurrency issues (race conditions, deadlocks, goroutine leaks)
-- Optimize Go code for performance (profiling, zero-allocation patterns)
-- Review code for correctness, concurrency safety, and Go idioms
-- Implement production patterns (graceful shutdown, observability, error handling)
-- Configure Go tooling (go.mod, linters, build tags, compiler flags)
-- Use gopls MCP for workspace-aware Go intelligence (symbol search, diagnostics, references)
-- Use LSP tool for go-to-definition, find-references, hover information
-
-### What This Agent CANNOT Do
-- **Cannot execute Go code**: Can provide implementation but you must run `go test`, `go build`.
-- **Cannot access external systems**: No network access to test APIs or databases.
-- **Cannot profile your code**: Can provide profiling commands but not actual profiling results.
-- **Cannot manage infrastructure**: Focus is code, not Kubernetes, Docker, or cloud deployments.
-- **Cannot guarantee CGO compatibility**: Focus is pure Go, limited CGO expertise.
-
-When asked to perform unavailable actions, explain the limitation and suggest appropriate workflows.
-
-## Output Format
-
-This agent uses the **Implementation Schema**:
-
-```markdown
-## Summary
-[1-2 sentence overview of what was implemented]
-
-## Implementation
-[Description of approach and key decisions]
-
-## Files Changed
-| File | Change | Lines |
-|------|--------|-------|
-| `path/file.go:42` | [description] | +N/-M |
-
-## Testing
-- [x] Tests pass: `go test -v -race ./...` output
-- [x] Vet clean: `go vet ./...` output
-- [x] Build succeeds: `go build ./...` output
-
-## Next Steps
-- [ ] [Follow-up if any]
-```
-
-See [shared-patterns/output-schemas.md](../skills/shared-patterns/output-schemas.md) for full schema.
-
-## Error Handling
-
-Common Go errors and solutions. See [references/go-errors.md](references/go-errors.md) for comprehensive catalog.
-
-### Goroutine Leak
-**Cause**: Goroutines not exiting, context not canceled, channels not closed
-**Solution**: Use context with cancel, ensure all goroutines have exit paths, use `sync.WaitGroup` to track completion, close channels when done producing
-
-### Race Condition
-**Cause**: Concurrent access to shared memory without synchronization
-**Solution**: Use `sync.Mutex`, `sync.RWMutex`, or channels for synchronization. Run `go test -race` to detect. Prefer message passing over shared memory.
-
-### Panic on Nil Pointer
-**Cause**: Accessing method/field on nil pointer, nil map write
-**Solution**: Check for nil before accessing, initialize maps with `make()`, validate pointers in constructors
-
-### Interface Conversion Panic
-**Cause**: Type assertion fails on nil interface or wrong type
-**Solution**: Use two-value type assertion: `v, ok := x.(Type)`. Check ok before using v. Consider type switch for multiple types.
-
-### Context Deadline Exceeded
-**Cause**: Operation took longer than context deadline/timeout
-**Solution**: Increase timeout, optimize slow operations, check if context is respected in loops, propagate context to all blocking calls
+## Reference Loading Table
+
+| When | Load |
+|------|------|
+| Go version features, modern idioms, migration checklist | [go-modern-features.md](references/go-modern-features.md) |
+| Error catalog (goroutine leak, race condition, nil pointer, context deadline) | [go-errors.md](references/go-errors.md) |
+| Anti-patterns and code smell detection | [go-anti-patterns.md](references/go-anti-patterns.md) |
+| Concurrency patterns (worker pools, fan-out/fan-in, pipelines) | [go-concurrency.md](references/go-concurrency.md) |
+| Testing patterns (table-driven, fuzzing, benchmarks, race detection) | [go-testing.md](references/go-testing.md) |
 
 ## Preferred Patterns
-
-Common Go patterns to follow. See [references/go-anti-patterns.md](references/go-anti-patterns.md) for full catalog.
 
 ### Modern Idiom Patterns
 
@@ -576,36 +247,6 @@ These are the most common AI-generated Go anti-patterns — using old patterns w
 | `wg.Add(1); go func() { defer wg.Done()... }()` | `wg.Go(func() { ... })` | Go 1.25 |
 | `x := val; &x` for pointer | `new(val)` | Go 1.26 |
 | `var t *T; errors.As(err, &t)` | `errors.AsType[*T](err)` | Go 1.26 |
-
-### Silent Error from defer rows.Close()
-**What it looks like**: `defer rows.Close()` in SQL query loops
-**Why wrong**: `rows.Close()` returns an error that `defer` silently discards. If the query succeeded but closing fails (connection drop, context cancel), the error is lost.
-**Do instead**: Use a named return and deferred closure that merges the `rows.Close()` error only when no prior error exists: `defer func() { if closeErr := rows.Close(); err == nil { err = closeErr } }()`
-
-### Ignoring Errors
-**What it looks like**: `result, _ := function()` or `function(); // ignore error`
-**Why wrong**: Silent failures, bugs in production, violates Go conventions
-**Do instead**: Always check errors: `if err != nil { return fmt.Errorf("context: %w", err) }`
-
-### Starting Goroutines Without Exit Strategy
-**What it looks like**: `go func() { for { work() } }()` with no way to stop
-**Why wrong**: Goroutine leaks, resource exhaustion, no graceful shutdown
-**Do instead**: Use context for cancellation, channels for signaling, ensure goroutines can exit
-
-### Using sync.WaitGroup Incorrectly
-**What it looks like**: `Add()` called inside goroutine, missing `Done()`, wrong counter
-**Why wrong**: Deadlocks, panics, incorrect synchronization
-**Do instead**: Use `wg.Go()` (Go 1.25+) which handles Add/Done automatically. For older versions: call `Add()` before spawning goroutine, defer `Done()`, match Add/Done calls exactly.
-
-### Mutating Loop Variable in Goroutine
-**What it looks like**: `for _, item := range items { go func() { process(item) }() }`
-**Why wrong**: Pre-Go 1.22: all goroutines see last value (closure captures variable, not value). Go 1.22+: each iteration has its own copy, so this is safe.
-**Do instead**: For Go < 1.22: pass as parameter `go func(i Item) { process(i) }(item)`. For Go 1.22+: safe as-is, but `wg.Go()` (Go 1.25+) is the cleanest pattern.
-
-### Not Closing Channels
-**What it looks like**: Producer never closes channel, range loop waits forever
-**Why wrong**: Goroutine leaks, deadlocks, range loops never complete
-**Do instead**: Producer closes channel when done: `defer close(ch)`, use `for range` to consume
 
 ### Protocol Reasoning Instead of Library Verification
 **What it looks like**: "Kafka consumer groups will rebalance after a member leaves, so this is safe."
@@ -687,14 +328,6 @@ STOP and ask the user (get explicit confirmation) before proceeding when:
 | Breaking API change | Affects consumers | "This changes public API. How to handle migration?" |
 | Database/storage choice | Long-term architecture | "SQL, NoSQL, or file-based? What are the requirements?" |
 
-### Always Confirm First
-- Concurrency patterns (worker pools, pipelines, fan-out)
-- Error handling strategy (wrapping, sentinels, custom types)
-- Interface contracts and public APIs
-- External dependencies and package selection
-- Database schema or storage format
-- Performance targets or optimization priorities
-
 ## Death Loop Prevention
 
 ### Retry Limits
@@ -715,34 +348,11 @@ STOP and ask the user (get explicit confirmation) before proceeding when:
 4. Check if fix addresses root cause vs symptom
 5. Use `go_diagnostics` if gopls MCP is available for richer error context
 
-## References
-
-For detailed Go patterns and examples:
-- **Error Catalog**: [references/go-errors.md](references/go-errors.md)
-- **Pattern Guide**: [references/go-anti-patterns.md](references/go-anti-patterns.md)
-- **Concurrency Patterns**: [references/go-concurrency.md](references/go-concurrency.md)
-- **Testing Patterns**: [references/go-testing.md](references/go-testing.md)
-- **Modern Features**: [references/go-modern-features.md](references/go-modern-features.md)
-
 ## Changelog
 
-### v3.0.0 (2026-03-10)
-- Integrated gopls MCP server with full Read/Edit workflows
-- Added complete JetBrains Modern Go Guidelines (Go 1.0 through 1.26)
-- Version-aware code generation: detect Go version from go.mod
-- Added gopls MCP tools table and usage instructions
-- Added Modern Idiom Patterns table with version annotations
-- Updated forbidden patterns with benchmark loop and omitzero checks
-- Updated anti-rationalization with version and gopls awareness
-- Bumped version references from 1.24+ to 1.26+
-
-### v2.0.0 (2026-02-13)
-- Migrated to v2.0 structure with Anthropic best practices
-- Added Error Handling, Preferred Patterns, Anti-Rationalization, Blocker Criteria sections
-- Created references/ directory for progressive disclosure
-- Maintained all routing metadata, hooks, and color
-- Updated to standard Operator Context structure
-- Moved detailed patterns to references for token efficiency
-
-### v1.0.0 (2025-12-07)
-- Initial implementation with modern Go patterns (1.25+)
+### v3.1.0 (2026-04-16)
+- Optimized body: moved version table to references/go-modern-features.md
+- Added Reference Loading Table for progressive disclosure
+- Removed generic boilerplate (Capabilities, Communication Style, verbose Output Format)
+- Removed duplicated error/pattern content (lives in references)
+- Kept all domain-specific content: gopls MCP, graduated anti-patterns, hard gates

--- a/agents/golang-general-engineer/references/go-modern-features.md
+++ b/agents/golang-general-engineer/references/go-modern-features.md
@@ -2,6 +2,16 @@
 
 > Reference file for golang-general-engineer agent. Loaded as context during Go development tasks.
 
+## Pre-Generics Era (Go 1.0 - 1.17)
+
+Key idioms introduced before generics that remain essential:
+
+| Feature | Idiom | Since |
+|---------|-------|-------|
+| `time.Since` | `time.Since(start)` not `time.Now().Sub(start)` | 1.0 |
+| `time.Until` | `time.Until(deadline)` not `deadline.Sub(time.Now())` | 1.8 |
+| `errors.Is` | `errors.Is(err, target)` not `err == target` (works with wrapped errors) | 1.13 |
+
 ## Go 1.18: Generics and Fuzzing
 
 **Generics** — type parameters for functions, types, and interfaces.
@@ -365,12 +375,53 @@ func BenchmarkMapLookup(b *testing.B) {
 }
 ```
 
+## Go 1.26: Extended new() and errors.AsType
+
+**Extended `new()` builtin** -- accepts expressions, not just types. Returns a pointer to a copy of the value.
+
+```go
+// OLD: variable + address-of
+timeout := 30
+debug := true
+cfg := Config{
+    Timeout: &timeout,
+    Debug:   &debug,
+}
+
+// NEW: new(val) returns pointer directly
+cfg := Config{
+    Timeout: new(30),   // *int
+    Debug:   new(true), // *bool
+}
+
+// Type is inferred: new(0) -> *int, new("s") -> *string, new(T{}) -> *T
+// Do NOT use redundant casts like new(int(0)) -- just write new(0)
+```
+
+**`errors.AsType[T]`** -- generic type assertion for errors, replacing `errors.As` with pointer dance.
+
+```go
+// OLD: declare target variable, pass pointer
+var pathErr *os.PathError
+if errors.As(err, &pathErr) {
+    handle(pathErr)
+}
+
+// NEW: generic, returns value and bool
+if pathErr, ok := errors.AsType[*os.PathError](err); ok {
+    handle(pathErr)
+}
+```
+
 ## Migration Checklist
 
 When upgrading a project to modern Go, apply these changes:
 
 | Old Pattern | New Pattern | Since |
 |---|---|---|
+| `time.Now().Sub(start)` | `time.Since(start)` | 1.0 |
+| `deadline.Sub(time.Now())` | `time.Until(deadline)` | 1.8 |
+| `err == target` | `errors.Is(err, target)` | 1.13 |
 | `interface{}` | `any` | 1.18 |
 | `atomic.AddInt64(&x, 1)` | `x.Add(1)` with `atomic.Int64` | 1.19 |
 | Custom multi-error | `errors.Join(errs...)` | 1.20 |
@@ -383,3 +434,5 @@ When upgrading a project to modern Go, apply these changes:
 | String dedup caches | `unique.Make(s)` | 1.23 |
 | Manual path sanitization | `os.OpenRoot(dir)` | 1.24 |
 | `time.Sleep` in tests | `testing/synctest` | 1.24 |
+| `x := val; &x` for pointer | `new(val)` | 1.26 |
+| `var t *T; errors.As(err, &t)` | `errors.AsType[*T](err)` | 1.26 |


### PR DESCRIPTION
## Summary
- Reduced golang-general-engineer.md from 748 to 358 lines (52% reduction)
- Moved 250-line Go version table to references/go-modern-features.md (enriched with pre-1.18 and Go 1.26 content)
- Removed generic boilerplate (Capabilities & Limitations, Communication Style)
- Added proper Reference Loading Table with signals for all 5 reference files
- All domain-specific content preserved: gopls MCP, graduated anti-patterns, hard gate patterns

## Test plan
- [ ] Reference validation 5/5 OK
- [ ] Progressive disclosure tests pass
- [ ] gopls integration instructions intact
- [ ] Ruff lint passes