### PR TITLE
feat(refs): codex-code-review (Level 0→3)

### DIFF
--- a/skills/codex-code-review/SKILL.md
+++ b/skills/codex-code-review/SKILL.md
@@ -29,7 +29,17 @@ routing:
 # Codex Code Review
 
 Invoke OpenAI's Codex CLI (GPT-5.4 with maximum reasoning effort) to get an
-independent second opinion on code changes. Claude orchestrates the review:
+independent second opinion on code changes.
+
+## Reference Loading
+
+Load these files when the corresponding signals appear:
+
+| Signal | Load |
+|--------|------|
+| Constructing or debugging `codex exec` command; flag errors; mktemp issues; model errors | `references/codex-cli-patterns.md` |
+| Classifying findings; adjusting severity; filtering Codex output; writing the report | `references/review-methodology.md` |
+| Looking up specific anti-patterns to verify; needs detection grep commands for Go/TS/Python | `references/code-anti-patterns.md` | Claude orchestrates the review:
 scoping what to review, constructing the prompt, invoking Codex in a read-only
 sandbox, then critically assessing the feedback before presenting it to the user.
 

--- a/skills/codex-code-review/references/code-anti-patterns.md
+++ b/skills/codex-code-review/references/code-anti-patterns.md
@@ -1,0 +1,334 @@
+# Code Anti-Patterns for Review
+
+> **Scope**: Common code anti-patterns to detect during review, with grep commands for codebase verification.
+> **Version range**: Language-specific version notes inline
+> **Generated**: 2026-04-16
+
+---
+
+## Overview
+
+Code review — whether by Codex, Claude, or a human — needs concrete patterns to look for.
+This file catalogs high-signal anti-patterns across Go, TypeScript/JavaScript, and Python.
+Detection commands let you verify findings in the actual codebase rather than relying on
+model interpretation alone.
+
+---
+
+## Go Anti-Patterns
+
+### Swallowed errors (blank identifier on error return)
+
+**Detection**:
+```bash
+rg ',\s*_\s*:?=' --type go -n | grep -v '_test\.go'
+grep -rn ',\s*_\s*=' --include="*.go" | grep -v test
+```
+
+**What it looks like**:
+```go
+result, _ := db.Query("SELECT ...")  // error silently dropped
+file.Close()                          // return value ignored
+```
+
+**Why wrong**: Silent failures compound — the next operation uses invalid state.
+Debugging in production becomes impossible without error context.
+
+**Fix**:
+```go
+result, err := db.Query("SELECT ...")
+if err != nil {
+    return fmt.Errorf("query users: %w", err)
+}
+defer func() {
+    if err := file.Close(); err != nil {
+        log.Printf("close file: %v", err)
+    }
+}()
+```
+
+**Version note**: `%w` for error wrapping requires Go 1.13+.
+
+---
+
+### Goroutine with no exit strategy
+
+**Detection**:
+```bash
+rg 'go func\(\)' --type go -n
+rg 'go\s+\w+\(' --type go -n | grep -v '_test'
+```
+
+**What it looks like**:
+```go
+func start() {
+    go func() {
+        for {
+            process()  // no context.Done(), no stop channel
+        }
+    }()
+}
+```
+
+**Why wrong**: Goroutines with no exit path leak on shutdown. Under load or repeated
+invocations, this causes unbounded memory growth.
+
+**Fix**:
+```go
+func start(ctx context.Context) {
+    go func() {
+        for {
+            select {
+            case <-ctx.Done():
+                return
+            default:
+                process()
+            }
+        }
+    }()
+}
+```
+
+---
+
+### Mutex copied by value (sync.Mutex in struct passed by value)
+
+**Detection**:
+```bash
+rg 'sync\.Mutex|sync\.RWMutex' --type go -n
+# Then check for value receivers on structs containing mutex
+grep -rn 'func\s*(\w\+\s\w\+)' --include="*.go" | grep -v '\*'
+```
+
+**What it looks like**:
+```go
+type Counter struct {
+    mu  sync.Mutex
+    val int
+}
+func process(c Counter) { ... }  // copies Counter — mutex state diverges
+```
+
+**Why wrong**: Copying `sync.Mutex` copies its internal state. The copy and original have
+independent lock states — concurrent access is not protected.
+
+**Fix**: Always pass structs containing mutexes by pointer:
+```go
+func process(c *Counter) { ... }
+```
+
+**Version note**: `go vet` detects this via the `copylocks` analyzer (all versions).
+
+---
+
+## TypeScript/JavaScript Anti-Patterns
+
+### Floating Promise (unhandled async)
+
+**Detection**:
+```bash
+rg '^\s+[a-zA-Z]\w*\(.*\);$' --type ts -n | grep -v 'await\|return\|const\|let\|var\|//'
+rg 'Promise\.' --type ts -n | grep -v '\.catch\|\.then\|await\|void'
+```
+
+**What it looks like**:
+```typescript
+async function handler() {
+    sendNotification(userId);  // promise not awaited — errors swallowed
+    return { ok: true };
+}
+```
+
+**Why wrong**: Errors from `sendNotification` are silently dropped. The function returns
+before the async work completes, making success/failure undetectable.
+
+**Fix**:
+```typescript
+async function handler() {
+    await sendNotification(userId);
+    return { ok: true };
+}
+// Or if truly fire-and-forget, handle errors explicitly:
+sendNotification(userId).catch(err => logger.error('notification failed', { err }));
+```
+
+---
+
+### `as any` silencing TypeScript type checking
+
+**Detection**:
+```bash
+rg 'as any' --type ts -n
+rg ':\s*any\b' --type ts -n | grep -v '\.d\.ts\|// '
+```
+
+**What it looks like**:
+```typescript
+const user = response.data as any;
+user.profile.name;  // no type safety — runtime error if profile is undefined
+```
+
+**Why wrong**: `as any` opts out of TypeScript's type system entirely. Downstream property
+access has no compile-time protection — null reference errors appear at runtime.
+
+**Fix**: Use proper typing or a type guard:
+```typescript
+interface UserResponse { profile: { name: string } | null }
+const user = response.data as UserResponse;
+if (user.profile) {
+    user.profile.name;  // safe
+}
+```
+
+---
+
+### `console.log` left in production code
+
+**Detection**:
+```bash
+rg 'console\.(log|error|warn|debug)\(' --type ts -n | grep -v '\.test\.\|\.spec\.\|__test'
+grep -rn 'console\.log' --include="*.ts" --include="*.js" | grep -v test
+```
+
+**What it looks like**:
+```typescript
+async function processOrder(id: string) {
+    console.log('processing order', id);  // leaks order IDs to stdout
+}
+```
+
+**Why wrong**: Console output bypasses structured logging, loses correlation IDs, and may
+leak PII to log aggregators that lack access controls.
+
+**Fix**: Use the project's structured logger:
+```typescript
+logger.info({ orderId: id }, 'processing order');
+```
+
+---
+
+## Python Anti-Patterns
+
+### Bare `except` clause
+
+**Detection**:
+```bash
+rg '^\s+except\s*:' --type py -n
+grep -rn 'except:$' --include="*.py"
+```
+
+**What it looks like**:
+```python
+try:
+    result = fetch_data()
+except:          # catches KeyboardInterrupt, SystemExit, everything
+    pass         # silently continues
+```
+
+**Why wrong**: Catches `KeyboardInterrupt` and `SystemExit` — Ctrl-C won't stop the process.
+Also swallows errors that should surface for debugging.
+
+**Fix**:
+```python
+try:
+    result = fetch_data()
+except (ValueError, ConnectionError) as e:
+    logger.error("fetch failed: %s", e)
+    raise
+```
+
+---
+
+### Mutable default argument
+
+**Detection**:
+```bash
+rg 'def \w+\(.*=\[\]|def \w+\(.*=\{\}' --type py -n
+grep -rn 'def .*=\[\]\|def .*={}' --include="*.py"
+```
+
+**What it looks like**:
+```python
+def add_item(item, items=[]):  # shared across ALL calls
+    items.append(item)
+    return items
+```
+
+**Why wrong**: The default list is created once at function definition, not per call. All
+invocations without an explicit `items` argument share the same list — state leaks.
+
+**Fix**:
+```python
+def add_item(item, items=None):
+    if items is None:
+        items = []
+    items.append(item)
+    return items
+```
+
+**Version note**: Applies to all Python versions. `pylint W0102` and `mypy` detect this.
+
+---
+
+### `os.system()` or `shell=True` with dynamic input
+
+**Detection**:
+```bash
+rg 'os\.system\(' --type py -n
+rg 'subprocess\.call\(.*shell=True|subprocess\.run\(.*shell=True' --type py -n
+```
+
+**What it looks like**:
+```python
+os.system(f"process {user_input}")  # injection if user_input contains ; or |
+subprocess.run(f"grep {pattern} log.txt", shell=True)
+```
+
+**Why wrong**: Shell metacharacters in dynamic input execute arbitrary commands. Classic
+injection vulnerability — always flag as Critical when input is from user or external source.
+
+**Fix**:
+```python
+subprocess.run(["process", user_input], check=True)  # shell=False (default)
+subprocess.run(["grep", pattern, "log.txt"], check=True)
+```
+
+---
+
+## Error-Fix Mappings
+
+| Code Pattern Found | Likely Root Cause | Review Severity |
+|-------------------|-------------------|-----------------|
+| `_, _ = fn()` in Go | Both return values discarded | Critical if fn returns error |
+| `as any` in hot path TypeScript | Type mismatch the author couldn't resolve | Improvements — suggest proper interface |
+| `shell=True` with f-string | Developer convenience over safety | Critical — injection risk |
+| `except: pass` | Debugging residue never removed | Critical — silences all exceptions |
+| `go func()` without `ctx` parameter | Pattern copied from simpler code | Improvements — check if caller has context |
+| `console.log` with user identifiers | Debug logging committed accidentally | Improvements — PII leak risk |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Go: swallowed errors
+rg ',\s*_\s*:?=' --type go -n | grep -v '_test'
+
+# Go: goroutine leaks
+rg 'go func\(\)' --type go -n
+
+# TypeScript: floating promises
+rg '^\s+[a-zA-Z]\w*\(' --type ts -n | grep -v 'await\|return\|const\|let\|var\|//'
+
+# TypeScript: any casts
+rg 'as any' --type ts -n
+
+# Python: bare except
+rg '^\s+except\s*:' --type py -n
+
+# Python: mutable defaults
+rg 'def \w+\(.*=\[\]' --type py -n
+
+# Python: shell injection risk
+rg 'os\.system\(|shell=True' --type py -n
+```

--- a/skills/codex-code-review/references/codex-cli-patterns.md
+++ b/skills/codex-code-review/references/codex-cli-patterns.md
@@ -1,0 +1,193 @@
+# Codex CLI Patterns
+
+> **Scope**: `codex exec` command variants, flags, and error recovery for code review invocations.
+> **Version range**: @openai/codex >=0.1.0, gpt-5.4 / gpt-4o / o4-mini models
+> **Generated**: 2026-04-16
+
+---
+
+## Overview
+
+The Codex CLI runs GPT models in a sandboxed environment with direct filesystem access.
+For code review, the key pattern is `codex exec review` (built-in review subcommand) or
+`codex exec` with a custom prompt. The CLI manages its own git context — embedding diffs
+wastes tokens and hits prompt-length limits.
+
+---
+
+## Command Pattern Table
+
+| Use Case | Command Variant | Key Flags |
+|----------|----------------|-----------|
+| Branch review vs main | `codex exec review --base main` | `--base <branch>` |
+| Single commit review | `codex exec review --commit <SHA>` | `--commit <SHA>` |
+| Unstaged changes only | `codex exec review --uncommitted` | `--uncommitted` |
+| Custom focus areas | `codex exec "YOUR PROMPT"` | no `--base/--commit` |
+| High-quality analysis | add to any | `-m gpt-5.4 -c 'model_reasoning_effort="xhigh"'` |
+| Capture output | add to any | `-o "$TMPFILE"` |
+| One-shot (no persist) | add to any | `--ephemeral` |
+| Container/VM bypass | add to any | `--dangerously-bypass-approvals-and-sandbox` |
+
+---
+
+## Correct Patterns
+
+### Branch review with output capture
+
+```bash
+TMPFILE=$(mktemp /tmp/codex-review.XXXXXXXX)
+
+codex exec review \
+  --base main \
+  -m gpt-5.4 \
+  -c 'model_reasoning_effort="xhigh"' \
+  --ephemeral \
+  --dangerously-bypass-approvals-and-sandbox \
+  -o "$TMPFILE"
+```
+
+**Why**: `mktemp` template must end in Xs — appending an extension (`.md`) after the Xs
+breaks macOS `mktemp`. `--base` and a custom prompt are mutually exclusive — `review`
+handles diff internally.
+
+### Custom prompt with heredoc
+
+```bash
+TMPFILE=$(mktemp /tmp/codex-review.XXXXXXXX)
+
+codex exec \
+  -m gpt-5.4 \
+  -c 'model_reasoning_effort="xhigh"' \
+  --ephemeral \
+  --dangerously-bypass-approvals-and-sandbox \
+  -o "$TMPFILE" \
+  "$(cat <<'PROMPT'
+Review the changes in git diff HEAD~1 focusing on error handling and security.
+Run: git diff HEAD~1
+PROMPT
+)"
+```
+
+**Why**: Let Codex run `git diff` itself rather than embedding the diff — Codex has repo
+access and embedding large diffs wastes tokens and loses formatting.
+
+### Check exit code before reading output
+
+```bash
+if ! codex exec review --base main -m gpt-5.4 -o "$TMPFILE"; then
+  echo "Codex failed — check stderr for API/auth errors"
+  rm -f "$TMPFILE"
+  exit 1
+fi
+
+if [ ! -s "$TMPFILE" ]; then
+  echo "Codex produced empty output"
+  rm -f "$TMPFILE"
+  exit 1
+fi
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### Embedding the diff in the prompt
+
+**Detection**:
+```bash
+# In constructed prompt strings — look for variable expansion with git diff output
+grep -n 'DIFF=\$(git diff' . -r
+```
+
+**What it looks like**:
+```bash
+DIFF=$(git diff main...HEAD)
+codex exec "Review this code: $DIFF"
+```
+
+**Why wrong**: Large diffs (>50 files) hit prompt-length limits. Formatting collapses.
+Codex already has filesystem access — it can run `git diff` directly.
+
+**Fix**: Tell Codex which command to run, not what the output is:
+```bash
+codex exec "Run \`git diff main...HEAD\` and review the changes for security issues."
+```
+
+---
+
+### Using `--base` and a custom prompt together with `codex exec review`
+
+**What it looks like**:
+```bash
+codex exec review --base main "Focus on error handling"
+```
+
+**Why wrong**: `--base`, `--commit`, and `--uncommitted` are mutually exclusive with a
+custom `[PROMPT]` argument in the `review` subcommand. The CLI errors.
+
+**Fix**: Use `codex exec` (not `codex exec review`) with a custom prompt:
+```bash
+codex exec -m gpt-5.4 -o "$TMPFILE" \
+  "Run \`git diff main...HEAD\` and focus on error handling patterns."
+```
+
+---
+
+### Appending extension to mktemp template
+
+**What it looks like**:
+```bash
+TMPFILE=$(mktemp /tmp/codex-review.XXXXXXXX.md)
+```
+
+**Why wrong**: macOS `mktemp` requires the template to end in Xs. Appending `.md` causes
+`mktemp: /tmp/codex-review.XXXXXXXX.md: invalid suffix`.
+
+**Fix**: No extension, Xs at the end:
+```bash
+TMPFILE=$(mktemp /tmp/codex-review.XXXXXXXX)
+```
+
+---
+
+### Using `-s read-only` with `--dangerously-bypass-approvals-and-sandbox`
+
+**What it looks like**:
+```bash
+codex exec review --dangerously-bypass-approvals-and-sandbox -s read-only ...
+```
+
+**Why wrong**: These flags are mutually exclusive. `-s read-only` configures the bwrap
+sandbox; the bypass flag disables it entirely. Combining them errors.
+
+**Fix**: Use one or the other. In containerized environments, use the bypass flag.
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| `codex: command not found` | CLI not installed or not in PATH | `npm install -g @openai/codex`; verify with `codex --version` |
+| `loopback: Failed RTM_NEWADDR: Operation not permitted` | bwrap sandbox fails in VM/container | Add `--dangerously-bypass-approvals-and-sandbox` |
+| `invalid suffix` from mktemp | Extension appended after Xs in template | Remove extension: `mktemp /tmp/codex-review.XXXXXXXX` |
+| `Error: cannot use --base with PROMPT` | `codex exec review` with both `--base` and positional prompt | Remove `--base` or switch to `codex exec` without review subcommand |
+| Empty output file | Timeout, model error, or prompt too long | Check stderr; do not retry automatically |
+| `401 Unauthorized` | OPENAI_API_KEY not set or expired | `export OPENAI_API_KEY=...` or check key validity |
+| `429 Too Many Requests` | Rate limit hit | Wait and report to user — do not retry in a loop |
+| `model not found: gpt-5.4` | Model unavailable in account tier | Fall back to `gpt-4o` and note in report |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Verify codex is installed
+codex --version
+
+# Check temp file has content before processing
+[ -s "$TMPFILE" ] && echo "has content" || echo "empty or missing"
+
+# Find embedded diffs in any shell scripts (anti-pattern signal)
+grep -rn 'DIFF=\$(git' . --include="*.sh" --include="*.bash"
+```

--- a/skills/codex-code-review/references/review-methodology.md
+++ b/skills/codex-code-review/references/review-methodology.md
@@ -1,0 +1,193 @@
+# Code Review Methodology
+
+> **Scope**: How to classify, filter, and synthesize Codex findings into a useful review report.
+> **Version range**: All versions
+> **Generated**: 2026-04-16
+
+---
+
+## Overview
+
+The value of cross-model review is triangulation, not aggregation. Codex findings need the
+same scrutiny as any automated tool — it can misread control flow, miss upstream handling,
+or flag intentional patterns as errors. The methodology below ensures Claude adds context
+rather than passing through Codex output verbatim.
+
+---
+
+## Finding Classification Table
+
+| Codex Finding Type | Claude Action | Report Section |
+|-------------------|---------------|----------------|
+| Correct, properly scoped | Agree — include as-is | Critical Issues or Improvements |
+| Directionally right, wrong severity | Agree with modification — adjust severity | Adjusted section |
+| Correct finding, already handled elsewhere | Disagree — document reason | Filtered Findings |
+| Hallucinated issue (misread logic) | Disagree — explain what Codex missed | Filtered Findings |
+| Style preference marked as critical | Disagree — regrade to Improvements | Improvements (regraded) |
+| Issue Claude found that Codex missed | Claude's own finding | Claude's Additional Observations |
+
+---
+
+## Severity Decision Tree
+
+```
+Is this issue reachable in production?
+├── No → Improvements (not Critical)
+└── Yes → Can it cause data loss, crash, or auth bypass?
+    ├── Yes → Critical Issues
+    └── No → Does it degrade performance measurably?
+        ├── Yes → Improvements (performance)
+        └── No → Positive Notes or style — not Critical
+```
+
+---
+
+## Correct Patterns
+
+### Verifying upstream handling before agreeing with a finding
+
+Before marking a finding as "Agreed", check if the concern is already handled at the call site:
+
+```bash
+# If Codex flags missing error handling in function X, check callers
+grep -rn "functionName(" --include="*.go" | head -20
+# Read the call site to see if errors are caught upstream
+```
+
+**Why**: Codex sees functions in isolation. A missing `err` check in a helper may be
+intentional if the caller always validates. Agreeing without checking creates noise.
+
+### Making severity adjustments visible in the report
+
+```markdown
+### Improvements
+
+**[CODEX: Critical — regraded to Improvement]** Missing nil check on `user.Profile`.
+`Profile` is always set by `NewUser()` before this path is reached — the risk is real
+but only in tests that bypass the constructor. Not production-blocking.
+```
+
+**Why**: Transparent reasoning lets the user disagree. Silent regrading looks like filtering
+and erodes trust in the review.
+
+### Surfacing what Codex missed
+
+```markdown
+### Claude's Additional Observations
+
+**Error channel not drained**: `results` channel in `processItems()` is written but never
+drained if the context is canceled — goroutine blocks forever. Codex reviewed the write
+path only, not the consumer.
+
+Detection:
+```bash
+rg 'chan.*results|results.*chan' --type go
+```
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### Passing through Codex output verbatim
+
+**Detection**:
+```bash
+# Report is a copy of $TMPFILE if it contains Codex's exact headers unchanged
+grep -c "## CRITICAL ISSUES\|## IMPROVEMENTS\|## POSITIVE NOTES" report.md
+```
+
+**Why wrong**: The entire value of cross-model review is Claude's assessment layer. Verbatim
+pass-through means the user could have run `codex exec` themselves.
+
+**Fix**: Every Codex finding must be explicitly classified (Agree/Agree-modified/Disagree)
+with at least one sentence of Claude's reasoning before it appears in the report.
+
+---
+
+### Silently dropping disagreed findings
+
+**What it looks like**: Codex flags 8 issues; report shows 4 with no explanation of the others.
+
+**Why wrong**: Users who know Codex ran and see fewer findings reported will distrust the
+filter. Opacity erodes confidence in the review process.
+
+**Fix**: Always include a "Filtered Findings" section:
+```markdown
+### Filtered Findings
+
+- **Unused variable `ctx`** (Codex: Critical): `ctx` is passed to `http.NewRequest` on
+  the next line — Codex didn't follow the variable reference. Not a real issue.
+- **Missing mutex lock** (Codex: Critical): This path is only reached from `ServeHTTP`
+  which Go's HTTP server serializes per-connection. Concern doesn't apply here.
+```
+
+---
+
+### Skipping assessment when output looks clean
+
+**What it looks like**: Codex output has no CRITICAL issues, so Claude presents it directly.
+
+**Why wrong**: Codex omission does not mean no issues exist. The most dangerous bugs are
+ones the first reviewer missed. Claude must check for omissions, especially in security paths.
+
+**Fix**: Always run the severity decision tree for each finding, including reviewing what
+Codex's Positive Notes section affirms — confirm those patterns are actually correct.
+
+---
+
+## Error-Fix Mappings
+
+| Scenario | Symptom | Recovery |
+|----------|---------|----------|
+| Codex output not in expected format | No `## CRITICAL ISSUES` headers | Extract findings manually; note unstructured output in report |
+| Codex flags 0 issues | Empty CRITICAL section | Verify scope was right; check for Claude-found issues before reporting clean |
+| Codex finding references wrong line | Line numbers don't match current file | Check if diff was applied; read current file version |
+| Codex flags entire file vaguely | "This file needs restructuring" | Treat as Improvements; don't flag as Critical without specifics |
+
+---
+
+## Report Structure Template
+
+```markdown
+## Codex Code Review (GPT-5.4 xhigh)
+
+**Scope**: {what was reviewed — e.g., "git diff main...HEAD (12 files, +340/-120 lines)"}
+**Review date**: {date}
+
+### Critical Issues
+{Agreed critical findings with Claude's assessment note}
+
+### Improvements
+{Agreed suggestions, modified suggestions with Claude's severity-change reasoning}
+
+### Positive Notes
+{Confirmed good patterns — verify these are actually good, not just things Codex skipped}
+
+### Filtered Findings
+{Disagreed findings with reasoning — never omit this section if anything was filtered}
+
+### Claude's Additional Observations
+{Issues Claude found that Codex missed — omit section if none}
+
+### Summary
+{2-3 sentences: combined assessment, biggest risk, biggest strength, merge recommendation}
+```
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Verify Codex output file has content before processing
+[ -s "$TMPFILE" ] && echo "has content" || echo "empty or missing"
+
+# Count top-level sections in Codex output
+grep -c "^##" "$TMPFILE"
+
+# Find context clues that Codex may have missed (upstream handling)
+grep -rn "if err\|recover()\|defer " --include="*.go" <path>
+
+# Check for nil guards at call sites
+grep -rn "!= nil\|== nil" --include="*.go" <path> | grep -i "profile\|user\|result"
+```


### PR DESCRIPTION
## Summary

Reference enrichment run 2026-04-16-0907 for `codex-code-review` skill.

**Targets processed**: 1/1
- `codex-code-review`: Level 0 → Level 3 (3 new reference files)

## New Reference Files

- `skills/codex-code-review/references/codex-cli-patterns.md` — `codex exec` command variants, flag table, mktemp anti-pattern, mutually-exclusive flag trap, error-fix mappings for 8 common failures
- `skills/codex-code-review/references/review-methodology.md` — Finding classification table (Agree/Agree-modified/Disagree), severity decision tree, Filtered Findings requirement, report structure template
- `skills/codex-code-review/references/code-anti-patterns.md` — 7 anti-patterns across Go/TypeScript/Python with `rg`/`grep` detection commands, code examples, version notes

## Changes

- `skills/codex-code-review/SKILL.md` — Added loading table mapping task signals to the 3 new reference files

## Validation Gate

- Loading table correctly maps 4 distinct signal types to reference files ✓
- All 3 reference files contain concrete patterns (detection commands, version notes, code examples) ✓
- No generic advice — each entry has a specific grep/rg command and code example ✓
- Decision: **KEEP**