### PR TITLE
refactor(agents): align playbook agent names with filenames (ADR-185)

### DIFF
--- a/agents/INDEX.json
+++ b/agents/INDEX.json
@@ -584,9 +584,9 @@
       "complexity": "Medium",
       "category": "research"
     },
-    "reviewer-code-playbook": {
+    "reviewer-code": {
       "file": "agents/reviewer-code.md",
-      "short_description": "Playbook-enhanced variant of reviewer-code for A/B testing (ADR-160)",
+      "short_description": "Code quality review: conventions, naming, dead code, performance, test coverage",
       "triggers": [
         "code review",
         "review code quality",
@@ -681,9 +681,9 @@
       "complexity": "Medium",
       "category": "review"
     },
-    "reviewer-system-playbook": {
+    "reviewer-system": {
       "file": "agents/reviewer-system.md",
-      "short_description": "Playbook-enhanced variant of reviewer-system for A/B testing (ADR-160)",
+      "short_description": "System-level review: security, concurrency, error handling, observability, API contracts",
       "triggers": [
         "system review",
         "security review",
@@ -805,7 +805,7 @@
       "complexity": "Complex",
       "category": "meta"
     },
-    "technical-documentation-engineer-playbook": {
+    "technical-documentation-engineer": {
       "file": "agents/technical-documentation-engineer.md",
       "short_description": "Technical documentation: API docs, system architecture, runbooks, enterprise standards",
       "triggers": [
@@ -836,9 +836,9 @@
       "complexity": "Comprehensive",
       "category": "content"
     },
-    "testing-automation-engineer-playbook": {
+    "testing-automation-engineer": {
       "file": "agents/testing-automation-engineer.md",
-      "short_description": "Playbook-enhanced testing agent: numeric anchors, STOP blocks, adversarial stance, explicit output contract",
+      "short_description": "Testing automation: Vitest, Playwright, E2E, coverage enforcement, CI/CD integration",
       "triggers": [
         "testing",
         "E2E",

--- a/agents/reviewer-code.md
+++ b/agents/reviewer-code.md
@@ -1,12 +1,8 @@
 ---
-name: reviewer-code-playbook
+name: reviewer-code
 model: sonnet
 version: 1.0.0
-description: |
-  Playbook-enhanced variant of reviewer-code for A/B testing (ADR-160).
-  Applies prompt architecture patterns: constraints at point of failure,
-  numeric anchors, anti-rationalization at point of use, explicit output
-  contract, and verifier stance.
+description: "Code quality review: conventions, naming, dead code, performance, test coverage"
 color: green
 routing:
   triggers:

--- a/agents/reviewer-system.md
+++ b/agents/reviewer-system.md
@@ -1,12 +1,8 @@
 ---
-name: reviewer-system-playbook
+name: reviewer-system
 model: sonnet
 version: 1.0.0
-description: |
-  Playbook-enhanced variant of reviewer-system for A/B testing (ADR-160).
-  Applies prompt architecture patterns: constraints at point of failure,
-  numeric anchors, anti-rationalization STOP blocks, explicit output
-  contract, and adversarial verifier stance.
+description: "System-level review: security, concurrency, error handling, observability, API contracts"
 color: red
 routing:
   triggers:

--- a/agents/technical-documentation-engineer.md
+++ b/agents/technical-documentation-engineer.md
@@ -1,8 +1,8 @@
 ---
-name: technical-documentation-engineer-playbook
+name: technical-documentation-engineer
 model: sonnet
 version: 2.0.0
-description: "Technical documentation: API docs, system architecture, runbooks, enterprise standards. Playbook-enhanced with adversarial verification."
+description: "Technical documentation: API docs, system architecture, runbooks, enterprise standards"
 color: blue
 routing:
   triggers:

--- a/agents/testing-automation-engineer.md
+++ b/agents/testing-automation-engineer.md
@@ -1,8 +1,8 @@
 ---
-name: testing-automation-engineer-playbook
+name: testing-automation-engineer
 model: sonnet
 version: 2.0.0
-description: "Playbook-enhanced testing agent: numeric anchors, STOP blocks, adversarial stance, explicit output contract."
+description: "Testing automation: Vitest, Playwright, E2E, coverage enforcement, CI/CD integration"
 color: yellow
 routing:
   triggers:

--- a/skills/do/references/routing-tables.md
+++ b/skills/do/references/routing-tables.md
@@ -38,9 +38,9 @@ Route to these agents based on the user's task domain. Each entry describes what
 | **pipeline-orchestrator-engineer** | User wants to create a new pipeline, scaffold a new structured workflow, or compose pipeline phases. |
 | **hook-development-engineer** | User wants to create or modify Python hooks for Claude Code's event-driven system (SessionStart, PostToolUse, etc.). |
 | **system-upgrade-engineer** | User wants to upgrade the agent/skill/hook ecosystem after a Claude model update or system-wide change. |
-| **technical-documentation-engineer-playbook** | User needs technical documentation created, maintained, or validated — API docs, READMEs, architecture guides. |
+| **technical-documentation-engineer** | User needs technical documentation created, maintained, or validated — API docs, READMEs, architecture guides. |
 | **technical-journalist-writer** | User needs professional technical writing in a journalism style — articles, posts, or content with a specific authored voice. |
-| **testing-automation-engineer-playbook** | User needs comprehensive testing strategy, E2E test setup, Playwright tests, or test infrastructure design. NOT: writing Go unit tests (use go-patterns force-route). |
+| **testing-automation-engineer** | User needs comprehensive testing strategy, E2E test setup, Playwright tests, or test infrastructure design. NOT: writing Go unit tests (use go-patterns force-route). |
 | **ui-design-engineer** | User is designing or implementing UI/UX for web applications: layout, Tailwind styling, component design, or visual hierarchy. |
 | **perses-engineer** | User is working with the Perses observability platform: dashboards, plugins, operator/K8s deployment, or core development. |
 | **github-profile-rules-engineer** | User wants to extract coding conventions, programming rules, or style guidelines from a GitHub profile's repositories. |
@@ -336,8 +336,8 @@ Consolidated reviewer agents, each covering multiple review perspectives:
 
 | Agent | When to Route Here |
 |-------|-------------------|
-| **reviewer-code-playbook** | Code quality review: conventions, naming, dead code, performance, types, tests, comments, config safety. Use for code style, readability, simplification, language idioms, naming consistency, unused code, comment accuracy, hot paths, type design, test coverage, and configuration review. |
-| **reviewer-system-playbook** | System review: security, concurrency, errors, observability, APIs, migrations, dependencies, docs. Use for vulnerability scans, race conditions, goroutine leaks, silent failures, error messages, logging quality, API contracts, migration safety, dependency audits, and documentation validation. |
+| **reviewer-code** | Code quality review: conventions, naming, dead code, performance, types, tests, comments, config safety. Use for code style, readability, simplification, language idioms, naming consistency, unused code, comment accuracy, hot paths, type design, test coverage, and configuration review. |
+| **reviewer-system** | System review: security, concurrency, errors, observability, APIs, migrations, dependencies, docs. Use for vulnerability scans, race conditions, goroutine leaks, silent failures, error messages, logging quality, API contracts, migration safety, dependency audits, and documentation validation. |
 | **reviewer-perspectives** | Multi-perspective review: newcomer, senior, pedant, contrarian, user advocate, meta-process. Use for fresh-eyes critique, skeptical senior review, technical precision, assumption challenges, user impact analysis, and system design meta-review. |
 | **reviewer-domain** | Domain-specific review: ADR compliance, business logic, SAP CC structural, pragmatic builder. Use for architecture decision compliance, domain correctness, sapcc Go conventions, and production readiness critique. |
 


### PR DESCRIPTION
## Summary
- Update frontmatter `name:` fields in four `-playbook` agents so they match their filename basenames, removing the mismatch that caused INDEX.json divergence and loaded stale A/B test provenance into every session prompt.
- Rewrite their descriptions from A/B-test voice to routing-intent language.
- Update `skills/do/references/routing-tables.md` to the canonical names and regenerate `skills/INDEX.json`.

## Validation
- `python3 scripts/validate-index-integrity.py` — PASS
- 0 name/file divergences
- 0 A/B test artifacts in INDEX.json

## Test plan
- [ ] CI (Tests workflow) passes
- [ ] Routing benchmark unchanged for unaffected cases