### PR TITLE
feat(hooks): add ruff-format-gate and adr-health-check (ADR-187)

### DIFF
--- a/hooks/pretool-ruff-format-gate.py
+++ b/hooks/pretool-ruff-format-gate.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+PreToolUse:Bash Hook: Ruff Format Gate
+
+Blocks git push when ruff format --check finds formatting violations.
+Forces agents to run ruff format before pushing, preventing CI failures.
+
+This is a HARD GATE — exits 0 with JSON permissionDecision:deny to block the Bash tool.
+
+Detection logic:
+- Tool is Bash
+- Command contains 'git push'
+- pyproject.toml with [tool.ruff] exists in project root
+- ruff format --check . --config pyproject.toml exits non-zero
+
+Allow-through conditions:
+- Command does not contain 'git push'
+- No pyproject.toml with [tool.ruff] section (non-Python project)
+- ruff format --check passes (no violations)
+- RUFF_FORMAT_GATE_BYPASS=1 env var
+
+Exit code semantics:
+- Always exits 0 (non-blocking requirement)
+- Deny signal delivered via JSON permissionDecision:deny on stdout
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
+_BYPASS_ENV = "RUFF_FORMAT_GATE_BYPASS"
+
+
+def _find_project_root(cwd: str | None) -> Path | None:
+    """Walk up from cwd to find the nearest pyproject.toml with [tool.ruff]."""
+    if not cwd:
+        return None
+    candidate = Path(cwd).resolve()
+    for _ in range(6):  # Max 6 levels up
+        toml = candidate / "pyproject.toml"
+        if toml.is_file():
+            try:
+                content = toml.read_text(encoding="utf-8")
+                if "[tool.ruff]" in content:
+                    return candidate
+            except OSError:
+                pass
+        parent = candidate.parent
+        if parent == candidate:
+            break
+        candidate = parent
+    return None
+
+
+def _extract_push_cwd(command: str, default_cwd: str | None) -> str | None:
+    """Extract the effective cwd from a git push command string.
+
+    Detects:
+    - ``cd <path> && git push``
+    - ``git -C <path> push``
+    """
+    m = re.match(r'cd\s+(?:"([^"]+)"|(\S+))\s*(?:&&|;)', command.lstrip())
+    if m:
+        p = (m.group(1) or m.group(2) or "").strip()
+        if p:
+            return p
+
+    m = re.search(r'\bgit\s+-C\s+(?:"([^"]+)"|(\S+))', command)
+    if m:
+        return m.group(1) or m.group(2)
+
+    return default_cwd
+
+
+def _run_ruff_format_check(project_root: Path) -> tuple[int, str]:
+    """Run ruff format --check in project_root.
+
+    Returns (return_code, combined_output).
+    """
+    try:
+        result = subprocess.run(
+            ["ruff", "format", "--check", ".", "--config", "pyproject.toml"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=str(project_root),
+        )
+        output = (result.stdout + result.stderr).strip()
+        return result.returncode, output
+    except FileNotFoundError:
+        # ruff not installed — fail open, don't block
+        return 0, ""
+    except subprocess.TimeoutExpired:
+        return 0, ""
+    except OSError:
+        return 0, ""
+
+
+def main() -> None:
+    debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
+
+    raw = read_stdin(timeout=2)
+    try:
+        event = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    if not isinstance(event, dict):
+        sys.exit(0)
+
+    command = event.get("tool_input", {}).get("command", "")
+    if not command:
+        sys.exit(0)
+
+    # Only fire on git push commands
+    if not re.search(r"\bgit\s+push\b", command):
+        sys.exit(0)
+
+    # Bypass env var
+    if os.environ.get(_BYPASS_ENV) == "1":
+        if debug:
+            print("[ruff-format-gate] Bypassed via RUFF_FORMAT_GATE_BYPASS=1", file=sys.stderr)
+        sys.exit(0)
+
+    default_cwd = event.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR")
+    effective_cwd = _extract_push_cwd(command, default_cwd)
+
+    project_root = _find_project_root(effective_cwd)
+    if project_root is None:
+        if debug:
+            print("[ruff-format-gate] No pyproject.toml with [tool.ruff] found — allowing through", file=sys.stderr)
+        sys.exit(0)
+
+    if debug:
+        print(f"[ruff-format-gate] Running ruff format --check in {project_root}", file=sys.stderr)
+
+    returncode, output = _run_ruff_format_check(project_root)
+
+    if returncode == 0:
+        if debug:
+            print("[ruff-format-gate] ruff format --check passed — allowing push", file=sys.stderr)
+        sys.exit(0)
+
+    # Violations found — block the push
+    print(
+        f"[ruff-format-gate] BLOCKED: ruff format --check found violations. Run: ruff format . --config pyproject.toml",
+        file=sys.stderr,
+    )
+    if output and debug:
+        print(f"[ruff-format-gate] ruff output: {output}", file=sys.stderr)
+
+    deny_reason = (
+        "ruff format --check found formatting violations. "
+        "Run `ruff format . --config pyproject.toml` to fix them, then push again. "
+        "Bypass with RUFF_FORMAT_GATE_BYPASS=1 if this is a false positive."
+    )
+    if output:
+        # Include a snippet of ruff's output in the reason for visibility
+        snippet = output[:300] + ("..." if len(output) > 300 else "")
+        deny_reason = f"{deny_reason}\n\nruff output:\n{snippet}"
+
+    deny_output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": deny_reason,
+        }
+    }
+    print(json.dumps(deny_output))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise  # Let sys.exit(0) propagate normally
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            traceback.print_exc(file=sys.stderr)
+        else:
+            print(f"[ruff-format-gate] Error: {type(e).__name__}: {e}", file=sys.stderr)
+        # Crashed hook must fail open — never block tools.
+    finally:
+        sys.exit(0)

--- a/hooks/session-adr-health-check.py
+++ b/hooks/session-adr-health-check.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+SessionStart Hook: ADR Session Health Check
+
+Detects orphaned .adr-session.json files at session start.
+An orphaned session is one where .adr-session.json exists but the
+referenced adr_file path does not exist on disk.
+
+This is an ADVISORY injection — no deny, no block. Surfaces the issue
+in additionalContext before the synthesis gate has a chance to deadlock.
+
+Detection logic:
+- .adr-session.json exists in CLAUDE_PROJECT_DIR
+- The adr_file (or adr_path) field references a path that does not exist
+
+Injection conditions:
+- Orphaned: injects a warning with the stale path and instructions to clear it
+- Healthy with active session: injects a brief status line (domain + adr_path)
+- No .adr-session.json: silent (empty output)
+
+Design:
+- Non-blocking (always exits 0)
+- Fast execution (<50ms — pure file reads, no subprocess)
+- Stderr-only debugging
+"""
+
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from hook_utils import context_output, empty_output
+
+EVENT_NAME = "SessionStart"
+
+
+def _load_session(project_dir: Path) -> dict | None:
+    """Load .adr-session.json from project_dir. Returns None if absent or malformed."""
+    session_path = project_dir / ".adr-session.json"
+    if not session_path.is_file():
+        return None
+    try:
+        return json.loads(session_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _resolve_adr_path(session: dict, project_dir: Path) -> tuple[str | None, bool]:
+    """Return (adr_path_str, exists_on_disk).
+
+    Checks both 'adr_path' and 'adr_file' keys (different versions of the schema
+    use different field names). Resolves relative paths against project_dir.
+    Returns (None, False) if no path field found.
+    """
+    raw_path = session.get("adr_path") or session.get("adr_file")
+    if not raw_path:
+        return None, False
+
+    adr_path = Path(raw_path)
+    if not adr_path.is_absolute():
+        adr_path = project_dir / adr_path
+
+    return str(raw_path), adr_path.exists()
+
+
+def main() -> None:
+    debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
+
+    # Resolve project directory: CLAUDE_PROJECT_DIR > cwd
+    project_dir_str = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = Path(project_dir_str).resolve()
+
+    session = _load_session(project_dir)
+    if session is None:
+        if debug:
+            print("[adr-health-check] No .adr-session.json found — silent pass", file=sys.stderr)
+        empty_output(EVENT_NAME).print_and_exit()
+        return
+
+    adr_path_raw, adr_exists = _resolve_adr_path(session, project_dir)
+    domain = session.get("domain", "")
+    registered_at = session.get("registered_at", "")
+
+    if debug:
+        print(
+            f"[adr-health-check] session found: domain={domain!r} adr_path={adr_path_raw!r} exists={adr_exists}",
+            file=sys.stderr,
+        )
+
+    if adr_path_raw is None:
+        # Session exists but has no adr_path / adr_file field — unusual schema
+        msg = (
+            "[adr-health-check] WARNING: .adr-session.json exists but has no adr_path or adr_file field. "
+            "The synthesis gate may behave unexpectedly. "
+            "Clear it with: rm .adr-session.json"
+        )
+        context_output(EVENT_NAME, msg).print_and_exit()
+        return
+
+    if not adr_exists:
+        # Orphaned session — the referenced ADR file is gone
+        msg = (
+            f"[adr-health-check] WARNING: Orphaned .adr-session.json detected.\n"
+            f"  Referenced ADR path does not exist: {adr_path_raw}\n"
+            f"  Domain: {domain or '(unknown)'}\n"
+            f"  Registered at: {registered_at or '(unknown)'}\n"
+            f"\n"
+            f"  The pretool-synthesis-gate will block all agents/ and skills/ writes "
+            f"until this is resolved.\n"
+            f"\n"
+            f"  To clear the orphaned session:\n"
+            f"    rm {project_dir}/.adr-session.json\n"
+            f"\n"
+            f"  If this ADR is still active, restore the ADR file at:\n"
+            f"    {adr_path_raw}"
+        )
+        print(f"[adr-health-check] ORPHANED session: {adr_path_raw} does not exist", file=sys.stderr)
+        context_output(EVENT_NAME, msg).print_and_exit()
+        return
+
+    # Healthy active session — surface a brief status line
+    status = f"[adr-health-check] Active ADR session: domain={domain!r} adr={adr_path_raw}"
+    if debug:
+        print(status, file=sys.stderr)
+    context_output(EVENT_NAME, status).print_and_exit()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise  # Let sys.exit(0) propagate normally
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            traceback.print_exc(file=sys.stderr)
+        else:
+            print(f"[adr-health-check] Error: {type(e).__name__}: {e}", file=sys.stderr)
+        # Crashed hook must fail open — never block session start.
+    finally:
+        sys.exit(0)

--- a/hooks/tests/test_pretool_ruff_format_gate.py
+++ b/hooks/tests/test_pretool_ruff_format_gate.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+Tests for the pretool-ruff-format-gate hook.
+
+Run with: python3 -m pytest hooks/tests/test_pretool_ruff_format_gate.py -v
+"""
+
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+HOOK_PATH = Path(__file__).parent.parent / "pretool-ruff-format-gate.py"
+
+spec = importlib.util.spec_from_file_location("pretool_ruff_format_gate", HOOK_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_bash_event(command: str, cwd: str | None = None) -> str:
+    event = {"tool_input": {"command": command}}
+    if cwd:
+        event["cwd"] = cwd
+    return json.dumps(event)
+
+
+def _run_main(stdin_payload: str, env: dict | None = None) -> tuple[int, dict | None]:
+    """Invoke mod.main() in-process.
+
+    Returns (logical_exit_code, parsed_stdout_json).
+    logical_exit_code is 2 if permissionDecision:deny was emitted, 0 otherwise.
+    """
+    base_env = dict(os.environ)
+    base_env.pop("RUFF_FORMAT_GATE_BYPASS", None)
+    if env:
+        base_env.update(env)
+
+    stdout_capture = io.StringIO()
+    with (
+        patch.dict(os.environ, base_env, clear=True),
+        patch.object(mod, "read_stdin", return_value=stdin_payload),
+        patch("sys.stdout", stdout_capture),
+    ):
+        try:
+            mod.main()
+        except SystemExit:
+            pass
+
+    output = stdout_capture.getvalue().strip()
+    parsed = None
+    if output:
+        try:
+            parsed = json.loads(output)
+        except json.JSONDecodeError:
+            pass
+
+    if parsed:
+        hook_out = parsed.get("hookSpecificOutput", {})
+        if hook_out.get("permissionDecision") == "deny":
+            return 2, parsed
+    return 0, parsed
+
+
+# ---------------------------------------------------------------------------
+# Non-push commands pass through
+# ---------------------------------------------------------------------------
+
+
+class TestNonPushCommandsPassThrough:
+    def test_git_status_allowed(self):
+        code, _ = _run_main(_make_bash_event("git status"))
+        assert code == 0
+
+    def test_git_commit_allowed(self):
+        code, _ = _run_main(_make_bash_event("git commit -m 'feat: something'"))
+        assert code == 0
+
+    def test_git_fetch_allowed(self):
+        code, _ = _run_main(_make_bash_event("git fetch origin"))
+        assert code == 0
+
+    def test_empty_command_allowed(self):
+        code, _ = _run_main(_make_bash_event(""))
+        assert code == 0
+
+    def test_non_git_command_allowed(self):
+        code, _ = _run_main(_make_bash_event("echo 'hello'"))
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# No pyproject.toml — pass through
+# ---------------------------------------------------------------------------
+
+
+class TestNoRuffConfig:
+    def test_no_pyproject_passes_through(self, tmp_path):
+        """No pyproject.toml means the gate is dormant (non-Python project)."""
+        payload = _make_bash_event("git push origin main", cwd=str(tmp_path))
+        code, _ = _run_main(payload)
+        assert code == 0
+
+    def test_pyproject_without_ruff_section_passes_through(self, tmp_path):
+        """pyproject.toml without [tool.ruff] is treated as non-Python project."""
+        (tmp_path / "pyproject.toml").write_text("[build-system]\nrequires = []\n")
+        payload = _make_bash_event("git push origin main", cwd=str(tmp_path))
+        code, _ = _run_main(payload)
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Bypass env var
+# ---------------------------------------------------------------------------
+
+
+class TestBypassEnv:
+    def test_bypass_allows_push_through(self, tmp_path):
+        """RUFF_FORMAT_GATE_BYPASS=1 skips the check entirely."""
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        payload = _make_bash_event("git push origin main", cwd=str(tmp_path))
+        code, _ = _run_main(payload, env={"RUFF_FORMAT_GATE_BYPASS": "1"})
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Ruff check outcomes
+# ---------------------------------------------------------------------------
+
+
+class TestRuffCheckOutcomes:
+    def test_ruff_check_passes_allows_push(self, tmp_path):
+        """When ruff format --check exits 0, the push is allowed."""
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        payload = _make_bash_event("git push origin main", cwd=str(tmp_path))
+
+        mock_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        with patch("subprocess.run", return_value=mock_result):
+            code, _ = _run_main(payload)
+        assert code == 0
+
+    def test_ruff_check_fails_blocks_push(self, tmp_path):
+        """When ruff format --check exits non-zero, the push is blocked."""
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        payload = _make_bash_event("git push origin main", cwd=str(tmp_path))
+
+        mock_result = type("R", (), {"returncode": 1, "stdout": "Would reformat: foo.py\n", "stderr": ""})()
+        with patch("subprocess.run", return_value=mock_result):
+            code, parsed = _run_main(payload)
+        assert code == 2
+        assert parsed is not None
+        hook_out = parsed["hookSpecificOutput"]
+        assert hook_out["permissionDecision"] == "deny"
+        assert "ruff format" in hook_out["permissionDecisionReason"]
+
+    def test_ruff_not_installed_allows_push(self, tmp_path):
+        """FileNotFoundError (ruff not installed) fails open — push allowed."""
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        payload = _make_bash_event("git push origin main", cwd=str(tmp_path))
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("ruff not found")):
+            code, _ = _run_main(payload)
+        assert code == 0
+
+    def test_ruff_timeout_allows_push(self, tmp_path):
+        """Timeout in ruff invocation fails open — push allowed."""
+        import subprocess
+
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        payload = _make_bash_event("git push origin main", cwd=str(tmp_path))
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(["ruff"], 15)):
+            code, _ = _run_main(payload)
+        assert code == 0
+
+    def test_deny_reason_includes_ruff_output(self, tmp_path):
+        """Ruff violation output is included in the deny reason for visibility."""
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        payload = _make_bash_event("git push origin main", cwd=str(tmp_path))
+
+        violation_msg = "Would reformat: src/app.py\n1 file would be reformatted"
+        mock_result = type("R", (), {"returncode": 1, "stdout": violation_msg, "stderr": ""})()
+        with patch("subprocess.run", return_value=mock_result):
+            code, parsed = _run_main(payload)
+        assert code == 2
+        reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "ruff output" in reason
+        assert "src/app.py" in reason
+
+
+# ---------------------------------------------------------------------------
+# CWD extraction
+# ---------------------------------------------------------------------------
+
+
+class TestCwdExtraction:
+    def test_cd_prefix_extracts_cwd(self, tmp_path):
+        """cd /path && git push correctly uses /path as project root."""
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        command = f"cd {tmp_path} && git push origin main"
+        payload = _make_bash_event(command)
+
+        mock_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            code, _ = _run_main(payload)
+        assert code == 0
+        # Verify ruff was invoked in the extracted directory
+        if mock_run.called:
+            call_kwargs = mock_run.call_args
+            assert str(tmp_path) in str(call_kwargs)
+
+    def test_git_C_flag_extracts_cwd(self, tmp_path):
+        """git -C /path push correctly uses /path as project root."""
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        command = f"git -C {tmp_path} push origin main"
+        payload = _make_bash_event(command)
+
+        mock_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        with patch("subprocess.run", return_value=mock_result):
+            code, _ = _run_main(payload)
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Fail open on malformed input
+# ---------------------------------------------------------------------------
+
+
+class TestFailOpen:
+    def test_malformed_json_exits_0(self):
+        code, _ = _run_main("not valid json {{{")
+        assert code == 0
+
+    def test_empty_stdin_exits_0(self):
+        code, _ = _run_main("")
+        assert code == 0
+
+    def test_null_json_exits_0(self):
+        code, _ = _run_main("null")
+        assert code == 0

--- a/hooks/tests/test_session_adr_health_check.py
+++ b/hooks/tests/test_session_adr_health_check.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+Tests for the session-adr-health-check hook.
+
+Run with: python3 -m pytest hooks/tests/test_session_adr_health_check.py -v
+"""
+
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+HOOK_PATH = Path(__file__).parent.parent / "session-adr-health-check.py"
+
+spec = importlib.util.spec_from_file_location("session_adr_health_check", HOOK_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_main(project_dir: str) -> tuple[int, dict | None]:
+    """Invoke mod.main() with CLAUDE_PROJECT_DIR set to project_dir.
+
+    Returns (exit_code, parsed_stdout_json). exit_code is always 0.
+    """
+    env = dict(os.environ)
+    env["CLAUDE_PROJECT_DIR"] = project_dir
+
+    stdout_capture = io.StringIO()
+    with (
+        patch.dict(os.environ, env, clear=True),
+        patch("sys.stdout", stdout_capture),
+    ):
+        try:
+            mod.main()
+        except SystemExit:
+            pass
+
+    output = stdout_capture.getvalue().strip()
+    parsed = None
+    if output:
+        try:
+            parsed = json.loads(output)
+        except json.JSONDecodeError:
+            pass
+    return 0, parsed
+
+
+def _write_session(project_dir: Path, data: dict) -> None:
+    (project_dir / ".adr-session.json").write_text(json.dumps(data))
+
+
+# ---------------------------------------------------------------------------
+# No .adr-session.json — silent pass
+# ---------------------------------------------------------------------------
+
+
+class TestNoSessionFile:
+    def test_no_session_file_emits_empty_output(self, tmp_path):
+        """No .adr-session.json produces empty HookOutput (no additionalContext)."""
+        _, parsed = _run_main(str(tmp_path))
+        assert parsed is not None
+        inner = parsed.get("hookSpecificOutput", {})
+        assert "additionalContext" not in inner
+
+    def test_exit_code_always_0(self, tmp_path):
+        code, _ = _run_main(str(tmp_path))
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Orphaned session — ADR file missing
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanedSession:
+    def test_orphaned_session_injects_warning(self, tmp_path):
+        """Orphaned .adr-session.json injects a warning in additionalContext."""
+        _write_session(
+            tmp_path,
+            {
+                "adr_path": "adr/999-nonexistent.md",
+                "domain": "999-nonexistent",
+                "registered_at": "2026-01-01T00:00:00+00:00",
+            },
+        )
+        _, parsed = _run_main(str(tmp_path))
+        assert parsed is not None
+        inner = parsed.get("hookSpecificOutput", {})
+        assert "additionalContext" in inner
+        context = inner["additionalContext"]
+        assert "Orphaned" in context or "WARNING" in context
+        assert "999-nonexistent.md" in context
+
+    def test_orphaned_session_includes_clear_command(self, tmp_path):
+        """Warning message includes the rm command to clear the stale session."""
+        _write_session(tmp_path, {"adr_path": "adr/000-gone.md", "domain": "000-gone"})
+        _, parsed = _run_main(str(tmp_path))
+        context = parsed["hookSpecificOutput"]["additionalContext"]
+        assert "rm" in context
+        assert ".adr-session.json" in context
+
+    def test_orphaned_session_via_adr_file_key(self, tmp_path):
+        """Supports 'adr_file' key in addition to 'adr_path'."""
+        _write_session(tmp_path, {"adr_file": "adr/old-schema.md", "domain": "old-schema"})
+        _, parsed = _run_main(str(tmp_path))
+        inner = parsed.get("hookSpecificOutput", {})
+        assert "additionalContext" in inner
+        context = inner["additionalContext"]
+        assert "old-schema.md" in context
+
+    def test_orphaned_always_exits_0(self, tmp_path):
+        """Advisory hook never blocks — always exits 0."""
+        _write_session(tmp_path, {"adr_path": "adr/gone.md", "domain": "gone"})
+        code, _ = _run_main(str(tmp_path))
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Healthy session — ADR file exists
+# ---------------------------------------------------------------------------
+
+
+class TestHealthySession:
+    def test_healthy_session_injects_status(self, tmp_path):
+        """Healthy session injects a brief status line in additionalContext."""
+        adr_file = tmp_path / "adr" / "187-test.md"
+        adr_file.parent.mkdir(parents=True)
+        adr_file.write_text("# ADR-187\n")
+
+        _write_session(
+            tmp_path,
+            {
+                "adr_path": "adr/187-test.md",
+                "domain": "187-test",
+                "registered_at": "2026-04-16T10:00:00+00:00",
+            },
+        )
+        _, parsed = _run_main(str(tmp_path))
+        inner = parsed.get("hookSpecificOutput", {})
+        assert "additionalContext" in inner
+        context = inner["additionalContext"]
+        assert "Active ADR session" in context or "adr-health-check" in context
+        assert "187-test" in context
+
+    def test_healthy_session_no_deny(self, tmp_path):
+        """Healthy session never produces a deny decision."""
+        adr_file = tmp_path / "adr" / "187-test.md"
+        adr_file.parent.mkdir(parents=True)
+        adr_file.write_text("# ADR-187\n")
+        _write_session(tmp_path, {"adr_path": "adr/187-test.md", "domain": "187-test"})
+
+        _, parsed = _run_main(str(tmp_path))
+        inner = parsed.get("hookSpecificOutput", {})
+        assert inner.get("permissionDecision") != "deny"
+
+    def test_absolute_adr_path_that_exists(self, tmp_path):
+        """Absolute adr_path pointing to an existing file is treated as healthy."""
+        adr_file = tmp_path / "187-abs.md"
+        adr_file.write_text("# ADR\n")
+
+        _write_session(tmp_path, {"adr_path": str(adr_file), "domain": "187-abs"})
+        _, parsed = _run_main(str(tmp_path))
+        inner = parsed.get("hookSpecificOutput", {})
+        assert "additionalContext" in inner
+        # Should be healthy — no orphan warning
+        context = inner["additionalContext"]
+        assert "Orphaned" not in context and "WARNING" not in context
+
+
+# ---------------------------------------------------------------------------
+# Missing adr_path / adr_file fields
+# ---------------------------------------------------------------------------
+
+
+class TestMissingPathField:
+    def test_session_without_path_field_injects_warning(self, tmp_path):
+        """Session with neither adr_path nor adr_file injects a schema warning."""
+        _write_session(tmp_path, {"domain": "no-path", "registered_at": "2026-04-01T00:00:00+00:00"})
+        _, parsed = _run_main(str(tmp_path))
+        inner = parsed.get("hookSpecificOutput", {})
+        assert "additionalContext" in inner
+        context = inner["additionalContext"]
+        assert "WARNING" in context or "adr_path" in context or "adr_file" in context
+
+
+# ---------------------------------------------------------------------------
+# Malformed .adr-session.json
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedSession:
+    def test_malformed_json_treated_as_no_session(self, tmp_path):
+        """Malformed JSON in .adr-session.json is treated as absent — silent pass."""
+        (tmp_path / ".adr-session.json").write_text("not valid json {{{")
+        _, parsed = _run_main(str(tmp_path))
+        inner = parsed.get("hookSpecificOutput", {})
+        assert "additionalContext" not in inner
+
+    def test_empty_json_object_treated_as_missing_path(self, tmp_path):
+        """Empty JSON object has no path fields — injects schema warning."""
+        _write_session(tmp_path, {})
+        _, parsed = _run_main(str(tmp_path))
+        inner = parsed.get("hookSpecificOutput", {})
+        # Empty session has no adr_path — warning is injected
+        assert "additionalContext" in inner


### PR DESCRIPTION
## Summary
- `pretool-ruff-format-gate.py`: `PreToolUse:Bash` gate that blocks `git push` when `ruff format --check` finds violations. Activates only in projects with a `pyproject.toml` containing `[tool.ruff]`. Bypass: `RUFF_FORMAT_GATE_BYPASS=1`.
- `session-adr-health-check.py`: SessionStart advisory hook that detects orphaned `.adr-session.json` files where the referenced ADR path is missing on disk. Injects a warning before the synthesis gate can deadlock mid-cycle. Context injection only, no blocking.
- 30 pytest tests covering pass-through, deny, bypass, fail-open, and malformed-input paths for both hooks.

## Test plan
- [ ] CI passes
- [ ] Smoke: trigger `git push` with an unformatted file → blocked
- [ ] Smoke: create a stale `.adr-session.json` → warning injected at session start