### PR TITLE
feat: toolkit-health.py and agent-evaluation scoring (ADR-188)

### DIFF
--- a/scripts/tests/test_toolkit_health.py
+++ b/scripts/tests/test_toolkit_health.py
@@ -1,0 +1,427 @@
+"""Tests for scripts/toolkit-health.py."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Imports under test — resolve relative to repo root
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPTS_DIR = str(REPO_ROOT / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+th = importlib.import_module("toolkit-health")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def default_config() -> th.HealthConfig:
+    return th.HealthConfig()
+
+
+@pytest.fixture
+def fresh_state_dir(tmp_path: Path) -> Path:
+    state = tmp_path / "state"
+    state.mkdir()
+    return state
+
+
+@pytest.fixture
+def learning_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "learning.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE governance_events (id INTEGER PRIMARY KEY, blocked INTEGER, created_at TEXT)")
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _insert_events(db_path: Path, *, blocked: int, total: int, age_days: float = 1.0) -> None:
+    """Insert test governance events into a learning.db fixture."""
+    conn = sqlite3.connect(str(db_path))
+    ts = (datetime.now(tz=timezone.utc) - timedelta(days=age_days)).isoformat()
+    for i in range(total):
+        conn.execute(
+            "INSERT INTO governance_events (blocked, created_at) VALUES (?, ?)",
+            (1 if i < blocked else 0, ts),
+        )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# check_hook_errors
+# ---------------------------------------------------------------------------
+
+
+class TestCheckHookErrors:
+    def test_db_missing_returns_ok(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        with patch.object(th, "LEARNING_DB", tmp_path / "nonexistent.db"):
+            result = th.check_hook_errors(default_config)
+        assert result.status == "OK"
+        assert result.db_missing is True
+
+    def test_low_error_rate_is_ok(self, default_config: th.HealthConfig, learning_db: Path) -> None:
+        # Spread events evenly across both halves of the 7-day window so trend is STABLE
+        _insert_events(learning_db, blocked=1, total=10, age_days=1.0)  # recent half
+        _insert_events(learning_db, blocked=1, total=10, age_days=5.0)  # older half
+        with patch.object(th, "LEARNING_DB", learning_db):
+            result = th.check_hook_errors(default_config)
+        assert result.status == "OK"
+        assert result.error_rate == pytest.approx(10.0)
+
+    def test_high_error_rate_warns(self, default_config: th.HealthConfig, learning_db: Path) -> None:
+        _insert_events(learning_db, blocked=10, total=20)  # 50%
+        with patch.object(th, "LEARNING_DB", learning_db):
+            result = th.check_hook_errors(default_config)
+        assert result.status == "WARN"
+        assert result.error_rate == pytest.approx(50.0)
+
+    def test_zero_events_is_ok(self, default_config: th.HealthConfig, learning_db: Path) -> None:
+        with patch.object(th, "LEARNING_DB", learning_db):
+            result = th.check_hook_errors(default_config)
+        assert result.status == "OK"
+        assert result.error_rate == 0.0
+
+    def test_trend_increasing(self, default_config: th.HealthConfig, learning_db: Path) -> None:
+        # Recent (last 3.5 days): many blocks
+        _insert_events(learning_db, blocked=10, total=10, age_days=1.0)
+        # Older (3.5-7 days ago): few blocks
+        _insert_events(learning_db, blocked=1, total=10, age_days=5.0)
+        with patch.object(th, "LEARNING_DB", learning_db):
+            result = th.check_hook_errors(default_config)
+        assert result.trend == "INCREASING"
+
+    def test_missing_table_handled(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        db_path = tmp_path / "empty.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.close()
+        with patch.object(th, "LEARNING_DB", db_path):
+            result = th.check_hook_errors(default_config)
+        assert result.db_missing is True
+        assert result.status == "OK"
+
+    def test_flag_message_none_when_ok(self, default_config: th.HealthConfig, learning_db: Path) -> None:
+        # Spread events evenly so trend is STABLE and rate is below threshold
+        _insert_events(learning_db, blocked=1, total=10, age_days=1.0)
+        _insert_events(learning_db, blocked=1, total=10, age_days=5.0)
+        with patch.object(th, "LEARNING_DB", learning_db):
+            result = th.check_hook_errors(default_config)
+        assert result.flag_message() is None
+
+    def test_flag_message_present_when_warn(self, default_config: th.HealthConfig, learning_db: Path) -> None:
+        _insert_events(learning_db, blocked=10, total=20)
+        with patch.object(th, "LEARNING_DB", learning_db):
+            result = th.check_hook_errors(default_config)
+        assert result.flag_message() is not None
+        assert "50.0%" in result.flag_message()  # type: ignore[operator]
+
+
+# ---------------------------------------------------------------------------
+# check_stale_memory
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStaleMemory:
+    def _make_memory_dir(self, tmp_path: Path, project: str = "test-proj") -> Path:
+        memory_dir = tmp_path / "projects" / project / "memory"
+        memory_dir.mkdir(parents=True)
+        return memory_dir
+
+    def test_no_projects_dir_is_ok(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        with patch.object(th, "MEMORY_PROJECTS_DIR", tmp_path / "projects"):
+            result = th.check_stale_memory(default_config)
+        assert result.status == "OK"
+        assert result.stale_files == []
+
+    def test_fresh_files_not_flagged(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        memory_dir = self._make_memory_dir(tmp_path)
+        (memory_dir / "user_role.md").write_text("content")
+        with patch.object(th, "MEMORY_PROJECTS_DIR", tmp_path / "projects"):
+            result = th.check_stale_memory(default_config)
+        assert result.status == "OK"
+
+    def test_stale_files_detected(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        memory_dir = self._make_memory_dir(tmp_path)
+        for i in range(6):
+            md = memory_dir / f"file_{i}.md"
+            md.write_text("x")
+            # Back-date mtime to 30 days ago
+            old_time = (datetime.now(tz=timezone.utc) - timedelta(days=30)).timestamp()
+            import os
+
+            os.utime(md, (old_time, old_time))
+        with patch.object(th, "MEMORY_PROJECTS_DIR", tmp_path / "projects"):
+            result = th.check_stale_memory(default_config)
+        assert result.status == "WARN"
+        assert len(result.stale_files) == 6
+
+    def test_memory_md_skipped(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        memory_dir = self._make_memory_dir(tmp_path)
+        md = memory_dir / "MEMORY.md"
+        md.write_text("index")
+        old_time = (datetime.now(tz=timezone.utc) - timedelta(days=60)).timestamp()
+        import os
+
+        os.utime(md, (old_time, old_time))
+        with patch.object(th, "MEMORY_PROJECTS_DIR", tmp_path / "projects"):
+            result = th.check_stale_memory(default_config)
+        assert result.stale_files == []
+
+
+# ---------------------------------------------------------------------------
+# check_state_files
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStateFiles:
+    def test_missing_state_dir_is_ok(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        with patch.object(th, "STATE_DIR", tmp_path / "nonexistent"):
+            result = th.check_state_files(default_config)
+        assert result.status == "OK"
+        assert result.file_count == 0
+
+    def test_below_threshold_is_ok(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        state = tmp_path / "state"
+        state.mkdir()
+        for i in range(10):
+            (state / f"file{i}.txt").write_text("x")
+        with patch.object(th, "STATE_DIR", state):
+            result = th.check_state_files(default_config)
+        assert result.status == "OK"
+        assert result.file_count == 10
+
+    def test_above_threshold_warns(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        state = tmp_path / "state"
+        state.mkdir()
+        for i in range(55):
+            (state / f"file{i}.txt").write_text("x")
+        with patch.object(th, "STATE_DIR", state):
+            result = th.check_state_files(default_config)
+        assert result.status == "WARN"
+        assert result.file_count == 55
+
+    def test_exact_threshold_is_ok(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        state = tmp_path / "state"
+        state.mkdir()
+        for i in range(50):
+            (state / f"file{i}.txt").write_text("x")
+        with patch.object(th, "STATE_DIR", state):
+            result = th.check_state_files(default_config)
+        assert result.status == "OK"
+
+
+# ---------------------------------------------------------------------------
+# check_adr_backlog
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAdrBacklog:
+    def test_missing_dir_is_ok(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        with patch.object(th, "ADR_DIR", tmp_path / "nonexistent"):
+            result = th.check_adr_backlog(default_config)
+        assert result.status == "OK"
+        assert result.adr_count == 0
+
+    def test_below_threshold_is_ok(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        adr_dir = tmp_path / "adr"
+        adr_dir.mkdir()
+        for i in range(5):
+            (adr_dir / f"00{i}-test.md").write_text("# ADR")
+        with patch.object(th, "ADR_DIR", adr_dir):
+            result = th.check_adr_backlog(default_config)
+        assert result.status == "OK"
+        assert result.adr_count == 5
+
+    def test_above_threshold_warns(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        adr_dir = tmp_path / "adr"
+        adr_dir.mkdir()
+        for i in range(25):
+            (adr_dir / f"{i:03d}-test.md").write_text("# ADR")
+        with patch.object(th, "ADR_DIR", adr_dir):
+            result = th.check_adr_backlog(default_config)
+        assert result.status == "WARN"
+        assert result.adr_count == 25
+
+    def test_non_md_files_not_counted(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        adr_dir = tmp_path / "adr"
+        adr_dir.mkdir()
+        (adr_dir / "001-test.md").write_text("# ADR")
+        (adr_dir / "README.txt").write_text("ignored")
+        with patch.object(th, "ADR_DIR", adr_dir):
+            result = th.check_adr_backlog(default_config)
+        assert result.adr_count == 1
+
+
+# ---------------------------------------------------------------------------
+# check_toolkit_health (orchestration)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckToolkitHealth:
+    def test_all_checks_run_by_default(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        with (
+            patch.object(th, "LEARNING_DB", tmp_path / "x.db"),
+            patch.object(th, "MEMORY_PROJECTS_DIR", tmp_path / "projects"),
+            patch.object(th, "STATE_DIR", tmp_path / "state"),
+            patch.object(th, "ADR_DIR", tmp_path / "adr"),
+        ):
+            report = th.check_toolkit_health(default_config)
+        assert report.hook_errors is not None
+        assert report.stale_memory is not None
+        assert report.state_files is not None
+        assert report.adr_backlog is not None
+
+    def test_subset_of_checks(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        with patch.object(th, "ADR_DIR", tmp_path / "adr"):
+            report = th.check_toolkit_health(default_config, checks=("adr-backlog",))
+        assert report.hook_errors is None
+        assert report.stale_memory is None
+        assert report.state_files is None
+        assert report.adr_backlog is not None
+
+    def test_flags_aggregated(self, default_config: th.HealthConfig, tmp_path: Path) -> None:
+        # Plant 25 ADR files to trigger a WARN
+        adr_dir = tmp_path / "adr"
+        adr_dir.mkdir()
+        for i in range(25):
+            (adr_dir / f"{i:03d}-test.md").write_text("# ADR")
+        with (
+            patch.object(th, "LEARNING_DB", tmp_path / "x.db"),
+            patch.object(th, "MEMORY_PROJECTS_DIR", tmp_path / "projects"),
+            patch.object(th, "STATE_DIR", tmp_path / "state"),
+            patch.object(th, "ADR_DIR", adr_dir),
+        ):
+            report = th.check_toolkit_health(default_config)
+        assert report.has_warnings()
+        assert any("ADR" in flag for flag in report.flags)
+
+
+# ---------------------------------------------------------------------------
+# load_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    def test_none_path_returns_defaults(self) -> None:
+        config = th.load_config(None)
+        assert config.stale_memory_days == 14
+        assert config.state_file_warn_count == 50
+        assert config.adr_backlog_warn_count == 20
+
+    def test_missing_file_returns_defaults(self, tmp_path: Path) -> None:
+        config = th.load_config(tmp_path / "nonexistent.json")
+        assert config.stale_memory_days == 14
+
+    def test_loads_thresholds_from_file(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "kairos.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "thresholds": {
+                        "stale_memory_days": 7,
+                        "state_file_warn_count": 30,
+                        "adr_backlog_warn_count": 10,
+                    }
+                }
+            )
+        )
+        config = th.load_config(cfg)
+        assert config.stale_memory_days == 7
+        assert config.state_file_warn_count == 30
+        assert config.adr_backlog_warn_count == 10
+
+    def test_invalid_json_exits_2(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "bad.json"
+        cfg.write_text("{not valid json")
+        with pytest.raises(SystemExit) as exc_info:
+            th.load_config(cfg)
+        assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# report_to_dict (JSON serialisation)
+# ---------------------------------------------------------------------------
+
+
+class TestReportToDict:
+    def test_structure(self, tmp_path: Path, default_config: th.HealthConfig) -> None:
+        with (
+            patch.object(th, "LEARNING_DB", tmp_path / "x.db"),
+            patch.object(th, "MEMORY_PROJECTS_DIR", tmp_path / "projects"),
+            patch.object(th, "STATE_DIR", tmp_path / "state"),
+            patch.object(th, "ADR_DIR", tmp_path / "adr"),
+        ):
+            report = th.check_toolkit_health(default_config)
+        d = th.report_to_dict(report)
+
+        assert "scan_timestamp" in d
+        assert "has_warnings" in d
+        assert "flags" in d
+        assert "checks" in d
+        assert "hook_errors" in d["checks"]
+        assert "stale_memory" in d["checks"]
+        assert "state_files" in d["checks"]
+        assert "adr_backlog" in d["checks"]
+
+    def test_json_serialisable(self, tmp_path: Path, default_config: th.HealthConfig) -> None:
+        with (
+            patch.object(th, "LEARNING_DB", tmp_path / "x.db"),
+            patch.object(th, "MEMORY_PROJECTS_DIR", tmp_path / "projects"),
+            patch.object(th, "STATE_DIR", tmp_path / "state"),
+            patch.object(th, "ADR_DIR", tmp_path / "adr"),
+        ):
+            report = th.check_toolkit_health(default_config)
+        d = th.report_to_dict(report)
+        # Must not raise
+        serialised = json.dumps(d)
+        assert len(serialised) > 0
+
+
+# ---------------------------------------------------------------------------
+# format_human_report
+# ---------------------------------------------------------------------------
+
+
+class TestFormatHumanReport:
+    def test_all_ok_shows_nominal(self, tmp_path: Path, default_config: th.HealthConfig) -> None:
+        with (
+            patch.object(th, "LEARNING_DB", tmp_path / "x.db"),
+            patch.object(th, "MEMORY_PROJECTS_DIR", tmp_path / "projects"),
+            patch.object(th, "STATE_DIR", tmp_path / "state"),
+            patch.object(th, "ADR_DIR", tmp_path / "adr"),
+        ):
+            report = th.check_toolkit_health(default_config)
+        text = th.format_human_report(report)
+        assert "All systems nominal." in text
+
+    def test_warn_present_in_output(self, tmp_path: Path, default_config: th.HealthConfig) -> None:
+        adr_dir = tmp_path / "adr"
+        adr_dir.mkdir()
+        for i in range(25):
+            (adr_dir / f"{i:03d}-test.md").write_text("# ADR")
+        with (
+            patch.object(th, "LEARNING_DB", tmp_path / "x.db"),
+            patch.object(th, "MEMORY_PROJECTS_DIR", tmp_path / "projects"),
+            patch.object(th, "STATE_DIR", tmp_path / "state"),
+            patch.object(th, "ADR_DIR", adr_dir),
+        ):
+            report = th.check_toolkit_health(default_config)
+        text = th.format_human_report(report)
+        assert "[WARN]" in text
+        assert "adr-backlog" in text

--- a/scripts/toolkit-health.py
+++ b/scripts/toolkit-health.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""Consolidated toolkit health checks.
+
+Consolidates the 4 Category C checks from kairos-lite monitor-prompt.md Phase 5
+into a single structured script. Each dimension can be queried independently or
+all at once.
+
+Usage:
+    python3 scripts/toolkit-health.py                  # human-readable report
+    python3 scripts/toolkit-health.py --json           # machine-readable JSON
+    python3 scripts/toolkit-health.py --check hook-errors
+    python3 scripts/toolkit-health.py --check stale-memory
+    python3 scripts/toolkit-health.py --check state-files
+    python3 scripts/toolkit-health.py --check adr-backlog
+    python3 scripts/toolkit-health.py --config ~/.claude/config/kairos.json
+
+Exit codes:
+    0 — All checks OK (no warnings)
+    1 — One or more WARN flags raised
+    2 — Script error (bad arguments, missing config)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Literal
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CLAUDE_DIR = Path.home() / ".claude"
+LEARNING_DB = CLAUDE_DIR / "state" / "learning.db"
+MEMORY_PROJECTS_DIR = CLAUDE_DIR / "projects"
+STATE_DIR = CLAUDE_DIR / "state"
+ADR_DIR = Path(__file__).resolve().parent.parent / "adr"
+
+HOOK_ERROR_RATE_THRESHOLD = 20.0  # percent
+STALE_MEMORY_WARN_COUNT = 5
+STATE_FILE_WARN_COUNT = 50
+ADR_BACKLOG_WARN_COUNT = 20
+
+CHECK_NAMES = ("hook-errors", "stale-memory", "state-files", "adr-backlog")
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+Status = Literal["OK", "WARN"]
+
+
+@dataclass
+class HookErrorResult:
+    """Result of the hook error rate check."""
+
+    blocked_count: int
+    total_count: int
+    error_rate: float
+    trend: Literal["INCREASING", "STABLE", "DECREASING"]
+    status: Status
+    db_missing: bool = False
+
+    def flag_message(self) -> str | None:
+        if self.db_missing:
+            return None
+        if self.status == "WARN":
+            return (
+                f"Hook error rate {self.error_rate:.1f}% "
+                f"({self.blocked_count}/{self.total_count} blocked, last 7d) "
+                f"— above {HOOK_ERROR_RATE_THRESHOLD:.0f}% threshold, trending {self.trend}"
+            )
+        return None
+
+
+@dataclass
+class StaleMemoryFile:
+    """A single stale memory file."""
+
+    name: str
+    age_days: int
+    project: str
+
+
+@dataclass
+class StaleMemoryResult:
+    """Result of the stale memory files check."""
+
+    stale_files: list[StaleMemoryFile]
+    status: Status
+    threshold_days: int
+
+    def flag_message(self) -> str | None:
+        if self.status == "WARN":
+            oldest = max(self.stale_files, key=lambda f: f.age_days)
+            return (
+                f"{len(self.stale_files)} stale memory files "
+                f"(oldest: {oldest.name}, {oldest.age_days} days, project: {oldest.project})"
+            )
+        return None
+
+
+@dataclass
+class StateFileResult:
+    """Result of the state file accumulation check."""
+
+    file_count: int
+    threshold: int
+    status: Status
+
+    def flag_message(self) -> str | None:
+        if self.status == "WARN":
+            return f"State directory: {self.file_count} files (threshold: {self.threshold})"
+        return None
+
+
+@dataclass
+class AdrBacklogResult:
+    """Result of the ADR backlog check."""
+
+    adr_count: int
+    threshold: int
+    status: Status
+    adr_dir: str
+
+    def flag_message(self) -> str | None:
+        if self.status == "WARN":
+            return f"ADR backlog: {self.adr_count} files in {self.adr_dir} (threshold: {self.threshold})"
+        return None
+
+
+@dataclass
+class HealthConfig:
+    """Runtime configuration for health checks."""
+
+    stale_memory_days: int = 14
+    state_file_warn_count: int = STATE_FILE_WARN_COUNT
+    adr_backlog_warn_count: int = ADR_BACKLOG_WARN_COUNT
+    hook_error_rate_threshold: float = HOOK_ERROR_RATE_THRESHOLD
+
+
+@dataclass
+class HealthReport:
+    """Aggregated health report for all dimensions."""
+
+    hook_errors: HookErrorResult | None = None
+    stale_memory: StaleMemoryResult | None = None
+    state_files: StateFileResult | None = None
+    adr_backlog: AdrBacklogResult | None = None
+    flags: list[str] = field(default_factory=list)
+    scan_timestamp: str = ""
+
+    def has_warnings(self) -> bool:
+        return bool(self.flags)
+
+
+# ---------------------------------------------------------------------------
+# Check implementations
+# ---------------------------------------------------------------------------
+
+
+def check_hook_errors(config: HealthConfig) -> HookErrorResult:
+    """Query learning.db for hook error rate over the last 7 days with trend.
+
+    Args:
+        config: Health configuration with thresholds.
+
+    Returns:
+        HookErrorResult with rate, trend, and pass/warn status.
+    """
+    if not LEARNING_DB.exists():
+        return HookErrorResult(
+            blocked_count=0,
+            total_count=0,
+            error_rate=0.0,
+            trend="STABLE",
+            status="OK",
+            db_missing=True,
+        )
+
+    cutoff_7d = (datetime.now(tz=timezone.utc) - timedelta(days=7)).isoformat()
+    cutoff_recent = (datetime.now(tz=timezone.utc) - timedelta(days=3.5)).isoformat()
+
+    conn = sqlite3.connect(str(LEARNING_DB))
+    try:
+        blocked_count = conn.execute(
+            "SELECT COUNT(*) FROM governance_events WHERE blocked=1 AND created_at > ?",
+            (cutoff_7d,),
+        ).fetchone()[0]
+
+        total_count = conn.execute(
+            "SELECT COUNT(*) FROM governance_events WHERE created_at > ?",
+            (cutoff_7d,),
+        ).fetchone()[0]
+
+        recent_blocked = conn.execute(
+            "SELECT COUNT(*) FROM governance_events WHERE blocked=1 AND created_at > ?",
+            (cutoff_recent,),
+        ).fetchone()[0]
+
+        older_blocked = conn.execute(
+            "SELECT COUNT(*) FROM governance_events WHERE blocked=1 AND created_at > ? AND created_at <= ?",
+            (cutoff_7d, cutoff_recent),
+        ).fetchone()[0]
+    except sqlite3.OperationalError:
+        # Table may not exist yet on fresh installs
+        return HookErrorResult(
+            blocked_count=0,
+            total_count=0,
+            error_rate=0.0,
+            trend="STABLE",
+            status="OK",
+            db_missing=True,
+        )
+    finally:
+        conn.close()
+
+    error_rate = (blocked_count / total_count * 100) if total_count > 0 else 0.0
+
+    if recent_blocked > older_blocked * 1.5:
+        trend: Literal["INCREASING", "STABLE", "DECREASING"] = "INCREASING"
+    elif older_blocked > 0 and recent_blocked < older_blocked * 0.5:
+        trend = "DECREASING"
+    else:
+        trend = "STABLE"
+
+    status: Status = "WARN" if error_rate > config.hook_error_rate_threshold or trend == "INCREASING" else "OK"
+
+    return HookErrorResult(
+        blocked_count=blocked_count,
+        total_count=total_count,
+        error_rate=error_rate,
+        trend=trend,
+        status=status,
+    )
+
+
+def check_stale_memory(config: HealthConfig) -> StaleMemoryResult:
+    """Scan project memory directories for files older than the stale threshold.
+
+    Args:
+        config: Health configuration with stale_memory_days threshold.
+
+    Returns:
+        StaleMemoryResult with list of stale files and pass/warn status.
+    """
+    threshold = timedelta(days=config.stale_memory_days)
+    now = datetime.now(tz=timezone.utc)
+    stale: list[StaleMemoryFile] = []
+
+    if MEMORY_PROJECTS_DIR.exists():
+        for memory_dir in MEMORY_PROJECTS_DIR.glob("*/memory"):
+            for md_file in memory_dir.glob("*.md"):
+                if md_file.name == "MEMORY.md":
+                    continue
+                mtime = datetime.fromtimestamp(md_file.stat().st_mtime, tz=timezone.utc)
+                age = now - mtime
+                if age > threshold:
+                    project_name = md_file.parent.parent.name
+                    stale.append(StaleMemoryFile(md_file.name, age.days, project_name))
+
+    stale.sort(key=lambda f: -f.age_days)
+    status: Status = "WARN" if len(stale) > STALE_MEMORY_WARN_COUNT else "OK"
+    return StaleMemoryResult(stale_files=stale, status=status, threshold_days=config.stale_memory_days)
+
+
+def check_state_files(config: HealthConfig) -> StateFileResult:
+    """Count files in the Claude state directory.
+
+    Args:
+        config: Health configuration with state_file_warn_count threshold.
+
+    Returns:
+        StateFileResult with count and pass/warn status.
+    """
+    count = 0
+    if STATE_DIR.exists():
+        count = sum(1 for _ in STATE_DIR.iterdir())
+
+    status: Status = "WARN" if count > config.state_file_warn_count else "OK"
+    return StateFileResult(file_count=count, threshold=config.state_file_warn_count, status=status)
+
+
+def check_adr_backlog(config: HealthConfig) -> AdrBacklogResult:
+    """Count ADR markdown files in the toolkit adr/ directory.
+
+    Args:
+        config: Health configuration with adr_backlog_warn_count threshold.
+
+    Returns:
+        AdrBacklogResult with count and pass/warn status.
+    """
+    count = 0
+    if ADR_DIR.exists():
+        count = sum(1 for p in ADR_DIR.glob("*.md"))
+
+    status: Status = "WARN" if count > config.adr_backlog_warn_count else "OK"
+    return AdrBacklogResult(
+        adr_count=count,
+        threshold=config.adr_backlog_warn_count,
+        status=status,
+        adr_dir=str(ADR_DIR),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def check_toolkit_health(
+    config: HealthConfig,
+    checks: tuple[str, ...] = CHECK_NAMES,
+) -> HealthReport:
+    """Run all requested health checks and aggregate results.
+
+    Args:
+        config: Runtime configuration for thresholds.
+        checks: Which check names to run (subset of CHECK_NAMES).
+
+    Returns:
+        HealthReport with results for each dimension and aggregated flags.
+    """
+    report = HealthReport(
+        scan_timestamp=datetime.now(tz=timezone.utc).isoformat(),
+    )
+
+    if "hook-errors" in checks:
+        report.hook_errors = check_hook_errors(config)
+        msg = report.hook_errors.flag_message()
+        if msg:
+            report.flags.append(msg)
+
+    if "stale-memory" in checks:
+        report.stale_memory = check_stale_memory(config)
+        msg = report.stale_memory.flag_message()
+        if msg:
+            report.flags.append(msg)
+
+    if "state-files" in checks:
+        report.state_files = check_state_files(config)
+        msg = report.state_files.flag_message()
+        if msg:
+            report.flags.append(msg)
+
+    if "adr-backlog" in checks:
+        report.adr_backlog = check_adr_backlog(config)
+        msg = report.adr_backlog.flag_message()
+        if msg:
+            report.flags.append(msg)
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def report_to_dict(report: HealthReport) -> dict:
+    """Serialise a HealthReport to a JSON-safe dict.
+
+    Args:
+        report: The health report to serialise.
+
+    Returns:
+        Dict suitable for json.dumps.
+    """
+    result: dict = {
+        "scan_timestamp": report.scan_timestamp,
+        "has_warnings": report.has_warnings(),
+        "flags": report.flags,
+        "checks": {},
+    }
+
+    if report.hook_errors is not None:
+        he = report.hook_errors
+        result["checks"]["hook_errors"] = {
+            "status": he.status,
+            "db_missing": he.db_missing,
+            "blocked_count": he.blocked_count,
+            "total_count": he.total_count,
+            "error_rate": round(he.error_rate, 1),
+            "trend": he.trend,
+        }
+
+    if report.stale_memory is not None:
+        sm = report.stale_memory
+        result["checks"]["stale_memory"] = {
+            "status": sm.status,
+            "stale_count": len(sm.stale_files),
+            "threshold_days": sm.threshold_days,
+            "files": [{"name": f.name, "age_days": f.age_days, "project": f.project} for f in sm.stale_files],
+        }
+
+    if report.state_files is not None:
+        sf = report.state_files
+        result["checks"]["state_files"] = {
+            "status": sf.status,
+            "file_count": sf.file_count,
+            "threshold": sf.threshold,
+        }
+
+    if report.adr_backlog is not None:
+        ab = report.adr_backlog
+        result["checks"]["adr_backlog"] = {
+            "status": ab.status,
+            "adr_count": ab.adr_count,
+            "threshold": ab.threshold,
+            "adr_dir": ab.adr_dir,
+        }
+
+    return result
+
+
+def format_human_report(report: HealthReport) -> str:
+    """Format a HealthReport for human-readable terminal output.
+
+    Args:
+        report: The health report to format.
+
+    Returns:
+        Multi-line string suitable for print().
+    """
+    lines: list[str] = [
+        f"Toolkit Health Report — {report.scan_timestamp}",
+        "",
+    ]
+
+    def status_prefix(s: Status) -> str:
+        return "[WARN]" if s == "WARN" else "[ OK ]"
+
+    if report.hook_errors is not None:
+        he = report.hook_errors
+        if he.db_missing:
+            lines.append("[ OK ] hook-errors: learning.db not found — skipped")
+        else:
+            lines.append(
+                f"{status_prefix(he.status)} hook-errors: "
+                f"{he.error_rate:.1f}% ({he.blocked_count}/{he.total_count} blocked, last 7d), "
+                f"trend={he.trend}"
+            )
+
+    if report.stale_memory is not None:
+        sm = report.stale_memory
+        lines.append(
+            f"{status_prefix(sm.status)} stale-memory: "
+            f"{len(sm.stale_files)} stale files (threshold: >{STALE_MEMORY_WARN_COUNT}, "
+            f"staleness: >{sm.threshold_days}d)"
+        )
+        for f in sm.stale_files[:5]:
+            lines.append(f"         {f.name} — {f.age_days}d (project: {f.project})")
+
+    if report.state_files is not None:
+        sf = report.state_files
+        lines.append(f"{status_prefix(sf.status)} state-files: {sf.file_count} files (threshold: {sf.threshold})")
+
+    if report.adr_backlog is not None:
+        ab = report.adr_backlog
+        lines.append(f"{status_prefix(ab.status)} adr-backlog: {ab.adr_count} ADRs (threshold: {ab.threshold})")
+
+    if report.flags:
+        lines.append("")
+        lines.append("Warnings:")
+        for flag in report.flags:
+            lines.append(f"  - {flag}")
+    else:
+        lines.append("")
+        lines.append("All systems nominal.")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+
+def load_config(config_path: Path | None) -> HealthConfig:
+    """Load health configuration from a JSON file.
+
+    Falls back to defaults if the file does not exist.
+
+    Args:
+        config_path: Optional path to kairos.json config.
+
+    Returns:
+        HealthConfig with values from file or defaults.
+
+    Raises:
+        SystemExit: If the config file exists but cannot be parsed.
+    """
+    defaults = HealthConfig()
+    if config_path is None:
+        return defaults
+
+    if not config_path.exists():
+        return defaults
+
+    try:
+        raw = json.loads(config_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Error: Cannot parse config {config_path}: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    thresholds = raw.get("thresholds", {})
+    return HealthConfig(
+        stale_memory_days=thresholds.get("stale_memory_days", defaults.stale_memory_days),
+        state_file_warn_count=thresholds.get("state_file_warn_count", defaults.state_file_warn_count),
+        adr_backlog_warn_count=thresholds.get("adr_backlog_warn_count", defaults.adr_backlog_warn_count),
+        hook_error_rate_threshold=thresholds.get("hook_error_rate_threshold", defaults.hook_error_rate_threshold),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for toolkit-health.py."""
+    parser = argparse.ArgumentParser(
+        prog="toolkit-health.py",
+        description="Toolkit health checks: hook errors, stale memory, state files, ADR backlog.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  python3 scripts/toolkit-health.py\n"
+            "  python3 scripts/toolkit-health.py --json\n"
+            "  python3 scripts/toolkit-health.py --check hook-errors --check adr-backlog\n"
+            "  python3 scripts/toolkit-health.py --config ~/.claude/config/kairos.json\n"
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output results as JSON for machine consumption",
+    )
+    parser.add_argument(
+        "--check",
+        action="append",
+        dest="checks",
+        choices=list(CHECK_NAMES),
+        metavar="CHECK",
+        help=(f"Run only specific checks (may be repeated). Choices: {', '.join(CHECK_NAMES)}"),
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Path to kairos.json config file (default: ~/.claude/config/kairos.json)",
+    )
+    return parser
+
+
+def main() -> int:
+    """Entry point for toolkit-health.py.
+
+    Returns:
+        0 if all checks pass, 1 if any checks warn, 2 on argument/config error.
+    """
+    parser = build_parser()
+    args = parser.parse_args()
+
+    config_path = args.config
+    if config_path is None:
+        config_path = CLAUDE_DIR / "config" / "kairos.json"
+
+    config = load_config(config_path)
+
+    checks_to_run: tuple[str, ...] = tuple(args.checks) if args.checks else CHECK_NAMES
+
+    report = check_toolkit_health(config, checks=checks_to_run)
+
+    if args.json_output:
+        print(json.dumps(report_to_dict(report), indent=2))
+    else:
+        print(format_human_report(report))
+
+    return 1 if report.has_warnings() else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/agent-evaluation/SKILL.md
+++ b/skills/agent-evaluation/SKILL.md
@@ -52,65 +52,33 @@ ls -la skills/{name}/
 
 Score every rubric category — never skip a category even if it "looks fine." Parse each required field explicitly rather than eyeballing YAML. Record PASS/FAIL with the line number for each check.
 
-**For Agents** — check each item and record PASS/FAIL with line number:
-
-1. YAML front matter: `name`, `description`, `color` fields present
-2. Operator Context section with all 3 behavior types (Hardcoded, Default, Optional)
-3. Hardcoded Behaviors: 5-8 items, MUST include CLAUDE.md Compliance and Over-Engineering Prevention
-4. Default Behaviors: 5-8 items
-5. Optional Behaviors: 3-5 items
-6. Examples in description: 3+ `<example>` blocks with `<commentary>`
-7. Error Handling section with 3+ documented errors
-8. CAN/CANNOT boundaries section
+Run `score-component.py` to get deterministic PASS/FAIL for all structural checks. The script implements the full ADR-031 rubric (frontmatter, operator context, error handling, referenced files, anti-patterns) and outputs per-check results with line references. Do not re-implement these checks inline — read the JSON output and move directly to scoring.
 
 ```bash
-# Agent structural checks
-head -20 agents/{name}.md | grep -E "^(name|description|color):"
-grep -c "## Operator Context" agents/{name}.md
-grep -c "### Hardcoded Behaviors" agents/{name}.md
-grep -c "### Default Behaviors" agents/{name}.md
-grep -c "### Optional Behaviors" agents/{name}.md
-grep -c "CLAUDE.md" agents/{name}.md
-grep -c "Over-Engineering" agents/{name}.md
-grep -c "<example>" agents/{name}.md
-grep -c "## Error Handling" agents/{name}.md
-grep -c "CAN Do" agents/{name}.md
-grep -c "CANNOT Do" agents/{name}.md
+# Deterministic structural checks via score-component.py
+python3 scripts/score-component.py agents/{name}.md --json
+# or for a skill:
+python3 scripts/score-component.py skills/{name}/SKILL.md --json
 ```
 
-**For Skills** — check each item and record PASS/FAIL with line number:
+The JSON output includes `results[0].checks` (per-check status, earned_points, max_points, detail) and `results[0].total` (aggregate score). Record each check status from the JSON — do not re-run `grep -c` for sections the script already covers.
 
-1. YAML front matter: `name`, `description`, `version`, `allowed-tools` present
-2. `allowed-tools` uses YAML list format (not comma-separated string)
-3. `description` uses pipe (`|`) format with WHAT + WHEN + negative constraint, under 1024 chars
-4. `version` set to `2.0.0` for migrated skills
-5. Operator Context section with all 3 behavior types
-6. Hardcoded Behaviors: 5-8 items, MUST include CLAUDE.md Compliance and Over-Engineering Prevention
-7. Default Behaviors: 5-8 items
-8. Optional Behaviors: 3-5 items
-9. Instructions section with gates between phases
-10. Error Handling section with 2-4 documented errors
-11. Anti-Patterns section with 3-5 patterns
-12. `references/` directory with substantive content
-13. CAN/CANNOT boundaries section
-14. References section with shared patterns and domain-specific anti-rationalization table
+**What score-component.py covers** (do not duplicate):
+- YAML frontmatter fields
+- Operator Context section presence
+- Error Handling section presence
+- Anti-Patterns section presence
+- Referenced file existence
+- Inline constraint presence
 
-```bash
-# Skill structural checks
-head -20 skills/{name}/SKILL.md | grep -E "^(name|description|version|allowed-tools):"
-grep -n "allowed-tools:" skills/{name}/SKILL.md  # Check YAML list vs comma format
-grep -c "## Operator Context" skills/{name}/SKILL.md
-grep -c "CLAUDE.md" skills/{name}/SKILL.md
-grep -c "Over-Engineering" skills/{name}/SKILL.md
-grep -c "## Instructions" skills/{name}/SKILL.md
-grep -c "Gate.*Proceed" skills/{name}/SKILL.md  # Count gates
-grep -c "## Error Handling" skills/{name}/SKILL.md
-grep -c "## Anti-Patterns" skills/{name}/SKILL.md
-grep -c "CAN Do" skills/{name}/SKILL.md
-grep -c "CANNOT Do" skills/{name}/SKILL.md
-grep -c "anti-rationalization-core" skills/{name}/SKILL.md
-ls skills/{name}/references/
-```
+**What requires LLM judgment in Phase 3+** (not covered by the script):
+- Operator Context item counts (Hardcoded 5-8, Default 5-8, Optional 3-5)
+- `allowed-tools` list format vs comma-separated string
+- `description` pipe format with WHAT + WHEN + negative constraint
+- `version` set to `2.0.0`
+- Gate presence in Instructions section
+- CAN/CANNOT boundaries section
+- Anti-rationalization table in References section
 
 **Structural Scoring** (60 points):
 


### PR DESCRIPTION
## Summary
- New `scripts/toolkit-health.py` consolidating the 4 Category C health checks from `kairos-lite/monitor-prompt.md` Phase 5 (hook error rate, stale memory files, state file count, ADR backlog) into a single structured CLI with `--json` and per-check `--check` flags.
- `skills/agent-evaluation/SKILL.md` Phase 2 now invokes `score-component.py --json` instead of re-implementing the same grep-c rubric checks inline. LLM judgment retained for Phase 3+ (item counts, format constraints, CAN/CANNOT).
- 31 pytest tests covering all 4 health dimensions, orchestration, config loading, JSON serialization, and human-readable output.

## Test plan
- [ ] CI passes (31 new tests green)
- [ ] `python3 scripts/toolkit-health.py --json` returns valid JSON
- [ ] Manual: run `/agent-evaluation` and confirm Phase 2 delegates to script