### PR TITLE
feat(hooks): pipeline-phase-gate hook (ADR-189)

### DIFF
--- a/hooks/pipeline-phase-gate.py
+++ b/hooks/pipeline-phase-gate.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+PreToolUse:Write,Edit Hook: Pipeline Phase Gate
+
+Blocks phase-advancing writes when the current phase's required artifact is
+absent. Converts LLM-instruction gates into enforced exit-code gates without
+per-pipeline scripting.
+
+Exit codes:
+  0 — allow (artifact exists, path not gated, or no active pipeline detected)
+  2 — block (phase artifact missing; hard gate)
+
+Detection strategy:
+  A phase-gate registry maps (pipeline_id, phase_number) -> expected artifact
+  filename. The hook resolves the pipeline from the target file path and the
+  current phase from the environment or a sentinel file, then checks artifact
+  existence before allowing the write.
+
+Registry pattern (extend to new pipelines without modifying core logic):
+  PHASE_GATE_REGISTRY = {
+      "do-perspectives": {
+          # Phase 3 (SYNTHESIZE) requires Phase 2 artifact
+          3: "perspectives-analysis.md",
+          # Phase 4 (APPLY) requires Phase 3 artifact
+          4: "synthesis.md",
+      },
+  }
+
+Phase detection:
+  The hook infers the current phase from a sentinel file
+  `.pipeline-phase` written by the skill when it advances. If the sentinel
+  is absent, the hook falls back to env var PIPELINE_CURRENT_PHASE.
+  If neither exists, the hook allows through (no active phase tracking).
+
+Environment overrides:
+  PIPELINE_PHASE_GATE_BYPASS=1   — bypass entirely (for skill own writes)
+  PIPELINE_CURRENT_PHASE=N       — override detected phase (integer)
+  CLAUDE_HOOKS_DEBUG=1           — verbose stderr output
+
+Triggering file paths (gate applies when write target is in one of these):
+  do-perspectives writes happen in the cwd (any .md at repo root/cwd).
+  The hook gates based on the file_path matching the artifact name for the
+  NEXT phase, not the current phase. That is: if Phase 3 is about to write
+  synthesis.md and perspectives-analysis.md doesn't exist yet, Phase 2 was
+  never completed.
+
+  Concretely: if the tool is trying to write "synthesis.md" and
+  "perspectives-analysis.md" is absent in the same directory, block.
+"""
+
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
+_BYPASS_ENV = "PIPELINE_PHASE_GATE_BYPASS"
+
+# Registry: maps pipeline_id -> { artifact_being_written -> prerequisite_artifact }
+# "artifact_being_written" is the basename of the file the LLM is about to create.
+# "prerequisite_artifact" must already exist in the same directory.
+#
+# Extend this dict to add gates for new pipelines. Core logic never changes.
+PREREQUISITE_REGISTRY: dict[str, dict[str, str]] = {
+    "do-perspectives": {
+        # Writing synthesis.md (Phase 3 output) requires perspectives-analysis.md (Phase 2 output)
+        "synthesis.md": "perspectives-analysis.md",
+        # Writing into the target agent/skill (Phase 4) requires synthesis.md (Phase 3 output)
+        # Phase 4 writes to the actual target, not a known filename — handled separately via
+        # the phase-sentinel approach below. This entry covers the synthesis -> apply gate.
+    },
+}
+
+# Phase-sentinel-based registry: maps pipeline_id -> { phase_number -> required_artifact }
+# Used when a .pipeline-phase sentinel file exists in the cwd.
+PHASE_SENTINEL_REGISTRY: dict[str, dict[int, str]] = {
+    "do-perspectives": {
+        3: "perspectives-analysis.md",  # Phase 3 (SYNTHESIZE) requires Phase 2 artifact
+        4: "synthesis.md",  # Phase 4 (APPLY) requires Phase 3 artifact
+    },
+}
+
+# Artifact basenames that are themselves phase outputs — used to detect which
+# pipeline is active when no sentinel file exists.
+ARTIFACT_TO_PIPELINE: dict[str, str] = {
+    "perspectives-analysis.md": "do-perspectives",
+    "synthesis.md": "do-perspectives",
+}
+
+
+def _debug(msg: str) -> None:
+    if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+        print(f"[pipeline-phase-gate] {msg}", file=sys.stderr)
+
+
+def _block(reason: str, expected_path: str) -> None:
+    """Print block output to stderr and exit 2."""
+    print(f"[pipeline-phase-gate] BLOCKED: {reason}", file=sys.stderr)
+    print(f"[pipeline-phase-gate] Expected artifact: {expected_path}", file=sys.stderr)
+    sys.exit(2)
+
+
+def _read_phase_sentinel(cwd: Path) -> int | None:
+    """Read .pipeline-phase sentinel file. Returns phase int or None."""
+    sentinel = cwd / ".pipeline-phase"
+    if not sentinel.is_file():
+        return None
+    try:
+        return int(sentinel.read_text(encoding="utf-8").strip())
+    except (ValueError, OSError):
+        return None
+
+
+def _detect_pipeline_from_path(file_path: str) -> str | None:
+    """Infer pipeline id from the target file basename."""
+    basename = Path(file_path).name
+    return ARTIFACT_TO_PIPELINE.get(basename)
+
+
+def main() -> None:
+    if os.environ.get(_BYPASS_ENV) == "1":
+        _debug("Bypassed via PIPELINE_PHASE_GATE_BYPASS=1")
+        sys.exit(0)
+
+    raw = read_stdin(timeout=2)
+    if not raw:
+        _debug("Empty stdin — allowing through")
+        sys.exit(0)
+
+    try:
+        event = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        _debug("Could not parse stdin JSON — allowing through")
+        sys.exit(0)
+
+    tool_input = event.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
+    if not file_path:
+        _debug("No file_path in tool_input — allowing through")
+        sys.exit(0)
+
+    target_basename = Path(file_path).name
+    cwd_str = event.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR", ".")
+    cwd = Path(cwd_str).resolve()
+    target_dir = Path(file_path).parent
+    # If file_path is relative, resolve against cwd
+    if not Path(file_path).is_absolute():
+        target_dir = (cwd / target_dir).resolve()
+    else:
+        target_dir = target_dir.resolve()
+
+    _debug(f"target={file_path} basename={target_basename} dir={target_dir}")
+
+    # --- Strategy 1: Prerequisite-by-artifact-name ---
+    # If the LLM is writing a known phase-N output artifact, check that the
+    # phase-(N-1) artifact already exists in the same directory.
+    for pipeline_id, prereq_map in PREREQUISITE_REGISTRY.items():
+        if target_basename in prereq_map:
+            required = prereq_map[target_basename]
+            required_path = target_dir / required
+            _debug(f"Pipeline={pipeline_id}: writing {target_basename} requires {required_path}")
+            if not required_path.is_file():
+                _block(
+                    f"Phase prerequisite missing for pipeline '{pipeline_id}'. "
+                    f"Writing '{target_basename}' requires '{required}' to exist first.",
+                    str(required_path),
+                )
+            else:
+                _debug(f"Prerequisite {required_path} exists — allowing")
+                sys.exit(0)
+
+    # --- Strategy 2: Phase-sentinel gate ---
+    # If .pipeline-phase exists, use it to look up what artifact is required
+    # for the current phase, regardless of what file is being written.
+    phase_env = os.environ.get("PIPELINE_CURRENT_PHASE")
+    current_phase: int | None = None
+    if phase_env is not None:
+        try:
+            current_phase = int(phase_env)
+        except ValueError:
+            pass
+
+    if current_phase is None:
+        current_phase = _read_phase_sentinel(cwd)
+
+    if current_phase is not None:
+        _debug(f"Detected phase={current_phase} from sentinel/env")
+        # Determine active pipeline: from env or from target basename
+        active_pipeline = os.environ.get("PIPELINE_ID") or _detect_pipeline_from_path(file_path)
+        if active_pipeline and active_pipeline in PHASE_SENTINEL_REGISTRY:
+            phase_map = PHASE_SENTINEL_REGISTRY[active_pipeline]
+            if current_phase in phase_map:
+                required = phase_map[current_phase]
+                required_path = cwd / required
+                _debug(f"Phase {current_phase} of {active_pipeline} requires {required_path}")
+                if not required_path.is_file():
+                    _block(
+                        f"Phase {current_phase} prerequisite missing for pipeline '{active_pipeline}'. "
+                        f"Phase {current_phase - 1} artifact '{required}' must exist before advancing.",
+                        str(required_path),
+                    )
+                else:
+                    _debug(f"Phase artifact {required_path} exists — allowing")
+                    sys.exit(0)
+
+    _debug(f"No gate matched for {file_path} — allowing through")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            traceback.print_exc(file=sys.stderr)
+        else:
+            print(f"[pipeline-phase-gate] Error: {type(e).__name__}: {e}", file=sys.stderr)
+        # Crashed hook fails OPEN — never block tools on unexpected error.
+        sys.exit(0)

--- a/skills/workflow/references/do-perspectives.md
+++ b/skills/workflow/references/do-perspectives.md
@@ -98,7 +98,13 @@ For each perspective, produce output in this format:
 - Each perspective MUST reference specific content from the source material, not generic observations that could apply anywhere. Generic rules add no value. The purpose is extracting patterns specific to the source material.
 - Cross-references to other perspectives are encouraged but optional
 
-**Gate**: All 10 perspectives documented with observations, rules, and source references. Proceed only when gate passes.
+**Artifact**: Write all 10 perspective sections to `perspectives-analysis.md` in the current working directory before advancing. Phase 3 reads from this file, not from context.
+
+```bash
+test -f perspectives-analysis.md || { echo "GATE FAIL: perspectives-analysis.md missing"; exit 1; }
+```
+
+**Gate**: All 10 perspectives documented with observations, rules, and source references. `perspectives-analysis.md` exists on disk. Proceed only when gate passes.
 
 ### Phase 3: SYNTHESIZE
 
@@ -137,7 +143,13 @@ Rules supported by 1-3 perspectives or moderate impact
 [Concrete templates or examples]
 ```
 
-**Gate**: Synthesis complete with priority-ranked rules and implementation guidance. Proceed only when gate passes.
+**Artifact**: Write the full synthesized recommendations block to `synthesis.md` in the current working directory before advancing. Phase 4 reads from this file, not from context.
+
+```bash
+test -f synthesis.md || { echo "GATE FAIL: synthesis.md missing"; exit 1; }
+```
+
+**Gate**: Synthesis complete with priority-ranked rules and implementation guidance. `synthesis.md` exists on disk. Proceed only when gate passes.
 
 ### Phase 4: APPLY
 


### PR DESCRIPTION
## Summary
- `do-perspectives` Phase 2 now writes `perspectives-analysis.md` before advancing; Phase 3 writes `synthesis.md` before advancing. Both gates are backed by file-existence checks, not LLM instructions.
- New `hooks/pipeline-phase-gate.py` enforces these gates mechanically: attempting to write `synthesis.md` when `perspectives-analysis.md` is absent exits 2 (hard block).
- Registry pattern supports extending to other pipelines without modifying core logic.
- Scope of this PR: `do-perspectives` only; broader registration deferred.

## Test plan
- [ ] CI passes
- [ ] Smoke: run `/do-perspectives` on a sample task and confirm phase artifacts are written
- [ ] Negative: attempt to skip Phase 2 → hook blocks