### PR TITLE
feat(learning-db): filter test fixtures from production (ADR-191)

### DIFF
--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -503,10 +503,27 @@ def query_learnings(
     project_path: str | None = None,
     session_id: str | None = None,
     exclude_graduated: bool = True,
+    exclude_test_sources: bool = True,
     order_by: str = "confidence DESC",
     limit: int = 50,
 ) -> list[dict]:
-    """Query learnings with filtering and ordering."""
+    """Query learnings with filtering and ordering.
+
+    Args:
+        topic: Filter by topic prefix.
+        category: Filter by category.
+        tags: Filter by tags (matches ANY).
+        min_confidence: Minimum confidence threshold.
+        project_path: Filter by project path (NULL or exact match).
+        session_id: Filter by session id.
+        exclude_graduated: If True, omit entries with a graduation target.
+        exclude_test_sources: If True (default), omit entries where source
+            starts with 'test'. This prevents test fixtures from leaking
+            into production session-context injection. Pass False to include
+            test-source rows (e.g. for auditing or purge scripts).
+        order_by: SQL ORDER BY clause (whitelisted).
+        limit: Maximum rows to return.
+    """
     init_db()
 
     conditions = ["confidence >= ?"]
@@ -526,6 +543,8 @@ def query_learnings(
         params.append(session_id)
     if exclude_graduated:
         conditions.append("graduated_to IS NULL")
+    if exclude_test_sources:
+        conditions.append("source NOT LIKE 'test%'")
 
     if tags:
         tag_clauses = []

--- a/hooks/tests/test_fts5_search.py
+++ b/hooks/tests/test_fts5_search.py
@@ -307,20 +307,21 @@ class TestBackwardCompatibility:
         _record("python-patterns", "dataclass", "Use dataclasses", tags=["python"])
 
         # Exact tag substring matching still works
-        results = db.query_learnings(tags=["go"])
+        # ADR-191: test fixtures use source="test"; opt back in via exclude_test_sources=False.
+        results = db.query_learnings(tags=["go"], exclude_test_sources=False)
         assert len(results) >= 1
         assert any(r["topic"] == "go-patterns" for r in results)
 
     def test_query_learnings_by_topic(self):
         _record("go-patterns", "mutex-usage", "Use sync.Mutex", tags=["go"])
 
-        results = db.query_learnings(topic="go-patterns")
+        results = db.query_learnings(topic="go-patterns", exclude_test_sources=False)
         assert len(results) == 1
 
     def test_both_apis_find_same_entry(self):
         _record("shared", "shared-key", "Shared content about concurrency", tags=["go", "concurrency"])
 
-        query_results = db.query_learnings(tags=["concurrency"])
+        query_results = db.query_learnings(tags=["concurrency"], exclude_test_sources=False)
         search_results = db.search_learnings("concurrency")
 
         assert len(query_results) >= 1

--- a/hooks/tests/test_integration.py
+++ b/hooks/tests/test_integration.py
@@ -3,21 +3,47 @@
 Integration tests for the complete learning system (v2 unified database).
 
 Tests the full workflow from error detection through learning to solution suggestion.
-Uses the unified learning database at ~/.claude/learning/learning.db.
+Uses an isolated temporary database — never touches the production DB at
+~/.claude/learning/learning.db.
 """
 
+import importlib
 import sys
 import uuid
 from pathlib import Path
+
+import pytest
 
 # Add parent lib directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
 
 
-def test_end_to_end_learning():
-    """Test complete learning workflow."""
-    print("Testing end-to-end learning workflow...")
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point learning DB to a temp directory so tests never touch production data."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+
+    # Reset the module-level _initialized flag so init_db() runs fresh each test.
+    import learning_db_v2
+
+    monkeypatch.setattr(learning_db_v2, "_initialized", False)
+    return db_dir
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_learning(isolated_db: Path) -> None:
+    """Test complete learning workflow."""
     from learning_db_v2 import (
         boost_confidence,
         classify_error,
@@ -27,18 +53,14 @@ def test_end_to_end_learning():
         record_learning,
     )
 
-    # Initialize database
     init_db()
 
-    # Use unique error message for this test run
     unique_id = str(uuid.uuid4())[:8]
     error_message = f"Found 3 matches of the string to replace test-{unique_id}"
 
-    # Classify error
     error_type = classify_error(error_message)
     assert error_type == "multiple_matches", f"Expected 'multiple_matches', got '{error_type}'"
 
-    # Record initial error (low confidence)
     signature = generate_signature(error_message, error_type)
     result = record_learning(
         topic=error_type,
@@ -46,18 +68,16 @@ def test_end_to_end_learning():
         value=f"{error_message} → Use replace_all or provide unique context",
         category="error",
         confidence=0.55,
-        source="test",
+        source="integration-test",
         project_path="/test/project",
         error_signature=signature,
         error_type=error_type,
     )
     assert result["is_new"] is True
 
-    # Simulate learning (multiple successes boost confidence)
     for _ in range(3):
         boost_confidence(error_type, signature, delta=0.12)
 
-    # Check confidence increased above threshold
     with get_connection() as conn:
         row = conn.execute(
             "SELECT confidence FROM learnings WHERE error_signature = ?",
@@ -66,13 +86,9 @@ def test_end_to_end_learning():
         assert row is not None, "Should find learning after recording"
         assert row["confidence"] >= 0.7, f"Expected confidence >= 0.7, got {row['confidence']}"
 
-    print("  ✓ Pattern learned and reached high confidence")
 
-
-def test_multiple_error_types():
+def test_multiple_error_types(isolated_db: Path) -> None:
     """Test learning multiple different error types."""
-    print("Testing multiple error type learning...")
-
     from learning_db_v2 import classify_error, init_db
 
     init_db()
@@ -86,17 +102,12 @@ def test_multiple_error_types():
     ]
 
     for error_msg, expected_type in error_scenarios:
-        # Classify
         error_type = classify_error(error_msg)
         assert error_type == expected_type, f"Expected {expected_type}, got {error_type}"
 
-    print("  ✓ Multiple error types classified correctly")
 
-
-def test_confidence_bounds():
+def test_confidence_bounds(isolated_db: Path) -> None:
     """Test confidence score bounds."""
-    print("Testing confidence bounds...")
-
     from learning_db_v2 import (
         boost_confidence,
         decay_confidence,
@@ -106,41 +117,34 @@ def test_confidence_bounds():
 
     init_db()
 
-    # Use unique error message
     unique_id = str(uuid.uuid4())[:8]
     topic = "test-bounds"
     key = f"bounds-test-{unique_id}"
 
-    # Start with low confidence
     record_learning(
         topic=topic,
         key=key,
         value="Test solution for bounds checking",
         category="error",
         confidence=0.55,
-        source="test",
+        source="integration-test",
     )
 
-    # Many decays should drive confidence down but not below 0
+    conf = 1.0
     for _ in range(15):
         conf = decay_confidence(topic, key, delta=0.18)
 
     assert conf >= 0.0, f"Confidence went below 0: {conf}"
 
-    # Many boosts should drive confidence up but not above 1
     for _ in range(25):
         conf = boost_confidence(topic, key, delta=0.12)
 
     assert conf <= 1.0, f"Confidence went above 1: {conf}"
     assert conf > 0.5, f"Confidence should be high after many successes: {conf}"
 
-    print("  ✓ Confidence bounds enforced correctly")
 
-
-def test_database_stats():
+def test_database_stats(isolated_db: Path) -> None:
     """Test database statistics."""
-    print("Testing database statistics...")
-
     from learning_db_v2 import get_stats, init_db
 
     init_db()
@@ -149,26 +153,3 @@ def test_database_stats():
     assert "total_learnings" in stats
     assert "by_category" in stats
     assert "high_confidence" in stats
-
-    print(f"  Stats: {stats['total_learnings']} learnings, {stats.get('high_confidence', 0)} high-confidence")
-    print("  ✓ Database statistics working correctly")
-
-
-def main():
-    """Run all integration tests."""
-    print("╔═══════════════════════════════════════════════════════════╗")
-    print("║    Learning System Integration Tests (v2 unified DB)     ║")
-    print("╚═══════════════════════════════════════════════════════════╝\n")
-
-    test_end_to_end_learning()
-    test_multiple_error_types()
-    test_confidence_bounds()
-    test_database_stats()
-
-    print("\n" + "=" * 60)
-    print("✅ All integration tests passed!")
-    print("=" * 60)
-
-
-if __name__ == "__main__":
-    main()

--- a/scripts/purge-test-learnings.py
+++ b/scripts/purge-test-learnings.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""One-shot script to remove test-source entries from the production learning DB.
+
+Dry-run by default: lists affected rows without deleting. Pass --commit to delete.
+
+Usage:
+    python3 scripts/purge-test-learnings.py
+    python3 scripts/purge-test-learnings.py --commit
+    python3 scripts/purge-test-learnings.py --db /path/to/learning.db
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def _default_db_path() -> Path:
+    """Return the default production DB path, respecting CLAUDE_LEARNING_DIR."""
+    import os
+
+    env_dir = os.environ.get("CLAUDE_LEARNING_DIR")
+    if env_dir:
+        return Path(env_dir) / "learning.db"
+    return Path.home() / ".claude" / "learning" / "learning.db"
+
+
+def _query_test_rows(conn: sqlite3.Connection) -> list[dict]:
+    """Return all rows whose source starts with 'test'."""
+    cursor = conn.execute(
+        """
+        SELECT id, topic, key, source, category, confidence, first_seen
+        FROM learnings
+        WHERE source LIKE 'test%'
+        ORDER BY source, topic, key
+        """,
+    )
+    col_names = [col[0] for col in cursor.description]
+    return [dict(zip(col_names, row)) for row in cursor.fetchall()]
+
+
+def _print_summary(rows: list[dict]) -> None:
+    """Print a human-readable table of rows that would be deleted."""
+    if not rows:
+        print("No test-source rows found.")
+        return
+
+    print(f"Test-source rows ({len(rows)} total):")
+    print(f"{'Source':<20} {'Topic':<35} {'Key':<14} {'Category':<14} {'Conf':>5}")
+    print("-" * 92)
+    for r in rows:
+        print(
+            f"{r['source']:<20} {r['topic'][:34]:<35} {r['key'][:13]:<14} {r['category']:<14} {r['confidence']:>5.2f}"
+        )
+    print("-" * 92)
+
+    by_source: dict[str, int] = {}
+    for r in rows:
+        by_source[r["source"]] = by_source.get(r["source"], 0) + 1
+    print("By source:")
+    for src, cnt in sorted(by_source.items(), key=lambda x: -x[1]):
+        print(f"  {src}: {cnt}")
+
+
+def main() -> None:
+    """Entry point."""
+    parser = argparse.ArgumentParser(
+        description="Remove test-source entries from the learning DB (dry-run by default)."
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Actually delete the rows. Without this flag the script is read-only.",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=None,
+        help="Path to learning.db (default: ~/.claude/learning/learning.db or $CLAUDE_LEARNING_DIR)",
+    )
+    args = parser.parse_args()
+
+    db_path = args.db or _default_db_path()
+    if not db_path.exists():
+        print(f"Database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    rows = _query_test_rows(conn)
+    _print_summary(rows)
+
+    if not rows:
+        conn.close()
+        return
+
+    if not args.commit:
+        print()
+        print("DRY RUN — no rows deleted.")
+        print(f"Run with --commit to delete these {len(rows)} rows from {db_path}")
+        conn.close()
+        return
+
+    # --commit: delete and report
+    print()
+    cursor = conn.execute("DELETE FROM learnings WHERE source LIKE 'test%'")
+    deleted = cursor.rowcount
+    conn.commit()
+    conn.close()
+
+    print(f"Deleted {deleted} test-source rows from {db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_learning_source_filter.py
+++ b/scripts/tests/test_learning_source_filter.py
@@ -1,0 +1,266 @@
+"""Tests for the source filter in query_learnings and the purge-test-learnings script.
+
+Covers:
+- query_learnings excludes test-source rows by default
+- query_learnings includes test-source rows with exclude_test_sources=False
+- purge-test-learnings dry-run reports rows without deleting
+- purge-test-learnings --commit deletes test-source rows only
+"""
+
+from __future__ import annotations
+
+import importlib
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repo hooks/lib is on the path for learning_db_v2
+_repo_root = Path(__file__).resolve().parent.parent.parent
+_repo_hooks_lib = str(_repo_root / "hooks" / "lib")
+if _repo_hooks_lib not in sys.path:
+    sys.path.insert(0, _repo_hooks_lib)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point learning DB to a temp directory so tests never touch production data."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+
+    import learning_db_v2
+
+    monkeypatch.setattr(learning_db_v2, "_initialized", False)
+    if "learning_db_v2" in sys.modules:
+        importlib.reload(sys.modules["learning_db_v2"])
+    return db_dir
+
+
+def _seed_mixed(isolated_db: Path) -> None:
+    """Insert two real rows and two test-source rows into the temp DB."""
+    from learning_db_v2 import init_db, record_learning
+
+    init_db()
+    record_learning(
+        topic="go-patterns",
+        key="mutex-over-atomics",
+        value="Use sync.Mutex for complex state; atomics for simple counters.",
+        category="design",
+        confidence=0.8,
+        source="manual:learn",
+    )
+    record_learning(
+        topic="debugging",
+        key="log-before-panic",
+        value="Always log state before calling panic() so postmortem has context.",
+        category="gotcha",
+        confidence=0.75,
+        source="hook:user-correction-capture",
+    )
+    record_learning(
+        topic="test-bounds",
+        key="bounds-abc123",
+        value="Test fixture — confidence boundary check.",
+        category="error",
+        confidence=0.55,
+        source="test",
+    )
+    record_learning(
+        topic="multiple_matches",
+        key="sig-deadbeef1234",
+        value="Test fixture — multiple match error pattern.",
+        category="error",
+        confidence=0.70,
+        source="test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# query_learnings source filter
+# ---------------------------------------------------------------------------
+
+
+class TestQueryLearningsSourceFilter:
+    """query_learnings must exclude test-source rows by default."""
+
+    def test_excludes_test_sources_by_default(self, isolated_db: Path) -> None:
+        _seed_mixed(isolated_db)
+        from learning_db_v2 import query_learnings
+
+        results = query_learnings()
+        sources = {r["source"] for r in results}
+        assert not any(s.startswith("test") for s in sources), f"Default query returned test-source rows: {sources}"
+
+    def test_real_rows_still_returned(self, isolated_db: Path) -> None:
+        _seed_mixed(isolated_db)
+        from learning_db_v2 import query_learnings
+
+        results = query_learnings()
+        keys = {r["key"] for r in results}
+        assert "mutex-over-atomics" in keys
+        assert "log-before-panic" in keys
+
+    def test_include_tests_flag_returns_all(self, isolated_db: Path) -> None:
+        _seed_mixed(isolated_db)
+        from learning_db_v2 import query_learnings
+
+        results = query_learnings(exclude_test_sources=False)
+        keys = {r["key"] for r in results}
+        assert "bounds-abc123" in keys
+        assert "sig-deadbeef1234" in keys
+
+    def test_test_prefix_variants_excluded(self, isolated_db: Path) -> None:
+        """source='test-harness' and source='test:fixture' are also excluded."""
+        from learning_db_v2 import init_db, query_learnings, record_learning
+
+        init_db()
+        record_learning(
+            topic="misc",
+            key="harness-row",
+            value="Row with test-harness source.",
+            category="design",
+            confidence=0.6,
+            source="test-harness",
+        )
+        record_learning(
+            topic="misc",
+            key="testcolon-row",
+            value="Row with test:fixture source.",
+            category="design",
+            confidence=0.6,
+            source="test:fixture",
+        )
+        record_learning(
+            topic="misc",
+            key="real-row",
+            value="Real row from hook.",
+            category="design",
+            confidence=0.6,
+            source="hook:session-guard",
+        )
+
+        results = query_learnings()
+        keys = {r["key"] for r in results}
+        assert "harness-row" not in keys
+        assert "testcolon-row" not in keys
+        assert "real-row" in keys
+
+    def test_category_filter_still_applies(self, isolated_db: Path) -> None:
+        """When filtering by category, test sources are still excluded."""
+        _seed_mixed(isolated_db)
+        from learning_db_v2 import query_learnings
+
+        # category=error has two test-source rows; with the filter none should appear
+        results = query_learnings(category="error")
+        assert results == [], f"Expected empty list, got: {results}"
+
+    def test_category_filter_with_include_tests(self, isolated_db: Path) -> None:
+        """exclude_test_sources=False lets test rows through even with category filter."""
+        _seed_mixed(isolated_db)
+        from learning_db_v2 import query_learnings
+
+        results = query_learnings(category="error", exclude_test_sources=False)
+        assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# purge-test-learnings script
+# ---------------------------------------------------------------------------
+
+# Import the script as a module
+_scripts_dir = str(_repo_root / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+
+def _import_purge_script():
+    """Import purge-test-learnings as a module (hyphen in filename)."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "purge_test_learnings",
+        _repo_root / "scripts" / "purge-test-learnings.py",
+    )
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestPurgeTestLearnings:
+    """purge-test-learnings.py dry-run and --commit behaviour."""
+
+    def test_dry_run_does_not_delete(self, isolated_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _seed_mixed(isolated_db)
+        db_path = isolated_db / "learning.db"
+        mod = _import_purge_script()
+
+        # Patch argparse so we can call main() without sys.argv conflicts
+        monkeypatch.setattr(
+            "sys.argv",
+            ["purge-test-learnings.py", "--db", str(db_path)],
+        )
+        mod.main()
+
+        # Rows must still be present after dry run
+        conn = sqlite3.connect(db_path)
+        count = conn.execute("SELECT COUNT(*) FROM learnings WHERE source LIKE 'test%'").fetchone()[0]
+        conn.close()
+        assert count == 2, f"Dry run deleted rows — expected 2 test rows, found {count}"
+
+    def test_commit_deletes_test_rows(self, isolated_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _seed_mixed(isolated_db)
+        db_path = isolated_db / "learning.db"
+        mod = _import_purge_script()
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["purge-test-learnings.py", "--db", str(db_path), "--commit"],
+        )
+        mod.main()
+
+        conn = sqlite3.connect(db_path)
+        test_count = conn.execute("SELECT COUNT(*) FROM learnings WHERE source LIKE 'test%'").fetchone()[0]
+        real_count = conn.execute("SELECT COUNT(*) FROM learnings WHERE source NOT LIKE 'test%'").fetchone()[0]
+        conn.close()
+        assert test_count == 0, f"Expected 0 test rows after --commit, found {test_count}"
+        assert real_count == 2, f"Expected 2 real rows preserved, found {real_count}"
+
+    def test_dry_run_output_lists_rows(
+        self, isolated_db: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _seed_mixed(isolated_db)
+        db_path = isolated_db / "learning.db"
+        mod = _import_purge_script()
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["purge-test-learnings.py", "--db", str(db_path)],
+        )
+        mod.main()
+        output = capsys.readouterr().out
+
+        assert "2" in output  # row count
+        assert "DRY RUN" in output
+        assert "--commit" in output
+
+    def test_empty_db_no_crash(self, isolated_db: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from learning_db_v2 import init_db
+
+        init_db()  # empty DB
+        db_path = isolated_db / "learning.db"
+        mod = _import_purge_script()
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["purge-test-learnings.py", "--db", str(db_path)],
+        )
+        mod.main()  # should not raise


### PR DESCRIPTION
## Summary
- `query_learnings()` now excludes rows where `source LIKE 'test%'` by default (`exclude_test_sources=True`). This stops test scaffolding written by `test_integration.py` from being injected into production sessions via the `session-context` hook, which was loading 10 test fixtures on every session start.
- `hooks/lib/learning_db_v2.py`: add `exclude_test_sources` param; default `True`, pass `False` for audit/purge workflows.
- `hooks/tests/test_integration.py`: fully isolated with `CLAUDE_LEARNING_DIR` fixture; source changed from `test` to `integration-test` to prevent future pollution.
- `scripts/purge-test-learnings.py`: one-shot script, dry-run default, `--commit` to delete; lists affected rows with summary before any action.
- `scripts/tests/test_learning_source_filter.py`: 10 tests covering the filter and both purge modes.
- `hooks/tests/test_fts5_search.py`: 3 backward-compat tests updated to pass `exclude_test_sources=False` for fixtures that intentionally use `source="test"`.

## Test plan
- [ ] CI passes (44 related tests green)
- [ ] Dry-run `python3 scripts/purge-test-learnings.py` on production DB before `--commit`