### PR TITLE
chore(settings): remove CLAUDE_CODE_EFFORT_LEVEL env var

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,6 @@
   "effortLevel": "max",
   "env": {
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
-    "CLAUDE_CODE_EFFORT_LEVEL": "max",
     "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000"
   },
   "attribution": {


### PR DESCRIPTION
## Summary
- Remove `CLAUDE_CODE_EFFORT_LEVEL` env variable from `.claude/settings.json`.
- The top-level `effortLevel` field continues to control effort selection; the env-exported variant was redundant.

## Test plan
- [x] JSON remains valid (`python3 -c "import json; json.load(open('.claude/settings.json'))"`)
- [x] Two sibling env vars preserved (`CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW`)
- [x] Single-line diff, no unrelated changes