### PR TITLE
feat(refs): condition-based-waiting (Level 2→3)

### DIFF
--- a/skills/condition-based-waiting/SKILL.md
+++ b/skills/condition-based-waiting/SKILL.md
@@ -225,5 +225,16 @@ Solution:
 
 ## References
 
+### Loading Table
+
+| Task Type | Signal Keywords | Load |
+|-----------|----------------|------|
+| Implementing any pattern | "implement", "add retry", "write polling", "create backoff" | `implementation-patterns.md` |
+| Reviewing existing code | "review", "check for", "find issues", "audit", "detect" | `anti-patterns.md` |
+| Replacing `sleep()` in tests | "sleep", "flaky test", "CI hang", "test timeout" | `anti-patterns.md` |
+| Writing tests for retry/wait code | "test", "pytest", "mock", "verify retry", "unit test" | `testing-patterns.md` |
+
 ### Reference Files
 - `${CLAUDE_SKILL_DIR}/references/implementation-patterns.md`: Complete Python/Bash implementations for all patterns
+- `${CLAUDE_SKILL_DIR}/references/anti-patterns.md`: Detection commands and fixes for common wait/retry mistakes
+- `${CLAUDE_SKILL_DIR}/references/testing-patterns.md`: pytest patterns for testing polling, backoff, and circuit breaker code

--- a/skills/condition-based-waiting/references/anti-patterns.md
+++ b/skills/condition-based-waiting/references/anti-patterns.md
@@ -1,0 +1,277 @@
+# Wait/Retry Anti-Patterns
+
+> **Scope**: Common mistakes in polling, retry, and backoff code — detection commands and fixes.
+> **Version range**: Python 3.8+, Bash (any POSIX)
+> **Generated**: 2026-04-16
+
+---
+
+## Overview
+
+Retry and wait code fails silently more than almost any other category: a loop that should timeout hangs forever, a "retry" that doesn't back off hammers a downed service, a test that passed locally flakes in CI because it depended on timing. The patterns below are the most frequent offenders found across real codebases.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Hardcoded `time.sleep()` Without Condition Check
+
+**Detection**:
+```bash
+grep -rn 'time\.sleep(' --include="*.py" | grep -v 'poll_interval\|wait_for\|retry\|backoff'
+rg 'time\.sleep\(\d' --type py
+```
+
+**What it looks like**:
+```python
+def wait_for_db():
+    time.sleep(5)  # Hope the DB is ready by now
+    return connect()
+```
+
+**Why wrong**: The sleep duration is a guess. If the DB starts in 1s you wasted 4s; if it takes 6s you got a connection error. There is no feedback — the code never checks whether the condition became true.
+
+**Fix**:
+```python
+wait_for(
+    lambda: try_connect() is not None,
+    "database connection",
+    timeout_seconds=30,
+    poll_interval_seconds=0.5,
+)
+```
+
+---
+
+### ❌ Infinite Loop Without Timeout
+
+**Detection**:
+```bash
+grep -rn 'while True' --include="*.py" | grep -v 'timeout\|deadline\|monotonic'
+rg 'while True:' --type py -A 5 | grep -v 'break\|timeout\|deadline'
+```
+
+**What it looks like**:
+```python
+while True:
+    if service_ready():
+        break
+    time.sleep(1)
+# Hangs forever if service never becomes ready
+```
+
+**Why wrong**: A downed service turns this into an infinite loop that blocks the process, pegs a thread, and never gives the caller an error to act on.
+
+**Fix**:
+```python
+start = time.monotonic()
+deadline = start + timeout_seconds
+while time.monotonic() < deadline:
+    if service_ready():
+        return
+    time.sleep(1)
+raise TimeoutError(f"Service not ready after {timeout_seconds}s")
+```
+
+---
+
+### ❌ Using `time.time()` for Elapsed Time Measurement
+
+**Detection**:
+```bash
+rg 'start\s*=\s*time\.time\(\)' --type py
+grep -rn 'time\.time()' --include="*.py" | grep -E 'deadline|elapsed|timeout'
+```
+
+**What it looks like**:
+```python
+start = time.time()
+deadline = start + timeout
+while time.time() < deadline:
+    ...
+```
+
+**Why wrong**: `time.time()` is wall-clock time and jumps backward on NTP sync or DST changes. A 1-second backward jump can cause the loop to run `timeout` extra seconds past the intended deadline. `time.monotonic()` never goes backward.
+
+**Fix**:
+```python
+start = time.monotonic()
+deadline = start + timeout
+while time.monotonic() < deadline:
+    ...
+```
+
+**Version note**: `time.monotonic()` available since Python 3.3.
+
+---
+
+### ❌ Retry Without Jitter (Thundering Herd)
+
+**Detection**:
+```bash
+grep -rn 'sleep.*delay\|sleep.*backoff' --include="*.py" | grep -v 'jitter\|random\|uniform'
+rg 'time\.sleep\(delay\)' --type py
+```
+
+**What it looks like**:
+```python
+for attempt in range(max_retries):
+    try:
+        return call_api()
+    except RequestException:
+        time.sleep(delay)
+        delay *= 2  # No jitter — all clients wake up simultaneously
+```
+
+**Why wrong**: After an outage, all clients waiting with the same deterministic delay retry at exactly the same instant. This creates a load spike that can re-trigger the very failure they were recovering from.
+
+**Fix**:
+```python
+jitter = 1.0 + random.uniform(-0.5, 0.5)
+time.sleep(min(delay * jitter, max_delay))
+delay = min(delay * backoff_factor, max_delay)
+```
+
+---
+
+### ❌ Retrying Non-Retryable Errors
+
+**Detection**:
+```bash
+grep -rn 'except Exception' --include="*.py" -B2 | grep -E 'retry|attempt|backoff'
+rg 'retryable_exceptions.*=.*Exception\b' --type py
+```
+
+**What it looks like**:
+```python
+for attempt in range(5):
+    try:
+        return api_call()
+    except Exception:  # Retries 401, 404, validation errors too
+        time.sleep(delay)
+```
+
+**Why wrong**: A 401 Unauthorized will never succeed on retry — you're burning quota and delaying the inevitable. A 400 Bad Request means your payload is wrong, not that the server is overloaded.
+
+**Fix**:
+```python
+RETRYABLE = (requests.Timeout, requests.ConnectionError)
+NON_RETRYABLE_CODES = {400, 401, 403, 404, 422}
+
+for attempt in range(max_retries):
+    try:
+        resp = requests.get(url)
+        if resp.status_code in NON_RETRYABLE_CODES:
+            resp.raise_for_status()  # Propagates immediately, no retry
+        resp.raise_for_status()
+        return resp
+    except RETRYABLE as e:
+        if attempt >= max_retries - 1:
+            raise
+        time.sleep(delay)
+```
+
+---
+
+### ❌ Busy-Wait (No Sleep in Poll Loop)
+
+**Detection**:
+```bash
+grep -rn -A 8 'while.*monotonic\(\)' --include="*.py" | grep -v 'sleep'
+rg 'while time\.monotonic' --type py -A 6 | grep -c 'sleep'
+```
+
+**What it looks like**:
+```python
+while time.monotonic() < deadline:
+    if condition():
+        return True
+# No sleep — spins at 100% CPU until timeout
+```
+
+**Why wrong**: A tight poll loop consumes 100% of one CPU core, starves other threads/processes, and triggers thermal throttling on laptops.
+
+**Fix**:
+```python
+while time.monotonic() < deadline:
+    if condition():
+        return True
+    time.sleep(poll_interval)  # min 0.01s in-process; 0.5s+ for external services
+```
+
+---
+
+### ❌ Bash Loop Without Timeout
+
+**Detection**:
+```bash
+grep -rn 'while.*sleep' --include="*.sh" | grep -v 'deadline\|SECONDS\|timeout\|end_time'
+grep -rn 'while true' --include="*.sh" -i | grep -v 'deadline\|SECONDS'
+```
+
+**What it looks like**:
+```bash
+while ! pg_isready -h localhost; do
+    sleep 2
+done
+# Hangs indefinitely if postgres never starts
+```
+
+**Why wrong**: No bound means this script hangs in CI until the job times out, with no diagnostic about what failed or how long it waited.
+
+**Fix**:
+```bash
+deadline=$((SECONDS + 60))
+while [ $SECONDS -lt $deadline ]; do
+    if pg_isready -h localhost; then
+        exit 0
+    fi
+    sleep 2
+done
+echo "Timeout: postgres not ready after 60s" >&2
+exit 1
+```
+
+**Note**: `$SECONDS` is a bash built-in counting seconds since shell started — no `date` subprocess needed.
+
+---
+
+## Error-Fix Mappings
+
+| Error Message | Root Cause | Fix |
+|---------------|------------|-----|
+| `TimeoutError: Timeout waiting for: X. Waited 30.0s, last result: None` | Condition function always returns falsy | Add logging inside condition; verify the target actually changes state |
+| `All retries exhausted` with 401/403 in logs | Retrying non-retryable auth errors | Add status-code check before retry; propagate 401/403 immediately |
+| Test hangs in CI but passes locally | Hardcoded `sleep()` too short for CI machine | Replace with condition-based wait; or add env-var timeout override |
+| High CPU during health check startup | Busy-wait with no sleep | Add `time.sleep(poll_interval)` inside the poll loop |
+| Retry storm after outage recovery | No jitter — all instances retry simultaneously | Add `random.uniform(-0.5, 0.5)` jitter multiplier |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Hardcoded sleep without condition
+grep -rn 'time\.sleep(' --include="*.py" | grep -v 'poll_interval\|wait_for\|retry'
+
+# Infinite loop without timeout
+grep -rn 'while True' --include="*.py" | grep -v 'deadline\|timeout\|monotonic'
+
+# Wall-clock time for elapsed measurement
+rg 'start\s*=\s*time\.time\(\)' --type py
+
+# Retry without jitter
+rg 'time\.sleep\(delay\)' --type py
+
+# Broad exception catch in retry context
+grep -rn 'except Exception' --include="*.py" -B2 | grep -E 'retry|attempt'
+
+# Bash loop without timeout
+grep -rn 'while.*sleep' --include="*.sh" | grep -v 'deadline\|SECONDS\|timeout'
+```
+
+---
+
+## See Also
+
+- `implementation-patterns.md` — complete Python/Bash implementations for all patterns

--- a/skills/condition-based-waiting/references/testing-patterns.md
+++ b/skills/condition-based-waiting/references/testing-patterns.md
@@ -1,0 +1,265 @@
+# Testing Wait and Retry Code
+
+> **Scope**: pytest patterns for testing condition-based polling, exponential backoff, and circuit breakers.
+> **Version range**: Python 3.8+, pytest 7+
+> **Generated**: 2026-04-16
+
+---
+
+## Overview
+
+Wait/retry code is notoriously hard to test correctly. The two failure modes: tests that pass because the real sleep ran (slow, flaky in CI), and tests that mock away the sleep but don't verify the retry logic actually ran. The patterns below separate timing from logic so tests are fast and deterministic.
+
+---
+
+## Pattern Table
+
+| Need | Tool | Notes |
+|------|------|-------|
+| Mock `time.sleep` | `unittest.mock.patch` | Verify call count and delay values |
+| Control `time.monotonic` | `freezegun` or `time_machine` | Advance clock without real sleep |
+| Force N failures then success | `side_effect` list | Returns exception N times, then returns value |
+| Verify retry count | `mock.call_count` | Assert exactly N+1 attempts |
+| Test timeout fires | `pytest.raises(TimeoutError)` | Never satisfy the condition |
+
+---
+
+## Correct Patterns
+
+### Testing Simple Polling with Mocked Sleep
+
+Verify the poll loop calls `time.sleep` with the right interval and raises `TimeoutError` when the condition never becomes true.
+
+```python
+from unittest.mock import patch, MagicMock
+import pytest
+from mymodule import wait_for
+
+def test_wait_for_success(mocker):
+    condition = mocker.MagicMock(side_effect=[False, False, True])
+    mocker.patch("time.sleep")
+
+    result = wait_for(condition, "test condition", timeout_seconds=10, poll_interval_seconds=0.1)
+
+    assert result is True
+    assert condition.call_count == 3
+
+def test_wait_for_timeout(mocker):
+    condition = mocker.MagicMock(return_value=False)
+    mocker.patch("time.monotonic", side_effect=[0, 1, 2, 31])  # Exceeds 30s timeout
+    mocker.patch("time.sleep")
+
+    with pytest.raises(TimeoutError, match="test condition"):
+        wait_for(condition, "test condition", timeout_seconds=30)
+```
+
+**Why**: Mocking `time.sleep` prevents actual delays. Controlling `time.monotonic` makes the timeout deterministic without requiring real time to pass.
+
+---
+
+### Testing Exponential Backoff — Delay Progression
+
+Verify delays grow exponentially and are capped at `max_delay`.
+
+```python
+from unittest.mock import patch, call
+import pytest
+from mymodule import retry_with_backoff
+
+def test_backoff_delay_progression(mocker):
+    operation = mocker.MagicMock(side_effect=[ValueError("fail")] * 3 + [42])
+    sleep_mock = mocker.patch("time.sleep")
+    # Patch random.uniform to return 0 so jitter is predictable
+    mocker.patch("random.uniform", return_value=0.0)
+
+    result = retry_with_backoff(
+        operation,
+        "test op",
+        max_retries=3,
+        initial_delay_seconds=1.0,
+        backoff_factor=2.0,
+        max_delay_seconds=10.0,
+        retryable_exceptions=(ValueError,),
+    )
+
+    assert result == 42
+    assert operation.call_count == 4
+    delays = [c.args[0] for c in sleep_mock.call_args_list]
+    assert delays == [1.0, 2.0, 4.0]  # 1 → 2 → 4, capped before 10
+
+def test_backoff_raises_after_max_retries(mocker):
+    operation = mocker.MagicMock(side_effect=ValueError("always fails"))
+    mocker.patch("time.sleep")
+    mocker.patch("random.uniform", return_value=0.0)
+
+    with pytest.raises(ValueError, match="always fails"):
+        retry_with_backoff(operation, "test", max_retries=3, retryable_exceptions=(ValueError,))
+
+    assert operation.call_count == 4  # Initial attempt + 3 retries
+```
+
+---
+
+### Testing Non-Retryable Errors Pass Through Immediately
+
+```python
+def test_non_retryable_error_not_retried(mocker):
+    operation = mocker.MagicMock(side_effect=PermissionError("not retryable"))
+    sleep_mock = mocker.patch("time.sleep")
+
+    with pytest.raises(PermissionError):
+        retry_with_backoff(
+            operation,
+            "test",
+            max_retries=5,
+            retryable_exceptions=(TimeoutError,),  # PermissionError is not in this list
+        )
+
+    assert operation.call_count == 1  # No retries
+    assert sleep_mock.call_count == 0
+```
+
+---
+
+### Testing Rate Limit Recovery (429 Handling)
+
+```python
+import requests
+from unittest.mock import MagicMock, patch
+
+def test_rate_limit_uses_retry_after_header(mocker):
+    rate_limited = MagicMock()
+    rate_limited.status_code = 429
+    rate_limited.headers = {"Retry-After": "3"}
+
+    success = MagicMock()
+    success.status_code = 200
+
+    session_mock = mocker.patch("requests.Session")
+    session_mock.return_value.request.side_effect = [rate_limited, success]
+    sleep_mock = mocker.patch("time.sleep")
+
+    from mymodule import RateLimitedClient
+    client = RateLimitedClient("https://api.example.com")
+    client.get("/data")
+
+    sleep_mock.assert_called_once_with(3.0)
+
+def test_rate_limit_uses_default_when_header_missing(mocker):
+    rate_limited = MagicMock(status_code=429, headers={})
+    success = MagicMock(status_code=200)
+
+    mocker.patch("requests.Session").return_value.request.side_effect = [rate_limited, success]
+    sleep_mock = mocker.patch("time.sleep")
+
+    from mymodule import RateLimitedClient
+    client = RateLimitedClient("https://api.example.com", default_retry_after=60.0)
+    client.get("/data")
+
+    sleep_mock.assert_called_once_with(60.0)
+```
+
+---
+
+### Testing Health Check Waiting
+
+```python
+def test_health_check_passes_when_all_ready(mocker):
+    mocker.patch("mymodule.check_tcp", return_value=True)
+    mocker.patch("mymodule.check_http", return_value=True)
+    mocker.patch("time.sleep")
+
+    from mymodule import wait_for_healthy, HealthCheck
+    result = wait_for_healthy(
+        [HealthCheck("db", "tcp", "localhost:5432"),
+         HealthCheck("api", "http", "http://localhost:8080/health")],
+        timeout_seconds=10,
+    )
+    assert result is True
+
+def test_health_check_times_out_when_service_down(mocker):
+    mocker.patch("mymodule.check_tcp", return_value=False)
+    mocker.patch("time.monotonic", side_effect=[0, 1, 2, 121])  # Exceeds 120s
+    mocker.patch("time.sleep")
+
+    with pytest.raises(TimeoutError, match="Health checks did not pass"):
+        wait_for_healthy([HealthCheck("db", "tcp", "localhost:5432")], timeout_seconds=120)
+```
+
+---
+
+### Testing Circuit Breaker State Transitions
+
+```python
+import time
+from mymodule import CircuitBreaker, CircuitOpenError
+
+def test_circuit_opens_after_failure_threshold():
+    cb = CircuitBreaker("test", failure_threshold=3, recovery_timeout_seconds=30)
+    failing_op = lambda: (_ for _ in ()).throw(RuntimeError("fail"))
+
+    for _ in range(3):
+        with pytest.raises(RuntimeError):
+            cb.call(failing_op)
+
+    with pytest.raises(CircuitOpenError):
+        cb.call(lambda: "should not run")
+
+def test_circuit_recovers_after_timeout(mocker):
+    cb = CircuitBreaker("test", failure_threshold=1, recovery_timeout_seconds=30, half_open_max_calls=2)
+    failing_op = lambda: (_ for _ in ()).throw(RuntimeError("fail"))
+
+    with pytest.raises(RuntimeError):
+        cb.call(failing_op)
+
+    # Simulate recovery timeout elapsed
+    mocker.patch("time.monotonic", return_value=time.monotonic() + 31)
+
+    # Circuit should be HALF_OPEN now — calls pass through
+    cb.call(lambda: "ok")
+    cb.call(lambda: "ok")  # Second success closes the circuit
+
+    from mymodule import CircuitState
+    assert cb.state == CircuitState.CLOSED
+```
+
+---
+
+## Anti-Pattern: Using `time.sleep` in Tests Directly
+
+**Detection**:
+```bash
+grep -rn 'time\.sleep' --include="test_*.py"
+rg 'time\.sleep\(\d' --type py -g 'test_*'
+```
+
+**What it looks like**:
+```python
+def test_retry_waits():
+    # Slow test — waits real time
+    start = time.time()
+    retry_with_backoff(flaky_op, "test", initial_delay_seconds=1.0)
+    assert time.time() - start >= 1.0
+```
+
+**Why wrong**: This makes the test suite slow. A 3-retry test with 1s initial delay takes 7+ real seconds. In CI with many such tests, suite time becomes a blocker. You also can't test timing precisely without mocking.
+
+**Fix**: Mock `time.sleep` and assert on the mock's call args instead of measuring wall time.
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|------------|-----|
+| Test passes locally but flakes in CI | Real `time.sleep` + slow CI runner | Mock `time.sleep`; use `mocker.patch("time.monotonic")` to control timeout |
+| `assert mock.call_count == 4` fails, got 1 | Non-retryable exception type used | Check `retryable_exceptions` tuple includes the exception being raised |
+| `TimeoutError` fires immediately in test | `time.monotonic` mock sequence exhausted | Add more return values to the `side_effect` list |
+| Circuit stays CLOSED after failure threshold | `failure_threshold` not reached | Verify loop calls `cb.call()` exactly `failure_threshold` times with failures |
+
+---
+
+## See Also
+
+- `implementation-patterns.md` — complete implementations for all patterns
+- `anti-patterns.md` — detection commands for common wait/retry mistakes


### PR DESCRIPTION
## Summary

Reference enrichment for the `condition-based-waiting` skill.

**Targets processed: 1/1**
- `condition-based-waiting`: Level 2 → Level 3

## New Reference Files

### `references/anti-patterns.md` (277 lines)
6 anti-pattern entries, each with grep/rg detection commands and fixes:
- Hardcoded `time.sleep()` without condition check
- Infinite loop without timeout
- `time.time()` vs `time.monotonic()` for elapsed time
- Retry without jitter (thundering herd)
- Retrying non-retryable errors (401, 403, 404)
- Busy-wait (no sleep in poll loop)
- Bash loop without timeout

### `references/testing-patterns.md` (265 lines)
pytest patterns for testing wait/retry code:
- Mocking `time.sleep` with `mocker.patch`
- Injecting failures via `side_effect` lists
- Verifying retry counts with `mock.call_count`
- Testing `TimeoutError` raises
- Rate limit recovery tests (429 + Retry-After header)
- Circuit breaker state transition tests

## SKILL.md Update
Added loading table mapping signal keywords to the correct reference files.

## Validation
- Level 3 criteria met: 34 detection commands, 86 concrete hits, 369 avg lines per file
- Loading table correctly maps: "sleep/CI hang" → anti-patterns.md, "test/pytest/mock" → testing-patterns.md, "implement/retry" → implementation-patterns.md
- [KEEP] decision: references contain concrete, signal-matched domain knowledge

## Run ID
2026-04-16-1407