### PR TITLE
feat(refs): e2e-testing — async coordination patterns, auth testing (Level 2→3)

### DIFF
--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -148,11 +148,16 @@ See `references/errors.md` for the symptom/cause/fix matrix covering tsc failure
 
 ## References
 
-- [templates.md](references/templates.md) -- playwright.config.ts, POM pattern, data-testid convention, quarantine protocol, e2e-report.md, GitHub Actions workflow
-- [errors.md](references/errors.md) -- Symptom/cause/fix matrix for common failures
-- [playwright-patterns.md](references/playwright-patterns.md) -- POM examples, condition-based waiting, multi-browser config, financial skip guards
-- [wallet-testing.md](references/wallet-testing.md) -- Web3/MetaMask mock patterns with `addInitScript`
-- [financial-flows.md](references/financial-flows.md) -- Production skip guards, blockchain confirmation waits
-- [flakiness-triage.md](references/flakiness-triage.md) -- `--repeat-each`, `--retries`, quarantine decision tree
+| Signal / Task Type | Load This Reference |
+|--------------------|---------------------|
+| async, Promise.all, race condition, waitForTimeout, fixture teardown | [async.md](references/async.md) |
+| auth, login, storageState, OAuth, SSO, JWT, RBAC, multi-role, session expiry | [auth.md](references/auth.md) |
+| config, playwright.config.ts, POM, data-testid, CI/CD workflow | [templates.md](references/templates.md) |
+| error, timeout, tsc fail, locator, fill, missing JSON | [errors.md](references/errors.md) |
+| POM examples, waiting, multi-browser, shared auth session | [playwright-patterns.md](references/playwright-patterns.md) |
+| Web3, MetaMask, wallet, addInitScript | [wallet-testing.md](references/wallet-testing.md) |
+| payment, financial, production skip, blockchain | [financial-flows.md](references/financial-flows.md) |
+| flaky, intermittent, repeat-each, retries, quarantine | [flakiness-triage.md](references/flakiness-triage.md) |
+
 - [ADR-107](../../adr/ADR-107-e2e-testing.md) -- Decision record for this skill
 - [Playwright docs](https://playwright.dev/docs/intro) -- Official API reference

--- a/skills/e2e-testing/references/async.md
+++ b/skills/e2e-testing/references/async.md
@@ -1,0 +1,274 @@
+# Async Patterns Reference
+
+> **Scope**: Async coordination patterns for Playwright tests — parallel execution, race conditions, and timing anti-patterns. Does not cover basic `await` usage or condition-based waiting (see `playwright-patterns.md`).
+> **Version range**: Playwright 1.20+ (Node 18+)
+> **Generated**: 2026-04-17
+
+---
+
+## Overview
+
+Async bugs are the primary source of intermittent E2E failures. The three failure modes are: (1) missing `await` causes assertions to run before actions complete, (2) `waitForTimeout` hard-codes delays that break on slow CI, and (3) uncoordinated parallel requests cause race conditions. Playwright's `Promise.all` and `waitForResponse` patterns eliminate all three by synchronizing on observable events rather than time.
+
+---
+
+## Pattern Table
+
+| Pattern | Version | Use When | Avoid When |
+|---------|---------|----------|------------|
+| `Promise.all([waitForResponse, click])` | `1.0+` | Action triggers network request | No network call involved |
+| `page.waitForEvent('dialog')` | `1.0+` | Click opens browser dialog | Dialog never appears |
+| `test.setTimeout(ms)` | `1.0+` | Single test needs extended timeout | All tests are slow (fix root cause) |
+| `expect.poll()` | `1.38+` | Polling an external state change | Element is already in DOM |
+| `Promise.race([success, error])` | Node | Two mutually exclusive outcomes | One outcome is always expected |
+
+---
+
+## Correct Patterns
+
+### Parallel Request + Click Coordination
+
+Clicking before registering the `waitForResponse` listener misses the response — it fires during the click, before the listener is set up.
+
+```typescript
+// Register listener BEFORE the action that triggers it
+const [response] = await Promise.all([
+  page.waitForResponse(r => r.url().includes('/api/save') && r.status() === 200),
+  page.getByTestId('save-button').click(),
+]);
+const body = await response.json();
+expect(body.id).toBeDefined();
+```
+
+**Why**: `waitForResponse` is a promise that resolves on the *next* matching response. If the click fires first, the response arrives before the promise is created and `.waitForResponse` hangs until timeout.
+
+---
+
+### Parallel Independent Actions in Setup
+
+When setup requires multiple independent async steps, run them in parallel:
+
+```typescript
+test.beforeEach(async ({ page, request }) => {
+  // Sequential (slow) — each waits for the previous
+  // await seedUser(request);
+  // await seedProducts(request);
+  // await page.goto('/dashboard');
+
+  // Parallel (fast) — all start at once
+  await Promise.all([
+    seedUser(request),
+    seedProducts(request),
+    page.goto('/dashboard'),
+  ]);
+});
+```
+
+**Why**: Sequential setup multiplies latency. Three 200ms API calls take 600ms sequentially vs 200ms in parallel.
+
+---
+
+### Polling External State with `expect.poll`
+
+For state that changes outside the browser (background job, webhook, database update):
+
+```typescript
+// Playwright 1.38+
+await expect.poll(
+  async () => {
+    const res = await request.get('/api/orders/123/status');
+    return (await res.json()).status;
+  },
+  { timeout: 30_000, intervals: [1000, 2000, 5000, 10000] }
+).toBe('completed');
+```
+
+**Why**: `expect.poll` retries the predicate on the given intervals without blocking the event loop between checks, unlike a sleep loop.
+
+---
+
+### Dialog Handling
+
+Dialogs must be registered before the action that opens them, or they close the browser context:
+
+```typescript
+page.on('dialog', async dialog => {
+  expect(dialog.message()).toContain('Are you sure?');
+  await dialog.accept();
+});
+await page.getByTestId('delete-button').click();
+await expect(page).toHaveURL('/items');
+```
+
+**Why**: An unhandled `alert`/`confirm` causes Playwright to auto-dismiss and log a warning. If the dialog is required for the flow, unhandled = broken test.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ `waitForTimeout` as a Timing Fix
+
+**Detection**:
+```bash
+grep -rn 'waitForTimeout' --include="*.ts" --include="*.spec.ts"
+rg 'waitForTimeout\(' --type ts
+```
+
+**What it looks like**:
+```typescript
+await page.getByTestId('save-button').click();
+await page.waitForTimeout(2000); // "give it time to save"
+await expect(page.getByTestId('success-banner')).toBeVisible();
+```
+
+**Why wrong**: Hard-coded delays fail silently on slow CI (timeout too short) or waste time on fast machines (timeout too long). `waitForTimeout` is a symptom of not knowing what observable event to wait for.
+
+**Fix**:
+```typescript
+await Promise.all([
+  page.waitForResponse(r => r.url().includes('/api/save')),
+  page.getByTestId('save-button').click(),
+]);
+await expect(page.getByTestId('success-banner')).toBeVisible();
+```
+
+**Version note**: `waitForTimeout` is deprecated in Playwright 1.39+ — the linter flags it as `no-wait-for-timeout`.
+
+---
+
+### ❌ Fire-and-Forget Click (Missing Await on Navigation)
+
+**Detection**:
+```bash
+grep -rn '\.click()$' --include="*.spec.ts"
+rg '\.click\(\)[^;]' --type ts
+```
+
+**What it looks like**:
+```typescript
+page.getByTestId('submit').click(); // missing await
+await expect(page).toHaveURL('/confirmation'); // races with navigation
+```
+
+**Why wrong**: Without `await`, the click fires but the test proceeds immediately. If the URL check runs before navigation completes, it sees the old URL and fails intermittently.
+
+**Fix**:
+```typescript
+await Promise.all([
+  page.waitForURL('/confirmation'),
+  page.getByTestId('submit').click(),
+]);
+```
+
+---
+
+### ❌ Async Fixture Without Teardown
+
+**Detection**:
+```bash
+grep -rn "test\.extend" --include="*.ts" -A 10
+rg 'test\.extend\b' --type ts -A 10
+```
+
+**What it looks like**:
+```typescript
+export const test = base.extend<{ db: Database }>({
+  db: async ({}, use) => {
+    const db = await Database.connect();
+    await use(db);
+    // Missing: await db.disconnect();  — resource leak
+  },
+});
+```
+
+**Why wrong**: Leaked connections accumulate across the test suite. In CI with 100 tests, this exhausts connection pools and causes later tests to fail with unrelated errors.
+
+**Fix**:
+```typescript
+export const test = base.extend<{ db: Database }>({
+  db: async ({}, use) => {
+    const db = await Database.connect();
+    try {
+      await use(db);
+    } finally {
+      await db.disconnect(); // always runs, even if test throws
+    }
+  },
+});
+```
+
+---
+
+### ❌ Sequential Waits for Independent Elements
+
+**Detection**:
+```bash
+grep -rn '\.waitFor(' --include="*.spec.ts" -A 1
+rg 'waitFor\(' --type ts --include="*.spec.ts"
+```
+
+**What it looks like**:
+```typescript
+await page.getByTestId('widget-a').waitFor({ state: 'visible' });
+await page.getByTestId('widget-b').waitFor({ state: 'visible' });
+await page.getByTestId('widget-c').waitFor({ state: 'visible' });
+```
+
+**Why wrong**: Each wait is sequential. If each element takes 500ms to render, this adds 1.5s of latency. Elements that load independently should be awaited in parallel.
+
+**Fix**:
+```typescript
+await Promise.all([
+  page.getByTestId('widget-a').waitFor({ state: 'visible' }),
+  page.getByTestId('widget-b').waitFor({ state: 'visible' }),
+  page.getByTestId('widget-c').waitFor({ state: 'visible' }),
+]);
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|------------|-----|
+| `Timeout 30000ms exceeded waiting for...` | Hard wait wasn't long enough, or wrong observable | Replace `waitForTimeout` with event-based wait |
+| `locator.click: Target closed` | Dialog auto-dismissed before handler registered | Register `page.on('dialog', ...)` before the action |
+| `browserContext.storageState: Target page, context or browser has been closed` | Parallel tests sharing a single context instance | Use per-test context or `test.use({ storageState })` |
+| `Error: page.waitForResponse: page closed` | Navigation completed before `waitForResponse` resolved | Wrap in `Promise.all` with the triggering click |
+| `UnhandledPromiseRejection` in fixture | Missing `await` in fixture setup | Add `await` to all async calls inside `test.extend` |
+
+---
+
+## Version-Specific Notes
+
+| Version | Change | Impact |
+|---------|--------|--------|
+| `1.39` | `waitForTimeout` deprecated | Linter rule `no-wait-for-timeout` flags usage |
+| `1.38` | `expect.poll()` added | Use instead of `waitForFunction` for polling external state |
+| `1.30` | `waitForResponse` accepts async predicate | Predicate can now `await response.json()` inline |
+| `1.25` | Worker-scoped fixtures stable | Share expensive async setup (DB, auth) across tests in a worker |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Find all waitForTimeout usage (replace with event-based waits)
+grep -rn 'waitForTimeout' --include="*.ts"
+
+# Find unawaited clicks (potential race conditions)
+grep -rn '\.click()$' --include="*.spec.ts"
+
+# Find test.extend fixtures (review for missing teardown)
+grep -rn 'test\.extend' --include="*.ts" -A 15
+
+# Find sequential waitFor calls that could be parallelized
+grep -rn '\.waitFor(' --include="*.spec.ts"
+```
+
+---
+
+## See Also
+
+- `playwright-patterns.md` — condition-based waiting, waitForLoadState, network request patterns
+- `flakiness-triage.md` — diagnosing and quarantining intermittent failures

--- a/skills/e2e-testing/references/auth.md
+++ b/skills/e2e-testing/references/auth.md
@@ -1,0 +1,326 @@
+# Authentication Testing Reference
+
+> **Scope**: Patterns for testing authentication flows in Playwright — multi-role state management, OAuth/SSO, session expiry, JWT, and RBAC. The basic `storageState` setup lives in `playwright-patterns.md`; this file covers advanced scenarios.
+> **Version range**: Playwright 1.25+ (worker-scoped fixtures required for multi-role)
+> **Generated**: 2026-04-17
+
+---
+
+## Overview
+
+Auth testing fails in two common ways: (1) tests share auth state across roles and pollute each other, and (2) tests log in via the UI for every test, spending 70%+ of runtime on login screens. The correct model is: authenticate once per role via the API, save the resulting `storageState`, and inject it into tests that need it. Session expiry, RBAC, and OAuth flows each require separate patterns.
+
+---
+
+## Pattern Table
+
+| Pattern | Version | Use When | Avoid When |
+|---------|---------|----------|------------|
+| `globalSetup` + `storageState` file | `1.0+` | Single user role, full suite | Multiple roles needed |
+| Worker-scoped fixture per role | `1.25+` | Multiple roles, parallel workers | Single role only |
+| `request.post('/api/login')` in setup | `1.0+` | App has API login endpoint | UI-only login required |
+| `page.addInitScript` for JWT injection | `1.0+` | JWT stored in localStorage | Cookie-based auth |
+| `page.route` to mock OAuth callback | `1.0+` | Testing OAuth-gated pages | Testing the OAuth provider itself |
+
+---
+
+## Correct Patterns
+
+### Multi-Role Auth via Worker Fixtures (Playwright 1.25+)
+
+Use one fixture file for all roles. Each fixture authenticates once per worker, not once per test:
+
+```typescript
+// fixtures/auth.ts
+import { test as base, expect } from '@playwright/test';
+
+type AuthFixtures = {
+  adminPage: Page;
+  viewerPage: Page;
+};
+
+export const test = base.extend<{}, AuthFixtures>({
+  // Worker-scoped: runs once per worker process, not per test
+  adminPage: [async ({ browser }, use) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    // Authenticate via API — avoid UI login overhead
+    const response = await page.request.post('/api/auth/login', {
+      data: { email: process.env.ADMIN_EMAIL, password: process.env.ADMIN_PASSWORD },
+    });
+    expect(response.ok()).toBeTruthy();
+    await context.storageState({ path: 'playwright/.auth/admin.json' });
+    await use(page);
+    await context.close();
+  }, { scope: 'worker' }],
+
+  viewerPage: [async ({ browser }, use) => {
+    const context = await browser.newContext({
+      storageState: 'playwright/.auth/viewer.json',
+    });
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  }, { scope: 'worker' }],
+});
+```
+
+```typescript
+// tests/e2e/admin/dashboard.spec.ts
+import { test, expect } from '../../fixtures/auth';
+
+test('admin can delete users', async ({ adminPage }) => {
+  await adminPage.goto('/admin/users');
+  await adminPage.getByTestId('user-row-42').getByTestId('delete').click();
+  await expect(adminPage.getByTestId('success-toast')).toBeVisible();
+});
+
+test('viewer cannot see delete button', async ({ viewerPage }) => {
+  await viewerPage.goto('/admin/users');
+  await expect(viewerPage.getByTestId('user-row-42').getByTestId('delete')).not.toBeVisible();
+});
+```
+
+**Why**: Worker-scoped fixtures share auth state across all tests in the same worker. Login happens once per worker, not once per test — 10x faster for suites with many authenticated tests.
+
+---
+
+### JWT Injection via `addInitScript`
+
+When the app reads JWT from `localStorage` on page load:
+
+```typescript
+// pages/AuthenticatedPage.ts
+import { type Page } from '@playwright/test';
+
+export async function injectJWT(page: Page, token: string) {
+  await page.addInitScript((jwt) => {
+    window.localStorage.setItem('auth_token', jwt);
+  }, token);
+}
+```
+
+```typescript
+// tests/e2e/features/profile.spec.ts
+import { test, expect } from '@playwright/test';
+import { injectJWT } from '../../pages/AuthenticatedPage';
+import { generateTestJWT } from '../../helpers/jwt';
+
+test('profile page loads with valid JWT', async ({ page }) => {
+  const token = generateTestJWT({ userId: '42', role: 'admin', expiresIn: '1h' });
+  await injectJWT(page, token);
+  await page.goto('/profile');
+  await expect(page.getByTestId('profile-name')).toBeVisible();
+});
+```
+
+**Why**: `addInitScript` runs before the page's own scripts execute, so the JWT is in `localStorage` when the app initializes. Injecting after navigation misses the initial auth check.
+
+---
+
+### Session Expiry Testing
+
+Test what users see when their session expires mid-flow:
+
+```typescript
+test('expired session redirects to login with return URL', async ({ page }) => {
+  // Start with valid session
+  await page.context().addCookies([{
+    name: 'session',
+    value: 'valid-session-token',
+    domain: 'localhost',
+    path: '/',
+  }]);
+  await page.goto('/dashboard');
+  await expect(page.getByTestId('dashboard-content')).toBeVisible();
+
+  // Simulate expiry: intercept next API call and return 401
+  await page.route('/api/**', route => {
+    route.fulfill({ status: 401, body: JSON.stringify({ error: 'session_expired' }) });
+  });
+
+  // Trigger an authenticated action
+  await page.getByTestId('load-more').click();
+
+  // App should redirect to login, preserving return URL
+  await expect(page).toHaveURL(/\/login\?returnUrl=/);
+  await expect(page.getByTestId('session-expired-message')).toBeVisible();
+});
+```
+
+---
+
+### OAuth / SSO Mock (Bypass the Provider)
+
+Never test against a real OAuth provider in E2E — mock the callback instead:
+
+```typescript
+test('OAuth login flow completes', async ({ page }) => {
+  // Intercept the OAuth redirect back to the app
+  await page.route('/auth/callback*', async route => {
+    const url = new URL(route.request().url());
+    // Simulate a successful OAuth callback with a test code
+    await route.fulfill({
+      status: 302,
+      headers: {
+        Location: '/dashboard',
+        'Set-Cookie': 'session=test-oauth-session; Path=/; HttpOnly',
+      },
+    });
+  });
+
+  await page.goto('/login');
+  await page.getByTestId('login-with-google').click();
+  // Playwright follows the redirect chain; our route intercepts the callback
+  await expect(page).toHaveURL('/dashboard');
+  await expect(page.getByTestId('nav-user-avatar')).toBeVisible();
+});
+```
+
+**Why**: Real OAuth providers add network latency, require live credentials, and may rate-limit CI. Mocking the callback tests your app's OAuth handling without testing Google/GitHub.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ UI Login in Every Test
+
+**Detection**:
+```bash
+grep -rn 'getByTestId.*login\|getByTestId.*password\|getByTestId.*signin' --include="*.spec.ts"
+rg '(login-email|login-password|login-submit)' --type ts --include="*.spec.ts" -l
+```
+
+**What it looks like**:
+```typescript
+test.beforeEach(async ({ page }) => {
+  await page.goto('/login');
+  await page.getByTestId('login-email').fill('user@test.com');
+  await page.getByTestId('login-password').fill('password');
+  await page.getByTestId('login-submit').click();
+  await page.waitForURL('/dashboard');
+});
+```
+
+**Why wrong**: A 10-test suite with a 3-second login flow spends 30 seconds on login alone. `storageState` eliminates this: authenticate once, reuse the session.
+
+**Fix**: Use `globalSetup` with `storageState` (single role) or worker-scoped fixtures (multiple roles). See `playwright-patterns.md` for the single-role pattern.
+
+---
+
+### ❌ Sharing Auth Context Between Roles
+
+**Detection**:
+```bash
+grep -rn 'storageState' --include="playwright.config.ts" -A 5
+rg 'storageState.*admin.*viewer|storageState.*viewer.*admin' --type ts
+```
+
+**What it looks like**:
+```typescript
+// playwright.config.ts — wrong: one storageState for all tests
+use: {
+  storageState: 'playwright/.auth/user.json', // which user? admin or viewer?
+},
+```
+
+**Why wrong**: When tests for different roles share one auth file, they run with the same permissions. An admin-privilege test passes for a viewer because the session is still admin. RBAC bugs go undetected.
+
+**Fix**: Use per-role `projects` in `playwright.config.ts`:
+```typescript
+projects: [
+  { name: 'admin-tests', use: { storageState: 'playwright/.auth/admin.json' } },
+  { name: 'viewer-tests', use: { storageState: 'playwright/.auth/viewer.json' } },
+  { name: 'unauthenticated-tests' }, // no storageState
+],
+```
+
+---
+
+### ❌ Hardcoded Credentials in Spec Files
+
+**Detection**:
+```bash
+grep -rn 'password.*:.*"[^"]\+"\|fill.*"password[^"]*"' --include="*.spec.ts"
+rg '(password|secret|token)\s*[:=]\s*["'"'"'][^"'"'"']+["'"'"']' --type ts --include="*.spec.ts"
+```
+
+**What it looks like**:
+```typescript
+await page.getByTestId('login-password').fill('MyP@ssw0rd123'); // hardcoded
+```
+
+**Why wrong**: Credentials in source code appear in git history permanently. They also break when rotated.
+
+**Fix**:
+```typescript
+await page.getByTestId('login-password').fill(process.env.TEST_USER_PASSWORD!);
+```
+Set `TEST_USER_PASSWORD` in `.env.test` (gitignored) and in CI secrets.
+
+---
+
+### ❌ Testing Real OAuth Provider Endpoints
+
+**Detection**:
+```bash
+grep -rn 'accounts\.google\.com\|github\.com/login/oauth\|login\.microsoftonline' --include="*.spec.ts"
+rg '(google|github|microsoft|auth0)\.com' --type ts --include="*.spec.ts"
+```
+
+**What it looks like**:
+```typescript
+await page.goto('https://accounts.google.com/o/oauth2/auth?...');
+await page.getByLabel('Email').fill(process.env.GOOGLE_TEST_EMAIL!);
+```
+
+**Why wrong**: Hits a live external service. Flaky on network issues. Requires a real test account. May trigger bot detection. Rate-limited in CI.
+
+**Fix**: Mock the OAuth callback with `page.route` as shown in the Correct Patterns section.
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|------------|-----|
+| `401 Unauthorized` in all API calls after test 50 | `storageState` session expired mid-suite | Re-generate auth state in `globalSetup`, or use shorter-lived tokens |
+| `storageState: path does not exist` | `globalSetup` didn't run, or path mismatch | Verify `playwright.config.ts` `globalSetup` is wired; check path matches exactly |
+| `Cannot read properties of undefined (reading 'token')` | JWT not in localStorage when page loaded | Use `addInitScript`, not `evaluate`, to inject JWT before page scripts run |
+| `page.route` callback not triggered | Route registered after navigation started | Register routes before `page.goto()` |
+| Tests pass locally, fail in CI with `403` | CI uses different `BASE_URL` hitting real auth | Check that CI env has `PLAYWRIGHT_BASE_URL` pointing to the test instance |
+
+---
+
+## Version-Specific Notes
+
+| Version | Change | Impact |
+|---------|--------|--------|
+| `1.25` | Worker-scoped fixtures stable | Multi-role auth fixtures now safe for parallel workers |
+| `1.31` | `request` context available in fixtures | Can use `fixture.request.post()` for API login without launching a browser |
+| `1.35` | `storageState` supports `origins` filter | Can scope saved auth to specific domains, preventing cross-domain cookie leaks |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Find tests doing UI login in beforeEach (migrate to storageState)
+grep -rn 'beforeEach' --include="*.spec.ts" -A 10 | grep -i 'login\|password\|signin'
+
+# Find hardcoded credentials
+rg '(password|secret)\s*[:=]\s*["'"'"'][^"'"'"']+["'"'"']' --type ts --include="*.spec.ts"
+
+# Find real OAuth provider URLs in tests
+grep -rn 'accounts\.google\.com\|github\.com/login\|auth0\.com' --include="*.spec.ts"
+
+# Find tests without any auth setup (may need storageState)
+grep -rn 'test(' --include="*.spec.ts" -l | xargs grep -rL 'storageState\|adminPage\|viewerPage\|login'
+```
+
+---
+
+## See Also
+
+- `playwright-patterns.md` — basic `storageState` setup, single-role global auth
+- `errors.md` — auth-related error symptom/cause/fix matrix


### PR DESCRIPTION
## Summary

- **Target**: `e2e-testing` skill
- **Level before**: 2 (6 reference files, async/auth gaps)
- **Level after**: 3 (8 reference files, detection commands, error-fix mappings)

## New Reference Files

**`async.md`** (274 lines, 12 detection commands)
- Promise.all + waitForResponse coordination pattern
- Parallel fixture setup vs sequential (with latency comparison)
- `expect.poll` for external state polling (Playwright 1.38+)
- Dialog handling
- Anti-patterns: `waitForTimeout`, unawaited clicks, fixture teardown leaks, sequential waitFor

**`auth.md`** (326 lines, 12 detection commands)
- Multi-role auth via worker-scoped fixtures (Playwright 1.25+)
- JWT injection via `addInitScript` (fires before page scripts)
- Session expiry simulation with `page.route`
- OAuth/SSO mock bypassing real providers
- Anti-patterns: UI login in every test, shared auth contexts across roles, hardcoded credentials

## SKILL.md Changes

Added signal-to-reference loading table mapping task keywords to the right reference file, so the agent loads `async.md` for timing/coordination questions and `auth.md` for auth/JWT/RBAC questions.

## Validation

- [KEEP] async.md: 4 anti-patterns with detection commands, correct pattern alternatives, error-fix table, version notes (1.38 expect.poll, 1.39 waitForTimeout deprecated)
- [KEEP] auth.md: 4 anti-patterns with detection commands, multi-role patterns, error-fix table, version notes (1.25 worker fixtures, 1.35 storageState origins)
- Loading table entries verified against actual file paths