### PR TITLE
feat(refs): endpoint-validator (Level 0→3)

### DIFF
--- a/skills/endpoint-validator/SKILL.md
+++ b/skills/endpoint-validator/SKILL.md
@@ -199,6 +199,16 @@ Solution:
 
 ---
 
+## Reference Loading
+
+| Task Type | Load This Reference |
+|-----------|-------------------|
+| Security header WARNs, HSTS/CSP/X-Frame issues | `references/security-headers.md` |
+| Config errors, hardcoded IPs, timeout problems | `references/endpoint-config-anti-patterns.md` |
+| 401/403 failures, Bearer/API-key/cookie auth | `references/auth-endpoint-patterns.md` |
+
+---
+
 ## References
 
 ### CI/CD Integration

--- a/skills/endpoint-validator/references/auth-endpoint-patterns.md
+++ b/skills/endpoint-validator/references/auth-endpoint-patterns.md
@@ -1,0 +1,259 @@
+# Auth Endpoint Patterns Reference
+
+> **Scope**: Configuring and validating authenticated API endpoints in endpoint-validator.
+> **Version range**: All HTTP auth schemes (Bearer, API key, Basic, session cookie)
+> **Generated**: 2026-04-17
+
+---
+
+## Overview
+
+Validating authenticated endpoints requires passing credentials without committing them to
+config files. The four most common schemes — Bearer tokens, API keys, Basic auth, and session
+cookies — each have distinct configuration patterns. The primary failure mode is a 401 that
+masquerades as an API bug when it's actually a credential misconfiguration.
+
+---
+
+## Pattern Table
+
+| Auth Scheme | Header | endpoints.json Pattern | Failure Signal |
+|-------------|--------|----------------------|----------------|
+| Bearer token | `Authorization: Bearer <token>` | `"Bearer ${BEARER_TOKEN}"` | 401 on otherwise valid endpoint |
+| API key (header) | `X-Api-Key: <key>` | `"${API_KEY}"` | 403 or 401 with no `WWW-Authenticate` |
+| Basic auth | `Authorization: Basic <b64>` | `"Basic ${BASIC_CREDS_B64}"` | 401 with `WWW-Authenticate: Basic` |
+| Session cookie | `Cookie: session=<token>` | `"${SESSION_TOKEN}"` | 302 redirect to login page |
+
+---
+
+## Correct Patterns
+
+### Bearer Token Authentication
+
+Pass the token via environment variable interpolation. Never hardcode.
+
+```json
+{
+  "base_url": "${API_BASE_URL}",
+  "endpoints": [
+    {
+      "path": "/api/v1/users",
+      "headers": {
+        "Authorization": "Bearer ${API_BEARER_TOKEN}",
+        "Accept": "application/json"
+      },
+      "expect_status": 200,
+      "expect_key": "data"
+    }
+  ]
+}
+```
+
+**Why**: `${API_BEARER_TOKEN}` is expanded from the shell environment at runtime. The same
+config works locally (export the var) and in CI (set as a secret). The token never touches
+the filesystem or git history.
+
+---
+
+### API Key in Custom Header
+
+```json
+{
+  "path": "/api/v1/search",
+  "headers": {
+    "X-Api-Key": "${SEARCH_API_KEY}",
+    "Accept": "application/json"
+  },
+  "expect_status": 200
+}
+```
+
+**Why**: `X-Api-Key` is not standardized — different APIs use `X-API-Key`, `Api-Key`,
+`X-Auth-Token`. HTTP headers are case-insensitive per RFC 7230, but match the API
+documentation exactly for readability.
+
+---
+
+### Validating the Auth Rejection Path
+
+Explicitly test that unauthenticated requests return 401, not 200.
+
+```json
+{
+  "path": "/api/v1/admin/users",
+  "expect_status": 401,
+  "description": "no-auth should reject with 401"
+}
+```
+
+**Why**: A misconfigured API may accidentally return 200 with empty data instead of 401
+on unauthenticated requests. Validating the rejection path catches authorization middleware
+that was accidentally disabled during a deploy.
+
+---
+
+### Verify Required Environment Variables Before Running
+
+```bash
+# Pre-flight check — run before endpoint-validator in CI
+python3 -c "
+import json, os, re, sys
+cfg = json.load(open('endpoints.json'))
+refs = re.findall(r'\\\${([A-Z_]+)}', json.dumps(cfg))
+missing = [r for r in set(refs) if not os.environ.get(r)]
+if missing:
+    print('MISSING env vars:', missing)
+    sys.exit(1)
+print('All env vars present')
+"
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Hardcoded Bearer Token in Config
+
+**Detection**:
+```bash
+grep -rn '"Authorization"' endpoints.json | grep -v '\${[A-Z_]'
+rg '"Authorization".*"Bearer [A-Za-z0-9._-]{20,}"' --type json
+```
+
+**What it looks like**:
+```json
+{"headers": {"Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.actual.token"}}
+```
+
+**Why wrong**: JWT tokens in config files get committed to git history. Even after rotation,
+the old token remains in every git clone. GitHub secret scanning flags base64-encoded JWTs.
+
+**Fix**: `{"headers": {"Authorization": "Bearer ${API_TOKEN}"}}`
+
+---
+
+### ❌ Skipping expect_status on Protected Endpoint
+
+**Detection**:
+```bash
+python3 -c "
+import json
+cfg = json.load(open('endpoints.json'))
+for ep in cfg.get('endpoints', []):
+    if 'Authorization' in str(ep.get('headers', {})):
+        if 'expect_status' not in ep:
+            print('WARN no expect_status on auth endpoint:', ep['path'])
+"
+```
+
+**What it looks like**:
+```json
+{
+  "path": "/api/v1/admin/users",
+  "headers": {"Authorization": "Bearer ${TOKEN}"}
+}
+```
+
+**Why wrong**: Without explicit `expect_status`, default is 200. If the token expires or
+loses its scope, the endpoint returns 401 — the validator reports FAIL (expected 200, got 401)
+with no context that it's an auth failure, not an API bug.
+
+**Fix**: Always set `expect_status: 200` explicitly on auth-protected endpoints so the
+failure message reads "expected 200, got 401" and the auth header is visible in the config.
+
+---
+
+### ❌ Using Admin Credentials for Smoke Tests
+
+**Detection**:
+```bash
+grep -rn "ADMIN\|ROOT\|MASTER\|SUPERUSER\|SUPER_" endpoints.json
+```
+
+**What it looks like**:
+```json
+{"headers": {"Authorization": "Bearer ${PROD_ADMIN_TOKEN}"}}
+```
+
+**Why wrong**: A validation run with a compromised CI environment gets full admin access
+to production. Blast radius is maximum. Use read-only service account tokens scoped to
+the specific paths being validated.
+
+**Fix**: Create a dedicated `endpoint-validator` service account with read-only access.
+Rotate its token independently of admin credentials.
+
+---
+
+### ❌ Session Cookie Validation Without Expiry Handling
+
+**Detection**:
+```bash
+grep -rn '"Cookie"' endpoints.json | grep -v '\${[A-Z_]'
+```
+
+**What it looks like**:
+```json
+{
+  "path": "/dashboard",
+  "headers": {"Cookie": "session=abc123fixed"},
+  "expect_status": 200
+}
+```
+
+**Why wrong**: Sessions expire. A hardcoded session value that worked during setup will
+silently redirect to a login page (302), which the validator may follow and report 200
+(the login page), masking the auth failure entirely.
+
+**Fix**: Use env var for session token and add `expect_key` on JSON dashboard APIs:
+```json
+{
+  "path": "/api/dashboard",
+  "headers": {"Cookie": "session=${SESSION_TOKEN}"},
+  "expect_status": 200,
+  "expect_key": "user"
+}
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|------------|-----|
+| `FAIL: expected 200, got 401` | Missing or expired auth header | Add `headers.Authorization` with fresh env var token |
+| `FAIL: expected 200, got 403` | Token lacks required scope/role | Use token with correct permissions or set `expect_status: 403` |
+| `FAIL: expected 200, got 302` | Session expired, redirected to login | Refresh `${SESSION_TOKEN}` in environment |
+| `FAIL: Invalid JSON` on auth endpoint | 401 returns HTML error page, not JSON | Catch the 401 first via `expect_status: 401` in a separate test |
+| Token works in curl but fails in validator | Token contains `%`, `&`, or `+` requiring encoding | URL-encode token or verify env var expansion strips quotes |
+| All auth endpoints fail in CI only | Env var not set in CI environment | Add token to CI secrets and export it before running validator |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Find all auth-related header configurations
+grep -rn '"Authorization"\|"X-Api-Key"\|"Cookie"\|"X-Auth"' endpoints.json
+
+# Detect hardcoded tokens (not env-var references)
+rg '"Authorization".*"(Bearer|Basic) [A-Za-z0-9+/=._-]{10,}"' --type json
+
+# Find admin/superuser tokens in config
+grep -rn "ADMIN\|admin\|ROOT\|root\|MASTER\|master" endpoints.json | grep -i "token\|key\|auth"
+
+# Check env vars required by endpoints.json are set
+python3 -c "
+import json, os, re
+cfg = json.load(open('endpoints.json'))
+refs = re.findall(r'\\\${([A-Z_]+)}', json.dumps(cfg))
+for r in set(refs):
+    print(('SET  ' if os.environ.get(r) else 'MISS '), r)
+"
+```
+
+---
+
+## See Also
+
+- `security-headers.md` — HSTS, CSP, and other response header validation
+- `endpoint-config-anti-patterns.md` — general configuration mistakes

--- a/skills/endpoint-validator/references/endpoint-config-anti-patterns.md
+++ b/skills/endpoint-validator/references/endpoint-config-anti-patterns.md
@@ -1,0 +1,244 @@
+# Endpoint Config Anti-Patterns Reference
+
+> **Scope**: Anti-patterns in `endpoints.json` configuration and common validation mistakes.
+> **Version range**: All versions of endpoint-validator
+> **Generated**: 2026-04-17
+
+---
+
+## Overview
+
+Most endpoint validation failures trace to configuration errors, not actual API bugs. This
+reference covers the most common `endpoints.json` mistakes: hardcoded values that break CI,
+mutating endpoints run against production, and timeout values that mask real problems.
+
+---
+
+## Correct Configuration Patterns
+
+### Standard endpoints.json Structure
+
+```json
+{
+  "base_url": "http://localhost:8000",
+  "endpoints": [
+    {"path": "/health", "expect_status": 200},
+    {"path": "/api/v1/users", "expect_key": "data", "timeout": 10},
+    {"path": "/api/v1/search?q=test", "expect_status": 200, "max_time": 2.0},
+    {
+      "path": "/api/v1/protected",
+      "headers": {"Authorization": "Bearer ${API_TOKEN}"},
+      "expect_status": 200
+    }
+  ]
+}
+```
+
+**Why**: Environment variables in header values (`${API_TOKEN}`) keep secrets out of config
+files. The validator expands them at runtime — never commit actual tokens.
+
+---
+
+### Environment-Variable Base URL
+
+```json
+{
+  "base_url": "${BASE_URL:-http://localhost:8000}",
+  "endpoints": [...]
+}
+```
+
+**Why**: `${VAR:-default}` allows CI to override the base URL without maintaining separate
+config files per environment. Local dev falls back to localhost automatically.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Hardcoded IP Address in base_url
+
+**Detection**:
+```bash
+grep -rn '"base_url"' . --include="*.json" | grep -E '"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
+rg '"base_url".*[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' --type json
+```
+
+**What it looks like**:
+```json
+{"base_url": "http://192.168.1.42:8000"}
+```
+
+**Why wrong**: IP addresses are machine-local. The config breaks on every other developer
+machine, in CI, and after any network reconfiguration.
+
+**Fix**:
+```json
+{"base_url": "http://localhost:8000"}
+```
+Or use an environment variable: `{"base_url": "${API_URL}"}`
+
+---
+
+### ❌ Write Endpoints Against Production base_url
+
+**Detection**:
+```bash
+grep -rn '"method"' . --include="*.json" | grep -iE '"POST"|"PUT"|"DELETE"|"PATCH"'
+```
+
+**What it looks like**:
+```json
+{
+  "base_url": "https://api.example.com",
+  "endpoints": [
+    {"path": "/api/v1/users", "method": "POST", "body": {"name": "test"}}
+  ]
+}
+```
+
+**Why wrong**: POST/PUT/DELETE against a production URL creates/mutates/deletes real data.
+A smoke test that runs pre-deploy will insert test records, trigger webhooks, or bill users.
+
+**Fix**: Use staging for mutating endpoints. Reserve production config for GET-only health
+checks. The validator warns when it detects write methods with a non-localhost `base_url`.
+
+---
+
+### ❌ Zero or Very High Timeout
+
+**Detection**:
+```bash
+grep -rn '"timeout"' . --include="*.json" | grep -E '"timeout":\s*0\b'
+grep -rn '"timeout"' . --include="*.json" | grep -E '"timeout":\s*[6-9][0-9]|[1-9][0-9]{2,}'
+```
+
+**What it looks like**:
+```json
+{"path": "/api/slow", "timeout": 0}
+{"path": "/api/upload", "timeout": 300}
+```
+
+**Why wrong**: `timeout: 0` means no timeout — a hung connection blocks the entire validation
+suite forever. `timeout: 300` hides performance regressions; an endpoint that starts taking
+60 seconds is clearly degraded but passes validation.
+
+**Fix**: Use `timeout: 5` (default) for health checks. For legitimately slow endpoints, set
+`timeout: 15` and `max_time: 5.0` to distinguish "too slow" from "timed out completely":
+```json
+{"path": "/api/report", "timeout": 15, "max_time": 5.0}
+```
+
+---
+
+### ❌ expect_key on Non-JSON Endpoint
+
+**Detection**:
+```bash
+grep -B2 '"expect_key"' endpoints.json | grep -E '"path".*\.(html|xml|csv|txt|pdf)'
+```
+
+**What it looks like**:
+```json
+{"path": "/sitemap.xml", "expect_key": "urlset"}
+```
+
+**Why wrong**: `expect_key` parses the response as JSON and checks for a top-level key.
+XML, HTML, and CSV responses will always fail JSON parsing, generating "Invalid JSON response"
+errors that obscure the real issue.
+
+**Fix**: For non-JSON endpoints, only check `expect_status`:
+```json
+{"path": "/sitemap.xml", "expect_status": 200}
+```
+
+---
+
+### ❌ Missing expect_status on Non-200 Endpoints
+
+**Detection**:
+```bash
+python3 -c "
+import json
+with open('endpoints.json') as f: cfg = json.load(f)
+for ep in cfg.get('endpoints', []):
+    path = ep.get('path', '')
+    if ('404' in path or 'error' in path.lower() or 'missing' in path.lower()):
+        if 'expect_status' not in ep:
+            print('WARN missing expect_status:', path)
+"
+```
+
+**What it looks like**:
+```json
+{"path": "/api/v1/nonexistent-resource"}
+```
+
+**Why wrong**: Default `expect_status` is 200. An endpoint that intentionally returns 404
+(e.g., validating your 404 handler) will report FAIL when it should PASS.
+
+**Fix**:
+```json
+{"path": "/api/v1/nonexistent-resource", "expect_status": 404}
+```
+
+---
+
+### ❌ Credentials in Config File
+
+**Detection**:
+```bash
+grep -rn '"Authorization"\|"X-Api-Key"\|"api_key"\|"token"' endpoints.json | grep -v '\${[A-Z_]*}'
+rg '"Bearer [A-Za-z0-9+/=._-]{20,}"' --type json
+```
+
+**What it looks like**:
+```json
+{"headers": {"Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.actual-token-here"}}
+```
+
+**Why wrong**: Tokens committed to config files end up in git history permanently. Even if
+rotated, the old token may be valid elsewhere or extractable from history. GitHub secret
+scanning will flag this.
+
+**Fix**: Use environment variable interpolation:
+```json
+{"headers": {"Authorization": "Bearer ${API_TOKEN}"}}
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|------------|-----|
+| `Connection refused` on every endpoint | Wrong port in `base_url` | Check service with `ss -tlnp` or `docker ps` |
+| `Invalid JSON response` on XML/HTML path | `expect_key` set on non-JSON endpoint | Remove `expect_key`, only check `expect_status` |
+| `Timeout after 5s` on one slow endpoint | Default timeout too low | Set `"timeout": 15` on that endpoint specifically |
+| FAIL on intentional 404 endpoint | Default `expect_status: 200` | Add `"expect_status": 404` |
+| Auth endpoint returns 401 | Missing `Authorization` header | Add `"headers": {"Authorization": "Bearer ${TOKEN}"}` |
+| CI fails but local passes | `base_url` hardcoded to local IP | Use `localhost` or `${BASE_URL}` env var |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Find hardcoded IPs in any endpoints config
+grep -rn '"base_url"' . --include="*.json" | grep -E "[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}"
+
+# Find write methods in config files
+grep -rn '"method"' . --include="*.json" | grep -iE "post|put|patch|delete"
+
+# Find suspiciously high timeouts (> 59 seconds)
+grep -rn '"timeout"' . --include="*.json" | grep -E '"timeout":\s*[6-9][0-9]|[1-9][0-9]{2,}'
+
+# Detect potential committed credentials
+grep -rn '"Authorization"\|"X-Api-Key"\|"api_key"' . --include="*.json" | grep -v '\${[A-Z_]*}'
+```
+
+---
+
+## See Also
+
+- `security-headers.md` — HSTS, CSP, and other response header validation
+- `auth-endpoint-patterns.md` — configuring authenticated endpoint validation

--- a/skills/endpoint-validator/references/security-headers.md
+++ b/skills/endpoint-validator/references/security-headers.md
@@ -1,0 +1,192 @@
+# Security Headers Reference
+
+> **Scope**: The four HTTP security headers endpoint-validator checks on non-localhost endpoints.
+> **Version range**: All HTTP/1.1+ servers
+> **Generated**: 2026-04-17 — verify against OWASP Secure Headers Project
+
+---
+
+## Overview
+
+The endpoint-validator checks four response headers for security compliance. These headers
+are absent by default in most frameworks — they must be explicitly set. Missing headers are
+reported as WARN (not FAIL): the API is reachable but misconfigured. Checks are skipped
+on `localhost`/`127.0.0.1` because development environments routinely omit them.
+
+---
+
+## Pattern Table
+
+| Header | Required Value | Skip Condition | Report Level |
+|--------|---------------|----------------|--------------|
+| `Strict-Transport-Security` | `max-age=...` (HTTPS only) | HTTP endpoints, localhost | WARN if absent on HTTPS |
+| `Content-Security-Policy` | Any value | localhost | WARN if absent |
+| `X-Content-Type-Options` | `nosniff` (exact) | localhost | WARN if absent or wrong value |
+| `X-Frame-Options` | `DENY` or `SAMEORIGIN` | localhost; if CSP has `frame-ancestors` | WARN if absent |
+
+---
+
+## Correct Patterns
+
+### Strict-Transport-Security (HSTS)
+
+Tells browsers to only access the site over HTTPS for the specified duration.
+
+```http
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+```
+
+**Why**: Without HSTS, a user who visits `http://example.com` can be intercepted even if the
+server redirects to HTTPS. HSTS eliminates the initial unprotected request.
+
+**Validation note**: Only expected on HTTPS endpoints. If `base_url` starts with `http://`,
+skip this check — HSTS on plain HTTP is meaningless and the browser ignores it.
+
+---
+
+### Content-Security-Policy (CSP)
+
+Restricts which scripts, stylesheets, and resources the browser may load.
+
+```http
+Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-abc123'
+Content-Security-Policy: default-src 'none'; frame-ancestors 'none'
+```
+
+**Why**: Absent CSP means a successful XSS attack can load arbitrary scripts. Even a restrictive
+`default-src 'self'` is vastly better than nothing for API responses that might be rendered.
+
+---
+
+### X-Content-Type-Options
+
+Prevents MIME-type sniffing — the browser must honor the `Content-Type` the server declares.
+
+```http
+X-Content-Type-Options: nosniff
+```
+
+**Why**: Without `nosniff`, a browser may execute a response with `Content-Type: text/plain`
+as JavaScript if the content "looks like" a script. This is the primary defense against
+MIME confusion attacks.
+
+**Valid value**: Only `nosniff`. Any other value (empty, custom string) is treated as absent.
+
+---
+
+### X-Frame-Options
+
+Prevents the page from being embedded in an iframe on another origin (clickjacking defense).
+
+```http
+X-Frame-Options: DENY
+X-Frame-Options: SAMEORIGIN
+```
+
+**Why**: Clickjacking overlays a hidden iframe over a legitimate UI. DENY is safest for APIs.
+
+**CSP alternative**: `Content-Security-Policy: frame-ancestors 'none'` is the modern replacement.
+If CSP already contains `frame-ancestors`, skip the X-Frame-Options check to avoid false WARNs.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Checking Security Headers on localhost
+
+**Detection**:
+```bash
+grep -rn '"base_url".*localhost\|"base_url".*127\.0\.0\.1' endpoints.json
+```
+
+**What it looks like**:
+```json
+{
+  "base_url": "http://localhost:8000",
+  "check_security_headers": true
+}
+```
+
+**Why wrong**: Development servers don't set these headers. Running the check against localhost
+generates spurious WARNs on every local run, training developers to ignore warnings entirely.
+
+**Fix**: The validator skips security header checks when `base_url` contains `localhost` or
+`127.0.0.1` by default. Only override with `force_security_check: true` when explicitly needed.
+
+---
+
+### ❌ Treating WARN as PASS in CI
+
+**Detection**:
+```bash
+grep -rn "|| true\|--allow-warn\|exit 0" .github/workflows/ .gitlab-ci.yml 2>/dev/null
+```
+
+**What it looks like**:
+```yaml
+- run: endpoint-validator || true  # suppress all failures
+```
+
+**Why wrong**: Suppressing exit codes means security header regressions (a deploy that removes
+CSP) pass CI silently. Use `--fail-on-warn` in production validation runs so header removal
+triggers a build failure.
+
+**Fix**:
+```yaml
+- run: endpoint-validator --base-url $PROD_URL --fail-on-warn
+  env:
+    PROD_URL: ${{ secrets.PROD_URL }}
+```
+
+---
+
+### ❌ HSTS Expected on HTTP Endpoint
+
+**Detection**:
+```bash
+grep -rn '"base_url".*"http://' endpoints.json | grep -v "localhost\|127\.0\.0\.1"
+```
+
+**What it looks like**:
+```json
+{"base_url": "http://api.example.com"}
+```
+
+**Why wrong**: HSTS is only meaningful over HTTPS. Browsers ignore HSTS headers delivered
+over HTTP (per RFC 6797 §8.1). Checking for it on HTTP endpoints always generates misleading WARNs.
+
+**Fix**: Use `https://` base_url for production validation, or the validator should auto-skip
+HSTS checks when base_url starts with `http://`.
+
+---
+
+## Error-Fix Mappings
+
+| Symptom | Root Cause | Fix |
+|---------|------------|-----|
+| `WARN: Missing Strict-Transport-Security` on all endpoints | Base URL is HTTP not HTTPS | Switch to `https://` in `base_url` or add HSTS in nginx config |
+| `WARN: X-Content-Type-Options` but header appears present | Value is not exactly `nosniff` | Fix server config: only `nosniff` is valid |
+| No security warnings on prod, failures on CI | CI `base_url` points to localhost | Point CI base_url to staging with real headers |
+| CSP check warns despite `frame-ancestors` in CSP | Validator doesn't parse CSP directives | Verify validator treats CSP `frame-ancestors` as X-Frame-Options substitute |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Check all four headers for a live endpoint
+curl -sI https://api.example.com/health | grep -iE "strict-transport|content-security|x-content-type|x-frame"
+
+# Find endpoints.json files referencing non-localhost URLs
+grep -rn '"base_url"' . --include="*.json" | grep -v "localhost\|127\.0\.0\.1"
+
+# Detect CSP presence in nginx config
+grep -rn "Content-Security-Policy\|add_header.*CSP" /etc/nginx/ 2>/dev/null
+```
+
+---
+
+## See Also
+
+- `endpoint-config-anti-patterns.md` — configuration mistakes in endpoints.json
+- `auth-endpoint-patterns.md` — configuring authenticated endpoint validation


### PR DESCRIPTION
## Summary

Reference enrichment for `skills/endpoint-validator` — Level 0 → Level 3.

**Targets processed:** endpoint-validator (Level 0 → Level 3)

**New reference files (3):**
- `skills/endpoint-validator/references/security-headers.md` — HSTS, CSP, X-Content-Type-Options, X-Frame-Options: correct patterns, localhost skip logic, CI WARN-suppression anti-pattern, error-fix mappings
- `skills/endpoint-validator/references/endpoint-config-anti-patterns.md` — hardcoded IPs, write endpoints against production, zero/high timeouts, expect_key on non-JSON, committed credentials
- `skills/endpoint-validator/references/auth-endpoint-patterns.md` — Bearer/API-key/cookie auth config, auth rejection path testing, admin credential scope risk, session expiry detection

**SKILL.md change:** Added reference loading table mapping task types to the three new files. No logic changes.

All files include: anti-pattern detection commands (grep/rg), copy-pasteable code examples, and error-fix mapping tables. Average 231 lines/file (well above 80-line Level 3 threshold).

**Validation gate:** KEEP — loading table signals correctly route to all three references; content adds concrete detection commands and domain-specific patterns beyond base model knowledge.