### PR TITLE
chore(gitignore): add ephemeral local artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,9 +54,11 @@ Thumbs.db
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+cron-logs/
 
 # Task plans (ephemeral, per-session)
 task_plan.md
+plan/
 
 # Internal migration/development docs (not for public release)
 MIGRATION_CHECKLIST_V2.md
@@ -68,9 +70,11 @@ research/
 # AB test output directories (raw trial outputs, not committed)
 ab-test-results/
 ab-test-results-r2/
+benchmark/
 
 # ADR session state (ephemeral, per-session, not committed)
 .adr-session.json
+.adr-session.json.stale
 
 # Credentials and secrets
 *.pem
@@ -101,8 +105,9 @@ agents/INDEX.local.json
 drafts/
 draft-*.md
 
-# Scratch notes (session working files, not committed)
+# Scratch notes and one-off research files (session working files, not committed)
 scratch/
+research-*.md
 
 # Eval workspaces (A/B/C test outputs, generated code, grading artifacts)
 # These are ephemeral experiment data — not committed


### PR DESCRIPTION
## Summary
- Evolution cycle proposal P2: Add untracked ephemeral artifacts to .gitignore
- Consensus score: 15/15 STRONG (unanimous across 5 personas)
- A/B result: 100% — git status reduced from 7+ untracked items to 0 (only modified .gitignore)

## Changes
- `.gitignore`: Adds patterns for `benchmark/`, `.adr-session.json.stale`, `plan/`, `research-*.md`, `cron-logs/`
- Each entry is added near its thematically related existing entries

## Test Results
| Artifact | Before | After |
|----------|--------|-------|
| benchmark/ (3 AB test dirs) | ?? benchmark/... | gitignored |
| .adr-session.json.stale | ?? .adr-session.json.stale | gitignored |
| plan/ | ?? plan/ | gitignored |
| research-aspens-comparison.md | ?? research-*.md | gitignored |
| cron-logs/ | ?? cron-logs/ | gitignored |

## Evolution Cycle
This PR was generated and validated by the toolkit-evolution skill (2026-04-17 cycle).