### PR TITLE
feat(evolve): add prior cycle query to DIAGNOSE Step 1

### DIFF
--- a/skills/toolkit-evolution/references/diagnose-scripts.md
+++ b/skills/toolkit-evolution/references/diagnose-scripts.md
@@ -58,16 +58,17 @@ for a in sorted(agents):
 
 ## DIAGNOSE Step 1: Learning DB Search Queries
 
-Run these four queries to surface recent failures and routing mismatches:
+Run these five queries to surface recent failures, routing mismatches, and prior cycle history:
 
 ```bash
 python3 ~/.claude/scripts/learning-db.py search "routing decision" --min-confidence 0.0 --limit 20
 python3 ~/.claude/scripts/learning-db.py search "routing gap mismatch reroute" --min-confidence 0.3 --limit 20
 python3 ~/.claude/scripts/learning-db.py search "error pattern failure bug" --min-confidence 0.3 --limit 20
 python3 ~/.claude/scripts/learning-db.py search "skill gap missing improvement" --min-confidence 0.3 --limit 20
+python3 ~/.claude/scripts/learning-db.py search "toolkit evolution" --min-confidence 0.0 --limit 5
 ```
 
-Note: The first query uses `--min-confidence 0.0` because `effectiveness` entries (routing decisions recorded by /do) start at 0.5-0.6 confidence. The FTS5 tokenizer splits hyphens, so use space-separated terms, not `routing-decision`.
+Note: The first query uses `--min-confidence 0.0` because `effectiveness` entries (routing decisions recorded by /do) start at 0.5-0.6 confidence. The FTS5 tokenizer splits hyphens, so use space-separated terms, not `routing-decision`. The fifth query surfaces prior cycle summaries and deferred proposals — use it to avoid re-proposing ideas that already received MODERATE consensus or were explicitly shelved.
 
 ## DIAGNOSE Step 2: Git History Scan
 


### PR DESCRIPTION
## Summary
- Evolution cycle proposal P3: Surface prior cycle history in DIAGNOSE Step 1
- Consensus score: 11/15 PROMISING (User Advocate: STRONG, 4 others: PROMISING)
- A/B result: 100% — query returns 5+ cycle records with deferred proposal history

## Changes
- `skills/toolkit-evolution/references/diagnose-scripts.md`: Adds fifth Step 1 query
  `python3 ~/.claude/scripts/learning-db.py search "toolkit evolution" --min-confidence 0.0 --limit 5`
- Updates Step 1 note to explain the FTS5 space-separated term requirement and the purpose of the new query

## Rationale
Without this query, proposals deferred across multiple cycles (like dependency-audit, deferred 3 times)
have no mechanism to surface their history. The same proposals re-enter the PROPOSE phase cycle after
cycle. The query uses "toolkit evolution" (space-separated) because FTS5 tokenizes hyphens; "toolkit-evolution"
returns empty.

## Test Results
| Test Case | Result |
|-----------|--------|
| Query returns cycle history | 5+ records including 2026-04-02 through 2026-04-15 |
| Empty DB degrades gracefully | Returns "No learnings found" (not an error) |
| Prior deferred proposals visible | "dependency-audit" visible in cycle text |

## Evolution Cycle
This PR was generated and validated by the toolkit-evolution skill (2026-04-17 cycle).