### PR TITLE
feat(refs): explanation-traces — anti-patterns, error-fix mappings (Level 2→3)

### DIFF
--- a/skills/explanation-traces/SKILL.md
+++ b/skills/explanation-traces/SKILL.md
@@ -242,5 +242,16 @@ Result: Specific gate failure reason from the trace, with what was expected vs. 
 
 ## References
 
+### Reference Loading Table
+
+| Task type | Signals | Reference file |
+|---|---|---|
+| Hook authoring / writing traces | "write hook", "add tracing", "record decisions", "emit trace" | `references/trace-schema.md` |
+| Diagnosing why trace is wrong | "alternatives null", "evidence empty", "overwrite", "post-hoc", "vague" | `references/anti-patterns.md` |
+| Handling parse or read errors | "malformed", "missing field", "no decisions", "invalid type", "not found" | `references/error-handling.md` |
+| Presenting filtered timeline | "why did you", "show trace", "decision log", "explain routing" | `references/trace-schema.md` |
+
 ### Reference Files
-- `${CLAUDE_SKILL_DIR}/references/trace-schema.md`: JSON schema for session-trace.json with field descriptions and example entries
+- `references/trace-schema.md`: JSON schema for session-trace.json with field descriptions and example entries
+- `references/anti-patterns.md`: Anti-pattern catalog for trace producers (hooks) and consumers (skill behavior) with detection commands
+- `references/error-handling.md`: Error-fix mappings for all error states — missing file, malformed JSON, empty decisions, invalid fields

--- a/skills/explanation-traces/references/anti-patterns.md
+++ b/skills/explanation-traces/references/anti-patterns.md
@@ -1,0 +1,240 @@
+# Explanation Traces — Anti-Patterns
+
+Anti-patterns for both trace producers (hooks that write session-trace.json) and trace
+consumers (this skill reading it). Organized by who makes the mistake.
+
+---
+
+## Producer Anti-Patterns (Hook Writers)
+
+### AP-1: Post-Hoc Trace Writing
+
+**Detection** (find hooks that append after execution rather than at decision time):
+```bash
+grep -rn "session-trace" hooks/ --include="*.py" | grep -v "import\|def "
+rg 'session.trace' hooks/ -l
+```
+
+**What it looks like**:
+```python
+# Hook writes after the full agent run completes
+def on_agent_stop(event):
+    # WRONG: Writing what happened, not what was decided
+    append_trace({
+        "timestamp": datetime.utcnow().isoformat(),
+        "type": "agent-selection",
+        "chosen": event["agent"],
+        "evidence": "agent completed successfully",  # outcome, not decision signal
+        "alternatives": [],
+    })
+```
+
+**Why wrong**: Post-hoc traces record outcomes, not decisions. The `evidence` becomes
+"it worked" rather than the actual scoring signals. Callers using `explanation-traces`
+get confident-sounding but meaningless answers.
+
+**Fix**:
+```python
+# Write at classification time, before dispatch
+def on_pre_tool_use(event):
+    if event["tool"] == "Agent":
+        chosen = event["input"]["subagent_type"]
+        # Capture scoring from the router, not the outcome
+        append_trace({
+            "timestamp": datetime.utcnow().isoformat(),
+            "type": "agent-selection",
+            "chosen": chosen,
+            "evidence": router_scores.get(chosen, "no score recorded"),
+            "alternatives": list(router_scores.keys()),
+        })
+```
+
+---
+
+### AP-2: Null Alternatives
+
+**Detection**:
+```bash
+grep -n '"alternatives": null' session-trace.json
+rg '"alternatives":\s*null' session-trace.json
+# Also catch missing alternatives field entirely:
+python3 -c "
+import json, sys
+data = json.load(open('session-trace.json'))
+bad = [i for i, d in enumerate(data['decisions']) if 'alternatives' not in d]
+print(f'Missing alternatives field at indices: {bad}')
+"
+```
+
+**What it looks like**:
+```json
+{
+  "timestamp": "2026-04-01T10:00:00Z",
+  "type": "routing",
+  "chosen": "skill:roast",
+  "alternatives": null,
+  "evidence": "force_route triggered"
+}
+```
+
+**Why wrong**: `null` is not the same as `[]`. The schema requires an array. When the
+skill parses this, `alternatives` fails the `isinstance(v, list)` check. Consumers
+cannot distinguish "no alternatives considered" from "alternatives field missing".
+
+**Fix**: Use `[]` (empty array) when force_route was used and no alternatives were scored:
+```json
+{ "alternatives": [] }
+```
+
+---
+
+### AP-3: Vague Evidence Strings
+
+**Detection**:
+```bash
+grep -n '"evidence": ""' session-trace.json
+rg '"evidence":\s*"(seemed right|best option|obvious choice|default)"' session-trace.json
+# Check evidence length — short evidence is usually vague:
+python3 -c "
+import json
+data = json.load(open('session-trace.json'))
+short = [(i, d['evidence']) for i, d in enumerate(data['decisions'])
+         if len(d.get('evidence', '')) < 20]
+for i, ev in short: print(f'[{i}] Short evidence: {repr(ev)}')
+"
+```
+
+**What it looks like**:
+```json
+{ "evidence": "seemed like the right choice" }
+{ "evidence": "best match" }
+{ "evidence": "" }
+```
+
+**Why wrong**: These evidence strings tell the user nothing. When they ask "why did you
+pick that agent?", the skill must quote the evidence field verbatim. Vague evidence
+produces vague explanations — the opposite of what the skill exists to provide.
+
+**Fix**: Evidence must include at least one of: trigger string, score value, or matched signal:
+```json
+{ "evidence": "Trigger 'roast this' matched skill:roast force_route=true; no scoring run" }
+{ "evidence": "reviewer-code scored 0.92 vs reviewer-domain 0.41; keywords: 'function', 'bug'" }
+```
+
+---
+
+### AP-4: Overwriting Instead of Appending
+
+**Detection**:
+```bash
+# Find hooks that open with 'w' mode (overwrite) instead of read-then-write:
+grep -rn "open.*session-trace.*['\"]w['\"]" hooks/
+rg 'open\([^)]*session.trace[^)]*["\']w["\']' hooks/ --type py
+```
+
+**What it looks like**:
+```python
+# WRONG: Overwrites entire file each time
+with open("session-trace.json", "w") as f:
+    json.dump({"decisions": [new_entry]}, f)
+```
+
+**Why wrong**: Every hook invocation destroys all prior decisions. A session that makes
+10 routing decisions ends up with only the last one in the trace. The timeline is
+unrecoverable.
+
+**Fix**:
+```python
+import json, os
+
+def append_trace(entry):
+    path = "session-trace.json"
+    if os.path.exists(path):
+        with open(path) as f:
+            data = json.load(f)
+    else:
+        data = {"session_id": generate_id(), "started_at": now_iso(), "decisions": []}
+    data["decisions"].append(entry)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+```
+
+---
+
+### AP-5: Non-Monotonic Timestamps
+
+**Detection**:
+```bash
+python3 -c "
+import json
+data = json.load(open('session-trace.json'))
+ts = [d['timestamp'] for d in data['decisions']]
+for i in range(1, len(ts)):
+    if ts[i] < ts[i-1]:
+        print(f'Non-monotonic: [{i-1}] {ts[i-1]} > [{i}] {ts[i]}')
+"
+```
+
+**Why wrong**: If timestamps go backwards, the skill cannot sort decisions reliably.
+Chronological presentation breaks. This often happens when a hook generates timestamps
+at initialization rather than at emission time.
+
+**Fix**: Always call `datetime.utcnow().isoformat() + "Z"` at the moment the entry is
+created, not at hook startup.
+
+---
+
+## Consumer Anti-Patterns (Skill Behavior)
+
+### AP-6: Reconstructing Decisions from Conversation History
+
+**What it looks like** (incorrect skill behavior):
+> "The trace file doesn't exist, but based on the conversation I can tell the router
+> probably chose the golang agent because the user mentioned Go..."
+
+**Why wrong**: This is exactly the rationalization the skill exists to prevent. If no
+trace file exists, the correct answer is "no trace file found" — not an inference from
+memory or conversation history.
+
+**Correct behavior**: Report the missing file. Explain how to enable tracing. Do not fill
+the gap with inference. See SKILL.md Phase 1 Step 2 for the exact message to produce.
+
+---
+
+### AP-7: Dumping Raw JSON Without Filtering
+
+**What it looks like**: Printing the entire `session-trace.json` content when the user
+asks a specific question like "why did you pick the code reviewer?".
+
+**Why wrong**: Unfiltered JSON forces the user to manually scan for the relevant entry.
+A 20-decision trace printed as raw JSON is noise, not an explanation.
+
+**Correct behavior**: Filter to the specific decision type, lead with the answer to the
+user's question, then offer the full timeline as supplementary context. See SKILL.md
+Phase 2 Step 2 for the filter strategy table.
+
+---
+
+### AP-8: Treating Incomplete Traces as Complete
+
+**What it looks like**: Presenting a timeline without flagging that several decisions have
+empty `evidence` fields.
+
+**Why wrong**: The user assumes the explanation is authoritative. Missing evidence means
+the "why" for those decisions is unknown — presenting them without a caveat creates false
+confidence in the explanation.
+
+**Correct behavior**: Flag incomplete entries explicitly (SKILL.md Phase 3 Step 3).
+Report count of entries with missing/empty evidence. Never fill gaps silently.
+
+---
+
+## Quick Detection Cheatsheet
+
+| Anti-pattern | Detection command |
+|---|---|
+| Empty evidence | `rg '"evidence":\s*""' session-trace.json` |
+| Null alternatives | `rg '"alternatives":\s*null' session-trace.json` |
+| Overwrite hooks | `grep -rn 'open.*session-trace.*"w"' hooks/` |
+| Non-monotonic timestamps | see AP-5 detection block |
+| Missing required fields | `python3 -c "import json; fields={'timestamp','type','chosen','alternatives','evidence','context'}; [print(i, fields-set(d)) for i,d in enumerate(json.load(open('session-trace.json'))['decisions']) if fields-set(d)]"` |

--- a/skills/explanation-traces/references/error-handling.md
+++ b/skills/explanation-traces/references/error-handling.md
@@ -1,0 +1,247 @@
+# Explanation Traces — Error Handling
+
+Error-fix mappings for every error state the skill encounters when reading and parsing
+`session-trace.json`. Each entry includes: what the error looks like, root cause, and
+exact response to give the user.
+
+---
+
+## Error: No Trace File Found
+
+**Trigger**: None of the search paths (`./session-trace.json`, `.claude/session-trace.json`,
+`**/session-trace.json`) return a readable file.
+
+**Root causes**:
+| Cause | How to identify |
+|---|---|
+| Tracing hook never installed | `ls hooks/ | grep trace` returns nothing |
+| Hook installed but never fired | Hook file exists, but session-trace.json absent |
+| File written to wrong path | `find . -name "session-trace*" 2>/dev/null` finds it elsewhere |
+| File cleaned up between sessions | `git status` shows it was deleted or .gitignored |
+
+**Detection** (run to diagnose which cause applies):
+```bash
+# Check if any hook references session-trace:
+grep -rn "session-trace" hooks/ --include="*.py"
+# Find any trace file anywhere in the project:
+find . -name "session-trace*" 2>/dev/null
+# Check gitignore:
+grep "session-trace" .gitignore
+```
+
+**Response to user**:
+```
+No session-trace.json found.
+
+To enable decision tracing, add a hook that writes routing decisions,
+agent selections, skill phase transitions, and gate verdicts to
+session-trace.json. See: skills/explanation-traces/references/trace-schema.md
+for the expected JSON format.
+```
+
+Do NOT guess at decisions from conversation history. If no file exists, there is nothing
+to read.
+
+---
+
+## Error: Trace File Is Malformed JSON
+
+**Trigger**: `json.JSONDecodeError` (Python) or `SyntaxError` when parsing.
+
+**Common error messages**:
+```
+json.JSONDecodeError: Expecting ',' delimiter: line 47 column 3 (char 1203)
+json.JSONDecodeError: Unterminated string starting at: line 23 (char 890)
+json.JSONDecodeError: Extra data: line 2 column 1 (char 247)
+```
+
+**Root causes**:
+| Cause | Symptom |
+|---|---|
+| Partial write (process killed mid-write) | File truncated; last `}` or `]` missing |
+| Race condition (two hooks writing simultaneously) | Duplicate or interleaved JSON objects |
+| Manual edit error | Trailing comma, unquoted key, etc. |
+
+**Detection**:
+```bash
+# Validate JSON syntax:
+python3 -m json.tool session-trace.json > /dev/null
+# Or:
+python3 -c "import json; json.load(open('session-trace.json'))"
+# Find the exact byte offset of the error:
+python3 -c "
+import json
+try:
+    json.load(open('session-trace.json'))
+except json.JSONDecodeError as e:
+    print(f'Error at line {e.lineno}, col {e.colno}, char {e.pos}: {e.msg}')
+"
+```
+
+**Response to user**:
+```
+session-trace.json exists but cannot be parsed.
+
+Parse error: [include exact error message and line/char offset]
+
+Attempting to recover entries before the corruption point...
+[show any valid decisions found before the error position]
+
+The trace is incomplete. Decisions after char [N] are unavailable.
+```
+
+**Recovery attempt**: Try to extract the valid prefix by parsing the file byte-by-byte
+up to the error position. Report what was recovered vs. what was lost.
+
+---
+
+## Error: Trace File Has No Decision Entries
+
+**Trigger**: File parses successfully, but `data["decisions"]` is empty (`[]`) or the
+`decisions` key is absent entirely.
+
+**Distinguish the two cases**:
+```python
+data = json.load(open("session-trace.json"))
+if "decisions" not in data:
+    # Key absent — hook is writing wrong schema
+    print("decisions key missing from trace file")
+elif len(data["decisions"]) == 0:
+    # Key present but empty — hook fired but recorded nothing
+    print("decisions array is present but empty")
+```
+
+**Detection**:
+```bash
+python3 -c "
+import json
+data = json.load(open('session-trace.json'))
+print('decisions key present:', 'decisions' in data)
+print('decision count:', len(data.get('decisions', [])))
+print('top-level keys:', list(data.keys()))
+"
+```
+
+**Root causes**:
+| Symptom | Likely cause |
+|---|---|
+| `decisions` key missing | Hook writes different schema (e.g., only metadata) |
+| `decisions` is `[]` | Hook fires but the decision-recording code path never runs |
+| File is `{}` | Hook creates the file but never populates it |
+
+**Response to user**:
+```
+session-trace.json exists [and the decisions array is present] but contains zero
+decision entries.
+
+This means the hook is running but no decisions were recorded. Check:
+1. Does the hook emit entries on PreToolUse (agent dispatch) or only on PostToolUse?
+2. Is the decision-writing code path gated behind a condition that never fires?
+
+See: skills/explanation-traces/references/trace-schema.md for the expected
+schema and hook writing rules.
+```
+
+---
+
+## Error: Decision Entry Missing Required Fields
+
+**Trigger**: An entry in `decisions` is missing one or more of the six required fields:
+`timestamp`, `type`, `chosen`, `alternatives`, `evidence`, `context`.
+
+**Detection**:
+```bash
+python3 -c "
+import json
+REQUIRED = {'timestamp', 'type', 'chosen', 'alternatives', 'evidence', 'context'}
+data = json.load(open('session-trace.json'))
+for i, d in enumerate(data['decisions']):
+    missing = REQUIRED - set(d.keys())
+    if missing:
+        print(f'Entry [{i}]: missing fields: {missing}')
+"
+```
+
+**Response to user**:
+```
+[N] decision entries have incomplete records:
+
+Entry [2]: missing fields: evidence, alternatives
+Entry [7]: missing fields: context
+
+These entries show WHAT was decided but not WHY. The recording hook did not
+capture full context at decision time. Presenting available fields only.
+```
+
+Flag each incomplete entry in the timeline output. Do not invent values for missing fields.
+
+---
+
+## Error: Invalid `type` Field Value
+
+**Trigger**: An entry's `type` field contains a value other than `routing`, `agent-selection`,
+`skill-phase`, or `gate-verdict`.
+
+**Detection**:
+```bash
+python3 -c "
+import json
+VALID = {'routing', 'agent-selection', 'skill-phase', 'gate-verdict'}
+data = json.load(open('session-trace.json'))
+for i, d in enumerate(data['decisions']):
+    t = d.get('type', '')
+    if t not in VALID:
+        print(f'Entry [{i}]: invalid type {repr(t)} (valid: {VALID})')
+"
+```
+
+**Common invalid values**: `"agent_selection"` (underscore instead of hyphen),
+`"Agent"` (capitalized), `"decision"` (wrong category name).
+
+**Response to user**: Include the entry in the timeline but label it `[UNKNOWN TYPE]`.
+Do not silently drop entries with invalid types.
+
+---
+
+## Error: User Asks About a Decision Not in the Trace
+
+**Trigger**: User asks "why did you choose X?" but no entry in `decisions` matches X
+in the `chosen` or `alternatives` fields.
+
+**Detection logic**:
+```python
+query = "golang-general-engineer"
+matches = [d for d in decisions
+           if query in d.get("chosen", "") or query in d.get("alternatives", [])]
+if not matches:
+    # Decision was not recorded
+```
+
+**Response to user**:
+```
+No trace entry found for [X].
+
+The session trace has [N] decisions recorded:
+  - [list types and chosen values from the trace]
+
+The decision you're asking about was not captured. To record [X] decisions,
+the hook needs to emit a [routing|agent-selection|skill-phase|gate-verdict]
+entry when [X] is selected.
+```
+
+Show what IS in the trace. Do not speculate about why X was chosen when it has no
+trace entry.
+
+---
+
+## Error-Fix Summary Table
+
+| Error | Root cause | User message keyword | Fix |
+|---|---|---|---|
+| No file found | Hook not installed or wrong path | "No session-trace.json found" | Install tracing hook; see trace-schema.md |
+| Malformed JSON | Partial write or race condition | "cannot be parsed" | Show error offset; attempt recovery of pre-error entries |
+| `decisions` key missing | Wrong schema from hook | "decisions key missing" | Fix hook to use correct top-level structure |
+| `decisions` is empty | Hook fires but records nothing | "zero decision entries" | Check hook's decision-recording code path |
+| Missing required fields | Incomplete hook implementation | "incomplete records" | Flag affected entries; never invent missing values |
+| Invalid `type` value | Typo or schema drift in hook | `[UNKNOWN TYPE]` label | Label in output; do not drop |
+| Decision not in trace | Hook doesn't record that decision type | "not captured" | Show what is in trace; explain what hook change would fix it |


### PR DESCRIPTION
## Reference Enrichment: explanation-traces

**Run ID**: 2026-04-17-0407
**Target**: explanation-traces skill

### Level Change
Level 2 (Domain) → Level 3 (Deep)

### New Reference Files

**`references/anti-patterns.md`** (240 lines, 53 concrete hits, cmds=Y)
- 5 producer anti-patterns for hook writers: post-hoc writing, null alternatives, vague evidence, overwriting instead of appending, non-monotonic timestamps
- 3 consumer anti-patterns for skill behavior: reconstructing decisions from memory, dumping raw JSON, treating incomplete traces as complete
- Each entry has: detection command (grep/rg/python3), bad pattern, why it's wrong, correct fix
- Quick detection cheatsheet table

**`references/error-handling.md`** (247 lines, 60 concrete hits, cmds=Y)
- Error-fix mappings for 7 error states: no file, malformed JSON, decisions key missing, empty decisions array, missing required fields, invalid type value, decision not in trace
- Each entry has: trigger condition, detection command, root cause table, exact user-facing message to produce
- Summary table mapping error → root cause → fix

### SKILL.md Updates
Added loading table mapping task-type signals to the correct reference file:
- `"alternatives null"`, `"evidence empty"`, `"overwrite"` → anti-patterns.md
- `"malformed"`, `"missing field"`, `"no decisions"`, `"invalid type"` → error-handling.md
- `"why did you"`, `"show trace"`, `"decision log"` → trace-schema.md

### Validation Gate (Phase 2.5)
All 3 test queries correctly triggered the right reference via loading table signal matching. Both new references contain concrete actionable patterns (detection commands + code examples), not generic advice. Decision: **KEEP**.