### PR TITLE
feat: Opus 4.7 tool-execution override in verification skills

### DIFF
--- a/skills/do/references/quality-loop.md
+++ b/skills/do/references/quality-loop.md
@@ -97,6 +97,8 @@ This artifact is read by PHASE 5 (intent verification), PHASE 7 (fix agent selec
 
 ### PHASE 3 — TEST
 
+> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+
 Run deterministic test suite. Language auto-detected from changed files.
 
 Detection and commands:
@@ -133,6 +135,8 @@ Each reviewer produces findings as:
 
 ### PHASE 5 — INTENT VERIFY
 
+> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+
 Adversarial verification: does the diff accomplish what the user actually asked for?
 
 Dispatch one read-only verifier agent that reads the original user request from `quality-loop-state.md` (written in PHASE 2) and compares it against the actual diff. The verifier answers:
@@ -146,6 +150,8 @@ Any gap between request and implementation is a CRITICAL finding — because pas
 **Gate:** Intent verification complete. Proceed to PHASE 6.
 
 ### PHASE 6 — LIVE VALIDATE
+
+> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
 
 Behavioral verification for web projects. **Skip if not a web project.**
 

--- a/skills/endpoint-validator/SKILL.md
+++ b/skills/endpoint-validator/SKILL.md
@@ -78,6 +78,8 @@ Make a single request to `base_url` before running the full suite. If unreachabl
 
 ### Phase 2: VALIDATE
 
+> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+
 **Goal**: Test each endpoint against its expected criteria and collect structured results.
 
 **Step 1: Execute requests sequentially**

--- a/skills/feature-lifecycle/SKILL.md
+++ b/skills/feature-lifecycle/SKILL.md
@@ -82,7 +82,7 @@ Determine which phase to execute based on feature state:
    - DESIGN: Read `references/design.md`
    - PLAN: Read `references/plan.md`
    - IMPLEMENT: Read `references/implement.md`
-   - VALIDATE: Read `references/validate.md`
+   - VALIDATE: Read `references/validate.md` — **Opus 4.7 override applies: run quality gate commands, do not reason about whether they would pass. Paste exit codes and output.**
    - RELEASE: Read `references/release.md`
    - END-TO-END: Read `references/pipeline.md`
 

--- a/skills/feature-lifecycle/references/validate.md
+++ b/skills/feature-lifecycle/references/validate.md
@@ -15,6 +15,8 @@ Run comprehensive quality gates on the implemented feature. Phase 4 of the featu
 
 ### Phase 1: EXECUTE (Quality Gates)
 
+> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+
 **Step 1: Language Detection**
 
 Auto-detect project language(s) from file extensions, build files, and the implementation artifact. This detection drives which quality gate skill runs next.

--- a/skills/shared-patterns/adversarial-verification.md
+++ b/skills/shared-patterns/adversarial-verification.md
@@ -6,6 +6,8 @@ Reusable 4-level artifact verification methodology for any agent or skill that n
 **Primary consumer**: `verification-before-completion` skill
 **Also useful for**: Code review agents, PR pipeline verification phases, any agent that validates another agent's output
 
+> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+
 ## Core Principle: Never Trust Summary Claims
 
 The verifier NEVER accepts statements like "implemented the scoring module" or "all tests pass" at face value. Every claim is independently verified by examining what actually exists in the codebase.

--- a/skills/shared-patterns/anti-rationalization-core.md
+++ b/skills/shared-patterns/anti-rationalization-core.md
@@ -18,7 +18,7 @@ Before completing ANY task, verify you haven't rationalized:
 | Rationalization Attempt | Why It's Wrong | Required Action |
 |------------------------|----------------|-----------------|
 | "Already done/verified" | Assumption ≠ Verification | **Actually verify with evidence** |
-| "Code looks correct" | Looking ≠ Being correct | **Run tests, check types** |
+| "Code looks correct" | Opus 4.7 override: Opus 4.7 default-reasons instead of executing. "Looks correct" without tool output is the model honoring its own default. | **Run the tests. Paste exit code and output. Anything else is not verification.** |
 | "Trivial change, skip tests" | All changes need verification | **Test anyway** |
 | "Time pressure" | Quality > Speed | **Complete all steps** |
 | "User said skip it" | CLAUDE.md > user shortcuts | **Follow protocol, explain why** |

--- a/skills/systematic-code-review/SKILL.md
+++ b/skills/systematic-code-review/SKILL.md
@@ -89,6 +89,8 @@ Questions for Author:
 
 ### Phase 2: VERIFY
 
+> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+
 **Goal**: Validate all assertions in code, comments, and PR description against actual behavior.
 
 **Step 1: Run tests**

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -33,6 +33,8 @@ This skill prevents the most common form of premature completion: claiming succe
 
 ## Instructions
 
+> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+
 ### Step 1: Identify What Changed
 
 Before verification, understand the scope of changes:

--- a/skills/wordpress-live-validation/SKILL.md
+++ b/skills/wordpress-live-validation/SKILL.md
@@ -98,6 +98,8 @@ See `references/phase-checks.md` "Phase 1: NAVIGATE — Detailed Steps" for the 
 
 ### Phase 2: VALIDATE
 
+> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+
 **Goal**: Inspect rendered DOM and network activity for content integrity and SEO completeness. Run all checks without stopping on individual failures.
 
 The 7 checks (with severity, JS extraction snippets, and pass/fail criteria) are documented in `references/phase-checks.md` "Phase 2: VALIDATE — All 7 Checks":


### PR DESCRIPTION
## Summary

- Injects canonical Opus 4.7 override text into every verification-bearing skill and shared pattern in the toolkit
- Opus 4.7 trades tool calls for reasoning by default; in verification phases that default produces verdicts without evidence, which the toolkit's verifier pattern (PHILOSOPHY.md line 129) explicitly prohibits
- Upgrades the `anti-rationalization-core.md` "Code looks correct" row to name the Opus 4.7 model-default failure mode explicitly, not just a generic rationalization

## Files Edited

| File | Placement |
|------|-----------|
| `skills/verification-before-completion/SKILL.md` | Top of Instructions section, before Step 1 |
| `skills/systematic-code-review/SKILL.md` | Top of Phase 2 VERIFY |
| `skills/do/references/quality-loop.md` | Top of PHASE 3 TEST, PHASE 5 INTENT VERIFY, PHASE 6 LIVE VALIDATE |
| `skills/endpoint-validator/SKILL.md` | Top of Phase 2 VALIDATE |
| `skills/wordpress-live-validation/SKILL.md` | Top of Phase 2 VALIDATE |
| `skills/shared-patterns/adversarial-verification.md` | Before Core Principle section |
| `skills/feature-lifecycle/SKILL.md` | VALIDATE routing line (inline note) |
| `skills/feature-lifecycle/references/validate.md` | Top of Phase 1 EXECUTE |
| `skills/shared-patterns/anti-rationalization-core.md` | "Code looks correct" row upgraded |

## ADR Reference

Implements `adr/opus-4-7-verification-tool-execution.md` (local-only, gitignored).

## Test Plan

- [ ] `grep -c "Opus 4.7 override" skills/verification-before-completion/SKILL.md` returns 1
- [ ] `grep -c "Opus 4.7 override" skills/systematic-code-review/SKILL.md` returns 1
- [ ] `grep -c "Opus 4.7 override" skills/do/references/quality-loop.md` returns 3
- [ ] `grep -c "Opus 4.7 override" skills/endpoint-validator/SKILL.md` returns 1
- [ ] `grep -c "Opus 4.7 override" skills/wordpress-live-validation/SKILL.md` returns 1
- [ ] `grep -c "Opus 4.7 override" skills/shared-patterns/adversarial-verification.md` returns 1
- [ ] `grep -c "Opus 4.7 override" skills/feature-lifecycle/SKILL.md` returns 1
- [ ] `grep -c "Opus 4.7 override" skills/shared-patterns/anti-rationalization-core.md` returns 1
- [ ] No files listed as owned by Wave 1 Agent A or Agent B were modified (docs/PHILOSOPHY.md, skills/do/SKILL.md)
- [ ] CI lint passes (no Python files changed)