### PR TITLE
feat(refs): fish-shell-config (Level 2→3)

### DIFF
--- a/skills/fish-shell-config/SKILL.md
+++ b/skills/fish-shell-config/SKILL.md
@@ -275,5 +275,14 @@ Solution: Use `set -gx VAR value` to make variable visible to subprocesses. Chec
 
 ## References
 
+| Task Signal | Load | Why |
+|-------------|------|-----|
+| Migrating from Bash, converting `.bashrc`/`.bash_aliases`, `source`, `export`, `[[` in Fish file | `bash-migration.md` | Full Bash-to-Fish syntax translation table |
+| Variable scoping, PATH management, `fish_add_path`, `set` flags, `abbr`, completions | `fish-quick-reference.md` | Variable scope guide, special variables, control flow cheatsheet |
+| Error audit, "unknown command", PATH not persisting, abbreviation not working, syntax error, broken conf.d | `fish-anti-patterns.md` | Anti-patterns with grep detection commands and error-fix mappings |
+| Go, Rust, Docker, Node.js, Python, pyenv, fnm, starship, direnv, fzf, zoxide, mise, tool setup | `tool-integrations.md` | Concrete integration patterns for common dev tools |
+
 - `${CLAUDE_SKILL_DIR}/references/bash-migration.md`: Complete Bash-to-Fish syntax translation table
 - `${CLAUDE_SKILL_DIR}/references/fish-quick-reference.md`: Variable scoping, special variables, and command cheatsheet
+- `${CLAUDE_SKILL_DIR}/references/fish-anti-patterns.md`: Anti-pattern catalog with grep detection commands and error-fix mappings
+- `${CLAUDE_SKILL_DIR}/references/tool-integrations.md`: Concrete integration patterns for Go, Rust, Docker, Node.js, Python, and shell enhancers

--- a/skills/fish-shell-config/references/fish-anti-patterns.md
+++ b/skills/fish-shell-config/references/fish-anti-patterns.md
@@ -1,0 +1,305 @@
+# Fish Shell Anti-Patterns
+
+> **Scope**: Common fish shell configuration mistakes that cause silent failures, broken environments, or scripts that work interactively but fail in CI/cron. Does not cover fish scripting logic errors unrelated to configuration.
+> **Version range**: Fish 3.0+ (Fish 4.0 Rust rewrite has identical syntax)
+> **Generated**: 2026-04-17
+
+---
+
+## Overview
+
+Fish configuration errors rarely throw loud errors — they silently produce wrong behavior: PATH entries that vanish after restart, abbreviations that expand in the terminal but break scripts, environment variables invisible to child processes. Detection requires grep-based auditing of `.fish` files rather than waiting for runtime failures.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Bash-Style Variable Assignment
+
+**Detection**:
+```bash
+grep -rn '^[A-Z_]*=[^=]' --include="*.fish" ~/.config/fish/
+rg '^\s*[A-Z_a-z]+=[^=]' --type-add 'fish:*.fish' --type fish ~/.config/fish/
+```
+
+**What it looks like**:
+```fish
+# WRONG — syntax error in Fish
+GOPATH=~/go
+MY_VAR=hello
+```
+
+**Why wrong**: `VAR=value` is a syntax error in Fish (not silently ignored). Fish rejects it at parse time, causing the entire conf.d file to fail to load — all subsequent lines in that file are skipped.
+
+**Fix**:
+```fish
+set -gx GOPATH ~/go
+set -g MY_VAR hello
+```
+
+**Version note**: No version where this worked. Fish has never supported `VAR=value` assignment syntax.
+
+---
+
+### ❌ `export VAR=value` (Bash Export Syntax)
+
+**Detection**:
+```bash
+grep -rn 'export ' --include="*.fish" ~/.config/fish/
+rg 'export \w+=' --type-add 'fish:*.fish' --type fish ~/.config/fish/
+```
+
+**What it looks like**:
+```fish
+# WRONG — syntax error in Fish
+export PATH="$PATH:~/.local/bin"
+export EDITOR=nvim
+```
+
+**Why wrong**: `export` is not a Fish builtin for variable assignment. The syntax `export VAR=value` is a parse error. Even `export EDITOR nvim` (space-separated) calls the external `export` binary, sets nothing in Fish scope, and is immediately discarded.
+
+**Fix**:
+```fish
+fish_add_path ~/.local/bin
+set -gx EDITOR nvim
+```
+
+---
+
+### ❌ Colon-Separated PATH Manipulation
+
+**Detection**:
+```bash
+grep -rn 'PATH.*:.*PATH\|"\$PATH:' --include="*.fish" ~/.config/fish/
+rg 'set.*PATH.*"\$PATH:' --type-add 'fish:*.fish' --type fish ~/.config/fish/
+```
+
+**What it looks like**:
+```fish
+# WRONG — creates a single malformed string element
+set -gx PATH "$PATH:$HOME/.local/bin"
+set -gx PATH "$HOME/.local/bin:$PATH"
+```
+
+**Why wrong**: Fish PATH is a list variable. Each element is a separate string. String-concatenating with colons creates a single element containing the literal colon — e.g., `"/home/user/.local/bin:/usr/bin"` becomes one list entry, not two PATH components. Commands in the new directory become unfindable.
+
+**Fix**:
+```fish
+fish_add_path ~/.local/bin        # Prepend, deduplicates, persists
+fish_add_path --append ~/bin      # Append to end
+set -gx PATH ~/.local/bin $PATH   # Session-only prepend (list syntax, not string)
+```
+
+---
+
+### ❌ Unguarded Abbreviations in conf.d/
+
+**Detection**:
+```bash
+grep -rn '^abbr ' --include="*.fish" ~/.config/fish/conf.d/
+rg '^abbr ' --type-add 'fish:*.fish' --type fish ~/.config/fish/conf.d/
+```
+
+**What it looks like**:
+```fish
+# ~/.config/fish/conf.d/20-abbreviations.fish — WRONG
+abbr -a g git
+abbr -a gst "git status"
+```
+
+**Why wrong**: Abbreviations are interactive-only. When Fish sources `conf.d/` in non-interactive mode (scripts, CI, cron, `fish -c "..."`), `abbr -a` emits a warning and is a no-op. More critically, they never expand in scripts regardless — so logic depending on abbreviation expansion in `.fish` scripts will silently fail.
+
+**Fix**:
+```fish
+# ~/.config/fish/conf.d/20-abbreviations.fish — CORRECT
+if status is-interactive
+    abbr -a g git
+    abbr -a gst "git status"
+    abbr -a gc "git commit"
+end
+```
+
+---
+
+### ❌ Bash Double-Bracket Conditionals
+
+**Detection**:
+```bash
+grep -rn '\[\[' --include="*.fish" ~/.config/fish/
+grep -rn 'if \[' --include="*.fish" ~/.config/fish/
+```
+
+**What it looks like**:
+```fish
+# WRONG — syntax error in Fish
+if [[ -f ~/.config/fish/local.fish ]]
+    source ~/.config/fish/local.fish
+end
+
+if [ -z "$TMUX" ]
+    echo "not in tmux"
+end
+```
+
+**Why wrong**: `[[` is not recognized by Fish — it is a Bash/Zsh construct and causes a parse error. `[ ]` calls the external `/bin/[` binary which has slightly different behavior from the Fish `test` builtin and incurs a fork/exec overhead.
+
+**Fix**:
+```fish
+if test -f ~/.config/fish/local.fish
+    source ~/.config/fish/local.fish
+end
+
+if test -z "$TMUX"
+    echo "not in tmux"
+end
+```
+
+---
+
+### ❌ Function/Filename Mismatch
+
+**Detection**:
+```bash
+# Bash: find functions/ files where function name doesn't match filename
+for f in ~/.config/fish/functions/*.fish; do
+    name=$(basename "$f" .fish)
+    grep -qL "function $name" "$f" && echo "MISMATCH: $f"
+done
+```
+
+**What it looks like**:
+```
+# File: ~/.config/fish/functions/mkcd.fish
+function make_directory_and_cd    # WRONG — name doesn't match file
+    mkdir -p $argv[1]
+    and cd $argv[1]
+end
+```
+
+**Why wrong**: Fish autoloads functions by filename. When `mkcd` is called, Fish looks for `~/.config/fish/functions/mkcd.fish`. If that file exists but defines `function make_directory_and_cd`, calling `mkcd` fails with "Unknown command: mkcd". The file loads but the desired name never registers.
+
+**Fix**:
+```fish
+# ~/.config/fish/functions/mkcd.fish — function name must match filename
+function mkcd --description "Create directory and cd into it"
+    mkdir -p $argv[1]
+    and cd $argv[1]
+end
+```
+
+---
+
+### ❌ Tool Integration Without Availability Guard
+
+**Detection**:
+```bash
+grep -rn 'init fish | source\|hook fish | source' --include="*.fish" ~/.config/fish/conf.d/
+rg '(starship|direnv|fnm|zoxide|mise|pyenv) (init|hook)' --type-add 'fish:*.fish' --type fish ~/.config/fish/conf.d/
+```
+
+**What it looks like**:
+```fish
+# WRONG — breaks on machines where tool is not installed
+starship init fish | source
+direnv hook fish | source
+fnm env --use-on-cd | source
+```
+
+**Why wrong**: If the tool is not installed, the command fails with "command not found: starship". This error may stop further `conf.d/` processing, producing error output for every new shell opened on machines without that tool.
+
+**Fix**:
+```fish
+if type -q starship
+    starship init fish | source
+end
+
+if type -q direnv
+    direnv hook fish | source
+end
+
+if type -q fnm
+    fnm env --use-on-cd | source
+end
+```
+
+---
+
+### ❌ Using `set -U` (Universal) in conf.d/ for Tool Paths
+
+**Detection**:
+```bash
+grep -rn 'set -U\|set --universal' --include="*.fish" ~/.config/fish/conf.d/
+rg 'set -U ' --type-add 'fish:*.fish' --type fish ~/.config/fish/conf.d/
+```
+
+**What it looks like**:
+```fish
+# ~/.config/fish/conf.d/10-env.fish — WRONG
+set -U GOPATH ~/go
+set -U EDITOR nvim
+set -U JAVA_HOME /usr/lib/jvm/java-17-openjdk
+```
+
+**Why wrong**: Universal variables are stored in `fish_variables` and persist across all sessions. Setting them in `conf.d/` re-sets them on every shell start — harmless for idempotent values but causes subtle bugs when the value changes (e.g., different JAVA_HOME on different machines). Universal scope is for user preferences set interactively, not for environment configuration deployed via conf.d/.
+
+**Fix**:
+```fish
+# Use -gx for environment variables in conf.d/ files
+set -gx GOPATH ~/go
+set -gx EDITOR nvim
+set -gx JAVA_HOME /usr/lib/jvm/java-17-openjdk
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error / Symptom | Root Cause | Fix |
+|-----------------|------------|-----|
+| `Unknown command: myfunction` | `functions/myfunction.fish` defines wrong function name | Rename function inside file to match filename exactly |
+| PATH entry disappears after reboot | Used `set -gx PATH ...` (session-only) | Replace with `fish_add_path /path` |
+| Abbreviation works in terminal, not in script | Abbreviations are interactive-only by design | Use a function in `functions/` instead |
+| Parse error on shell start | `export VAR=value` or `VAR=value` in `.fish` file | Replace with `set -gx VAR value` |
+| Garbled PATH with colons visible | `set PATH "$PATH:/new"` colon concatenation | Replace with `fish_add_path /new` |
+| `[[: command not found` | Bash `[[` brackets used in Fish file | Replace with `test` builtin |
+| Tool init error on every new shell | Init call without `type -q` guard | Wrap in `if type -q toolname; ... end` |
+| Universal variable duplicated in PATH | `fish_user_paths` has duplicate entries | `set -U fish_user_paths (string split \n (printf "%s\n" $fish_user_paths \| sort -u))` |
+| conf.d changes not taking effect | File has syntax error from Bash constructs | Run `fish -n ~/.config/fish/conf.d/myfile.fish` to check |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Bash-style assignment
+grep -rn '^[A-Z_a-z]*=[^=]' --include="*.fish" ~/.config/fish/
+
+# Bash export syntax
+grep -rn 'export ' --include="*.fish" ~/.config/fish/
+
+# Colon PATH manipulation
+grep -rn '"\$PATH:' --include="*.fish" ~/.config/fish/
+
+# Unguarded abbreviations
+grep -rn '^abbr ' --include="*.fish" ~/.config/fish/conf.d/
+
+# Bash bracket conditionals
+grep -rn '\[\[' --include="*.fish" ~/.config/fish/
+
+# Tool integrations without availability guard
+grep -rn 'init fish | source\|hook fish | source' --include="*.fish" ~/.config/fish/conf.d/
+
+# Universal variables set in conf.d (likely should be -gx)
+grep -rn 'set -U ' --include="*.fish" ~/.config/fish/conf.d/
+
+# Syntax check all conf.d files
+for f in ~/.config/fish/conf.d/*.fish; do fish -n "$f" || echo "SYNTAX ERROR: $f"; done
+```
+
+---
+
+## See Also
+
+- `bash-migration.md` — Bash-to-Fish syntax translation table
+- `fish-quick-reference.md` — Variable scoping, PATH management, control flow cheatsheet
+- `tool-integrations.md` — Complete tool integration patterns (Go, Rust, Docker, Node.js, pyenv)

--- a/skills/fish-shell-config/references/tool-integrations.md
+++ b/skills/fish-shell-config/references/tool-integrations.md
@@ -1,0 +1,318 @@
+# Fish Shell Tool Integrations
+
+> **Scope**: Concrete fish shell integration patterns for common dev tools (Go, Rust, Docker, Node.js, Python, and shell enhancers). Covers PATH setup, init hooks, and abbreviation patterns. Does not cover tool installation.
+> **Version range**: Fish 3.0+; tool-version notes inline where behavior differs
+> **Generated**: 2026-04-17
+
+---
+
+## Overview
+
+Each tool integration follows the same three-part structure: (1) PATH and env setup in `conf.d/00-path.fish` or `conf.d/10-env.fish`, (2) init hook with `type -q` guard in `conf.d/30-tools.fish`, (3) abbreviations in `conf.d/20-abbreviations.fish` guarded by `status is-interactive`. Copy-paste sections into the appropriate file.
+
+---
+
+## Pattern Table
+
+| Tool | Init Pattern | PATH Location | Version Notes |
+|------|-------------|---------------|---------------|
+| Go | `set -gx GOPATH` | `fish_add_path ~/go/bin` | Go 1.16+: `GOPATH` auto-set if unset |
+| Rust/Cargo | none (cargo sets PATH via rustup) | `fish_add_path ~/.cargo/bin` | rustup 1.24+ writes to `fish_user_paths` on install |
+| Node/fnm | `fnm env --use-on-cd \| source` | handled by fnm | fnm 1.32+ has native Fish support |
+| Python/pyenv | `pyenv init - fish \| source` | `fish_add_path ~/.pyenv/bin` | pyenv 2.0+ Fish init command |
+| Docker | none (PATH handled by install) | none | abbreviations only |
+| starship | `starship init fish \| source` | none | requires starship 0.46+ for Fish |
+| direnv | `direnv hook fish \| source` | none | requires direnv 2.21+ for Fish |
+| fzf | `fzf --fish \| source` | none | `--fish` flag: fzf 0.48+; older: use fzf.fish plugin |
+| zoxide | `zoxide init fish \| source` | none | all versions |
+| mise/rtx | `mise activate fish \| source` | none | replaces asdf for Fish |
+
+---
+
+## Go
+
+```fish
+# conf.d/10-env.fish
+set -gx GOPATH ~/go
+set -gx GOROOT /usr/local/go          # Only if Go installed outside $PATH
+set -gx CGO_ENABLED 0                 # Optional: disable CGO for pure Go builds
+
+# conf.d/00-path.fish
+fish_add_path ~/go/bin                # Your compiled binaries (go install output)
+fish_add_path /usr/local/go/bin       # Go toolchain itself (if not in /usr/bin)
+```
+
+```fish
+# conf.d/20-abbreviations.fish — inside is-interactive guard
+abbr -a gob "go build ./..."
+abbr -a got "go test ./..."
+abbr -a gotr "go test -race ./..."
+abbr -a gom "go mod tidy"
+abbr -a gor "go run ."
+```
+
+**Version note**: Go 1.16+ sets `GOPATH` to `~/go` automatically if unset. Explicitly setting it is harmless but redundant. `GOROOT` is only needed for non-standard Go installations.
+
+---
+
+## Rust / Cargo
+
+```fish
+# conf.d/00-path.fish
+fish_add_path ~/.cargo/bin            # All cargo-installed tools end up here
+```
+
+```fish
+# conf.d/20-abbreviations.fish — inside is-interactive guard
+abbr -a cb "cargo build"
+abbr -a cbr "cargo build --release"
+abbr -a ct "cargo test"
+abbr -a cr "cargo run"
+abbr -a cc "cargo check"
+abbr -a ccl "cargo clippy"
+abbr -a cf "cargo fmt"
+```
+
+**Note**: `rustup` writes a `~/.cargo/env` script for Bash. Ignore it — just add `~/.cargo/bin` to PATH as above. Rustup 1.24+ also tries to update `fish_user_paths` on install; `fish_add_path` is idempotent so running both is harmless.
+
+---
+
+## Node.js — fnm (Recommended)
+
+```fish
+# conf.d/30-tools.fish
+if type -q fnm
+    fnm env --use-on-cd | source      # Auto-switches Node version on cd
+end
+```
+
+```fish
+# conf.d/20-abbreviations.fish — inside is-interactive guard
+if type -q fnm
+    abbr -a ni "npm install"
+    abbr -a nid "npm install --save-dev"
+    abbr -a nr "npm run"
+    abbr -a nx "npx"
+end
+```
+
+**Version note**: `fnm env --use-on-cd` requires fnm 1.32+. For older fnm, use `fnm env | source` without `--use-on-cd` and manually run `fnm use` when changing projects.
+
+## Node.js — nvm (Alternative)
+
+```fish
+# conf.d/30-tools.fish — nvm is Bash-native; use bass or nvm.fish wrapper
+if test -d ~/.nvm
+    # Option A: nvm.fish plugin (preferred — native Fish)
+    # Install: fisher install jorgebucaran/nvm.fish
+    # No additional config needed after plugin install
+
+    # Option B: bass (Bash source wrapper)
+    if type -q bass
+        function nvm
+            bass source ~/.nvm/nvm.sh --no-use ";" nvm $argv
+        end
+    end
+end
+```
+
+**Note**: nvm is a Bash project. The `nvm.fish` Fisher plugin is a drop-in replacement that avoids the Bash interop complexity. Prefer fnm or nvm.fish over Bash-bridge patterns.
+
+---
+
+## Python — pyenv
+
+```fish
+# conf.d/00-path.fish
+fish_add_path ~/.pyenv/bin
+fish_add_path ~/.pyenv/shims
+
+# conf.d/30-tools.fish
+if type -q pyenv
+    pyenv init - fish | source
+end
+```
+
+```fish
+# conf.d/20-abbreviations.fish — inside is-interactive guard
+if type -q pyenv
+    abbr -a py "python"
+    abbr -a pip3 "python -m pip"
+end
+```
+
+**Version note**: pyenv 2.0+ uses `pyenv init - fish`. Older versions (< 2.0) used `pyenv init -` without the `fish` argument — both work but the newer form is more explicit.
+
+## Python — virtualenv Activation
+
+```fish
+# functions/venv.fish — activate/deactivate shortcut
+function venv --description "Activate or create .venv"
+    if test -d .venv
+        source .venv/bin/activate.fish
+    else if test -n "$argv[1]"
+        python -m venv $argv[1]
+        source $argv[1]/bin/activate.fish
+    else
+        python -m venv .venv
+        source .venv/bin/activate.fish
+    end
+end
+```
+
+**Why a function, not an abbreviation**: Activation requires `source`, which only works in Fish function context.
+
+---
+
+## Docker / Docker Compose
+
+```fish
+# conf.d/20-abbreviations.fish — inside is-interactive guard
+if type -q docker
+    abbr -a d "docker"
+    abbr -a dc "docker compose"
+    abbr -a dcu "docker compose up"
+    abbr -a dcud "docker compose up -d"
+    abbr -a dcd "docker compose down"
+    abbr -a dcl "docker compose logs -f"
+    abbr -a dps "docker ps"
+    abbr -a dpsa "docker ps -a"
+    abbr -a drm "docker rm"
+    abbr -a drmi "docker rmi"
+    abbr -a dex "docker exec -it"
+end
+```
+
+**Note**: `docker compose` (V2, no hyphen) is the current syntax. `docker-compose` (V1, with hyphen) is deprecated since Docker Desktop 4.20 / Docker Engine 23.0.
+
+---
+
+## Shell Enhancers
+
+### starship (Cross-Shell Prompt)
+
+```fish
+# conf.d/30-tools.fish
+if type -q starship
+    starship init fish | source
+end
+```
+
+**Version note**: starship 0.46+ has native Fish support. Requires Fish 3.0+. The `starship init fish` command outputs a Fish function definition — `source` evaluates it in the current shell.
+
+### direnv (Per-Directory Env)
+
+```fish
+# conf.d/30-tools.fish
+if type -q direnv
+    direnv hook fish | source
+end
+```
+
+**Note**: direnv 2.21+ has native Fish hook support. The hook adds a `cd` event handler; it does not slow down non-cd commands.
+
+### fzf (Fuzzy Finder)
+
+```fish
+# conf.d/30-tools.fish
+if type -q fzf
+    fzf --fish | source              # fzf 0.48+: native Fish key bindings
+    # For older fzf (< 0.48), use the fzf.fish Fisher plugin instead
+end
+```
+
+**Version note**: `fzf --fish` (outputting Fish-native bindings) was introduced in fzf 0.48.0 (2024-01). For fzf < 0.48, the `fzf.fish` Fisher plugin provides equivalent Ctrl+R, Ctrl+T, Alt+C bindings.
+
+### zoxide (Smart cd Replacement)
+
+```fish
+# conf.d/30-tools.fish
+if type -q zoxide
+    zoxide init fish | source
+    # After init, 'z dirname' jumps to frecent match
+    # 'zi' opens interactive selection with fzf
+end
+```
+
+### mise / rtx (Version Manager, asdf Replacement)
+
+```fish
+# conf.d/30-tools.fish
+if type -q mise
+    mise activate fish | source
+end
+```
+
+**Note**: mise (formerly rtx) replaces asdf. The Fish activation hook manages shims automatically. Do not use `asdf` Fish integration alongside mise — they conflict.
+
+---
+
+## Full conf.d Example: Complete Setup
+
+```fish
+# ~/.config/fish/conf.d/30-tools.fish
+# Tool integrations — all guarded with type -q
+
+# Prompt
+if type -q starship
+    starship init fish | source
+end
+
+# Directory env
+if type -q direnv
+    direnv hook fish | source
+end
+
+# Node version management
+if type -q fnm
+    fnm env --use-on-cd | source
+end
+
+# Python version management
+if type -q pyenv
+    pyenv init - fish | source
+end
+
+# Version manager (mise/rtx)
+if type -q mise
+    mise activate fish | source
+end
+
+# Fuzzy finder
+if type -q fzf
+    fzf --fish | source
+end
+
+# Smart directory navigation
+if type -q zoxide
+    zoxide init fish | source
+end
+
+# Homebrew (macOS only)
+if test -x /opt/homebrew/bin/brew
+    eval (/opt/homebrew/bin/brew shellenv)
+end
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error / Symptom | Root Cause | Fix |
+|-----------------|------------|-----|
+| `command not found: go` after install | Go bin not in PATH | `fish_add_path /usr/local/go/bin` |
+| `cargo: command not found` | `~/.cargo/bin` not in PATH | `fish_add_path ~/.cargo/bin` |
+| `fnm: Unknown version` on new shell | `--use-on-cd` not in init | Add `fnm env --use-on-cd \| source` |
+| direnv not loading `.envrc` | direnv hook not sourced | Add `direnv hook fish \| source` to conf.d |
+| `fzf --fish` flag unknown | fzf version < 0.48 | Install fzf.fish plugin via Fisher instead |
+| `pyenv: command not found` | pyenv shims not in PATH | `fish_add_path ~/.pyenv/bin ~/.pyenv/shims` |
+| nvm not found in Fish | nvm is Bash-only | Use nvm.fish plugin or fnm instead |
+| `GOPATH` changes not persisting | Set with `set -g` instead of `set -gx` | Use `set -gx GOPATH ~/go` |
+
+---
+
+## See Also
+
+- `fish-anti-patterns.md` — Detection commands for common Fish config mistakes
+- `bash-migration.md` — Bash-to-Fish syntax translation
+- `fish-quick-reference.md` — Variable scoping and PATH management cheatsheet


### PR DESCRIPTION
## Summary

- Targets processed: fish-shell-config
- Level before: 2 (domain-specific, no detection commands)
- Level after: 3 (deep — detection commands + anti-pattern catalog + tool integration patterns)

## New Reference Files

**`fish-anti-patterns.md`** (305 lines)
- 8 anti-patterns with grep/rg detection commands for each
- Error-fix mappings table (9 entries)
- Detection commands reference section
- Covers: bash-style assignment, `export` syntax, colon PATH manipulation, unguarded abbreviations, `[[` conditionals, function/filename mismatch, unguarded tool integrations, `set -U` in conf.d

**`tool-integrations.md`** (318 lines)
- Concrete integration patterns for 10 tools: Go, Rust/Cargo, Node.js (fnm/nvm), Python (pyenv/virtualenv), Docker/Compose, starship, direnv, fzf, zoxide, mise
- Pattern table with version ranges
- Error-fix mappings table (8 entries)
- Full conf.d example showing complete setup

## SKILL.md Changes

Added loading table mapping task signals to reference files — agents can now select the right reference based on what the user is trying to do (migration, error audit, tool setup, etc.).