### PR TITLE
chore: add Do-pair validation to templates and enrichment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       - run: pip install ruff
       - run: ruff check . --config pyproject.toml
       - run: ruff format --check . --config pyproject.toml
+      - run: python scripts/validate-references.py --check-do-framing
 
   test:
     runs-on: ubuntu-latest

--- a/AGENT_TEMPLATE_V2.md
+++ b/AGENT_TEMPLATE_V2.md
@@ -194,20 +194,22 @@ Common errors and their solutions. See [references/{domain}-errors.md](reference
 
 Common mistakes to avoid. See [references/{domain}-anti-patterns.md](references/{domain}-anti-patterns.md) for full catalog.
 
+**Do-pairing rule (mandatory):** Every anti-pattern block must include a "Do instead" counterpart. A bare negative encodes no actionable knowledge; the positive counterpart is the actual learning. If a prohibition genuinely has no correct alternative, annotate it with `<!-- no-pair-required: reason -->` to pass structural validation. Run `python3 scripts/validate-references.py --check-do-framing` before shipping.
+
 ### ❌ Anti-Pattern 1 Name
 **What it looks like**: [Code example or description]
 **Why wrong**: [Consequence or problem]
-**✅ Do instead**: [Correct approach with example]
+**✅ Do instead**: [Correct approach with example — mandatory]
 
 ### ❌ Anti-Pattern 2 Name
 **What it looks like**: [Code example or description]
 **Why wrong**: [Consequence or problem]
-**✅ Do instead**: [Correct approach with example]
+**✅ Do instead**: [Correct approach with example — mandatory]
 
 ### ❌ Anti-Pattern 3 Name
 **What it looks like**: [Code example or description]
 **Why wrong**: [Consequence or problem]
-**✅ Do instead**: [Correct approach with example]
+**✅ Do instead**: [Correct approach with example — mandatory]
 
 ## Anti-Rationalization
 
@@ -319,6 +321,8 @@ command2
 
 ### references/{domain}-anti-patterns.md
 
+**Do-pairing rule:** Every anti-pattern in this file must include a "✅ Correct approach" block. Blocks without one will be flagged by `python3 scripts/validate-references.py --check-do-framing`. If a prohibition has no correct alternative, annotate with `<!-- no-pair-required: reason -->`.
+
 ```markdown
 # [Agent Name] Anti-Patterns
 
@@ -349,7 +353,7 @@ Common mistakes and their corrections.
 
 ---
 
-[Repeat for each anti-pattern]
+[Repeat for each anti-pattern — every one must have a Correct approach block]
 ```
 
 ### references/{domain}-patterns.md

--- a/artifacts/joy-check-sweep-backlog.json
+++ b/artifacts/joy-check-sweep-backlog.json
@@ -1,0 +1,8393 @@
+{
+  "total": 932,
+  "findings": [
+    {
+      "file": "skills/explanation-traces/SKILL.md",
+      "line_range": [
+        199,
+        199
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "explanation"
+    },
+    {
+      "file": "skills/multi-persona-critique/SKILL.md",
+      "line_range": [
+        175,
+        183
+      ],
+      "block_text": "## Examples, Anti-Patterns, Error Handling\n\nSee `${CLAUDE_SKILL_DIR}/references/examples-and-errors.md` for:\n\n- **Examples**: critique provided proposals, generate+critique ideas, evaluate architectural options\n- **Anti-Patterns**: averaging disagreement, post-hoc rationalization, consensus-as-truth, skipping justification, resolving contested items, sequential execution\n- **Error Handling**: bare ratings, skipped proposals, uniform agreement, fewer than 2 proposals\n\n---\n",
+      "domain_hint": "multi"
+    },
+    {
+      "file": "skills/perses/SKILL.md",
+      "line_range": [
+        41,
+        50
+      ],
+      "block_text": "## How to Use (MANDATORY)\n\n**You MUST load the matching reference file before starting any Perses work.** The table below routes tasks to domain-specific references containing the actual methodology, commands, and patterns.\n\n1. **Match** the user's task to a sub-domain in the table below\n2. **Load** the reference file using `Read` tool on `${CLAUDE_SKILL_DIR}/references/<name>.md`\n3. **Follow** the instructions in the loaded reference exactly\n4. If the task spans multiple sub-domains, load each ...",
+      "domain_hint": "perses"
+    },
+    {
+      "file": "skills/with-anti-rationalization/SKILL.md",
+      "line_range": [
+        180,
+        180
+      ],
+      "block_text": "### Anti-Pattern Checklist: What NOT To Do\n",
+      "domain_hint": "with"
+    },
+    {
+      "file": "skills/workflow/SKILL.md",
+      "line_range": [
+        67,
+        78
+      ],
+      "block_text": "## How to Use (MANDATORY)\n\n**You MUST load the reference file before executing any workflow phase.** The table above is a routing index \u2014 the actual methodology, phases, gates, and instructions are in the reference files.\n\n1. **Identify** the workflow category from the user's task using the table above\n2. **Load** the matching reference file using `Read` tool on `${CLAUDE_SKILL_DIR}/references/<name>.md`\n3. **Follow** the phases and gates defined in that reference exactly \u2014 do not improvise phas...",
+      "domain_hint": "workflow"
+    },
+    {
+      "file": "skills/adr-consultation/references/consultation-anti-patterns.md",
+      "line_range": [
+        1,
+        8
+      ],
+      "block_text": "# ADR Consultation \u2014 Anti-Patterns\n\n> **Scope**: Common failures in ADR consultation orchestration and synthesis. Covers what goes wrong\n> and how to detect and fix it. Does NOT cover ADR authoring style or implementation quality.\n> **Version range**: Standard mode (3 agents), Complex mode (5 agents)\n> **Generated**: 2026-04-15\n\n---\n",
+      "domain_hint": "adr-consultation"
+    },
+    {
+      "file": "skills/adr-consultation/references/consultation-anti-patterns.md",
+      "line_range": [
+        18,
+        18
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "adr-consultation"
+    },
+    {
+      "file": "skills/adr-consultation/references/consultation-anti-patterns.md",
+      "line_range": [
+        29,
+        45
+      ],
+      "block_text": "# All three should exist simultaneously after dispatch completes\n```\n\n**What it looks like**:\n```markdown\n[Message 1]: Dispatching contrarian reviewer now...\n[Message 2]: Contrarian complete. Now dispatching user-advocate...\n[Message 3]: User-advocate complete. Now dispatching meta-process...\n```\n\n**Why wrong**: Triples wall-clock time with no benefit. Each agent is supposed to assess\nindependently; sequential dispatch means agents 2 and 3 may see context contaminated by\nagent 1's findings, unde...",
+      "domain_hint": "adr-consultation"
+    },
+    {
+      "file": "skills/adr-consultation/references/consultation-anti-patterns.md",
+      "line_range": [
+        54,
+        59
+      ],
+      "block_text": "# Healthy: synthesis.md + 3 agent files. Unhealthy: synthesis.md + 0 agent files.\n```\n\n**What it looks like**:\n```markdown\n<!-- synthesis.md created without the orchestrator having read agent files from disk -->",
+      "domain_hint": "adr-consultation"
+    },
+    {
+      "file": "skills/adr-consultation/references/consultation-anti-patterns.md",
+      "line_range": [
+        61,
+        72
+      ],
+      "block_text": "## Verdict: PROCEED\n[Based on what the agents reported in this session...]\n```\n\n**Why wrong**: Task return context disappears when context is cleared or a new session starts.\nSynthesis built from context cannot be re-read, audited, or resumed. If the session drops\nmid-consultation, the entire analysis is lost. File-based artifacts are the permanent record.\n\n**Fix**: After all agents complete, explicitly read each `adr/{name}/reviewer-perspectives-*.md`\nfile before synthesizing \u2014 even if Task ret...",
+      "domain_hint": "adr-consultation"
+    },
+    {
+      "file": "skills/adr-consultation/references/consultation-anti-patterns.md",
+      "line_range": [
+        78,
+        90
+      ],
+      "block_text": "# Check if any concerns.md has blocking severity while synthesis says PROCEED\nfor dir in adr/*/; do\n  name=$(basename \"$dir\")\n  if grep -q \"Severity.*blocking\" \"$dir/concerns.md\" 2>/dev/null; then\n    if grep -q \"## Verdict: PROCEED\" \"$dir/synthesis.md\" 2>/dev/null; then\n      echo \"RATIONALIZATION DETECTED: $name\"\n    fi\n  fi\ndone\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "adr-consultation"
+    },
+    {
+      "file": "skills/adr-consultation/references/consultation-anti-patterns.md",
+      "line_range": [
+        91,
+        105
+      ],
+      "block_text": "## Verdict: PROCEED\nAlthough the contrarian reviewer raised a blocking concern about the data migration\nrisk, this seems theoretical given our team's experience with similar migrations.\nWe'll keep an eye on it during implementation.\n```\n\n**Why wrong**: \"Theoretical risk is still risk.\" The gate exists to surface blocking concerns\nbefore implementation. Post-implementation discovery of the same issue costs dramatically\nmore: the feature is already built, tests written, and the fix requires archit...",
+      "domain_hint": "adr-consultation"
+    },
+    {
+      "file": "skills/adr-consultation/references/consultation-anti-patterns.md",
+      "line_range": [
+        111,
+        130
+      ],
+      "block_text": "# Standard mode: expect exactly 3 reviewer files\ncount=$(ls adr/{name}/reviewer-perspectives-*.md 2>/dev/null | wc -l)\nif [ \"$count\" -lt 3 ]; then\n  echo \"PARTIAL CONSULTATION: only $count/3 reviewers present\"\nfi\n```\n\n**What it looks like**: Dispatching only 1 or 2 agents because the ADR \"seems simple\" or\n\"is mostly a config change\" or \"we've done this type of decision before.\"\n\n**Why wrong**: Partial consultation gives false confidence. An agent that genuinely finds no\nconcerns returns PROCEED ...",
+      "domain_hint": "adr-consultation"
+    },
+    {
+      "file": "skills/adr-consultation/references/consultation-anti-patterns.md",
+      "line_range": [
+        138,
+        152
+      ],
+      "block_text": "# If files exist with recent timestamps, this is prior work \u2014 confirm before overwriting\n```\n\n**What it looks like**: Re-running consultation on an ADR that already has consultation\nartifacts without acknowledging or showing the existing results.\n\n**Why wrong**: Silently overwriting prior consultation destroys the audit trail. The prior\nconsultation may have reached a BLOCKED verdict that was intentionally deferred, or may\ncontain concerns that were addressed in the ADR revision \u2014 losing this hi...",
+      "domain_hint": "adr-consultation"
+    },
+    {
+      "file": "skills/adr-consultation/references/consultation-anti-patterns.md",
+      "line_range": [
+        158,
+        174
+      ],
+      "block_text": "# Verify all pre-dispatch requirements before sending Task calls\nls adr/{name}/ 2>/dev/null || echo \"MISSING DIRECTORY\"\ncat .adr-session.json 2>/dev/null || echo \"NO SESSION\"\nwc -l < adr/{name}.md 2>/dev/null || echo \"ADR NOT READ\"\n```\n\n**What it looks like**: Dispatching agents before confirming the ADR has been read, the\nconsultation directory exists, and the ADR name has been confirmed.\n\n**Why wrong**: Agents need a valid directory to write output files. An agent that cannot\nwrite `adr/{name}...",
+      "domain_hint": "adr-consultation"
+    },
+    {
+      "file": "skills/adr-consultation/references/consultation-anti-patterns.md",
+      "line_range": [
+        180,
+        185
+      ],
+      "block_text": "# Count NEEDS_CHANGES vs PROCEED vs BLOCK in agent files\ngrep -h \"## Verdict:\" adr/{name}/reviewer-perspectives-*.md 2>/dev/null | sort | uniq -c\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "adr-consultation"
+    },
+    {
+      "file": "skills/adr-consultation/references/consultation-anti-patterns.md",
+      "line_range": [
+        193,
+        206
+      ],
+      "block_text": "## Verdict: PROCEED\nTwo reviewers had minor concerns but overall the approach is sound.\n```\n\n**Why wrong**: Two NEEDS_CHANGES verdicts mean two independent reviewers identified specific\nthings that must change. Aggregating this to PROCEED discards both sets of concerns. The\nsynthesis verdict table is not a voting system \u2014 it is a concern aggregator. Multiple\nNEEDS_CHANGES is a signal that the ADR needs revision before proceeding.\n\n**Fix**: When multiple agents return NEEDS_CHANGES, treat as BLOC...",
+      "domain_hint": "adr-consultation"
+    },
+    {
+      "file": "skills/agent-evaluation/references/scoring-rubric.md",
+      "line_range": [
+        104,
+        116
+      ],
+      "block_text": "### 6. Anti-Patterns Section (5 points)\n\n**Full Credit (5 points)**:\n- `## Anti-Patterns` section present with 3-5 patterns\n- Each pattern has \"What it looks like\", \"Why wrong\", \"Do instead\" structure\n- Patterns are specific to the skill's domain\n\n**Partial Credit (2 points)**:\n- Section present with fewer than 3 patterns\n- Patterns lack the required 3-part structure\n\n**No Credit (0 points)**:\n- No anti-patterns section\n",
+      "domain_hint": "agent-evaluation"
+    },
+    {
+      "file": "skills/anti-ai-editor/references/cliche-replacements.md",
+      "line_range": [
+        49,
+        73
+      ],
+      "block_text": "## Tier 1b: Copula Avoidance (AI Verb Substitution)\n\nAI substitutes complex verbs for simple \"is/has/are\". Sourced from Wikipedia's WikiProject AI Cleanup.\n\n| AI Phrase | Replacement | Notes |\n|-----------|-------------|-------|\n| serves as a/the | is a/the | Unless describing actual service role |\n| stands as a/the | is a/the | Almost never correct |\n| functions as a/the | is a/the | Unless describing actual function |\n| acts as a/the | is a/the | Unless describing actual acting role |\n| boasts...",
+      "domain_hint": "anti-ai-editor"
+    },
+    {
+      "file": "skills/anti-ai-editor/references/cliche-replacements.md",
+      "line_range": [
+        319,
+        320
+      ],
+      "block_text": "# Copula avoidance (Tier 1b)\nserves as a|stands as a|functions as a|acts as a|boasts a|features a|offers a\n",
+      "domain_hint": "anti-ai-editor"
+    },
+    {
+      "file": "skills/anti-ai-editor/references/detection-patterns.md",
+      "line_range": [
+        304,
+        325
+      ],
+      "block_text": "### Contraction Avoidance (AI Formality Tell)\n\nAI models tend to avoid contractions, producing unnaturally formal text. In news articles and blog posts, humans use contractions at 80%+ rate. Low contraction rates are a strong AI signal.\n\n**Detection heuristic:**\n```\n1. Count expandable contractions present: don't, can't, won't, isn't, aren't, hasn't, haven't, didn't, doesn't, shouldn't, wouldn't, couldn't, it's, he's, she's, they've, we've, he'd, she'd, they'd, we'd\n2. Count missed contraction o...",
+      "domain_hint": "anti-ai-editor"
+    },
+    {
+      "file": "skills/anti-ai-editor/references/detection-patterns.md",
+      "line_range": [
+        342,
+        346
+      ],
+      "block_text": "### Tier 1b: Copula Avoidance (AI Verb Substitution)\n\nAI models avoid simple copulas (\"is\", \"has\", \"are\") by substituting unnecessarily complex verbs. Sourced from Wikipedia's WikiProject AI Cleanup via OpenClaw's Humanizer skill.\n\n```regex",
+      "domain_hint": "anti-ai-editor"
+    },
+    {
+      "file": "skills/anti-ai-editor/references/detection-patterns.md",
+      "line_range": [
+        347,
+        348
+      ],
+      "block_text": "# \"Is/are\" avoidance \u2014 substituting complex verbs for simple copulas\n\\b(serves|stands|functions|acts)\\s+as\\s+(a|an|the)\\b\n",
+      "domain_hint": "anti-ai-editor"
+    },
+    {
+      "file": "skills/anti-ai-editor/references/detection-patterns.md",
+      "line_range": [
+        350,
+        365
+      ],
+      "block_text": "# \"Has\" avoidance \u2014 inflated verbs replacing \"has\"\n\\b(boasts|features|offers)\\s+(a|an|the)\\b\n```\n\n**Before/After Examples:**\n\n| AI Pattern | Human Version |\n|-----------|---------------|\n| \"The library **serves as a** bridge between APIs\" | \"The library **is a** bridge between APIs\" |\n| \"The framework **stands as a** testament to good design\" | \"The framework **is** a testament to good design\" |\n| \"The package **functions as a** wrapper\" | \"The package **is** a wrapper\" |\n| \"The city **boasts a*...",
+      "domain_hint": "anti-ai-editor"
+    },
+    {
+      "file": "skills/anti-ai-editor/references/detection-rules.md",
+      "line_range": [
+        26,
+        41
+      ],
+      "block_text": "## High-Priority Flags: Copula Avoidance (Almost Always Fix)\n\n| Pattern | Issue | Fix |\n|---------|-------|-----|\n| \"serves as a\" | Copula avoidance | \"is a\" |\n| \"stands as a\" | Copula avoidance | \"is a\" |\n| \"functions as a\" | Copula avoidance | \"is a\" |\n| \"acts as a\" | Copula avoidance | \"is a\" (unless describing actual role) |\n| \"boasts a/the\" | Inflated \"has\" | \"has a/the\" |\n| \"features a/the\" | Inflated \"has\" | \"has a/the\" |\n| \"offers a/the\" | Inflated \"has\" | \"has a/the\" |\n| \"is a testament...",
+      "domain_hint": "anti-ai-editor"
+    },
+    {
+      "file": "skills/auto-dream/references/concurrency.md",
+      "line_range": [
+        137,
+        137
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/concurrency.md",
+      "line_range": [
+        143,
+        148
+      ],
+      "block_text": "# Find flock without -n (non-blocking) flag in wrapper scripts\ngrep -rn 'flock' scripts/ | grep -v '\\-n\\b'\n```\n\n**What it looks like**:\n```bash",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/concurrency.md",
+      "line_range": [
+        149,
+        163
+      ],
+      "block_text": "# Blocking flock \u2014 waits indefinitely for the lock\nflock /tmp/auto-dream.lock claude -p \"...\"\n```\n\n**Why wrong**: If a dream run takes 8 minutes and cron fires every 5, the second invocation waits 3 minutes, then runs immediately after the first finishes. The second run's SCAN sees the same memory state as the first (before consolidation results are visible). The result is two consecutive consolidation cycles that produce conflicting MEMORY.md states.\n\n**Fix**:\n```bash\nflock -n -E 1 /tmp/auto-dr...",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/concurrency.md",
+      "line_range": [
+        169,
+        183
+      ],
+      "block_text": "# Find code that tests for .tmp existence before writing\ngrep -rn '\\.tmp.*exist\\|os\\.path\\.exists.*\\.tmp' scripts/ hooks/\n```\n\n**What it looks like**:\n```python\nif os.path.exists(\"memory/MEMORY.md.tmp\"):\n    print(\"Previous write failed, skipping update\")\n    return  # Wrong: leaves the index stale\n```\n\n**Why wrong**: A `.tmp` file left behind means the rename failed \u2014 the `.tmp` file may contain a valid newer index. Skipping the update leaves the index pointing to files that were already archiv...",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/concurrency.md",
+      "line_range": [
+        202,
+        206
+      ],
+      "block_text": "# Both lines should exist; if stash is missing, the pattern is broken\n```\n\n**What it looks like**:\n```bash",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/concurrency.md",
+      "line_range": [
+        209,
+        216
+      ],
+      "block_text": "# Error: Your local changes to the following files would be overwritten by checkout\n```\n\n**Why wrong**: Phase 3 CONSOLIDATE writes new memory files. If those writes are not tracked on any git branch (the dream cycle does not commit memory files to git), `git checkout` refuses to switch and GRADUATE fails entirely. All graduation candidates are deferred, and the missed cycle compounds on subsequent runs.\n\n**Fix**: Always check `git status --porcelain` before any branch switch in Phase 5. Stash if...",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/concurrency.md",
+      "line_range": [
+        224,
+        229
+      ],
+      "block_text": "# Also check Python DB access\ngrep -rn 'sqlite3.connect' hooks/lib/ | head -20\n```\n\n**What it looks like**:\n```bash",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/concurrency.md",
+      "line_range": [
+        232,
+        239
+      ],
+      "block_text": "# Returns: Error: database is locked\n```\n\n**Why wrong**: During active development sessions, the learning hook fires on every tool call and holds brief write locks. A dream SCAN that queries graduation candidates without a timeout fails with `SQLITE_BUSY` if a hook write happens to coincide. The scan aborts Phase 1, which means Phase 5 GRADUATE has no candidates to evaluate \u2014 silent data loss.\n\n**Fix**: Add `PRAGMA busy_timeout=5000;` before every dream-cycle query. For Python, pass `timeout=5.0...",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/dream-cycle-testing.md",
+      "line_range": [
+        127,
+        127
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/dream-cycle-testing.md",
+      "line_range": [
+        133,
+        154
+      ],
+      "block_text": "# Look for --execute runs in cron logs without a preceding dry-run same day\ngrep -l 'execute' cron-logs/auto-dream/run-*.log | while read f; do\n  date=$(basename \"$f\" | grep -oP '\\d{4}-\\d{2}-\\d{2}')\n  grep -l \"dry\" cron-logs/auto-dream/run-*${date}*.log 2>/dev/null || echo \"No dry-run: $f\"\ndone\n```\n\n**What it looks like**:\n```bash\n./scripts/auto-dream-cron.sh --execute  # What will it consolidate? Unknown.\n```\n\n**Why wrong**: The dream cycle can archive active memories if it mis-classifies them ...",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/dream-cycle-testing.md",
+      "line_range": [
+        162,
+        167
+      ],
+      "block_text": "# Check if the last dream report noted a SQLite failure\ngrep -i 'sqlite\\|database\\|learning.db\\|failed' ~/.claude/state/last-dream.md | head -5\n```\n\n**What it looks like**:\n```",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/dream-cycle-testing.md",
+      "line_range": [
+        168,
+        178
+      ],
+      "block_text": "## Dream Report: 2026-04-16\n\nSCAN: Read 28 memory files.\nSQLite query failed: unable to open database file\nANALYZE: Cross-session patterns: none (no session data available)\n```\n\n**Why wrong**: When learning.db is missing, SCAN notes the failure and continues \u2014 the cycle does not abort. But ANALYZE then lacks session data, so SYNTHESIZE produces low-quality or no cross-session insights. A silent SQLite failure looks like a successful run when it's actually missing half its input.\n\n**Fix**:\n```bas...",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/dream-cycle-testing.md",
+      "line_range": [
+        193,
+        213
+      ],
+      "block_text": "# In any custom test scripts that pipe auto-dream-cron.sh output:\ngrep -n '\\$?' test*.sh 2>/dev/null | grep -v 'PIPESTATUS'\n```\n\n**What it looks like**:\n```bash\n./scripts/auto-dream-cron.sh --execute | tee test-output.log\necho \"Exit: $?\"  # Always 0 \u2014 tee's exit code, not claude's\n```\n\n**Why wrong**: The wrapper script handles `PIPESTATUS[0]` internally, but a custom test wrapper that pipes the cron script inherits the same problem. `$?` after a pipe reflects the last command (`tee`), not the cr...",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/headless-cron-patterns.md",
+      "line_range": [
+        119,
+        119
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/headless-cron-patterns.md",
+      "line_range": [
+        121,
+        141
+      ],
+      "block_text": "### \u274c Using `--dangerously-skip-permissions` in cron\n\n**Detection**:\n```bash\ngrep -rn 'dangerously-skip-permissions' scripts/\nrg 'dangerously.skip' scripts/ --type sh\n```\n\n**What it looks like**:\n```bash\nclaude --dangerously-skip-permissions -p \"${PROMPT}\" | tee \"${LOG}\"\n```\n\n**Why wrong**: Semantically equivalent to `--permission-mode auto` today but communicates \"I know this is risky\" and may diverge in future Claude Code versions. Cron scripts are long-lived; use the explicit stable flag.\n\n**...",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/headless-cron-patterns.md",
+      "line_range": [
+        147,
+        166
+      ],
+      "block_text": "# Find scripts that pipe to tee but don't capture PIPESTATUS\ngrep -A3 '| tee' scripts/*.sh | grep -v 'PIPESTATUS'\n```\n\n**What it looks like**:\n```bash\nclaude -p \"${PROMPT}\" | tee \"${LOG}\"\necho \"Done, exit: $?\"   # $? is tee's exit code, always 0\n```\n\n**Why wrong**: A Claude session that crashes or hits the budget cap exits non-zero, but the script reports success. Cron mail, monitoring alerts, and retry logic all miss the failure.\n\n**Fix**:\n```bash\nclaude -p \"${PROMPT}\" | tee \"${LOG}\"\nCLAUDE_EXI...",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/headless-cron-patterns.md",
+      "line_range": [
+        172,
+        179
+      ],
+      "block_text": "# Find cron scripts invoking claude without a budget cap\ngrep -L 'max-budget-usd' scripts/*cron*.sh\nrg 'claude' scripts/ --type sh -l | xargs grep -L 'max-budget-usd'\n```\n\n**What it looks like**:\n```bash\nclaude --permission-mode auto --no-session-persistence -p \"${LARGE_PROMPT}\"",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/headless-cron-patterns.md",
+      "line_range": [
+        180,
+        193
+      ],
+      "block_text": "# No --max-budget-usd: a prompt bug or unexpectedly large context can cost $50+\n```\n\n**Why wrong**: Budget cap is the last defense against a runaway unattended session. Even with `--no-session-persistence`, a misbehaving prompt can loop reasoning across tools and accumulate large costs before timing out.\n\n**Fix**:\n```bash\nclaude --permission-mode auto \\\n       --no-session-persistence \\\n       --max-budget-usd 3.00 \\\n       -p \"${PROMPT}\"\n```\n\n---\n",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/headless-cron-patterns.md",
+      "line_range": [
+        199,
+        220
+      ],
+      "block_text": "# Find flock calls missing the -n (non-blocking) flag\ngrep -n 'flock' scripts/*.sh | grep -v '\\-n '\n```\n\n**What it looks like**:\n```bash\nexec 9>\"${LOCKFILE}\"\nflock 9                # Blocking \u2014 waits indefinitely for the lock\nclaude -p \"${PROMPT}\" ...\n```\n\n**Why wrong**: If a slow run holds the lock past the next cron tick, the second instance queues rather than skipping. When the first finishes, the second starts immediately \u2014 creating back-to-back full cycles and doubling cost and mutations in...",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/logging-patterns.md",
+      "line_range": [
+        121,
+        121
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/logging-patterns.md",
+      "line_range": [
+        127,
+        134
+      ],
+      "block_text": "# Check if last-dream.md date matches today's cron log\ngrep '^# Dream Report' ~/.claude/state/last-dream.md\nls -t cron-logs/auto-dream/run-*.log | head -1\n```\n\n**What it looks like**:\n```bash\nhead -1 ~/.claude/state/last-dream.md",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/logging-patterns.md",
+      "line_range": [
+        135,
+        141
+      ],
+      "block_text": "# Dream Report: 2026-04-15   \u2190 yesterday's date, today's cron supposedly ran\n```\n\n**Why wrong**: `last-dream.md` is written by the REPORT phase. If today's run was blocked by the lockfile (prior run still active) or crashed before REPORT, the file retains yesterday's content. The file date confirms the *last successful* cycle, not whether *today's* cycle ran.\n\n**Fix**:\n```bash",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/logging-patterns.md",
+      "line_range": [
+        153,
+        158
+      ],
+      "block_text": "# Scanning run log for \"success\" when the report might tell a different story\ngrep 'success\\|complete\\|done' \"$(ls -t cron-logs/auto-dream/run-*.log | head -1)\"\n```\n\n**What it looks like**:\n```bash",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/logging-patterns.md",
+      "line_range": [
+        163,
+        169
+      ],
+      "block_text": "# (CONSOLIDATE then crashed \u2014 but grep found \"complete\" so we thought it worked)\n```\n\n**Why wrong**: The dream cycle writes \"phase X complete\" at the end of each phase. If CONSOLIDATE crashes mid-write, the log contains \"ANALYZE complete\" but no \"CONSOLIDATE complete\". Grepping for any \"complete\" produces a false positive.\n\n**Fix**:\n```bash",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/logging-patterns.md",
+      "line_range": [
+        186,
+        190
+      ],
+      "block_text": "# > 100 files suggests no rotation policy\n```\n\n**What it looks like**:\n```bash",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/logging-patterns.md",
+      "line_range": [
+        194,
+        200
+      ],
+      "block_text": "# No cleanup step \u2014 files accumulate forever\n```\n\n**Why wrong**: At nightly frequency, 365 log files/year is manageable, but after a few years the directory becomes hard to navigate and the disk usage is non-trivial. More importantly, missing a rotation policy means the first time you actually need to debug a failure, you have to scroll through hundreds of files to find the relevant one.\n\n**Fix**: Add to the end of the wrapper script:\n```bash",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/memory-file-operations.md",
+      "line_range": [
+        156,
+        156
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/memory-file-operations.md",
+      "line_range": [
+        162,
+        170
+      ],
+      "block_text": "# Find code that writes MEMORY.md without going through a .tmp file\ngrep -rn 'MEMORY\\.md' hooks/ scripts/ | grep -v '\\.tmp' | grep -v 'read\\|cat\\|grep\\|open.*r'\nrg 'write.*MEMORY\\.md(?!\\.tmp)' --type py\n```\n\n**What it looks like**:\n```python\nwith open(\"memory/MEMORY.md\", \"w\") as f:\n    f.write(new_index_content)",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/memory-file-operations.md",
+      "line_range": [
+        171,
+        183
+      ],
+      "block_text": "# If interrupted here, MEMORY.md is partially written\n```\n\n**Why wrong**: A partial write leaves MEMORY.md in an invalid state. The session-start hook reads this file to load context \u2014 a corrupted index means no memory injection at all until manually repaired.\n\n**Fix**:\n```python\nwith open(\"memory/MEMORY.md.tmp\", \"w\") as f:\n    f.write(new_index_content)\nos.rename(\"memory/MEMORY.md.tmp\", \"memory/MEMORY.md\")\n```\n\n---\n",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/memory-file-operations.md",
+      "line_range": [
+        189,
+        207
+      ],
+      "block_text": "# Find any rm operations on memory files\ngrep -rn 'rm.*memory/' scripts/ hooks/\nrg 'os\\.remove|os\\.unlink|Path.*unlink' --type py | grep -i 'memory'\n```\n\n**What it looks like**:\n```bash\nrm memory/stale-project-memory.md  # Unrecoverable if assessment was wrong\n```\n\n**Why wrong**: Staleness assessment can be wrong. A memory that looks inactive (no recent git refs, no session refs) might still be valid ongoing guidance. Archive preserves reversibility; deletion does not. Dream cycle design rule: \"...",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/memory-file-operations.md",
+      "line_range": [
+        214,
+        229
+      ],
+      "block_text": "# Review: does the consolidation code ever rewrite one memory based on another?\ngrep -rn 'conflict\\|contradict' scripts/ | grep -v 'flag\\|report\\|human'\n```\n\n**What it looks like**:\n```\nMemory A: \"Use ruff for Python linting\"\nMemory B: \"Use flake8 for Python linting\"\n\u2192 Auto-consolidation picks A because it's newer and deletes B\n```\n\n**Why wrong**: The conflict may reflect a real, unresolved project decision. Auto-resolution buries the disagreement. The human reviewer needs to see both to make th...",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/auto-dream/references/memory-file-operations.md",
+      "line_range": [
+        236,
+        246
+      ],
+      "block_text": "# Should be under 200 lines; every line after 200 is truncated in context injection\n```\n\n**What it looks like**:\nAn index that grows unbounded as new memories are added without old ones being consolidated or archived, eventually exceeding the 200-line truncation limit.\n\n**Why wrong**: The session-start hook injects MEMORY.md contents. Context injection is truncated at 200 lines \u2014 memories after that line are silently excluded from session context, defeating the purpose of writing them.\n\n**Fix**:...",
+      "domain_hint": "auto-dream"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        1,
+        7
+      ],
+      "block_text": "# AT Protocol Anti-Patterns\n\n> **Scope**: Common mistakes when reading Bluesky/AT Protocol data with Python and the public XRPC API\n> **Version range**: AT Protocol v1, all versions\n> **Generated**: 2026-04-16\n\n---\n",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        18,
+        18
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        20,
+        29
+      ],
+      "block_text": "### Using bsky.social for Public Reads\n\n**Detection**:\n```bash\nrg 'bsky\\.social/xrpc' --type py\ngrep -rn 'https://bsky.social/xrpc' --include=\"*.py\"\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        30,
+        39
+      ],
+      "block_text": "# Wrong \u2014 bsky.social requires auth for most endpoints\nurl = f\"https://bsky.social/xrpc/app.bsky.feed.getAuthorFeed?actor={handle}\"\n```\n\n**Why wrong**: `bsky.social` is a PDS (Personal Data Server) that requires JWT authentication\nfor most endpoints. Unauthenticated requests return `HTTP 401: AuthRequired`. The public app\nview (`public.api.bsky.app`) is purpose-built for unauthenticated reads.\n\n**Fix**:\n```python",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        56,
+        66
+      ],
+      "block_text": "# Wrong \u2014 AT Protocol has no offset parameter\nfor page in range(10):\n    url = f\"{BASE}/app.bsky.feed.getAuthorFeed?actor={handle}&limit=100&offset={page * 100}\"\n    data = fetch_json(url)\n```\n\n**Why wrong**: The AT Protocol lexicon has no `offset` parameter \u2014 the API ignores it silently.\nAll pagination is cursor-based. Passing `offset` fetches the same first page on every iteration.\n\n**Fix**:\n```python",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        84,
+        93
+      ],
+      "block_text": "### Using \"posts\" Key on Author Feed Response\n\n**Detection**:\n```bash\ngrep -rn '\\.get(\"posts\"' --include=\"*.py\" | grep -i 'author\\|feed'\ngrep -rn '\\[\"posts\"\\]' --include=\"*.py\"\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        94,
+        103
+      ],
+      "block_text": "# Wrong \u2014 getAuthorFeed uses \"feed\" key, not \"posts\"\ndata = fetch_json(url)\nposts = data[\"posts\"]  # KeyError or empty list\n```\n\n**Why wrong**: `getAuthorFeed` returns `{\"feed\": [...], \"cursor\": \"...\"}`. The `posts` key\nis only used by `searchPosts`. Confusing the two silently returns nothing.\n\n**Fix**:\n```python",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        115,
+        124
+      ],
+      "block_text": "### Accessing post.text Directly on a Feed Item\n\n**Detection**:\n```bash\ngrep -rn 'item\\[\"text\"\\]\\|item\\.get(\"text\"' --include=\"*.py\"\ngrep -rn 'feed_item\\[\"text\"\\]' --include=\"*.py\"\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        125,
+        144
+      ],
+      "block_text": "# Wrong \u2014 feed items wrap the post data, text is nested\nfor item in data[\"feed\"]:\n    text = item[\"text\"]  # KeyError \u2014 text lives at item[\"post\"][\"record\"][\"text\"]\n```\n\n**Why wrong**: `getAuthorFeed` returns `FeedViewPost` objects, not raw posts. The actual post\nrecord is nested at `item[\"post\"][\"record\"]`. The outer `item` holds `post`, `reason`, and\n`reply` sub-keys.\n\n**Fix**:\n```python\nfor item in data.get(\"feed\", []):\n    post_data = item.get(\"post\", {})\n    record = post_data.get(\"record\",...",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        151,
+        155
+      ],
+      "block_text": "# Should find code handling the reason key; absence means reposts are silently misattributed\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        156,
+        184
+      ],
+      "block_text": "# Wrong \u2014 treats reposts as original posts by the feed owner\nfor item in data[\"feed\"]:\n    handle = item[\"post\"][\"author\"][\"handle\"]  # This is the ORIGINAL author, not reposter\n    print(f\"@{handle}: {item['post']['record']['text']}\")\n```\n\n**Why wrong**: When a user reposts, `item[\"reason\"][\"$type\"]` is\n`\"app.bsky.feed.defs#reasonRepost\"` and `item[\"reason\"][\"by\"]` holds the reposter's info.\nThe `item[\"post\"][\"author\"]` is always the original author. Without checking `reason`, every\nrepost is p...",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        191,
+        196
+      ],
+      "block_text": "# Check if urllib.parse.quote or urllib.request.quote is missing around the handle\nrg 'actor=\\{' --type py\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        201,
+        217
+      ],
+      "block_text": "# Colon in DID may be misinterpreted by proxies/CDNs\n```\n\n**Why wrong**: While most handles (`user.bsky.social`) survive unencoded, DID identifiers\n(`did:plc:...`, `did:web:...`) contain colons that some HTTP proxies interpret as port\nseparators, producing corrupted requests. Always encode `actor` consistently.\n\n**Fix**:\n```python\nimport urllib.request\n\nhandle = \"did:plc:abc123def456\"\nencoded = urllib.request.quote(handle, safe=\"\")\nurl = f\"{BASE}/app.bsky.feed.getAuthorFeed?actor={encoded}&limit...",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        219,
+        227
+      ],
+      "block_text": "### Ignoring Timeout on urllib.request.urlopen\n\n**Detection**:\n```bash\ngrep -rn 'urlopen(' --include=\"*.py\" | grep -v 'timeout'\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/bluesky-reader/references/at-protocol-anti-patterns.md",
+      "line_range": [
+        228,
+        237
+      ],
+      "block_text": "# Wrong \u2014 no timeout, hangs indefinitely on network stall\nwith urllib.request.urlopen(req) as resp:\n    return json.loads(resp.read())\n```\n\n**Why wrong**: The Bluesky public API can stall under load. Without a timeout, the script\nhangs until the OS TCP timeout (often 2+ minutes), making the tool appear frozen.\n\n**Fix**:\n```python",
+      "domain_hint": "bluesky-reader"
+    },
+    {
+      "file": "skills/cobalt-core/references/concurrency-patterns.md",
+      "line_range": [
+        128,
+        128
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "cobalt-core"
+    },
+    {
+      "file": "skills/cobalt-core/references/concurrency-patterns.md",
+      "line_range": [
+        134,
+        152
+      ],
+      "block_text": "# Find goroutine launches \u2014 review each for semaphore acquire\nrg 'go func\\(' --type go internal/\ngrep -rn 'go func(' --include=\"*.go\" internal/\n```\n\n**What it looks like**:\n```go\nfor _, domain := range domains {\n    go func(d libvirt.Domain) {\n        collectDomain(ctx, d, ch) // no semaphore\n    }(domain)\n}\n```\n\n**Why wrong**: On a hypervisor with 500 VMs, this launches 500 goroutines simultaneously. Each goroutine makes libvirt RPC calls over the same Unix socket. libvirt queues drop, connecti...",
+      "domain_hint": "cobalt-core"
+    },
+    {
+      "file": "skills/cobalt-core/references/concurrency-patterns.md",
+      "line_range": [
+        154,
+        178
+      ],
+      "block_text": "### \u274c Blocking Lock in Prometheus Collect Path\n\n**Detection**:\n```bash\nrg '\\.Lock\\(\\)' --type go internal/libvirt/\ngrep -n \"\\.Lock()\" internal/libvirt/*.go\n```\nReview if `Lock()` appears in any `Collect()` or `Describe()` method.\n\n**What it looks like**:\n```go\nfunc (s *ServiceImpl) Collect(ch chan<- prometheus.Metric) {\n    s.mu.Lock()         // blocks if previous scrape running\n    defer s.mu.Unlock()\n    s.retrieveMetrics(ctx, ch)\n}\n```\n\n**Why wrong**: Prometheus's default scrape timeout is 1...",
+      "domain_hint": "cobalt-core"
+    },
+    {
+      "file": "skills/cobalt-core/references/concurrency-patterns.md",
+      "line_range": [
+        180,
+        205
+      ],
+      "block_text": "### \u274c Skipping ClearScrapeCache() on Error Exit\n\n**Detection**:\n```bash\nrg 'ClearScrapeCache' --type go\ngrep -rn 'ClearScrapeCache' --include=\"*.go\" .\n```\nConfirm it is called in `defer` or in all exit paths of `retrieveMetrics`.\n\n**What it looks like**:\n```go\nfunc (s *ServiceImpl) retrieveMetrics(ctx context.Context, ch chan<- prometheus.Metric) {\n    if err := s.connectLibvirt(); err != nil {\n        log.Errorf(\"connect: %v\", err)\n        return // scrape cache NOT cleared \u2014 stale data persist...",
+      "domain_hint": "cobalt-core"
+    },
+    {
+      "file": "skills/cobalt-core/references/concurrency-patterns.md",
+      "line_range": [
+        207,
+        231
+      ],
+      "block_text": "### \u274c Plain map for Concurrent Domain State\n\n**Detection**:\n```bash\nrg 'map\\[string\\]' --type go internal/libvirt/\ngrep -n \"map\\[string\\]\" internal/libvirt/*.go\n```\nAny `map[string]` accessed from goroutines without a wrapping mutex is a data race.\n\n**What it looks like**:\n```go\nvar history = map[string]uint64{} // shared, no mutex\n\nfunc updateHistory(key string, val uint64) uint64 {\n    prev := history[key]  // concurrent read \u2014 data race\n    history[key] = val    // concurrent write \u2014 data rac...",
+      "domain_hint": "cobalt-core"
+    },
+    {
+      "file": "skills/cobalt-core/references/testing-patterns.md",
+      "line_range": [
+        130,
+        130
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "cobalt-core"
+    },
+    {
+      "file": "skills/cobalt-core/references/testing-patterns.md",
+      "line_range": [
+        132,
+        155
+      ],
+      "block_text": "### \u274c Hand-Editing interface_mock_gen.go\n\n**Detection**:\n```bash\ngit log --oneline internal/libvirt/interface_mock_gen.go\ngrep -n \"hand\" internal/libvirt/interface_mock_gen.go\nrg 'interface_mock_gen' --type go\n```\nCheck if the file has commits that don't come from `make generate`.\n\n**What it looks like**:\n```go\n// In interface_mock_gen.go \u2014 manually added method:\nfunc (m *LibVirtMock) NewMethod(ctx context.Context) error {\n    // hand-written \u2014 not from moq\n    return nil\n}\n```\n\n**Why wrong**: T...",
+      "domain_hint": "cobalt-core"
+    },
+    {
+      "file": "skills/cobalt-core/references/testing-patterns.md",
+      "line_range": [
+        157,
+        182
+      ],
+      "block_text": "### \u274c Skipping Race Detector in Tests with Goroutines\n\n**Detection**:\n```bash\nrg 'go test' Makefile\ngrep -n \"go test\" Makefile\n```\nCheck that all `go test` invocations in Makefile include `-race`.\n\n**What it looks like**:\n```makefile\ntest:\n    go test ./internal/...   # no -race\n```\n\n**Why wrong**: kvm-exporter's domain collection is concurrent. Tests that exercise collection without `-race` can pass even with data races \u2014 the race detector is not enabled by default. Race conditions surface only...",
+      "domain_hint": "cobalt-core"
+    },
+    {
+      "file": "skills/cobalt-core/references/testing-patterns.md",
+      "line_range": [
+        219,
+        230
+      ],
+      "block_text": "# Compare against collector list in DISABLED_COLLECTORS docs\n```\nIf a new collector name does not appear in `test-metrics.sh`, its E2E coverage is missing.\n\n**What it looks like**:\nNew collector `hugepages` is added to `internal/libvirt/hugepages.go` but `test/test-metrics.sh` has no `check_metric \"kvm_domain_hugepages_bytes\"` line.\n\n**Why wrong**: Unit tests cover the mock path. The E2E cluster deploys the exporter against real VMs. If hugepages collection silently returns no metrics (e.g., sma...",
+      "domain_hint": "cobalt-core"
+    },
+    {
+      "file": "skills/code-linting/references/biome-rules-reference.md",
+      "line_range": [
+        110,
+        110
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "code-linting"
+    },
+    {
+      "file": "skills/code-linting/references/biome-rules-reference.md",
+      "line_range": [
+        166,
+        191
+      ],
+      "block_text": "### \u274c Using `let` when `const` suffices (useConst)\n\n**Detection**:\n```bash\nruff check --select UP .  # Python only \u2014 for JS/TS use Biome directly\nnpx @biomejs/biome check --reporter=json src/ | python3 -c \"\nimport json,sys; data=json.load(sys.stdin)\n[print(d['location']['path']['file'], d['rule_name']) for d in data.get('diagnostics',[]) if 'useConst' in d.get('rule_name','')]\n\"\n```\n\n**What it looks like**:\n```typescript\nlet name = \"Alice\";   // never reassigned below\nlet config = { debug: false...",
+      "domain_hint": "code-linting"
+    },
+    {
+      "file": "skills/code-linting/references/biome-rules-reference.md",
+      "line_range": [
+        193,
+        222
+      ],
+      "block_text": "### \u274c TypeScript `any` type annotation (noExplicitAny)\n\n**Detection**:\n```bash\ngrep -rn ': any\\b\\|as any\\b' --include=\"*.ts\" --include=\"*.tsx\"\nrg ':\\s*any\\b|as any\\b' --type ts\n```\n\n**What it looks like**:\n```typescript\nfunction process(data: any): any {\n    return data.value;\n}\nconst result = response as any;\n```\n\n**Why wrong**: `any` disables TypeScript's type checker for that value. Errors that TypeScript would catch at compile time become runtime crashes. Propagates through the codebase \u2014 on...",
+      "domain_hint": "code-linting"
+    },
+    {
+      "file": "skills/code-linting/references/biome-rules-reference.md",
+      "line_range": [
+        250,
+        276
+      ],
+      "block_text": "### \u274c Optional chain avoidance (useOptionalChain)\n\n**Detection**:\n```bash\ngrep -rn '&& .*\\.' --include=\"*.ts\" --include=\"*.tsx\"\nrg '\\w+\\s*&&\\s*\\w+\\.' --type ts\n```\n\n**What it looks like**:\n```typescript\nconst city = user && user.address && user.address.city;\nconst len = arr && arr.length;\nconst name = response && response.data && response.data.user && response.data.user.name;\n```\n\n**Why wrong**: Manual null checks via `&&` chains are verbose and easy to get wrong (short-circuits at wrong level)....",
+      "domain_hint": "code-linting"
+    },
+    {
+      "file": "skills/code-linting/references/ruff-rules-reference.md",
+      "line_range": [
+        82,
+        82
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "code-linting"
+    },
+    {
+      "file": "skills/code-linting/references/ruff-rules-reference.md",
+      "line_range": [
+        84,
+        114
+      ],
+      "block_text": "### \u274c Using `== None` / `== True` / `== False` (E711/E712)\n\n**Detection**:\n```bash\ngrep -rn '== None\\|== True\\|== False\\|!= None' --include=\"*.py\"\nrg '(==|!=)\\s+(None|True|False)' --type py\n```\n\n**What it looks like**:\n```python\nif result == None:\n    return\nif flag == True:\n    process()\nif items != None and len(items) == 0:\n    return []\n```\n\n**Why wrong**: `== None` uses equality comparison for an identity check. Works in CPython but `is None` is correct and triggers no E711. `== True` trigge...",
+      "domain_hint": "code-linting"
+    },
+    {
+      "file": "skills/code-linting/references/ruff-rules-reference.md",
+      "line_range": [
+        116,
+        146
+      ],
+      "block_text": "### \u274c Mutable default argument (B006)\n\n**Detection**:\n```bash\nrg 'def \\w+\\([^)]*=\\s*(\\[\\]|\\{\\}|\\(\\))' --type py\ngrep -rn 'def .*=\\s*\\[\\|def .*=\\s*{' --include=\"*.py\"\n```\n\n**What it looks like**:\n```python\ndef append_item(item, container=[]):   # B006\n    container.append(item)\n    return container\n\ndef merge_config(opts={}):  # B006\n    opts.update({\"debug\": False})\n    return opts\n```\n\n**Why wrong**: Default argument is evaluated once at function definition time. All callers share the same list...",
+      "domain_hint": "code-linting"
+    },
+    {
+      "file": "skills/code-linting/references/ruff-rules-reference.md",
+      "line_range": [
+        148,
+        167
+      ],
+      "block_text": "### \u274c Deprecated typing generics (UP006/UP007/UP035)\n\n**Detection**:\n```bash\ngrep -rn 'from typing import.*List\\|from typing import.*Dict\\|from typing import.*Optional' --include=\"*.py\"\nrg 'typing\\.(List|Dict|Optional|Tuple|Set|FrozenSet)\\[' --type py\n```\n\n**What it looks like**:\n```python\nfrom typing import List, Dict, Optional, Tuple\n\ndef process(items: List[str], config: Dict[str, int]) -> Optional[Tuple[int, str]]:\n    ...\n```\n\n**Why wrong**: Python 3.9+ supports `list[str]`, `dict[str, int]...",
+      "domain_hint": "code-linting"
+    },
+    {
+      "file": "skills/code-linting/references/ruff-rules-reference.md",
+      "line_range": [
+        183,
+        209
+      ],
+      "block_text": "### \u274c Lambda capturing loop variable (B023)\n\n**Detection**:\n```bash\nrg 'lambda.*:\\s*.*\\b\\w+\\b' --type py -A2 | grep -B2 'for .* in'\ngrep -rn 'lambda' --include=\"*.py\"\n```\n\n**What it looks like**:\n```python\nhandlers = [lambda x: x + i for i in range(5)]   # all lambdas use i=4\ncallbacks = []\nfor name in names:\n    callbacks.append(lambda: process(name))  # all use final name\n```\n\n**Why wrong**: Lambda captures the variable by reference, not value. By execution time, the loop variable holds its fi...",
+      "domain_hint": "code-linting"
+    },
+    {
+      "file": "skills/code-linting/references/ruff-rules-reference.md",
+      "line_range": [
+        211,
+        236
+      ],
+      "block_text": "### \u274c Unused imports not cleaned up (F401)\n\n**Detection**:\n```bash\nruff check --select F401 . --config pyproject.toml\nrg '^import |^from .* import' --type py\n```\n\n**What it looks like**:\n```python\nimport os       # never used below\nimport sys      # never used below\nfrom pathlib import Path  # used\n```\n\n**Why wrong**: Dead imports slow startup, confuse readers, and fail CI. Common culprit: imports used in removed code, or imports that were only in type comments.\n\n**Fix**:\n```bash\nruff check --fi...",
+      "domain_hint": "code-linting"
+    },
+    {
+      "file": "skills/codebase-analyzer/references/three-lenses.md",
+      "line_range": [
+        205,
+        205
+      ],
+      "block_text": "## Avoiding False Positives\n",
+      "domain_hint": "codebase-analyzer"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        1,
+        3
+      ],
+      "block_text": "# Comment Quality Anti-Patterns\n\nThis document catalogs common problematic patterns found in code comments and documentation, with explanations of why they're problematic and how to fix them.\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        5,
+        5
+      ],
+      "block_text": "## High Priority Anti-Patterns\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        7,
+        20
+      ],
+      "block_text": "### Anti-Pattern 1: \"X now does Y\"\n**Problem**: The word \"now\" implies a temporal change - something used to work differently\n**Why it's bad**: Future readers don't care what it used to do, only what it does currently\n**Examples**:\n```go\n// Bad: validateInput now checks for SQL injection\n// Good: validateInput checks for SQL injection patterns\n\n// Bad: The API now returns JSON instead of XML\n// Good: The API returns JSON responses\n\n// Bad: Errors now include stack traces\n// Good: Errors include ...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        22,
+        35
+      ],
+      "block_text": "### Anti-Pattern 2: \"Improved/Better/Enhanced X\"\n**Problem**: Comparative adjectives imply comparison to a past state\n**Why it's bad**: \"Better\" is meaningless without knowing what came before; focus on current behavior\n**Examples**:\n```go\n// Bad: Uses improved caching mechanism\n// Good: Uses LRU cache with 1000-entry limit\n\n// Bad: Provides better error messages\n// Good: Provides error messages with error codes and context\n\n// Bad: Enhanced performance through parallel processing\n// Good: Proce...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        37,
+        50
+      ],
+      "block_text": "### Anti-Pattern 3: \"Fixed bug where...\"\n**Problem**: References a bug that existed in the past\n**Why it's bad**: Code should explain current behavior, not past problems\n**Examples**:\n```go\n// Bad: Fixed bug where nil caused panic\n// Good: Guards against nil to prevent panic\n\n// Bad: Fixed race condition in counter\n// Good: Mutex protects counter from concurrent modification\n\n// Bad: Fixed memory leak by closing connections\n// Good: Closes connections to prevent resource exhaustion\n```\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        52,
+        65
+      ],
+      "block_text": "### Anti-Pattern 4: \"Added/Removed/Changed X\"\n**Problem**: Development activity language describes history, not current state\n**Why it's bad**: Focuses on what changed rather than what exists\n**Examples**:\n```go\n// Bad: Added validation for email format\n// Good: Validates email format using RFC 5322 regex\n\n// Bad: Removed deprecated authentication method\n// Good: Authenticates using JWT tokens\n\n// Bad: Changed database from MySQL to PostgreSQL\n// Good: Uses PostgreSQL with connection pooling\n```...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        67,
+        80
+      ],
+      "block_text": "### Anti-Pattern 5: \"New/Old system/approach/method\"\n**Problem**: Temporal designation of current vs previous implementation\n**Why it's bad**: Everything is \"new\" until it's \"old\" - these labels are time-dependent\n**Examples**:\n```go\n// Bad: The new authentication system uses OAuth\n// Good: Authenticates using OAuth 2.0 with PKCE\n\n// Bad: Replaced old caching with new Redis-based cache\n// Good: Caches frequently accessed data in Redis\n\n// Bad: New error handling approach\n// Good: Error handling ...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        82,
+        82
+      ],
+      "block_text": "## Medium Priority Anti-Patterns\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        84,
+        97
+      ],
+      "block_text": "### Anti-Pattern 6: \"Updated/Refactored/Optimized X\"\n**Problem**: Past tense development activity\n**Why it's bad**: Tells you something changed, not what it does now\n**Examples**:\n```go\n// Bad: Updated to use goroutines\n// Good: Processes tasks concurrently using goroutines\n\n// Bad: Refactored for better maintainability\n// Good: Separates concerns: validation, processing, storage\n\n// Bad: Optimized database queries\n// Good: Uses indexed columns for O(log n) lookups\n```\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        99,
+        112
+      ],
+      "block_text": "### Anti-Pattern 7: \"This allows us to...\" / \"We can now...\"\n**Problem**: Focuses on capability gained rather than current functionality\n**Why it's bad**: \"Allows us to\" implies past limitation; describe what it does\n**Examples**:\n```go\n// Bad: This allows us to handle larger datasets\n// Good: Handles datasets up to 1GB using streaming\n\n// Bad: We can now process requests in parallel\n// Good: Processes up to 10 requests concurrently\n\n// Bad: This allows for better error reporting\n// Good: Report...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        129,
+        142
+      ],
+      "block_text": "### Anti-Pattern 9: \"Temporary/Interim/Stopgap X\"\n**Problem**: Indicates non-permanent solution without context\n**Why it's bad**: If it's truly temporary, fix it properly or explain the constraint\n**Examples**:\n```go\n// Bad: Temporary workaround for database limitation\n// Good: Performs aggregation in-memory because database lacks GROUP BY support\n\n// Bad: Interim solution until API v2\n// Good: Uses v1 API endpoint /users (v2 migration pending - requires server upgrade)\n\n// Bad: Stopgap until pr...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        144,
+        157
+      ],
+      "block_text": "### Anti-Pattern 10: \"As of version X\" / \"Since version X\"\n**Problem**: Ties comment to specific version timeline\n**Why it's bad**: Future readers don't care when it was introduced, only what it does\n**Examples**:\n```go\n// Bad: As of v2.0, supports WebSocket connections\n// Good: Supports WebSocket connections for real-time updates\n\n// Bad: Since version 1.5, validates input data\n// Good: Validates input data against schema\n\n// Bad: Available from v3.0 onwards\n// Good: Available in current versio...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        159,
+        159
+      ],
+      "block_text": "## Subtle Anti-Patterns\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        161,
+        174
+      ],
+      "block_text": "### Anti-Pattern 11: \"More/Less efficient/effective\"\n**Problem**: Relative comparison without baseline\n**Why it's bad**: \"More efficient\" compared to what? Be specific.\n**Examples**:\n```go\n// Bad: More efficient algorithm for sorting\n// Good: QuickSort provides O(n log n) average case\n\n// Bad: Less memory intensive approach\n// Good: Streams data in 1KB chunks to limit memory to 10MB\n\n// Bad: More effective error handling\n// Good: Error handling with retry logic (3 attempts, exponential backoff)\n...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        176,
+        189
+      ],
+      "block_text": "### Anti-Pattern 12: \"Unlike X\" / \"Compared to X\"\n**Problem**: Defines behavior by what it's not\n**Why it's bad**: Focuses on difference rather than actual behavior\n**Examples**:\n```go\n// Bad: Unlike the previous version, this doesn't cache\n// Good: Fetches fresh data on every request (no caching)\n\n// Bad: Compared to the old system, this is faster\n// Good: Responds within 100ms (p95 latency)\n\n// Bad: Unlike other methods, this is thread-safe\n// Good: Thread-safe: uses mutex for concurrent acces...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        191,
+        204
+      ],
+      "block_text": "### Anti-Pattern 13: \"Will/Going to/Eventually X\"\n**Problem**: Future tense for current code\n**Why it's bad**: Code should describe current state, not future plans\n**Examples**:\n```go\n// Bad: Will support pagination in future\n// Good: TODO: Add pagination support for result sets > 1000 items\n\n// Bad: Going to be replaced with GraphQL API\n// Good: REST API (GraphQL migration planned - see ROADMAP.md)\n\n// Bad: Eventually will use Redis for caching\n// Good: In-memory cache (Redis integration tracke...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        206,
+        219
+      ],
+      "block_text": "### Anti-Pattern 14: \"Used to X but now Y\"\n**Problem**: Explicit before/after comparison\n**Why it's bad**: Historical context doesn't help understand current code\n**Examples**:\n```go\n// Bad: Used to return nil but now returns empty slice\n// Good: Returns empty slice (never nil) when no results found\n\n// Bad: Used to block but now times out after 5 seconds\n// Good: Times out after 5 seconds to prevent indefinite blocking\n\n// Bad: Used to be synchronous but now async\n// Good: Processes asynchronou...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        221,
+        234
+      ],
+      "block_text": "### Anti-Pattern 15: \"Originally X\"\n**Problem**: References original implementation\n**Why it's bad**: Original design is irrelevant to current functionality\n**Examples**:\n```go\n// Bad: Originally designed for single-threaded use\n// Good: Not thread-safe - use separate instance per goroutine\n\n// Bad: Originally returned XML, now JSON\n// Good: Returns JSON response with content-type application/json\n\n// Bad: Originally limited to 100 items\n// Good: Returns up to 1000 items (configurable via MAX_IT...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        286,
+        286
+      ],
+      "block_text": "### Go-Specific Anti-Patterns\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        288,
+        292
+      ],
+      "block_text": "#### Anti-Pattern: \"Fixed panic\"\n```go\n// Bad: Fixed panic when receiver is nil\n// Good: Returns error when receiver is nil to prevent panic\n```\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        294,
+        298
+      ],
+      "block_text": "#### Anti-Pattern: \"Now uses context\"\n```go\n// Bad: Updated to use context for cancellation\n// Good: Accepts context for cancellation and timeout control\n```\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        300,
+        304
+      ],
+      "block_text": "#### Anti-Pattern: \"Improved error handling\"\n```go\n// Bad: Improved error handling with wrapping\n// Good: Wraps errors with operation context using fmt.Errorf\n```\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        306,
+        306
+      ],
+      "block_text": "### Python-Specific Anti-Patterns\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        308,
+        309
+      ],
+      "block_text": "#### Anti-Pattern: \"Changed to use type hints\"\n```python",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        314,
+        315
+      ],
+      "block_text": "#### Anti-Pattern: \"Refactored to use dataclass\"\n```python",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        320,
+        320
+      ],
+      "block_text": "### JavaScript/TypeScript Anti-Patterns\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        322,
+        326
+      ],
+      "block_text": "#### Anti-Pattern: \"Migrated to async/await\"\n```javascript\n// Bad: Migrated from promises to async/await\n// Good: Uses async/await for sequential asynchronous operations\n```\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        328,
+        332
+      ],
+      "block_text": "#### Anti-Pattern: \"Updated to ES6 syntax\"\n```javascript\n// Bad: Updated to use arrow functions\n// Good: Arrow function preserves outer 'this' context\n```\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        334,
+        334
+      ],
+      "block_text": "## Documentation-Specific Anti-Patterns\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        338,
+        339
+      ],
+      "block_text": "#### Anti-Pattern: Version-specific feature lists\n```markdown",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        351,
+        352
+      ],
+      "block_text": "#### Anti-Pattern: Historical installation instructions\n```markdown",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        366,
+        367
+      ],
+      "block_text": "#### Anti-Pattern: Endpoint evolution\n```markdown",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/anti-patterns.md",
+      "line_range": [
+        379,
+        380
+      ],
+      "block_text": "#### Anti-Pattern: Parameter history\n```markdown",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/error-handling-patterns.md",
+      "line_range": [
+        1,
+        8
+      ],
+      "block_text": "# Error Handling Comment Anti-Patterns\n\n> **Scope**: Temporal and activity-based comment anti-patterns in error handling code, across\n> Go, Python, JavaScript, and TypeScript.\n> **Version range**: Go 1.13+ (error wrapping), Python 3.11+ (exception groups)\n> **Generated**: 2026-04-16\n\n---\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/error-handling-patterns.md",
+      "line_range": [
+        19,
+        19
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/error-handling-patterns.md",
+      "line_range": [
+        21,
+        59
+      ],
+      "block_text": "### \u274c \"Fixed bug where X caused error Y\" \u2014 Bug archaeology\n\n**Detection**:\n```bash\ngrep -rn '//.*[Ff]ixed.*\\(bug\\|issue\\|error\\|problem\\|crash\\)\\|//.*[Bb]ug.*fix' \\\n  --include=\"*.go\" --include=\"*.py\" --include=\"*.ts\" --include=\"*.js\"\nrg '//\\s*(Fixed|Fixes|Patched|Resolved) (bug|issue|error|crash|problem)' -i\n```\n\n**What it looks like**:\n```go\n// Fixed bug where nil map access caused panic during error aggregation\nif errs == nil {\n    errs = make(map[string]error)\n}\n\n// Fixed error swallowing is...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/error-handling-patterns.md",
+      "line_range": [
+        61,
+        91
+      ],
+      "block_text": "### \u274c \"Better/improved/enhanced error messages\" \u2014 Enhancement residue\n\n**Detection**:\n```bash\ngrep -rn '//.*\\(better\\|improved\\|enhanced\\|richer\\|more descriptive\\).*\\(error\\|message\\|msg\\)' \\\n  --include=\"*.go\" --include=\"*.py\" --include=\"*.ts\" -i\nrg '//\\s*(better|improved|enhanced) (error|err|message)' -i\n```\n\n**What it looks like**:\n```go\n// Provides better error messages with more context\nreturn fmt.Errorf(\"validate user %d: field %q: %w\", id, field, err)\n\n// Improved error reporting to incl...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/error-handling-patterns.md",
+      "line_range": [
+        93,
+        140
+      ],
+      "block_text": "### \u274c \"Added retry logic\" / \"Now retries on failure\" \u2014 Capability addition\n\n**Detection**:\n```bash\ngrep -rn '//.*added.*retr\\|//.*now.*retr\\|//.*retr.*added\\|//.*retr.*now' \\\n  --include=\"*.go\" --include=\"*.py\" --include=\"*.ts\" -i\nrg '//\\s*(added|now (has|includes|uses)) retry' -i\n```\n\n**What it looks like**:\n```go\n// Added retry logic to handle transient failures\nfunc callWithRetry(ctx context.Context, fn func() error) error {\n    for i := 0; i < 3; i++ {\n        if err := fn(); err == nil {\n  ...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/error-handling-patterns.md",
+      "line_range": [
+        142,
+        177
+      ],
+      "block_text": "### \u274c \"Changed error type from X to Y\" \u2014 Migration narrative\n\n**Detection**:\n```bash\ngrep -rn '//.*changed.*error\\|//.*error.*changed\\|//.*switched.*error\\|//.*error.*switched' \\\n  --include=\"*.go\" --include=\"*.py\" --include=\"*.ts\" -i\nrg '//\\s*(changed|switched|migrated) (error|exception) (type|from|to)' -i\n```\n\n**What it looks like**:\n```go\n// Changed from returning bool to returning error for better composability\nfunc Validate(input string) error { ... }\n\n// Switched to custom error types inst...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/error-handling-patterns.md",
+      "line_range": [
+        179,
+        189
+      ],
+      "block_text": "### \u274c Python: \"Added exception handling for X\"\n\n**Detection**:\n```bash\ngrep -rn '#.*added.*except\\|#.*now.*except\\|#.*handles.*exception.*added' \\\n  --include=\"*.py\" -i\nrg '#\\s*(added|now handles|catches) (exception|error)' --type py -i\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/error-handling-patterns.md",
+      "line_range": [
+        197,
+        207
+      ],
+      "block_text": "# Now catches ValueError to avoid crashing on bad input\ntry:\n    value = int(raw)\nexcept ValueError:\n    return default\n```\n\n**Why wrong**: Describes the history of adding the handler, not what it handles or why.\n\n**Fix**:\n```python",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/error-handling-patterns.md",
+      "line_range": [
+        224,
+        261
+      ],
+      "block_text": "### \u274c TypeScript/JavaScript: \"Now handles promise rejection\"\n\n**Detection**:\n```bash\ngrep -rn '//.*now.*reject\\|//.*added.*catch\\|//.*handles.*rejection.*now' \\\n  --include=\"*.ts\" --include=\"*.js\" -i\nrg '//\\s*(now handles|added) (promise rejection|catch|error handling)' -i\n```\n\n**What it looks like**:\n```typescript\n// Now handles promise rejection to prevent unhandled promise errors\nasync function fetchData(url: string): Promise<Data> {\n    try {\n        const res = await fetch(url);\n        ret...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/examples.md",
+      "line_range": [
+        264,
+        264
+      ],
+      "block_text": "## Common Pitfalls to Avoid\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/go-comment-patterns.md",
+      "line_range": [
+        1,
+        7
+      ],
+      "block_text": "# Go Comment Anti-Patterns\n\n> **Scope**: Temporal and activity-based comment anti-patterns specific to Go source files.\n> **Version range**: Go 1.13+ (error wrapping), Go 1.18+ (generics)\n> **Generated**: 2026-04-16\n\n---\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/go-comment-patterns.md",
+      "line_range": [
+        19,
+        19
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/go-comment-patterns.md",
+      "line_range": [
+        21,
+        50
+      ],
+      "block_text": "### \u274c \"Now uses context\" \u2014 Concurrency migration residue\n\n**Detection**:\n```bash\ngrep -rn '//.*now.*context\\|//.*context.*now\\|//.*added.*context' --include=\"*.go\" -i\nrg '//.*now uses context|//.*added context|//.*context.*added' --type go -i\n```\n\n**What it looks like**:\n```go\n// Bad: Updated to use context for cancellation\nfunc FetchUser(ctx context.Context, id int) (*User, error) { ... }\n\n// Bad: Now propagates context to downstream calls\nfunc processRequest(ctx context.Context, req *Request) ...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/go-comment-patterns.md",
+      "line_range": [
+        52,
+        87
+      ],
+      "block_text": "### \u274c \"Fixed panic\" / \"Fixed nil\" \u2014 Bug fix residue\n\n**Detection**:\n```bash\ngrep -rn '//.*[Ff]ixed.*\\(panic\\|nil\\|crash\\|race\\)' --include=\"*.go\"\nrg '//\\s*(Fixed|Fixes|Fixing) (panic|nil|crash|race condition)' --type go\n```\n\n**What it looks like**:\n```go\n// Fixed panic when receiver is nil\nif r == nil {\n    return errors.New(\"nil receiver\")\n}\n\n// Fixed race condition by adding mutex\nmu.Lock()\ndefer mu.Unlock()\n```\n\n**Why wrong**: The bug is gone. \"Fixed\" describes historical surgery; the invaria...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/go-comment-patterns.md",
+      "line_range": [
+        89,
+        123
+      ],
+      "block_text": "### \u274c \"Improved error handling\" / \"Better errors\"\n\n**Detection**:\n```bash\ngrep -rn '//.*\\(improved\\|better\\|enhanced\\).*err\\|//.*err.*\\(improved\\|better\\|enhanced\\)' --include=\"*.go\" -i\nrg '//\\s*(improved|better|enhanced) error' --type go -i\n```\n\n**What it looks like**:\n```go\n// Improved error handling for database operations\nfunc queryUser(id int) (*User, error) {\n    if err != nil {\n        return nil, fmt.Errorf(\"query user %d: %w\", id, err)\n    }\n}\n```\n\n**Why wrong**: \"Improved\" is relative ...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/go-comment-patterns.md",
+      "line_range": [
+        125,
+        164
+      ],
+      "block_text": "### \u274c \"Updated to use goroutines\" \u2014 Parallelism migration\n\n**Detection**:\n```bash\ngrep -rn '//.*\\(updated\\|changed\\|switched\\|migrated\\).*goroutine\\|//.*now.*concurrent' --include=\"*.go\" -i\nrg '//\\s*(updated|changed|switched) to (use )?goroutine' --type go -i\n```\n\n**What it looks like**:\n```go\n// Updated to use goroutines for better performance\nfunc processItems(items []Item) error {\n    var wg sync.WaitGroup\n    for _, item := range items {\n        wg.Add(1)\n        go func(it Item) { defer wg....",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/go-comment-patterns.md",
+      "line_range": [
+        166,
+        192
+      ],
+      "block_text": "### \u274c Package-level doc comments with activity language\n\n**Detection**:\n```bash\ngrep -rn '^// Package.*\\b\\(added\\|updated\\|improved\\|fixed\\|now\\|new\\|recently\\|refactored\\)\\b' --include=\"*.go\" -i\nrg '^// Package \\w+ (was|has been|now|recently|is new)' --type go\n```\n\n**What it looks like**:\n```go\n// Package auth provides authentication. Recently updated to support OAuth 2.0 and JWT.\n\n// Package cache was refactored to use Redis instead of in-memory storage.\n```\n\n**Why wrong**: Package doc comment...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/performance-patterns.md",
+      "line_range": [
+        1,
+        8
+      ],
+      "block_text": "# Performance Comment Anti-Patterns\n\n> **Scope**: Temporal and relative-comparison comment anti-patterns in performance-sensitive\n> code: caching, batching, concurrency limits, and algorithmic complexity notes.\n> **Version range**: All languages; Go goroutine pool patterns, Python asyncio, JS Promise.all\n> **Generated**: 2026-04-16\n\n---\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/performance-patterns.md",
+      "line_range": [
+        20,
+        20
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/performance-patterns.md",
+      "line_range": [
+        22,
+        71
+      ],
+      "block_text": "### \u274c \"Optimized/improved for performance\" \u2014 Vague praise\n\n**Detection**:\n```bash\ngrep -rn '//.*optimized.*\\(for\\|performance\\|speed\\|efficiency\\)\\|//.*improved.*performance' \\\n  --include=\"*.go\" --include=\"*.py\" --include=\"*.ts\" --include=\"*.js\" -i\nrg '//\\s*(optimized|improved|enhanced|tuned) (for )?(performance|speed|efficiency|throughput)' -i\n```\n\n**What it looks like**:\n```go\n// Optimized for performance using goroutine pool\nfunc processQueue(items []Item) {\n    sem := make(chan struct{}, 10...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/performance-patterns.md",
+      "line_range": [
+        73,
+        83
+      ],
+      "block_text": "### \u274c \"Faster than X\" / \"More efficient than X\" \u2014 Comparative without baseline\n\n**Detection**:\n```bash\ngrep -rn '//.*faster than\\|//.*more efficient than\\|//.*quicker than\\|//.*slower than' \\\n  --include=\"*.go\" --include=\"*.py\" --include=\"*.ts\" --include=\"*.js\" -i\nrg '//\\s*(faster|more efficient|quicker|better) than' -i\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/performance-patterns.md",
+      "line_range": [
+        87,
+        102
+      ],
+      "block_text": "# More efficient than loading all records at once\ndef get_users_paginated(page_size=100):\n    offset = 0\n    while True:\n        batch = db.query(User).limit(page_size).offset(offset).all()\n        if not batch:\n            break\n        yield batch\n        offset += page_size\n```\n\n**Why wrong**: \"Faster than sequential\" is historical context. How much faster? Under what\nconditions? The reader needs to know what the parallelism model is and its trade-offs.\n\n**Fix**:\n```python",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/performance-patterns.md",
+      "line_range": [
+        107,
+        107
+      ],
+      "block_text": "# Streams users in batches of 100 to avoid loading the full table into memory.",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/performance-patterns.md",
+      "line_range": [
+        121,
+        161
+      ],
+      "block_text": "### \u274c \"Now uses cache\" / \"Added caching\" \u2014 Cache capability addition\n\n**Detection**:\n```bash\ngrep -rn '//.*now.*cach\\|//.*added.*cach\\|//.*cach.*now\\|//.*cach.*added' \\\n  --include=\"*.go\" --include=\"*.py\" --include=\"*.ts\" --include=\"*.js\" -i\nrg '//\\s*(now uses|added|uses) (a |the )?(cache|caching|LRU|Redis)' -i\n```\n\n**What it looks like**:\n```go\n// Now uses Redis cache to avoid repeated database lookups\nfunc getUser(id int) (*User, error) {\n    if v, ok := cache.Get(id); ok {\n        return v.(*...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/performance-patterns.md",
+      "line_range": [
+        163,
+        173
+      ],
+      "block_text": "### \u274c \"Optimized database queries\" / \"Reduced N+1\" \u2014 Query optimization narrative\n\n**Detection**:\n```bash\ngrep -rn '//.*optimized.*quer\\|//.*quer.*optimized\\|//.*N\\+1\\|//.*reduced.*quer' \\\n  --include=\"*.go\" --include=\"*.py\" --include=\"*.ts\" --include=\"*.js\" -i\nrg '//\\s*(optimized|reduced|fixed) (query|queries|N\\+1|database)' -i\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/performance-patterns.md",
+      "line_range": [
+        174,
+        175
+      ],
+      "block_text": "# Optimized to avoid N+1 query problem\nusers = User.objects.prefetch_related('orders').filter(active=True)\n",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/performance-patterns.md",
+      "line_range": [
+        177,
+        186
+      ],
+      "block_text": "# Reduced database queries by batching inserts\ndef bulk_insert(records):\n    db.bulk_create(records, batch_size=500)\n```\n\n**Why wrong**: \"Optimized to avoid\" is history. The current behavior \u2014 eager loading, batch\nsize, indexed column \u2014 is what matters.\n\n**Fix**:\n```python",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/performance-patterns.md",
+      "line_range": [
+        197,
+        226
+      ],
+      "block_text": "### \u274c \"Replaced X with Y for better performance\" \u2014 Replacement narrative\n\n**Detection**:\n```bash\ngrep -rn '//.*replaced.*\\(better\\|improve\\|faster\\|performance\\)\\|//.*\\(better\\|improve\\|faster\\|performance\\).*replaced' \\\n  --include=\"*.go\" --include=\"*.py\" --include=\"*.ts\" --include=\"*.js\" -i\nrg '//\\s*replaced .* (for|with) better (performance|speed|efficiency)' -i\n```\n\n**What it looks like**:\n```typescript\n// Replaced array.find() with Map for better performance on large collections\nconst userI...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/comment-quality/references/performance-patterns.md",
+      "line_range": [
+        228,
+        268
+      ],
+      "block_text": "### \u274c \"Reduced memory usage\" / \"Less memory\" \u2014 Vague memory claim\n\n**Detection**:\n```bash\ngrep -rn '//.*reduced.*memory\\|//.*less.*memory\\|//.*memory.*reduced\\|//.*lower.*memory' \\\n  --include=\"*.go\" --include=\"*.py\" --include=\"*.ts\" --include=\"*.js\" -i\nrg '//\\s*(reduced|lower|less|minimal) memory' -i\n```\n\n**What it looks like**:\n```go\n// Reduced memory usage by streaming instead of loading all data\nfunc exportCSV(w io.Writer, db *DB) error {\n    rows, _ := db.Query(\"SELECT * FROM users\")\n    de...",
+      "domain_hint": "comment-quality"
+    },
+    {
+      "file": "skills/condition-based-waiting/references/anti-patterns.md",
+      "line_range": [
+        1,
+        7
+      ],
+      "block_text": "# Wait/Retry Anti-Patterns\n\n> **Scope**: Common mistakes in polling, retry, and backoff code \u2014 detection commands and fixes.\n> **Version range**: Python 3.8+, Bash (any POSIX)\n> **Generated**: 2026-04-16\n\n---\n",
+      "domain_hint": "condition-based-waiting"
+    },
+    {
+      "file": "skills/condition-based-waiting/references/anti-patterns.md",
+      "line_range": [
+        15,
+        15
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "condition-based-waiting"
+    },
+    {
+      "file": "skills/condition-based-waiting/references/anti-patterns.md",
+      "line_range": [
+        17,
+        44
+      ],
+      "block_text": "### \u274c Hardcoded `time.sleep()` Without Condition Check\n\n**Detection**:\n```bash\ngrep -rn 'time\\.sleep(' --include=\"*.py\" | grep -v 'poll_interval\\|wait_for\\|retry\\|backoff'\nrg 'time\\.sleep\\(\\d' --type py\n```\n\n**What it looks like**:\n```python\ndef wait_for_db():\n    time.sleep(5)  # Hope the DB is ready by now\n    return connect()\n```\n\n**Why wrong**: The sleep duration is a guess. If the DB starts in 1s you wasted 4s; if it takes 6s you got a connection error. There is no feedback \u2014 the code never...",
+      "domain_hint": "condition-based-waiting"
+    },
+    {
+      "file": "skills/condition-based-waiting/references/anti-patterns.md",
+      "line_range": [
+        46,
+        59
+      ],
+      "block_text": "### \u274c Infinite Loop Without Timeout\n\n**Detection**:\n```bash\ngrep -rn 'while True' --include=\"*.py\" | grep -v 'timeout\\|deadline\\|monotonic'\nrg 'while True:' --type py -A 5 | grep -v 'break\\|timeout\\|deadline'\n```\n\n**What it looks like**:\n```python\nwhile True:\n    if service_ready():\n        break\n    time.sleep(1)",
+      "domain_hint": "condition-based-waiting"
+    },
+    {
+      "file": "skills/condition-based-waiting/references/anti-patterns.md",
+      "line_range": [
+        60,
+        76
+      ],
+      "block_text": "# Hangs forever if service never becomes ready\n```\n\n**Why wrong**: A downed service turns this into an infinite loop that blocks the process, pegs a thread, and never gives the caller an error to act on.\n\n**Fix**:\n```python\nstart = time.monotonic()\ndeadline = start + timeout_seconds\nwhile time.monotonic() < deadline:\n    if service_ready():\n        return\n    time.sleep(1)\nraise TimeoutError(f\"Service not ready after {timeout_seconds}s\")\n```\n\n---\n",
+      "domain_hint": "condition-based-waiting"
+    },
+    {
+      "file": "skills/condition-based-waiting/references/anti-patterns.md",
+      "line_range": [
+        78,
+        106
+      ],
+      "block_text": "### \u274c Using `time.time()` for Elapsed Time Measurement\n\n**Detection**:\n```bash\nrg 'start\\s*=\\s*time\\.time\\(\\)' --type py\ngrep -rn 'time\\.time()' --include=\"*.py\" | grep -E 'deadline|elapsed|timeout'\n```\n\n**What it looks like**:\n```python\nstart = time.time()\ndeadline = start + timeout\nwhile time.time() < deadline:\n    ...\n```\n\n**Why wrong**: `time.time()` is wall-clock time and jumps backward on NTP sync or DST changes. A 1-second backward jump can cause the loop to run `timeout` extra seconds pa...",
+      "domain_hint": "condition-based-waiting"
+    },
+    {
+      "file": "skills/condition-based-waiting/references/anti-patterns.md",
+      "line_range": [
+        108,
+        135
+      ],
+      "block_text": "### \u274c Retry Without Jitter (Thundering Herd)\n\n**Detection**:\n```bash\ngrep -rn 'sleep.*delay\\|sleep.*backoff' --include=\"*.py\" | grep -v 'jitter\\|random\\|uniform'\nrg 'time\\.sleep\\(delay\\)' --type py\n```\n\n**What it looks like**:\n```python\nfor attempt in range(max_retries):\n    try:\n        return call_api()\n    except RequestException:\n        time.sleep(delay)\n        delay *= 2  # No jitter \u2014 all clients wake up simultaneously\n```\n\n**Why wrong**: After an outage, all clients waiting with the sam...",
+      "domain_hint": "condition-based-waiting"
+    },
+    {
+      "file": "skills/condition-based-waiting/references/anti-patterns.md",
+      "line_range": [
+        137,
+        174
+      ],
+      "block_text": "### \u274c Retrying Non-Retryable Errors\n\n**Detection**:\n```bash\ngrep -rn 'except Exception' --include=\"*.py\" -B2 | grep -E 'retry|attempt|backoff'\nrg 'retryable_exceptions.*=.*Exception\\b' --type py\n```\n\n**What it looks like**:\n```python\nfor attempt in range(5):\n    try:\n        return api_call()\n    except Exception:  # Retries 401, 404, validation errors too\n        time.sleep(delay)\n```\n\n**Why wrong**: A 401 Unauthorized will never succeed on retry \u2014 you're burning quota and delaying the inevitab...",
+      "domain_hint": "condition-based-waiting"
+    },
+    {
+      "file": "skills/condition-based-waiting/references/anti-patterns.md",
+      "line_range": [
+        176,
+        188
+      ],
+      "block_text": "### \u274c Busy-Wait (No Sleep in Poll Loop)\n\n**Detection**:\n```bash\ngrep -rn -A 8 'while.*monotonic\\(\\)' --include=\"*.py\" | grep -v 'sleep'\nrg 'while time\\.monotonic' --type py -A 6 | grep -c 'sleep'\n```\n\n**What it looks like**:\n```python\nwhile time.monotonic() < deadline:\n    if condition():\n        return True",
+      "domain_hint": "condition-based-waiting"
+    },
+    {
+      "file": "skills/condition-based-waiting/references/anti-patterns.md",
+      "line_range": [
+        189,
+        202
+      ],
+      "block_text": "# No sleep \u2014 spins at 100% CPU until timeout\n```\n\n**Why wrong**: A tight poll loop consumes 100% of one CPU core, starves other threads/processes, and triggers thermal throttling on laptops.\n\n**Fix**:\n```python\nwhile time.monotonic() < deadline:\n    if condition():\n        return True\n    time.sleep(poll_interval)  # min 0.01s in-process; 0.5s+ for external services\n```\n\n---\n",
+      "domain_hint": "condition-based-waiting"
+    },
+    {
+      "file": "skills/condition-based-waiting/references/anti-patterns.md",
+      "line_range": [
+        204,
+        216
+      ],
+      "block_text": "### \u274c Bash Loop Without Timeout\n\n**Detection**:\n```bash\ngrep -rn 'while.*sleep' --include=\"*.sh\" | grep -v 'deadline\\|SECONDS\\|timeout\\|end_time'\ngrep -rn 'while true' --include=\"*.sh\" -i | grep -v 'deadline\\|SECONDS'\n```\n\n**What it looks like**:\n```bash\nwhile ! pg_isready -h localhost; do\n    sleep 2\ndone",
+      "domain_hint": "condition-based-waiting"
+    },
+    {
+      "file": "skills/condition-based-waiting/references/anti-patterns.md",
+      "line_range": [
+        217,
+        237
+      ],
+      "block_text": "# Hangs indefinitely if postgres never starts\n```\n\n**Why wrong**: No bound means this script hangs in CI until the job times out, with no diagnostic about what failed or how long it waited.\n\n**Fix**:\n```bash\ndeadline=$((SECONDS + 60))\nwhile [ $SECONDS -lt $deadline ]; do\n    if pg_isready -h localhost; then\n        exit 0\n    fi\n    sleep 2\ndone\necho \"Timeout: postgres not ready after 60s\" >&2\nexit 1\n```\n\n**Note**: `$SECONDS` is a bash built-in counting seconds since shell started \u2014 no `date` su...",
+      "domain_hint": "condition-based-waiting"
+    },
+    {
+      "file": "skills/condition-based-waiting/references/testing-patterns.md",
+      "line_range": [
+        228,
+        249
+      ],
+      "block_text": "## Anti-Pattern: Using `time.sleep` in Tests Directly\n\n**Detection**:\n```bash\ngrep -rn 'time\\.sleep' --include=\"test_*.py\"\nrg 'time\\.sleep\\(\\d' --type py -g 'test_*'\n```\n\n**What it looks like**:\n```python\ndef test_retry_waits():\n    # Slow test \u2014 waits real time\n    start = time.time()\n    retry_with_backoff(flaky_op, \"test\", initial_delay_seconds=1.0)\n    assert time.time() - start >= 1.0\n```\n\n**Why wrong**: This makes the test suite slow. A 3-retry test with 1s initial delay takes 7+ real seco...",
+      "domain_hint": "condition-based-waiting"
+    },
+    {
+      "file": "skills/content-calendar/references/error-handling.md",
+      "line_range": [
+        67,
+        67
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/error-handling.md",
+      "line_range": [
+        73,
+        79
+      ],
+      "block_text": "# Find entries where title casing may differ from user input\ngrep -in \"topic keyword\" content-calendar.md\n```\n\n**What it looks like**:\n```\nUser: \"move hugo caching to drafted\"",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/error-handling.md",
+      "line_range": [
+        81,
+        87
+      ],
+      "block_text": "# Error: topic not found\n```\n\n**Why wrong**: Users type partial titles or wrong case. \"Hugo caching\" and \"Hugo partial caching issues\" \u2014 the latter is the real entry. Hard stop wastes user time when a partial match could resolve it.\n\n**Fix**:\n```bash",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/error-handling.md",
+      "line_range": [
+        103,
+        108
+      ],
+      "block_text": "# ... write operation ...\nwc -l content-calendar.md  # after \u2014 should be >= before for add/move\n```\n\n**What it looks like**:\n```",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/error-handling.md",
+      "line_range": [
+        110,
+        117
+      ],
+      "block_text": "# Result: other stages' content is overwritten with cached state\n```\n\n**Why wrong**: The calendar may have been edited manually or by another process between reads. Writing from cached state silently destroys changes. The file is the source of truth, not the model's memory.\n\n**Fix**: Always `Read content-calendar.md` immediately before any write, even if it was read earlier in the same operation.\n\n---\n",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/error-handling.md",
+      "line_range": [
+        123,
+        129
+      ],
+      "block_text": "# Unchecked items in Ready or Published (should all be [x])\ngrep -A 200 \"^## Ready\" content-calendar.md | grep \"^- \\[ \\]\"\ngrep -A 200 \"^## Published\" content-calendar.md | grep \"^- \\[ \\]\"\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/error-handling.md",
+      "line_range": [
+        130,
+        138
+      ],
+      "block_text": "## Ready\n- [ ] **Hugo build errors** (ready: 2025-01-14)  <!-- should be [x] -->\n```\n\n**Why wrong**: Checkbox state `[x]` must flip at the Editing\u2192Ready transition. If a topic lands in Ready as `- [ ]`, the Published and Historical sections will contain unchecked items, making the file unreadable as a kanban board.\n\n**Fix**: Enforce checkbox flip during move-to-ready. If a topic arrives in Ready with `[ ]`, convert to `[x]` before writing.\n\n---\n",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/error-handling.md",
+      "line_range": [
+        148,
+        163
+      ],
+      "block_text": "# Single-digit month/day (should be zero-padded)\ngrep -E \"\\((outline|draft|editing|ready|published): [0-9]{4}-[0-9]-\" content-calendar.md\n```\n\n**What it looks like**:\n```markdown\n- [ ] **Hugo debugging guide** (outline: Jan 10, 2025)\n- [x] **Build errors** (ready: 2025-1-5)\n  - Scheduled: January 20\n```\n\n**Why wrong**: Date parsing logic expects `YYYY-MM-DD`. Non-ISO dates break velocity calculations, stuck-content detection, and archive operations that compare dates to the current month.\n\n**Fix...",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/error-handling.md",
+      "line_range": [
+        165,
+        173
+      ],
+      "block_text": "### \u274c Duplicate Section Headers\n\n**Detection**:\n```bash\ngrep -n \"^## Ideas\\|^## Outlined\\|^## Drafted\\|^## Editing\\|^## Ready\\|^## Published\" content-calendar.md | sort | uniq -d\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/error-handling.md",
+      "line_range": [
+        180,
+        188
+      ],
+      "block_text": "## Ideas        <!-- duplicate \u2014 botched merge or manual edit -->\n- [ ] Topic B\n```\n\n**Why wrong**: Only the first `## Ideas` section is parsed. Topic B is silently invisible to all operations and the count table is wrong.\n\n**Fix**: On load, detect duplicate section headers. Merge content from all instances into one section and warn the user before proceeding.\n\n---\n",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/metrics.md",
+      "line_range": [
+        76,
+        76
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/metrics.md",
+      "line_range": [
+        82,
+        104
+      ],
+      "block_text": "# Find editing entries older than threshold (14 days back)\nCUTOFF=$(python3 -c \"from datetime import date, timedelta; print((date.today() - timedelta(days=14)).isoformat())\")\ngrep -E \"\\(editing: [0-9]{4}-[0-9]{2}-[0-9]{2}\\)\" content-calendar.md | \\\n  awk -F'editing: ' '{print $2}' | tr -d ')' | awk -v c=\"$CUTOFF\" '$1 < c'\n```\n\n**What it looks like**:\n```\nIN PROGRESS:\n  -> \"Hugo debugging guide\" (editing)     \u2190 no age shown\n  -> \"Image optimization\" (drafted)       \u2190 no age shown\n```\n\n**Why wrong...",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/metrics.md",
+      "line_range": [
+        112,
+        128
+      ],
+      "block_text": "# Compare to sum of active stages\ngrep -E \"^\\| (Outlined|Drafted|Editing|Ready)\" content-calendar.md\n```\n\n**What it looks like**:\n```\nPipeline Overview:\n| Ideas    | 23 |\n| Outlined |  1 |\n| Drafted  |  0 |\n```\n\n**Why wrong**: 23 ideas with 1 outlined means idea generation is not bottlenecked \u2014 advancement is. Reporting a \"full\" pipeline when Ideas=23 gives false confidence. Ideas are potential, not velocity.\n\n**Fix**: When displaying pipeline health, separate \"idea backlog depth\" from \"active p...",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/metrics.md",
+      "line_range": [
+        138,
+        143
+      ],
+      "block_text": "# Then check if each has a Scheduled: line following it\ngrep -A 1 \"(ready:\" content-calendar.md | grep -v \"Scheduled:\"\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/metrics.md",
+      "line_range": [
+        144,
+        153
+      ],
+      "block_text": "## Ready\n- [x] **Hugo build errors** (ready: 2025-01-14)\n<!-- no Scheduled: line \u2014 when does this publish? -->\n```\n\n**Why wrong**: Content without a scheduled date clogs the Ready stage indefinitely. A 3-month-old \"Ready\" item is effectively abandoned, but looks like active work.\n\n**Fix**: Block the move-to-ready operation from completing until a publication date is provided. Show: \"When should this be published? (YYYY-MM-DD or 'tbd' to skip)\".\n\n---\n",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/metrics.md",
+      "line_range": [
+        159,
+        166
+      ],
+      "block_text": "# Find Published entries from previous months\nCURRENT_MONTH=$(date +%Y-%m)\ngrep -E \"\\(published: [0-9]{4}-[0-9]{2}-[0-9]{2}\\)\" content-calendar.md | \\\n  grep -v \"published: ${CURRENT_MONTH}\"\n```\n\n**What it looks like**:\n```",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-calendar/references/metrics.md",
+      "line_range": [
+        168,
+        175
+      ],
+      "block_text": "# December and January posts remain in Published \u2014 not moved to Historical\n```\n\n**Why wrong**: The Published section grows unbounded. A 6-month-old pipeline will have dozens of entries in Published, making counts misleading and dashboard output unreadable.\n\n**Fix**: Run archive check on every `view` operation (warn-only) and require explicit user confirmation before moving to Historical on `archive` operation.\n\n---\n",
+      "domain_hint": "content-calendar"
+    },
+    {
+      "file": "skills/content-engine/references/error-handling.md",
+      "line_range": [
+        15,
+        15
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "content-engine"
+    },
+    {
+      "file": "skills/content-engine/references/error-handling.md",
+      "line_range": [
+        21,
+        31
+      ],
+      "block_text": "# Repeated Phase headers in session artifacts signal a full restart occurred\ngrep -c \"## Atomic Ideas\" content_ideas.md\n```\n\n**What it looks like**: Deleting `content_ideas.md` and `content_drafts.md` and starting over when Phase 4 flags a single hype phrase.\n\n**Why wrong**: Gate failures are surgical \u2014 one phrase in one draft. Restarting discards clean work from passing sections. The gate exists to target the failure, not trigger a full rewrite.\n\n**Fix**: Identify the flagged section, rewrite o...",
+      "domain_hint": "content-engine"
+    },
+    {
+      "file": "skills/content-engine/references/error-handling.md",
+      "line_range": [
+        39,
+        48
+      ],
+      "block_text": "# \"DRAFT \u2014 pending Phase 4 gate\" means gate was never run\n```\n\n**What it looks like**: \"I've reviewed the drafts carefully and they look clean. Proceeding to Phase 5.\"\n\n**Why wrong**: Self-assessment misses hype phrases embedded in context and cannot reliably detect verbatim cross-platform sentences. The scripts use exact string matching; LLMs use paraphrase matching \u2014 these produce different results.\n\n**Fix**: Always run both script checks before Phase 5. If scripts are unavailable, use the man...",
+      "domain_hint": "content-engine"
+    },
+    {
+      "file": "skills/content-engine/references/error-handling.md",
+      "line_range": [
+        56,
+        65
+      ],
+      "block_text": "# If count > platforms user asked for, drafts were overproduced\n```\n\n**What it looks like**: User says \"make some social posts\" with no platform specified; skill produces drafts for X, LinkedIn, TikTok, and Newsletter simultaneously without asking.\n\n**Why wrong**: Each platform requires distinct register, length, and hook style. Producing all platforms without platform-specific intent produces content that fits none of them natively. It also creates ambiguity downstream about which drafts to act...",
+      "domain_hint": "content-engine"
+    },
+    {
+      "file": "skills/content-engine/references/error-handling.md",
+      "line_range": [
+        71,
+        81
+      ],
+      "block_text": "# Find sentences that appear verbatim across platform sections\ngrep -v \"^#\\|^---\\|^$\\|^Status:\\|^Generated:\\|^Primary\" content_drafts.md | sort | uniq -d\n```\n\n**What it looks like**: LinkedIn draft opens with \"We cut deploy time by 80%. Here's what changed.\" X thread also opens with \"We cut deploy time by 80%. Here's what changed.\" Rewrite swaps \"Here's\" to \"This is\".\n\n**Why wrong**: Synonym swaps preserve the same sentence structure, register, and cadence. A LinkedIn hook and an X hook serve di...",
+      "domain_hint": "content-engine"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/concurrency-and-locks.md",
+      "line_range": [
+        84,
+        84
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/concurrency-and-locks.md",
+      "line_range": [
+        86,
+        106
+      ],
+      "block_text": "### \u274c No concurrency protection at all\n\n**Detection**:\n```bash\ngrep -rL \"flock\\|\\.lock\\|\\.pid\\|lockrun\" --include=\"*.sh\" scripts/ cron/ jobs/\nrg -L 'flock|\\.lock|\\.pid' --type sh\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -euo pipefail\ncd /var/data\npython3 process_all_records.py   # runs for 45 min, cron fires again at minute 0\n```\n\n**Why wrong**: If the job takes longer than its interval, two instances run simultaneously. Both read the same input, both write to the same output, both u...",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/concurrency-and-locks.md",
+      "line_range": [
+        108,
+        136
+      ],
+      "block_text": "### \u274c Testing lock file existence without flock (TOCTOU race)\n\n**Detection**:\n```bash\ngrep -rn \"if \\[ -f.*lock\\|test -f.*lock\" --include=\"*.sh\" scripts/ cron/\nrg 'if \\[ -f.*lock' --type sh\n```\n\n**What it looks like**:\n```bash\nLOCK=\"/tmp/myjob.lock\"\nif [ -f \"$LOCK\" ]; then\n    echo \"Running, exit\"\n    exit 0\nfi\ntouch \"$LOCK\"    # race window between [ -f ] check and touch\ntrap 'rm -f $LOCK' EXIT\n```\n\n**Why wrong**: There is a TOCTOU race: two instances can both pass `[ -f \"$LOCK\" ]` before either...",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/concurrency-and-locks.md",
+      "line_range": [
+        138,
+        151
+      ],
+      "block_text": "### \u274c Using sleep-retry as a \"lock\"\n\n**Detection**:\n```bash\ngrep -rn \"while.*lock\\|sleep.*lock\" --include=\"*.sh\" scripts/ cron/\nrg 'while.*lock' --type sh\n```\n\n**What it looks like**:\n```bash\nwhile [ -f /tmp/myjob.lock ]; do\n    sleep 5\ndone\ntouch /tmp/myjob.lock",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/concurrency-and-locks.md",
+      "line_range": [
+        152,
+        160
+      ],
+      "block_text": "# ... work ...\nrm /tmp/myjob.lock\n```\n\n**Why wrong**: Busy-waits waste CPU, has the same TOCTOU race as file existence checks, and if the script crashes before `rm`, subsequent runs loop forever.\n\n**Fix**: `flock -w TIMEOUT` for waiting with a timeout, or `flock -n` to exit immediately.\n\n```bash",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/concurrency-and-locks.md",
+      "line_range": [
+        171,
+        187
+      ],
+      "block_text": "# Files that mention lock but not trap\ngrep -rl \"lock\\|\\.pid\" --include=\"*.sh\" scripts/ cron/ | xargs grep -L \"trap\"\nrg -l 'lock|\\.pid' --type sh | xargs rg -L 'trap'\n```\n\n**What it looks like**:\n```bash\ntouch /tmp/myjob.lock\ndo_work\nrm /tmp/myjob.lock   # only runs on success; if set -e fires, lock is never removed\n```\n\n**Why wrong**: With `set -e`, any failure exits the script immediately \u2014 `rm` never runs. The lock file persists. All future runs think a job is still running and exit immediate...",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/logging-and-rotation.md",
+      "line_range": [
+        90,
+        90
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/logging-and-rotation.md",
+      "line_range": [
+        92,
+        113
+      ],
+      "block_text": "### \u274c No logging at all (relying on cron email)\n\n**Detection**:\n```bash\ngrep -rL '>> .*log\\|tee.*log\\|LOG=' --include=\"*.sh\" scripts/ cron/ jobs/\nrg -L '>> .*\\.log|tee .*\\.log|LOG=' --type sh\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -e\ncd /var/data\npython3 process.py\nrsync -avz output/ backup/\n```\n\n**Why wrong**: All output goes to cron's mail system (usually `nobody@localhost`, usually discarded). When the job fails, there is no record of what was running, what the error was, or whe...",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/logging-and-rotation.md",
+      "line_range": [
+        121,
+        127
+      ],
+      "block_text": "# Scripts with echo/printf but no date at all\ngrep -rl \"echo\\|printf\" --include=\"*.sh\" scripts/ | xargs grep -L \"date\"\n```\n\n**What it looks like**:\n```bash\necho \"Starting job\"   # no timestamp at all\n",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/logging-and-rotation.md",
+      "line_range": [
+        129,
+        137
+      ],
+      "block_text": "# or locale-dependent:\necho \"$(date): Starting\"  # Thu Apr 16 20:07:00 UTC 2026 \u2014 hard to sort/grep\n```\n\n**Why wrong**: Without timestamps, log lines from different runs blend together. Locale-dependent `date` output sorts lexicographically wrong and is hard to parse programmatically. In a post-incident review, \"which run caused this?\" becomes guesswork.\n\n**Fix**:\n```bash\necho \"$(date '+%Y-%m-%d %H:%M:%S'): Starting job\"",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/logging-and-rotation.md",
+      "line_range": [
+        143,
+        155
+      ],
+      "block_text": "### \u274c No log rotation (unbounded growth)\n\n**Detection**:\n```bash\ngrep -rl \"\\.log\" --include=\"*.sh\" scripts/ | xargs grep -L \"mtime\\|logrotate\\|rotate\"\nrg -l '\\.log' --type sh | xargs rg -L 'mtime|logrotate|rotate'\n```\n\n**What it looks like**:\n```bash\nLOG=\"/var/log/myjob.log\"\nexec >> \"$LOG\" 2>&1\necho \"$(date): Starting\"",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/logging-and-rotation.md",
+      "line_range": [
+        156,
+        162
+      ],
+      "block_text": "# ... no rotation, this file grows forever ...\n```\n\n**Why wrong**: A daily cron job writing 1 MB of output fills 365 MB/year into a single file. On a VPS with a small `/var` partition, this causes disk-full failures in other services (nginx, postgres, syslog) \u2014 usually noticed at 3am when cron itself fails to write.\n\n**Fix**:\n```bash",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/logging-and-rotation.md",
+      "line_range": [
+        173,
+        187
+      ],
+      "block_text": "### \u274c Logging to stdout only (lost in cron daemon)\n\n**Detection**:\n```bash\ngrep -rL \">>\" --include=\"*.sh\" scripts/ cron/ | xargs grep -l \"echo\\|printf\" 2>/dev/null\nrg -L '>>' --type sh | xargs rg -l 'echo|printf' 2>/dev/null\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -e\necho \"Starting at $(date)\"\ndo_work\necho \"Done\"",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/logging-and-rotation.md",
+      "line_range": [
+        188,
+        198
+      ],
+      "block_text": "# All output captured by cron daemon, usually discarded or emailed to root\n```\n\n**Why wrong**: Cron captures stdout/stderr and emails them. Most systems have cron email disabled or pointing to an unread mailbox. Even when email works, you lose historical logs \u2014 only the most recent run's output is potentially available.\n\n**Fix**:\n```bash\nexec >> \"/var/log/myjob_$(date +%Y%m%d).log\" 2>&1\n```\n\n---\n",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/shell-error-handling.md",
+      "line_range": [
+        85,
+        85
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/shell-error-handling.md",
+      "line_range": [
+        87,
+        112
+      ],
+      "block_text": "### \u274c Missing set -e / no error handling\n\n**Detection**:\n```bash\ngrep -rL \"set -e\" --include=\"*.sh\" scripts/ cron/ jobs/ bin/\nrg -L \"set -e\" --type sh\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\ncd /var/data\nrm -rf old_files/\nprocess_data.py input.csv > output.csv\nmv output.csv /var/reports/\n```\n\n**Why wrong**: If `process_data.py` fails (non-zero exit), `mv` still runs, overwriting `/var/reports/` with an empty or corrupt file. The failure is invisible \u2014 cron marks the job as succeeded.\n\n*...",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/shell-error-handling.md",
+      "line_range": [
+        114,
+        141
+      ],
+      "block_text": "### \u274c Piped commands ignoring pipeline failures\n\n**Detection**:\n```bash\ngrep -rl \"\\|\" --include=\"*.sh\" scripts/ cron/ | xargs grep -L \"pipefail\"\nrg '\\|\\s+\\w+' --type sh -l | xargs rg -L 'pipefail'\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -e  # but no pipefail!\npg_dump mydb | gzip > backup.sql.gz    # if pg_dump fails, gzip writes a 0-byte gz file\nfind /data -name \"*.log\" | xargs gzip  # if find fails, gzip still runs on partial list\n```\n\n**Why wrong**: Without `pipefail`, the exit co...",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/shell-error-handling.md",
+      "line_range": [
+        143,
+        163
+      ],
+      "block_text": "### \u274c Undefined variable silently expanding to empty string\n\n**Detection**:\n```bash\ngrep -rL \"set -u\\|set -euo\\|nounset\" --include=\"*.sh\" scripts/ cron/\ngrep -rn 'rm -rf.*\\$' --include=\"*.sh\" scripts/\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -e\nrm -rf \"$BACKUP_DIR/\"    # if BACKUP_DIR is unset, expands to \"rm -rf /\"\nrsync -avz \"$SRC_PATH/\" \"$DEST/\"   # silently copies nothing if SRC_PATH unset\n```\n\n**Why wrong**: Without `set -u`, unset variables expand to empty string. `rm -rf \"$BAC...",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/cron-job-auditor/references/shell-error-handling.md",
+      "line_range": [
+        170,
+        187
+      ],
+      "block_text": "### \u274c Swallowing errors with bare || true\n\n**Detection**:\n```bash\ngrep -rn \"|| true\" --include=\"*.sh\" scripts/ cron/ jobs/\nrg '\\|\\|\\s*true' --type sh\n```\n\n**What it looks like**:\n```bash\ncreate_schema.sql || true    # if schema creation fails, continue anyway\nvalidate_data.py || true     # silently ignores validation failures\n```\n\n**Why wrong**: `|| true` converts any failure into success. Combined with `set -e`, it suppresses the exit but also suppresses the failure signal \u2014 the script continue...",
+      "domain_hint": "cron-job-auditor"
+    },
+    {
+      "file": "skills/csuite/references/audience-segmentation.md",
+      "line_range": [
+        149,
+        149
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/audience-segmentation.md",
+      "line_range": [
+        151,
+        154
+      ],
+      "block_text": "### Demographic persona without a problem\n**What it looks like**: \"Our audience is software engineers, 28-40, living in urban areas, interested in career growth.\"\n**Why wrong**: This describes who they are, not why they need your content. Two engineers with identical demographics can have wildly different content needs based on their specific problem and job context.\n**Fix**: Every persona must include a \"Primary frustration\" and a \"Current workaround.\" If you cannot fill those in, the persona i...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/audience-segmentation.md",
+      "line_range": [
+        161,
+        166
+      ],
+      "block_text": "### Persona proliferation\n**What it looks like**: 7 detailed personas, all with equal priority, representing every possible reader type.\n**Why wrong**: If everything is a priority, nothing is a priority. Content written to serve 7 personas simultaneously serves none of them distinctively.\n**Fix**: Maximum 2 active personas at any time. One primary (80% of content) and one secondary (20% of content). Additional personas go on the watch list for future quarters.\n\n---\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/channel-evaluation.md",
+      "line_range": [
+        167,
+        167
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/channel-evaluation.md",
+      "line_range": [
+        169,
+        172
+      ],
+      "block_text": "### Platform-native metrics as success metrics\n**What it looks like**: \"We got 50 retweets!\" \u2014 but zero new email subscribers, zero traffic, zero revenue.\n**Why wrong**: Platform metrics (likes, impressions, follower count) measure engagement with the platform, not growth of YOUR asset. A viral tweet that doesn't move subscribers is entertainment, not growth.\n**Fix**: Track only metrics that connect to your owned channel (email subscribers, direct traffic) or revenue. Report platform metrics onl...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/channel-evaluation.md",
+      "line_range": [
+        174,
+        177
+      ],
+      "block_text": "### Optimizing for CAC without measuring LTV\n**What it looks like**: \"Reddit drives the cheapest subscriber acquisition at $0.50 each.\"\n**Why wrong**: If Reddit subscribers have 50% lower LTV (because they signed up for one specific post and have low topic affinity), the channel is less efficient than it appears.\n**Fix**: Track subscriber cohort behavior by acquisition channel. Measure 90-day engagement rate per channel. CAC \u00d7 engagement rate gives channel-adjusted CAC.\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/channel-evaluation.md",
+      "line_range": [
+        179,
+        184
+      ],
+      "block_text": "### Treating all funnel stages as the same\n**What it looks like**: Every piece of content ends with \"check out my other posts.\" No direct subscribe CTAs, no product mentions, no differentiated asks by content type.\n**Why wrong**: Awareness content with hard conversion CTAs drives away top-of-funnel readers. Consideration content without conversion paths wastes intent. Each stage needs its own CTA.\n**Fix**: Assign one primary CTA per funnel stage. Awareness = subscribe. Interest = download resour...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/competitive-mapping.md",
+      "line_range": [
+        167,
+        167
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/competitive-mapping.md",
+      "line_range": [
+        169,
+        173
+      ],
+      "block_text": "### Analyzing features, ignoring momentum\n**What it looks like**: Competitor B has fewer features than us today. No further analysis.\n**Why wrong**: Momentum matters more than current state. A competitor shipping 10 features/quarter with high user satisfaction will surpass a feature-rich stagnant product within 12-18 months.\n**Detection**: Check competitor's changelog/release notes. If releases are accelerating and quality is high, treat them as stronger than their current position suggests.\n**F...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/competitive-mapping.md",
+      "line_range": [
+        175,
+        178
+      ],
+      "block_text": "### Mapping on irrelevant dimensions\n**What it looks like**: Positioning map uses \"enterprise vs. SMB\" and \"cloud vs. on-premise\" when all relevant players are SMB-focused SaaS. Everyone clusters in one quadrant.\n**Why wrong**: If dimensions don't separate the competitors, the map reveals nothing.\n**Fix**: Require that the chosen dimensions separate at least 50% of plotted players. If everyone clusters, try different dimensions.\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/competitive-mapping.md",
+      "line_range": [
+        180,
+        185
+      ],
+      "block_text": "### Static competitive landscape\n**What it looks like**: Competitive analysis document dated 18 months ago, still being cited in strategy discussions.\n**Why wrong**: Companies pivot, funding changes strategies, new entrants emerge, and products get discontinued. A stale map actively misleads.\n**Detection**: Check the date on any competitive document. Over 12 months = must refresh core data before using. Over 18 months = discard and redo.\n\n---\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/content-funnel.md",
+      "line_range": [
+        280,
+        280
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/content-funnel.md",
+      "line_range": [
+        282,
+        285
+      ],
+      "block_text": "### Awareness content without subscribe CTA\n**What it looks like**: SEO articles driving 5,000 unique visitors/month with no email subscribe prompt, no content upgrade, no follow CTA.\n**Why wrong**: Traffic without capture is rented attention. If the newsletter/product is not capturing subscribers from Awareness content, growing traffic does nothing for the business.\n**Fix**: Every Awareness piece needs one primary CTA (subscribe to email) in at least 2 locations: midpoint and end of content. Co...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/content-funnel.md",
+      "line_range": [
+        287,
+        290
+      ],
+      "block_text": "### Consideration content gated behind subscribe when audience is unaware\n**What it looks like**: Comparison guide (\"our product vs. Competitor X\") is email-gated. But audience doesn't know the product exists yet.\n**Why wrong**: High-intent comparison content is searched by people not yet in your funnel. Gating it prevents discovery by the exact audience most likely to convert.\n**Fix**: Consideration content targeting high-intent search queries (X vs. Y, alternative to Z) should be freely access...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/content-funnel.md",
+      "line_range": [
+        292,
+        295
+      ],
+      "block_text": "### Single attribution model driving all decisions\n**What it looks like**: Team uses last-touch attribution exclusively. SEO posts driving first-touch subscribers are consistently \"credited\" with zero revenue, so SEO investment is cut.\n**Why wrong**: Last-touch attribution systematically undervalues Awareness content. A reader who finds you via a blog post, subscribes, reads 6 newsletters, and then buys after a conversion email credits the conversion email \u2014 but the blog post started the relatio...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/content-funnel.md",
+      "line_range": [
+        297,
+        302
+      ],
+      "block_text": "### Revenue attributed to content that did not exist at time of purchase\n**What it looks like**: Post published this month credited with converting subscribers who joined 14 months ago.\n**Why wrong**: The post could not have influenced subscribers who joined before it existed.\n**Fix**: First-touch attribution must use the subscriber's original acquisition touchpoint. Cohort attribution must use the subscriber's cohort join date, not their purchase date, as the grouping variable.\n\n---\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/decision-matrices.md",
+      "line_range": [
+        142,
+        142
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/decision-matrices.md",
+      "line_range": [
+        144,
+        147
+      ],
+      "block_text": "### Criteria added after scoring\n**What it looks like**: Team scores options, then someone says \"shouldn't we also consider X?\" and adds it \u2014 but only because option they preferred scored low.\n**Detection**: Track criteria list from start of session. Any addition after first score row is filled = suspect.\n**Fix**: Lock criteria before any scoring. New criteria trigger a full restart.\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/decision-matrices.md",
+      "line_range": [
+        149,
+        152
+      ],
+      "block_text": "### Equal weighting as a default\n**What it looks like**: 5 criteria, each gets 20% because \"everything matters equally.\"\n**Why wrong**: Hides real priorities. If cost and strategic fit genuinely matter equally, that is an unusual organization \u2014 say so explicitly. Usually it means the weighter avoided a political conversation about what actually matters.\n**Fix**: Force-rank criteria first. Top criterion gets at least 2\u00d7 weight of bottom criterion.\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/decision-matrices.md",
+      "line_range": [
+        154,
+        157
+      ],
+      "block_text": "### Scoring without evidence\n**What it looks like**: Team assigns scores in 60 seconds per criterion without citing data.\n**Why wrong**: Scores become opinions wearing the costume of analysis.\n**Fix**: Require a one-sentence evidence statement for any score above 7 or below 4. \"I scored technical feasibility 3 because we have zero experience with Kubernetes and our last infrastructure project overran by 3x\" is valid.\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/decision-matrices.md",
+      "line_range": [
+        159,
+        164
+      ],
+      "block_text": "### Ignoring the default option\n**What it looks like**: Matrix compares Option A vs. Option B but does not include \"do nothing.\"\n**Why wrong**: Every decision has a status quo. If the status quo scores higher than the options, that is the most important finding in the analysis.\n**Fix**: Always include \"do nothing / stay the course\" as an explicit option.\n\n---\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/estimation-techniques.md",
+      "line_range": [
+        338,
+        338
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/estimation-techniques.md",
+      "line_range": [
+        340,
+        343
+      ],
+      "block_text": "### Point estimate at concept stage\n**What it looks like**: \"We'll budget 200 hours for this project.\" \u2014 said before requirements exist.\n**Why wrong**: At concept stage, cone of uncertainty is 4\u00d7. A 200-hour estimate could legitimately be anywhere from 50 to 800 hours. Committing to 200 hours is not an estimate \u2014 it is a wish.\n**Fix**: At concept stage, provide a range. \"Based on similar projects, this could be 100-400 hours. We need requirements defined before we can narrow this.\" If stakeholde...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/estimation-techniques.md",
+      "line_range": [
+        345,
+        348
+      ],
+      "block_text": "### Averaging through expert disagreement\n**What it looks like**: Three estimators give 40, 200, and 350 hours. Team averages to 197 and moves on.\n**Why wrong**: 5\u00d7 divergence between estimators means they are estimating different projects. Averaging does not resolve the disagreement \u2014 it obscures it. The 350-hour estimator saw something the 40-hour estimator did not.\n**Fix**: Before averaging Delphi estimates, require that estimates within the same round are within 2\u00d7 of each other. If they are...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/estimation-techniques.md",
+      "line_range": [
+        350,
+        353
+      ],
+      "block_text": "### Historical data ignored because \"this project is different\"\n**What it looks like**: Team has a 2.5\u00d7 overrun history on integration projects. New integration project is estimated without reference class adjustment because \"this integration is simpler.\"\n**Why wrong**: \"This one is different\" is the most common entry point for planning fallacy. The outside view exists precisely to counteract the inside view's over-confidence in project uniqueness.\n**Fix**: Reference class adjustment is mandator...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/estimation-techniques.md",
+      "line_range": [
+        355,
+        360
+      ],
+      "block_text": "### Estimation accuracy measured at delivery\n**What it looks like**: Team compares initial estimate to final delivery date \u2014 and it's always wrong. No intermediate comparison, no component-level tracking.\n**Why wrong**: By measuring only at the end, you cannot improve estimation technique. You don't know whether the estimate was wrong because of scope change, wrong assumptions, or poor technique.\n**Fix**: Track estimates at three points: initial estimate, post-design estimate, and actual. Compar...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/feasibility-scoring.md",
+      "line_range": [
+        202,
+        202
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/feasibility-scoring.md",
+      "line_range": [
+        204,
+        207
+      ],
+      "block_text": "### Feasibility conflated with desirability\n**What it looks like**: \"We can build it, so it's feasible.\" Team with strong engineering capability scores technical feasibility 9 for everything, ignoring whether the market wants it.\n**Why wrong**: Feasibility and desirability are orthogonal. The most common startup failure is a product that was technically feasible and built on time, that nobody wanted.\n**Fix**: Require three separate dimension scores. A project that is technically feasible but has...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/feasibility-scoring.md",
+      "line_range": [
+        209,
+        212
+      ],
+      "block_text": "### Feasibility assessed at vision scope, not MVP scope\n**What it looks like**: \"We can't build a real-time collaboration tool \u2014 that's too hard.\" But the MVP is just shared document state with 5-second polling, which is straightforward.\n**Why wrong**: Feasibility must be assessed against the specific, scoped version of the project \u2014 the MVP \u2014 not the aspirational full version.\n**Fix**: Before scoring, confirm the project definition is frozen at MVP scope (from Phase 1 of project-evaluation SKIL...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/feasibility-scoring.md",
+      "line_range": [
+        214,
+        219
+      ],
+      "block_text": "### High confidence on everything\n**What it looks like**: All three dimensions rated High confidence. Team is decisive and agrees.\n**Why wrong**: If you have not validated assumptions through direct evidence, high confidence is overconfidence. Teams in alignment often reinforce each other's assumptions rather than challenging them.\n**Detection**: Ask \"what evidence do we have that this is true?\" for each High confidence rating. If the answer is \"we believe\" or \"we've discussed,\" confidence is ac...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/market-positioning.md",
+      "line_range": [
+        210,
+        210
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/market-positioning.md",
+      "line_range": [
+        212,
+        215
+      ],
+      "block_text": "### Positioning by negation only\n**What it looks like**: \"We're not like those enterprise tools. We're different.\"\n**Why wrong**: Negation tells the customer what you are not. It does not tell them what you are. The brain cannot hold \"not X\" \u2014 it has to form a positive association.\n**Fix**: Every positioning statement must have a positive claim: \"We are the [specific thing] for [specific people] who need [specific outcome].\" The competitor reference is a clarifier, not the definition.\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/market-positioning.md",
+      "line_range": [
+        217,
+        220
+      ],
+      "block_text": "### Claiming differentiation on commodity dimensions\n**What it looks like**: \"We differentiate on quality, service, and reliability.\"\n**Why wrong**: Every competitor claims quality, service, and reliability. These are table stakes, not differentiators. Scoring these high in the differentiation matrix with low ease-to-copy is usually wishful thinking.\n**Detection**: Run the defensibility scoring. Any dimension where \"ease for competitor to copy\" is above 7 is not a strategic differentiator.\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/migration-planning.md",
+      "line_range": [
+        324,
+        324
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/migration-planning.md",
+      "line_range": [
+        326,
+        330
+      ],
+      "block_text": "### Big-bang cutover\n**What it looks like**: All users moved from old to new system in a single weekend deployment. No pilot, no phased rollout, no shadow period.\n**Why wrong**: Big-bang cutover concentrates all migration risk into a single point. If anything goes wrong \u2014 and something always does \u2014 the entire user base is affected simultaneously and the rollback affects the entire user base.\n**Detection**: If the migration plan says \"go live on [date]\" with no mention of cohorts, pilot groups, ...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/migration-planning.md",
+      "line_range": [
+        332,
+        335
+      ],
+      "block_text": "### Rollback plan written after cutover\n**What it looks like**: Migration proceeds, and then someone asks \"how do we roll back if this fails?\" The answer is \"we'd figure it out.\"\n**Why wrong**: Under incident pressure, ad-hoc rollback takes 4-10\u00d7 longer than a planned rollback and introduces additional errors. The migration should not start until rollback has been tested.\n**Fix**: Rollback is a phase gate \u2014 migration to Phase 1 cannot proceed until rollback procedure for Phase 1 has been documen...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/migration-planning.md",
+      "line_range": [
+        337,
+        340
+      ],
+      "block_text": "### Migrating data quality problems forward\n**What it looks like**: Source database has 15% null values in required fields, duplicate records, and inconsistent date formats. Migration copies all of this into the new system verbatim.\n**Why wrong**: Migrating dirty data validates bad data in the new system and causes downstream failures that are blamed on the new system, not the migration.\n**Fix**: Before migration begins, run a data quality assessment (null counts, duplicate counts, format incons...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/migration-planning.md",
+      "line_range": [
+        342,
+        347
+      ],
+      "block_text": "### Testing migration on wrong data volume\n**What it looks like**: Migration scripts tested on a 1,000-row staging dataset. Production has 80 million rows. Performance characteristics are completely different.\n**Why wrong**: Migration performance is non-linear. Scripts that complete in 2 minutes on 1K rows may take 8 hours on 80M rows due to index contention, network I/O, and API rate limits.\n**Fix**: Migrate a random 5% sample of production data (anonymized) in a staging environment and extrapo...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/risk-assessment.md",
+      "line_range": [
+        255,
+        255
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/risk-assessment.md",
+      "line_range": [
+        257,
+        260
+      ],
+      "block_text": "### Pre-mortem as validation exercise\n**What it looks like**: Team runs pre-mortem but all proposed failure modes are minor and easily dismissed. The session feels like box-checking.\n**Why wrong**: If your pre-mortem does not generate at least one uncomfortable insight \u2014 something that changes the plan or makes the team nervous \u2014 it was not conducted with intellectual honesty. Good pre-mortems hurt a little.\n**Fix**: Require the most skeptical person in the room to lead Round 1. If no one is pla...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/risk-assessment.md",
+      "line_range": [
+        262,
+        265
+      ],
+      "block_text": "### Scenario planning without probability assignment\n**What it looks like**: Four beautifully written scenarios with no probabilities. All scenarios treated as equally likely in discussion.\n**Why wrong**: If all scenarios are equally likely, the expected value calculation cannot be done. The team defaults to discussing the most vivid scenario (usually worst-case) and either overcorrects or dismisses it.\n**Fix**: Require probability assignments before discussing scenario implications. Probabiliti...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/risk-assessment.md",
+      "line_range": [
+        267,
+        270
+      ],
+      "block_text": "### Black swan conflated with low-probability planned risk\n**What it looks like**: \"The black swan scenario is that we only close 50% of our projected pipeline.\"\n**Why wrong**: 50% pipeline miss is a normal risk, not a black swan. It belongs in the scenario planning matrix. Black swans are outside the planning range, not just the pessimistic end of the normal range.\n**Fix**: For a risk to qualify as a black swan, it must satisfy: (1) would not appear in a standard risk register, (2) is outside t...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/risk-assessment.md",
+      "line_range": [
+        272,
+        277
+      ],
+      "block_text": "### Risk register without owners\n**What it looks like**: 12-item risk register, all marked \"Team\" as owner.\n**Why wrong**: Team ownership is no ownership. No one monitors the risk; no one detects early warning signals; no one escalates.\n**Fix**: Every risk in the register must have a single named individual as owner. If no one will own it, escalate the risk to decision-maker level immediately \u2014 unowned high-probability risks are the most dangerous items in any plan.\n\n---\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/roi-frameworks.md",
+      "line_range": [
+        229,
+        229
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/roi-frameworks.md",
+      "line_range": [
+        231,
+        234
+      ],
+      "block_text": "### Planning fallacy (systematic underestimation)\n**What it looks like**: \"This will take 2 weeks.\" Team has never shipped a project of this complexity in under 6 weeks.\n**Detection**: Compare the current estimate against historical actuals for similar projects. If this team has a history of 2\u00d7 overruns, this estimate needs to be doubled before being used in ROI calculations.\n**Fix**: Use reference class forecasting. Require the estimator to name the 3 most similar past projects and their actual...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/roi-frameworks.md",
+      "line_range": [
+        236,
+        239
+      ],
+      "block_text": "### ROI calculated at fantasy scope\n**What it looks like**: ROI analysis uses the full product vision (V3 feature set) but effort estimate uses MVP scope (V1 feature set). Value is dramatically overstated.\n**Why wrong**: The ROI analysis and the effort estimate must use the same scope definition.\n**Fix**: Explicitly verify that the \"value delivered\" section and the \"build cost\" section reference the same project definition before finalizing.\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/roi-frameworks.md",
+      "line_range": [
+        241,
+        244
+      ],
+      "block_text": "### Opportunity cost excluded from total cost\n**What it looks like**: ROI shows positive return. But the team has 3 other projects that must be delayed to work on this. Those delayed projects have their own value.\n**Why wrong**: Every yes is a no to something else. Excluding opportunity cost inflates apparent ROI.\n**Fix**: Always include a \"what won't get done\" row in the cost section. If you cannot name what gets delayed, the capacity assumption is wrong.\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/roi-frameworks.md",
+      "line_range": [
+        246,
+        251
+      ],
+      "block_text": "### Ignoring ongoing cost in 3-year model\n**What it looks like**: Year 1 implementation cost is $50K. Year 2 and Year 3 show $0 cost because \"it's built.\"\n**Why wrong**: Every system requires maintenance. Every piece of content requires updating. Even \"done\" projects consume support time.\n**Rule**: Year 2-3 minimum ongoing cost = 15-20% of Year 1 implementation cost for software projects. For content: 20-30% of creation cost for curation and updating.\n\n---\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/strategic-frameworks.md",
+      "line_range": [
+        180,
+        180
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/strategic-frameworks.md",
+      "line_range": [
+        182,
+        185
+      ],
+      "block_text": "### Five Forces as a one-time exercise\n**What it looks like**: Five Forces analysis done at company founding, cited 3 years later.\n**Why wrong**: Industry forces shift. A 3-year-old analysis of supplier power in cloud infrastructure predates major pricing moves. Forces should be re-run at every major strategic inflection.\n**Detection**: Check the date on any Five Forces document. Over 18 months old = must refresh before citing.\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/strategic-frameworks.md",
+      "line_range": [
+        187,
+        190
+      ],
+      "block_text": "### SWOT without prioritization\n**What it looks like**: 20-item SWOT with equal visual weight given to \"strong team culture\" and \"no enterprise sales motion.\"\n**Why wrong**: Without scores, SWOT becomes a list that feels like analysis but produces no action.\n**Fix**: Every SWOT item must have a score and an owner. Items below score 5 are archived, not acted on.\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/strategic-frameworks.md",
+      "line_range": [
+        192,
+        195
+      ],
+      "block_text": "### OKRs set after strategy, not before\n**What it looks like**: Leadership decides the strategy in Q4, then writes OKRs in January to match it.\n**Why wrong**: OKRs should constrain strategy choice, not validate it retroactively. If OKRs are written to match decisions already made, the alignment matrix is theater.\n**Fix**: Set OKRs for the period before running the OKR alignment matrix. If OKRs don't exist, the matrix is not useful \u2014 run the decision matrix instead.\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/strategic-frameworks.md",
+      "line_range": [
+        197,
+        202
+      ],
+      "block_text": "### \"We have no competitors\" (Porter's Forces Denial)\n**What it looks like**: Founder refuses to name competitors; \"we're unique.\"\n**Why wrong**: No competitors = no market, or no market research. Porter's Threat of Substitutes force always has content even in novel markets (the substitute is \"doing nothing\" or \"using the old way\").\n**Fix**: Replace \"competitors\" with \"alternatives the buyer considers.\" Every buyer has alternatives, even if not commercial products.\n\n---\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/tco-framework.md",
+      "line_range": [
+        187,
+        187
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/tco-framework.md",
+      "line_range": [
+        189,
+        192
+      ],
+      "block_text": "### Comparing development cost to license cost\n**What it looks like**: \"Auth0 costs $2,880/year. We can build it for free.\"\n**Why wrong**: \"Free to build\" ignores 120+ engineering hours, security maintenance, incident response, and opportunity cost. The license is year 2+ maintenance savings, not just year 1 build savings.\n**Fix**: Always run the 3-year TCO template. If the comparison is still in favor of building after year 2-3 costs are included, building may be right.\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/tco-framework.md",
+      "line_range": [
+        194,
+        198
+      ],
+      "block_text": "### Underestimating maintenance burden\n**What it looks like**: Year 2 estimate shows zero hours for maintenance on custom-built system.\n**Why wrong**: Every system has dependencies that release updates. Security vulnerabilities require patches. Load characteristics change. Features accumulate bugs over time. 10-20% of initial build effort per year is the historical baseline.\n**Detection**: If Year 2 internal maintenance estimate is less than 10% of Year 1 build estimate, it is too optimistic.\n**...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/tco-framework.md",
+      "line_range": [
+        200,
+        205
+      ],
+      "block_text": "### TCO without usage growth modeling\n**What it looks like**: SaaS cost calculated at current usage (100 users), not at expected usage in year 3 (1,000 users).\n**Why wrong**: Many SaaS platforms have non-linear pricing. What looks affordable at 100 users can be prohibitive at 1,000. The opposite is also true \u2014 build costs are largely fixed.\n**Fix**: Model three usage scenarios: current, 3\u00d7 growth, 10\u00d7 growth. Pick the option that remains affordable across all three plausible scenarios.\n\n---\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/trend-analysis.md",
+      "line_range": [
+        237,
+        237
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/trend-analysis.md",
+      "line_range": [
+        239,
+        242
+      ],
+      "block_text": "### Treating Hype Cycle peak as confirmation of sustained growth\n**What it looks like**: \"Gartner put us at the Peak of Inflated Expectations \u2014 that means we're mainstream.\"\n**Why wrong**: Gartner's Peak of Inflated Expectations precedes the Trough of Disillusionment. Being at the peak means hype has outpaced delivery and a correction is coming. Companies that raise at peak valuations and expand at peak rates are maximally exposed to the trough.\n**Fix**: Treat Hype Cycle peak as a warning to red...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/trend-analysis.md",
+      "line_range": [
+        244,
+        247
+      ],
+      "block_text": "### Confusing single-vendor activity for market trend\n**What it looks like**: \"Competitor X launched three features this month. This space is growing fast.\"\n**Why wrong**: A single vendor's product velocity is company signal, not market signal. A competitor may be launching features because they are desperate, because they have a new head of product, or because a large customer demanded it. None of those explain the market.\n**Fix**: Market trends require signal from at least 3 independent source...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/trend-analysis.md",
+      "line_range": [
+        249,
+        252
+      ],
+      "block_text": "### Ignoring disruption until it is in your customer segment\n**What it looks like**: Disruption is identified in the low-end segment. Team says \"that's not our market\" and takes no action.\n**Why wrong**: Disruption moves upmarket. The low-end is where it starts, not where it stays. Christensen documented this across 20+ industries: the disruption that starts at the bottom reliably migrates into the incumbent's core market within 3-8 years.\n**Fix**: When low-end disruption is identified, run a \"f...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/trend-analysis.md",
+      "line_range": [
+        254,
+        259
+      ],
+      "block_text": "### Trend analysis without refresh cadence\n**What it looks like**: Trend analysis done in Q1, cited in Q4 as the basis for strategy decisions.\n**Why wrong**: Tech markets move faster than annual strategy cycles. A signal logged as \"Emerging\" in January can be \"Confirmed\" by April.\n**Fix**: Tier 1 signals: check monthly. Tier 2 signals: check quarterly. Full trend report: refresh every 6 months. Any trend report over 6 months old should include a freshness warning before it is cited in a decision...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/vendor-evaluation.md",
+      "line_range": [
+        156,
+        156
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/vendor-evaluation.md",
+      "line_range": [
+        158,
+        161
+      ],
+      "block_text": "### Buying based on demo, not hands-on trial\n**What it looks like**: Sales demo shows everything working perfectly, contract signed, integration begins, and a different reality emerges.\n**Why wrong**: Demos are curated. Integration complexity, actual API reliability, and support quality only reveal themselves in practice.\n**Fix**: Require a proof-of-concept (POC) period with a representative integration task before committing to annual contract. \"We need to complete integration milestone X befor...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/vendor-evaluation.md",
+      "line_range": [
+        163,
+        166
+      ],
+      "block_text": "### Evaluating current feature set, not roadmap direction\n**What it looks like**: Vendor has 9/10 of features needed today. Missing 1 feature is \"on the roadmap.\"\n**Why wrong**: \"On the roadmap\" has no SLA. Features promised in sales negotiations are not features in contracts.\n**Fix**: Ask to see the public changelog and last 4 release notes. If the velocity is high and roadmap direction matches your needs, that is more reliable than verbal promises. Require a contract addendum for features that...",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/csuite/references/vendor-evaluation.md",
+      "line_range": [
+        168,
+        173
+      ],
+      "block_text": "### Evaluating one vendor at a time (serial evaluation)\n**What it looks like**: Full evaluation of Vendor A, then if not satisfied, evaluate Vendor B.\n**Why wrong**: Serial evaluation introduces time pressure at Vendor B. You may sign with B because you are tired of evaluating, not because B is the best option.\n**Fix**: Run parallel evaluations with 2-3 vendors simultaneously using the same RFP criteria. Takes more coordination but produces better decisions.\n\n---\n",
+      "domain_hint": "csuite"
+    },
+    {
+      "file": "skills/data-analysis/references/anti-patterns.md",
+      "line_range": [
+        1,
+        5
+      ],
+      "block_text": "# Data Analysis Anti-Patterns\n\nExtended catalog of anti-patterns beyond the top 5 in the main SKILL.md. Each pattern includes what it looks like, why it's wrong, and what to do instead.\n\n---\n",
+      "domain_hint": "data-analysis"
+    },
+    {
+      "file": "skills/data-analysis/references/anti-patterns.md",
+      "line_range": [
+        7,
+        7
+      ],
+      "block_text": "## Methodology Anti-Patterns\n",
+      "domain_hint": "data-analysis"
+    },
+    {
+      "file": "skills/data-analysis/references/anti-patterns.md",
+      "line_range": [
+        19,
+        23
+      ],
+      "block_text": "### Confirmation Bias in Extraction\n\n**What it looks like**: Loading data and immediately computing the metric the analyst expects to find, without profiling the data first.\n\n```python",
+      "domain_hint": "data-analysis"
+    },
+    {
+      "file": "skills/data-analysis/references/anti-patterns.md",
+      "line_range": [
+        90,
+        90
+      ],
+      "block_text": "## Statistical Anti-Patterns\n",
+      "domain_hint": "data-analysis"
+    },
+    {
+      "file": "skills/data-analysis/references/anti-patterns.md",
+      "line_range": [
+        146,
+        146
+      ],
+      "block_text": "## Communication Anti-Patterns\n",
+      "domain_hint": "data-analysis"
+    },
+    {
+      "file": "skills/data-analysis/references/anti-patterns.md",
+      "line_range": [
+        197,
+        197
+      ],
+      "block_text": "## Process Anti-Patterns\n",
+      "domain_hint": "data-analysis"
+    },
+    {
+      "file": "skills/decision-helper/references/decision-anti-patterns.md",
+      "line_range": [
+        1,
+        7
+      ],
+      "block_text": "# Decision Analysis Anti-Patterns\n\n> **Scope**: Behavioral failure modes that corrupt weighted decision scoring. Covers framing, scoring, and interpretation errors. Does not cover domain-specific criteria selection (see `decision-archetypes.md`).\n> **Version range**: All versions of decision-helper skill\n> **Generated**: 2026-04-16\n\n---\n",
+      "domain_hint": "decision-helper"
+    },
+    {
+      "file": "skills/decision-helper/references/decision-anti-patterns.md",
+      "line_range": [
+        15,
+        15
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "decision-helper"
+    },
+    {
+      "file": "skills/decision-helper/references/decision-anti-patterns.md",
+      "line_range": [
+        17,
+        35
+      ],
+      "block_text": "### \u274c Confirmation Bias via Post-Hoc Weight Adjustment\n\n**Detection signal**: User adjusts weights AFTER seeing the scored matrix, specifically to change the winner.\n\n```\n\"Actually, I think Familiarity should be weight 4, not 2.\"  [after seeing their preferred option lost on Familiarity]\n\"Can we lower Risk? I don't think it's that important here.\" [after seeing their preferred option scored badly on Risk]\n```\n\n**Why wrong**: Weights represent what matters for this decision. If weights were set c...",
+      "domain_hint": "decision-helper"
+    },
+    {
+      "file": "skills/decision-helper/references/decision-anti-patterns.md",
+      "line_range": [
+        37,
+        56
+      ],
+      "block_text": "### \u274c Analysis Paralysis via Option Proliferation\n\n**Detection signal**: User presents 5+ options, or keeps adding options mid-scoring.\n\n```\n\"We're also considering Option D, and actually Option E is worth looking at...\"\n\"Before we score, what if we added the hybrid approach as Option F?\"\n```\n\n**Why wrong**: Scoring more than 4 options dilutes focus and invites false precision. A 6-option matrix signals the decision hasn't been framed yet \u2014 it's research, not decision-making. The math becomes me...",
+      "domain_hint": "decision-helper"
+    },
+    {
+      "file": "skills/decision-helper/references/decision-anti-patterns.md",
+      "line_range": [
+        58,
+        72
+      ],
+      "block_text": "### \u274c Anchoring to the First Option\n\n**Detection signal**: First option stated gets systematically higher scores across criteria, even weak ones, or other options are evaluated relative to the first rather than absolutely.\n\n```\n\"Option A does X well. Option B doesn't do X as well as A.\" [A becomes the reference point]\n```\n\n**Why wrong**: Scores should be absolute (1-10 on the criterion itself), not relative to another option. When the first option anchors scoring, the matrix measures \"distance f...",
+      "domain_hint": "decision-helper"
+    },
+    {
+      "file": "skills/decision-helper/references/decision-anti-patterns.md",
+      "line_range": [
+        74,
+        96
+      ],
+      "block_text": "### \u274c False Precision on Tied Scores\n\n**Detection signal**: User treats a 0.1 or 0.2 weighted score difference as a meaningful recommendation.\n\n```\nOption A: 6.89\nOption B: 6.71\n\"So we should go with Option A.\"\n```\n\n**Why wrong**: Individual scores are subjective 1-10 estimates. A score of 7 vs 8 on Complexity is not a measurement \u2014 it's an opinion. Weighted differences below 0.5 are noise, not signal. Treating them as decisive ignores the uncertainty in every input score.\n\n**Fix**: Apply the cl...",
+      "domain_hint": "decision-helper"
+    },
+    {
+      "file": "skills/decision-helper/references/decision-anti-patterns.md",
+      "line_range": [
+        98,
+        117
+      ],
+      "block_text": "### \u274c Criteria Scope Creep Mid-Scoring\n\n**Detection signal**: New criteria added after scoring has started, especially if the new criterion favors a particular option that was losing.\n\n```\n\"Actually, we should add 'Vendor Support' as a criterion.\"  [halfway through scoring]\n\"I forgot to include 'Team Learning Opportunity.'\"  [after Option A is clearly losing]\n```\n\n**Why wrong**: Adding criteria after partial scoring means earlier options were scored on a different basis than later ones. The matr...",
+      "domain_hint": "decision-helper"
+    },
+    {
+      "file": "skills/decision-helper/references/decision-anti-patterns.md",
+      "line_range": [
+        119,
+        132
+      ],
+      "block_text": "### \u274c Skipping Hard Constraint Elimination\n\n**Detection signal**: Options with obvious eliminators still make it into the scoring matrix.\n\n```\nScoring a vendor that doesn't support the required data residency region.\nScoring an open-source library with a GPL license for a commercial product.\nScoring a framework whose last commit was 4 years ago.\n```\n\n**Why wrong**: Hard constraints are binary eliminators, not scored criteria. Including non-starters in the matrix wastes time and creates noise. Wo...",
+      "domain_hint": "decision-helper"
+    },
+    {
+      "file": "skills/decision-helper/references/decision-anti-patterns.md",
+      "line_range": [
+        147,
+        162
+      ],
+      "block_text": "### \u274c No Hard Criteria for \"Scores Feel Wrong\"\n\n**Detection signal**: User repeatedly adjusts scores without reasoning, or says \"something feels off.\"\n\n```\n\"I think Risk should be 9, not 7.\" [no explanation]\n\"Let's change Maintainability to 5.\" [changing a score without new information]\n```\n\n**Why wrong**: Score changes without justification are gut feelings overriding the framework. The framework's value is making implicit reasoning explicit. Unexplained score changes re-obscure the reasoning.\n...",
+      "domain_hint": "decision-helper"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/css-audit-patterns.md",
+      "line_range": [
+        15,
+        15
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/css-audit-patterns.md",
+      "line_range": [
+        29,
+        57
+      ],
+      "block_text": "# Find Google Fonts imports loading banned fonts\ngrep -rn 'fonts.googleapis.com.*\\(Inter\\|Roboto\\|Space.Grotesk\\)' --include=\"*.html\" --include=\"*.tsx\" --include=\"*.jsx\"\ngrep -rn \"next/font.*\\(inter\\|roboto\\)\" --include=\"*.tsx\" --include=\"*.jsx\" -i\n```\n\n**What it looks like**:\n```css\nbody {\n  font-family: Inter, -apple-system, sans-serif; /* banned: Inter + system stack */\n}\nh1 {\n  font-family: 'Space Grotesk', Roboto, Arial; /* banned: all three */\n}\n```\n\n**Why wrong**: These fonts are overused...",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/css-audit-patterns.md",
+      "line_range": [
+        70,
+        96
+      ],
+      "block_text": "# Find Tailwind arbitrary color values (should use CSS vars via theme config instead)\nrg 'text-\\[#[0-9a-fA-F]+\\]|bg-\\[#[0-9a-fA-F]+\\]|border-\\[#[0-9a-fA-F]+\\]' -g \"*.tsx\" -g \"*.jsx\"\n```\n\n**What it looks like**:\n```css\n.hero-title {\n  color: #1a1a2e;           /* hardcoded \u2014 bypasses token system */\n  background: #4a90e2;      /* hardcoded \u2014 impossible to audit ratio */\n}\n```\n\n**Why wrong**: Hardcoded colors scattered across files break the 60/30/10 dominance ratio audit \u2014 you cannot verify palet...",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/css-audit-patterns.md",
+      "line_range": [
+        111,
+        140
+      ],
+      "block_text": "# Find blanket transition (anti-pattern: animating everything with *)\ngrep -rn '\\*\\s*{[^}]*transition' --include=\"*.css\" --include=\"*.scss\"\ngrep -rn 'transition:\\s*all' --include=\"*.css\" --include=\"*.scss\"\n```\n\n**What it looks like**:\n```css\n/* Animating everything \u2014 loses impact */\n.hero         { animation: fade-in 0.4s ease; }\n.hero-title   { animation: slide-up 0.5s ease 0.1s; }\n.hero-subtitle{ animation: slide-up 0.5s ease 0.2s; }\n.hero-cta     { animation: slide-up 0.5s ease 0.3s; }\n.nav  ...",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/css-audit-patterns.md",
+      "line_range": [
+        150,
+        176
+      ],
+      "block_text": "# Verify hero/section elements have gradient layers (count should be > 0)\ngrep -rn '\\.hero\\b\\|\\.landing\\b\\|\\.page-hero\\b' --include=\"*.css\" -A 8 | grep -c 'gradient'\n```\n\n**What it looks like**:\n```css\n.hero {\n  background-color: #0a0a1a; /* flat \u2014 fails the 2-layer Phase 5 gate */\n}\n.landing-section {\n  background: #f5f5f0;       /* single value \u2014 no atmospheric depth */\n}\n```\n\n**Why wrong**: A flat background creates no visual depth, no focal point, no mood. It is the visual equivalent of sayi...",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/css-audit-patterns.md",
+      "line_range": [
+        186,
+        204
+      ],
+      "block_text": "# Find missing fallback (only one font in stack, no comma)\ngrep -rn \"font-family:\\s*'[^']*'\" --include=\"*.css\" | grep -v ','\n```\n\n**What it looks like**:\n```css\nbody { font-family: sans-serif; }        /* OS default \u2014 different on every platform */\nh1   { font-family: 'Outfit'; }          /* no fallback \u2014 FOUT on slow connections */\n```\n\n**Why wrong**: `sans-serif` alone renders as Helvetica (macOS), Arial (Windows), or Liberation Sans (Linux) \u2014 three different pages. A missing fallback causes F...",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/css-audit-patterns.md",
+      "line_range": [
+        236,
+        237
+      ],
+      "block_text": "# Blanket transition anti-pattern\ngrep -rn 'transition:\\s*all' --include=\"*.css\" --include=\"*.scss\"\n",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/performance-budgets.md",
+      "line_range": [
+        119,
+        119
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/performance-budgets.md",
+      "line_range": [
+        131,
+        160
+      ],
+      "block_text": "# Find transition on layout properties\ngrep -rn 'transition:.*\\(width\\|height\\|top\\|left\\|margin\\)' --include=\"*.css\" --include=\"*.scss\"\nrg 'transition-property:\\s*(width|height|top|left|margin)' --type css\n```\n\n**What it looks like**:\n```css\n@keyframes expand {\n  from { width: 0; height: 0; }\n  to   { width: 200px; height: 200px; }\n}\n.card {\n  transition: margin-top 0.3s ease; /* layout shift on hover */\n}\n```\n\n**Why wrong**: Layout properties trigger the full pipeline (Layout \u2192 Paint \u2192 Composi...",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/performance-budgets.md",
+      "line_range": [
+        170,
+        201
+      ],
+      "block_text": "# Find color in keyframes\nrg '@keyframes' --type css -A 15 | grep -E 'color:|background-color:'\n```\n\n**What it looks like**:\n```css\n.nav-link {\n  transition: color 0.2s ease, background-color 0.2s ease;\n}\n```\n\n**Why wrong**: Both `color` and `background-color` trigger paint. For short transitions (< 200ms) this is acceptable on desktop. On mobile, or for elements that appear many times on the page (nav items, list rows), it causes accumulated paint cost.\n\n**Fix**:\n```css\n/* Wrap text in a span; ...",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/performance-budgets.md",
+      "line_range": [
+        207,
+        228
+      ],
+      "block_text": "# Find transition: all declarations\ngrep -rn 'transition:\\s*all\\b' --include=\"*.css\" --include=\"*.scss\" --include=\"*.module.css\"\nrg 'transition:\\s*all\\b' --type css\n```\n\n**What it looks like**:\n```css\n.card {\n  transition: all 0.3s ease; /* animates everything that changes */\n}\n```\n\n**Why wrong**: `transition: all` watches every animatable property. Adding a layout-triggering property later (even indirectly through a media query) silently introduces jank. It also animates properties you never in...",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/performance-budgets.md",
+      "line_range": [
+        234,
+        249
+      ],
+      "block_text": "# Find will-change declarations\ngrep -rn 'will-change:' --include=\"*.css\" --include=\"*.scss\" --include=\"*.module.css\"\nrg 'will-change:' --type css\n```\n\n**What it looks like**:\n```css\n* { will-change: transform; }  /* nuclear option \u2014 crashes low-end devices */\n.card { will-change: transform, opacity, filter; } /* too many properties */\n```\n\n**Why wrong**: Each `will-change` layer consumes GPU memory. Blanket use exhausts VRAM on low-end mobile (typically 512MB\u20131GB GPU memory budget), causing the...",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/phase-details.md",
+      "line_range": [
+        60,
+        67
+      ],
+      "block_text": "### Phase 3: Anti-Pattern Checks\n\nCheck against anti-patterns in `references/anti-patterns.json`:\n- No purple (#8B5CF6, #A855F7) as accent on white background -- the most cliched color scheme in modern web design, signaling generic SaaS template\n- No evenly distributed colors without clear dominance\n- No generic blue (#3B82F6) as primary on white\n- No pastels without saturation variation\n- No pure black (#000000) or pure white (#FFFFFF) as dominant color\n",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/distinctive-frontend-design/references/phase-details.md",
+      "line_range": [
+        73,
+        76
+      ],
+      "block_text": "# Manual alternative: check palette against anti-patterns in references/anti-patterns.json\n```\n\nManually verify: no cliche patterns, clear 60/30/10 dominance ratio, sufficient contrast for accessibility. Report results with specific hex values rather than describing colors abstractly.\n",
+      "domain_hint": "distinctive-frontend-design"
+    },
+    {
+      "file": "skills/do/references/perspective-prompts.md",
+      "line_range": [
+        220,
+        225
+      ],
+      "block_text": "### Poor Sources (avoid)\n- Marketing fluff without technical depth\n- Auto-generated documentation\n- Listicles without underlying methodology\n- Opinion pieces without supporting evidence\n- Code dumps without explanation",
+      "domain_hint": "do"
+    },
+    {
+      "file": "skills/do/references/progressive-depth.md",
+      "line_range": [
+        98,
+        106
+      ],
+      "block_text": "## Anti-Patterns\n\n| Anti-pattern | Why it fails | Correct behavior |\n|--------------|-------------|------------------|\n| Starting at Level 2 \"just to be safe\" | Defeats the purpose; burns tokens on methodology the task doesn't need | Start at Level 1, let evidence drive escalation |\n| Escalating without evidence | Phantom complexity; the agent imagines problems that don't exist | Must cite a concrete escalation signal |\n| Silent degradation | Shallow agent produces wrong output instead of escala...",
+      "domain_hint": "do"
+    },
+    {
+      "file": "skills/e2e-testing/references/async.md",
+      "line_range": [
+        107,
+        107
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "e2e-testing"
+    },
+    {
+      "file": "skills/e2e-testing/references/async.md",
+      "line_range": [
+        109,
+        137
+      ],
+      "block_text": "### \u274c `waitForTimeout` as a Timing Fix\n\n**Detection**:\n```bash\ngrep -rn 'waitForTimeout' --include=\"*.ts\" --include=\"*.spec.ts\"\nrg 'waitForTimeout\\(' --type ts\n```\n\n**What it looks like**:\n```typescript\nawait page.getByTestId('save-button').click();\nawait page.waitForTimeout(2000); // \"give it time to save\"\nawait expect(page.getByTestId('success-banner')).toBeVisible();\n```\n\n**Why wrong**: Hard-coded delays fail silently on slow CI (timeout too short) or waste time on fast machines (timeout too ...",
+      "domain_hint": "e2e-testing"
+    },
+    {
+      "file": "skills/e2e-testing/references/async.md",
+      "line_range": [
+        139,
+        163
+      ],
+      "block_text": "### \u274c Fire-and-Forget Click (Missing Await on Navigation)\n\n**Detection**:\n```bash\ngrep -rn '\\.click()$' --include=\"*.spec.ts\"\nrg '\\.click\\(\\)[^;]' --type ts\n```\n\n**What it looks like**:\n```typescript\npage.getByTestId('submit').click(); // missing await\nawait expect(page).toHaveURL('/confirmation'); // races with navigation\n```\n\n**Why wrong**: Without `await`, the click fires but the test proceeds immediately. If the URL check runs before navigation completes, it sees the old URL and fails interm...",
+      "domain_hint": "e2e-testing"
+    },
+    {
+      "file": "skills/e2e-testing/references/async.md",
+      "line_range": [
+        165,
+        200
+      ],
+      "block_text": "### \u274c Async Fixture Without Teardown\n\n**Detection**:\n```bash\ngrep -rn \"test\\.extend\" --include=\"*.ts\" -A 10\nrg 'test\\.extend\\b' --type ts -A 10\n```\n\n**What it looks like**:\n```typescript\nexport const test = base.extend<{ db: Database }>({\n  db: async ({}, use) => {\n    const db = await Database.connect();\n    await use(db);\n    // Missing: await db.disconnect();  \u2014 resource leak\n  },\n});\n```\n\n**Why wrong**: Leaked connections accumulate across the test suite. In CI with 100 tests, this exhausts ...",
+      "domain_hint": "e2e-testing"
+    },
+    {
+      "file": "skills/e2e-testing/references/async.md",
+      "line_range": [
+        202,
+        228
+      ],
+      "block_text": "### \u274c Sequential Waits for Independent Elements\n\n**Detection**:\n```bash\ngrep -rn '\\.waitFor(' --include=\"*.spec.ts\" -A 1\nrg 'waitFor\\(' --type ts --include=\"*.spec.ts\"\n```\n\n**What it looks like**:\n```typescript\nawait page.getByTestId('widget-a').waitFor({ state: 'visible' });\nawait page.getByTestId('widget-b').waitFor({ state: 'visible' });\nawait page.getByTestId('widget-c').waitFor({ state: 'visible' });\n```\n\n**Why wrong**: Each wait is sequential. If each element takes 500ms to render, this ad...",
+      "domain_hint": "e2e-testing"
+    },
+    {
+      "file": "skills/e2e-testing/references/auth.md",
+      "line_range": [
+        184,
+        184
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "e2e-testing"
+    },
+    {
+      "file": "skills/e2e-testing/references/auth.md",
+      "line_range": [
+        186,
+        209
+      ],
+      "block_text": "### \u274c UI Login in Every Test\n\n**Detection**:\n```bash\ngrep -rn 'getByTestId.*login\\|getByTestId.*password\\|getByTestId.*signin' --include=\"*.spec.ts\"\nrg '(login-email|login-password|login-submit)' --type ts --include=\"*.spec.ts\" -l\n```\n\n**What it looks like**:\n```typescript\ntest.beforeEach(async ({ page }) => {\n  await page.goto('/login');\n  await page.getByTestId('login-email').fill('user@test.com');\n  await page.getByTestId('login-password').fill('password');\n  await page.getByTestId('login-sub...",
+      "domain_hint": "e2e-testing"
+    },
+    {
+      "file": "skills/e2e-testing/references/auth.md",
+      "line_range": [
+        211,
+        238
+      ],
+      "block_text": "### \u274c Sharing Auth Context Between Roles\n\n**Detection**:\n```bash\ngrep -rn 'storageState' --include=\"playwright.config.ts\" -A 5\nrg 'storageState.*admin.*viewer|storageState.*viewer.*admin' --type ts\n```\n\n**What it looks like**:\n```typescript\n// playwright.config.ts \u2014 wrong: one storageState for all tests\nuse: {\n  storageState: 'playwright/.auth/user.json', // which user? admin or viewer?\n},\n```\n\n**Why wrong**: When tests for different roles share one auth file, they run with the same permissions....",
+      "domain_hint": "e2e-testing"
+    },
+    {
+      "file": "skills/e2e-testing/references/auth.md",
+      "line_range": [
+        240,
+        261
+      ],
+      "block_text": "### \u274c Hardcoded Credentials in Spec Files\n\n**Detection**:\n```bash\ngrep -rn 'password.*:.*\"[^\"]\\+\"\\|fill.*\"password[^\"]*\"' --include=\"*.spec.ts\"\nrg '(password|secret|token)\\s*[:=]\\s*[\"'\"'\"'][^\"'\"'\"']+[\"'\"'\"']' --type ts --include=\"*.spec.ts\"\n```\n\n**What it looks like**:\n```typescript\nawait page.getByTestId('login-password').fill('MyP@ssw0rd123'); // hardcoded\n```\n\n**Why wrong**: Credentials in source code appear in git history permanently. They also break when rotated.\n\n**Fix**:\n```typescript\nawa...",
+      "domain_hint": "e2e-testing"
+    },
+    {
+      "file": "skills/e2e-testing/references/auth.md",
+      "line_range": [
+        263,
+        281
+      ],
+      "block_text": "### \u274c Testing Real OAuth Provider Endpoints\n\n**Detection**:\n```bash\ngrep -rn 'accounts\\.google\\.com\\|github\\.com/login/oauth\\|login\\.microsoftonline' --include=\"*.spec.ts\"\nrg '(google|github|microsoft|auth0)\\.com' --type ts --include=\"*.spec.ts\"\n```\n\n**What it looks like**:\n```typescript\nawait page.goto('https://accounts.google.com/o/oauth2/auth?...');\nawait page.getByLabel('Email').fill(process.env.GOOGLE_TEST_EMAIL!);\n```\n\n**Why wrong**: Hits a live external service. Flaky on network issues. R...",
+      "domain_hint": "e2e-testing"
+    },
+    {
+      "file": "skills/endpoint-validator/references/auth-endpoint-patterns.md",
+      "line_range": [
+        113,
+        113
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/auth-endpoint-patterns.md",
+      "line_range": [
+        115,
+        133
+      ],
+      "block_text": "### \u274c Hardcoded Bearer Token in Config\n\n**Detection**:\n```bash\ngrep -rn '\"Authorization\"' endpoints.json | grep -v '\\${[A-Z_]'\nrg '\"Authorization\".*\"Bearer [A-Za-z0-9._-]{20,}\"' --type json\n```\n\n**What it looks like**:\n```json\n{\"headers\": {\"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.actual.token\"}}\n```\n\n**Why wrong**: JWT tokens in config files get committed to git history. Even after rotation,\nthe old token remains in every git clone. GitHub secret scanning flags base64-encode...",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/auth-endpoint-patterns.md",
+      "line_range": [
+        135,
+        164
+      ],
+      "block_text": "### \u274c Skipping expect_status on Protected Endpoint\n\n**Detection**:\n```bash\npython3 -c \"\nimport json\ncfg = json.load(open('endpoints.json'))\nfor ep in cfg.get('endpoints', []):\n    if 'Authorization' in str(ep.get('headers', {})):\n        if 'expect_status' not in ep:\n            print('WARN no expect_status on auth endpoint:', ep['path'])\n\"\n```\n\n**What it looks like**:\n```json\n{\n  \"path\": \"/api/v1/admin/users\",\n  \"headers\": {\"Authorization\": \"Bearer ${TOKEN}\"}\n}\n```\n\n**Why wrong**: Without expli...",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/auth-endpoint-patterns.md",
+      "line_range": [
+        166,
+        185
+      ],
+      "block_text": "### \u274c Using Admin Credentials for Smoke Tests\n\n**Detection**:\n```bash\ngrep -rn \"ADMIN\\|ROOT\\|MASTER\\|SUPERUSER\\|SUPER_\" endpoints.json\n```\n\n**What it looks like**:\n```json\n{\"headers\": {\"Authorization\": \"Bearer ${PROD_ADMIN_TOKEN}\"}}\n```\n\n**Why wrong**: A validation run with a compromised CI environment gets full admin access\nto production. Blast radius is maximum. Use read-only service account tokens scoped to\nthe specific paths being validated.\n\n**Fix**: Create a dedicated `endpoint-validator` ...",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/auth-endpoint-patterns.md",
+      "line_range": [
+        187,
+        217
+      ],
+      "block_text": "### \u274c Session Cookie Validation Without Expiry Handling\n\n**Detection**:\n```bash\ngrep -rn '\"Cookie\"' endpoints.json | grep -v '\\${[A-Z_]'\n```\n\n**What it looks like**:\n```json\n{\n  \"path\": \"/dashboard\",\n  \"headers\": {\"Cookie\": \"session=abc123fixed\"},\n  \"expect_status\": 200\n}\n```\n\n**Why wrong**: Sessions expire. A hardcoded session value that worked during setup will\nsilently redirect to a login page (302), which the validator may follow and report 200\n(the login page), masking the auth failure enti...",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/endpoint-config-anti-patterns.md",
+      "line_range": [
+        1,
+        7
+      ],
+      "block_text": "# Endpoint Config Anti-Patterns Reference\n\n> **Scope**: Anti-patterns in `endpoints.json` configuration and common validation mistakes.\n> **Version range**: All versions of endpoint-validator\n> **Generated**: 2026-04-17\n\n---\n",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/endpoint-config-anti-patterns.md",
+      "line_range": [
+        56,
+        56
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/endpoint-config-anti-patterns.md",
+      "line_range": [
+        58,
+        80
+      ],
+      "block_text": "### \u274c Hardcoded IP Address in base_url\n\n**Detection**:\n```bash\ngrep -rn '\"base_url\"' . --include=\"*.json\" | grep -E '\"[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+'\nrg '\"base_url\".*[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}' --type json\n```\n\n**What it looks like**:\n```json\n{\"base_url\": \"http://192.168.1.42:8000\"}\n```\n\n**Why wrong**: IP addresses are machine-local. The config breaks on every other developer\nmachine, in CI, and after any network reconfiguration.\n\n**Fix**:\n```json\n{\"base_url\": \"http://localho...",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/endpoint-config-anti-patterns.md",
+      "line_range": [
+        82,
+        105
+      ],
+      "block_text": "### \u274c Write Endpoints Against Production base_url\n\n**Detection**:\n```bash\ngrep -rn '\"method\"' . --include=\"*.json\" | grep -iE '\"POST\"|\"PUT\"|\"DELETE\"|\"PATCH\"'\n```\n\n**What it looks like**:\n```json\n{\n  \"base_url\": \"https://api.example.com\",\n  \"endpoints\": [\n    {\"path\": \"/api/v1/users\", \"method\": \"POST\", \"body\": {\"name\": \"test\"}}\n  ]\n}\n```\n\n**Why wrong**: POST/PUT/DELETE against a production URL creates/mutates/deletes real data.\nA smoke test that runs pre-deploy will insert test records, trigger w...",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/endpoint-config-anti-patterns.md",
+      "line_range": [
+        107,
+        131
+      ],
+      "block_text": "### \u274c Zero or Very High Timeout\n\n**Detection**:\n```bash\ngrep -rn '\"timeout\"' . --include=\"*.json\" | grep -E '\"timeout\":\\s*0\\b'\ngrep -rn '\"timeout\"' . --include=\"*.json\" | grep -E '\"timeout\":\\s*[6-9][0-9]|[1-9][0-9]{2,}'\n```\n\n**What it looks like**:\n```json\n{\"path\": \"/api/slow\", \"timeout\": 0}\n{\"path\": \"/api/upload\", \"timeout\": 300}\n```\n\n**Why wrong**: `timeout: 0` means no timeout \u2014 a hung connection blocks the entire validation\nsuite forever. `timeout: 300` hides performance regressions; an endp...",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/endpoint-config-anti-patterns.md",
+      "line_range": [
+        133,
+        154
+      ],
+      "block_text": "### \u274c expect_key on Non-JSON Endpoint\n\n**Detection**:\n```bash\ngrep -B2 '\"expect_key\"' endpoints.json | grep -E '\"path\".*\\.(html|xml|csv|txt|pdf)'\n```\n\n**What it looks like**:\n```json\n{\"path\": \"/sitemap.xml\", \"expect_key\": \"urlset\"}\n```\n\n**Why wrong**: `expect_key` parses the response as JSON and checks for a top-level key.\nXML, HTML, and CSV responses will always fail JSON parsing, generating \"Invalid JSON response\"\nerrors that obscure the real issue.\n\n**Fix**: For non-JSON endpoints, only check...",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/endpoint-config-anti-patterns.md",
+      "line_range": [
+        156,
+        184
+      ],
+      "block_text": "### \u274c Missing expect_status on Non-200 Endpoints\n\n**Detection**:\n```bash\npython3 -c \"\nimport json\nwith open('endpoints.json') as f: cfg = json.load(f)\nfor ep in cfg.get('endpoints', []):\n    path = ep.get('path', '')\n    if ('404' in path or 'error' in path.lower() or 'missing' in path.lower()):\n        if 'expect_status' not in ep:\n            print('WARN missing expect_status:', path)\n\"\n```\n\n**What it looks like**:\n```json\n{\"path\": \"/api/v1/nonexistent-resource\"}\n```\n\n**Why wrong**: Default `e...",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/endpoint-config-anti-patterns.md",
+      "line_range": [
+        186,
+        208
+      ],
+      "block_text": "### \u274c Credentials in Config File\n\n**Detection**:\n```bash\ngrep -rn '\"Authorization\"\\|\"X-Api-Key\"\\|\"api_key\"\\|\"token\"' endpoints.json | grep -v '\\${[A-Z_]*}'\nrg '\"Bearer [A-Za-z0-9+/=._-]{20,}\"' --type json\n```\n\n**What it looks like**:\n```json\n{\"headers\": {\"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiJ9.actual-token-here\"}}\n```\n\n**Why wrong**: Tokens committed to config files end up in git history permanently. Even if\nrotated, the old token may be valid elsewhere or extractable from history. GitHub ...",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/security-headers.md",
+      "line_range": [
+        93,
+        93
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/security-headers.md",
+      "line_range": [
+        95,
+        116
+      ],
+      "block_text": "### \u274c Checking Security Headers on localhost\n\n**Detection**:\n```bash\ngrep -rn '\"base_url\".*localhost\\|\"base_url\".*127\\.0\\.0\\.1' endpoints.json\n```\n\n**What it looks like**:\n```json\n{\n  \"base_url\": \"http://localhost:8000\",\n  \"check_security_headers\": true\n}\n```\n\n**Why wrong**: Development servers don't set these headers. Running the check against localhost\ngenerates spurious WARNs on every local run, training developers to ignore warnings entirely.\n\n**Fix**: The validator skips security header che...",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/security-headers.md",
+      "line_range": [
+        118,
+        141
+      ],
+      "block_text": "### \u274c Treating WARN as PASS in CI\n\n**Detection**:\n```bash\ngrep -rn \"|| true\\|--allow-warn\\|exit 0\" .github/workflows/ .gitlab-ci.yml 2>/dev/null\n```\n\n**What it looks like**:\n```yaml\n- run: endpoint-validator || true  # suppress all failures\n```\n\n**Why wrong**: Suppressing exit codes means security header regressions (a deploy that removes\nCSP) pass CI silently. Use `--fail-on-warn` in production validation runs so header removal\ntriggers a build failure.\n\n**Fix**:\n```yaml\n- run: endpoint-validat...",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/endpoint-validator/references/security-headers.md",
+      "line_range": [
+        143,
+        161
+      ],
+      "block_text": "### \u274c HSTS Expected on HTTP Endpoint\n\n**Detection**:\n```bash\ngrep -rn '\"base_url\".*\"http://' endpoints.json | grep -v \"localhost\\|127\\.0\\.0\\.1\"\n```\n\n**What it looks like**:\n```json\n{\"base_url\": \"http://api.example.com\"}\n```\n\n**Why wrong**: HSTS is only meaningful over HTTPS. Browsers ignore HSTS headers delivered\nover HTTP (per RFC 6797 \u00a78.1). Checking for it on HTTP endpoints always generates misleading WARNs.\n\n**Fix**: Use `https://` base_url for production validation, or the validator should ...",
+      "domain_hint": "endpoint-validator"
+    },
+    {
+      "file": "skills/explanation-traces/references/anti-patterns.md",
+      "line_range": [
+        1,
+        6
+      ],
+      "block_text": "# Explanation Traces \u2014 Anti-Patterns\n\nAnti-patterns for both trace producers (hooks that write session-trace.json) and trace\nconsumers (this skill reading it). Organized by who makes the mistake.\n\n---\n",
+      "domain_hint": "explanation-traces"
+    },
+    {
+      "file": "skills/explanation-traces/references/anti-patterns.md",
+      "line_range": [
+        8,
+        8
+      ],
+      "block_text": "## Producer Anti-Patterns (Hook Writers)\n",
+      "domain_hint": "explanation-traces"
+    },
+    {
+      "file": "skills/explanation-traces/references/anti-patterns.md",
+      "line_range": [
+        10,
+        19
+      ],
+      "block_text": "### AP-1: Post-Hoc Trace Writing\n\n**Detection** (find hooks that append after execution rather than at decision time):\n```bash\ngrep -rn \"session-trace\" hooks/ --include=\"*.py\" | grep -v \"import\\|def \"\nrg 'session.trace' hooks/ -l\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "explanation-traces"
+    },
+    {
+      "file": "skills/explanation-traces/references/anti-patterns.md",
+      "line_range": [
+        20,
+        37
+      ],
+      "block_text": "# Hook writes after the full agent run completes\ndef on_agent_stop(event):\n    # WRONG: Writing what happened, not what was decided\n    append_trace({\n        \"timestamp\": datetime.utcnow().isoformat(),\n        \"type\": \"agent-selection\",\n        \"chosen\": event[\"agent\"],\n        \"evidence\": \"agent completed successfully\",  # outcome, not decision signal\n        \"alternatives\": [],\n    })\n```\n\n**Why wrong**: Post-hoc traces record outcomes, not decisions. The `evidence` becomes\n\"it worked\" rather...",
+      "domain_hint": "explanation-traces"
+    },
+    {
+      "file": "skills/explanation-traces/references/anti-patterns.md",
+      "line_range": [
+        60,
+        89
+      ],
+      "block_text": "# Also catch missing alternatives field entirely:\npython3 -c \"\nimport json, sys\ndata = json.load(open('session-trace.json'))\nbad = [i for i, d in enumerate(data['decisions']) if 'alternatives' not in d]\nprint(f'Missing alternatives field at indices: {bad}')\n\"\n```\n\n**What it looks like**:\n```json\n{\n  \"timestamp\": \"2026-04-01T10:00:00Z\",\n  \"type\": \"routing\",\n  \"chosen\": \"skill:roast\",\n  \"alternatives\": null,\n  \"evidence\": \"force_route triggered\"\n}\n```\n\n**Why wrong**: `null` is not the same as `[]`...",
+      "domain_hint": "explanation-traces"
+    },
+    {
+      "file": "skills/explanation-traces/references/anti-patterns.md",
+      "line_range": [
+        97,
+        124
+      ],
+      "block_text": "# Check evidence length \u2014 short evidence is usually vague:\npython3 -c \"\nimport json\ndata = json.load(open('session-trace.json'))\nshort = [(i, d['evidence']) for i, d in enumerate(data['decisions'])\n         if len(d.get('evidence', '')) < 20]\nfor i, ev in short: print(f'[{i}] Short evidence: {repr(ev)}')\n\"\n```\n\n**What it looks like**:\n```json\n{ \"evidence\": \"seemed like the right choice\" }\n{ \"evidence\": \"best match\" }\n{ \"evidence\": \"\" }\n```\n\n**Why wrong**: These evidence strings tell the user not...",
+      "domain_hint": "explanation-traces"
+    },
+    {
+      "file": "skills/explanation-traces/references/anti-patterns.md",
+      "line_range": [
+        130,
+        136
+      ],
+      "block_text": "# Find hooks that open with 'w' mode (overwrite) instead of read-then-write:\ngrep -rn \"open.*session-trace.*['\\\"]w['\\\"]\" hooks/\nrg 'open\\([^)]*session.trace[^)]*[\"\\']w[\"\\']' hooks/ --type py\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "explanation-traces"
+    },
+    {
+      "file": "skills/explanation-traces/references/anti-patterns.md",
+      "line_range": [
+        137,
+        162
+      ],
+      "block_text": "# WRONG: Overwrites entire file each time\nwith open(\"session-trace.json\", \"w\") as f:\n    json.dump({\"decisions\": [new_entry]}, f)\n```\n\n**Why wrong**: Every hook invocation destroys all prior decisions. A session that makes\n10 routing decisions ends up with only the last one in the trace. The timeline is\nunrecoverable.\n\n**Fix**:\n```python\nimport json, os\n\ndef append_trace(entry):\n    path = \"session-trace.json\"\n    if os.path.exists(path):\n        with open(path) as f:\n            data = json.loa...",
+      "domain_hint": "explanation-traces"
+    },
+    {
+      "file": "skills/explanation-traces/references/anti-patterns.md",
+      "line_range": [
+        164,
+        185
+      ],
+      "block_text": "### AP-5: Non-Monotonic Timestamps\n\n**Detection**:\n```bash\npython3 -c \"\nimport json\ndata = json.load(open('session-trace.json'))\nts = [d['timestamp'] for d in data['decisions']]\nfor i in range(1, len(ts)):\n    if ts[i] < ts[i-1]:\n        print(f'Non-monotonic: [{i-1}] {ts[i-1]} > [{i}] {ts[i]}')\n\"\n```\n\n**Why wrong**: If timestamps go backwards, the skill cannot sort decisions reliably.\nChronological presentation breaks. This often happens when a hook generates timestamps\nat initialization rather...",
+      "domain_hint": "explanation-traces"
+    },
+    {
+      "file": "skills/explanation-traces/references/anti-patterns.md",
+      "line_range": [
+        187,
+        187
+      ],
+      "block_text": "## Consumer Anti-Patterns (Skill Behavior)\n",
+      "domain_hint": "explanation-traces"
+    },
+    {
+      "file": "skills/explanation-traces/references/anti-patterns.md",
+      "line_range": [
+        189,
+        202
+      ],
+      "block_text": "### AP-6: Reconstructing Decisions from Conversation History\n\n**What it looks like** (incorrect skill behavior):\n> \"The trace file doesn't exist, but based on the conversation I can tell the router\n> probably chose the golang agent because the user mentioned Go...\"\n\n**Why wrong**: This is exactly the rationalization the skill exists to prevent. If no\ntrace file exists, the correct answer is \"no trace file found\" \u2014 not an inference from\nmemory or conversation history.\n\n**Correct behavior**: Repor...",
+      "domain_hint": "explanation-traces"
+    },
+    {
+      "file": "skills/explanation-traces/references/anti-patterns.md",
+      "line_range": [
+        204,
+        216
+      ],
+      "block_text": "### AP-7: Dumping Raw JSON Without Filtering\n\n**What it looks like**: Printing the entire `session-trace.json` content when the user\nasks a specific question like \"why did you pick the code reviewer?\".\n\n**Why wrong**: Unfiltered JSON forces the user to manually scan for the relevant entry.\nA 20-decision trace printed as raw JSON is noise, not an explanation.\n\n**Correct behavior**: Filter to the specific decision type, lead with the answer to the\nuser's question, then offer the full timeline as s...",
+      "domain_hint": "explanation-traces"
+    },
+    {
+      "file": "skills/explanation-traces/references/anti-patterns.md",
+      "line_range": [
+        218,
+        230
+      ],
+      "block_text": "### AP-8: Treating Incomplete Traces as Complete\n\n**What it looks like**: Presenting a timeline without flagging that several decisions have\nempty `evidence` fields.\n\n**Why wrong**: The user assumes the explanation is authoritative. Missing evidence means\nthe \"why\" for those decisions is unknown \u2014 presenting them without a caveat creates false\nconfidence in the explanation.\n\n**Correct behavior**: Flag incomplete entries explicitly (SKILL.md Phase 3 Step 3).\nReport count of entries with missing/e...",
+      "domain_hint": "explanation-traces"
+    },
+    {
+      "file": "skills/feature-lifecycle/references/error-handling.md",
+      "line_range": [
+        78,
+        78
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "feature-lifecycle"
+    },
+    {
+      "file": "skills/feature-lifecycle/references/error-handling.md",
+      "line_range": [
+        84,
+        90
+      ],
+      "block_text": "# Look for advance calls without a preceding status check in the same block\ngrep -rn 'feature-state.py advance' skills/feature-lifecycle/\nrg 'feature-state\\.py (checkpoint|advance)' skills/\n```\n\n**What it looks like**:\n```bash",
+      "domain_hint": "feature-lifecycle"
+    },
+    {
+      "file": "skills/feature-lifecycle/references/error-handling.md",
+      "line_range": [
+        91,
+        99
+      ],
+      "block_text": "# Missing: python3 ~/.claude/scripts/feature-state.py status my-feature\npython3 ~/.claude/scripts/feature-state.py advance my-feature\n```\n\n**Why wrong**: Advancing without reading state can skip a phase or double-advance when a prior partial run already moved the state forward. The state file is authoritative; skipping the read assumes it matches session context.\n\n**Fix**:\n```bash\npython3 ~/.claude/scripts/feature-state.py status my-feature",
+      "domain_hint": "feature-lifecycle"
+    },
+    {
+      "file": "skills/feature-lifecycle/references/error-handling.md",
+      "line_range": [
+        106,
+        134
+      ],
+      "block_text": "### \u274c Retrying a Failed Agent More Than Three Times\n\n**Detection**:\n```bash\ngrep -rn 'Attempt [4-9]\\|Attempt [0-9][0-9]' .feature/state/implement/\nrg 'retry.*attempt|attempt.*[4-9]' .feature/ --ignore-case\n```\n\n**What it looks like**:\n```\nAttempt 1: Agent dispatch failed (no output)\nAttempt 2: Agent dispatch failed (timeout)\nAttempt 3: Agent dispatch failed (malformed response)\nAttempt 4: Retrying with more context...  \u2190 wrong\n```\n\n**Why wrong**: Three consecutive failures signal a structural pr...",
+      "domain_hint": "feature-lifecycle"
+    },
+    {
+      "file": "skills/feature-lifecycle/references/error-handling.md",
+      "line_range": [
+        136,
+        160
+      ],
+      "block_text": "### \u274c Proceeding Past a Gate Failure\n\n**Detection**:\n```bash\ngrep -rn 'gate.*fail\\|BLOCKED.*proceed\\|proceeding.*fail' .feature/state/ --ignore-case\nrg 'minor failure|appears minor|otherwise complete' .feature/\n```\n\n**What it looks like**:\n```\nGate: Validate failed (2 tests failing), but proceeding to release because\n      failures appear minor and the feature is otherwise complete.\n```\n\n**Why wrong**: Gates are binary. Downstream phases depend on upstream correctness \u2014 releasing with failing va...",
+      "domain_hint": "feature-lifecycle"
+    },
+    {
+      "file": "skills/feature-lifecycle/references/error-handling.md",
+      "line_range": [
+        166,
+        181
+      ],
+      "block_text": "# Find scripts opening the state JSON directly instead of via CLI\nrg '\\.feature/state.*\\.json' . --type py\ngrep -rn 'open.*feature.*state' . --include=\"*.py\"\n```\n\n**What it looks like**:\n```python\nimport json\nwith open('.feature/state/my-feature.json', 'w') as f:\n    json.dump({'phase': 'validate', ...}, f)  # direct write \u2014 wrong\n```\n\n**Why wrong**: The state file format is an implementation detail of `feature-state.py`. Direct writes bypass validation, lock acquisition, and event recording. Th...",
+      "domain_hint": "feature-lifecycle"
+    },
+    {
+      "file": "skills/feature-lifecycle/references/error-handling.md",
+      "line_range": [
+        212,
+        213
+      ],
+      "block_text": "# Find direct state file manipulation (bypass anti-pattern)\nrg '\\.feature/state.*\\.json' . --type py\n",
+      "domain_hint": "feature-lifecycle"
+    },
+    {
+      "file": "skills/gemini-image-generator/references/prompts.md",
+      "line_range": [
+        228,
+        235
+      ],
+      "block_text": "### To Avoid Unwanted Elements\n\nAlways include:\n- \"no text\"\n- \"no labels\"\n- \"no watermarks\"\n- \"no UI elements\"\n- \"character/object only\"\n",
+      "domain_hint": "gemini-image-generator"
+    },
+    {
+      "file": "skills/go-patterns/references/anti-patterns.md",
+      "line_range": [
+        2,
+        4
+      ],
+      "block_text": "# Go Anti-Patterns Skill\n\nDetect and remediate the 7 core Go anti-patterns: premature interface abstraction, goroutine overkill, error wrapping without context, channel misuse, generic abuse, context soup, and unnecessary function extraction. Every detection is evidence-based with code location and concrete harm explanation, and every recommendation aligns with Go proverbs and standard library conventions.\n",
+      "domain_hint": "go-patterns"
+    },
+    {
+      "file": "skills/go-patterns/references/anti-patterns.md",
+      "line_range": [
+        14,
+        28
+      ],
+      "block_text": "### Phase 2: Scan for Anti-Patterns\n\nUse the Quick Detection Guide to systematically check each file under review. Work through the table row by row against the code.\n\n| Code Smell | Detection Question | If Yes |\n|------------|-------------------|--------|\n| Interface with one impl | Do you have 2+ implementations? | Remove interface |\n| Goroutine + WaitGroup | Is work I/O bound or CPU heavy? | Use sequential loop |\n| `fmt.Errorf(\"error: %w\")` | Does wrap add context? | Add operation + ID |\n| Ch...",
+      "domain_hint": "go-patterns"
+    },
+    {
+      "file": "skills/go-patterns/references/anti-patterns.md",
+      "line_range": [
+        58,
+        58
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "go-patterns"
+    },
+    {
+      "file": "skills/joy-check/references/instruction-rubric.md",
+      "line_range": [
+        116,
+        116
+      ],
+      "block_text": "## Anti-Patterns",
+      "domain_hint": "joy-check"
+    },
+    {
+      "file": "skills/kb/references/compile.md",
+      "line_range": [
+        182,
+        192
+      ],
+      "block_text": "## Anti-Patterns\n\n**Do NOT rewrite existing concept articles from scratch.** Incremental updates preserve the accumulated knowledge from prior compilations. If the existing article is good, only add what is new.\n\n**Do NOT create concepts with a single source** unless the concept is clearly significant (a named algorithm, a major pattern, an established term). Single-source concepts that are not significant just create noise.\n\n**Do NOT include raw source content verbatim.** Summarize and synthesi...",
+      "domain_hint": "kb"
+    },
+    {
+      "file": "skills/kb/references/lint.md",
+      "line_range": [
+        97,
+        103
+      ],
+      "block_text": "## Anti-patterns\n\n- Do NOT fix issues silently \u2014 always report before fixing\n- Do NOT suggest concepts for every minor term \u2014 only significant gaps (max 5)\n- Do NOT report passing checks \u2014 only failures and suggestions\n- Do NOT read every raw source during lint \u2014 structural checks use wiki files only\n- Do NOT treat missing `research/{topic}/` as a lint failure \u2014 exit with a clear error message before phase 1",
+      "domain_hint": "kb"
+    },
+    {
+      "file": "skills/kb/references/query.md",
+      "line_range": [
+        87,
+        97
+      ],
+      "block_text": "## Anti-Patterns\n\n**Do NOT answer from general knowledge if the KB has relevant content.** The point of the system is to build and use a local knowledge base. Bypassing it defeats the flywheel.\n\n**Do NOT read every wiki file.** Use the `_index.md` to select relevant articles. Reading every file wastes time and context on irrelevant material.\n\n**Do NOT write query files longer than 1500 words.** If the answer requires more than that, it is probably two separate questions. Answer the specific ques...",
+      "domain_hint": "kb"
+    },
+    {
+      "file": "skills/kotlin-coroutines/references/anti-patterns.md",
+      "line_range": [
+        7,
+        7
+      ],
+      "block_text": "# Kotlin Coroutine Anti-Patterns\n",
+      "domain_hint": "anti"
+    },
+    {
+      "file": "skills/kubernetes-security/references/supply-chain.md",
+      "line_range": [
+        100,
+        106
+      ],
+      "block_text": "### Anti-Patterns (Do Not Use)\n\n- Mounting secrets as environment variables in the pod spec (visible in `kubectl describe pod`)\n- Storing secrets in ConfigMaps\n- Hardcoding credentials in container images or Dockerfiles\n\n---\n",
+      "domain_hint": "kubernetes-security"
+    },
+    {
+      "file": "skills/multi-persona-critique/references/examples-and-errors.md",
+      "line_range": [
+        1,
+        1
+      ],
+      "block_text": "# Multi-Persona Critique \u2014 Templates, Examples, Anti-Patterns, and Error Handling\n",
+      "domain_hint": "multi-persona-critique"
+    },
+    {
+      "file": "skills/multi-persona-critique/references/examples-and-errors.md",
+      "line_range": [
+        94,
+        105
+      ],
+      "block_text": "## Anti-Patterns\n\n| Anti-Pattern | Why It Is Wrong | What To Do Instead |\n|--------------|----------------|-------------------|\n| Averaging away disagreement | The disagreements ARE the insight | Preserve and present disagreements as first-class findings |\n| Post-hoc rationalization of persona views | Each persona's output is final | Report persona outputs as-is; synthesize across them, do not edit them |\n| Treating consensus as truth | 5 agents from the same model share blind spots | Note the c...",
+      "domain_hint": "multi-persona-critique"
+    },
+    {
+      "file": "skills/phaser-gamedev/references/game-feel-patterns.md",
+      "line_range": [
+        295,
+        295
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "Phaser Game Feel Patterns"
+    },
+    {
+      "file": "skills/phaser-gamedev/references/game-feel-patterns.md",
+      "line_range": [
+        334,
+        373
+      ],
+      "block_text": "### \u274c Creating Physics Bodies Inside update()\n\n**Detection**:\n```bash\ngrep -rn \"physics\\.add\\.\\(sprite\\|image\\|existing\\)\\|add\\.group\" --include=\"*.ts\" --include=\"*.js\"\nrg \"update\\(.*delta\\)\" --type ts -A 30 | grep \"physics\\.add\"\n```\n\n**What it looks like**:\n```typescript\nupdate(_time: number, _delta: number): void {\n  if (this.fireButton.isDown) {\n    // BAD: new physics sprite every frame the button is held\n    const bullet = this.physics.add.image(this.player.x, this.player.y, 'bullet');\n    ...",
+      "domain_hint": "Phaser Game Feel Patterns"
+    },
+    {
+      "file": "skills/phaser-gamedev/references/game-feel-patterns.md",
+      "line_range": [
+        375,
+        398
+      ],
+      "block_text": "### \u274c Camera Shake Without Bounds\n\n**Detection**:\n```bash\ngrep -rn \"camera\\.shake\\|cameras\\.main\\.shake\" --include=\"*.ts\" --include=\"*.js\"\nrg \"cameras\\.main\" --type ts | grep -v \"bounds\\|follow\\|setZoom\"\n```\n\n**What it looks like**:\n```typescript\n// BAD: camera shakes past world edge, revealing void outside the map\nthis.cameras.main.shake(300, 0.05); // no world bounds set\n```\n\n**Why wrong**: Camera shake pans the camera. Without bounds, the camera reveals empty space outside the tilemap, breaki...",
+      "domain_hint": "Phaser Game Feel Patterns"
+    },
+    {
+      "file": "skills/phaser-gamedev/references/performance.md",
+      "line_range": [
+        99,
+        140
+      ],
+      "block_text": "## GC Optimization \u2014 Avoid Allocations in update()\n\nEvery object created in `update()` becomes garbage. Garbage collection pauses manifest as micro-stutters.\n\n**Patterns to eliminate from `update()`:**\n\n```typescript\n// BAD \u2014 allocates a new Vector2 every frame (60 allocs/sec)\nupdate(): void {\n  const dir = new Phaser.Math.Vector2(this.target.x - this.x, this.target.y - this.y);\n  dir.normalize();\n}\n\n// GOOD \u2014 reuse a pre-allocated vector\nprivate _dir = new Phaser.Math.Vector2();\n\nupdate(): void...",
+      "domain_hint": "phaser-gamedev"
+    },
+    {
+      "file": "skills/phaser-gamedev/references/tilemaps-and-physics.md",
+      "line_range": [
+        259,
+        259
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "Phaser Tilemaps and Physics"
+    },
+    {
+      "file": "skills/phaser-gamedev/references/tilemaps-and-physics.md",
+      "line_range": [
+        261,
+        284
+      ],
+      "block_text": "### \u274c Calling setCollisionByProperty After Layer Already Has Colliders\n\n**Detection**:\n```bash\ngrep -rn \"setCollisionByProperty\\|setCollision\\b\" --include=\"*.ts\" --include=\"*.js\"\nrg \"setCollision\" --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: setting collision after a Matter tilemapLayer already generated bodies\nthis.matter.add.tilemapLayer(groundLayer, { isStatic: true });\ngroundLayer.setCollisionByProperty({ collides: true }); // no effect \u2014 Matter ignores this\n```\n\n**Why wrong*...",
+      "domain_hint": "Phaser Tilemaps and Physics"
+    },
+    {
+      "file": "skills/phaser-gamedev/references/tilemaps-and-physics.md",
+      "line_range": [
+        286,
+        315
+      ],
+      "block_text": "### \u274c Creating Physics Bodies Inside update()\n\n**Detection**:\n```bash\ngrep -rn \"matter\\.add\\.\\(sprite\\|image\\|circle\\|rectangle\\)\" --include=\"*.ts\" --include=\"*.js\"\nrg \"update\\b\" --type ts -A 40 | grep \"matter\\.add\\|physics\\.add\\.sprite\"\n```\n\n**What it looks like**:\n```typescript\nupdate(_time: number, delta: number): void {\n  if (this.fireButton.isDown) {\n    // BAD: creates a new Matter body every frame\n    const bullet = this.matter.add.image(this.player.x, this.player.y, 'bullet');\n    bullet...",
+      "domain_hint": "Phaser Tilemaps and Physics"
+    },
+    {
+      "file": "skills/php-testing/references/patterns.md",
+      "line_range": [
+        266,
+        278
+      ],
+      "block_text": "## Common Testing Anti-Patterns\n\n| Anti-Pattern | Problem | Fix |\n|---|---|---|\n| Testing private methods directly | Couples tests to implementation | Test through public API |\n| One assertion per test (dogmatic) | Explosion of near-identical tests | Group related assertions; use data providers |\n| No data providers for repetitive cases | Duplicate test methods | Extract to `@dataProvider` |\n| Database state leaking between tests | Flaky, order-dependent tests | Use `DatabaseTransactions` or `se...",
+      "domain_hint": "php-testing"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-anti-patterns.md",
+      "line_range": [
+        1,
+        7
+      ],
+      "block_text": "# Code Anti-Patterns for Review\n\n> **Scope**: Common code anti-patterns to detect during review, with grep commands for codebase verification.\n> **Version range**: Language-specific version notes inline\n> **Generated**: 2026-04-16\n\n---\n",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-anti-patterns.md",
+      "line_range": [
+        18,
+        18
+      ],
+      "block_text": "## Go Anti-Patterns\n",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-anti-patterns.md",
+      "line_range": [
+        20,
+        52
+      ],
+      "block_text": "### Swallowed errors (blank identifier on error return)\n\n**Detection**:\n```bash\nrg ',\\s*_\\s*:?=' --type go -n | grep -v '_test\\.go'\ngrep -rn ',\\s*_\\s*=' --include=\"*.go\" | grep -v test\n```\n\n**What it looks like**:\n```go\nresult, _ := db.Query(\"SELECT ...\")  // error silently dropped\nfile.Close()                          // return value ignored\n```\n\n**Why wrong**: Silent failures compound \u2014 the next operation uses invalid state.\nDebugging in production becomes impossible without error context.\n\n**...",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-anti-patterns.md",
+      "line_range": [
+        54,
+        92
+      ],
+      "block_text": "### Goroutine with no exit strategy\n\n**Detection**:\n```bash\nrg 'go func\\(\\)' --type go -n\nrg 'go\\s+\\w+\\(' --type go -n | grep -v '_test'\n```\n\n**What it looks like**:\n```go\nfunc start() {\n    go func() {\n        for {\n            process()  // no context.Done(), no stop channel\n        }\n    }()\n}\n```\n\n**Why wrong**: Goroutines with no exit path leak on shutdown. Under load or repeated\ninvocations, this causes unbounded memory growth.\n\n**Fix**:\n```go\nfunc start(ctx context.Context) {\n    go func(...",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-anti-patterns.md",
+      "line_range": [
+        99,
+        122
+      ],
+      "block_text": "# Then check for value receivers on structs containing mutex\ngrep -rn 'func\\s*(\\w\\+\\s\\w\\+)' --include=\"*.go\" | grep -v '\\*'\n```\n\n**What it looks like**:\n```go\ntype Counter struct {\n    mu  sync.Mutex\n    val int\n}\nfunc process(c Counter) { ... }  // copies Counter \u2014 mutex state diverges\n```\n\n**Why wrong**: Copying `sync.Mutex` copies its internal state. The copy and original have\nindependent lock states \u2014 concurrent access is not protected.\n\n**Fix**: Always pass structs containing mutexes by poi...",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-anti-patterns.md",
+      "line_range": [
+        124,
+        124
+      ],
+      "block_text": "## TypeScript/JavaScript Anti-Patterns\n",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-anti-patterns.md",
+      "line_range": [
+        126,
+        155
+      ],
+      "block_text": "### Floating Promise (unhandled async)\n\n**Detection**:\n```bash\nrg '^\\s+[a-zA-Z]\\w*\\(.*\\);$' --type ts -n | grep -v 'await\\|return\\|const\\|let\\|var\\|//'\nrg 'Promise\\.' --type ts -n | grep -v '\\.catch\\|\\.then\\|await\\|void'\n```\n\n**What it looks like**:\n```typescript\nasync function handler() {\n    sendNotification(userId);  // promise not awaited \u2014 errors swallowed\n    return { ok: true };\n}\n```\n\n**Why wrong**: Errors from `sendNotification` are silently dropped. The function returns\nbefore the asyn...",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-anti-patterns.md",
+      "line_range": [
+        157,
+        183
+      ],
+      "block_text": "### `as any` silencing TypeScript type checking\n\n**Detection**:\n```bash\nrg 'as any' --type ts -n\nrg ':\\s*any\\b' --type ts -n | grep -v '\\.d\\.ts\\|// '\n```\n\n**What it looks like**:\n```typescript\nconst user = response.data as any;\nuser.profile.name;  // no type safety \u2014 runtime error if profile is undefined\n```\n\n**Why wrong**: `as any` opts out of TypeScript's type system entirely. Downstream property\naccess has no compile-time protection \u2014 null reference errors appear at runtime.\n\n**Fix**: Use pro...",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-anti-patterns.md",
+      "line_range": [
+        185,
+        208
+      ],
+      "block_text": "### `console.log` left in production code\n\n**Detection**:\n```bash\nrg 'console\\.(log|error|warn|debug)\\(' --type ts -n | grep -v '\\.test\\.\\|\\.spec\\.\\|__test'\ngrep -rn 'console\\.log' --include=\"*.ts\" --include=\"*.js\" | grep -v test\n```\n\n**What it looks like**:\n```typescript\nasync function processOrder(id: string) {\n    console.log('processing order', id);  // leaks order IDs to stdout\n}\n```\n\n**Why wrong**: Console output bypasses structured logging, loses correlation IDs, and may\nleak PII to log a...",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-anti-patterns.md",
+      "line_range": [
+        210,
+        210
+      ],
+      "block_text": "## Python Anti-Patterns\n",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-anti-patterns.md",
+      "line_range": [
+        212,
+        240
+      ],
+      "block_text": "### Bare `except` clause\n\n**Detection**:\n```bash\nrg '^\\s+except\\s*:' --type py -n\ngrep -rn 'except:$' --include=\"*.py\"\n```\n\n**What it looks like**:\n```python\ntry:\n    result = fetch_data()\nexcept:          # catches KeyboardInterrupt, SystemExit, everything\n    pass         # silently continues\n```\n\n**Why wrong**: Catches `KeyboardInterrupt` and `SystemExit` \u2014 Ctrl-C won't stop the process.\nAlso swallows errors that should surface for debugging.\n\n**Fix**:\n```python\ntry:\n    result = fetch_data()...",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-anti-patterns.md",
+      "line_range": [
+        242,
+        271
+      ],
+      "block_text": "### Mutable default argument\n\n**Detection**:\n```bash\nrg 'def \\w+\\(.*=\\[\\]|def \\w+\\(.*=\\{\\}' --type py -n\ngrep -rn 'def .*=\\[\\]\\|def .*={}' --include=\"*.py\"\n```\n\n**What it looks like**:\n```python\ndef add_item(item, items=[]):  # shared across ALL calls\n    items.append(item)\n    return items\n```\n\n**Why wrong**: The default list is created once at function definition, not per call. All\ninvocations without an explicit `items` argument share the same list \u2014 state leaks.\n\n**Fix**:\n```python\ndef add_i...",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-anti-patterns.md",
+      "line_range": [
+        273,
+        296
+      ],
+      "block_text": "### `os.system()` or `shell=True` with dynamic input\n\n**Detection**:\n```bash\nrg 'os\\.system\\(' --type py -n\nrg 'subprocess\\.call\\(.*shell=True|subprocess\\.run\\(.*shell=True' --type py -n\n```\n\n**What it looks like**:\n```python\nos.system(f\"process {user_input}\")  # injection if user_input contains ; or |\nsubprocess.run(f\"grep {pattern} log.txt\", shell=True)\n```\n\n**Why wrong**: Shell metacharacters in dynamic input execute arbitrary commands. Classic\ninjection vulnerability \u2014 always flag as Critica...",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-cli-patterns.md",
+      "line_range": [
+        92,
+        92
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-cli-patterns.md",
+      "line_range": [
+        98,
+        116
+      ],
+      "block_text": "# In constructed prompt strings \u2014 look for variable expansion with git diff output\ngrep -n 'DIFF=\\$(git diff' . -r\n```\n\n**What it looks like**:\n```bash\nDIFF=$(git diff main...HEAD)\ncodex exec \"Review this code: $DIFF\"\n```\n\n**Why wrong**: Large diffs (>50 files) hit prompt-length limits. Formatting collapses.\nCodex already has filesystem access \u2014 it can run `git diff` directly.\n\n**Fix**: Tell Codex which command to run, not what the output is:\n```bash\ncodex exec \"Run \\`git diff main...HEAD\\` and ...",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-cli-patterns.md",
+      "line_range": [
+        118,
+        134
+      ],
+      "block_text": "### Using `--base` and a custom prompt together with `codex exec review`\n\n**What it looks like**:\n```bash\ncodex exec review --base main \"Focus on error handling\"\n```\n\n**Why wrong**: `--base`, `--commit`, and `--uncommitted` are mutually exclusive with a\ncustom `[PROMPT]` argument in the `review` subcommand. The CLI errors.\n\n**Fix**: Use `codex exec` (not `codex exec review`) with a custom prompt:\n```bash\ncodex exec -m gpt-5.4 -o \"$TMPFILE\" \\\n  \"Run \\`git diff main...HEAD\\` and focus on error han...",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-cli-patterns.md",
+      "line_range": [
+        136,
+        151
+      ],
+      "block_text": "### Appending extension to mktemp template\n\n**What it looks like**:\n```bash\nTMPFILE=$(mktemp /tmp/codex-review.XXXXXXXX.md)\n```\n\n**Why wrong**: macOS `mktemp` requires the template to end in Xs. Appending `.md` causes\n`mktemp: /tmp/codex-review.XXXXXXXX.md: invalid suffix`.\n\n**Fix**: No extension, Xs at the end:\n```bash\nTMPFILE=$(mktemp /tmp/codex-review.XXXXXXXX)\n```\n\n---\n",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-cli-patterns.md",
+      "line_range": [
+        153,
+        165
+      ],
+      "block_text": "### Using `-s read-only` with `--dangerously-bypass-approvals-and-sandbox`\n\n**What it looks like**:\n```bash\ncodex exec review --dangerously-bypass-approvals-and-sandbox -s read-only ...\n```\n\n**Why wrong**: These flags are mutually exclusive. `-s read-only` configures the bwrap\nsandbox; the bypass flag disables it entirely. Combining them errors.\n\n**Fix**: Use one or the other. In containerized environments, use the bypass flag.\n\n---\n",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-cli-patterns.md",
+      "line_range": [
+        191,
+        193
+      ],
+      "block_text": "# Find embedded diffs in any shell scripts (anti-pattern signal)\ngrep -rn 'DIFF=\\$(git' . --include=\"*.sh\" --include=\"*.bash\"\n```",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-methodology.md",
+      "line_range": [
+        90,
+        90
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-methodology.md",
+      "line_range": [
+        96,
+        106
+      ],
+      "block_text": "# Report is a copy of $TMPFILE if it contains Codex's exact headers unchanged\ngrep -c \"## CRITICAL ISSUES\\|## IMPROVEMENTS\\|## POSITIVE NOTES\" report.md\n```\n\n**Why wrong**: The entire value of cross-model review is Claude's assessment layer. Verbatim\npass-through means the user could have run `codex exec` themselves.\n\n**Fix**: Every Codex finding must be explicitly classified (Agree/Agree-modified/Disagree)\nwith at least one sentence of Claude's reasoning before it appears in the report.\n\n---\n",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-methodology.md",
+      "line_range": [
+        108,
+        116
+      ],
+      "block_text": "### Silently dropping disagreed findings\n\n**What it looks like**: Codex flags 8 issues; report shows 4 with no explanation of the others.\n\n**Why wrong**: Users who know Codex ran and see fewer findings reported will distrust the\nfilter. Opacity erodes confidence in the review process.\n\n**Fix**: Always include a \"Filtered Findings\" section:\n```markdown",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/pr-workflow/references/codex-review-methodology.md",
+      "line_range": [
+        127,
+        137
+      ],
+      "block_text": "### Skipping assessment when output looks clean\n\n**What it looks like**: Codex output has no CRITICAL issues, so Claude presents it directly.\n\n**Why wrong**: Codex omission does not mean no issues exist. The most dangerous bugs are\nones the first reviewer missed. Claude must check for omissions, especially in security paths.\n\n**Fix**: Always run the severity decision tree for each finding, including reviewing what\nCodex's Positive Notes section affirms \u2014 confirm those patterns are actually corre...",
+      "domain_hint": "pr-workflow"
+    },
+    {
+      "file": "skills/publish/references/seo-guidelines.md",
+      "line_range": [
+        171,
+        176
+      ],
+      "block_text": "### What to Avoid\n- Vague titles (\"My Thoughts on Hugo\")\n- Excessive jargon without explanation\n- Outdated information without date context\n- Promises that content doesn't deliver\n- Clickbait that contradicts technical brand\n",
+      "domain_hint": "publish"
+    },
+    {
+      "file": "skills/publish/references/seo-keyword-placement.md",
+      "line_range": [
+        162,
+        165
+      ],
+      "block_text": "### How to Avoid\n- Each post should target unique primary keyword\n- Related posts can share secondary keywords\n- Use internal links to establish hierarchy\n",
+      "domain_hint": "publish"
+    },
+    {
+      "file": "skills/publish/references/seo-title-patterns.md",
+      "line_range": [
+        123,
+        123
+      ],
+      "block_text": "## Title Anti-Patterns\n",
+      "domain_hint": "publish"
+    },
+    {
+      "file": "skills/publish/references/seo-title-patterns.md",
+      "line_range": [
+        233,
+        241
+      ],
+      "block_text": "### Avoid for YourBlog\n```\n\"My Frustrating Journey with Hugo\"  <- Too personal/blog-y\n\"Hugo Tips and Tricks\"              <- Too generic\n\"Awesome Hugo Hacks!\"               <- Wrong tone\n\"The Ultimate Hugo Guide\"           <- Overpromising\n```\n\nThe YourBlog brand is about the satisfaction of solving hard problems - titles should reflect the technical depth, not the emotional journey.",
+      "domain_hint": "publish"
+    },
+    {
+      "file": "skills/publish/references/taxonomy-guidelines.md",
+      "line_range": [
+        190,
+        190
+      ],
+      "block_text": "## Common Mistakes to Avoid\n",
+      "domain_hint": "publish"
+    },
+    {
+      "file": "skills/reference-enrichment/references/quality-rubric.md",
+      "line_range": [
+        94,
+        131
+      ],
+      "block_text": "## Anti-Pattern: Using errors.New() When Wrapping\n\n**Detection**:\n```bash\ngrep -rn 'errors\\.New(' --include=\"*.go\" | grep -v \"_test.go\"\nrg 'return errors\\.New\\(' --type go\n```\n\n**What it looks like**:\n```go\nfunc fetchUser(id int) (*User, error) {\n    u, err := db.QueryRow(...).Scan(&u)\n    if err != nil {\n        return nil, errors.New(\"database error\")  // loses context\n    }\n}\n```\n\n**Why wrong**: `errors.New()` creates a fresh error with no link to the original. Callers\nusing `errors.Is(err, s...",
+      "domain_hint": "reference-enrichment"
+    },
+    {
+      "file": "skills/reference-enrichment/references/quality-rubric.md",
+      "line_range": [
+        133,
+        144
+      ],
+      "block_text": "## Level 3 Checklist (Per Anti-Pattern Entry)\n\nUse this checklist in Phase 4 Tier 2 self-assessment. Each anti-pattern entry should pass\nat least 3 of 5:\n\n- [ ] Detection command that finds the pattern in a real codebase (`grep`, `rg`, `find`)\n- [ ] Code block showing the bad pattern (copy-pasteable, not pseudocode)\n- [ ] Code block showing the correct fix\n- [ ] Explanation of *why* the pattern is wrong (behavioral consequence, not style opinion)\n- [ ] Version qualifier (when did this change? wh...",
+      "domain_hint": "reference-enrichment"
+    },
+    {
+      "file": "skills/reference-enrichment/references/reference-file-template.md",
+      "line_range": [
+        61,
+        61
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "reference-enrichment"
+    },
+    {
+      "file": "skills/reference-enrichment/references/reference-file-template.md",
+      "line_range": [
+        63,
+        86
+      ],
+      "block_text": "### \u274c {{Anti-Pattern Name}}\n\n**Detection**:\n```bash\ngrep -rn '{{pattern}}' --include=\"*.{{ext}}\"\nrg '{{pattern}}' --type {{lang}}\n```\n\n**What it looks like**:\n```{{language}}\n{{bad code example \u2014 should be something grep above would find}}\n```\n\n**Why wrong**: {{Behavioral consequence \u2014 what actually breaks, not just \"it's bad practice\".\nMention the specific failure mode: data loss, silent error, performance degradation, etc.}}\n\n**Fix**:\n```{{language}}\n{{corrected code example}}\n```\n\n**Version n...",
+      "domain_hint": "reference-enrichment"
+    },
+    {
+      "file": "skills/reference-enrichment/references/reference-file-template.md",
+      "line_range": [
+        88,
+        107
+      ],
+      "block_text": "### \u274c {{Anti-Pattern Name}}\n\n**Detection**:\n```bash\ngrep -rn '{{pattern}}' --include=\"*.{{ext}}\"\n```\n\n**What it looks like**:\n```{{language}}\n{{bad code}}\n```\n\n**Why wrong**: {{Consequence.}}\n\n**Fix**:\n```{{language}}\n{{fix}}\n```\n\n---\n",
+      "domain_hint": "reference-enrichment"
+    },
+    {
+      "file": "skills/reference-enrichment/references/reference-file-template.md",
+      "line_range": [
+        136,
+        137
+      ],
+      "block_text": "# {{Anti-pattern 1 name}}\ngrep -rn '{{pattern1}}' --include=\"*.{{ext}}\"\n",
+      "domain_hint": "reference-enrichment"
+    },
+    {
+      "file": "skills/reference-enrichment/references/reference-file-template.md",
+      "line_range": [
+        139,
+        143
+      ],
+      "block_text": "# {{Anti-pattern 2 name}}\nrg '{{pattern2}}' --type {{lang}}\n```\n\n---\n",
+      "domain_hint": "reference-enrichment"
+    },
+    {
+      "file": "skills/sapcc-review/references/agent-dispatch-prompts.md",
+      "line_range": [
+        215,
+        238
+      ],
+      "block_text": "## Agent 10: Anti-Patterns, LLM Tells, Community Divergences\n\n**Sections**: \u00a722 (Divergences), \u00a724 (Anti-Patterns), \u00a725 (LLM Code Feedback), \u00a733 (Portunus Architecture), \u00a735 (Reinforcement Table)\n**Extra Reference**: `anti-patterns.md`\n\n**This is the highest-value agent.** It checks for patterns that LLMs generate by default but the project explicitly rejects:\n\n- Functional options pattern (project convention: positional params)\n- Table-driven tests (project convention: sequential scenario narra...",
+      "domain_hint": "sapcc-review"
+    },
+    {
+      "file": "skills/series-planner/references/cross-linking.md",
+      "line_range": [
+        126,
+        141
+      ],
+      "block_text": "### Bad Patterns (Avoid)\n\nDo not gate content behind future parts:\n\n```markdown\n<!-- BAD: Cliff-hanger -->\n...but the real solution is in Part 2!\n\n<!-- BAD: Required reading -->\nTo understand this, you MUST read Part 3 first.\n\n<!-- BAD: Empty promise -->\nThe code will be provided in the next part.\n```\n\n---\n",
+      "domain_hint": "series-planner"
+    },
+    {
+      "file": "skills/series-planner/references/cross-linking.md",
+      "line_range": [
+        161,
+        176
+      ],
+      "block_text": "### Bad Patterns (Avoid)\n\nDon't re-explain or over-reference:\n\n```markdown\n<!-- BAD: Re-explanation -->\nAs we discussed extensively in Part 1, Hugo is a static site generator that...\n\n<!-- BAD: Excessive callbacks -->\nRemember in Part 1 when we set up the config? And in Part 2 when we added templates?\n\n<!-- BAD: Assumes complete reading -->\nFollowing the exact steps from Part 2's error handling section...\n```\n\n---\n",
+      "domain_hint": "series-planner"
+    },
+    {
+      "file": "skills/skill-composer/references/skill-patterns.md",
+      "line_range": [
+        284,
+        284
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "skill-composer"
+    },
+    {
+      "file": "skills/skill-creator/references/anti-patterns.md",
+      "line_range": [
+        1,
+        3
+      ],
+      "block_text": "# Skill Creator Anti-Patterns\n\nCommon mistakes when designing skills and their corrections.\n",
+      "domain_hint": "skill-creator"
+    },
+    {
+      "file": "skills/skill-creator/references/anti-patterns.md",
+      "line_range": [
+        30,
+        33
+      ],
+      "block_text": "## \u274c Anti-Pattern: Phases Without Gates\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "skill-creator"
+    },
+    {
+      "file": "skills/skill-creator/references/anti-patterns.md",
+      "line_range": [
+        201,
+        204
+      ],
+      "block_text": "## \u274c Anti-Pattern: Infinite Retry Loops\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "skill-creator"
+    },
+    {
+      "file": "skills/skill-creator/references/anti-patterns.md",
+      "line_range": [
+        231,
+        234
+      ],
+      "block_text": "## \u274c Anti-Pattern: Hardcoded Secrets\n\n**What it looks like**:\n```python",
+      "domain_hint": "skill-creator"
+    },
+    {
+      "file": "skills/skill-creator/references/anti-patterns.md",
+      "line_range": [
+        271,
+        274
+      ],
+      "block_text": "## \u274c Anti-Pattern: No Error Handling\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "skill-creator"
+    },
+    {
+      "file": "skills/skill-creator/references/anti-patterns.md",
+      "line_range": [
+        382,
+        385
+      ],
+      "block_text": "## \u274c Anti-Pattern: Mandates Without Motivation\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "skill-creator"
+    },
+    {
+      "file": "skills/skill-creator/references/complexity-tiers.md",
+      "line_range": [
+        259,
+        259
+      ],
+      "block_text": "## Anti-Patterns in Tier Selection\n",
+      "domain_hint": "skill-creator"
+    },
+    {
+      "file": "skills/skill-creator/references/complexity-tiers.md",
+      "line_range": [
+        261,
+        268
+      ],
+      "block_text": "### \u274c Over-Tiering\n**What it looks like**: Simple workflow (pr-workflow (cleanup)) implemented as Complex tier with references/, death loop prevention, 10+ error cases\n\n**Why wrong**: Creates maintenance burden, confuses users, violates Over-Engineering Prevention\n\n**Fix**: Reduce to appropriate tier - Simple workflows stay Simple\n\n---\n",
+      "domain_hint": "skill-creator"
+    },
+    {
+      "file": "skills/skill-creator/references/complexity-tiers.md",
+      "line_range": [
+        270,
+        277
+      ],
+      "block_text": "### \u274c Under-Tiering\n**What it looks like**: Multi-agent orchestration skill (parallel-code-review) implemented as Medium tier with no death loop prevention\n\n**Why wrong**: Missing critical patterns, will fail in production, no scaling considerations\n\n**Fix**: Upgrade to Complex tier, add death loop prevention, create references/\n\n---\n",
+      "domain_hint": "skill-creator"
+    },
+    {
+      "file": "skills/skill-creator/references/complexity-tiers.md",
+      "line_range": [
+        279,
+        284
+      ],
+      "block_text": "### \u274c Tier Drift\n**What it looks like**: Skill starts as Simple (400 lines), grows to 2000 lines over time without restructuring\n\n**Why wrong**: Violates progressive disclosure, bloats context, makes skill hard to maintain\n\n**Fix**: Promote to appropriate tier, extract references/, apply progressive disclosure",
+      "domain_hint": "skill-creator"
+    },
+    {
+      "file": "skills/skill-creator/references/domain-research-targets.md",
+      "line_range": [
+        160,
+        182
+      ],
+      "block_text": "## Testing (test-driven-development, testing-anti-patterns, e2e-testing)\n\n**Primary sources**\n- [Playwright docs](https://playwright.dev/docs/intro) \u2014 extract: Page Object Model\n  structure, locator best practices, network interception patterns\n- [pytest docs](https://docs.pytest.org) \u2014 extract: fixture patterns, parametrize,\n  conftest scope decisions\n\n**Secondary sources**\n- Kent C. Dodds \u2014 Testing Trophy and [testing-library principles](https://testing-library.com/docs/guiding-principles)\n  \u2014...",
+      "domain_hint": "skill-creator"
+    },
+    {
+      "file": "skills/skill-eval/references/self-improve-loop.md",
+      "line_range": [
+        306,
+        319
+      ],
+      "block_text": "## Anti-Patterns\n\n| Anti-Pattern | Why it's wrong | What to do instead |\n|-------------|---------------|-------------------|\n| Changing multiple things per variant | Can't attribute improvement to any single change | One hypothesis, one change, one variant |\n| Testing without baseline | No basis for comparison; can't calculate win rate | Always run Phase 1 first |\n| Promoting on vibes | \"This one feels better\" is not evidence | Require quantitative win rate >= 60% |\n| Ignoring regressions | A va...",
+      "domain_hint": "skill-eval"
+    },
+    {
+      "file": "skills/swift-concurrency/references/anti-patterns.md",
+      "line_range": [
+        7,
+        7
+      ],
+      "block_text": "# Common Anti-Patterns\n",
+      "domain_hint": "swift"
+    },
+    {
+      "file": "skills/systematic-code-review/references/severity-classification.md",
+      "line_range": [
+        56,
+        65
+      ],
+      "block_text": "## Common Misclassifications to Avoid\n\n| Issue | Wrong | Correct | Why |\n|-------|-------|---------|-----|\n| Missing error check on `os.Open()` | SUGGESTION | BLOCKING | Resource leak + potential panic |\n| No test for new endpoint | SUGGESTION | SHOULD FIX | Untested code is liability |\n| Race condition in cache | NEEDS DISCUSSION | BLOCKING | Data corruption risk |\n| Inconsistent naming | BLOCKING | SUGGESTION | No functional impact |\n| Missing context in error | SUGGESTION | SHOULD FIX | Debug...",
+      "domain_hint": "systematic-code-review"
+    },
+    {
+      "file": "skills/test-driven-development/references/examples.md",
+      "line_range": [
+        766,
+        766
+      ],
+      "block_text": "## TDD Anti-Patterns to Avoid\n",
+      "domain_hint": "test-driven-development"
+    },
+    {
+      "file": "skills/testing-anti-patterns/references/anti-pattern-catalog.md",
+      "line_range": [
+        1,
+        5
+      ],
+      "block_text": "# Testing Anti-Pattern Catalog\n\nDetailed code examples for all 10 anti-patterns. Each section shows BAD (what to avoid) and GOOD (what to do instead) in Go, Python, and JavaScript where applicable.\n\n---\n",
+      "domain_hint": "testing-anti-patterns"
+    },
+    {
+      "file": "skills/threejs-builder/references/advanced-animation.md",
+      "line_range": [
+        333,
+        333
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "Three.js Advanced Animation"
+    },
+    {
+      "file": "skills/threejs-builder/references/advanced-animation.md",
+      "line_range": [
+        335,
+        362
+      ],
+      "block_text": "### \u274c Calling mixer.update() with Raw Timestamp (Not Delta)\n\n**Detection**:\n```bash\ngrep -rn \"mixer\\.update\" --include=\"*.js\" --include=\"*.ts\"\nrg \"mixer\\.update\\(time\\)\" --type js\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop((time) => {\n  mixer.update(time); // BAD: time is ms since page load (~120000ms after 2 minutes)\n});\n```\n\n**Why wrong**: `mixer.update()` expects elapsed seconds since last frame (delta), not absolute timestamp. Passing raw `time` makes animations pla...",
+      "domain_hint": "Three.js Advanced Animation"
+    },
+    {
+      "file": "skills/threejs-builder/references/advanced-animation.md",
+      "line_range": [
+        364,
+        391
+      ],
+      "block_text": "### \u274c Applying Bone Rotation After mixer.update()\n\n**Detection**:\n```bash\ngrep -rn \"bone\\.rotation\\|bone\\.quaternion\" --include=\"*.js\" --include=\"*.ts\"\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop(() => {\n  mixer.update(delta); // sets bone transforms from keyframe data\n  headBone.rotation.y = mouseTargetY; // immediately overwritten \u2014 no effect seen\n});\n```\n\n**Why wrong**: `mixer.update()` overwrites bone transforms from animation keyframes on the same frame tick. Manual...",
+      "domain_hint": "Three.js Advanced Animation"
+    },
+    {
+      "file": "skills/threejs-builder/references/advanced-animation.md",
+      "line_range": [
+        393,
+        426
+      ],
+      "block_text": "### \u274c Not Disposing Mixer on Component Unmount\n\n**Detection**:\n```bash\ngrep -rn \"AnimationMixer\" --include=\"*.js\" --include=\"*.ts\"\nrg \"mixer\\.\" --type js | grep -v \"dispose\\|update\\|stopAll\"\n```\n\n**What it looks like**:\n```javascript\n// In a React Three Fiber component:\nuseEffect(() => {\n  const mixer = new THREE.AnimationMixer(scene);\n  // No cleanup\n}, []);\n```\n\n**Why wrong**: `AnimationMixer` holds references to scene objects, preventing GC. Multiple mixers accumulate on route changes.\n\n**Fix...",
+      "domain_hint": "Three.js Advanced Animation"
+    },
+    {
+      "file": "skills/threejs-builder/references/performance-patterns.md",
+      "line_range": [
+        276,
+        276
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "Three.js Performance Patterns"
+    },
+    {
+      "file": "skills/threejs-builder/references/performance-patterns.md",
+      "line_range": [
+        278,
+        311
+      ],
+      "block_text": "### \u274c Creating Geometry in the Animation Loop\n\n**Detection**:\n```bash\ngrep -rn \"new THREE\\.\\(Box\\|Sphere\\|Plane\\|Cylinder\\)Geometry\" --include=\"*.js\" --include=\"*.ts\"\nrg \"setAnimationLoop|useFrame\" --type js -A 20 | grep \"new THREE\\.\"\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop((time) => {\n  // BAD: allocates new geometry every frame at 60fps\n  const geo = new THREE.SphereGeometry(Math.sin(time * 0.001), 32, 32);\n  mesh.geometry = geo;\n  renderer.render(scene, camera);\n}...",
+      "domain_hint": "Three.js Performance Patterns"
+    },
+    {
+      "file": "skills/threejs-builder/references/performance-patterns.md",
+      "line_range": [
+        313,
+        346
+      ],
+      "block_text": "### \u274c `new THREE.Vector3()` Inside render Loop\n\n**Detection**:\n```bash\ngrep -rn \"new THREE\\.Vector3\\|new THREE\\.Color\\|new THREE\\.Matrix4\" --include=\"*.js\" --include=\"*.ts\"\nrg \"setAnimationLoop|useFrame\" --type js -A 30 | grep \"new THREE\\.\"\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop(() => {\n  // BAD: 3 allocations per frame = 10,800 objects/min of GC pressure\n  const pos = new THREE.Vector3(mesh.position);\n  const dir = new THREE.Vector3(0, 1, 0);\n  const target = new T...",
+      "domain_hint": "Three.js Performance Patterns"
+    },
+    {
+      "file": "skills/threejs-builder/references/performance-patterns.md",
+      "line_range": [
+        348,
+        369
+      ],
+      "block_text": "### \u274c Using `renderer.render()` with EffectComposer\n\n**Detection**:\n```bash\ngrep -rn \"renderer\\.render\\|composer\\.render\" --include=\"*.js\" --include=\"*.ts\"\n```\n\n**What it looks like**:\n```javascript\nconst composer = new EffectComposer(renderer);\n// ...\n\nrenderer.setAnimationLoop(() => {\n  renderer.render(scene, camera); // BAD when composer is active \u2014 skips postprocessing\n});\n```\n\n**Why wrong**: `renderer.render()` writes directly to the canvas, bypassing the composer's pass chain. Postprocessi...",
+      "domain_hint": "Three.js Performance Patterns"
+    },
+    {
+      "file": "skills/threejs-builder/references/react-three-fiber.md",
+      "line_range": [
+        473,
+        473
+      ],
+      "block_text": "## Common Anti-Patterns\n",
+      "domain_hint": "threejs-builder"
+    },
+    {
+      "file": "skills/threejs-builder/references/shader-patterns.md",
+      "line_range": [
+        397,
+        397
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "Three.js Shader Patterns"
+    },
+    {
+      "file": "skills/threejs-builder/references/shader-patterns.md",
+      "line_range": [
+        399,
+        433
+      ],
+      "block_text": "### \u274c Recreating ShaderMaterial in Animation Loop\n\n**Detection**:\n```bash\ngrep -rn \"new THREE.ShaderMaterial\" --include=\"*.js\" --include=\"*.ts\"\nrg \"new THREE\\.ShaderMaterial\" --type js\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop((time) => {\n  // BAD: creates new material every frame \u2014 leaks GPU memory\n  mesh.material = new THREE.ShaderMaterial({\n    uniforms: { uTime: { value: time } },\n    ...\n  });\n  renderer.render(scene, camera);\n});\n```\n\n**Why wrong**: GPU memory le...",
+      "domain_hint": "Three.js Shader Patterns"
+    },
+    {
+      "file": "skills/threejs-builder/references/shader-patterns.md",
+      "line_range": [
+        435,
+        459
+      ],
+      "block_text": "### \u274c Forgetting OutputPass (Washed-Out Colors in r150+)\n\n**Detection**:\n```bash\ngrep -rn \"EffectComposer\" --include=\"*.js\" --include=\"*.ts\" -l\nrg \"GammaCorrectionShader\" --type js\n```\n\n**What it looks like**:\n```javascript\n// r150+ \u2014 GammaCorrectionShader is deprecated, OutputPass is required\nimport { GammaCorrectionShader } from 'three/addons/shaders/GammaCorrectionShader.js'; // deprecated r154+\n```\n\n**Why wrong**: In Three.js r150+, `renderer.outputColorSpace` defaults to `SRGBColorSpace`. W...",
+      "domain_hint": "Three.js Shader Patterns"
+    },
+    {
+      "file": "skills/threejs-builder/references/shader-patterns.md",
+      "line_range": [
+        461,
+        483
+      ],
+      "block_text": "### \u274c Using ShaderChunk Injection Without Understanding Side Effects\n\n**Detection**:\n```bash\ngrep -rn \"onBeforeCompile\" --include=\"*.js\" --include=\"*.ts\"\nrg \"shader\\.vertexShader\\.replace\" --type js\n```\n\n**What it looks like**:\n```javascript\nmaterial.onBeforeCompile = (shader) => {\n  shader.vertexShader = shader.vertexShader.replace(\n    '#include <begin_vertex>',\n    `vec3 transformed = position + vec3(sin(uTime), 0.0, 0.0);`\n  );\n};\n```\n\n**Why wrong**: `#include` tokens change between Three.js...",
+      "domain_hint": "Three.js Shader Patterns"
+    },
+    {
+      "file": "skills/threejs-builder/references/webgpu.md",
+      "line_range": [
+        573,
+        573
+      ],
+      "block_text": "## Common Anti-Patterns\n",
+      "domain_hint": "threejs-builder"
+    },
+    {
+      "file": "skills/toolkit-evolution/references/evolve-anti-patterns.md",
+      "line_range": [
+        1,
+        5
+      ],
+      "block_text": "# Toolkit Evolution \u2014 Anti-Patterns, Errors, and Cost\n\nReference for Phase 3 CRITIQUE (fallback), anti-patterns, error handling, and cost estimates.\n\n---\n",
+      "domain_hint": "toolkit-evolution"
+    },
+    {
+      "file": "skills/toolkit-evolution/references/evolve-anti-patterns.md",
+      "line_range": [
+        7,
+        18
+      ],
+      "block_text": "## Anti-Patterns\n\n- **Improving without measuring** -- every change must have a baseline and A/B result. \"It looks better\" is not evidence.\n- **Merging without validation** -- every winner must pass multi-persona critique (STRONG consensus) AND A/B testing (WIN status) before merge. The validation gates are the review.\n- **Ignoring negative results** -- failed experiments are valuable data. Record them in the learning DB so the same idea is not re-proposed.\n- **Improving everything at once** -- ...",
+      "domain_hint": "toolkit-evolution"
+    },
+    {
+      "file": "skills/topic-brainstormer/references/content-filter.md",
+      "line_range": [
+        68,
+        93
+      ],
+      "block_text": "### Question 3: Would this help others avoid the same struggle?\n\n**YES signals:**\n- Problem is common (not unique to your setup)\n- Solution is reproducible\n- Error message is searchable\n- Technology is widely used\n- Pattern appears in other contexts\n\n**NO signals:**\n- Problem was caused by your typo\n- Solution requires your specific infrastructure\n- No one else uses this obscure tool\n- Problem was already fixed in next version\n- Too simple (covered in official docs)\n\n**Examples:**\n\n| Candidate |...",
+      "domain_hint": "topic-brainstormer"
+    },
+    {
+      "file": "skills/verification-before-completion/references/checklist.md",
+      "line_range": [
+        301,
+        301
+      ],
+      "block_text": "## Anti-Patterns to Avoid\n",
+      "domain_hint": "verification-before-completion"
+    },
+    {
+      "file": "skills/webgl-card-effects/references/balatro-shader-breakdown.md",
+      "line_range": [
+        331,
+        343
+      ],
+      "block_text": "## Anti-Patterns\n\n**Animating hue at full time speed**: `hue = fract(uv.x + u_time)` cycles through the full rainbow every second. Real holo foil shifts hue based on viewing angle, not time \u2014 it doesn't pulse like a disco ball. Use mouse position as the primary hue driver; time should only add a slow ambient drift.\n\n**Skipping the distortion field for performance**: Without UV distortion, the rainbow bands are perfectly straight lines. Real holo foil has organic, slightly random banding. Even 2 ...",
+      "domain_hint": "webgl-card-effects"
+    },
+    {
+      "file": "skills/webgl-card-effects/references/card-shader-patterns.md",
+      "line_range": [
+        342,
+        354
+      ],
+      "block_text": "## Anti-Patterns\n\n**Allocating arrays or objects in the fragment shader loop**: GLSL `for` loops with dynamic bounds or large local arrays cause driver stalls. Use a fixed iteration count (e.g., `for (int i = 0; i < 5; i++)`) and use `break` only when the loop count is truly constant.\n\n**Using `gl_FragCoord` for UV**: Derive UVs from `v_uv` (passed from vertex shader), not `gl_FragCoord / u_resolution`. The varyings are more stable and the math is cleaner.\n\n**Sampling `u_time` directly at full s...",
+      "domain_hint": "webgl-card-effects"
+    },
+    {
+      "file": "skills/webgl-card-effects/references/shader-integration-react.md",
+      "line_range": [
+        530,
+        542
+      ],
+      "block_text": "## Anti-Patterns\n\n**Creating a new WebGL2 context per card instance**: Browsers cap at 8\u201316 total contexts. With a hand of 8+ cards, you will hit this limit. The singleton pattern above is non-negotiable.\n\n**Running RAF at 60fps for card shimmer**: Card shimmer doesn't need 60fps. The 30fps throttle (`TARGET_FRAME_MS = 1000 / 30`) halves GPU load with no perceptible quality difference for a slow organic shimmer.\n\n**Skipping IntersectionObserver**: Cards not in the viewport still consume RAF budg...",
+      "domain_hint": "webgl-card-effects"
+    },
+    {
+      "file": "skills/workflow/references/pipeline-scaffolder/references/architecture-rules.md",
+      "line_range": [
+        248,
+        256
+      ],
+      "block_text": "### Anti-Pattern: Single-Threaded Research\n\n**BANNED**: Research phases that use sequential `grep` or `search` commands without dispatching parallel agents.\n\n**Why wrong**: Sequential search is narrow by construction \u2014 each search informs the next, creating tunnel vision. Parallel agents explore independently, producing broader coverage.\n\n**Exception**: If the pipeline's research phase takes <30 seconds total (e.g., single file lookup), sequential is acceptable. But any research involving \"find ...",
+      "domain_hint": "workflow"
+    },
+    {
+      "file": "skills/workflow/references/pipeline-scaffolder/references/generated-skill-template.md",
+      "line_range": [
+        253,
+        253
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "workflow"
+    },
+    {
+      "file": "skills/workflow/references/pipeline-scaffolder/references/generated-skill-template.md",
+      "line_range": [
+        989,
+        1006
+      ],
+      "block_text": "### Default Anti-Patterns by Task Type\n\n| Task Type | Name | Description | Reason | Alternative |\n|-----------|------|-------------|--------|-------------|\n| `generation` | Generate Without Research | Producing output without the research phase | Unresearched output lacks grounding and examples | Always research first |\n| `generation` | Skip Validation | Delivering without running validation | Unvalidated output may contain errors | Always validate |\n| `generation` | Ignore Template | Writing fr...",
+      "domain_hint": "workflow"
+    },
+    {
+      "file": "skills/workflow/references/voice-calibrator.md",
+      "line_range": [
+        396,
+        399
+      ],
+      "block_text": "## Negative Constraints (What to avoid)\n```\n\n**Mechanism**: Helps model separate distinct logical tasks, reducing \"instruction bleeding.\"\n",
+      "domain_hint": "voice"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/modules.md",
+      "line_range": [
+        130,
+        130
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/modules.md",
+      "line_range": [
+        136,
+        164
+      ],
+      "block_text": "# Find shell/command used for package installation\ngrep -rn \"command:\\|shell:\" playbooks/ roles/ \\\n  | grep -E \"apt-get|yum|dnf|pip install|npm install\"\n\nrg -t yaml '(command|shell):.*\\b(apt-get|yum|dnf|pip)\\b' roles/ playbooks/\n```\n\n**What it looks like**:\n```yaml\n- name: Install nginx\n  shell: apt-get install -y nginx\n\n- name: Update packages\n  command: yum update -y\n```\n\n**Why wrong**: `shell`/`command` always report `changed` regardless of whether nginx was already installed. Running twice i...",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/modules.md",
+      "line_range": [
+        206,
+        234
+      ],
+      "block_text": "# Find hardcoded config files that should be templates\ngrep -rn \"copy:\" roles/ playbooks/ -A3 \\\n  | grep \"src:.*\\.conf\\|src:.*\\.cfg\\|src:.*\\.ini\"\n```\n\n**What it looks like**:\n```yaml\n- name: Copy nginx config\n  ansible.builtin.copy:\n    src: files/nginx.conf  # Static file, no variable substitution\n    dest: /etc/nginx/nginx.conf\n    # But the file contains: listen {{ nginx_port }};  \u2190 variable!\n```\n\n**Why wrong**: `copy` sends the file verbatim \u2014 Jinja2 variables are NOT evaluated. The destinat...",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/security.md",
+      "line_range": [
+        106,
+        106
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/security.md",
+      "line_range": [
+        116,
+        122
+      ],
+      "block_text": "# Find variables that LOOK like secrets but aren't encrypted\ngrep -rn \"password:\" playbooks/ roles/ \\\n  | grep -v \"!vault\" | grep -v \"_password:\" | grep -v \"#\"\n```\n\n**What it looks like**:\n```yaml",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/security.md",
+      "line_range": [
+        123,
+        132
+      ],
+      "block_text": "# vars/main.yml \u2014 NEVER DO THIS\ndb_password: MyS3cr3tP@ssword!\naws_access_key: AKIAIOSFODNN7EXAMPLE\naws_secret_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n```\n\n**Why wrong**: Plaintext secrets in any file will eventually reach git history. Git history is permanent \u2014 even after deletion, the secret exists in every clone and every CI artifact that ran during that period. Rotation requires assuming full compromise.\n\n**Fix**:\n```bash",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/security.md",
+      "line_range": [
+        151,
+        156
+      ],
+      "block_text": "# Find PEM headers accidentally committed\ngrep -rn \"BEGIN.*PRIVATE KEY\\|BEGIN RSA\" .\n```\n\n**What it looks like**:\n```ini",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/security.md",
+      "line_range": [
+        157,
+        165
+      ],
+      "block_text": "# inventory/hosts.ini \u2014 NEVER DO THIS\n[webservers]\nweb01 ansible_ssh_private_key_file=keys/deploy_key.pem\n```\n\n**Why wrong**: Private keys committed to a repository expose root access to every server in the inventory. Even with a gitignore rule added later, the key exists in git history.\n\n**Fix**:\n```yaml",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/security.md",
+      "line_range": [
+        182,
+        187
+      ],
+      "block_text": "# Find vault password files referenced in ansible.cfg\ngrep -n \"vault_password_file\" ansible.cfg\n```\n\n**What it looks like**:\n```ini",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/security.md",
+      "line_range": [
+        188,
+        196
+      ],
+      "block_text": "# ansible.cfg\n[defaults]\nvault_password_file = .vault_pass  # .vault_pass contains plaintext password\n```\n\n**Why wrong**: If `.vault_pass` is readable and stored with the repo, it defeats the purpose of encryption. Anyone with repo access can decrypt all vault values.\n\n**Fix**:\n```ini",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/testing.md",
+      "line_range": [
+        138,
+        138
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/testing.md",
+      "line_range": [
+        148,
+        177
+      ],
+      "block_text": "# Or with ripgrep\nrg -t yaml '^\\s+(command|shell):' roles/ playbooks/ -A5 \\\n  | grep -B3 -v \"changed_when\"\n```\n\n**What it looks like**:\n```yaml\n- name: Check disk usage\n  command: df -h\n  register: disk_result\n  # Missing: changed_when: false\n```\n\n**Why wrong**: `command` and `shell` always report `changed` unless told otherwise. This breaks idempotency checks (idempotency scenario always fails), makes `--check` output noisy, and triggers handlers incorrectly.\n\n**Fix**:\n```yaml\n- name: Check dis...",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/testing.md",
+      "line_range": [
+        186,
+        192
+      ],
+      "block_text": "# Find verify.yml files with only ping/gather_facts\ngrep -rn \"tasks:\" molecule/*/verify.yml -A5 \\\n  | grep -v \"assert\\|stat\\|uri\\|service_facts\\|command\"\n```\n\n**What it looks like**:\n```yaml",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/testing.md",
+      "line_range": [
+        193,
+        232
+      ],
+      "block_text": "# molecule/default/verify.yml \u2014 provides zero value\n---\n- name: Verify\n  hosts: all\n  tasks:\n    - name: Check connectivity\n      ping:\n```\n\n**Why wrong**: Ping passing means the container is alive, not that the role worked. A role that fails to install nginx will still pass this verify.\n\n**Fix**:\n```yaml\n---\n- name: Verify\n  hosts: all\n  gather_facts: false\n  tasks:\n    - name: Check nginx listening on port 80\n      wait_for:\n        port: 80\n        timeout: 5\n\n    - name: Check nginx config s...",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/ansible-automation-engineer/references/testing.md",
+      "line_range": [
+        241,
+        250
+      ],
+      "block_text": "# Run with verbose to see what rules are active\nansible-lint --list-rules 2>&1 | wc -l\n```\n\n**What it looks like**: Running `ansible-lint` without config defaults to the \"basic\" profile, which misses production-critical rules for key management and deprecated syntax.\n\n**Why wrong**: The default profile skips rules that catch security issues (plaintext passwords, deprecated `include` vs `import_tasks`) and style issues that cause maintenance problems.\n\n**Fix**:\n```yaml",
+      "domain_hint": "ansible-automation-engineer"
+    },
+    {
+      "file": "agents/combat-effects-upgrade.md",
+      "line_range": [
+        170,
+        170
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "combat"
+    },
+    {
+      "file": "agents/data-engineer/references/anti-patterns.md",
+      "line_range": [
+        1,
+        3
+      ],
+      "block_text": "# Data Engineer Anti-Patterns and Rationalizations\n\nCommon data engineering mistakes and their corrections, plus domain-specific rationalizations. Loaded when reviewing pipeline designs or pushing back on shortcuts.\n",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/performance.md",
+      "line_range": [
+        153,
+        153
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/performance.md",
+      "line_range": [
+        172,
+        196
+      ],
+      "block_text": "# PostgreSQL: Find queries doing sequential scans on large tables\ngrep -n \"Seq Scan on fact_\" query_plans/*.txt\n```\n\n**What it looks like**:\n```sql\n-- Dashboard query that scans ALL data despite date-partitioned table\nSELECT customer_segment, SUM(amount)\nFROM fact_orders\nWHERE status = 'completed'  -- No date filter!\nGROUP BY customer_segment\n```\n\n**Why wrong**: On a 3-year table partitioned by day (1095 partitions), this scans every partition. 1TB scanned instead of 1GB (30-day window). In BigQ...",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/performance.md",
+      "line_range": [
+        206,
+        230
+      ],
+      "block_text": "# In BigQuery console: Query Plan tab \u2192 look for large \"Write\" steps\n```\n\n**What it looks like**:\n```sql\n-- fact_orders (1B rows) joined to dim_customer (10M rows)\n-- Neither table clustered on customer_id\nSELECT fo.*, dc.segment\nFROM fact_orders fo\nJOIN dim_customer dc ON fo.customer_id = dc.customer_id\nWHERE fo.order_date = CURRENT_DATE\n```\n\n**Why wrong**: Without clustering on `customer_id`, the join shuffles all data across nodes to co-locate matching rows. On 1B rows, this is a multi-minute...",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/performance.md",
+      "line_range": [
+        239,
+        245
+      ],
+      "block_text": "# Check refresh timing against peak query windows\ngrep -rn \"schedule_interval\\|cron\" dags/ --include=\"*.py\" \\\n  | grep -E \"REFRESH|materialized\"\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/performance.md",
+      "line_range": [
+        246,
+        256
+      ],
+      "block_text": "# Airflow DAG that runs at 9 AM \u2014 peak dashboard hour\nrefresh_mv = PostgresOperator(\n    sql=\"REFRESH MATERIALIZED VIEW daily_revenue_by_segment;\",\n    schedule_interval=\"0 9 * * *\",  # 9 AM = peak load\n)\n```\n\n**Why wrong**: `REFRESH MATERIALIZED VIEW` (non-CONCURRENT) takes an exclusive lock that blocks all queries to the view. Running during 9 AM peak hour blocks dashboards for the duration of the refresh (potentially minutes on large datasets).\n\n**Fix**:\n```python",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/performance.md",
+      "line_range": [
+        260,
+        264
+      ],
+      "block_text": "# Or use CONCURRENTLY to avoid locking (requires unique index)\nsql=\"REFRESH MATERIALIZED VIEW CONCURRENTLY daily_revenue_by_segment;\"\n```\n\n---\n",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/sql.md",
+      "line_range": [
+        156,
+        156
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/sql.md",
+      "line_range": [
+        167,
+        187
+      ],
+      "block_text": "# Find INSERT without ON CONFLICT or MERGE in SQL files\ngrep -rn \"INSERT INTO\" pipelines/ dbt/ sql/ --include=\"*.sql\" \\\n  | grep -v \"ON CONFLICT\\|MERGE\\|INSERT OVERWRITE\\|IGNORE INTO\"\n\nrg 'INSERT INTO \\w+ SELECT' --type sql | grep -v \"ON CONFLICT\"\n```\n\n**What it looks like**:\n```sql\n-- BROKEN: Creates duplicates on every pipeline re-run\nINSERT INTO fact_orders (order_id, amount, created_at)\nSELECT order_id, SUM(amount), created_at\nFROM staging_orders\nGROUP BY order_id, created_at;\n```\n\n**Why wro...",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/sql.md",
+      "line_range": [
+        189,
+        220
+      ],
+      "block_text": "### \u274c SELECT * in Pipeline Transforms\n\n**Detection**:\n```bash\ngrep -rn \"SELECT \\*\" models/ pipelines/ sql/ --include=\"*.sql\"\nrg 'SELECT \\*' --type sql\n```\n\n**What it looks like**:\n```sql\n-- Staging model that passes through everything\nSELECT * FROM raw.orders\n```\n\n**Why wrong**: When the source schema adds a column, the staging model now passes that column downstream \u2014 potentially breaking downstream models that don't expect it, or silently including PII that shouldn't flow through the pipeline....",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/sql.md",
+      "line_range": [
+        226,
+        255
+      ],
+      "block_text": "# Find hardcoded date literals in SQL pipeline files\ngrep -rn \"WHERE.*[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}\" pipelines/ sql/ --include=\"*.sql\" \\\n  | grep -v \"-- example\\|-- comment\"\n\nrg \"'\\d{4}-\\d{2}-\\d{2}'\" --type sql | grep -v \"#\"\n```\n\n**What it looks like**:\n```sql\n-- Can't backfill, can't test, breaks next day\nINSERT INTO fact_orders\nSELECT * FROM staging_orders\nWHERE DATE(created_at) = '2026-04-04'  -- hardcoded!\n```\n\n**Why wrong**: This pipeline can only run for one specific date. Backfilling r...",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/testing.md",
+      "line_range": [
+        173,
+        173
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/testing.md",
+      "line_range": [
+        186,
+        197
+      ],
+      "block_text": "# Quick check: ratio of tests to models\necho \"Models: $(dbt ls --resource-type model | wc -l)\"\necho \"Tests: $(dbt ls --resource-type test | wc -l)\"\n```\n\n**What it looks like**: Models in `models/` directory with no corresponding entries in `schema.yml`, or schema.yml entries with empty `tests:` lists.\n\n**Why wrong**: Untransformed SQL that silently produces wrong data. Without `unique` + `not_null` tests on PKs, duplicate or null keys can corrupt downstream joins, producing 2x or 0.5x metrics wi...",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/testing.md",
+      "line_range": [
+        203,
+        221
+      ],
+      "block_text": "# Count tests by model path\ndbt ls --resource-type test --output json \\\n  | python3 -c \"\nimport json, sys, collections\ntests = [json.loads(l) for l in sys.stdin if l.strip()]\npaths = [t.get('path', '') for t in tests]\nfor path_prefix in ['staging', 'intermediate', 'marts']:\n    count = sum(1 for p in paths if path_prefix in p)\n    print(f'{path_prefix}: {count} tests')\n\"\n```\n\n**What it looks like**: Many tests on `models/staging/` but zero tests on `models/marts/` or `models/reporting/`.\n\n**Why ...",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/data-engineer/references/testing.md",
+      "line_range": [
+        227,
+        250
+      ],
+      "block_text": "# Find not_null tests on potentially nullable columns\ngrep -rn \"not_null\" models/ --include=\"*.yml\" -B2 \\\n  | grep -E \"name: (description|notes|middle_name|phone|optional)\"\n```\n\n**What it looks like**:\n```yaml\n- name: customer_notes\n  tests:\n    - not_null  # Customers often don't have notes\n```\n\n**Why wrong**: `not_null` on optional columns causes valid data to fail tests. When tests always fail, engineers start skipping them or marking them as warnings, which erodes confidence in the entire te...",
+      "domain_hint": "data-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/performance.md",
+      "line_range": [
+        141,
+        141
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/performance.md",
+      "line_range": [
+        143,
+        185
+      ],
+      "block_text": "### \u274c Over-Indexing (Index on Every Column)\n\n**Detection**:\n```sql\n-- Find tables with unusually high index count\nSELECT\n  schemaname,\n  tablename,\n  COUNT(*) AS index_count\nFROM pg_indexes\nWHERE schemaname = 'public'\nGROUP BY schemaname, tablename\nHAVING COUNT(*) > 8\nORDER BY index_count DESC;\n\n-- Find unused indexes (no scans since last statistics reset)\nSELECT\n  schemaname,\n  tablename,\n  indexname,\n  idx_scan AS times_used\nFROM pg_stat_user_indexes\nWHERE idx_scan = 0\n  AND indexname NOT LIKE...",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/performance.md",
+      "line_range": [
+        195,
+        229
+      ],
+      "block_text": "# Check table size before running migration\npsql -c \"SELECT pg_size_pretty(pg_total_relation_size('orders'));\"\n```\n\n**What it looks like**:\n```sql\n-- This takes an ExclusiveLock for the duration on a 500GB table\nALTER TABLE orders ADD COLUMN processed BOOLEAN NOT NULL DEFAULT false;\n-- PostgreSQL 11+: default value is safe \u2014 metadata-only change\n-- PostgreSQL < 11: rewrites entire table with new column!\n```\n\n**Why wrong**: On PostgreSQL < 11, adding a column with a default value requires rewriti...",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/performance.md",
+      "line_range": [
+        231,
+        258
+      ],
+      "block_text": "### \u274c No Query Timeout Set (Runaway Queries)\n\n**Detection**:\n```sql\n-- Find queries running longer than 5 minutes\nSELECT pid, now() - query_start AS duration, query\nFROM pg_stat_activity\nWHERE state = 'active'\n  AND query_start < NOW() - INTERVAL '5 minutes';\n```\n\n**What it looks like**: Application has no statement timeout configured. A user runs `SELECT * FROM orders` (full table scan, no WHERE clause) that runs for 30 minutes and holds shared locks.\n\n**Why wrong**: Long-running queries on Pos...",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/postgres.md",
+      "line_range": [
+        153,
+        153
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/postgres.md",
+      "line_range": [
+        155,
+        190
+      ],
+      "block_text": "### \u274c Unindexed Foreign Key Column\n\n**Detection**:\n```sql\n-- Find all foreign keys without corresponding indexes (PostgreSQL)\nSELECT\n  tc.table_name,\n  kcu.column_name,\n  ccu.table_name AS references_table\nFROM information_schema.table_constraints AS tc\nJOIN information_schema.key_column_usage AS kcu\n  ON tc.constraint_name = kcu.constraint_name\nJOIN information_schema.referential_constraints AS rc\n  ON tc.constraint_name = rc.constraint_name\nJOIN information_schema.key_column_usage AS ccu\n  ON ...",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/postgres.md",
+      "line_range": [
+        196,
+        229
+      ],
+      "block_text": "# Find LIKE patterns with leading wildcards in application queries\ngrep -rn \"LIKE '%\\|ilike '%\\|SIMILAR TO '%\" src/ --include=\"*.py\" --include=\"*.go\" --include=\"*.ts\"\n```\n\n**What it looks like**:\n```sql\n-- Scans entire table \u2014 no index can help with leading wildcard\nSELECT * FROM products WHERE name ILIKE '%laptop%';\n```\n\n**Why wrong**: B-tree indexes require a known prefix. `LIKE '%term%'` always does a full sequential scan regardless of indexes. On 100K products, this is 100K string comparison...",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/postgres.md",
+      "line_range": [
+        231,
+        268
+      ],
+      "block_text": "### \u274c Not Updating Table Statistics After Bulk Loads\n\n**Detection**:\n```sql\n-- Find tables with stale statistics (last analyzed > 7 days for busy tables)\nSELECT\n  schemaname,\n  tablename,\n  n_live_tup,\n  last_analyze,\n  last_autoanalyze,\n  now() - last_analyze AS time_since_analyze\nFROM pg_stat_user_tables\nWHERE (last_analyze < NOW() - INTERVAL '7 days' OR last_analyze IS NULL)\n  AND n_live_tup > 10000\nORDER BY n_live_tup DESC;\n```\n\n**What it looks like**: After a bulk insert of 500K rows into a...",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/sql.md",
+      "line_range": [
+        147,
+        147
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/sql.md",
+      "line_range": [
+        157,
+        162
+      ],
+      "block_text": "# Find in ORM query builders\ngrep -rn \"\\.find_all\\(\\|\\.all()\\|fetchAll()\" src/ --include=\"*.py\" --include=\"*.rb\"\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/sql.md",
+      "line_range": [
+        163,
+        177
+      ],
+      "block_text": "# Python example\ncursor.execute(\"SELECT * FROM users WHERE id = %s\", (user_id,))\n```\n\n**Why wrong**: Retrieves all columns including large TEXT/BLOB fields even when only `name` and `email` are needed. Breaks when schema adds columns (new columns appear in API responses). Prevents index-only scans (which need only indexed columns).\n\n**Fix**:\n```python\ncursor.execute(\n    \"SELECT id, name, email, created_at FROM users WHERE id = %s\",\n    (user_id,)\n)\n```\n\n---\n",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/sql.md",
+      "line_range": [
+        187,
+        206
+      ],
+      "block_text": "# PostgreSQL: check pg_stat_statements for full seq scans that shouldn't be\nSELECT query, rows, shared_blks_read\nFROM pg_stat_statements\nWHERE shared_blks_read > 10000\nORDER BY shared_blks_read DESC;\n```\n\n**What it looks like**:\n```sql\n-- users.id is BIGINT, but query passes a string\nSELECT * FROM users WHERE id = '12345';\n\n-- MySQL: silently converts, but prevents index use\n-- PostgreSQL: may work or throw type mismatch error depending on context\n```\n\n**Why wrong**: In MySQL, comparing an integ...",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/sql.md",
+      "line_range": [
+        217,
+        225
+      ],
+      "block_text": "# Find string interpolation in SQL queries (critical security issue)\ngrep -rn \"f\\\"SELECT\\|f'SELECT\\|\\\"SELECT.*%s.*%\\\" %\\|'SELECT.*format(\" \\\n  src/ --include=\"*.py\"\n\ngrep -rn \"\\\"SELECT.*\\+.*\\|query.*\\+.*where\" src/ --include=\"*.go\" --include=\"*.java\"\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/sql.md",
+      "line_range": [
+        226,
+        235
+      ],
+      "block_text": "# SQL injection vulnerability\nuser_id = request.args.get('id')\nquery = f\"SELECT * FROM users WHERE id = {user_id}\"  # NEVER DO THIS\ncursor.execute(query)\n```\n\n**Why wrong**: Attacker passes `id=1 OR 1=1` to dump all users, or `id=1; DROP TABLE users` to destroy data. This is OWASP Top 10 #3.\n\n**Fix**:\n```python",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/database-engineer/references/sql.md",
+      "line_range": [
+        249,
+        278
+      ],
+      "block_text": "# Find function calls wrapping column names in WHERE clauses\ngrep -rn \"WHERE.*DATE(\\|WHERE.*LOWER(\\|WHERE.*UPPER(\\|WHERE.*YEAR(\\|WHERE.*MONTH(\" \\\n  src/ --include=\"*.sql\" --include=\"*.py\"\n```\n\n**What it looks like**:\n```sql\n-- B-tree index on created_at is useless here\nSELECT * FROM orders WHERE DATE(created_at) = '2026-04-04';\n\n-- B-tree index on email is useless here\nSELECT * FROM users WHERE LOWER(email) = 'alice@example.com';\n```\n\n**Why wrong**: Applying a function to an indexed column preve...",
+      "domain_hint": "database-engineer"
+    },
+    {
+      "file": "agents/github-profile-rules-engineer/references/github-api-patterns.md",
+      "line_range": [
+        127,
+        127
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "github-profile-rules-engineer"
+    },
+    {
+      "file": "agents/github-profile-rules-engineer/references/github-api-patterns.md",
+      "line_range": [
+        129,
+        137
+      ],
+      "block_text": "### \u274c Fetching Files One by One Without Tree\n\n**Detection** (in your own code pattern):\n```bash\ngrep -rn 'GET /repos.*contents' scripts/ | grep -v 'tree'\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "github-profile-rules-engineer"
+    },
+    {
+      "file": "agents/github-profile-rules-engineer/references/github-api-patterns.md",
+      "line_range": [
+        138,
+        152
+      ],
+      "block_text": "# Expensive: 1 request per directory level, recursive\ndef list_files(owner, repo, path=\"\"):\n    items = github_get(f\"/repos/{owner}/{repo}/contents/{path}\")\n    for item in items:\n        if item[\"type\"] == \"dir\":\n            yield from list_files(owner, repo, item[\"path\"])  # N+1 requests!\n        else:\n            yield item[\"path\"]\n```\n\n**Why wrong**: A 200-file repo with 20 directories requires 21 API requests just to list files. The recursive tree endpoint does it in 1.\n\n**Fix**: Use `GET /...",
+      "domain_hint": "github-profile-rules-engineer"
+    },
+    {
+      "file": "agents/github-profile-rules-engineer/references/github-api-patterns.md",
+      "line_range": [
+        154,
+        163
+      ],
+      "block_text": "### \u274c Not Checking Pagination\n\n**Detection**:\n```bash\ngrep -rn 'per_page' scripts/ | grep -v 'pagination\\|next\\|link'\n```\n\n**What it looks like**:\n```python\nrepos = github_get(f\"/users/{username}/repos?per_page=100\")",
+      "domain_hint": "github-profile-rules-engineer"
+    },
+    {
+      "file": "agents/github-profile-rules-engineer/references/github-api-patterns.md",
+      "line_range": [
+        164,
+        181
+      ],
+      "block_text": "# Assumes all repos fit in one page \u2014 fails for users with 100+ repos\n```\n\n**Why wrong**: GitHub API returns max 100 items per page. Users with 100+ repos silently get incomplete data. The API includes a `Link` header with `rel=\"next\"` for pagination.\n\n**Fix**:\n```python\ndef paginate(url: str) -> list:\n    results = []\n    while url:\n        resp = requests.get(url, headers=auth_headers)\n        results.extend(resp.json())\n        # GitHub uses Link header for pagination\n        url = resp.links...",
+      "domain_hint": "github-profile-rules-engineer"
+    },
+    {
+      "file": "agents/github-profile-rules-engineer/references/github-api-patterns.md",
+      "line_range": [
+        183,
+        192
+      ],
+      "block_text": "### \u274c Using Unauthenticated Requests for Full Analysis\n\n**Detection**:\n```bash\ngrep -rn 'github_get\\|requests.get' scripts/ | grep -v 'Authorization\\|token'\n```\n\n**What it looks like**:\n```python\nheaders = {\"Accept\": \"application/vnd.github.v3+json\"}",
+      "domain_hint": "github-profile-rules-engineer"
+    },
+    {
+      "file": "agents/github-profile-rules-engineer/references/github-api-patterns.md",
+      "line_range": [
+        193,
+        208
+      ],
+      "block_text": "# Missing: Authorization header \u2014 capped at 60 req/hr\n```\n\n**Why wrong**: 60 requests/hr is exhausted by analyzing 2-3 repos. Profile analysis needs 50-200 requests minimum.\n\n**Fix**: Accept `--token` CLI flag; check for `GITHUB_TOKEN` env var:\n```python\nimport os\ntoken = args.token or os.environ.get(\"GITHUB_TOKEN\")\nheaders = {\n    \"Accept\": \"application/vnd.github.v3+json\",\n    **({\"Authorization\": f\"token {token}\"} if token else {})\n}\n```\n\n---\n",
+      "domain_hint": "github-profile-rules-engineer"
+    },
+    {
+      "file": "agents/github-profile-rules-engineer/references/rule-categories.md",
+      "line_range": [
+        81,
+        81
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "github-profile-rules-engineer"
+    },
+    {
+      "file": "agents/github-profile-rules-engineer/references/rule-categories.md",
+      "line_range": [
+        83,
+        99
+      ],
+      "block_text": "### \u274c Extracting Universal Patterns\n\n**Detection** (in your own rule output \u2014 review before emitting):\nLook for rules that would appear in any developer's CLAUDE.md:\n- \"Use meaningful variable names\"\n- \"Write tests for your code\"\n- \"Handle errors appropriately\"\n- \"Use consistent formatting\"\n\n**Why wrong**: Universal patterns add no value. The user already knows these. The value of extraction is finding *this developer's* specific choices that differ from the default.\n\n**Fix**: Only emit rules wh...",
+      "domain_hint": "github-profile-rules-engineer"
+    },
+    {
+      "file": "agents/github-profile-rules-engineer/references/rule-categories.md",
+      "line_range": [
+        101,
+        116
+      ],
+      "block_text": "### \u274c Rules Without Repo + File Evidence\n\n**Detection** (in your rule generation):\n```\nRule: \"Always wrap errors with context\"\nEvidence: [none cited]\n```\n\n**Why wrong**: Without evidence, the rule is a guess. The user can't verify it, and it may conflict with their actual preference.\n\n**Fix**: Every rule must cite at minimum:\n- Which repo the pattern was observed in\n- Which file (or file pattern) contains the example\n- Optionally: the specific line or code snippet\n\n---\n",
+      "domain_hint": "github-profile-rules-engineer"
+    },
+    {
+      "file": "agents/github-profile-rules-engineer/references/rule-categories.md",
+      "line_range": [
+        118,
+        128
+      ],
+      "block_text": "### \u274c Confusing Project Convention with Personal Style\n\n**Detection**: When a pattern appears in only one repo, check if that repo has a contributing guide, linter config, or external style guide that explains it.\n\n**What it looks like**: Extracting \"Always use 2-space indentation in Python\" from one repo \u2014 but the repo is a web framework with enforced formatter config.\n\n**Why wrong**: The developer may be following the project's style, not their own preference. They may write 4-space indentatio...",
+      "domain_hint": "github-profile-rules-engineer"
+    },
+    {
+      "file": "agents/github-profile-rules-engineer/references/rule-categories.md",
+      "line_range": [
+        130,
+        142
+      ],
+      "block_text": "### \u274c Over-Weighting Authored Code vs Review Comments\n\n**Detection**: If rule extraction only reads authored code files without checking PR reviews, it misses preference signals.\n\n**Why wrong**: PR review comments reveal what the developer considers important enough to enforce on *others*. A developer who writes sloppy error handling in their own draft PRs but consistently requests proper error wrapping in reviews is showing you their real standard.\n\n**Correct priority order**:\n1. PR review comm...",
+      "domain_hint": "github-profile-rules-engineer"
+    },
+    {
+      "file": "agents/github-profile-rules-engineer.md",
+      "line_range": [
+        112,
+        112
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "github"
+    },
+    {
+      "file": "agents/golang-general-engineer/references/go-anti-patterns.md",
+      "line_range": [
+        1,
+        3
+      ],
+      "block_text": "# Go General Engineer - Anti-Patterns\n\nCommon Go mistakes and corrections.\n",
+      "domain_hint": "golang-general-engineer"
+    },
+    {
+      "file": "agents/golang-general-engineer-compact/references/concurrency-patterns.md",
+      "line_range": [
+        92,
+        92
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "golang-general-engineer-compact"
+    },
+    {
+      "file": "agents/golang-general-engineer-compact/references/concurrency-patterns.md",
+      "line_range": [
+        94,
+        133
+      ],
+      "block_text": "### \u274c Goroutine Without Exit Strategy\n\n**Detection**:\n```bash\ngrep -rn 'go func()' --include=\"*.go\" | grep -v \"_test.go\"\nrg 'go func\\(\\)' --type go -l\n```\n\n**What it looks like**:\n```go\nfunc startBackgroundJob() {\n    go func() {\n        for {\n            doWork() // No ctx.Done(), no stop channel\n        }\n    }()\n}\n```\n\n**Why wrong**: The goroutine runs until process exit. If called repeatedly (e.g., in tests), goroutines accumulate. `goleak` in tests will catch this; production just slowly ru...",
+      "domain_hint": "golang-general-engineer-compact"
+    },
+    {
+      "file": "agents/golang-general-engineer-compact/references/concurrency-patterns.md",
+      "line_range": [
+        135,
+        178
+      ],
+      "block_text": "### \u274c WaitGroup Add Inside Goroutine (Pre-1.25)\n\n**Detection**:\n```bash\ngrep -A2 'go func' --include=\"*.go\" -rn . | grep 'wg.Add'\nrg 'go func.*\\{' --type go -A 3 | grep 'wg\\.Add'\n```\n\n**What it looks like**:\n```go\nfor _, item := range items {\n    go func(i Item) {\n        wg.Add(1) // Race: Wait() can return before Add() runs\n        defer wg.Done()\n        process(i)\n    }(item)\n}\nwg.Wait()\n```\n\n**Why wrong**: `wg.Wait()` may return before some goroutines call `wg.Add(1)`. This is a race condit...",
+      "domain_hint": "golang-general-engineer-compact"
+    },
+    {
+      "file": "agents/golang-general-engineer-compact/references/concurrency-patterns.md",
+      "line_range": [
+        180,
+        215
+      ],
+      "block_text": "### \u274c Closing Channel from Multiple Writers\n\n**Detection**:\n```bash\ngrep -rn 'close(' --include=\"*.go\" | grep -v \"_test.go\"\nrg 'close\\(ch\\)' --type go\n```\n\n**What it looks like**:\n```go\nfor _, worker := range workers {\n    go func(w Worker) {\n        result := w.Compute()\n        results <- result\n        close(results) // Panic: multiple goroutines close same channel\n    }(worker)\n}\n```\n\n**Why wrong**: Only one goroutine should close a channel. Multiple goroutines closing the same channel cause...",
+      "domain_hint": "golang-general-engineer-compact"
+    },
+    {
+      "file": "agents/golang-general-engineer-compact/references/concurrency-patterns.md",
+      "line_range": [
+        217,
+        245
+      ],
+      "block_text": "### \u274c Benchmark Using b.N Loop (Pre-1.24)\n\n**Detection**:\n```bash\ngrep -rn 'for i := 0; i < b.N' --include=\"*_test.go\"\nrg 'i < b\\.N' --type go\n```\n\n**What it looks like**:\n```go\nfunc BenchmarkOp(b *testing.B) {\n    for i := 0; i < b.N; i++ { // Old idiom, still works but verbose\n        op()\n    }\n}\n```\n\n**Fix** (Go 1.24+):\n```go\nfunc BenchmarkOp(b *testing.B) {\n    for b.Loop() { // b.Loop() is idiomatic Go 1.24+\n        op()\n    }\n}\n```\n\n**Version note**: `b.Loop()` was added in Go 1.24. It al...",
+      "domain_hint": "golang-general-engineer-compact"
+    },
+    {
+      "file": "agents/golang-general-engineer-compact/references/go-patterns.md",
+      "line_range": [
+        127,
+        127
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "golang-general-engineer-compact"
+    },
+    {
+      "file": "agents/golang-general-engineer-compact/references/go-patterns.md",
+      "line_range": [
+        155,
+        187
+      ],
+      "block_text": "### \u274c Bare Error Return (No Context)\n\n**Detection**:\n```bash\ngrep -rn 'return err$' --include=\"*.go\" | grep -v \"_test.go\"\nrg 'return nil, err$' --type go | grep -v '_test.go'\n```\n\n**What it looks like**:\n```go\nfunc getConfig(path string) (*Config, error) {\n    data, err := os.ReadFile(path)\n    if err != nil {\n        return nil, err // Loses call context\n    }\n    ...\n}\n```\n\n**Why wrong**: Caller receives `open /etc/config: no such file or directory` with no indication that `getConfig` was the ...",
+      "domain_hint": "golang-general-engineer-compact"
+    },
+    {
+      "file": "agents/golang-general-engineer-compact/references/go-patterns.md",
+      "line_range": [
+        197,
+        219
+      ],
+      "block_text": "# Old numeric loop\ngrep -rn 'for i := 0; i < [0-9]' --include=\"*.go\"\n```\n\n**What it looks like**:\n```go\nfor i := 0; i < 5; i++ { // Pre-1.22 numeric loop\n    wg.Add(1)             // Pre-1.25 WaitGroup\n    go func(n int) {\n        defer wg.Done()\n        process(n)\n    }(i)\n}\n```\n\n**Fix** (Go 1.25+):\n```go\nfor i := range 5 { // Go 1.22+\n    wg.Go(func() { process(i) }) // Go 1.25+: i captured by value in wg.Go\n}\n```\n\n---\n",
+      "domain_hint": "golang-general-engineer-compact"
+    },
+    {
+      "file": "agents/golang-general-engineer-compact/references/testing-patterns.md",
+      "line_range": [
+        119,
+        119
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "golang-general-engineer-compact"
+    },
+    {
+      "file": "agents/golang-general-engineer-compact/references/testing-patterns.md",
+      "line_range": [
+        121,
+        144
+      ],
+      "block_text": "### \u274c Missing t.Parallel() in Subtests\n\n**Detection**:\n```bash\ngrep -A5 't.Run(' --include=\"*_test.go\" -rn . | grep -v 't.Parallel'\nrg 't\\.Run\\(' --type go -A 3 | grep -v 't\\.Parallel'\n```\n\n**What it looks like**:\n```go\nfor _, tt := range tests {\n    t.Run(tt.name, func(t *testing.T) {\n        // No t.Parallel() \u2014 runs sequentially\n        result := expensiveCompute(tt.input)\n        ...\n    })\n}\n```\n\n**Why wrong**: Sequential subtests are 10-100x slower on multi-core machines. `go test -count=1...",
+      "domain_hint": "golang-general-engineer-compact"
+    },
+    {
+      "file": "agents/golang-general-engineer-compact/references/testing-patterns.md",
+      "line_range": [
+        177,
+        215
+      ],
+      "block_text": "### \u274c Context Not Canceled in Test Goroutines\n\n**Detection**:\n```bash\ngrep -rn 'context.Background()' --include=\"*_test.go\"\nrg 'context\\.Background\\(\\)' --type go --glob '*_test.go'\n```\n\n**What it looks like**:\n```go\nfunc TestServer(t *testing.T) {\n    ctx := context.Background() // Never canceled \u2014 goroutines may outlive test\n    go startServer(ctx)\n    ...\n}\n```\n\n**Why wrong**: Goroutines started with `context.Background()` in tests run until process exit, causing goroutine leaks detected by `...",
+      "domain_hint": "golang-general-engineer-compact"
+    },
+    {
+      "file": "agents/golang-general-engineer-compact/references/testing-patterns.md",
+      "line_range": [
+        217,
+        248
+      ],
+      "block_text": "### \u274c Benchmark Without Reset or Skip Setup\n\n**Detection**:\n```bash\ngrep -B5 'for.*b\\.N' --include=\"*_test.go\" -rn . | grep -v 'b.ResetTimer'\nrg 'for i := 0.*b\\.N' --type go --glob '*_test.go'\n```\n\n**What it looks like**:\n```go\nfunc BenchmarkProcess(b *testing.B) {\n    data := loadLargeDataset() // Counted in benchmark time!\n    for i := 0; i < b.N; i++ {\n        process(data)\n    }\n}\n```\n\n**Why wrong**: `loadLargeDataset()` runs once but the time is counted in benchmark initialization, skewing ...",
+      "domain_hint": "golang-general-engineer-compact"
+    },
+    {
+      "file": "agents/hook-development-engineer/references/anti-patterns.md",
+      "line_range": [
+        1,
+        3
+      ],
+      "block_text": "# Hook Development Anti-Patterns Reference\n\n> Loaded by hook-development-engineer when reviewing hook code for correctness, performance, or registration safety issues.\n",
+      "domain_hint": "hook-development-engineer"
+    },
+    {
+      "file": "agents/kubernetes-helm-engineer/references/helm-patterns.md",
+      "line_range": [
+        132,
+        132
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "kubernetes-helm-engineer"
+    },
+    {
+      "file": "agents/kubernetes-helm-engineer/references/helm-patterns.md",
+      "line_range": [
+        134,
+        143
+      ],
+      "block_text": "### \u274c Hardcoded Secrets in Values Files\n\n**Detection**:\n```bash\ngrep -rn 'password\\|secret\\|token\\|apiKey\\|api_key' --include=\"values*.yaml\" .\nrg '(password|secret|token|apiKey|api_key): ' --type yaml\n```\n\n**What it looks like**:\n```yaml",
+      "domain_hint": "kubernetes-helm-engineer"
+    },
+    {
+      "file": "agents/kubernetes-helm-engineer/references/helm-patterns.md",
+      "line_range": [
+        144,
+        153
+      ],
+      "block_text": "# values-prod.yaml \u2014 NEVER DO THIS\ndatabase:\n  password: \"mysecretpassword\"   # Exposed in git history\n  connectionString: \"postgres://user:pass@host/db\"\n```\n\n**Why wrong**: Values files are checked into git. Secrets in git history persist forever even after deletion. CI logs, PR previews, and `helm get values` all expose them.\n\n**Fix**: Use external secret management:\n```yaml",
+      "domain_hint": "kubernetes-helm-engineer"
+    },
+    {
+      "file": "agents/kubernetes-helm-engineer/references/helm-patterns.md",
+      "line_range": [
+        172,
+        180
+      ],
+      "block_text": "### \u274c Not Using `required` for Mandatory Values\n\n**Detection**:\n```bash\ngrep -rn '\\.Values\\.' --include=\"*.yaml\" charts/*/templates/ | grep -v 'default\\|required' | head -20\n```\n\n**What it looks like**:\n```yaml",
+      "domain_hint": "kubernetes-helm-engineer"
+    },
+    {
+      "file": "agents/kubernetes-helm-engineer/references/helm-patterns.md",
+      "line_range": [
+        183,
+        193
+      ],
+      "block_text": "# If image.tag is missing: renders as \"myapp:<no value>\" \u2014 deploys broken pod\n```\n\n**Why wrong**: Missing values render as `<no value>` or empty string. The chart deploys without error, but the pod fails at runtime with a confusing image pull error.\n\n**Fix**:\n```yaml\nimage: {{ .Values.image.repository }}:{{ required \"image.tag is required\" .Values.image.tag }}\n```\n\n---\n",
+      "domain_hint": "kubernetes-helm-engineer"
+    },
+    {
+      "file": "agents/kubernetes-helm-engineer/references/helm-patterns.md",
+      "line_range": [
+        199,
+        205
+      ],
+      "block_text": "# Find deprecated API versions in chart templates\ngrep -rn 'apps/v1beta\\|extensions/v1beta\\|networking.k8s.io/v1beta1' --include=\"*.yaml\" charts/\nrg 'v1beta' --type yaml charts/\n```\n\n**What it looks like**:\n```yaml",
+      "domain_hint": "kubernetes-helm-engineer"
+    },
+    {
+      "file": "agents/kubernetes-helm-engineer/references/helm-patterns.md",
+      "line_range": [
+        221,
+        234
+      ],
+      "block_text": "### \u274c No Chart Tests\n\n**Detection**:\n```bash\nls charts/*/templates/tests/ 2>/dev/null || echo \"No test directory found\"\nfind charts/ -name \"*test*\" -path \"*/templates/*\"\n```\n\n**What it looks like**: A chart with no `templates/tests/` directory and no `helm.sh/hook: test` annotated pods.\n\n**Why wrong**: `helm install` can succeed with pods in Pending/Unready state. Without tests, there's no way to verify the chart actually works.\n\n**Fix**:\n```yaml",
+      "domain_hint": "kubernetes-helm-engineer"
+    },
+    {
+      "file": "agents/kubernetes-helm-engineer/references/kubernetes-troubleshooting.md",
+      "line_range": [
+        81,
+        81
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "kubernetes-helm-engineer"
+    },
+    {
+      "file": "agents/kubernetes-helm-engineer/references/kubernetes-troubleshooting.md",
+      "line_range": [
+        92,
+        123
+      ],
+      "block_text": "# Find pods currently running without resource limits\nkubectl get pods --all-namespaces -o json | \\\n  jq '.items[] | select(.spec.containers[] | .resources.limits == null) | .metadata.name'\n```\n\n**What it looks like**:\n```yaml\ncontainers:\n- name: app\n  image: myapp:v1.2.3\n  # No resources block at all\n```\n\n**Why wrong**: Without limits, a single pod can consume all node memory/CPU. OOMKiller will evict other pods first. Kubernetes scheduler can't pack nodes efficiently without requests.\n\n**Fix**...",
+      "domain_hint": "kubernetes-helm-engineer"
+    },
+    {
+      "file": "agents/kubernetes-helm-engineer/references/kubernetes-troubleshooting.md",
+      "line_range": [
+        135,
+        144
+      ],
+      "block_text": "# Check in manifests/helm values\ngrep -rn ':latest' --include=\"*.yaml\" --include=\"*.yml\" .\nrg ':latest' --type yaml\n```\n\n**Why wrong**: `:latest` is pulled differently based on `imagePullPolicy`. `Always` causes unnecessary registry calls; `IfNotPresent` means different nodes run different versions silently. Rollbacks are impossible \u2014 you can't pin `:latest` to a previous image.\n\n**Fix**: Use immutable tags: `image: myapp:v1.2.3` or `image: myapp:$(git rev-parse --short HEAD)`.\n\n---\n",
+      "domain_hint": "kubernetes-helm-engineer"
+    },
+    {
+      "file": "agents/kubernetes-helm-engineer/references/kubernetes-troubleshooting.md",
+      "line_range": [
+        150,
+        192
+      ],
+      "block_text": "# Find pods with short liveness probe timeouts\nkubectl get pods --all-namespaces -o json | \\\n  jq '.items[] | select(.spec.containers[].livenessProbe.failureThreshold <= 2) | \n  {name: .metadata.name, threshold: .spec.containers[].livenessProbe.failureThreshold}'\n\ngrep -rn 'failureThreshold: [12]$' --include=\"*.yaml\" .\n```\n\n**What it looks like**:\n```yaml\nlivenessProbe:\n  httpGet:\n    path: /health\n    port: 8080\n  initialDelaySeconds: 5\n  periodSeconds: 5\n  failureThreshold: 2  # Kills pod afte...",
+      "domain_hint": "kubernetes-helm-engineer"
+    },
+    {
+      "file": "agents/kubernetes-helm-engineer/references/kubernetes-troubleshooting.md",
+      "line_range": [
+        198,
+        222
+      ],
+      "block_text": "# Find deployments without a matching PDB\nkubectl get deployments -n <namespace> -o jsonpath='{.items[*].metadata.name}' | \\\n  tr ' ' '\\n' | while read dep; do\n    kubectl get pdb -n <namespace> -o jsonpath='{.items[*].spec.selector.matchLabels}' | \\\n      grep -q \"$dep\" || echo \"No PDB for: $dep\"\n  done\n```\n\n**Why wrong**: Without a PDB, node drains (maintenance, rolling upgrades) can take down all replicas simultaneously, causing a production outage.\n\n**Fix**:\n```yaml\napiVersion: policy/v1\nkin...",
+      "domain_hint": "kubernetes-helm-engineer"
+    },
+    {
+      "file": "agents/kubernetes-helm-engineer/references/kubernetes-troubleshooting.md",
+      "line_range": [
+        257,
+        262
+      ],
+      "block_text": "# Deployments using :latest tag (production anti-pattern)\nkubectl get deployments --all-namespaces -o json | \\\n  jq '.items[] | select(.spec.template.spec.containers[].image | endswith(\":latest\")) | .metadata.name'\n```\n\n---\n",
+      "domain_hint": "kubernetes-helm-engineer"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
+      "line_range": [
+        6,
+        12
+      ],
+      "block_text": "# MCP Server Anti-Patterns\n\n> **Scope**: Anti-patterns specific to MCP documentation servers in TypeScript/Node.js. Covers front matter parsing failures, indexing bugs, and protocol misuse.\n> **Version range**: `@modelcontextprotocol/sdk` 0.5.0+, Node.js 18+\n> **Generated**: 2026-04-08 \u2014 verify against current MCP spec\n\n---\n",
+      "domain_hint": "MCP Server Anti"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
+      "line_range": [
+        20,
+        20
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "MCP Server Anti"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
+      "line_range": [
+        28,
+        70
+      ],
+      "block_text": "# Check if they're wrapped in try/catch\ngrep -B5 'yaml\\.parse\\|yaml\\.load' --include=\"*.ts\" -rn src/\n```\n\n**What it looks like**:\n```typescript\nfunction parseFrontMatter(content: string): DocMetadata {\n  const parts = content.split('---');\n  // Crashes if YAML is malformed \u2014 kills entire server\n  const metadata = yaml.parse(parts[1]);\n  return metadata as DocMetadata;\n}\n```\n\n**Why wrong**: A single documentation file with a tab in YAML (invalid) or an unclosed quote crashes `yaml.parse()` and pr...",
+      "domain_hint": "MCP Server Anti"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
+      "line_range": [
+        78,
+        108
+      ],
+      "block_text": "# Check if server strips them\ngrep -rn 'shortcode\\|{{%\\|{{<' --include=\"*.ts\" src/\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ReadResourceRequestSchema, async (request) => {\n  const doc = this.docsIndex.get(request.params.uri);\n  // Returns raw markdown with Hugo shortcodes intact\n  return { contents: [{ uri: doc.uri, mimeType: 'text/markdown', text: doc.content }] };\n});\n```\n\n**Why wrong**: Hugo shortcodes like `{{< youtube abc123 >}}` or `{{% notice warning %}}` are no...",
+      "domain_hint": "MCP Server Anti"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
+      "line_range": [
+        115,
+        146
+      ],
+      "block_text": "# Must include capabilities matching registered handlers\n```\n\n**What it looks like**:\n```typescript\nthis.server = new Server(\n  { name: 'local-docs', version: '1.0.0' },\n  { capabilities: {} }  // Empty \u2014 client won't discover tools or resources\n);\n```\n\n**Why wrong**: MCP clients negotiate capabilities during the `initialize` handshake. If `capabilities.resources` is absent, clients skip the `resources/list` call entirely and never discover documents. If `capabilities.tools` is absent, the `sear...",
+      "domain_hint": "MCP Server Anti"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
+      "line_range": [
+        152,
+        185
+      ],
+      "block_text": "# Find URI-to-path conversion without traversal check\ngrep -rn 'uriToPath\\|path\\.join.*params\\.uri\\|path\\.resolve.*params' --include=\"*.ts\" src/\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ReadResourceRequestSchema, async (request) => {\n  // URI: docs://../../../etc/passwd \u2014 traverses out of docs root!\n  const filePath = path.join(this.docsRoot, request.params.uri.slice('docs://'.length));\n  const content = await fs.promises.readFile(filePath, 'utf-8');\n  return { content...",
+      "domain_hint": "MCP Server Anti"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
+      "line_range": [
+        193,
+        222
+      ],
+      "block_text": "# Check Hugo content for draft: true documents\ngrep -rn '^draft: true\\|^draft: \"true\"' --include=\"*.md\" content/\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ListResourcesRequestSchema, async () => {\n  const resources = Array.from(this.docsIndex.values()).map((doc) => ({\n    uri: doc.uri,\n    name: doc.metadata.title ?? 'Untitled',\n  }));\n  return { resources }; // Includes draft: true documents\n});\n```\n\n**Why wrong**: Hugo draft documents are unpublished content \u2014 WIP, in...",
+      "domain_hint": "MCP Server Anti"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/mcp-patterns.md",
+      "line_range": [
+        135,
+        135
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "MCP Server Development Patterns"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/mcp-patterns.md",
+      "line_range": [
+        137,
+        165
+      ],
+      "block_text": "### \u274c Synchronous File I/O in Request Handlers\n\n**Detection**:\n```bash\ngrep -rn 'readFileSync\\|existsSync\\|readdirSync' --include=\"*.ts\" src/\nrg 'Sync\\(' --type ts src/\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ReadResourceRequestSchema, (request) => {\n  // NOT async \u2014 blocks the entire Node.js event loop\n  const content = fs.readFileSync(uriToPath(request.params.uri), 'utf-8');\n  return { contents: [{ uri: request.params.uri, text: content }] };\n});\n```\n\n**Why wrong**:...",
+      "domain_hint": "MCP Server Development Patterns"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/mcp-patterns.md",
+      "line_range": [
+        172,
+        207
+      ],
+      "block_text": "# Flag if found inside a setRequestHandler callback\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ListResourcesRequestSchema, async () => {\n  // Re-parses all markdown files on every list call \u2014 seconds of delay\n  const docs = await this.indexDocs();\n  return { resources: docs.map((d) => ({ uri: d.uri, name: d.metadata.title })) };\n});\n```\n\n**Why wrong**: Claude calls `resources/list` repeatedly during a session. Re-parsing 1000 files takes 3-10 seconds each time. The LLM c...",
+      "domain_hint": "MCP Server Development Patterns"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/mcp-patterns.md",
+      "line_range": [
+        214,
+        244
+      ],
+      "block_text": "# Should be McpError for protocol failures\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ReadResourceRequestSchema, async (request) => {\n  const doc = this.docsIndex.get(request.params.uri);\n  if (!doc) {\n    throw new Error(`Not found: ${request.params.uri}`); // Generic JS error\n  }\n  return { contents: [{ uri: doc.uri, text: doc.content }] };\n});\n```\n\n**Why wrong**: Generic `Error` objects get wrapped in an internal error JSON-RPC response with code `-32603`. MCP clients...",
+      "domain_hint": "MCP Server Development Patterns"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/typescript-async-patterns.md",
+      "line_range": [
+        146,
+        146
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "TypeScript Async Patterns for MCP Servers"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/typescript-async-patterns.md",
+      "line_range": [
+        152,
+        177
+      ],
+      "block_text": "# Find Promise.all with .map() on potentially large arrays\ngrep -rn 'Promise\\.all.*\\.map' --include=\"*.ts\" src/\nrg 'Promise\\.all\\(' --type ts src/ -A2 | grep '\\.map'\n```\n\n**What it looks like**:\n```typescript\n// Reads ALL files simultaneously \u2014 EMFILE on large repos\nconst docs = await Promise.all(\n  allFiles.map((f) => fs.promises.readFile(f, 'utf-8'))\n);\n```\n\n**Why wrong**: `EMFILE: too many open files` at runtime. Default ulimit is 1024 file descriptors on Linux. A repo with 2000 markdown file...",
+      "domain_hint": "TypeScript Async Patterns for MCP Servers"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/typescript-async-patterns.md",
+      "line_range": [
+        184,
+        209
+      ],
+      "block_text": "# More specifically: promises not awaited inside handlers\nrg 'setRequestHandler.*\\{' --type ts src/ -A5 | grep '^\\s*[a-zA-Z].*\\(\\)' | grep -v 'await'\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(CallToolRequestSchema, (request) => {\n  // Not async, not returning promise properly\n  this.searchIndex(request.params.arguments?.query).then((results) => {\n    return { content: [{ type: 'text', text: JSON.stringify(results) }] };\n  });\n  // Returns undefined! Handler completes be...",
+      "domain_hint": "TypeScript Async Patterns for MCP Servers"
+    },
+    {
+      "file": "agents/mcp-local-docs-engineer/references/typescript-async-patterns.md",
+      "line_range": [
+        211,
+        251
+      ],
+      "block_text": "### \u274c Swallowing Errors in indexDocs\n\n**Detection**:\n```bash\ngrep -rn 'catch.*{}' --include=\"*.ts\" src/\ngrep -rn 'catch.*return\\s*$\\|catch.*return;\\s*$' --include=\"*.ts\" src/\n```\n\n**What it looks like**:\n```typescript\nasync indexDocs(): Promise<void> {\n  const files = await glob('**/*.md', { cwd: this.docsPath });\n  await Promise.all(files.map(async (f) => {\n    try {\n      await this.parseAndCache(f);\n    } catch {\n      // Silently swallow \u2014 no log, no counter\n    }\n  }));\n}\n```\n\n**Why wrong**...",
+      "domain_hint": "TypeScript Async Patterns for MCP Servers"
+    },
+    {
+      "file": "agents/nextjs-ecommerce-engineer/references/anti-patterns.md",
+      "line_range": [
+        1,
+        4
+      ],
+      "block_text": "# Anti-Patterns Reference\n<!-- Loaded by nextjs-ecommerce-engineer when reviewing e-commerce code for security, correctness, or reliability issues -->\n\nThese are the e-commerce mistakes that cause real damage \u2014 lost revenue, security incidents, overselling, and data corruption. Each one has a canonical fix.\n",
+      "domain_hint": "nextjs-ecommerce-engineer"
+    },
+    {
+      "file": "agents/nodejs-api-engineer/references/auth-patterns.md",
+      "line_range": [
+        149,
+        149
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "Authentication Patterns for Node.js APIs"
+    },
+    {
+      "file": "agents/nodejs-api-engineer/references/auth-patterns.md",
+      "line_range": [
+        180,
+        220
+      ],
+      "block_text": "# Look for early returns before bcrypt.compare\ngrep -rn 'findUser\\|findByEmail' --include=\"*.ts\" src/ -A10 | grep -v 'compare\\|bcrypt'\n```\n\n**What it looks like**:\n```typescript\nasync function login(email: string, password: string) {\n  const user = await db.users.findByEmail(email);\n  if (!user) {\n    return { error: 'User not found' }; // Responds fast \u2014 user doesn't exist\n  }\n  const valid = await bcrypt.compare(password, user.passwordHash); // Responds slow\n  if (!valid) {\n    return { error:...",
+      "domain_hint": "Authentication Patterns for Node.js APIs"
+    },
+    {
+      "file": "agents/nodejs-api-engineer/references/auth-patterns.md",
+      "line_range": [
+        227,
+        244
+      ],
+      "block_text": "# Flag anything longer than 1 hour\ngrep -rn \"expiresIn.*['\\\"].*[0-9][dw]\\|expiresIn.*3600[0-9]\" --include=\"*.ts\" src/\n```\n\n**What it looks like**:\n```typescript\nconst token = jwt.sign(\n  { sub: userId },\n  process.env.JWT_SECRET!,\n  { expiresIn: '7d' } // 7-day access token\n);\n```\n\n**Why wrong**: A 7-day access token means a stolen token gives 7 days of unauthorized access. With no server-side revocation on logout, all active sessions for a user remain valid even after a password change.\n\n**Fix*...",
+      "domain_hint": "Authentication Patterns for Node.js APIs"
+    },
+    {
+      "file": "agents/nodejs-api-engineer/references/auth-patterns.md",
+      "line_range": [
+        246,
+        266
+      ],
+      "block_text": "### \u274c Storing Refresh Tokens in localStorage\n\n**Detection**: This is a frontend anti-pattern but confirm with client team.\n```bash\ngrep -rn 'localStorage.*refresh\\|localStorage.*token' --include=\"*.ts\" --include=\"*.tsx\" src/\n```\n\n**Why wrong**: `localStorage` is accessible to any JavaScript running on the page, including XSS-injected scripts. Refresh tokens in localStorage are stolen by any XSS vulnerability.\n\n**Fix**: `httpOnly` cookies for refresh tokens \u2014 inaccessible to JavaScript:\n```typesc...",
+      "domain_hint": "Authentication Patterns for Node.js APIs"
+    },
+    {
+      "file": "agents/nodejs-api-engineer/references/middleware-patterns.md",
+      "line_range": [
+        223,
+        223
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "Express/Next.js Middleware Patterns"
+    },
+    {
+      "file": "agents/nodejs-api-engineer/references/middleware-patterns.md",
+      "line_range": [
+        230,
+        247
+      ],
+      "block_text": "# Find error handlers with only 3 params\ngrep -rn 'function.*err.*req.*res\\b' --include=\"*.ts\" src/\nrg '\\(err,\\s*req,\\s*res\\)' --type ts src/\n```\n\n**What it looks like**:\n```typescript\n// 3 args \u2014 Express treats this as REGULAR middleware, not error middleware\napp.use((err: Error, req: Request, res: Response) => {\n  res.status(500).json({ error: err.message });\n});\n```\n\n**Why wrong**: Express identifies error-handling middleware by arity (argument count). A 3-argument function is a regular middl...",
+      "domain_hint": "Express/Next.js Middleware Patterns"
+    },
+    {
+      "file": "agents/nodejs-api-engineer/references/middleware-patterns.md",
+      "line_range": [
+        249,
+        266
+      ],
+      "block_text": "### \u274c Wildcard CORS Origin\n\n**Detection**:\n```bash\ngrep -rn \"origin.*'\\*'\\|origin.*\\\"\\\\*\\\"\" --include=\"*.ts\" src/\nrg \"cors\\(\\{.*origin.*\\*\" --type ts src/\n```\n\n**What it looks like**:\n```typescript\napp.use(cors({ origin: '*', credentials: true }));\n```\n\n**Why wrong**: `origin: '*'` with `credentials: true` is rejected by browsers (CORS spec prohibits it), but `origin: '*'` without credentials still allows any malicious site to read API responses. Attack: attacker hosts `evil.com`, victim visits ...",
+      "domain_hint": "Express/Next.js Middleware Patterns"
+    },
+    {
+      "file": "agents/nodejs-api-engineer/references/middleware-patterns.md",
+      "line_range": [
+        272,
+        293
+      ],
+      "block_text": "# Find validation that comes after DB calls or side effects\ngrep -rn 'parse\\|safeParse\\|validate' --include=\"*.ts\" src/ -B10 | grep -E 'await.*db|await.*createUser|sendEmail'\n```\n\n**What it looks like**:\n```typescript\napp.post('/users', async (req, res) => {\n  // Creates user BEFORE validating input\n  const user = await db.users.create({ data: req.body });\n  const validated = UserSchema.safeParse(req.body);\n  if (!validated.success) {\n    res.status(422).json({ error: 'Invalid' });\n  }\n  res.jso...",
+      "domain_hint": "Express/Next.js Middleware Patterns"
+    },
+    {
+      "file": "agents/nodejs-api-engineer/references/webhook-patterns.md",
+      "line_range": [
+        163,
+        163
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "Webhook Patterns for Node.js APIs"
+    },
+    {
+      "file": "agents/nodejs-api-engineer/references/webhook-patterns.md",
+      "line_range": [
+        170,
+        189
+      ],
+      "block_text": "# Check if webhook routes are registered after app.use(express.json())\ngrep -rn 'app\\.post.*webhook' --include=\"*.ts\" src/ -B20 | grep 'express\\.json'\n```\n\n**What it looks like**:\n```typescript\napp.use(express.json()); // Parses ALL bodies first\n\napp.post('/webhooks/stripe', (req, res) => {\n  // req.body is now a JS object, not the original bytes\n  const sig = req.headers['stripe-signature'];\n  stripe.webhooks.constructEvent(req.body, sig, secret); // Always fails!\n});\n```\n\n**Why wrong**: `expre...",
+      "domain_hint": "Webhook Patterns for Node.js APIs"
+    },
+    {
+      "file": "agents/nodejs-api-engineer/references/webhook-patterns.md",
+      "line_range": [
+        195,
+        219
+      ],
+      "block_text": "# Look for awaited DB calls or email sends inside webhook handlers\ngrep -rn 'app\\.post.*webhook' --include=\"*.ts\" src/ -A30 | grep -E 'await.*db|await.*email|await.*stripe|sendMail'\n```\n\n**What it looks like**:\n```typescript\napp.post('/webhooks/stripe', async (req, res) => {\n  const event = JSON.parse(req.body.toString());\n\n  if (event.type === 'payment_intent.succeeded') {\n    // Doing heavy work before responding \u2014 may exceed 30s timeout\n    await db.orders.update({ where: { paymentId: event.d...",
+      "domain_hint": "Webhook Patterns for Node.js APIs"
+    },
+    {
+      "file": "agents/nodejs-api-engineer/references/webhook-patterns.md",
+      "line_range": [
+        226,
+        250
+      ],
+      "block_text": "# Queue push before res.status(200) \u2014 blocks acknowledgment\ngrep -rn 'queue\\.add' --include=\"*.ts\" src/ -A5 | grep 'res\\.status'\n```\n\n**What it looks like**:\n```typescript\napp.post('/webhooks', async (req, res) => {\n  await webhookQueue.add('event', req.body); // Blocks if Redis is slow\n  res.status(200).json({ received: true }); // Only after queue push\n});\n```\n\n**Why wrong**: If Redis is slow or down, the queue push blocks and may exceed the webhook sender's timeout. The sender retries, causin...",
+      "domain_hint": "Webhook Patterns for Node.js APIs"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
+      "line_range": [
+        174,
+        174
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
+      "line_range": [
+        182,
+        194
+      ],
+      "block_text": "# Convert bytes to GB and flag if > 31GB\ncurl -s \"$ES_HOST/_nodes/stats/jvm\" | python3 -c \"\nimport json, sys\ndata = json.load(sys.stdin)\nfor nid, n in data['nodes'].items():\n    heap_gb = n['jvm']['mem']['heap_max_in_bytes'] / (1024**3)\n    flag = ' *** ABOVE 31GB ***' if heap_gb > 31 else ''\n    print(f\\\"{n['name']}: {heap_gb:.1f}GB{flag}\\\")\n\"\n```\n\n**What it looks like**:\n```bash",
+      "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
+      "line_range": [
+        195,
+        204
+      ],
+      "block_text": "# jvm.options\n-Xms64g\n-Xmx64g  # 64GB \u2014 loses compressed OOPs\n```\n\n**Why wrong**: Above ~31GB, JVM object pointers are 64-bit instead of 32-bit compressed. Memory per object increases significantly. The JVM now needs a larger heap to hold the same amount of data. A 64GB heap may hold less effective data than a properly configured 31GB heap. GC pauses also increase with heap size.\n\n**Fix**: Split heap across two nodes rather than increase past 31GB. Two nodes with 15GB heap each outperform one no...",
+      "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
+      "line_range": [
+        212,
+        216
+      ],
+      "block_text": "# Anything other than 'all' or null is suspect\n```\n\n**What it looks like**:\n```bash",
+      "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
+      "line_range": [
+        224,
+        235
+      ],
+      "block_text": "# Maintenance completes, engineer leaves \u2014 setting persists\n```\n\n**Why wrong**: With `allocation.enable: none`, no new shard assignments occur. Adding a new node does nothing \u2014 no shards migrate to it. A data node failure causes replicas to become unassigned but not recovered. The cluster silently degrades toward red status.\n\n**Fix**: After every maintenance operation, verify allocation is re-enabled:\n```bash\nPUT /_cluster/settings { \"transient\": { \"cluster.routing.allocation.enable\": null } }\nG...",
+      "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
+      "line_range": [
+        245,
+        263
+      ],
+      "block_text": "# Verify via settings\nGET /_all/_settings?filter_path=*.settings.index.number_of_replicas\n```\n\n**What it looks like**:\n```json\nPUT /logs-2024-01\n{\n  \"settings\": {\n    \"number_of_replicas\": 0\n  }\n}\n```\n\n**Why wrong**: A node failure with 0 replicas causes data loss for all primary shards on that node. Cluster status goes RED. Documents indexed after the last snapshot are permanently lost.\n\n**Fix**: `number_of_replicas: 1` minimum in production. Even for a single-node dev cluster, set to 0 explici...",
+      "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
+      "line_range": [
+        275,
+        279
+      ],
+      "block_text": "# Target: 20-50GB per shard\n```\n\n**What it looks like**:\n```bash",
+      "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
+      "line_range": [
+        285,
+        292
+      ],
+      "block_text": "# 5 shards of 100MB each \u2014 massive overhead for tiny data\n```\n\n**Why wrong**: Each shard has overhead: file descriptors, JVM memory in the shard metadata, cluster state size. 1000 shards of 1MB each consume as much overhead as 1000 shards of 50GB each \u2014 but the 1MB shards return results 100x slower due to cross-shard coordination cost on empty shards.\n\n**Fix**: `number_of_shards: 1` for indices < 5GB. Use rollover for growing indices rather than pre-allocating many shards.\n\n---\n",
+      "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/index-management.md",
+      "line_range": [
+        191,
+        191
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "OpenSearch/Elasticsearch Index Management"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/index-management.md",
+      "line_range": [
+        206,
+        244
+      ],
+      "block_text": "# Check all indices for field counts\nGET /_cat/indices?v&h=index,docs.count\nGET /your-index/_mapping | jq '.[] | .mappings.properties | keys | length'\n```\n\n**What it looks like**:\n```json\n{\n  \"mappings\": {\n    \"dynamic\": true,\n    \"properties\": {\n      \"event_data\": {\n        \"properties\": {\n          \"user_pref_color\": { \"type\": \"text\" },\n          \"user_pref_font_size\": { \"type\": \"long\" },\n          \"experiment_ab_1234_variant\": { \"type\": \"text\" },\n          \"experiment_ab_5678_variant\": { \"ty...",
+      "domain_hint": "OpenSearch/Elasticsearch Index Management"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/index-management.md",
+      "line_range": [
+        252,
+        276
+      ],
+      "block_text": "# Check mapping for fields used in term queries\nGET /your-index/_mapping\n```\n\n**What it looks like**:\n```json\n{\n  \"mappings\": {\n    \"properties\": {\n      \"status\": { \"type\": \"text\" }\n    }\n  }\n}\n\n// Query that silently fails:\n{\n  \"query\": { \"term\": { \"status\": \"active\" } }\n}\n```\n\n**Why wrong**: `text` fields are analyzed \u2014 `\"active\"` is tokenized and lowercased. A `term` query for `\"active\"` works, but `\"Active\"` misses. `\"IS_ACTIVE\"` gets tokenized to `[\"is\", \"active\"]` \u2014 `term` query on `\"IS_A...",
+      "domain_hint": "OpenSearch/Elasticsearch Index Management"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/index-management.md",
+      "line_range": [
+        285,
+        289
+      ],
+      "block_text": "# Check for type conflicts\n```\n\n**What it looks like**:\n```bash",
+      "domain_hint": "OpenSearch/Elasticsearch Index Management"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/index-management.md",
+      "line_range": [
+        296,
+        303
+      ],
+      "block_text": "# Then discover v2 has \"date\" field mapped as \"text\" in v1\n```\n\n**Why wrong**: If `published_at` is `text` in v1 and `date` in v2, reindex fails on any document where `published_at` doesn't parse as a date. `_reindex` continues by default, silently skipping failed documents. The result is an incomplete index with no clear indication of what was dropped.\n\n**Fix**: Use `\"conflicts\": \"proceed\"` only intentionally, and check task results for failures:\n```bash\nGET _tasks/{taskId}",
+      "domain_hint": "OpenSearch/Elasticsearch Index Management"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/query-optimization.md",
+      "line_range": [
+        148,
+        148
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "OpenSearch/Elasticsearch Query Optimization"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/query-optimization.md",
+      "line_range": [
+        156,
+        188
+      ],
+      "block_text": "# Also check application code\nrg '\"wildcard\"' --type json queries/\ngrep -rn 'wildcard.*\\*.*value\\|value.*\\*.*wild' --include=\"*.py\" --include=\"*.ts\" --include=\"*.go\" src/\n```\n\n**What it looks like**:\n```json\n{\n  \"query\": {\n    \"wildcard\": {\n      \"username\": {\n        \"value\": \"*smith*\"\n      }\n    }\n  }\n}\n```\n\n**Why wrong**: Leading wildcards (`*smith`) force a full index scan \u2014 every term in the inverted index must be checked. On a 10M document index with 500K unique usernames, this scans 500K...",
+      "domain_hint": "OpenSearch/Elasticsearch Query Optimization"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/query-optimization.md",
+      "line_range": [
+        195,
+        221
+      ],
+      "block_text": "# Find large from values\nrg '\"from\":\\s*[0-9]{4,}' --type json\n```\n\n**What it looks like**:\n```json\n{\n  \"from\": 10000,\n  \"size\": 20,\n  \"query\": { \"match_all\": {} }\n}\n```\n\n**Why wrong**: `from: 10000` fetches 10,020 documents per shard, discards 10,000, returns 20. On a 5-shard index: 50,100 documents fetched, 50,080 discarded. Memory and CPU scale linearly with `from` value. Default limit is `index.max_result_window: 10000` \u2014 exceeding it throws an exception.\n\n**Fix**: Use search_after for deep p...",
+      "domain_hint": "OpenSearch/Elasticsearch Query Optimization"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/query-optimization.md",
+      "line_range": [
+        227,
+        250
+      ],
+      "block_text": "# Find terms aggregations without explicit size\ngrep -rn '\"terms\"' --include=\"*.json\" queries/ -A5 | grep -v '\"size\"'\nrg '\"terms\"' --type json queries/ -A5 | grep -B3 '\"field\"' | grep -v size\n```\n\n**What it looks like**:\n```json\n{\n  \"aggs\": {\n    \"all_users\": {\n      \"terms\": {\n        \"field\": \"user_id.keyword\"\n        // No size \u2014 defaults to 10, but 100K users exist\n      }\n    }\n  }\n}\n```\n\n**Why wrong**: Default `size: 10` returns only the top 10 buckets, which is often wrong but doesn't cau...",
+      "domain_hint": "OpenSearch/Elasticsearch Query Optimization"
+    },
+    {
+      "file": "agents/opensearch-elasticsearch-engineer/references/query-optimization.md",
+      "line_range": [
+        257,
+        280
+      ],
+      "block_text": "# Painless scripts in frequently-used queries\ngrep -rn 'script_score\\|script_fields\\|scripted_metric' --include=\"*.json\" queries/\n```\n\n**What it looks like**:\n```json\n{\n  \"query\": {\n    \"script_score\": {\n      \"query\": { \"match_all\": {} },\n      \"script\": {\n        \"source\": \"Math.log(1 + doc['view_count'].value) * params.boost\",\n        \"params\": { \"boost\": 1.5 }\n      }\n    }\n  }\n}\n```\n\n**Why wrong**: Painless scripts run JVM-compiled code per document. On a 1M document index with `match_all`,...",
+      "domain_hint": "OpenSearch/Elasticsearch Query Optimization"
+    },
+    {
+      "file": "agents/performance-optimization-engineer/references/anti-patterns.md",
+      "line_range": [
+        1,
+        3
+      ],
+      "block_text": "# Performance Optimization Anti-Patterns\n\nCommon performance optimization mistakes to avoid with examples.\n",
+      "domain_hint": "performance-optimization-engineer"
+    },
+    {
+      "file": "agents/performance-optimization-engineer/references/metrics-and-monitoring.md",
+      "line_range": [
+        115,
+        115
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "performance-optimization-engineer"
+    },
+    {
+      "file": "agents/performance-optimization-engineer/references/metrics-and-monitoring.md",
+      "line_range": [
+        181,
+        208
+      ],
+      "block_text": "### \u274c Blocking Metric Reporting in the Critical Path\n\n**Detection**:\n```bash\ngrep -rn \"await.*vitals\\|vitals.*await\\|onLCP.*await\" --include=\"*.ts\" --include=\"*.tsx\"\n```\n\n**What it looks like**:\n```typescript\n// In _app.tsx or layout.tsx\nawait setupVitalsMonitoring() // Blocks rendering\n```\n\n**Why wrong**: Metric setup code in the render critical path adds to LCP. Vitals measurement is observational \u2014 it should never affect what it's measuring.\n\n**Fix**:\n```typescript\n// Use useEffect or defer t...",
+      "domain_hint": "performance-optimization-engineer"
+    },
+    {
+      "file": "agents/performance-optimization-engineer/references/nextjs-optimization.md",
+      "line_range": [
+        161,
+        161
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "performance-optimization-engineer"
+    },
+    {
+      "file": "agents/performance-optimization-engineer/references/nextjs-optimization.md",
+      "line_range": [
+        163,
+        196
+      ],
+      "block_text": "### \u274c Blocking Layout with Slow Data Fetching\n\n**Detection**:\n```bash\ngrep -rn \"async function.*Layout\\|async.*layout\" --include=\"*.tsx\" --include=\"*.ts\" app/\nrg \"await.*fetch\\|await.*db\\|await.*prisma\" app/layout.tsx app/**/layout.tsx\n```\n\n**What it looks like**:\n```typescript\n// app/layout.tsx\nexport default async function RootLayout({ children }) {\n  const config = await fetchSiteConfig() // Blocks EVERY page render\n  return (\n    <html>\n      <body><Header config={config} />{children}</body>...",
+      "domain_hint": "performance-optimization-engineer"
+    },
+    {
+      "file": "agents/performance-optimization-engineer/references/nextjs-optimization.md",
+      "line_range": [
+        198,
+        224
+      ],
+      "block_text": "### \u274c Using `next/dynamic` When Server Components Are Available\n\n**Detection**:\n```bash\ngrep -rn \"next/dynamic\" --include=\"*.tsx\" --include=\"*.ts\"\nrg \"dynamic\\(\" --type ts --type tsx -A 3 | grep -v \"ssr: false\"\n```\n\n**What it looks like**:\n```typescript\n// Using dynamic() for a component with no browser-only dependencies\nimport dynamic from 'next/dynamic'\nconst ProductCard = dynamic(() => import('./ProductCard'))\n```\n\n**Why wrong**: In App Router, `dynamic()` forces client-side rendering. For co...",
+      "domain_hint": "performance-optimization-engineer"
+    },
+    {
+      "file": "agents/performance-optimization-engineer/references/nextjs-optimization.md",
+      "line_range": [
+        226,
+        253
+      ],
+      "block_text": "### \u274c Missing `priority` on Above-Fold Images\n\n**Detection**:\n```bash\ngrep -rn \"next/image\" --include=\"*.tsx\" -A 5 | grep -B 3 -v \"priority\"\nrg '<Image' --type tsx -A 4 | grep -v \"priority\"\n```\n\n**What it looks like**:\n```tsx\n// Hero image \u2014 the LCP element \u2014 without priority\n<Image src=\"/hero.jpg\" width={1200} height={600} alt=\"Hero\" />\n```\n\n**Why wrong**: `next/image` lazy-loads by default using Intersection Observer. The hero image is immediately visible and is the LCP element \u2014 lazy loading ...",
+      "domain_hint": "performance-optimization-engineer"
+    },
+    {
+      "file": "agents/performance-optimization-engineer/references/performance-testing.md",
+      "line_range": [
+        140,
+        140
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "performance-optimization-engineer"
+    },
+    {
+      "file": "agents/performance-optimization-engineer/references/performance-testing.md",
+      "line_range": [
+        147,
+        173
+      ],
+      "block_text": "# If no output: numberOfRuns is not configured (defaults to 1)\n```\n\n**What it looks like**:\n```javascript\n// .lighthouserc.js\nmodule.exports = {\n  ci: {\n    collect: {\n      url: ['http://localhost:3000'],\n      // numberOfRuns missing \u2014 defaults to 1\n    },\n  },\n}\n```\n\n**Why wrong**: A single Lighthouse run has 10-15 point score variance on CI machines (shared CPU, GC pauses, network jitter). A score of 85 one run, 72 the next \u2014 both from the same code. Single-run CI gates either false-positive...",
+      "domain_hint": "performance-optimization-engineer"
+    },
+    {
+      "file": "agents/performance-optimization-engineer/references/performance-testing.md",
+      "line_range": [
+        180,
+        201
+      ],
+      "block_text": "# Check if it uses 'warn' instead of 'error' for core metrics\n```\n\n**What it looks like**:\n```javascript\nassertions: {\n  'largest-contentful-paint': ['warn', { maxNumericValue: 2500 }],\n  // 'warn' doesn't fail CI \u2014 regressions ship silently\n},\n```\n\n**Why wrong**: `warn` level assertions appear in logs but do NOT fail the CI step. LCP regressions will accumulate indefinitely. The only way a performance budget prevents regressions is if it fails the build.\n\n**Fix**:\n```javascript\nassertions: {\n  ...",
+      "domain_hint": "performance-optimization-engineer"
+    },
+    {
+      "file": "agents/performance-optimization-engineer/references/performance-testing.md",
+      "line_range": [
+        203,
+        227
+      ],
+      "block_text": "### \u274c Running Lighthouse Against Development Server\n\n**Detection**:\n```bash\ngrep -rn \"next dev\\|npm run dev\\|yarn dev\" .lighthouserc.* .github/workflows/*.yml\n```\n\n**What it looks like**:\n```javascript\ncollect: {\n  startServerCommand: 'npm run dev', // Development server!\n},\n```\n\n**Why wrong**: `next dev` doesn't minify, doesn't split bundles, doesn't optimize images. A dev server Lighthouse score is meaningless for production performance \u2014 typically 20-40 points lower than production. You're te...",
+      "domain_hint": "performance-optimization-engineer"
+    },
+    {
+      "file": "agents/performance-optimization-engineer/references/performance-testing.md",
+      "line_range": [
+        236,
+        243
+      ],
+      "block_text": "# If neither exists: no automated bundle regression detection\n```\n\n**Why wrong**: Without automated bundle size gates, bundle size grows incrementally. Each PR adds \"just a small dependency\" until the main bundle is 500KB and LCP is 4.5s. Manual review doesn't catch this \u2014 bundle analysis is only done when performance is already bad.\n\n**Fix**: Add `size-limit` with `error` thresholds to CI. Start with current bundle size as the baseline and set limits 10% above it to allow headroom, then tighten...",
+      "domain_hint": "performance-optimization-engineer"
+    },
+    {
+      "file": "agents/pipeline-orchestrator-engineer/references/anti-patterns.md",
+      "line_range": [
+        1,
+        7
+      ],
+      "block_text": "# Pipeline Orchestration \u2014 Anti-Patterns\n\n> **Scope**: Common mistakes when creating, scaffolding, and routing toolkit pipelines. Does NOT cover general Go/Python anti-patterns \u2014 see those agents for language-specific issues.\n> **Version range**: claude-code-toolkit all versions\n> **Generated**: 2026-04-09 \u2014 verify detection commands against current repo structure\n\n---\n",
+      "domain_hint": "pipeline-orchestrator-engineer"
+    },
+    {
+      "file": "agents/pipeline-orchestrator-engineer/references/anti-patterns.md",
+      "line_range": [
+        15,
+        15
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "pipeline-orchestrator-engineer"
+    },
+    {
+      "file": "agents/pipeline-orchestrator-engineer/references/anti-patterns.md",
+      "line_range": [
+        21,
+        49
+      ],
+      "block_text": "# Look for agent dispatch calls missing spec/manifest references in a worktree\ngrep -rn 'subagent_type' agents/ --include=\"*.md\" | grep -v \"spec\\|manifest\\|discovery\"\n```\n\n**What it looks like**:\n```\nAgent(description=\"Create skill\", prompt=\"Create a skill for Prometheus alerting.\")\n```\n\n**Why wrong**: The sub-agent starts with no knowledge of existing components, naming conventions, or inter-component relationships. It will create components that conflict with or duplicate existing ones. The pi...",
+      "domain_hint": "pipeline-orchestrator-engineer"
+    },
+    {
+      "file": "agents/pipeline-orchestrator-engineer/references/anti-patterns.md",
+      "line_range": [
+        57,
+        66
+      ],
+      "block_text": "# If count is low relative to agent count, discovery was likely skipped\nls agents/*.md | wc -l\n```\n\n**What it looks like**: Creating `monitoring-engineer.md` when `prometheus-grafana-engineer.md` already exists with 80% coverage.\n\n**Why wrong**: Creates a duplicate routing entry. Two agents with overlapping triggers produce non-deterministic routing \u2014 `/do` will route to whichever appears first in the routing table. Users get inconsistent behavior. The duplicate is harder to merge later than to ...",
+      "domain_hint": "pipeline-orchestrator-engineer"
+    },
+    {
+      "file": "agents/pipeline-orchestrator-engineer/references/anti-patterns.md",
+      "line_range": [
+        80,
+        102
+      ],
+      "block_text": "# Skills that handle more than one distinct task type in their frontmatter description\ngrep -rn 'description:' skills/*/SKILL.md | grep ' and \\| & ' | grep -v \"test\\|spec\"\n```\n\n**What it looks like**:\n```yaml\nname: prometheus-skill\ndescription: \"Prometheus: metrics, alerting, dashboards, operations, performance tuning\"\n```\n\n**Why wrong**: Each subdomain has different task types needing different pipeline chains. A skill handling 5 subdomains dilutes expertise, overloads context, and can't be rou...",
+      "domain_hint": "pipeline-orchestrator-engineer"
+    },
+    {
+      "file": "agents/pipeline-orchestrator-engineer/references/anti-patterns.md",
+      "line_range": [
+        110,
+        126
+      ],
+      "block_text": "# Zero hits = validation was likely skipped\n```\n\n**What it looks like**: Composing a chain intuitively \u2014 `research \u2192 draft \u2192 review \u2192 publish` \u2014 without checking that each step's output type matches the next step's expected input type.\n\n**Why wrong**: Type incompatibilities surface at runtime, not during scaffolding. A `research` step produces a `ResearchReport` artifact; a `review` step expects `DraftContent`. Connecting them directly produces a type mismatch that silently produces empty or mal...",
+      "domain_hint": "pipeline-orchestrator-engineer"
+    },
+    {
+      "file": "agents/pipeline-orchestrator-engineer/references/anti-patterns.md",
+      "line_range": [
+        132,
+        144
+      ],
+      "block_text": "# Agents in agents/ that have no entry in skills/do/references/routing-tables.md\ncomm -23 \\\n  <(ls agents/*.md | xargs -I{} basename {} .md | sort) \\\n  <(grep -o '`[a-z-]*-engineer\\|[a-z-]*-agent`' skills/do/references/routing-tables.md | tr -d '`' | sort)\n```\n\n**What it looks like**: \"I'll add the routing entry in a follow-up PR.\"\n\n**Why wrong**: An unrouted pipeline is invisible. No trigger phrase reaches it. It exists as a file but is dead code \u2014 users get no error, just wrong routing to an u...",
+      "domain_hint": "pipeline-orchestrator-engineer"
+    },
+    {
+      "file": "agents/pipeline-orchestrator-engineer/references/anti-patterns.md",
+      "line_range": [
+        152,
+        185
+      ],
+      "block_text": "# OR manually:\ngrep -rL 'allowed-tools' agents/*.md\n```\n\n**What it looks like**:\n```yaml\n---\nname: my-new-agent\nmodel: sonnet\ndescription: \"...\"\n---\n```\n\n**Why wrong**: Agents without `allowed-tools` get the full tool set regardless of their role. A read-only reviewer agent that can Edit/Write/Bash can silently modify files during review \u2014 a violation of the reviewer role. ADR-063 mandates tool restriction by role type.\n\n**Fix**: Match tools to role:\n```yaml\nallowed-tools:  # for reviewers / res...",
+      "domain_hint": "pipeline-orchestrator-engineer"
+    },
+    {
+      "file": "agents/pipeline-orchestrator-engineer/references/orchestration-patterns.md",
+      "line_range": [
+        147,
+        147
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "pipeline-orchestrator-engineer"
+    },
+    {
+      "file": "agents/pipeline-orchestrator-engineer/references/orchestration-patterns.md",
+      "line_range": [
+        155,
+        164
+      ],
+      "block_text": "# Conceptually: synthesis lines appearing before all agent completions\n```\n\n**What it looks like**: Starting Phase 4 INTEGRATE after only 2 of 3 scaffolding sub-agents complete (e.g., skills and hooks done, but agent manifest still running).\n\n**Why wrong**: Partial integration produces inconsistent routing. An agent registered in INDEX.json that doesn't yet exist on disk will cause Agent tool failures. A skill registered in routing-tables.md whose agent isn't created yet produces \"unknown agent\"...",
+      "domain_hint": "pipeline-orchestrator-engineer"
+    },
+    {
+      "file": "agents/pipeline-orchestrator-engineer/references/orchestration-patterns.md",
+      "line_range": [
+        171,
+        185
+      ],
+      "block_text": "# (ADR files are gitignored \u2014 check local disk)\nls adr/pipeline-*.md 2>/dev/null | wc -l\n```\n\n**What it looks like**: Starting Phase 1 research without creating `adr/pipeline-{name}.md` first.\n\n**Why wrong**: Without an ADR, context drifts across phases. Phase 3 sub-agents don't know the Phase 2 decisions. The component manifest from Phase 1 gets lost between phases. In sessions longer than 30 minutes, orchestrators re-derive decisions already made in earlier phases \u2014 wasting context and sometim...",
+      "domain_hint": "pipeline-orchestrator-engineer"
+    },
+    {
+      "file": "agents/pipeline-orchestrator-engineer/references/orchestration-patterns.md",
+      "line_range": [
+        192,
+        202
+      ],
+      "block_text": "# Check: does the domain have genuinely distinct task types?\npython3 scripts/artifact-utils.py discover --domain {name} 2>/dev/null | grep \"subdomains\"\n```\n\n**What it looks like**: Creating 4 sub-agents, a hook, and 3 scripts for a request that needed one skill bound to an existing agent.\n\n**Why wrong**: Over-decomposition creates maintenance overhead. Each component needs its own routing entry, its own template compliance check, its own reference files. A pipeline with 8 components for a 2-comp...",
+      "domain_hint": "pipeline-orchestrator-engineer"
+    },
+    {
+      "file": "agents/pixijs-combat-renderer/references/combat-visual-effects.md",
+      "line_range": [
+        358,
+        358
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "PixiJS Combat Visual Effects"
+    },
+    {
+      "file": "agents/pixijs-combat-renderer/references/combat-visual-effects.md",
+      "line_range": [
+        360,
+        385
+      ],
+      "block_text": "### \u274c Creating New PIXI.Texture Per Frame\n\n**Detection**:\n```bash\ngrep -rn \"new PIXI\\.Texture\\|Texture\\.from\\|RenderTexture\\.create\" --include=\"*.ts\" --include=\"*.js\"\nrg \"useTick|Ticker\\.shared\" --type ts -A 20 | grep \"Texture\"\n```\n\n**What it looks like**:\n```typescript\napp.ticker.add(() => {\n  const texture = Texture.from('spark_' + Math.floor(Math.random() * 4)); // BAD\n  const sprite = new Sprite(texture);\n  stage.addChild(sprite);\n});\n```\n\n**Why wrong**: Each frame adds a sprite with unclean...",
+      "domain_hint": "PixiJS Combat Visual Effects"
+    },
+    {
+      "file": "agents/pixijs-combat-renderer/references/pixi-2d-lighting.md",
+      "line_range": [
+        326,
+        326
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "pixijs-combat-renderer"
+    },
+    {
+      "file": "agents/pixijs-combat-renderer/references/pixi-particle-systems.md",
+      "line_range": [
+        276,
+        276
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "pixijs-combat-renderer"
+    },
+    {
+      "file": "agents/pixijs-combat-renderer/references/pixi-performance.md",
+      "line_range": [
+        271,
+        271
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "PixiJS Rendering Performance"
+    },
+    {
+      "file": "agents/pixijs-combat-renderer/references/pixi-performance.md",
+      "line_range": [
+        273,
+        307
+      ],
+      "block_text": "### \u274c Changing Tint Per Frame on Many Sprites\n\n**Detection**:\n```bash\ngrep -rn \"\\.tint\\s*=\" --include=\"*.ts\" --include=\"*.js\"\nrg \"ticker\\.add|useTick\" --type ts -A 20 | grep \"\\.tint\"\n```\n\n**What it looks like**:\n```typescript\napp.ticker.add(() => {\n  // BAD: tint change per frame flushes the batch for each sprite\n  sprites.forEach((sprite, i) => {\n    sprite.tint = hslToHex(i / sprites.length, 1, 0.5 + Math.sin(Date.now() * 0.001 + i) * 0.2);\n  });\n});\n```\n\n**Why wrong**: Setting `.tint` marks t...",
+      "domain_hint": "PixiJS Rendering Performance"
+    },
+    {
+      "file": "agents/pixijs-combat-renderer/references/pixi-performance.md",
+      "line_range": [
+        339,
+        365
+      ],
+      "block_text": "### \u274c Loading Individual Textures per Sprite (No Atlas)\n\n**Detection**:\n```bash\ngrep -rn \"Texture\\.from\\|Assets\\.load.*\\.png\" --include=\"*.ts\" --include=\"*.js\"\nrg \"\\.load\\(['\\\"].*\\.png['\\\"]\" --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: each unique PNG = separate GPU texture = separate draw call\nconst playerTexture = await Assets.load('/sprites/player.png');\nconst enemyTexture  = await Assets.load('/sprites/enemy.png');\nconst sparkTexture  = await Assets.load('/sprites/spark.png')...",
+      "domain_hint": "PixiJS Rendering Performance"
+    },
+    {
+      "file": "agents/pixijs-combat-renderer/references/pixi-post-processing.md",
+      "line_range": [
+        364,
+        364
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "pixijs-combat-renderer"
+    },
+    {
+      "file": "agents/pixijs-combat-renderer/references/pixi-react-integration.md",
+      "line_range": [
+        398,
+        398
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "pixijs-combat-renderer"
+    },
+    {
+      "file": "agents/pixijs-combat-renderer.md",
+      "line_range": [
+        58,
+        68
+      ],
+      "block_text": "# Find DOM particle anti-pattern\ngrep -rn \"document.createElement\\|setTimeout.*remove\\|classList.add.*particle\" src/ --include=\"*.ts\" --include=\"*.tsx\"\n```\n\nFlag the DOM particle anti-pattern immediately if found \u2014 `document.createElement` + `setTimeout` removal is the primary replacement target. Each DOM particle adds reflow cost; GPU particles are free by comparison.\n\nIdentify what Zustand stores drive combat state. Read the store file before writing any PixiJS component \u2014 display object updat...",
+      "domain_hint": "pixijs"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/agent-capability-map.md",
+      "line_range": [
+        123,
+        123
+      ],
+      "block_text": "## Routing Anti-Patterns\n",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/agent-capability-map.md",
+      "line_range": [
+        125,
+        133
+      ],
+      "block_text": "### \u274c General-Purpose Agent for Specialized Work\n\n**What it looks like**: Dispatching `Agent({ subagent_type: undefined })` for Go compilation errors.\n\n**Why wrong**: General-purpose agent lacks Go-specific pattern libraries, anti-pattern catalog, idiomatic corrections. Produces functional-but-non-idiomatic code that causes rework.\n\n**Fix**: Always specify `subagent_type` for language/infrastructure work.\n\n---\n",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/agent-capability-map.md",
+      "line_range": [
+        135,
+        143
+      ],
+      "block_text": "### \u274c Wrong Language Agent\n\n**What it looks like**: Sending TypeScript backend work to `typescript-frontend-engineer`.\n\n**Why wrong**: Frontend agent optimizes for bundle size, React patterns, CSR/SSR \u2014 not REST APIs, database connection pooling, or request middleware.\n\n**Detection**:\n```\nrg \"import.*express|import.*@nestjs\" --files-with-matches src/",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/agent-capability-map.md",
+      "line_range": [
+        151,
+        159
+      ],
+      "block_text": "### \u274c Application Agent Doing Schema Work\n\n**What it looks like**: Asking `nodejs-api-engineer` to add a database column.\n\n**Why wrong**: Application agent will add the column in the ORM model but not create the migration, causing runtime errors on deploy.\n\n**Fix**: Schema changes always go to `database-engineer` first. Application agents pick up the committed migration.\n\n---\n",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/anti-patterns.md",
+      "line_range": [
+        1,
+        7
+      ],
+      "block_text": "# Coordination Anti-Patterns Reference\n\n> **Scope**: Common multi-agent coordination mistakes \u2014 what they look like, why they fail, and the corrected pattern.\n> **Version range**: Claude Code multi-agent workflows (all versions)\n> **Generated**: 2026-04-09\n\n---\n",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/anti-patterns.md",
+      "line_range": [
+        15,
+        15
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/anti-patterns.md",
+      "line_range": [
+        23,
+        47
+      ],
+      "block_text": "# Any TASK: block without a SUCCESS CRITERIA: line is at risk\n```\n\n**What it looks like**:\n```markdown\nTASK: Fix the authentication module\nAGENT: nodejs-api-engineer\nSUCCESS: Make sure it works\n```\n\n**Why wrong**: \"Make sure it works\" is unverifiable. The agent cannot confirm it succeeded; the coordinator cannot confirm the handoff is complete. This creates ambiguity about when to move to the next phase, causing coordination stalls or premature integration.\n\n**Fix**:\n```markdown\nTASK: Fix JWT to...",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/anti-patterns.md",
+      "line_range": [
+        55,
+        64
+      ],
+      "block_text": "# Duplicate file paths mean two agents share a domain \u2014 conflict waiting to happen\n```\n\n**What it looks like**:\n```markdown\nAGENT A: python-general-engineer\nFILES: src/models.py, src/utils.py, src/api.py\n\nAGENT B: data-engineer\nFILES: src/utils.py, src/pipeline.py, src/transformers.py",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/anti-patterns.md",
+      "line_range": [
+        65,
+        82
+      ],
+      "block_text": "# src/utils.py is in BOTH domains \u2014 conflict\n```\n\n**Why wrong**: Two agents editing the same file concurrently produce merge conflicts at integration. Neither agent's changes are complete in isolation, and combined output is non-deterministic. Common outcome: Agent B's changes overwrite Agent A's without awareness.\n\n**Fix**:\n```markdown\nAGENT A: python-general-engineer\nFILES: src/models.py, src/api.py  \u2190 utils.py REMOVED\n\nAGENT B: data-engineer\nFILES: src/utils.py, src/pipeline.py, src/transform...",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/anti-patterns.md",
+      "line_range": [
+        90,
+        115
+      ],
+      "block_text": "# Retry entries without strategy change documentation are retry theater\n```\n\n**What it looks like**:\n```markdown\nHANDOFF (Attempt 2):\n  Previous attempt failed. Please try again to implement the database migration.\n  The migration should add the user_preferences column.\n```\n\n**Why wrong**: The agent has the same context, the same constraints, and no new information. The expected outcome is identical to Attempt 1. This is wasted budget disguised as coordination effort.\n\n**Fix**:\n```markdown\nHANDO...",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/anti-patterns.md",
+      "line_range": [
+        123,
+        153
+      ],
+      "block_text": "# Any parallel task that depends on another parallel task's output is mis-scheduled\n```\n\n**What it looks like**:\n```markdown\nPHASE 2 (parallel execution):\n  Agent A: Generate database schema \u2192 schema.sql\n  Agent B: Write ORM models (requires schema.sql from Agent A)\n  Agent C: Write API endpoints (requires ORM models from Agent B)\n  # All three marked as parallel \u2014 B and C will fail\n```\n\n**Why wrong**: Agent B and C will start before Agent A completes. Without schema.sql, Agent B generates specu...",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/anti-patterns.md",
+      "line_range": [
+        161,
+        168
+      ],
+      "block_text": "# If missing and coordination is multi-phase, context loss has already occurred\n```\n\n**What it looks like**:\n```markdown\n[No PROGRESS.md exists]\n[Coordinator is at 75% context capacity]\n[Coordinator spawns new agent with \"continue from where we left off\"]",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/anti-patterns.md",
+      "line_range": [
+        169,
+        175
+      ],
+      "block_text": "# New agent has no record of what phases completed, what files were changed\n```\n\n**Why wrong**: Agent context does not persist across spawns. \"Continue from where we left off\" is meaningless to a fresh agent \u2014 it has no memory of prior phases, no record of completed work, and no list of modified files. It will either repeat completed work or invent a fabricated prior state.\n\n**Fix**:\n```markdown",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/anti-patterns.md",
+      "line_range": [
+        205,
+        219
+      ],
+      "block_text": "# Coordinator should only use Agent, Read, Glob, Grep \u2014 not file-modifying tools\n```\n\n**What it looks like**:\n```markdown\n[Coordinator reads a failing test]\n[Coordinator directly edits src/auth.py to fix the test]\n[Coordinator marks task complete without verification by the assigned agent]\n```\n\n**Why wrong**: The coordinator loses its orchestration perspective when it drops into implementation. It cannot simultaneously track project state and debug a specific file. It also bypasses the specializ...",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/death-loop-prevention.md",
+      "line_range": [
+        121,
+        121
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/death-loop-prevention.md",
+      "line_range": [
+        129,
+        143
+      ],
+      "block_text": "# If uniq -d returns lines, identical errors are repeating\n```\n\n**What it looks like**:\n```markdown\nATTEMPT 1 \u2014 Error: `undefined: UserRepository`\nATTEMPT 2 \u2014 Error: `undefined: UserRepository`\nATTEMPT 3 \u2014 Error: `undefined: UserRepository`\n```\n\n**Why wrong**: Retrying without strategy change is guaranteed to fail. The 3-attempt limit exists specifically to prevent this. Each retry burns context budget with zero probability of success.\n\n**Fix**: Before any retry, the coordinator must answer: \"Wh...",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/death-loop-prevention.md",
+      "line_range": [
+        151,
+        171
+      ],
+      "block_text": "# Success criteria should reference compilation, not just lint exit code\n```\n\n**What it looks like**:\n```markdown\nTASK: Fix all linting errors in src/\nSUCCESS CRITERIA: `ruff check . --fix` exits 0\n```\n\n**Why wrong**: `ruff --fix` can change syntax that breaks Python's AST. `gofmt` can reformat imports that expose missing packages. Assigning lint-only success criteria hides compilation regression.\n\n**Fix**:\n```markdown\nTASK: Fix all linting errors in src/\nSUCCESS CRITERIA:\n  1. `python3 -c \"impo...",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/death-loop-prevention.md",
+      "line_range": [
+        179,
+        200
+      ],
+      "block_text": "# Any count > 0 warrants review of whether strategy changed\n```\n\n**What it looks like**:\n```markdown\nHANDOFF to golang-general-engineer:\n  Previous attempt failed with compilation errors.\n  Please try again and fix the compilation errors.\n```\n\n**Why wrong**: \"Try again\" without specifying what to do differently is identical retry disguised as new instruction. The agent has no new information, so it will repeat the same approach.\n\n**Fix**:\n```markdown\nHANDOFF to golang-general-engineer:\n  Previou...",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/parallel-execution-patterns.md",
+      "line_range": [
+        102,
+        106
+      ],
+      "block_text": "# Anti-pattern \u2014 will fail:\n[WRONG] Step 1 + Step 2 parallel \u2192 Step 2 reads schema before it exists\n```\n\n---\n",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/parallel-execution-patterns.md",
+      "line_range": [
+        108,
+        108
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/parallel-execution-patterns.md",
+      "line_range": [
+        110,
+        122
+      ],
+      "block_text": "### \u274c Assumed Domain Isolation\n\n**What it looks like**: Dispatching 3 agents without checking if any share `pkg/config/config.go`.\n\n**Detection**:\n```\ngrep -r \"config/config\" src/ | cut -d: -f1 | sort | uniq -d\n```\nAny file appearing in multiple agent domains signals a conflict.\n\n**Fix**: Run domain conflict check before dispatch. Serialize agents that share any file.\n\n---\n",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/parallel-execution-patterns.md",
+      "line_range": [
+        124,
+        132
+      ],
+      "block_text": "### \u274c Optimistic Parallelism on Generated Files\n\n**What it looks like**: Running `go generate` in STREAM A while STREAM B reads generated files.\n\n**Why wrong**: Generated file content is undefined mid-generation. STREAM B reads partial state.\n\n**Fix**: Generation is always sequential. Downstream consumers wait for generation fan-in.\n\n---\n",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/parallel-execution-patterns.md",
+      "line_range": [
+        134,
+        142
+      ],
+      "block_text": "### \u274c Lint/Format Before Compile in Parallel\n\n**What it looks like**: Dispatching lint agent and compile agent simultaneously.\n\n**Why wrong**: If compile fails, lint output is wasted work. If lint changes code, compile state is stale.\n\n**Fix**: Compile \u2192 Test \u2192 Lint \u2192 Format (always sequential, never parallel within a domain).\n\n---\n",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/todowrite-integration.md",
+      "line_range": [
+        110,
+        110
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/todowrite-integration.md",
+      "line_range": [
+        118,
+        137
+      ],
+      "block_text": "# Any completed entry without verification evidence is premature\n```\n\n**What it looks like**:\n```markdown\nTask: \"Implement user endpoint\"\n  status: completed  \u2190 marked complete based on agent message alone\n  note: \"Agent said it was done\"\n```\n\n**Why wrong**: Agent self-report is not evidence of completion. The agent may have hit a timeout, written partial output, or misread a test result. Premature `completed` causes the next dependent task to start with missing inputs.\n\n**Fix**: Every `complete...",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/todowrite-integration.md",
+      "line_range": [
+        143,
+        158
+      ],
+      "block_text": "# Find tasks that reference prior phases in their description but have no blockedBy\ngrep -B2 \"Phase [2-9]\\|depends on\\|requires\" todo*.md 2>/dev/null | grep -v \"blockedBy\"\n```\n\n**What it looks like**:\n```markdown\nTask: \"Phase 2: Write ORM models using the schema\"\n  status: pending\n  # No blockedBy \u2014 can be accidentally dispatched before Phase 1 completes\n```\n\n**Why wrong**: Without `blockedBy`, the coordinator has no automated signal to wait. In multi-session or parallel scenarios, a fresh coord...",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/project-coordinator-engineer/references/todowrite-integration.md",
+      "line_range": [
+        166,
+        180
+      ],
+      "block_text": "# Multiple agent assignments to one task without parallel_agents structure = ambiguous ownership\n```\n\n**What it looks like**:\n```markdown\nTask: \"Implement and test the API\"\n  assigned: nodejs-api-engineer, python-general-engineer, database-engineer\n  # Who owns what? What happens if one fails?\n```\n\n**Why wrong**: Single-task multi-agent assignment has no file domain boundaries, no independent completion criteria, and no retry tracking per agent. If one agent fails, the entire task fails with no ...",
+      "domain_hint": "project-coordinator-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/alerting-patterns.md",
+      "line_range": [
+        116,
+        116
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/alerting-patterns.md",
+      "line_range": [
+        118,
+        145
+      ],
+      "block_text": "### \u274c Single-Window Burn Rate Alert\n\n**Detection**:\n```bash\ngrep -rn 'burn_rate\\|burnrate\\|error_rate.*ratio' --include=\"*.yml\" -A 5 | grep -v 'and'\nrg 'alert.*[Bb]urn' --type yaml -A 8 | grep -v 'and\\s*$'\n```\n\n**What it looks like**:\n```yaml\n- alert: SLOBurnRate\n  expr: job:error_rate:ratio5m > 0.01\n  # Single window \u2014 misses slow burns over hours\n```\n\n**Why wrong**: A single 5-minute window catches fast burns (many errors quickly) but misses slow burns (few errors sustained over hours) that al...",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/alerting-patterns.md",
+      "line_range": [
+        153,
+        157
+      ],
+      "block_text": "# If no results: amtool validation is missing from deployment pipeline\n```\n\n**What it looks like**:\n```bash",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/alerting-patterns.md",
+      "line_range": [
+        160,
+        166
+      ],
+      "block_text": "# A YAML syntax error silences ALL alerts\n```\n\n**Why wrong**: A single YAML syntax error in `alertmanager.yml` causes Alertmanager to reject the config and continue using the previous valid config \u2014 or fail to start. No error surfaces in the UI until alerts fail to route. Silent alert failures are worse than loud ones.\n\n**Fix**:\n```bash",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/alerting-patterns.md",
+      "line_range": [
+        180,
+        210
+      ],
+      "block_text": "### \u274c Missing Runbook Annotations\n\n**Detection**:\n```bash\ngrep -rn '^\\s*- alert:' --include=\"*.yml\" -A 15 | grep -B 10 'severity: critical' | grep -v 'runbook'\nrg 'alert:' --type yaml -A 12 | grep -B8 'severity: critical' | grep -v runbook_url\n```\n\n**What it looks like**:\n```yaml\n- alert: DatabaseConnectionPoolExhausted\n  expr: pg_stat_activity_count > 90\n  labels:\n    severity: critical\n  annotations:\n    summary: \"DB connections exhausted\"\n    # No runbook_url \u2014 on-call must guess remediation ...",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/alerting-patterns.md",
+      "line_range": [
+        217,
+        222
+      ],
+      "block_text": "# If only 1-2 unique receivers with no routes: flat routing\ngrep -c 'routes:' alertmanager.yml\n```\n\n**What it looks like**:\n```yaml",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/alerting-patterns.md",
+      "line_range": [
+        223,
+        247
+      ],
+      "block_text": "# alertmanager.yml\nroute:\n  receiver: all-alerts-slack  # everything goes to one channel\nreceivers:\n  - name: all-alerts-slack\n    slack_configs:\n      - channel: \"#alerts\"\n```\n\n**Why wrong**: Mixing critical pages (database down), warnings (disk at 70%), and informational (deployment complete) into one channel trains teams to ignore the channel. Critical alerts get lost in noise. Mean time to acknowledge increases.\n\n**Fix**: Route by severity and team:\n```yaml\nroute:\n  receiver: default\n  route...",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/cardinality-management.md",
+      "line_range": [
+        62,
+        62
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/cardinality-management.md",
+      "line_range": [
+        75,
+        102
+      ],
+      "block_text": "# Check actual cardinality of suspect metrics in PromQL\ncount by (user_id) (http_requests_total)  # should return 0 results if correctly designed\n```\n\n**What it looks like**:\n```go\n// Go example \u2014 unbounded label\nhttpRequests.With(prometheus.Labels{\n    \"user_id\": userID,      // WRONG: unbounded\n    \"endpoint\": endpoint,\n    \"status\":  strconv.Itoa(statusCode),\n}).Inc()\n```\n\n**Why wrong**: 100K users \u00d7 50 endpoints \u00d7 5 status codes = 25M series. Prometheus memory usage becomes `25M \u00d7 4KB = 100G...",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/cardinality-management.md",
+      "line_range": [
+        112,
+        118
+      ],
+      "block_text": "# Check what labels are coming in from a target\ncurl -s 'http://localhost:9090/api/v1/targets' | \\\n  python3 -c \"import json,sys; d=json.load(sys.stdin); [print(t['labels']) for t in d['data']['activeTargets'][:5]]\"\n```\n\n**What it looks like**:\n```yaml",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/cardinality-management.md",
+      "line_range": [
+        119,
+        150
+      ],
+      "block_text": "# prometheus.yml \u2014 no relabeling\nscrape_configs:\n  - job_name: 'kubernetes-pods'\n    kubernetes_sd_configs:\n      - role: pod\n    # No relabel_configs \u2014 ingests all labels from pod annotations\n```\n\n**Why wrong**: Kubernetes pods can expose dozens of labels (app, version, helm-release, git-commit, build-time, namespace). Without `relabel_configs`, all of these become Prometheus label dimensions. A git commit hash label creates unique series per deployment, exploding cardinality.\n\n**Fix**:\n```yaml...",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/cardinality-management.md",
+      "line_range": [
+        156,
+        171
+      ],
+      "block_text": "# Find recording rules that preserve high-cardinality labels\ngrep -A 5 'record:' prometheus-rules.yml | grep 'by (' | grep -i 'user\\|request_id\\|pod_name'\nrg 'record:' --type yaml -A 5 | grep 'by\\s*\\(' | grep -v 'service\\|job\\|namespace\\|status'\n```\n\n**What it looks like**:\n```yaml\n- record: job:http_requests:rate5m\n  expr: sum(rate(http_requests_total[5m])) by (job, user_id)\n  # Aggregates but still fans out by user_id \u2014 doesn't help\n```\n\n**Why wrong**: Recording rules are meant to reduce query...",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/cardinality-management.md",
+      "line_range": [
+        185,
+        211
+      ],
+      "block_text": "# If no results: no proactive cardinality monitoring\n```\n\n**What it looks like**: No alert for growing series count \u2014 OOM is the first signal.\n\n**Why wrong**: Cardinality growth is gradual. A new deployment adds 50K series per day unnoticed until Prometheus hits memory limits under query load 2 weeks later. By then, the causing deployment is long merged and difficult to identify.\n\n**Fix**:\n```yaml\n- alert: PrometheusHighCardinality\n  expr: prometheus_tsdb_head_series > 1500000\n  for: 10m\n  label...",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/promql-patterns.md",
+      "line_range": [
+        93,
+        93
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/promql-patterns.md",
+      "line_range": [
+        95,
+        104
+      ],
+      "block_text": "### \u274c Using irate() in Alert Rules\n\n**Detection**:\n```bash\ngrep -rn 'irate(' --include=\"*.yml\" --include=\"*.yaml\"\nrg 'irate\\(' --type yaml\n```\n\n**What it looks like**:\n```yaml",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/promql-patterns.md",
+      "line_range": [
+        105,
+        119
+      ],
+      "block_text": "# alert_rules.yml\n- alert: HighErrorRate\n  expr: irate(http_requests_total{status=~\"5..\"}[5m]) > 0.01\n```\n\n**Why wrong**: `irate()` uses only the last two samples, making it extremely sensitive to single-scrape spikes. Alert rules evaluated every 30s will flap on transient spikes, generating spurious notifications. Production alert fatigue follows.\n\n**Fix**:\n```yaml\n- alert: HighErrorRate\n  expr: rate(http_requests_total{status=~\"5..\"}[5m]) > 0.01\n  for: 5m  # also add a for: clause to require s...",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/promql-patterns.md",
+      "line_range": [
+        121,
+        147
+      ],
+      "block_text": "### \u274c Missing `for:` Clause on Latency Alerts\n\n**Detection**:\n```bash\ngrep -B5 'latency\\|duration\\|p99\\|p95\\|quantile' --include=\"*.yml\" --include=\"*.yaml\" -rn | grep -v 'for:'\nrg 'alert:.*[Ll]atency' --type yaml -A 10 | grep -v 'for:'\n```\n\n**What it looks like**:\n```yaml\n- alert: HighLatency\n  expr: histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m])) > 0.5\n  # No for: clause!\n```\n\n**Why wrong**: Without `for:`, a single evaluation above the threshold fires the alert immedia...",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/promql-patterns.md",
+      "line_range": [
+        149,
+        158
+      ],
+      "block_text": "### \u274c Querying Summaries with histogram_quantile()\n\n**Detection**:\n```bash\ngrep -rn 'histogram_quantile.*_summary\\|histogram_quantile.*quantile=' --include=\"*.yml\"\nrg 'histogram_quantile' --type yaml -A 3 | grep 'quantile='\n```\n\n**What it looks like**:\n```promql",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/promql-patterns.md",
+      "line_range": [
+        159,
+        166
+      ],
+      "block_text": "# Wrong \u2014 using histogram_quantile on a summary type metric\nhistogram_quantile(0.99, rate(rpc_duration_seconds{quantile=\"0.99\"}[5m]))\n```\n\n**Why wrong**: Summary metrics expose pre-computed quantiles (via the `quantile` label) that cannot be re-aggregated. Passing them to `histogram_quantile()` produces nonsense \u2014 the function expects `le` bucket labels, not pre-computed quantile values. The query may not error but will silently return wrong numbers.\n\n**Fix**: Use the pre-computed quantile label...",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/promql-patterns.md",
+      "line_range": [
+        175,
+        183
+      ],
+      "block_text": "### \u274c Using `increase()` Across Different Windows for Comparison\n\n**Detection**:\n```bash\ngrep -rn 'increase(' --include=\"*.yml\" --include=\"*.yaml\" | grep -v 'record:'\n```\n\n**What it looks like**:\n```promql",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/promql-patterns.md",
+      "line_range": [
+        184,
+        191
+      ],
+      "block_text": "# Wrong \u2014 comparing increase over different windows\nincrease(http_requests_total[1h]) > increase(http_requests_total[24h]) * 0.1\n```\n\n**Why wrong**: `increase()` results are not comparable across different window sizes without normalization. This expression always evaluates false since 1h increase is always < 24h \u00d7 0.1 for any reasonable traffic. Use `rate()` for comparisons.\n\n**Fix**:\n```promql",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/prometheus-grafana-engineer/references/promql-patterns.md",
+      "line_range": [
+        198,
+        223
+      ],
+      "block_text": "### \u274c Absent Alert Without Sufficient For Clause\n\n**Detection**:\n```bash\ngrep -rn 'absent(' --include=\"*.yml\" --include=\"*.yaml\" -A 5 | grep -v 'for:\\s*[5-9][0-9]\\|for:\\s*[1-9][0-9][0-9]'\n```\n\n**What it looks like**:\n```yaml\n- alert: MetricMissing\n  expr: absent(up{job=\"api\"})\n  for: 1m  # too short \u2014 scrape gaps cause false positives\n```\n\n**Why wrong**: Scrape targets can have momentary gaps during pod restarts, rolling deployments, or network blips. A 1-minute `for:` fires during normal K8s po...",
+      "domain_hint": "prometheus-grafana-engineer"
+    },
+    {
+      "file": "agents/python-general-engineer/references/python-anti-patterns.md",
+      "line_range": [
+        1,
+        3
+      ],
+      "block_text": "# Python General Engineer - Anti-Patterns\n\nCommon Python mistakes and their corrections.\n",
+      "domain_hint": "python-general-engineer"
+    },
+    {
+      "file": "agents/python-general-engineer/references/python-anti-patterns.md",
+      "line_range": [
+        5,
+        9
+      ],
+      "block_text": "## \u274c Anti-Pattern: Over-Engineering with Abstract Base Classes\n\n**What it looks like**:\n```python\nfrom abc import ABC, abstractmethod\n",
+      "domain_hint": "python-general-engineer"
+    },
+    {
+      "file": "agents/python-general-engineer/references/python-anti-patterns.md",
+      "line_range": [
+        61,
+        64
+      ],
+      "block_text": "## \u274c Anti-Pattern: Premature Async Conversion\n\n**What it looks like**:\n```python",
+      "domain_hint": "python-general-engineer"
+    },
+    {
+      "file": "agents/python-general-engineer/references/python-anti-patterns.md",
+      "line_range": [
+        170,
+        176
+      ],
+      "block_text": "## \u274c Anti-Pattern: Mutable Default Arguments\n\n**What it looks like**:\n```python\ndef add_item(item: str, items: list[str] = []) -> list[str]:\n    items.append(item)\n    return items\n",
+      "domain_hint": "python-general-engineer"
+    },
+    {
+      "file": "agents/python-general-engineer/references/python-anti-patterns.md",
+      "line_range": [
+        376,
+        384
+      ],
+      "block_text": "## \u274c Anti-Pattern: Not Using Context Managers\n\n**What it looks like**:\n```python\ndef process_file(path: str):\n    f = open(path)\n    data = f.read()\n    # Forgot to close! Resource leak\n    return process(data)\n",
+      "domain_hint": "python-general-engineer"
+    },
+    {
+      "file": "agents/python-general-engineer/references/python-anti-patterns.md",
+      "line_range": [
+        448,
+        452
+      ],
+      "block_text": "## \u274c Anti-Pattern: Importing * (Star Imports)\n\n**What it looks like**:\n```python\nfrom module import *\n",
+      "domain_hint": "python-general-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/hacking-rules.md",
+      "line_range": [
+        106,
+        106
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/hacking-rules.md",
+      "line_range": [
+        108,
+        136
+      ],
+      "block_text": "### \u274c H201: Bare `except:` Clause\n\n**Detection**:\n```bash\ngrep -rn 'except:' --include=\"*.py\"\nrg 'except:\\s*$' --type py\n```\n\n**What it looks like**:\n```python\ntry:\n    result = db.get_resource(context, resource_id)\nexcept:   # H201 \u2014 catches SystemExit, KeyboardInterrupt, GeneratorExit\n    LOG.warning('Resource not found')\n    return None\n```\n\n**Why wrong**: Catches `SystemExit` and `KeyboardInterrupt`, preventing clean service shutdown. `tox -e pep8` hard blocks this.\n\n**Fix**:\n```python\ntry:\n...",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/hacking-rules.md",
+      "line_range": [
+        138,
+        160
+      ],
+      "block_text": "### \u274c H303: Wildcard Imports\n\n**Detection**:\n```bash\ngrep -rn 'from .* import \\*' --include=\"*.py\"\nrg 'from \\S+ import \\*' --type py\n```\n\n**What it looks like**:\n```python\nfrom oslo_config.cfg import *\nfrom myservice.common import *\n```\n\n**Why wrong**: Pollutes namespace, breaks introspection, makes `tox -e pep8` fail, and hides dependency chain from code review tools like Zuul.\n\n**Fix**: Import only what you use explicitly.\n\n```python\nfrom oslo_config.cfg import CONF, StrOpt, IntOpt\n```\n\n---\n",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/hacking-rules.md",
+      "line_range": [
+        162,
+        184
+      ],
+      "block_text": "### \u274c H304: Relative Imports\n\n**Detection**:\n```bash\ngrep -rn 'from \\.' --include=\"*.py\" | grep -v \"test\\|#\"\nrg 'from \\.' --type py\n```\n\n**What it looks like**:\n```python\nfrom .utils import format_id\nfrom ..exception import ResourceNotFound\n```\n\n**Why wrong**: OpenStack enforces absolute imports throughout. Relative imports break `oslo-config-generator`, tox environments, and Zuul dependency resolution.\n\n**Fix**:\n```python\nfrom myservice.common.utils import format_id\nfrom myservice import except...",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/hacking-rules.md",
+      "line_range": [
+        186,
+        209
+      ],
+      "block_text": "### \u274c H501: % Formatting with locals()/self.__dict__\n\n**Detection**:\n```bash\ngrep -rn 'locals()\\|self\\.__dict__' --include=\"*.py\" | grep '%'\nrg '% (locals|self\\.__dict__)' --type py\n```\n\n**What it looks like**:\n```python\nmsg = 'Creating %(resource_type)s for user %(user_id)s' % locals()\nLOG.debug('State: %(state)s timeout: %(timeout)s' % self.__dict__)\n```\n\n**Why wrong**: `locals()` captures entire local scope including sensitive values (passwords, tokens). Implicit coupling makes refactoring si...",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/oslo-patterns.md",
+      "line_range": [
+        158,
+        158
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/oslo-patterns.md",
+      "line_range": [
+        160,
+        184
+      ],
+      "block_text": "### \u274c Direct `import logging` in Service Code\n\n**Detection**:\n```bash\ngrep -rn '^import logging$' --include=\"*.py\"\ngrep -rn 'logging\\.getLogger' --include=\"*.py\" | grep -v \"oslo_log\\|# noqa\"\n```\n\n**What it looks like**:\n```python\nimport logging  # Wrong in OpenStack service modules\n\nLOG = logging.getLogger(__name__)\n```\n\n**Why wrong**: Bypasses `oslo.log` integration. Log messages won't carry Oslo context fields (`request_id`, `project_id`), and runtime log level changes via `CONF.debug` won't a...",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/oslo-patterns.md",
+      "line_range": [
+        186,
+        202
+      ],
+      "block_text": "### \u274c Hardcoded Transport URL in Code\n\n**Detection**:\n```bash\ngrep -rn 'rabbit://\\|amqp://' --include=\"*.py\" | grep -v \"# example\\|\\.cfg\\|test\"\n```\n\n**What it looks like**:\n```python\ntransport = messaging.get_rpc_transport(\n    CONF, url='rabbit://guest:guest@localhost:5672/')\n```\n\n**Why wrong**: Transport URL must come from oslo.config (`CONF.transport_url`) to be overridable in deployment configs and testable with `oslo_messaging.fake`.\n\n**Fix**:\n```python",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/oslo-patterns.md",
+      "line_range": [
+        212,
+        233
+      ],
+      "block_text": "### \u274c Raw SQLAlchemy `create_engine` Without Oslo Session\n\n**Detection**:\n```bash\ngrep -rn 'create_engine\\|sessionmaker' --include=\"*.py\" | grep -v \"enginefacade\\|migration\\|test\"\n```\n\n**What it looks like**:\n```python\nfrom sqlalchemy import create_engine\nfrom sqlalchemy.orm import sessionmaker\n\nengine = create_engine(CONF.database.connection)\nSession = sessionmaker(bind=engine)\nsession = Session()\n```\n\n**Why wrong**: Bypasses oslo.db retry logic (deadlock retries via `@api.wrap_db_retry`), conn...",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/oslo-patterns.md",
+      "line_range": [
+        235,
+        266
+      ],
+      "block_text": "### \u274c Missing `oslo.policy` Enforcement\n\n**Detection**:\n```bash\ngrep -rn 'def (create|update|delete|get|list)_' --include=\"*.py\" -A 10 | grep -v \"policy\\|enforce\"\n```\n\n**What it looks like**:\n```python\ndef delete_resource(self, context, resource_id):\n    # No policy check \u2014 any authenticated user can delete\n    return db.resource_delete(context, resource_id)\n```\n\n**Why wrong**: All API operations must enforce oslo.policy rules. Missing enforcement silently bypasses RBAC \u2014 a security vulnerabilit...",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/rpc-versioning.md",
+      "line_range": [
+        152,
+        152
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/rpc-versioning.md",
+      "line_range": [
+        160,
+        165
+      ],
+      "block_text": "# Then verify RPC_API_VERSION changed in same diff\ngit diff HEAD~1 HEAD -- '*.py' | grep 'RPC_API_VERSION'\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/rpc-versioning.md",
+      "line_range": [
+        170,
+        179
+      ],
+      "block_text": "# After (version still '1.2' \u2014 NOT bumped!):\ndef create_resource(self, context, name, resource_type):  # Added required arg\n    ...\n```\n\n**Why wrong**: Old nodes calling `create_resource(ctx, name)` will crash with `TypeError` on the new server. Rolling upgrade fails.\n\n**Fix**: Bump `RPC_API_VERSION` to `'1.3'`, make `resource_type` optional with a default, and pin new client calls to `prepare(version='1.3')`.\n\n---\n",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/rpc-versioning.md",
+      "line_range": [
+        181,
+        189
+      ],
+      "block_text": "### \u274c Calling New Method Without Version Pin\n\n**Detection**:\n```bash\ngrep -rn 'cctxt\\.call\\|cctxt\\.cast' --include=\"*.py\" -B 2 | grep -v \"prepare\"\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/rpc-versioning.md",
+      "line_range": [
+        190,
+        201
+      ],
+      "block_text": "# Client calling method added in 1.4 without prepare()\ndef resize_resource(self, context, resource_id, new_size):\n    return self._client.call(context, 'resize_resource',\n                             resource_id=resource_id,\n                             new_size=new_size)\n```\n\n**Why wrong**: `_client.call()` without `.prepare(version=X)` sends no version requirement. If the server is on `1.3` and doesn't have `resize_resource`, the call fails with `MethodNotFound`.\n\n**Fix**: Always use `self._cl...",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/python-openstack-engineer/references/rpc-versioning.md",
+      "line_range": [
+        208,
+        227
+      ],
+      "block_text": "# Then check if the file has methods added after initial creation\ngit log --follow --oneline agents/ | head -20\n```\n\n**What it looks like**:\n```python\nclass MyServiceManager:\n    RPC_API_VERSION = '1.0'  # Never changed despite 3 years of new methods\n    target = messaging.Target(version=RPC_API_VERSION)\n\n    def create(self, context, name): ...       # original\n    def delete(self, context, id): ...         # added later, no version bump\n    def resize(self, context, id, size): ...   # added la...",
+      "domain_hint": "python-openstack-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/channels.md",
+      "line_range": [
+        113,
+        113
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/channels.md",
+      "line_range": [
+        123,
+        152
+      ],
+      "block_text": "# Go: channel opened without assignment to struct field\nrg 'conn\\.Channel\\(\\)' --type go | grep -v 'var ch\\|:= ch'\n```\n\n**What it looks like**:\n```python\ndef publish_event(body: bytes) -> None:\n    connection = get_connection()\n    channel = connection.channel()  # new channel every call\n    channel.basic_publish(exchange='events', routing_key='task', body=body)\n    # channel not closed, leaked\n```\n\n**Why wrong**: Each `channel()` call opens a new AMQP channel. Default channel limit is 2047 per ...",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/channels.md",
+      "line_range": [
+        162,
+        185
+      ],
+      "block_text": "# Go: channel passed to goroutines by reference\nrg 'go func.*ch\\s+\\*amqp\\.Channel' --type go\n```\n\n**What it looks like**:\n```python\nclass Worker:\n    def __init__(self):\n        self.channel = connection.channel()\n\n    def start(self):\n        for _ in range(4):\n            threading.Thread(target=self._process).start()\n\n    def _process(self):\n        while True:\n            self.channel.basic_ack(tag)  # multiple threads, same channel!\n```\n\n**Why wrong**: AMQP frames from concurrent threads in...",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/channels.md",
+      "line_range": [
+        187,
+        206
+      ],
+      "block_text": "### \u274c Forgetting to Drain Confirm Notifications\n\n**Detection**:\n```bash\nrg 'confirm_delivery|Confirm\\(false\\)' --type py --type go -A 3 | grep -v 'NotifyPublish\\|wait_for_confirms'\n```\n\n**What it looks like**:\n```python\nchannel.confirm_delivery()\nfor msg in messages:\n    channel.basic_publish(...)\n    # never calls channel.wait_for_confirms_or_die()\n```\n\n**Why wrong**: Unread confirms accumulate in pika's internal buffer. After ~1000 unconfirmed messages the channel stalls waiting for the applic...",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/error-handling.md",
+      "line_range": [
+        175,
+        175
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/error-handling.md",
+      "line_range": [
+        189,
+        206
+      ],
+      "block_text": "# Go\nrg '\\.Consume\\(' --type go -A 3 | grep 'autoAck.*true'\n```\n\n**What it looks like**:\n```python\nchannel.basic_consume(\n    queue='orders',\n    on_message_callback=handle_order,\n    auto_ack=True,  # Broker deletes message on delivery\n)\n```\n\n**Why wrong**: Message is deleted from the queue the instant the broker delivers it to the consumer socket buffer \u2014 before `handle_order` even starts. Consumer crash, OOM kill, or application exception after delivery means the message is permanently lost.\n...",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/error-handling.md",
+      "line_range": [
+        216,
+        232
+      ],
+      "block_text": "# Go: Nack with requeue=true in error path\nrg '\\.Nack\\(' --type go -A 2 | grep 'true'\n```\n\n**What it looks like**:\n```python\nexcept Exception as e:\n    log.error(\"processing failed: %s\", e)\n    channel.basic_nack(delivery_tag=method.delivery_tag, requeue=True)\n    # Message goes back to queue head \u2014 immediately redelivered \u2014 infinite loop\n```\n\n**Why wrong**: A poison message (malformed JSON, missing field, encoding error) that always raises an exception will loop: deliver \u2192 fail \u2192 requeue \u2192 deli...",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/error-handling.md",
+      "line_range": [
+        241,
+        247
+      ],
+      "block_text": "# Check live queues missing DLX\nrabbitmqctl list_queues name dead_letter_exchange | grep -v '\\S\\s\\S'\n```\n\n**What it looks like**:\n```python\nchannel.queue_declare(queue='payments', durable=True)",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/error-handling.md",
+      "line_range": [
+        248,
+        255
+      ],
+      "block_text": "# No DLX \u2014 rejected/expired messages vanish\n```\n\n**Why wrong**: Any `basic_nack(requeue=False)` or expired message is silently dropped. There is no audit trail, no replay capability, no alerting on message failures.\n\n**Fix**: Always declare a DLX for any production queue. At minimum, route to a `{queue}.dead` queue with 7-day TTL for investigation.\n\n---\n",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/performance.md",
+      "line_range": [
+        129,
+        129
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/performance.md",
+      "line_range": [
+        140,
+        146
+      ],
+      "block_text": "# Go: no QoS set before Consume\nrg '\\.Consume\\(' --type go -B 10 | grep -v 'Qos\\('\n```\n\n**What it looks like**:\n```python\nchannel.basic_consume(queue='tasks', on_message_callback=handle)",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/performance.md",
+      "line_range": [
+        147,
+        154
+      ],
+      "block_text": "# No basic_qos call \u2014 broker pushes unlimited messages\n```\n\n**Why wrong**: Broker pushes all queued messages to the first consumer that connects. Memory on the consumer grows without bound. Other consumers get nothing until the first consumer's buffer drains. Under spike load this causes OOM kills on consumer processes.\n\n**Fix**: Always call `channel.basic_qos(prefetch_count=N)` before `basic_consume`. Start with `prefetch_count=10` and tune upward.\n\n---\n",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/performance.md",
+      "line_range": [
+        163,
+        192
+      ],
+      "block_text": "# Check existing queues without TTL policy\nrabbitmqctl list_queues name policy | grep -v 'ttl\\|expire'\n```\n\n**What it looks like**:\n```python\nchannel.queue_declare(\n    queue='notifications',\n    durable=True,\n    # No TTL, no max-length \u2014 grows forever if consumers are slow\n)\n```\n\n**Why wrong**: Queues without TTL or max-length policies grow unboundedly if consumers fall behind. A queue with 10M messages consumes GB of memory/disk. Memory alarm fires at 40% (default watermark), blocking all pub...",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/rabbitmq-messaging-engineer/references/performance.md",
+      "line_range": [
+        201,
+        213
+      ],
+      "block_text": "# Code setting ha-mode in policy\nrg 'ha-mode|ha_mode' --type py --type go --type js\n```\n\n**What it looks like**:\n```bash\nrabbitmqctl set_policy ha-all \".*\" '{\"ha-mode\":\"all\"}' --apply-to queues\n```\n\n**Why wrong**: Classic mirrored queues replicate via synchronous replication to all mirror nodes. This causes write amplification proportional to cluster size. Under high throughput (>10K msg/s), mirrors can't keep up and the queue enters `slave_not_synchronized` state \u2014 at which point failover promo...",
+      "domain_hint": "rabbitmq-messaging-engineer"
+    },
+    {
+      "file": "agents/react-native-engineer/references/error-handling.md",
+      "line_range": [
+        150,
+        150
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "react-native-engineer"
+    },
+    {
+      "file": "agents/react-native-engineer/references/error-handling.md",
+      "line_range": [
+        152,
+        184
+      ],
+      "block_text": "### \u274c Using `console.error` as the Only Error Reporting\n\n**Detection**:\n```bash\ngrep -rn 'console\\.error' --include=\"*.tsx\" --include=\"*.ts\" | grep -v \"\\.test\\.\" | grep -v \"\\.spec\\.\"\nrg 'console\\.error' --type ts --type tsx | grep -v test\n```\n\n**What it looks like**:\n```tsx\ntry {\n  await syncData()\n} catch (err) {\n  console.error('Sync failed', err)  // invisible in production\n}\n```\n\n**Why wrong**: `console.error` is stripped or suppressed in production builds. Errors logged this way are invisib...",
+      "domain_hint": "react-native-engineer"
+    },
+    {
+      "file": "agents/react-native-engineer/references/error-handling.md",
+      "line_range": [
+        186,
+        216
+      ],
+      "block_text": "### \u274c Empty Catch Blocks\n\n**Detection**:\n```bash\ngrep -rn 'catch\\s*(.*)\\s*{\\s*}' --include=\"*.ts\" --include=\"*.tsx\"\nrg 'catch\\s*\\(.*\\)\\s*\\{\\s*\\}' --type ts\n```\n\n**What it looks like**:\n```ts\ntry {\n  await loadUserPreferences()\n} catch (err) {\n  // TODO: handle this\n}\n```\n\n**Why wrong**: Silent swallow. The error is gone. The app is now in an inconsistent state \u2014 preferences were not loaded, but no error boundary fired, no fallback rendered, no alert triggered. These are the hardest bugs to diagn...",
+      "domain_hint": "react-native-engineer"
+    },
+    {
+      "file": "agents/react-native-engineer/references/error-handling.md",
+      "line_range": [
+        218,
+        254
+      ],
+      "block_text": "### \u274c Missing Error Boundary at Navigation Root\n\n**Detection**:\n```bash\ngrep -rn 'Stack.Screen\\|Tabs.Screen' --include=\"*.tsx\" | grep -v ErrorBoundary\nrg 'NavigationContainer' --type tsx | grep -B5 -A10 'NavigationContainer'\n```\n\n**What it looks like**:\n```tsx\nexport default function RootLayout() {\n  return (\n    <Stack>\n      <Stack.Screen name=\"(tabs)\" component={TabsLayout} />\n      <Stack.Screen name=\"profile\" component={ProfileScreen} />\n    </Stack>\n  )\n}\n```\n\n**Why wrong**: If `ProfileScr...",
+      "domain_hint": "react-native-engineer"
+    },
+    {
+      "file": "agents/react-native-engineer/references/error-handling.md",
+      "line_range": [
+        256,
+        282
+      ],
+      "block_text": "### \u274c Accessing `.data` on an Unvalidated API Response\n\n**Detection**:\n```bash\ngrep -rn '\\.data\\.' --include=\"*.ts\" --include=\"*.tsx\" | grep -v \"\\.test\\.\" | grep \"await fetch\\|axios\\|useFetch\"\nrg '(await\\s+\\w+\\(.*\\))\\.data\\.' --type ts\n```\n\n**What it looks like**:\n```ts\nconst response = await fetch('/api/user')\nconst json = await response.json()\nsetUser(json.data.profile.name)  // throws if data or profile is undefined\n```\n\n**Why wrong**: API contracts break. A server returns `{ error: \"not foun...",
+      "domain_hint": "react-native-engineer"
+    },
+    {
+      "file": "agents/react-native-engineer/references/testing.md",
+      "line_range": [
+        117,
+        117
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "react-native-engineer"
+    },
+    {
+      "file": "agents/react-native-engineer/references/testing.md",
+      "line_range": [
+        167,
+        193
+      ],
+      "block_text": "### \u274c Mocking `useNavigation` Inside Individual Test Files\n\n**Detection**:\n```bash\ngrep -rn \"jest.mock.*navigation\\|jest.mock.*router\" --include=\"*.test.tsx\"\n```\n\n**What it looks like**:\n```tsx\njest.mock('@react-navigation/native', () => ({\n  useNavigation: () => ({ navigate: jest.fn() }),\n}))\n```\n\n**Why wrong**: Repeated local mocks diverge over time. When the real API adds a new field (`navigation.setOptions`, `navigation.getId`), each test file needs updating separately. Components that call ...",
+      "domain_hint": "react-native-engineer"
+    },
+    {
+      "file": "agents/react-native-engineer/references/testing.md",
+      "line_range": [
+        195,
+        221
+      ],
+      "block_text": "### \u274c Using Snapshots for UI Components\n\n**Detection**:\n```bash\ngrep -rn 'toMatchSnapshot\\|toMatchInlineSnapshot' --include=\"*.test.tsx\"\nrg 'toMatchSnapshot' --type tsx\n```\n\n**What it looks like**:\n```tsx\nit('renders correctly', () => {\n  const tree = render(<Card title=\"Hello\" />).toJSON()\n  expect(tree).toMatchSnapshot()\n})\n```\n\n**Why wrong**: Snapshot tests fail on every styling or structure change, creating update churn. They assert nothing about behavior \u2014 a component that renders the wrong...",
+      "domain_hint": "react-native-engineer"
+    },
+    {
+      "file": "agents/react-portfolio-engineer/references/nextjs-app-router.md",
+      "line_range": [
+        132,
+        132
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "react-portfolio-engineer"
+    },
+    {
+      "file": "agents/react-portfolio-engineer/references/nextjs-app-router.md",
+      "line_range": [
+        134,
+        170
+      ],
+      "block_text": "### \u274c Marking the Whole Page as Client Component\n\n**Detection**:\n```bash\ngrep -rn \"'use client'\" app/ --include=\"*.tsx\" | grep \"page.tsx\"\nrg \"'use client'\" --type tsx -l | xargs grep -l \"export default function\"\n```\n\n**What it looks like**:\n```tsx\n// app/gallery/page.tsx\n'use client'  // \u2190 entire page becomes a Client Component\nimport { useState } from 'react'\nimport Image from 'next/image'\nimport { artworks } from '@/data/artworks'\n\nexport default function GalleryPage() {\n  const [filter, setFi...",
+      "domain_hint": "react-portfolio-engineer"
+    },
+    {
+      "file": "agents/react-portfolio-engineer/references/nextjs-app-router.md",
+      "line_range": [
+        224,
+        249
+      ],
+      "block_text": "### \u274c Calling getServerSideProps in App Router Pages\n\n**Detection**:\n```bash\ngrep -rn \"getServerSideProps\\|getStaticProps\" app/ --include=\"*.tsx\"\n```\n\n**What it looks like**:\n```tsx\n// app/gallery/page.tsx \u2014 WRONG in App Router\nexport async function getStaticProps() { ... }\nexport async function getServerSideProps() { ... }\n```\n\n**Why wrong**: These are Pages Router APIs. In App Router they are silently ignored \u2014 the functions exist but never run. Data fetching must happen in the `async` compone...",
+      "domain_hint": "react-portfolio-engineer"
+    },
+    {
+      "file": "agents/react-portfolio-engineer/references/performance.md",
+      "line_range": [
+        135,
+        135
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "react-portfolio-engineer"
+    },
+    {
+      "file": "agents/react-portfolio-engineer/references/performance.md",
+      "line_range": [
+        137,
+        170
+      ],
+      "block_text": "### \u274c Multiple `priority` Images\n\n**Detection**:\n```bash\ngrep -rn \"priority\" --include=\"*.tsx\" | grep -v \"//.*priority\"\nrg \"priority(?:={true})?\" --type tsx\n```\n\n**What it looks like**:\n```tsx\n// Every gallery card has priority \u2014 defeats the purpose\n{artworks.map(art => (\n  <Image src={art.src} alt={art.alt} width={600} height={400} priority />\n))}\n```\n\n**Why wrong**: `priority` injects a `<link rel=\"preload\">` for each image. With 12 gallery items, that's 12 preloads competing for bandwidth at ...",
+      "domain_hint": "react-portfolio-engineer"
+    },
+    {
+      "file": "agents/react-portfolio-engineer/references/performance.md",
+      "line_range": [
+        172,
+        207
+      ],
+      "block_text": "### \u274c Missing `sizes` on Responsive Gallery Images\n\n**Detection**:\n```bash\ngrep -rn \"next/image\\|from 'next/image'\" --include=\"*.tsx\" -l | xargs grep -L \"sizes=\"\nrg \"width=\\{[0-9]+\\}.*height=\\{[0-9]+\\}\" --type tsx | grep -v \"sizes=\"\n```\n\n**What it looks like**:\n```tsx\n<Image\n  src={artwork.src}\n  alt={artwork.alt}\n  width={1200}\n  height={800}\n  // no sizes prop \u2014 browser defaults to requesting 1200px image on all viewports\n/>\n```\n\n**Why wrong**: The browser requests a 1200px image even on a 375...",
+      "domain_hint": "react-portfolio-engineer"
+    },
+    {
+      "file": "agents/react-portfolio-engineer/references/performance.md",
+      "line_range": [
+        209,
+        240
+      ],
+      "block_text": "### \u274c Synchronous Heavy Computation on Filter Interaction\n\n**Detection**:\n```bash\ngrep -rn \"\\.filter\\(.*\\.map\\|\\.sort\\(.*\\.filter\" --include=\"*.tsx\"\nrg \"useMemo|useCallback\" --type tsx -l\n```\n\n**What it looks like**:\n```tsx\n'use client'\nconst filtered = artworks\n  .filter(a => a.category === activeCategory)\n  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())\n  .map(a => ({ ...a, formattedDate: formatDate(a.date) }))\n// Runs on every render, including every keystroke in a s...",
+      "domain_hint": "react-portfolio-engineer"
+    },
+    {
+      "file": "agents/react-portfolio-engineer/references/performance.md",
+      "line_range": [
+        242,
+        274
+      ],
+      "block_text": "### \u274c Importing Full Icon Libraries\n\n**Detection**:\n```bash\ngrep -rn \"from 'react-icons'\" --include=\"*.tsx\"\ngrep -rn \"from '@heroicons/react'\" --include=\"*.tsx\" | grep \"^[^/]\"\n```\n\n**What it looks like**:\n```tsx\nimport { FaArrowLeft, FaArrowRight, FaTimes } from 'react-icons/fa'\n// Imports entire react-icons/fa barrel \u2014 adds ~50KB to bundle\n```\n\n**Why wrong**: Named imports from barrel files like `react-icons/fa` often pull in the entire icon set due to CommonJS export semantics. Even with tree-...",
+      "domain_hint": "react-portfolio-engineer"
+    },
+    {
+      "file": "agents/react-portfolio-engineer/references/portfolio-seo.md",
+      "line_range": [
+        224,
+        224
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "react-portfolio-engineer"
+    },
+    {
+      "file": "agents/research-coordinator-engineer/references/delegation-patterns.md",
+      "line_range": [
+        121,
+        121
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "research-coordinator-engineer"
+    },
+    {
+      "file": "agents/research-coordinator-engineer/references/delegation-patterns.md",
+      "line_range": [
+        129,
+        148
+      ],
+      "block_text": "# Check for dangerously short instructions (under 50 words)\nawk 'NF>0{count+=NF} END{if(count<50) print FILENAME\": too short (\"count\" words)\"}' research/*/instructions/*.md 2>/dev/null\n```\n\n**What it looks like**:\n```markdown\nSubagent 1: \"Research AI trends in 2025.\"\n```\n\n**Why wrong**: No scope = no boundary = subagent expands to cover everything tangentially related to AI. The coordinator receives a 1000-word survey that overlaps with what the other two subagents produced. Synthesis degrades t...",
+      "domain_hint": "research-coordinator-engineer"
+    },
+    {
+      "file": "agents/research-coordinator-engineer/references/delegation-patterns.md",
+      "line_range": [
+        156,
+        161
+      ],
+      "block_text": "# Look for single Task calls in plan when query is medium+ complexity\ngrep -c \"Task\\|TaskCreate\\|subagent\" research/*/plan.md\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "research-coordinator-engineer"
+    },
+    {
+      "file": "agents/research-coordinator-engineer/references/delegation-patterns.md",
+      "line_range": [
+        162,
+        174
+      ],
+      "block_text": "# Plan:\n1. Deploy subagent to research GPU supply\n2. WAIT for result\n3. Deploy subagent to research energy requirements\n4. WAIT for result\n5. Deploy subagent to research regulation\n```\n\n**Why wrong**: These three topics are independent \u2014 none requires the GPU supply finding to start the energy research. Sequential deployment triples latency for no reason. On a 60-second subagent, sequential = 180 seconds; parallel = 60 seconds.\n\n**Fix**: Move all three Task calls into a single message. Only use ...",
+      "domain_hint": "research-coordinator-engineer"
+    },
+    {
+      "file": "agents/research-coordinator-engineer/references/delegation-patterns.md",
+      "line_range": [
+        180,
+        193
+      ],
+      "block_text": "# Check if instructions specify word count or format\ngrep -rL \"word\\|paragraph\\|bullet\\|table\\|summary\" research/*/instructions/ 2>/dev/null\n```\n\n**What it looks like**:\n```markdown\n\"Research the regulatory landscape for AI development and provide your findings.\"\n```\n\n**Why wrong**: Subagent may return a 50-word paragraph or a 1500-word essay. Lead agent cannot predict what arrives, making synthesis planning impossible. It also removes the quality bar \u2014 \"provide your findings\" accepts any output...",
+      "domain_hint": "research-coordinator-engineer"
+    },
+    {
+      "file": "agents/research-coordinator-engineer/references/error-catalog.md",
+      "line_range": [
+        67,
+        75
+      ],
+      "block_text": "# Find research plans that delegate synthesis\ngrep -ri \"subagent.*final\\|delegate.*synthesis\\|compile.*report\" research/*/plan.md\ngrep -ri \"write.*final.*report\" research/*/instructions/ | grep -v \"lead agent\"\n```\n\n**Why wrong**: Synthesis delegation violates the hardcoded lead-agent-synthesizes rule. When subagents synthesize, the coordinator loses the cross-stream perspective needed to reconcile conflicts. A subagent sees only its own research stream \u2014 it cannot identify what the other subagen...",
+      "domain_hint": "research-coordinator-engineer"
+    },
+    {
+      "file": "agents/research-coordinator-engineer/references/error-catalog.md",
+      "line_range": [
+        97,
+        105
+      ],
+      "block_text": "# Find inline citations\ngrep -rn \"\\[[0-9]\\+\\]\\|([A-Z][a-z]*,\\s*20[0-9][0-9])\" research/*/report.md\n```\n\n**Why wrong**: The citation agent handles citations separately as a downstream step. Including citations in the research report creates duplication, formatting conflicts, and incorrect attribution when the citation agent reformats. Citation-free output is a hardcoded behavior \u2014 the coordinator must strip citations from its synthesis.\n\n**Fix**: Remove all citation markers from the final report....",
+      "domain_hint": "research-coordinator-engineer"
+    },
+    {
+      "file": "agents/research-coordinator-engineer/references/query-classification.md",
+      "line_range": [
+        91,
+        91
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "research-coordinator-engineer"
+    },
+    {
+      "file": "agents/research-coordinator-engineer/references/query-classification.md",
+      "line_range": [
+        99,
+        114
+      ],
+      "block_text": "# Manual check: are all subagent subjects identical?\ngrep \"Subagent [0-9]\\+:\" research/*/plan.md | sort | uniq -d\n```\n\n**What it looks like**:\n```markdown\nSubagent 1: \"Research AI regulation trends\"\nSubagent 2: \"Research AI regulation trends\"\nSubagent 3: \"Research AI regulation trends\"\n```\n\n**Why wrong**: All three subagents converge on the same sources and produce redundant content. The lead agent has nothing to reconcile \u2014 just three copies of similar findings. Synthesis produces an averaged s...",
+      "domain_hint": "research-coordinator-engineer"
+    },
+    {
+      "file": "agents/research-coordinator-engineer/references/query-classification.md",
+      "line_range": [
+        120,
+        138
+      ],
+      "block_text": "# Check for inconsistent word count specifications across parallel instructions\ngrep -E \"words|word count|[0-9]+-[0-9]+ word\" research/*/plan.md\n```\n\n**What it looks like**:\n```markdown\nSubagent 1 (PostgreSQL): \"Write a detailed technical analysis, include all relevant benchmarks,\nhistorical context, and community adoption trends.\"\n\nSubagent 2 (MongoDB): \"Provide a 200-word overview of write performance.\"\n\nSubagent 3 (Cassandra): \"List the pros and cons.\"\n```\n\n**Why wrong**: Lead agent cannot co...",
+      "domain_hint": "research-coordinator-engineer"
+    },
+    {
+      "file": "agents/research-coordinator-engineer/references/query-classification.md",
+      "line_range": [
+        144,
+        149
+      ],
+      "block_text": "# Queries containing \"compare\", \"vs\", \"versus\", \"difference between\" should use breadth-first\ngrep -i \"compare\\|vs\\.\\|versus\\|difference between\" research/*/report.md | head -20\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "research-coordinator-engineer"
+    },
+    {
+      "file": "agents/research-coordinator-engineer/references/query-classification.md",
+      "line_range": [
+        151,
+        161
+      ],
+      "block_text": "# Wrong strategy applied:\nSubagent 1: \"Theoretical foundations of frontend frameworks\"\nSubagent 2: \"Historical evolution of JavaScript frameworks\"\nSubagent 3: \"Performance characteristics of SPAs\"\n```\n\n**Why wrong**: Angles don't map to options. The lead agent now has generic framework theory but cannot answer \"which should I choose for enterprise apps?\"\n\n**Fix**: Detect comparison keywords and switch to breadth-first \u2014 one subagent per option.\n\n---\n",
+      "domain_hint": "research-coordinator-engineer"
+    },
+    {
+      "file": "agents/research-subagent-executor/references/research-execution-patterns.md",
+      "line_range": [
+        96,
+        96
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "research-subagent-executor"
+    },
+    {
+      "file": "agents/research-subagent-executor/references/research-execution-patterns.md",
+      "line_range": [
+        103,
+        120
+      ],
+      "block_text": "# Pattern in agent output to look for:\ngrep -i \"web_search\" agent_log.txt | sort | uniq -d\n```\n\n**What it looks like**:\n```\nTurn 3: web_search(\"kubernetes pod crash loop\")\nTurn 7: web_search(\"kubernetes pod crash loop\")  # exact repeat\n```\n\n**Why wrong**: Identical queries return identical results. Repeating them consumes budget with zero new information. The second call returns the same top-10 results as the first.\n\n**Fix**: Vary query angle, add specificity, or add a version/date qualifier.\n``...",
+      "domain_hint": "research-subagent-executor"
+    },
+    {
+      "file": "agents/research-subagent-executor/references/research-execution-patterns.md",
+      "line_range": [
+        126,
+        141
+      ],
+      "block_text": "# Pattern: web_search call followed by direct claim, no web_fetch in between\ngrep -A5 \"web_search\" agent_log.txt | grep -v \"web_fetch\"\n```\n\n**What it looks like**:\n```\nweb_search(\"Python 3.12 release date\")\n\u2192 Snippet: \"Python 3.12 was released...\"\nReport: \"Python 3.12 was released on October 2, 2023\"  # from snippet alone\n```\n\n**Why wrong**: Snippets are truncated, sometimes from outdated cached versions of pages. A claim sourced only from a snippet has no URL citation trail and may omit critica...",
+      "domain_hint": "research-subagent-executor"
+    },
+    {
+      "file": "agents/research-subagent-executor/references/research-execution-patterns.md",
+      "line_range": [
+        143,
+        161
+      ],
+      "block_text": "### \u274c Starting Research Without a Budget\n\n**What it looks like**:\n```\nTask received: \"Research the state of WebAssembly tooling in 2025\"\nTurn 1: web_search(\"WebAssembly 2025\")  # No budget stated\n...\nTurn 19: web_search(\"WASI spec status\")  # About to hit hard limit\nTurn 20: [forced termination]\n```\n\n**Why wrong**: Without a budget, the agent has no early-warning system. Hitting turn 20 mid-research produces an incomplete report with no synthesis. The coordinator receives a truncated artifact.\n\n...",
+      "domain_hint": "research-subagent-executor"
+    },
+    {
+      "file": "agents/research-subagent-executor/references/research-execution-patterns.md",
+      "line_range": [
+        163,
+        177
+      ],
+      "block_text": "### \u274c Querying More Than 5 Words\n\n**What it looks like**:\n```\nweb_search(\"what are the best practices for configuring kubernetes resource limits in production\")\n```\n\n**Why wrong**: Search engines perform better with short, keyword-dense queries. Long natural-language queries introduce stop words that dilute ranking signals. They also reduce result diversity (engine interprets as a phrase match).\n\n**Fix**:\n```\nweb_search(\"kubernetes resource limits production 2024\")\n```\n\n---\n",
+      "domain_hint": "research-subagent-executor"
+    },
+    {
+      "file": "agents/research-subagent-executor/references/source-quality-assessment.md",
+      "line_range": [
+        84,
+        84
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "research-subagent-executor"
+    },
+    {
+      "file": "agents/research-subagent-executor/references/source-quality-assessment.md",
+      "line_range": [
+        90,
+        105
+      ],
+      "block_text": "# In research logs, flag these URL patterns\ngrep -E \"best-[0-9]|top-[0-9]|vs\\.|comparison|alternative\" urls.txt\nrg \"(best|top|vs|versus|comparison|alternative)\" fetched_urls.txt -i\n```\n\n**What it looks like**:\n```\nweb_fetch(\"https://www.toolscomparison.io/best-kubernetes-monitoring-tools-2024/\")\n\u2192 Report: \"According to industry experts, Prometheus is the leading monitoring tool...\"\n```\n\n**Why wrong**: The aggregator's claim \"according to industry experts\" cites no specific expert. The actual sou...",
+      "domain_hint": "research-subagent-executor"
+    },
+    {
+      "file": "agents/research-subagent-executor/references/source-quality-assessment.md",
+      "line_range": [
+        111,
+        129
+      ],
+      "block_text": "# Flag community site domains in source list\ngrep -E \"(reddit\\.com|news\\.ycombinator\\.com|stackoverflow\\.com)\" source_list.txt\n```\n\n**What it looks like**:\n```\nSource: HackerNews comment from user \"fastdev99\":\n  \"From what I've heard, they're planning to rewrite the scheduler in Rust next quarter\"\nReport: \"The project plans to rewrite the scheduler in Rust next quarter\"\n```\n\n**Why wrong**: HackerNews comments are unverified community speculation. Presenting them as planning facts will corrupt th...",
+      "domain_hint": "research-subagent-executor"
+    },
+    {
+      "file": "agents/research-subagent-executor/references/source-quality-assessment.md",
+      "line_range": [
+        131,
+        146
+      ],
+      "block_text": "### \u274c Missing Source Citation for Precise Numbers\n\n**What it looks like**:\n```\nReport: \"Kubernetes 1.28 reduced pod startup latency by 23%\"\n[No URL, no source cited]\n```\n\n**Why wrong**: Precise numbers (percentages, benchmarks, release dates, version numbers) are the most likely to be misremembered, misquoted, or context-dependent. Without a URL, the coordinator cannot verify or qualify the claim.\n\n**Fix**: Every numeric claim gets a citation.\n```\nFACT: Kubernetes 1.28 release notes claim ~23% r...",
+      "domain_hint": "research-subagent-executor"
+    },
+    {
+      "file": "agents/research-subagent-executor/references/source-quality-assessment.md",
+      "line_range": [
+        152,
+        167
+      ],
+      "block_text": "# Scan fetched content for marketing signals\ngrep -iE \"(industry.leading|best.in.class|enterprise.grade|cutting.edge|blazing.fast|seamless)\" fetched_content.txt\n```\n\n**What it looks like**:\n```\nSource: vendor blog post\n  \"Our solution delivers enterprise-grade reliability with blazing-fast performance\"\nReport: \"Tool X delivers enterprise-grade reliability\"\n```\n\n**Why wrong**: Marketing superlatives have no technical definition. \"Enterprise-grade\" means nothing without benchmarks, SLA numbers, or...",
+      "domain_hint": "research-subagent-executor"
+    },
+    {
+      "file": "agents/reviewer-code/references/code-quality.md",
+      "line_range": [
+        95,
+        102
+      ],
+      "block_text": "## Anti-Patterns\n\n| Rationalization | Why It's Wrong | Required Action |\n|-----------------|----------------|-----------------|\n| \"It's just style\" | Style violations accumulate | Report if confidence 80+ |\n| \"Linter didn't catch it\" | Linters miss semantic issues | Review independently |\n| \"Works fine\" | Working code can still violate conventions | Report convention violations |\n| \"Too many findings, skip some\" | Suppressing findings hides issues | Report all 80+ findings |",
+      "domain_hint": "reviewer-code"
+    },
+    {
+      "file": "agents/reviewer-code/references/comments.md",
+      "line_range": [
+        76,
+        83
+      ],
+      "block_text": "## Anti-Patterns\n\n| Rationalization | Why It's Wrong | Required Action |\n|-----------------|----------------|-----------------|\n| \"Comment is close enough\" | Close-enough comments mislead subtly | Fix to match exactly or remove |\n| \"Nobody reads comments\" | Comments are the first thing maintainers read | Ensure accuracy |\n| \"Code is the documentation\" | Complex logic needs context comments | Document WHY, not WHAT |\n| \"It was accurate when written\" | Code evolves, comments must follow | Flag sta...",
+      "domain_hint": "reviewer-code"
+    },
+    {
+      "file": "agents/reviewer-code/references/config-safety.md",
+      "line_range": [
+        80,
+        88
+      ],
+      "block_text": "## Anti-Patterns\n\n| Rationalization | Why It's Wrong | Required Action |\n|-----------------|----------------|-----------------|\n| \"It's just a test key\" | Test keys in source teach bad habits | Use env vars even for test |\n| \"We'll rotate it\" | Rotation doesn't erase git history | Remove now, rotate immediately |\n| \"Default is fine for dev\" | Dev defaults in prod cause incidents | Production-safe defaults |\n| \"We validate later\" | Later = after user sees error | Validate at startup |\n| \"It's int...",
+      "domain_hint": "reviewer-code"
+    },
+    {
+      "file": "agents/reviewer-code/references/dead-code.md",
+      "line_range": [
+        77,
+        84
+      ],
+      "block_text": "## Anti-Patterns\n\n| Rationalization | Why It's Wrong | Required Action |\n|-----------------|----------------|-----------------|\n| \"Might need it later\" | Git history exists for this | Delete now |\n| \"It documents the old approach\" | Use comments for intent, not old code | Delete code, add comment if needed |\n| \"Someone might import it\" | Check all consumers first | If no consumers, remove |\n| \"TODO is still valid\" | If it was valid, it would be done | Complete or delete |",
+      "domain_hint": "reviewer-code"
+    },
+    {
+      "file": "agents/reviewer-code/references/language-specialist.md",
+      "line_range": [
+        72,
+        72
+      ],
+      "block_text": "### Anti-patterns detected",
+      "domain_hint": "reviewer-code"
+    },
+    {
+      "file": "agents/reviewer-code/references/language-specialist.md",
+      "line_range": [
+        89,
+        96
+      ],
+      "block_text": "## Anti-Patterns\n\n| Rationalization | Why It's Wrong | Required Action |\n|-----------------|----------------|-----------------|\n| \"Old pattern still works\" | Works != idiomatic; maintenance burden grows | Report with migration path |\n| \"That's just style\" | Idioms affect readability for the whole team | Report as idiom violation |\n| \"LLM generated is fine if correct\" | LLM tells signal lack of expert review | Flag patterns |\n| \"Framework overrides language\" | Only for documented framework conven...",
+      "domain_hint": "reviewer-code"
+    },
+    {
+      "file": "agents/reviewer-code/references/naming.md",
+      "line_range": [
+        72,
+        79
+      ],
+      "block_text": "## Anti-Patterns\n\n| Rationalization | Why It's Wrong | Required Action |\n|-----------------|----------------|-----------------|\n| \"Both are valid\" | Valid != consistent | Pick one, flag deviations |\n| \"Nobody notices\" | Inconsistency causes subtle bugs | Report for consistency |\n| \"Too many to fix\" | Fix incrementally | Report all, fix in scope |\n| \"It's just style\" | Inconsistent style is cognitive load | Reduce load with consistency |",
+      "domain_hint": "reviewer-code"
+    },
+    {
+      "file": "agents/reviewer-code/references/performance.md",
+      "line_range": [
+        73,
+        80
+      ],
+      "block_text": "## Anti-Patterns\n\n| Rationalization | Why It's Wrong | Required Action |\n|-----------------|----------------|-----------------|\n| \"It's fast enough\" | Fast enough today, slow tomorrow at scale | Report with scale analysis |\n| \"Premature optimization\" | O(n^2) in a handler is not premature | Report algorithmic issues always |\n| \"Only runs once\" | Verify it actually runs once | Check call sites |\n| \"Database handles it\" | Database can't fix N+1 from application | Fix query patterns |",
+      "domain_hint": "reviewer-code"
+    },
+    {
+      "file": "agents/reviewer-code/references/simplifier.md",
+      "line_range": [
+        85,
+        92
+      ],
+      "block_text": "## Anti-Patterns\n\n| Rationalization | Why It's Wrong | Required Action |\n|-----------------|----------------|-----------------|\n| \"Shorter is simpler\" | Brevity != clarity | Optimize for readability |\n| \"Tests still pass\" | Tests may not cover changed behavior | Verify test coverage of modified paths |\n| \"It's just a refactor\" | Refactors can change behavior | Run tests after every change |\n| \"The original was bad\" | Bad doesn't justify risky changes | Incremental improvement with verification |...",
+      "domain_hint": "reviewer-code"
+    },
+    {
+      "file": "agents/reviewer-code/references/test-analyzer.md",
+      "line_range": [
+        92,
+        99
+      ],
+      "block_text": "## Anti-Patterns\n\n| Rationalization | Why It's Wrong | Required Action |\n|-----------------|----------------|-----------------|\n| \"Coverage is high enough\" | Coverage number != behavioral coverage | Analyze behavioral gaps |\n| \"Happy path tests are sufficient\" | Bugs hide in error paths | Check negative cases |\n| \"Tests would be too complex\" | Complex code needs complex tests | Recommend test helpers |\n| \"This code never breaks\" | All code eventually breaks | Test critical paths regardless |\n",
+      "domain_hint": "reviewer-code"
+    },
+    {
+      "file": "agents/reviewer-code/references/type-design.md",
+      "line_range": [
+        83,
+        90
+      ],
+      "block_text": "## Anti-Patterns\n\n| Rationalization | Why It's Wrong | Required Action |\n|-----------------|----------------|-----------------|\n| \"Validation happens elsewhere\" | Types should be self-validating | Add constructor validation |\n| \"Too much ceremony\" | Ceremony prevents bugs | Evaluate actual bug prevention value |\n| \"Language doesn't support it\" | Use best available alternative | Document limitation, use workaround |\n| \"Tests catch invalid states\" | Compile-time prevention > test-time detection | ...",
+      "domain_hint": "reviewer-code"
+    },
+    {
+      "file": "agents/reviewer-domain/references/operational-anti-patterns.md",
+      "line_range": [
+        1,
+        3
+      ],
+      "block_text": "# Pragmatic Builder Roaster - Operational Anti-Patterns\n\nCommon operational mistakes and their corrections.\n",
+      "domain_hint": "reviewer-domain"
+    },
+    {
+      "file": "agents/reviewer-domain/references/operational-anti-patterns.md",
+      "line_range": [
+        5,
+        8
+      ],
+      "block_text": "## \u274c Anti-Pattern: No Rollback Plan\n\n**What it looks like**:\n```bash",
+      "domain_hint": "reviewer-domain"
+    },
+    {
+      "file": "agents/reviewer-domain/references/operational-anti-patterns.md",
+      "line_range": [
+        127,
+        132
+      ],
+      "block_text": "## \u274c Anti-Pattern: Untested Edge Cases\n\n**What it looks like**:\n```python\ndef calculate_discount(cart_total, discount_percent):\n    return cart_total * (discount_percent / 100)\n",
+      "domain_hint": "reviewer-domain"
+    },
+    {
+      "file": "agents/reviewer-domain/references/pragmatic-builder.md",
+      "line_range": [
+        79,
+        88
+      ],
+      "block_text": "## Operational Anti-Patterns\n\n1. **No Rollback Plan**: Document rollback steps, test before deploying, automate triggers\n2. **Logging After Failures**: Log before risky operations, in error handlers, at decision branches\n3. **Untested Edge Cases**: Test boundary conditions, error paths, concurrent access\n4. **No Circuit Breaker**: Wrap external calls, implement fallback paths\n5. **Trusting User Input**: Validate, sanitize, parameterize queries\n6. **Synchronous Long-Running Ops**: Queue jobs, ret...",
+      "domain_hint": "reviewer-domain"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/clarity-and-assumption-detection.md",
+      "line_range": [
+        15,
+        15
+      ],
+      "block_text": "## Newcomer: Clarity Anti-Patterns\n",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/clarity-and-assumption-detection.md",
+      "line_range": [
+        27,
+        48
+      ],
+      "block_text": "# Python: magic numbers in conditionals\nrg -n 'if.*[^=!<>]=\\s*[2-9][0-9]+' --type py\n```\n\n**What it looks like**:\n```python\nif response_code == 429:\n    time.sleep(60)  # Why 60? Why 429 specifically?\n```\n\n**Why wrong**: A newcomer cannot distinguish `60` (seconds) from `60` (max retries) or `60` (a business rule). When the value changes, they don't know all the places to update.\n\n**Fix**:\n```python\nHTTP_TOO_MANY_REQUESTS = 429\nRATE_LIMIT_BACKOFF_SECONDS = 60\n\nif response_code == HTTP_TOO_MANY_R...",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/clarity-and-assumption-detection.md",
+      "line_range": [
+        63,
+        78
+      ],
+      "block_text": "# Go: entire packages without package docs\nfind . -name \"*.go\" -not -path \"*/vendor/*\" | xargs grep -L \"^// Package\" | grep -v \"_test.go\"\n```\n\n**What it looks like**:\n```go\nfunc ProcessEvent(e Event, cfg *Config, dry bool) (Result, error) {\n    // 200 lines of business logic with no explanation\n}\n```\n\n**Why wrong**: The newcomer cannot call this function without reading all 200 lines to understand what `dry bool` does or what errors to expect.\n\n**Fix**: Add a doc comment explaining the function'...",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/clarity-and-assumption-detection.md",
+      "line_range": [
+        90,
+        107
+      ],
+      "block_text": "# Type-only names (just the type repeated as variable name)\nrg -n 'var user User\\|var config Config\\|var err error\\b' --type go | rg -v ':=\\|_test'\n```\n\n**What it looks like**:\n```go\nfunc calc(d []float64, n int) float64 {\n    var s float64\n    for _, v := range d {\n        s += v\n    }\n    return s / float64(n)\n}\n```\n\n**Why wrong**: `d`, `n`, `s`, `v` carry zero information. Is this averaging? Summing? What is `d`? Why is `n` separate from `len(d)`?\n\n---\n",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/clarity-and-assumption-detection.md",
+      "line_range": [
+        119,
+        135
+      ],
+      "block_text": "# Python: Assumes non-empty list without guard\nrg -n '\\[0\\]\\|\\.first()\\b' --type py -B3 | rg -v 'if.*len\\|if.*empty\\|assert'\n```\n\n**What it looks like**:\n```go\nfunc ProcessOrder(order *Order) {\n    customer := order.Customer // panics if Customer is nil\n    send(customer.Email)\n}\n```\n\n**Why wrong**: A newcomer calling `ProcessOrder` does not know they must pre-populate `Customer`. The panic surfaces far from the actual mistake.\n\n**Fix**: Either guard with a nil check and return an error, or docu...",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/clarity-and-assumption-detection.md",
+      "line_range": [
+        149,
+        155
+      ],
+      "block_text": "# Port numbers hardcoded in business logic (not config)\nrg -n ':8080|:3000|:5432|:6379' --type go --type py --type ts | rg -v 'test\\|example\\|default'\n```\n\n**Why wrong**: The Contrarian perspective asks \"what happens in CI, staging, or prod?\" Code assuming `localhost:5432` silently breaks in containerized environments.\n\n---\n",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/clarity-and-assumption-detection.md",
+      "line_range": [
+        167,
+        180
+      ],
+      "block_text": "# JSON unmarshaling field access without existence check (JS/TS)\nrg -n 'data\\.\\w+\\.\\w+' --type ts | rg -v '\\?\\.\\|if.*data\\.\\w+\\|&&'\n```\n\n**What it looks like**:\n```go\nfunc parseFlags(args []string) string {\n    return args[1] // assumes at least 2 args \u2014 no validation\n}\n```\n\n**Why wrong**: The Contrarian asks: \"what if the caller passes zero args?\" The assumption is invisible and produces a panic, not a clear error message.\n\n---\n",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/clarity-and-assumption-detection.md",
+      "line_range": [
+        192,
+        198
+      ],
+      "block_text": "# Node.js: singleton state assumed safe under concurrent requests\nrg -n 'module\\.exports\\.\\w+ = \\[\\|module\\.exports\\.\\w+ = \\{' --type js\n```\n\n**Why wrong**: The Contrarian asks: \"this code runs fine with one request \u2014 what about 100 simultaneous requests?\" Module-level mutable state is shared across all requests in most web frameworks.\n\n---\n",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/clarity-and-assumption-detection.md",
+      "line_range": [
+        210,
+        223
+      ],
+      "block_text": "# Array.sort() without comparator (JS default is lexicographic, not numeric)\nrg -n '\\.sort()' --type ts --type js | rg -v '(a,\\s*b)\\|(a:\\|b:'\n```\n\n**What it looks like**:\n```go\nfor key, val := range configMap {\n    applyInOrder(key, val) // map iteration order is random in Go\n}\n```\n\n**Why wrong**: The Contrarian asks: \"what assumption is the author making here?\" Map iteration being ordered is a frequent hidden assumption that causes intermittent bugs.\n\n---\n",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/code-review-detection.md",
+      "line_range": [
+        15,
+        15
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/code-review-detection.md",
+      "line_range": [
+        32,
+        53
+      ],
+      "block_text": "# Shell: unchecked command exits\ngrep -rn '^\\s*[a-z].*&&\\|;\\s*$' --include=\"*.sh\" | grep -v 'if\\|then\\|else'\n```\n\n**What it looks like**:\n```go\nresult, _ := db.Query(\"SELECT * FROM users WHERE id = ?\", id)\n```\n\n**Why wrong**: Silent error discard means data corruption or partial writes proceed undetected. In production, this surfaces as corrupted records with no error logs.\n\n**Fix**:\n```go\nresult, err := db.Query(\"SELECT * FROM users WHERE id = ?\", id)\nif err != nil {\n    return fmt.Errorf(\"quer...",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/code-review-detection.md",
+      "line_range": [
+        68,
+        86
+      ],
+      "block_text": "# 404 used for authorization failures (should be 403 or 401)\nrg -n 'NotFound|status.*404' --type go | rg -i 'auth\\|permission\\|forbidden'\n```\n\n**What it looks like**:\n```go\nfunc handler(w http.ResponseWriter, r *http.Request) {\n    user, err := getUser(id)\n    if err != nil {\n        http.Error(w, err.Error(), http.StatusOK) // wrong: 200 on error\n    }\n}\n```\n\n**Why wrong**: RFC 7231 \u00a76 defines status code semantics. Clients (including monitoring tools and API gateways) use status codes to route...",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/code-review-detection.md",
+      "line_range": [
+        104,
+        112
+      ],
+      "block_text": "# Connection strings\ngrep -rn 'postgres://\\|mysql://\\|mongodb://' --include=\"*.go\" --include=\"*.ts\" --include=\"*.py\" | grep -v '_test\\|example\\|sample'\n```\n\n**Why wrong**: Credentials in version history are permanent \u2014 `git filter-branch` does not remove them from forks or cached copies. Leaked credentials require key rotation even after removal.\n\n**Fix**: Load from environment variables (`os.Getenv`, `process.env`, `os.environ`) or a secrets manager. Never commit `.env` files containing real va...",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/code-review-detection.md",
+      "line_range": [
+        127,
+        135
+      ],
+      "block_text": "# GraphQL resolvers returning all items\ngrep -rn 'findAll\\|getAll\\|fetchAll' --include=\"*.ts\" --include=\"*.go\"\n```\n\n**Why wrong**: A query returning 1,000 rows in development returns 50 million in production, causing OOM crashes or 30-second response times that cascade into timeouts.\n\n**Fix**: Add `LIMIT`/`OFFSET` or cursor-based pagination. Default page size should be \u2264 100.\n\n---\n",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/code-review-detection.md",
+      "line_range": [
+        149,
+        164
+      ],
+      "block_text": "# JavaScript: async race (read then write without transaction)\nrg -n 'await.*get\\|await.*find' --type ts -A2 | rg 'await.*set\\|await.*update\\|await.*save'\n```\n\n**What it looks like**:\n```go\nif _, exists := cache[key]; !exists {\n    cache[key] = computeExpensive(key) // not atomic \u2014 two goroutines can reach this\n}\n```\n\n**Why wrong**: Two goroutines can both pass the `!exists` check before either writes, causing double computation or overwriting a valid value.\n\n**Fix**: Use `sync.Map.LoadOrStore()...",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/code-review-detection.md",
+      "line_range": [
+        178,
+        193
+      ],
+      "block_text": "# TypeScript: await in for loop with DB calls\nrg -n 'for.*of\\|for.*in' --type ts -A3 | rg 'await.*find\\|await.*get\\|await.*fetch'\n```\n\n**What it looks like**:\n```python\nposts = Post.objects.all()\nfor post in posts:\n    print(post.author.name)  # SELECT for every iteration\n```\n\n**Why wrong**: 100 posts = 101 queries. 10,000 posts = 10,001 queries. Degrades exponentially with data growth.\n\n**Fix**: Use `select_related`/`prefetch_related` (Django), `JOIN` (raw SQL), or batch fetch with `IN (...)`.\n...",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/code-review-detection.md",
+      "line_range": [
+        207,
+        215
+      ],
+      "block_text": "# Express routes without auth middleware\nrg -n 'router\\.(get|post|put|delete)\\(' --type ts -B2 | rg -v 'auth\\|verify\\|require'\n```\n\n**Why wrong**: Authenticated users can access other users' resources. Classic IDOR (Insecure Direct Object Reference) vulnerability \u2014 OWASP A01:2021.\n\n**Fix**: Always filter queries by the authenticated user's ID: `WHERE user_id = $currentUser`.\n\n---\n",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/review-detection-commands.md",
+      "line_range": [
+        344,
+        347
+      ],
+      "block_text": "## Anti-Pattern: Running Perspective Without Detection Pass\n\n**Detection**:\n```bash",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-perspectives/references/review-detection-commands.md",
+      "line_range": [
+        348,
+        358
+      ],
+      "block_text": "# Check if the review output cites file:line evidence\ngrep -c 'File:\\|Where:\\|:\\d\\+:' review_output.md 2>/dev/null || echo \"No line references found\"\n```\n\n**What it looks like**: A review with findings like \"the code seems complex\" or \"error handling may be insufficient\" \u2014 no file reference, no line number, no grep evidence.\n\n**Why wrong**: Vague findings are unfalsifiable. The author cannot verify them, cannot rebut them, and cannot be sure what to fix. Evidence-free reviews waste everyone's ti...",
+      "domain_hint": "reviewer-perspectives"
+    },
+    {
+      "file": "agents/reviewer-system/references/api-contract.md",
+      "line_range": [
+        74,
+        74
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "reviewer-system"
+    },
+    {
+      "file": "agents/reviewer-system/references/concurrency.md",
+      "line_range": [
+        86,
+        86
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "reviewer-system"
+    },
+    {
+      "file": "agents/reviewer-system/references/dependency-audit.md",
+      "line_range": [
+        78,
+        78
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "reviewer-system"
+    },
+    {
+      "file": "agents/reviewer-system/references/docs-validator.md",
+      "line_range": [
+        76,
+        76
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "reviewer-system"
+    },
+    {
+      "file": "agents/reviewer-system/references/error-messages.md",
+      "line_range": [
+        73,
+        73
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "reviewer-system"
+    },
+    {
+      "file": "agents/reviewer-system/references/migration-safety.md",
+      "line_range": [
+        72,
+        72
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "reviewer-system"
+    },
+    {
+      "file": "agents/reviewer-system/references/observability.md",
+      "line_range": [
+        68,
+        68
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "reviewer-system"
+    },
+    {
+      "file": "agents/rive-skeletal-animator/references/rive-animation-library.md",
+      "line_range": [
+        213,
+        219
+      ],
+      "block_text": "## State Machine Anti-Patterns\n\n**Dead-end states**: Every state must have a transition back to idle. Test this by manually triggering each input in the Rive Editor's preview \u2014 if any state doesn't return to idle, add the transition.\n\n**Race condition on rapid inputs**: If `attack` fires twice in 100ms, the second trigger may interrupt mid-windup. Decide policy in CombatEngine: either debounce triggers (reject new inputs while animation is active) or accept interruption (second attack starts fro...",
+      "domain_hint": "rive-skeletal-animator"
+    },
+    {
+      "file": "agents/rive-skeletal-animator/references/rive-async-patterns.md",
+      "line_range": [
+        128,
+        128
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "rive-skeletal-animator"
+    },
+    {
+      "file": "agents/rive-skeletal-animator/references/rive-async-patterns.md",
+      "line_range": [
+        130,
+        154
+      ],
+      "block_text": "### \u274c Accessing Rive Instance Outside Effect or Callback\n\n**Detection**:\n```bash\ngrep -rn 'rive\\.' --include=\"*.tsx\" | grep -v 'useEffect\\|onLoad\\|onStateChange\\|useCallback\\|//' | grep -v 'RiveComponent\\|useRive\\|import'\nrg '^\\s+rive\\.' --type tsx\n```\n\n**What it looks like**:\n```tsx\nfunction PlayerCharacter() {\n  const { rive, RiveComponent } = useRive({ ... });\n\n  // BUG: rive is null on first render\n  rive.stateMachineInputs('CombatStateMachine')?.find(i => i.name === 'triggerAttack')?.fire()...",
+      "domain_hint": "rive-skeletal-animator"
+    },
+    {
+      "file": "agents/rive-skeletal-animator/references/rive-async-patterns.md",
+      "line_range": [
+        156,
+        180
+      ],
+      "block_text": "### \u274c Using setTimeout for Animation Sequencing\n\n**Detection**:\n```bash\ngrep -rn 'setTimeout' --include=\"*.tsx\" | grep -i 'anim\\|rive\\|attack\\|hit\\|state'\nrg 'setTimeout.*anim' --type tsx\n```\n\n**What it looks like**:\n```tsx\nconst handleAttack = () => {\n  attackInput?.fire();\n  setTimeout(() => {\n    recoverInput?.fire(); // assume attack finishes in 300ms\n  }, 300);\n};\n```\n\n**Why wrong**: Animation duration in the Rive editor and the `setTimeout` duration in code drift independently. When a desi...",
+      "domain_hint": "rive-skeletal-animator"
+    },
+    {
+      "file": "agents/rive-skeletal-animator/references/rive-async-patterns.md",
+      "line_range": [
+        182,
+        207
+      ],
+      "block_text": "### \u274c Polling rive for Non-Null in a Loop or Interval\n\n**Detection**:\n```bash\ngrep -rn 'setInterval\\|while.*rive\\|poll' --include=\"*.tsx\" | grep -i 'rive'\nrg 'setInterval' --type tsx -l | xargs grep -l 'rive'\n```\n\n**What it looks like**:\n```tsx\nuseEffect(() => {\n  const poll = setInterval(() => {\n    if (rive) {\n      clearInterval(poll);\n      rive.play();\n    }\n  }, 50);\n  return () => clearInterval(poll);\n}, []);\n```\n\n**Why wrong**: This re-implements what `useRive` already does with `onLoad`...",
+      "domain_hint": "rive-skeletal-animator"
+    },
+    {
+      "file": "agents/rive-skeletal-animator/references/rive-async-patterns.md",
+      "line_range": [
+        230,
+        231
+      ],
+      "block_text": "# Polling for rive instance (anti-pattern)\nrg 'setInterval' --type tsx -l | xargs grep -l 'rive'\n",
+      "domain_hint": "rive-skeletal-animator"
+    },
+    {
+      "file": "agents/rive-skeletal-animator/references/rive-performance.md",
+      "line_range": [
+        104,
+        104
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "rive-skeletal-animator"
+    },
+    {
+      "file": "agents/rive-skeletal-animator/references/rive-performance.md",
+      "line_range": [
+        106,
+        131
+      ],
+      "block_text": "### \u274c Wrapping RiveComponent in Framer Motion\n\n**Detection**:\n```bash\ngrep -rn 'motion\\.' --include=\"*.tsx\" | grep -i 'rive'\nrg 'motion\\.(div|span)' --type tsx -l | xargs grep -l 'RiveComponent'\n```\n\n**What it looks like**:\n```tsx\n<motion.div animate={{ opacity: 1 }} initial={{ opacity: 0 }}>\n  <RiveComponent />\n</motion.div>\n```\n\n**Why wrong**: Framer Motion and Rive both own animation timing. When Framer Motion drives opacity/transform on the container, it forces composite layer repaints on ev...",
+      "domain_hint": "rive-skeletal-animator"
+    },
+    {
+      "file": "agents/rive-skeletal-animator/references/rive-performance.md",
+      "line_range": [
+        133,
+        166
+      ],
+      "block_text": "### \u274c Creating Rive Instances Outside React Lifecycle\n\n**Detection**:\n```bash\ngrep -rn 'new Rive(' --include=\"*.ts\" --include=\"*.tsx\"\nrg 'new Rive\\(' --type ts\n```\n\n**What it looks like**:\n```ts\n// In a Zustand store or utility function\nconst riveInstance = new Rive({ src: '/characters/player.riv', canvas: canvasEl });\n```\n\n**Why wrong**: Rive instances created outside React components lose their cleanup path. `useRive` manages the instance lifecycle \u2014 loading, resize observation, cleanup \u2014 and ...",
+      "domain_hint": "rive-skeletal-animator"
+    },
+    {
+      "file": "agents/rive-skeletal-animator/references/rive-performance.md",
+      "line_range": [
+        168,
+        193
+      ],
+      "block_text": "### \u274c Rendering Multiple Rive Canvases Simultaneously Without Shared Context\n\n**Detection**:\n```bash\ngrep -rn 'useRive' --include=\"*.tsx\" | grep -v 'test\\|spec\\|story'\n```\n\nCount the number of `useRive` calls active at once. If more than 12, context exhaustion is likely.\n\n**What it looks like**:\n```tsx\n// Character select screen with 8 previews + combat scene with 2 active characters = 10+ contexts\n{characters.map(c => <CharacterPreview key={c.id} rivFile={c.riv} />)}\n```\n\n**Why wrong**: Each `u...",
+      "domain_hint": "rive-skeletal-animator"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-migrations.md",
+      "line_range": [
+        182,
+        182
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-migrations.md",
+      "line_range": [
+        188,
+        194
+      ],
+      "block_text": "# Find raw execute_sql calls that look like schema changes\ngrep -rn 'execute_sql.*ALTER TABLE\\|execute_sql.*CREATE TABLE\\|execute_sql.*DROP TABLE' --include=\"*.py\"\nrg 'execute_sql\\([\\'\\\"](ALTER|CREATE|DROP)' --type py\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-migrations.md",
+      "line_range": [
+        195,
+        214
+      ],
+      "block_text": "# WRONG: Bypasses Playhouse migration tracking and SQLite safety checks\ndb.execute_sql(\"ALTER TABLE user ADD COLUMN phone TEXT\")\ndb.execute_sql(\"DROP TABLE IF EXISTS temp_data\")\n```\n\n**Why wrong**: Raw schema SQL skips Playhouse's pre-flight checks (e.g., does column already\nexist?), produces no migration record, and on SQLite may silently succeed when the operation\nhas unintended side effects (like dropping all triggers on a table).\n\n**Fix**:\n```python\nfrom playhouse.migrate import SqliteMigrat...",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-migrations.md",
+      "line_range": [
+        216,
+        225
+      ],
+      "block_text": "### \u274c Adding NOT NULL Column Without Default on Non-Empty Table\n\n**Detection**:\n```bash\ngrep -rn 'add_column' --include=\"*.py\" -A 2 | grep -v 'null=True\\|default='\nrg 'add_column\\([^)]*\\)' --type py | grep -v 'null=True|default='\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-migrations.md",
+      "line_range": [
+        226,
+        235
+      ],
+      "block_text": "# FAILS on any non-empty table \u2014 existing rows have no value for 'status'\nmigrate(migrator.add_column('post', 'status', CharField()))\n```\n\n**Why wrong**: SQLite requires all existing rows to have a valid value for the new column.\nA non-null column with no default fails with `OperationalError: Cannot add a NOT NULL column\nwith default value NULL`.\n\n**Fix**:\n```python",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-migrations.md",
+      "line_range": [
+        248,
+        257
+      ],
+      "block_text": "### \u274c Dropping Column on SQLite < 3.35\n\n**Detection**:\n```bash\ngrep -rn 'drop_column' --include=\"*.py\"\nrg 'migrator\\.drop_column\\(' --type py\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-migrations.md",
+      "line_range": [
+        258,
+        289
+      ],
+      "block_text": "# Fails silently or errors on SQLite < 3.35\nmigrate(migrator.drop_column('user', 'legacy_field'))\n```\n\n**Why wrong**: `DROP COLUMN` was not supported in SQLite before version 3.35 (released 2021-03-12).\nMany Linux distributions ship SQLite 3.31 or earlier. Calling `drop_column()` on older SQLite\neither raises `OperationalError` or does nothing depending on Playhouse version.\n\n**Fix**:\n```python\nimport sqlite3\n\ndef sqlite_version(db):\n    return db.execute_sql('SELECT sqlite_version()').fetchone(...",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-migrations.md",
+      "line_range": [
+        291,
+        303
+      ],
+      "block_text": "### \u274c Running Schema Changes Outside Transaction\n\n**Detection**:\n```bash\ngrep -rn 'migrate(' --include=\"*.py\" -B 3 | grep -v 'atomic\\|with db'\nrg 'migrate\\(' --type py -B 3 | grep -v 'atomic'\n```\n\n**What it looks like**:\n```python\nmigrator = SqliteMigrator(db)\nmigrate(migrator.add_column('user', 'email', TextField(null=True)))  # No atomic()!\nmigrate(migrator.add_index('user', ('email',), False))               # Separate call",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-migrations.md",
+      "line_range": [
+        304,
+        316
+      ],
+      "block_text": "# If second migrate() fails, first is committed \u2014 schema partially updated\n```\n\n**Why wrong**: Each `migrate()` call is its own implicit transaction. If the second call fails,\nthe first is already committed. The schema is now partially updated with no clean rollback path.\n\n**Fix**:\n```python\nwith db.atomic():\n    migrate(\n        migrator.add_column('user', 'email', TextField(null=True)),\n        migrator.add_index('user', ('email',), False),\n    )",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-query-patterns.md",
+      "line_range": [
+        98,
+        102
+      ],
+      "block_text": "### Targeted SELECT to Avoid Overfetch\n\nSpecify only needed columns \u2014 prevents loading TEXT/BLOB columns when only IDs or names needed.\n\n```python",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-query-patterns.md",
+      "line_range": [
+        118,
+        118
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-query-patterns.md",
+      "line_range": [
+        126,
+        145
+      ],
+      "block_text": "# More targeted: find ForeignKeyField backrefs accessed in for loops\nrg 'for \\w+ in \\w+\\.\\w+:' --type py\nrg '\\.select\\(\\)' --type py -A 5 | grep '\\.\\w+\\.\\w+'\n```\n\n**What it looks like**:\n```python\nusers = User.select()\nfor user in users:\n    # BAD: executes SELECT for every iteration\n    post_count = user.posts.count()\n    latest = user.posts.order_by(Post.created_at.desc()).first()\n```\n\n**Why wrong**: Each `user.posts` access opens a new database connection and executes a SELECT.\nWith 500 users...",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-query-patterns.md",
+      "line_range": [
+        173,
+        204
+      ],
+      "block_text": "# Check if index=True is absent\nrg 'ForeignKeyField\\([^)]*\\)' --type py | grep -v 'index=True'\n```\n\n**What it looks like**:\n```python\nclass Post(Model):\n    user = ForeignKeyField(User, backref='posts')  # No index!\n    category = ForeignKeyField(Category, backref='posts')  # No index!\n```\n\n**Why wrong**: Peewee does NOT automatically index ForeignKeyField (unlike Django). Queries\nfiltering on `Post.user == user_id` do a full table scan. At 10k rows this is noticeable; at\n100k rows it's a report...",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-query-patterns.md",
+      "line_range": [
+        206,
+        215
+      ],
+      "block_text": "### \u274c Cartesian Product from Prefetch + Join Combination\n\n**Detection**:\n```bash\nrg '\\.prefetch\\(' --type py -A 2 | grep '\\.join\\('\ngrep -rn 'prefetch' --include=\"*.py\" -A 3 | grep 'join'\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-query-patterns.md",
+      "line_range": [
+        216,
+        228
+      ],
+      "block_text": "# BUG: join + prefetch on same model produces cartesian product rows\nusers = (User\n    .select()\n    .join(Post)  # Creates JOIN\n    .prefetch(Post))  # Also prefetches \u2014 duplicates Post rows\n```\n\n**Why wrong**: `join()` and `prefetch()` for the same model are mutually exclusive operations.\nUsing both causes Post rows to appear multiple times in `user.posts` after prefetch populates\nfrom the JOIN result set.\n\n**Fix**:\n```python",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-query-patterns.md",
+      "line_range": [
+        242,
+        248
+      ],
+      "block_text": "# Model.select() with no arguments \u2014 loads all columns\nrg '\\.select\\(\\s*\\)' --type py\ngrep -rn '\\.select()' --include=\"*.py\" | grep -v 'select(.*\\.'\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-query-patterns.md",
+      "line_range": [
+        249,
+        263
+      ],
+      "block_text": "# Loads all columns including large TEXT/BLOB fields\nposts = Post.select()  # Includes body, attachments_json, etc.\nfor post in posts:\n    print(post.title)  # Only needed title\n```\n\n**Why wrong**: SQLite reads entire row pages into cache. Loading unused large columns wastes\ncache and increases I/O, especially in list views rendering only titles or IDs.\n\n**Fix**:\n```python\nposts = Post.select(Post.id, Post.title, Post.created_at)\n```\n\n---\n",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-testing.md",
+      "line_range": [
+        187,
+        187
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-testing.md",
+      "line_range": [
+        193,
+        200
+      ],
+      "block_text": "# Find test files using module-level database setup\ngrep -rn 'db = SqliteDatabase' --include=\"test_*.py\"\ngrep -rn 'setUpClass\\|setup_module' --include=\"test_*.py\" -A 5 | grep 'create_tables'\nrg 'SqliteDatabase.*test' --type py | grep -v 'fixture\\|conftest'\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-testing.md",
+      "line_range": [
+        201,
+        219
+      ],
+      "block_text": "# conftest.py \u2014 WRONG: shared database across all tests\ndb = SqliteDatabase(':memory:')\ndb.bind([User, Post])\ndb.create_tables([User, Post])\n\ndef test_create_user():\n    User.create(username='alice')\n\ndef test_user_count():\n    # FAILS if test_create_user ran first \u2014 count is 1, not 0\n    assert User.select().count() == 0\n```\n\n**Why wrong**: Module-level `:memory:` databases persist for the entire test session. Rows\ncreated in one test are visible to all subsequent tests. Test order determines r...",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-testing.md",
+      "line_range": [
+        235,
+        241
+      ],
+      "block_text": "# Find SqliteDatabase with file path in test files\ngrep -rn 'SqliteDatabase(' --include=\"test_*.py\" | grep -v ':memory:'\nrg 'SqliteDatabase\\([^:)]' --type py --glob 'test_*'\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-testing.md",
+      "line_range": [
+        242,
+        272
+      ],
+      "block_text": "# Uses real app.db in tests \u2014 modifies production data\ndb = SqliteDatabase('app.db')\n\ndef test_delete_user():\n    User.delete().where(User.username == 'test').execute()\n    # Deletes from real database!\n```\n\n**Why wrong**: Test teardown failures, CI environment errors, or parallel test runs corrupt\nthe production database file. SQLite file databases have no transaction isolation between\nprocesses.\n\n**Fix**: Always use `SqliteDatabase(':memory:')` in tests. For integration tests that need\na file,...",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-testing.md",
+      "line_range": [
+        274,
+        283
+      ],
+      "block_text": "### \u274c Not Enabling FK Constraints in Test DB\n\n**Detection**:\n```bash\nrg 'SqliteDatabase.*:memory:' --type py | grep -v 'foreign_keys'\ngrep -rn \"SqliteDatabase(':memory:')\" --include=\"*.py\" -A 3 | grep -v 'foreign_keys'\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/sqlite-peewee-engineer/references/peewee-testing.md",
+      "line_range": [
+        284,
+        301
+      ],
+      "block_text": "# SQLite disables FK checks by default \u2014 tests pass but prod fails\ndb = SqliteDatabase(':memory:')  # No foreign_keys pragma\n\ndef test_post_without_user():\n    # This succeeds in test \u2014 SQLite allows orphaned FK\n    Post.create(user_id=99999, title='Orphan')\n    # In production with foreign_keys=1 this raises IntegrityError\n```\n\n**Why wrong**: SQLite disables foreign key constraints by default for backwards compatibility.\nTests pass with invalid data that production rejects. The divergence is in...",
+      "domain_hint": "sqlite-peewee-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/component-audit-checklists.md",
+      "line_range": [
+        47,
+        61
+      ],
+      "block_text": "# 5. Check for stale anti-pattern entries (patterns that have been fixed)\ngrep -rn \"Anti-Pattern\" agents/*.md\n```\n\n**Per-agent audit fields to verify**:\n\n| Field | Check | Stale Signal |\n|-------|-------|-------------|\n| `model:` | Is this a current model name? | Model ID no longer in active release |\n| `allowed-tools:` | Are all listed tools still available? | Tool removed from Claude Code |\n| `routing.triggers` | Does at least one trigger match the user's actual phrasing? | All triggers are te...",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/component-audit-checklists.md",
+      "line_range": [
+        159,
+        159
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/component-audit-checklists.md",
+      "line_range": [
+        167,
+        176
+      ],
+      "block_text": "# Should be > 0 for a real audit\n```\n\n**Why wrong**: File existence confirms a component exists; it does not confirm it's stale or\ncurrent. Triggers that are never phrased by actual users will never route. A model name frozen\nat an old value will use the wrong capability tier.\n\n**Fix**: Open and read each component's frontmatter and body. Check specific fields.\n\n---\n",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/component-audit-checklists.md",
+      "line_range": [
+        184,
+        192
+      ],
+      "block_text": "# An audit for 2 hooks should not produce a 500-line task plan\n```\n\n**Why wrong**: Auditing 120+ skills for a single hook event change produces noise and makes\nit impossible to distinguish affected from unaffected components. Tier assignment degrades.\n\n**Fix**: Scope audit to the component types identified in the Change Manifest signal column.\n\n---\n",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-anti-patterns.md",
+      "line_range": [
+        1,
+        7
+      ],
+      "block_text": "# Upgrade Orchestration Anti-Patterns Reference\n\n> **Scope**: Common orchestration failures in the 6-phase system-upgrade workflow: premature implementation, approval gate bypass, inline edits, and scope creep. Covers detection and remediation.\n> **Version range**: system-upgrade-engineer, all versions\n> **Generated**: 2026-04-15\n\n---\n",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-anti-patterns.md",
+      "line_range": [
+        18,
+        18
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-anti-patterns.md",
+      "line_range": [
+        28,
+        43
+      ],
+      "block_text": "# Check git log for commits that skip the plan-present step\ngit log --oneline --since=\"1 hour ago\" | grep \"chore/system-upgrade\"\n```\n\n**What it looks like**: Moving from Phase 2 AUDIT directly to Phase 4 IMPLEMENT without\npresenting the ranked table and waiting for a response.\n\n**Why wrong**: Users lose control of what changes in their system. Bulk edits to governance\ninfrastructure (hooks, routing tables, agent frontmatter) are hard to reverse and affect\nevery subsequent session. The approval g...",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-anti-patterns.md",
+      "line_range": [
+        45,
+        52
+      ],
+      "block_text": "### \u274c Implementing Domain Changes Inline\n\n**What it looks like**: Directly editing `hooks/posttool-rename-sweep.py` instead of\ndispatching `hook-development-engineer`. Writing new agent frontmatter inline instead of\ndispatching `skill-creator`.\n\n**Detection**:\n```bash",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-anti-patterns.md",
+      "line_range": [
+        55,
+        69
+      ],
+      "block_text": "# system-upgrade-engineer should only create task_plan.md and branch setup files\n```\n\n**Why wrong**: Domain specialists (hook-development-engineer, skill-creator) carry template\nconventions, event schema knowledge, and frontmatter validation that inline edits bypass.\nA hook written inline without hook-development-engineer's exit code contract knowledge will\nlikely use wrong exit codes. An agent written inline will miss required frontmatter fields.\n\n**Fix**:\n- Hook changes \u2192 dispatch `hook-develo...",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-anti-patterns.md",
+      "line_range": [
+        81,
+        92
+      ],
+      "block_text": "# Should be present \u2014 if missing, audit had no scope\n```\n\n**Why wrong**: Auditing all 120+ skills for a 2-hook change produces noise proportional to\nscope. When every component appears in the audit, the PLAN phase cannot distinguish affected\nfrom unaffected. Tier assignment degrades to noise.\n\n**Fix**: Build the Change Manifest with a \"Component Types\" column first. Default scope\nis 10 most-recently-modified agents + all hooks + affected routing tables. Comprehensive\naudit only with the explicit...",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-anti-patterns.md",
+      "line_range": [
+        100,
+        114
+      ],
+      "block_text": "# Should appear in Phase 5 section; if absent, validation was skipped\n```\n\n**What it looks like**: Creating PR directly after IMPLEMENT without running\n`agent-evaluation` on modified components.\n\n**Why wrong**: An agent that scores lower after modification has regressed. Without the\nbefore/after delta, regressions are invisible until users report breakage. The upgrade\npipeline exists to *improve* quality, not maintain it.\n\n**Fix**: Run `agent-evaluation` on each modified component. Report the nu...",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-anti-patterns.md",
+      "line_range": [
+        124,
+        135
+      ],
+      "block_text": "# Check no force-push flags in recent git commands\nhistory | grep \"push --force\\|push -f\"\n```\n\n**Why wrong**: Commits to main bypass branch protection and review. Force-push to main\noverwrites upstream state and is unrecoverable without a backup. The branch naming\nconvention (`chore/system-upgrade-YYYY-MM-DD`) exists to ensure all changes go through PR.\n\n**Fix**: Always `git checkout -b chore/system-upgrade-YYYY-MM-DD` before Phase 4. Never\nuse `--force` or `-f` on push. If already on main, stas...",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-anti-patterns.md",
+      "line_range": [
+        143,
+        154
+      ],
+      "block_text": "# These phrases in the same context indicate a rationalized regression\n```\n\n**Why wrong**: Regressions are user decisions, not agent decisions. When a component\nscores lower after modification, the agent's job is to surface it clearly, not to\nrationalize it away. The user may have context that makes the tradeoff acceptable;\nthe agent does not have that context.\n\n**Fix**: Report the regression factually: \"Component X scored N before, M after (delta -K).\nCause: [specific change]. Recommend: revert...",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-anti-patterns.md",
+      "line_range": [
+        224,
+        225
+      ],
+      "block_text": "# Check for regression justification phrases (anti-pattern)\ngrep -i \"necessary\\|intentional\\|expected trade\" task_plan.md\n",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-signal-parsing.md",
+      "line_range": [
+        101,
+        101
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-signal-parsing.md",
+      "line_range": [
+        109,
+        118
+      ],
+      "block_text": "# Should be > 1 (header row + at least one data row)\n```\n\n**Why wrong**: A zero-signal manifest means the trigger was too vague. The AUDIT phase will\nscan all components with no scoping, producing noise and wasting time. Phase 1 instructions\nexplicitly say: \"If you extracted 0 actionable signals, do not proceed.\"\n\n**Fix**: Ask the user for specifics. Quote the exact feature or change being referenced.\n\n---\n",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-signal-parsing.md",
+      "line_range": [
+        120,
+        131
+      ],
+      "block_text": "### \u274c Treating a Mention as an Upgrade Requirement\n\n**What it looks like**: A release note mentions \"improved JSON output\" and the agent\nimmediately schedules upgrades to every script that uses JSON.\n\n**Why wrong**: Not every mention is a breaking change. Only changes that alter the\ninterface (tool signature, event schema, model name) require upgrades.\n\n**Fix**: For each signal, ask: \"Does this change the interface a component depends on?\"\nIf no: Minor or skip. If yes: Important or Critical.\n\n--...",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer/references/upgrade-signal-parsing.md",
+      "line_range": [
+        133,
+        143
+      ],
+      "block_text": "### \u274c Mixing Signal Types in One Manifest\n\n**What it looks like**: A single Change Manifest combining release-note signals, user\ngoal-change statements, and retro signals without flagging their source.\n\n**Why wrong**: Each signal type has different urgency heuristics and different component\nscope. Mixing them without source labels causes the PLAN phase to assign wrong tiers.\n\n**Fix**: Separate into sections by signal type. Label each row with its source.\n\n---\n",
+      "domain_hint": "system-upgrade-engineer"
+    },
+    {
+      "file": "agents/system-upgrade-engineer.md",
+      "line_range": [
+        169,
+        169
+      ],
+      "block_text": "## Anti-Patterns\n",
+      "domain_hint": "system"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/api-doc-anti-patterns.md",
+      "line_range": [
+        1,
+        7
+      ],
+      "block_text": "# API Documentation Anti-Patterns\n\n> **Scope**: Detectable anti-patterns in API documentation \u2014 hallucinated params, untested examples, missing source verification. Does NOT cover style/structure standards (see `documentation-standards.md`).\n> **Version range**: REST APIs, OpenAPI 3.x, curl 7.x+\n> **Generated**: 2026-04-15\n\n---\n",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/api-doc-anti-patterns.md",
+      "line_range": [
+        15,
+        15
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/api-doc-anti-patterns.md",
+      "line_range": [
+        24,
+        40
+      ],
+      "block_text": "# Then verify each one exists in the source\ngrep -rn \"PARAM_NAME\" src/ --include=\"*.go\"\ngrep -rn \"PARAM_NAME\" src/ --include=\"*.py\"\nrg \"PARAM_NAME\" src/\n```\n\n**What it looks like**:\n```markdown\n| user_id  | string | Yes | The user's unique identifier |\n| metadata | object | No  | Optional metadata key-value pairs |\n```\n*(where `metadata` doesn't exist in the route handler)*\n\n**Why wrong**: Integration failures happen silently. The caller sends `metadata`, the API ignores it, and the caller assum...",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/api-doc-anti-patterns.md",
+      "line_range": [
+        60,
+        73
+      ],
+      "block_text": "# Find the actual type in source (Go example)\ngrep -n \"int\\|string\\|bool\\|float\" handlers/*.go | grep \"PARAM_NAME\"\n```\n\n**What it looks like**:\n```markdown\n| page_size | string | No | Number of results per page. Default: 20 |\n```\n*(where the handler actually validates it as `int`)*\n\n**Why wrong**: The caller sends `\"50\"` (string) and gets a 400. Or worse: the API coerces it silently and the caller never learns the real type. Type contracts are part of the API surface.\n\n**Fix**: Read the validati...",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/api-doc-anti-patterns.md",
+      "line_range": [
+        87,
+        103
+      ],
+      "block_text": "# Find placeholder patterns in curl examples\ngrep -n \"YOUR_TOKEN\\|<token>\\|example\\.com\\|placeholder\" docs/**/*.md | grep \"curl\"\nrg \"Authorization: Bearer YOUR_\" --glob \"*.md\"\n```\n\n**What it looks like**:\n```bash\ncurl -X POST https://api.example.com/v1/users \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" \\\n  -d '{\"name\": \"John\", \"role\": \"admin\"}'\n```\n*(where `role` was removed from the API last sprint)*\n\n**Why wrong**: Copy-pasted examples become stale. If `role` was removed and the example still inc...",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/api-doc-anti-patterns.md",
+      "line_range": [
+        131,
+        145
+      ],
+      "block_text": "# Python/Flask\ngrep -rn \"abort(400)\\|abort(401)\\|jsonify.*400\\|make_response.*400\" routes/\n```\n\n**What it looks like**:\n```markdown\n| 418 | Teapot mode enabled | Disable teapot mode in config |\n```\n*(where the handler never returns 418)*\n\n**Why wrong**: Readers write error handling code for 418. That code path is dead. The actual error they get from the API is 400 with an unhelpful message, and they have no documented path to resolution.\n\n**Fix**: Only document error codes that appear in the sou...",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/api-doc-anti-patterns.md",
+      "line_range": [
+        158,
+        177
+      ],
+      "block_text": "# Python/Pydantic\ngrep -n \"FIELD_NAME.*:\" models/resource.py\n```\n\n**What it looks like**:\n```json\n{\n  \"id\": \"res_abc123\",\n  \"name\": \"my-resource\",\n  \"owner\": \"user_xyz\",\n  \"created_at\": \"2025-01-15T10:30:00Z\"\n}\n```\n*(where the API removed `owner` and renamed it `created_by_id` in v2)*\n\n**Why wrong**: Callers write code like `response[\"owner\"]` and get a KeyError or undefined in production. The doc is a lie.\n\n**Fix**: Find the serialization struct/model and use its exact field names. For Go, look...",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/api-doc-anti-patterns.md",
+      "line_range": [
+        183,
+        192
+      ],
+      "block_text": "# Find endpoint headings without nearby \"Authentication\" or \"Bearer\" mentions\ngrep -n \"^### [A-Z]\\{2,6\\} /\" docs/**/*.md | while read line; do\n  lineno=$(echo \"$line\" | cut -d: -f2)\n  # Check if auth documented within 10 lines after endpoint heading\n  sed -n \"$((lineno+1)),$((lineno+10))p\" docs/**/*.md | grep -q \"Auth\\|Bearer\\|token\\|API[- ]key\" || echo \"MISSING AUTH: $line\"\ndone\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/api-doc-anti-patterns.md",
+      "line_range": [
+        193,
+        206
+      ],
+      "block_text": "### GET /api/v1/resources\n\nReturns a list of resources.\n\n**Parameters:**\n| Parameter | Type | Required | Description |\n...\n```\n*(no mention of authentication)*\n\n**Why wrong**: New users hit 401 without any documentation telling them what credential is needed or how to obtain it.\n\n**Fix**: Add authentication immediately after the endpoint description, before parameters:\n```markdown",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/documentation-standards.md",
+      "line_range": [
+        104,
+        104
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/documentation-standards.md",
+      "line_range": [
+        106,
+        128
+      ],
+      "block_text": "### \u274c Vague Parameter Descriptions\n\n**Detection**:\n```bash\ngrep -n \"the [a-z]* to\\|value of\\|represents the\\|specifies the\" docs/**/*.md\nrg \"the \\w+ to use|value of the|this is the\" --glob \"*.md\"\n```\n\n**What it looks like**:\n```markdown\n| config | object | No | The config object to use |\n| data   | string | No | The data value |\n```\n\n**Why wrong**: \"The config object to use\" tells the reader nothing they couldn't infer from the parameter name. It's word-count theater. Readers need to know: what ...",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/documentation-standards.md",
+      "line_range": [
+        130,
+        156
+      ],
+      "block_text": "### \u274c Missing Required/Optional Distinction\n\n**Detection**:\n```bash\ngrep -n \"| Parameter | Type | Description |\" docs/**/*.md\nrg \"\\| Parameter \\| Type \\| Description \\|\" --glob \"*.md\"\n```\n\n**What it looks like**:\n```markdown\n| Parameter | Type | Description |\n|-----------|------|-------------|\n| name      | string | Resource name |\n| config    | object | Configuration |\n```\n\n**Why wrong**: Reader cannot tell which parameters are mandatory without making a failed request. A missing `name` returns...",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/documentation-standards.md",
+      "line_range": [
+        158,
+        176
+      ],
+      "block_text": "### \u274c Prose Error Documentation\n\n**Detection**:\n```bash\ngrep -n \"returns.*400\\|returns.*401\\|returns.*500\\|will return an error\" docs/**/*.md\nrg \"returns? (a )?4\\d\\d|returns? (a )?5\\d\\d\" --glob \"*.md\"\n```\n\n**What it looks like**:\n```markdown\nThe endpoint will return a 400 error if the name is invalid, or a 500 error if there\nis an internal server error. Authentication failures result in a 401.\n```\n\n**Why wrong**: Prose error documentation cannot be scanned. The reader must parse English sentence...",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/documentation-standards.md",
+      "line_range": [
+        178,
+        199
+      ],
+      "block_text": "### \u274c Undated Version Notes\n\n**Detection**:\n```bash\ngrep -n \"changed\\|deprecated\\|removed\\|added in\" docs/**/*.md | grep -v \"v[0-9]\\|[0-9]\\.[0-9]\"\nrg \"(changed|deprecated|removed|added) in\" --glob \"*.md\" | grep -v \"v\\d|\\d\\.\\d\"\n```\n\n**What it looks like**:\n```markdown\n> **Note:** The `legacy_mode` parameter was deprecated in a recent release.\n```\n\n**Why wrong**: \"Recent release\" becomes meaningless after time passes. Readers cannot determine if the deprecation applies to the version they're runni...",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/runbook-patterns.md",
+      "line_range": [
+        145,
+        145
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/runbook-patterns.md",
+      "line_range": [
+        147,
+        156
+      ],
+      "block_text": "### \u274c Vague Symptoms Section\n\n**Detection**:\n```bash\ngrep -n \"may\\|might\\|could\\|possibly\\|sometimes\" runbooks/**/*.md | grep -i \"symptom\\|alert\\|issue\"\nrg \"(may|might|could) (be|indicate|suggest|mean)\" --glob \"runbooks/**/*.md\"\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/runbook-patterns.md",
+      "line_range": [
+        157,
+        165
+      ],
+      "block_text": "## Symptoms\nThe service may be experiencing issues. Performance might degrade under load.\nUsers could see errors.\n```\n\n**Why wrong**: \"May be experiencing issues\" is a description of the alert condition, not the symptom. The oncall engineer is reading this because they got paged \u2014 they already know something is wrong. They need to know what specific signal confirms the diagnosis.\n\n**Fix**:\n```markdown",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/runbook-patterns.md",
+      "line_range": [
+        180,
+        186
+      ],
+      "block_text": "# Lines with fix commands but no adjacent verify command (manual review needed)\n\ngrep -A5 \"^## Fix\\|^## Resolution\" runbooks/**/*.md | grep -c \"verify\\|confirm\\|check\"\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/runbook-patterns.md",
+      "line_range": [
+        187,
+        207
+      ],
+      "block_text": "## Fix\n\nRestart the service:\n```bash\nkubectl rollout restart deploy/checkout -n prod\n```\n```\n*(no verification step after)*\n\n**Why wrong**: The restart command runs but the deployment might fail (OOMKilled, ImagePullError). The oncall engineer thinks they fixed it but the pods are crash-looping. The alert fires again in 2 minutes.\n\n**Fix**:\n```markdown\nRestart the service:\n```bash\nkubectl rollout restart deploy/checkout -n prod\n```\n\nVerify restart succeeded (wait up to 2 minutes):\n```bash\nkubect...",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/runbook-patterns.md",
+      "line_range": [
+        220,
+        230
+      ],
+      "block_text": "### \u274c Escalation Section Without Contact Details\n\n**Detection**:\n```bash\ngrep -n \"escalate\\|contact\\|reach out\\|ask\" runbooks/**/*.md \\\n  | grep -v \"#[a-z]\\|@[a-z]\\|pagerduty\\|phone\\|email\"\nrg \"escalate to (the )?team|contact support\" --glob \"runbooks/**/*.md\"\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/runbook-patterns.md",
+      "line_range": [
+        231,
+        239
+      ],
+      "block_text": "## Escalation\n\nIf the issue persists, escalate to the platform team.\n```\n\n**Why wrong**: \"The platform team\" doesn't exist at 2am \u2014 specific people and channels do. Vague escalation paths cause delay while the oncall engineer asks \"who is the platform team?\"\n\n**Fix**:\n```markdown",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-documentation-engineer/references/runbook-patterns.md",
+      "line_range": [
+        257,
+        267
+      ],
+      "block_text": "# Deploy runbooks without rollback are a gap \u2014 flag manually\ngrep -l \"deploy\\|release\" runbooks/**/*.md \\\n  | xargs grep -L \"rollback\\|undo\\|revert\"\n```\n\n**What it looks like**: A deploy runbook with steps to apply a new version, but no section on what to do if the deploy breaks production.\n\n**Why wrong**: When a deploy causes a P0, the first question is \"how do we roll back?\" A missing rollback section means someone must figure this out under pressure without documentation.\n\n**Fix**: Every depl...",
+      "domain_hint": "technical-documentation-engineer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/article-structure-patterns.md",
+      "line_range": [
+        114,
+        114
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/article-structure-patterns.md",
+      "line_range": [
+        123,
+        128
+      ],
+      "block_text": "# Vague dramatic headers\nrg '^#{1,3} (The Problem|The Solution|Why This Matters|What Comes Next|The Future)$' --type md\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/article-structure-patterns.md",
+      "line_range": [
+        131,
+        137
+      ],
+      "block_text": "### What Happens Next Will Surprise You\n```\n\n**Why wrong**: Clickbait headers delay information by making the reader read the section to find out what it covers. Descriptive headers function as navigation \u2014 the reader scans headers to find relevant sections.\n\n**Fix**:\n```markdown",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/article-structure-patterns.md",
+      "line_range": [
+        154,
+        174
+      ],
+      "block_text": "# Paragraphs starting with transition words without a preceding claim\ngrep -n '^However,\\|^Additionally,\\|^Furthermore,\\|^Also,' article.md\n```\n\n**What it looks like**:\n```\nRollback strategies are an important consideration when thinking about\nmigrations. There are several things to keep in mind when approaching\nthis problem...\n```\n\n**Why wrong**: The first sentence doesn't state what the paragraph covers. \"Important consideration\" is a label, not information. The reader can't tell from the firs...",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/article-structure-patterns.md",
+      "line_range": [
+        181,
+        195
+      ],
+      "block_text": "# Count paragraphs before the first concrete claim sentence\nawk '/^$/{para++} para>=3 && /[0-9]%|[0-9]ms|[A-Z][a-z]+ (changed|failed|broke)/{print NR\": first concrete claim at paragraph \"para; exit}' article.md\n```\n\n**What it looks like**:\n```\n[3 paragraphs of context and background]\n[Paragraph 4: \"The system failed because the lock timeout was 30 seconds.\"]\n```\n\n**Why wrong**: The reader has to read through context to find the information they came for. Technical readers skim; burying the lead ...",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/article-structure-patterns.md",
+      "line_range": [
+        201,
+        206
+      ],
+      "block_text": "# Sections with only one paragraph (possible padding or incomplete treatment)\nawk '/^#{1,3}/{section=$0} /^$/{if(para==1) print \"Single-para section: \"section; para=0} /^[^#]/{para++}' article.md\n```\n\n**What it looks like**:\n```",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/article-structure-patterns.md",
+      "line_range": [
+        211,
+        218
+      ],
+      "block_text": "### What To Do\n```\n\n**Why wrong**: A section with one short paragraph is either padding (can be deleted) or incomplete (the idea wasn't developed). The journalist voice covers each point thoroughly or cuts it.\n\n**Fix**: Either develop the section with specific examples, data, or mechanisms \u2014 or remove the section header and fold the content into an adjacent paragraph.\n\n---\n",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/sourcing-and-claims.md",
+      "line_range": [
+        94,
+        94
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/sourcing-and-claims.md",
+      "line_range": [
+        103,
+        122
+      ],
+      "block_text": "# Numeric comparative claims (\"X times faster\", \"X% improvement\")\nrg '\\b[0-9]+ times (faster|slower|larger|smaller)\\b' article.md\n```\n\n**What it looks like**:\n```\nStudies show that 80% of developers prefer this approach. It's 3x faster\nthan the alternative in most workloads.\n```\n\n**Why wrong**: \"Studies show\" without a specific study is not a source \u2014 it's a rhetorical move. \"3x faster\" without a benchmark methodology is marketing language. Both patterns erode credibility when readers verify the...",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/sourcing-and-claims.md",
+      "line_range": [
+        131,
+        156
+      ],
+      "block_text": "# \"The reason is...\" patterns (often inference stated as fact)\nrg '\\b(the reason (is|was|for)\\b|this is because\\b|this happens because\\b)' article.md -i\n```\n\n**What it looks like**:\n```\nThe reason the system is slow is definitely the database. The query\nalways takes 200ms because of missing indexes.\n```\n\n**Why wrong**: Without profiling data or execution plans, this is inference stated as fact. If the reader checks and the database isn't the bottleneck, the article loses all credibility.\n\n**Fix*...",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/sourcing-and-claims.md",
+      "line_range": [
+        165,
+        184
+      ],
+      "block_text": "# \"When X was released/launched/introduced\" without year\nrg 'when .* (was released|launched|introduced|shipped)' article.md -i | grep -v '\\b(19|20)[0-9][0-9]\\b'\n```\n\n**What it looks like**:\n```\nWhen Kubernetes was first released, the networking model was much simpler.\nOriginally, services used flat networks without namespace isolation.\n```\n\n**Why wrong**: \"When Kubernetes was first released\" is vague \u2014 Kubernetes 1.0 shipped July 2015. Without the date, the reader can't evaluate how much the eco...",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/sourcing-and-claims.md",
+      "line_range": [
+        193,
+        215
+      ],
+      "block_text": "# \"Widely adopted\", \"commonly used\", \"most teams\" \u2014 popularity claims need data\nrg '\\b(widely|commonly|most teams|most developers|industry standard|best practice)\\b' article.md -i\n```\n\n**What it looks like**:\n```\nPostgreSQL is more reliable than MySQL for write-heavy workloads.\nMost teams have moved away from monolithic architectures.\n```\n\n**Why wrong**: \"More reliable\" requires a specific reliability metric and measured workload. \"Most teams\" requires a survey. Without these, the claims are opi...",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/voice-patterns.md",
+      "line_range": [
+        42,
+        42
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/voice-patterns.md",
+      "line_range": [
+        44,
+        70
+      ],
+      "block_text": "### \u274c Enthusiasm Markers\n\n**Detection**:\n```bash\nrg -i '\\b(amazing|incredible|revolutionary|powerful|elegant|game-changing|cutting-edge)\\b' --type md\n```\n\n**What it looks like**:\n```\nThe system is amazing! It elegantly leverages PostgreSQL's powerful MVCC capabilities\nto beautifully solve concurrency without compromising performance.\n```\n\n**Why wrong**: Enthusiasm adjectives make claims that can't be verified. \"Powerful\" compared to what? \"Elegantly\" by whose standard? These words add editoriali...",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/voice-patterns.md",
+      "line_range": [
+        72,
+        95
+      ],
+      "block_text": "### \u274c Persuasive Framing\n\n**Detection**:\n```bash\nrg -i '\\b(you should|you must|you need to|you will want to|trust me|make sure to|I recommend)\\b' --type md\n```\n\n**What it looks like**:\n```\nYou absolutely must write documentation! It's the single most important thing\nyou can do. Trust me, you'll thank yourself later.\n```\n\n**Why wrong**: The journalist voice informs, it doesn't prescribe. \"You must\" assumes authority over the reader's situation \u2014 which the author doesn't have. \"Trust me\" substitut...",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/voice-patterns.md",
+      "line_range": [
+        97,
+        120
+      ],
+      "block_text": "### \u274c Throat-Clearing Openers\n\n**Detection**:\n```bash\nrg -i '^(Have you ever|Did you know|In today|In this article|Welcome to|As we all know)' --type md\nrg '^[A-Z][^.!?]{10,60}\\?$' --type md -m 3  # Rhetorical question openers\n```\n\n**What it looks like**:\n```\nHave you ever wondered about the best way to handle database migrations?\nIt's a fascinating problem that many developers face! Let me share an\nexciting new approach...\n```\n\n**Why wrong**: The first sentence is the highest-value real estate ...",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/voice-patterns.md",
+      "line_range": [
+        122,
+        144
+      ],
+      "block_text": "### \u274c Condescending Explanations\n\n**Detection**:\n```bash\nrg -i \"\\b(as you (probably )?know|don't worry|let me explain|i'll break|for those who don't|in simple terms|step by step)\\b\" --type md\n```\n\n**What it looks like**:\n```\nAs you probably know, JWT stands for JSON Web Token. Don't worry if this\nsounds complicated \u2014 I'll break it down step by step!\n```\n\n**Why wrong**: The knowledgeable reader assumption means this audience knows JWT basics. Explaining them signals the author misjudged the audie...",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/voice-patterns.md",
+      "line_range": [
+        146,
+        167
+      ],
+      "block_text": "### \u274c Vague Abstractions\n\n**Detection**:\n```bash\nrg -i '\\b(appropriate(ly)?|proper(ly)?|correct(ly)?|graceful(ly)?|careful(ly)?|thorough(ly)?)\\b' --type md\n```\n\n**What it looks like**:\n```\nThe API has rate limiting. It returns an error when you make too many requests.\nYou should implement appropriate backoff strategies to handle this gracefully.\n```\n\n**Why wrong**: \"Appropriate\" and \"gracefully\" are placeholders for specific knowledge the author didn't provide. The reader needs the specific beha...",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/voice-patterns.md",
+      "line_range": [
+        176,
+        181
+      ],
+      "block_text": "# Find consecutive numbered items (listicle blocks)\ngrep -n '^[0-9]\\+\\.' article.md | awk -F: 'prev && $1-prev==1{count++} {prev=$1} count>=4{print \"Listicle block at line \"$1; count=0}'\n```\n\n**What it looks like**:\n```",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/technical-journalist-writer/references/voice-patterns.md",
+      "line_range": [
+        182,
+        194
+      ],
+      "block_text": "### Top 5 Reasons Schema Files Failed\n\n1. Synchronization issues across environments\n2. Merge conflicts in large teams\n3. No deployment history\n4. Difficult rollbacks\n5. State drift over time\n```\n\n**Why wrong**: Numbered lists atomize related ideas and hide logical relationships. The journalist voice builds arguments in prose where causation is explicit (\"X caused Y because Z\"), not implied by list adjacency.\n\n**Fix**:\n```",
+      "domain_hint": "technical-journalist-writer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/anti-patterns.md",
+      "line_range": [
+        1,
+        3
+      ],
+      "block_text": "# Testing Automation Anti-Patterns\n\nCommon testing mistakes to avoid with examples.\n",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/async-testing.md",
+      "line_range": [
+        143,
+        143
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/async-testing.md",
+      "line_range": [
+        145,
+        180
+      ],
+      "block_text": "### \u274c setTimeout / sleep Delays in Tests\n\n**Detection**:\n```bash\ngrep -rn 'setTimeout\\|waitForTimeout\\|new Promise.*sleep' --include=\"*.test.ts\" --include=\"*.test.tsx\" --include=\"*.spec.ts\"\nrg 'waitForTimeout|page\\.waitFor\\b' --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: arbitrary delay in RTL\nit('shows result after fetch', async () => {\n  render(<DataLoader />)\n  await new Promise(resolve => setTimeout(resolve, 500))  // hope it loaded\n  expect(screen.getByText(/result/i)).toBeIn...",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/async-testing.md",
+      "line_range": [
+        182,
+        211
+      ],
+      "block_text": "### \u274c Un-awaited userEvent Actions (RTL 14+)\n\n**Detection**:\n```bash\ngrep -rn 'user\\.' --include=\"*.test.ts\" --include=\"*.test.tsx\" | grep -v 'await user\\.\\|const user\\|let user'\nrg 'userEvent\\.(click|type|clear|selectOptions)\\(' --type tsx | grep -v 'await '\n```\n\n**What it looks like**:\n```typescript\n// BAD: missing await on user actions (RTL 14+ requires await)\nconst user = userEvent.setup()\nuser.click(button)         // fire-and-forget\nuser.type(input, 'hello')\nexpect(screen.getByText(/hello/...",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/async-testing.md",
+      "line_range": [
+        213,
+        234
+      ],
+      "block_text": "### \u274c getBy* After Async Operations\n\n**Detection**:\n```bash\nrg 'await user\\.(click|submit|type)' --type ts -A1 | grep 'getBy'\n```\n\n**What it looks like**:\n```typescript\nawait user.click(screen.getByRole('button', { name: /save/i }))\nexpect(screen.getByText(/saved/i)).toBeInTheDocument()  // may not exist yet\n```\n\n**Why wrong**: `user.click` resolves after the event dispatches, not after React re-renders from async work (API calls, state transitions). The `getByText` assertion runs synchronously ...",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/async-testing.md",
+      "line_range": [
+        236,
+        257
+      ],
+      "block_text": "### \u274c MSW Without onUnhandledRequest: 'error'\n\n**Detection**:\n```bash\ngrep -rn 'server\\.listen' --include=\"*.ts\" --include=\"*.tsx\" | grep -v 'onUnhandledRequest'\nrg 'setupServer' --type ts -l | xargs rg -L 'onUnhandledRequest'\n```\n\n**What it looks like**:\n```typescript\nserver.listen()  // no onUnhandledRequest \u2014 silent network failures\n```\n\n**Why wrong**: When a component makes an unexpected API call (wrong path, URL typo), MSW passes it through or returns undefined without failing the test. The...",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/mocking-patterns.md",
+      "line_range": [
+        127,
+        127
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/mocking-patterns.md",
+      "line_range": [
+        133,
+        163
+      ],
+      "block_text": "# vi.mock calls targeting src/ (internal modules)\ngrep -rn \"vi\\.mock('\\.\\.\" --include=\"*.test.ts\" --include=\"*.test.tsx\" | grep \"src/\"\nrg \"vi\\.mock\\('\\./|vi\\.mock\\('\\.\\.\" --type ts | grep -v \"node_modules\\|__mocks__\"\n```\n\n**What it looks like**:\n```typescript\n// BAD: mocking internal business logic\nvi.mock('../services/orderCalculator')\nvi.mock('../utils/priceFormatter')\nvi.mock('../hooks/useCart')\n\nit('displays total', () => {\n  (calculateTotal as Mock).mockReturnValue(99.99)\n  render(<OrderSum...",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/mocking-patterns.md",
+      "line_range": [
+        169,
+        200
+      ],
+      "block_text": "# vi.mock on node_modules (not starting with ./ or ../)\ngrep -rn \"vi\\.mock('\" --include=\"*.test.ts\" | grep -v \"vi\\.mock('\\.\" | grep -v \"msw\\|vitest\\|node:\"\nrg \"vi\\.mock\\('(?!\\.)\" --type ts | grep -v msw\n```\n\n**What it looks like**:\n```typescript\n// BAD: mocking React Router internals\nvi.mock('react-router-dom', () => ({\n  useNavigate: () => vi.fn(),\n  useParams: () => ({ id: '1' }),\n}))\n```\n\n**Why wrong**: When `react-router-dom` updates its API, the mock silently diverges. The test passes but t...",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/mocking-patterns.md",
+      "line_range": [
+        206,
+        237
+      ],
+      "block_text": "# Test files with toHaveBeenCalledWith but no toBeInTheDocument/toBe\nrg 'toHaveBeenCalledWith' --type ts -l | xargs rg -L 'toBeInTheDocument\\|toBe\\b\\|toEqual'\ngrep -rn 'expect.*toHaveBeenCalled' --include=\"*.test.ts\" | wc -l\n```\n\n**What it looks like**:\n```typescript\n// BAD: asserting implementation, not behavior\nit('saves user preferences', async () => {\n  const saveSpy = vi.spyOn(userService, 'savePreferences')\n  await user.click(screen.getByRole('button', { name: /save/i }))\n  expect(saveSpy)...",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/mocking-patterns.md",
+      "line_range": [
+        239,
+        268
+      ],
+      "block_text": "### \u274c Mocking console.error to Suppress All Warnings\n\n**Detection**:\n```bash\ngrep -rn 'spyOn.*console.*error\\|mock.*console\\.error' --include=\"*.test.ts\" --include=\"*.test.tsx\"\nrg 'console\\.error.*mockImplementation\\(\\s*\\)' --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: blanket suppression hides real problems\nbeforeAll(() => {\n  vi.spyOn(console, 'error').mockImplementation(() => {})\n})\n```\n\n**Why wrong**: This suppresses all React prop-type warnings, act() warnings, and real error...",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/vitest-patterns.md",
+      "line_range": [
+        135,
+        135
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/vitest-patterns.md",
+      "line_range": [
+        137,
+        165
+      ],
+      "block_text": "### \u274c Using jest.mock() or jest.fn() in Vitest files\n\n**Detection**:\n```bash\ngrep -rn 'jest\\.mock\\|jest\\.fn\\|jest\\.spyOn' --include=\"*.test.ts\" --include=\"*.test.tsx\" --include=\"*.spec.ts\"\nrg 'jest\\.(mock|fn|spyOn|clearAllMocks|resetAllMocks)' --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: jest.fn() is undefined in Vitest\nconst mockFn = jest.fn()\njest.mock('../utils')\njest.spyOn(console, 'error')\n```\n\n**Why wrong**: Vitest does not polyfill the `jest` global by default. These calls...",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/vitest-patterns.md",
+      "line_range": [
+        167,
+        198
+      ],
+      "block_text": "### \u274c Missing vi.restoreAllMocks() \u2014 Spy Leak Between Tests\n\n**Detection**:\n```bash\ngrep -rn 'vi\\.spyOn' --include=\"*.test.ts\" --include=\"*.test.tsx\" -l | xargs grep -L 'restoreAllMocks\\|resetAllMocks'\nrg 'vi\\.spyOn' --type ts -l | xargs rg -l 'restoreAllMocks' --files-without-match\n```\n\n**What it looks like**:\n```typescript\ndescribe('Suite A', () => {\n  it('mocks fetch', () => {\n    vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))\n    // NO afterEach/vi.restoreAllMocks()\n  })\n})\n...",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/testing-automation-engineer/references/vitest-patterns.md",
+      "line_range": [
+        200,
+        223
+      ],
+      "block_text": "### \u274c No Branch Coverage Threshold\n\n**Detection**:\n```bash\ngrep -rn 'thresholds' vitest.config.ts vitest.config.js\nrg 'thresholds' vitest.config.ts | grep -v branches\n```\n\n**What it looks like**:\n```typescript\ncoverage: {\n  thresholds: {\n    lines: 80,\n    functions: 80,\n    // branches MISSING \u2014 silently passes with 0% branch coverage\n  }\n}\n```\n\n**Why wrong**: A function with `if (user.isAdmin)` tested only with admin users shows 100% line coverage but 0% branch coverage. The non-admin code pat...",
+      "domain_hint": "testing-automation-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/adr-lifecycle.md",
+      "line_range": [
+        118,
+        118
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/adr-lifecycle.md",
+      "line_range": [
+        127,
+        132
+      ],
+      "block_text": "# Find Implemented ADRs missing Validation Criteria section\ngrep -rn \"Implemented\" adr/*.md | cut -d: -f1 | sort -u | xargs grep -L \"Validation Criteria\"\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/adr-lifecycle.md",
+      "line_range": [
+        135,
+        142
+      ],
+      "block_text": "# (no Accepted state, no Validation Criteria section)\n```\n\n**Why wrong**: Skipping `Accepted` means the decision was never formally reviewed and alternatives were never documented. `Implemented` status becomes meaningless \u2014 it cannot be distinguished from \"I started writing code\" versus \"all criteria verified.\"\n\n**Fix**: Add an `Accepted` block with alternatives and validation criteria, then re-evaluate whether `Implemented` is truly warranted.\n\n---\n",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/adr-lifecycle.md",
+      "line_range": [
+        148,
+        167
+      ],
+      "block_text": "# Gaps in ADR numbering indicate deletions\npython3 -c \"\nimport glob, re, os\nnums = []\nfor f in glob.glob('adr/*.md'):\n    m = re.search(r'(\\d+)-', os.path.basename(f))\n    if m: nums.append(int(m.group(1)))\nnums.sort()\nif nums:\n    gaps = [i for i in range(nums[0], nums[-1]+1) if i not in nums]\n    if gaps: print('GAPS (possible deletions):', gaps)\n    else: print('No numbering gaps found')\n\"\n```\n\n**Why wrong**: Deleting an ADR erases the decision history. Future contributors cannot tell whether...",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/adr-lifecycle.md",
+      "line_range": [
+        176,
+        181
+      ],
+      "block_text": "# Alternative: find Proposed/Accepted/Implemented lines missing date pattern\ngrep -rn \"^Proposed\\|^Accepted\\|^Implemented\\|^Superseded\\|^Rejected\" adr/*.md | grep -v \" \u2014 20[0-9][0-9]-\"\n```\n\n**What it looks like**:\n```markdown",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/adr-lifecycle.md",
+      "line_range": [
+        182,
+        190
+      ],
+      "block_text": "## Status\nImplemented\n```\n\n**Why wrong**: `scripts/adr-status.py` parses the date from the status line to compute age and detect stale proposals. Missing dates silently break age-based reporting and make the audit trail unreliable.\n\n**Fix**: Always append ` \u2014 YYYY-MM-DD` to every status line.\n\n---\n",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/adr-lifecycle.md",
+      "line_range": [
+        192,
+        198
+      ],
+      "block_text": "### \u274c Validation Criteria Written After Marking Implemented\n\n**What it looks like**:\nCriteria written in future tense (\"will verify\", \"should check\") or added to the ADR after the `Implemented` date stamp.\n\n**Detection**:\n```bash",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/adr-lifecycle.md",
+      "line_range": [
+        199,
+        207
+      ],
+      "block_text": "# Find criteria using future tense (indicative of post-hoc writing)\ngrep -rn \"will verify\\|should check\\|to be verified\\|TBD\" adr/*.md\n```\n\n**Why wrong**: Validation criteria written after the fact are retroactive justifications, not pre-agreed standards. They cannot prove the implementation met a standard that didn't exist when work was done.\n\n**Fix**: Write criteria in present tense as checkboxes during the `Accepted` phase. Mark each criterion complete only when verified during implementation...",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/frontmatter-compliance.md",
+      "line_range": [
+        93,
+        93
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/frontmatter-compliance.md",
+      "line_range": [
+        95,
+        112
+      ],
+      "block_text": "### \u274c Missing `allowed-tools` in Agent Frontmatter\n\n**Detection**:\n```bash\ngrep -rL \"allowed-tools\" agents/*.md\nrg -L 'allowed-tools' --glob 'agents/*.md'\n```\n\n**What it looks like**:\n```yaml\n---\nname: my-agent\nmodel: sonnet\ndescription: \"Does something\"\nrouting:\n  triggers: [do thing]\n  complexity: Medium\n  category: engineering",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/frontmatter-compliance.md",
+      "line_range": [
+        113,
+        121
+      ],
+      "block_text": "# allowed-tools: missing entirely\n---\n```\n\n**Why wrong**: Without `allowed-tools`, the agent inherits an undefined tool set. Behavior varies by runtime \u2014 some runtimes grant all tools (dangerous), others grant none (agent cannot function).\n\n**Fix**: Add `allowed-tools` matching the agent's role type per the Tool Restrictions table above.\n\n---\n",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/frontmatter-compliance.md",
+      "line_range": [
+        123,
+        143
+      ],
+      "block_text": "### \u274c Unquoted Description with Colon\n\n**Detection**:\n```bash\ngrep -n \"^description: [^\\\"'].*:\" agents/*.md\ngrep -n \"^description: [^\\\"'].*:\" skills/*/SKILL.md\n```\n\n**What it looks like**:\n```yaml\ndescription: Toolkit governance: edit skills, update routing  # YAML parse error\n```\n\n**Why wrong**: The YAML parser sees `Toolkit governance` as the value and `edit skills` as an unknown key, producing a parse error. The component becomes invisible to the routing system.\n\n**Fix**:\n```yaml\ndescription:...",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/frontmatter-compliance.md",
+      "line_range": [
+        145,
+        163
+      ],
+      "block_text": "### \u274c Wrong Complexity Casing\n\n**Detection**:\n```bash\ngrep -rn \"complexity:\" agents/*.md skills/*/SKILL.md | grep -vE \"complexity: (Low|Medium|High)\"\n```\n\n**What it looks like**:\n```yaml\nrouting:\n  complexity: moderate  # wrong casing\n  complexity: medium    # wrong casing \u2014 must be capitalized\n```\n\n**Why wrong**: Complexity matching is case-sensitive. `medium` does not match `Medium` \u2014 the router silently assigns a default.\n\n**Fix**: Use exactly `Low`, `Medium`, or `High`.\n\n---\n",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/frontmatter-compliance.md",
+      "line_range": [
+        165,
+        185
+      ],
+      "block_text": "### \u274c Reviewer Agent with Write/Edit Tools (ADR-063 Violation)\n\n**Detection**:\n```bash\ngrep -l \"reviewer\" agents/*.md | xargs grep -l \"Edit\\|Write\"\n```\n\n**What it looks like**:\n```yaml\nname: reviewer-code-quality\nallowed-tools:\n  - Read\n  - Edit    # violation: reviewers should not modify files\n  - Grep\n```\n\n**Why wrong**: Reviewer agents with write access can modify files during review passes, creating unintended side-effects. ADR-063 requires reviewers to be read-only.\n\n**Fix**: Remove `Edit` ...",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/frontmatter-compliance.md",
+      "line_range": [
+        187,
+        202
+      ],
+      "block_text": "### \u274c Pre-Production Version on Stable Agent\n\n**Detection**:\n```bash\ngrep -rn \"^version: 0\\.\" agents/*.md\n```\n\n**What it looks like**:\n```yaml\n```\n\n**Why wrong**: Agents in active production use should be at `1.x.x` or higher. `0.x.x` affects coverage reporting confidence scores.\n\n**Fix**: Bump to `version: 1.0.0` once the agent is in stable use.\n\n---\n",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/hook-standardization.md",
+      "line_range": [
+        164,
+        164
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/hook-standardization.md",
+      "line_range": [
+        170,
+        195
+      ],
+      "block_text": "# Find hooks registered without timeout field\npython3 -c \"\nimport json\nsettings = json.load(open('$HOME/.claude/settings.json'))\nfor event, groups in settings.get('hooks', {}).items():\n    for group in groups:\n        for hook in group.get('hooks', []):\n            if 'timeout' not in hook:\n                print(f'NO TIMEOUT: [{event}] {hook.get(\\\"description\\\", hook.get(\\\"command\\\", \\\"?\\\"))}')\n\"\n```\n\n**What it looks like**:\n```json\n{\n  \"type\": \"command\",\n  \"command\": \"python3 \\\"$HOME/.claude/ho...",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/hook-standardization.md",
+      "line_range": [
+        197,
+        205
+      ],
+      "block_text": "### \u274c Using `sys.stdin.isatty()` to Detect Session Type\n\n**Detection**:\n```bash\ngrep -rn \"stdin.isatty\\|stdout.isatty\" ~/.claude/hooks/*.py\n```\n\n**What it looks like**:\n```python",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/hook-standardization.md",
+      "line_range": [
+        206,
+        223
+      ],
+      "block_text": "# In a hook \u2014 WRONG\nif sys.stdin.isatty():\n    print(\"Interactive session\")\nelse:\n    print(\"Non-interactive \u2014 activating AFK mode\")\n```\n\n**Why wrong**: Claude Code pipes stdin (the event JSON) into hooks and captures stdout (the hook output). Both are always non-TTY in hook context, so `isatty()` always returns False \u2014 every session is classified as non-interactive regardless of actual session type.\n\n**Fix**: Detect session type via environment variables instead.\n```python\nimport os\nis_ssh = bo...",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/hook-standardization.md",
+      "line_range": [
+        229,
+        253
+      ],
+      "block_text": "# Find hooks that call sys.exit with non-zero values\ngrep -rn \"sys.exit([^0)]\" ~/.claude/hooks/*.py\ngrep -rn \"exit(1\\|exit(2\\|exit(-\" ~/.claude/hooks/*.py\n```\n\n**What it looks like**:\n```python\ndef main():\n    if not validate_something():\n        print(\"Validation failed\")\n        sys.exit(1)  # WRONG for advisory hook\n```\n\n**Why wrong**: Exit code 1 signals Claude to block and surface the error to the user. For advisory hooks (lint hints, context injection, learning), this is almost always wron...",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/hook-standardization.md",
+      "line_range": [
+        259,
+        279
+      ],
+      "block_text": "# Check that all registered hook commands reference files that exist\npython3 -c \"\nimport json, os, re\nsettings = json.load(open(os.path.expanduser('~/.claude/settings.json')))\nfor event, groups in settings.get('hooks', {}).items():\n    for group in groups:\n        for hook in group.get('hooks', []):\n            cmd = hook.get('command', '')\n            m = re.search(r'[\\\"\\047]([^\\\"\\047]+\\.py)[\\\"\\047]', cmd)\n            if m:\n                path = os.path.expandvars(m.group(1))\n                i...",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/hook-standardization.md",
+      "line_range": [
+        323,
+        324
+      ],
+      "block_text": "# Find hook files using isatty (TTY detection anti-pattern)\ngrep -rn \"isatty\" ~/.claude/hooks/*.py\n",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/routing-table-patterns.md",
+      "line_range": [
+        121,
+        121
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/routing-table-patterns.md",
+      "line_range": [
+        142,
+        158
+      ],
+      "block_text": "# Quick grep for a specific missing component\ngrep -rn \"pairs_with\" agents/*.md | grep \"deleted-agent-name\"\n```\n\n**What it looks like**:\n```yaml\nrouting:\n  pairs_with:\n    - old-reviewer-agent    # renamed or deleted 3 months ago\n    - legacy-skill-name     # skill was removed in a cleanup\n```\n\n**Why wrong**: The router follows `pairs_with` hints when orchestrating multi-agent workflows. A phantom entry either causes a lookup failure or triggers a fallback to a generic agent, breaking the intend...",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/routing-table-patterns.md",
+      "line_range": [
+        164,
+        192
+      ],
+      "block_text": "# Find duplicate trigger phrases across all agents\npython3 -c \"\nimport yaml, glob\nfrom collections import defaultdict\ntriggers = defaultdict(list)\nfor f in glob.glob('agents/*.md'):\n    txt = open(f).read()\n    if '---' not in txt: continue\n    try:\n        fm = yaml.safe_load(txt.split('---')[1])\n        for t in fm.get('routing', {}).get('triggers', []):\n            triggers[t.lower()].append(f)\n    except: pass\nfor t, files in triggers.items():\n    if len(files) > 1:\n        print(f'CONFLICT:...",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/routing-table-patterns.md",
+      "line_range": [
+        203,
+        219
+      ],
+      "block_text": "# List agents on disk but not in index\npython3 -c \"\nimport json, glob, os\nidx = json.load(open('agents/INDEX.json'))\nregistered = {a['name'] for a in idx.get('agents', [])}\nfor f in glob.glob('agents/*.md'):\n    name = os.path.basename(f).replace('.md','')\n    if name not in registered and name != 'README':\n        print(f'UNREGISTERED: {name}')\n\"\n```\n\n**Why wrong**: An unregistered component exists on disk but is invisible to the routing system. It can never be selected, even if its triggers pe...",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/toolkit-governance-engineer/references/routing-table-patterns.md",
+      "line_range": [
+        225,
+        245
+      ],
+      "block_text": "# Find pairs_with that reference the agent itself\npython3 -c \"\nimport yaml, glob, os\nfor f in glob.glob('agents/*.md'):\n    name = os.path.basename(f).replace('.md','')\n    txt = open(f).read()\n    if '---' not in txt: continue\n    try:\n        fm = yaml.safe_load(txt.split('---')[1])\n        pairs = fm.get('routing', {}).get('pairs_with', [])\n        if name in pairs:\n            print(f'CIRCULAR: {name} pairs_with itself')\n    except: pass\n\"\n```\n\n**Why wrong**: An agent that lists itself in `p...",
+      "domain_hint": "toolkit-governance-engineer"
+    },
+    {
+      "file": "agents/typescript-frontend-engineer/references/typescript-anti-patterns.md",
+      "line_range": [
+        1,
+        3
+      ],
+      "block_text": "# TypeScript Frontend Anti-Patterns\n\nCommon mistakes and their corrections for TypeScript frontend development.\n",
+      "domain_hint": "typescript-frontend-engineer"
+    },
+    {
+      "file": "agents/ui-design-engineer/references/animation-patterns.md",
+      "line_range": [
+        118,
+        118
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "ui-design-engineer"
+    },
+    {
+      "file": "agents/ui-design-engineer/references/animation-patterns.md",
+      "line_range": [
+        128,
+        177
+      ],
+      "block_text": "# Check for CSS @media prefers-reduced-motion\ngrep -rn \"prefers-reduced-motion\" --include=\"*.css\"\n```\n\n**What it looks like**:\n```tsx\n// WRONG: No check for user preference\n<motion.div\n  initial={{ opacity: 0, y: 40 }}\n  animate={{ opacity: 1, y: 0 }}\n  transition={{ duration: 0.6 }}\n>\n```\n```css\n/* WRONG: No reduced-motion override */\n.card {\n  transition: transform 0.3s ease, box-shadow 0.3s ease;\n}\n.card:hover {\n  transform: translateY(-4px);\n}\n```\n\n**Why wrong**: Users with vestibular disord...",
+      "domain_hint": "ui-design-engineer"
+    },
+    {
+      "file": "agents/ui-design-engineer/references/animation-patterns.md",
+      "line_range": [
+        185,
+        225
+      ],
+      "block_text": "# If exit prop exists but no AnimatePresence in the same file, that's the bug\ngrep -rn \"exit={{\" --include=\"*.tsx\" | xargs grep -L \"AnimatePresence\"\n```\n\n**What it looks like**:\n```tsx\n// WRONG: exit prop present but AnimatePresence is absent \u2014 exit never runs\n{isOpen && (\n  <motion.div\n    initial={{ opacity: 0 }}\n    animate={{ opacity: 1 }}\n    exit={{ opacity: 0 }}  // silently ignored\n  >\n    Modal content\n  </motion.div>\n)}\n```\n\n**Why wrong**: React unmounts the component synchronously whe...",
+      "domain_hint": "ui-design-engineer"
+    },
+    {
+      "file": "agents/ui-design-engineer/references/animation-patterns.md",
+      "line_range": [
+        233,
+        279
+      ],
+      "block_text": "# Or with rg\nrg \"motion\\.\" --type tsx -c | awk -F: '$2 > 6'\n```\n\n**What it looks like**:\n```tsx\n// WRONG: Every element has entrance animation \u2014 hierarchy collapses into noise\n<motion.nav initial={{ y: -20 }} animate={{ y: 0 }}>\n  <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>\n    <motion.ul initial={{ x: -10 }} animate={{ x: 0 }}>\n      {items.map(item => (\n        <motion.li key={item.id} whileHover={{ scale: 1.05 }}>\n          <motion.span initial={{ opacity: 0 }} animate={{ o...",
+      "domain_hint": "ui-design-engineer"
+    },
+    {
+      "file": "agents/ui-design-engineer/references/animation-patterns.md",
+      "line_range": [
+        285,
+        311
+      ],
+      "block_text": "# Find whileHover on non-interactive elements (div, span, p)\ngrep -rn \"whileHover\" --include=\"*.tsx\" | grep \"motion\\.div\\|motion\\.span\\|motion\\.p\"\n```\n\n**What it looks like**:\n```tsx\n// WRONG: hover animation on non-interactive element confuses keyboard users\n<motion.div whileHover={{ scale: 1.02 }} className=\"card\">\n  {content}\n</motion.div>\n```\n\n**Why wrong**: `whileHover` triggers on CSS `:hover`, not on keyboard focus. A card with hover animation but no `tabIndex` and no focus animation is i...",
+      "domain_hint": "ui-design-engineer"
+    },
+    {
+      "file": "agents/ui-design-engineer/references/tailwind-anti-patterns.md",
+      "line_range": [
+        1,
+        10
+      ],
+      "block_text": "# Tailwind CSS Anti-Patterns Reference\n<!-- Loaded by ui-design-engineer when task involves Tailwind configuration, class composition, theme customization, or build-time CSS issues -->\n\n> **Scope**: Tailwind-specific pitfalls that cause style breakage, build bloat, or maintenance debt. Does not cover general CSS anti-patterns.\n> **Version range**: Tailwind CSS v3.0+\n> **Generated**: 2026-04-15 \u2014 verify against current Tailwind v3/v4 release notes\n\nTailwind's utility-first model creates a specifi...",
+      "domain_hint": "ui-design-engineer"
+    },
+    {
+      "file": "agents/ui-design-engineer/references/tailwind-anti-patterns.md",
+      "line_range": [
+        12,
+        12
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "ui-design-engineer"
+    },
+    {
+      "file": "agents/ui-design-engineer/references/tailwind-anti-patterns.md",
+      "line_range": [
+        18,
+        55
+      ],
+      "block_text": "# Find string-concatenated Tailwind classes\ngrep -rn \"text-\\${\" --include=\"*.tsx\" --include=\"*.ts\" --include=\"*.jsx\"\ngrep -rn \"\\`bg-\\${\" --include=\"*.tsx\" --include=\"*.jsx\"\nrg 'className=\\{.*\\$\\{.*\\}' --type tsx\n```\n\n**What it looks like**:\n```tsx\n// WRONG: Tailwind cannot statically detect these classes at build time\nconst color = 'red'\n<div className={`text-${color}-500`}>Error</div>\n\n// Also wrong: computed key lookups\nconst variantClasses = { primary: 'blue', danger: 'red' }\n<button classNam...",
+      "domain_hint": "ui-design-engineer"
+    },
+    {
+      "file": "agents/ui-design-engineer/references/tailwind-anti-patterns.md",
+      "line_range": [
+        62,
+        97
+      ],
+      "block_text": "# Count @apply lines per file \u2014 flag files with >8 occurrences\ngrep -c \"@apply\" src/**/*.css 2>/dev/null | awk -F: '$2 > 8 {print $1\": \"$2\" @apply lines\"}'\n```\n\n**What it looks like**:\n```css\n/* WRONG: Recreating component abstractions in CSS using @apply */\n.card {\n  @apply bg-white rounded-lg shadow-md p-6 border border-gray-200\n         hover:shadow-lg transition-shadow duration-200\n         dark:bg-gray-800 dark:border-gray-700;\n}\n```\n\n**Why wrong**: `@apply` re-couples design to CSS files, ...",
+      "domain_hint": "ui-design-engineer"
+    },
+    {
+      "file": "agents/ui-design-engineer/references/tailwind-anti-patterns.md",
+      "line_range": [
+        105,
+        137
+      ],
+      "block_text": "# Lines with larger breakpoint before smaller on the same property\nrg 'lg:\\S+\\s+sm:\\S+' --type tsx\n```\n\n**What it looks like**:\n```tsx\n// WRONG: Starting with desktop size, patching down to mobile\n<h1 className=\"text-4xl sm:text-2xl md:text-xl\">\n  {/* mobile gets text-4xl (the bare class), sm gets text-2xl \u2014 opposite of intent */}\n</h1>\n\n// Also wrong: bare class after responsive prefix (bare always applies at all widths)\n<div className=\"sm:flex block\">\n  {/* block applies at ALL widths, sm:flex...",
+      "domain_hint": "ui-design-engineer"
+    },
+    {
+      "file": "agents/ui-design-engineer/references/tailwind-anti-patterns.md",
+      "line_range": [
+        145,
+        183
+      ],
+      "block_text": "# Find arbitrary px values (except standard touch target sizes)\ngrep -rn \"\\[[0-9]\\+px\\]\" --include=\"*.tsx\" | grep -v \"44px\\|48px\"\n```\n\n**What it looks like**:\n```tsx\n// WRONG: Brand color repeated as arbitrary value across multiple files\n<header className=\"bg-[#1a237e]\">\n<button className=\"bg-[#1a237e] hover:bg-[#283593]\">\n<div className=\"border-[#1a237e]\">\n```\n\n**Why wrong**: Arbitrary values scatter magic numbers across files. A brand color change requires finding every `[#1a237e]` instance. T...",
+      "domain_hint": "ui-design-engineer"
+    }
+  ]
+}

--- a/artifacts/joy-check-sweep-backlog.json
+++ b/artifacts/joy-check-sweep-backlog.json
@@ -1,5 +1,5 @@
 {
-  "total": 932,
+  "total": 950,
   "findings": [
     {
       "file": "skills/explanation-traces/SKILL.md",
@@ -3168,6 +3168,168 @@
       ],
       "block_text": "# Find direct state file manipulation (bypass anti-pattern)\nrg '\\.feature/state.*\\.json' . --type py\n",
       "domain_hint": "feature-lifecycle"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        1,
+        7
+      ],
+      "block_text": "# Fish Shell Anti-Patterns\n\n> **Scope**: Common fish shell configuration mistakes that cause silent failures, broken environments, or scripts that work interactively but fail in CI/cron. Does not cover fish scripting logic errors unrelated to configuration.\n> **Version range**: Fish 3.0+ (Fish 4.0 Rust rewrite has identical syntax)\n> **Generated**: 2026-04-17\n\n---\n",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        15,
+        15
+      ],
+      "block_text": "## Anti-Pattern Catalog\n",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        17,
+        26
+      ],
+      "block_text": "### \u274c Bash-Style Variable Assignment\n\n**Detection**:\n```bash\ngrep -rn '^[A-Z_]*=[^=]' --include=\"*.fish\" ~/.config/fish/\nrg '^\\s*[A-Z_a-z]+=[^=]' --type-add 'fish:*.fish' --type fish ~/.config/fish/\n```\n\n**What it looks like**:\n```fish",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        27,
+        42
+      ],
+      "block_text": "# WRONG \u2014 syntax error in Fish\nGOPATH=~/go\nMY_VAR=hello\n```\n\n**Why wrong**: `VAR=value` is a syntax error in Fish (not silently ignored). Fish rejects it at parse time, causing the entire conf.d file to fail to load \u2014 all subsequent lines in that file are skipped.\n\n**Fix**:\n```fish\nset -gx GOPATH ~/go\nset -g MY_VAR hello\n```\n\n**Version note**: No version where this worked. Fish has never supported `VAR=value` assignment syntax.\n\n---\n",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        44,
+        53
+      ],
+      "block_text": "### \u274c `export VAR=value` (Bash Export Syntax)\n\n**Detection**:\n```bash\ngrep -rn 'export ' --include=\"*.fish\" ~/.config/fish/\nrg 'export \\w+=' --type-add 'fish:*.fish' --type fish ~/.config/fish/\n```\n\n**What it looks like**:\n```fish",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        54,
+        67
+      ],
+      "block_text": "# WRONG \u2014 syntax error in Fish\nexport PATH=\"$PATH:~/.local/bin\"\nexport EDITOR=nvim\n```\n\n**Why wrong**: `export` is not a Fish builtin for variable assignment. The syntax `export VAR=value` is a parse error. Even `export EDITOR nvim` (space-separated) calls the external `export` binary, sets nothing in Fish scope, and is immediately discarded.\n\n**Fix**:\n```fish\nfish_add_path ~/.local/bin\nset -gx EDITOR nvim\n```\n\n---\n",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        69,
+        78
+      ],
+      "block_text": "### \u274c Colon-Separated PATH Manipulation\n\n**Detection**:\n```bash\ngrep -rn 'PATH.*:.*PATH\\|\"\\$PATH:' --include=\"*.fish\" ~/.config/fish/\nrg 'set.*PATH.*\"\\$PATH:' --type-add 'fish:*.fish' --type fish ~/.config/fish/\n```\n\n**What it looks like**:\n```fish",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        79,
+        93
+      ],
+      "block_text": "# WRONG \u2014 creates a single malformed string element\nset -gx PATH \"$PATH:$HOME/.local/bin\"\nset -gx PATH \"$HOME/.local/bin:$PATH\"\n```\n\n**Why wrong**: Fish PATH is a list variable. Each element is a separate string. String-concatenating with colons creates a single element containing the literal colon \u2014 e.g., `\"/home/user/.local/bin:/usr/bin\"` becomes one list entry, not two PATH components. Commands in the new directory become unfindable.\n\n**Fix**:\n```fish\nfish_add_path ~/.local/bin        # Prepe...",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        95,
+        104
+      ],
+      "block_text": "### \u274c Unguarded Abbreviations in conf.d/\n\n**Detection**:\n```bash\ngrep -rn '^abbr ' --include=\"*.fish\" ~/.config/fish/conf.d/\nrg '^abbr ' --type-add 'fish:*.fish' --type fish ~/.config/fish/conf.d/\n```\n\n**What it looks like**:\n```fish",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        105,
+        113
+      ],
+      "block_text": "# ~/.config/fish/conf.d/20-abbreviations.fish \u2014 WRONG\nabbr -a g git\nabbr -a gst \"git status\"\n```\n\n**Why wrong**: Abbreviations are interactive-only. When Fish sources `conf.d/` in non-interactive mode (scripts, CI, cron, `fish -c \"...\"`), `abbr -a` emits a warning and is a no-op. More critically, they never expand in scripts regardless \u2014 so logic depending on abbreviation expansion in `.fish` scripts will silently fail.\n\n**Fix**:\n```fish",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        124,
+        133
+      ],
+      "block_text": "### \u274c Bash Double-Bracket Conditionals\n\n**Detection**:\n```bash\ngrep -rn '\\[\\[' --include=\"*.fish\" ~/.config/fish/\ngrep -rn 'if \\[' --include=\"*.fish\" ~/.config/fish/\n```\n\n**What it looks like**:\n```fish",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        134,
+        157
+      ],
+      "block_text": "# WRONG \u2014 syntax error in Fish\nif [[ -f ~/.config/fish/local.fish ]]\n    source ~/.config/fish/local.fish\nend\n\nif [ -z \"$TMUX\" ]\n    echo \"not in tmux\"\nend\n```\n\n**Why wrong**: `[[` is not recognized by Fish \u2014 it is a Bash/Zsh construct and causes a parse error. `[ ]` calls the external `/bin/[` binary which has slightly different behavior from the Fish `test` builtin and incurs a fork/exec overhead.\n\n**Fix**:\n```fish\nif test -f ~/.config/fish/local.fish\n    source ~/.config/fish/local.fish\nend\n\n...",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        163,
+        171
+      ],
+      "block_text": "# Bash: find functions/ files where function name doesn't match filename\nfor f in ~/.config/fish/functions/*.fish; do\n    name=$(basename \"$f\" .fish)\n    grep -qL \"function $name\" \"$f\" && echo \"MISMATCH: $f\"\ndone\n```\n\n**What it looks like**:\n```",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        172,
+        182
+      ],
+      "block_text": "# File: ~/.config/fish/functions/mkcd.fish\nfunction make_directory_and_cd    # WRONG \u2014 name doesn't match file\n    mkdir -p $argv[1]\n    and cd $argv[1]\nend\n```\n\n**Why wrong**: Fish autoloads functions by filename. When `mkcd` is called, Fish looks for `~/.config/fish/functions/mkcd.fish`. If that file exists but defines `function make_directory_and_cd`, calling `mkcd` fails with \"Unknown command: mkcd\". The file loads but the desired name never registers.\n\n**Fix**:\n```fish",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        192,
+        201
+      ],
+      "block_text": "### \u274c Tool Integration Without Availability Guard\n\n**Detection**:\n```bash\ngrep -rn 'init fish | source\\|hook fish | source' --include=\"*.fish\" ~/.config/fish/conf.d/\nrg '(starship|direnv|fnm|zoxide|mise|pyenv) (init|hook)' --type-add 'fish:*.fish' --type fish ~/.config/fish/conf.d/\n```\n\n**What it looks like**:\n```fish",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        202,
+        225
+      ],
+      "block_text": "# WRONG \u2014 breaks on machines where tool is not installed\nstarship init fish | source\ndirenv hook fish | source\nfnm env --use-on-cd | source\n```\n\n**Why wrong**: If the tool is not installed, the command fails with \"command not found: starship\". This error may stop further `conf.d/` processing, producing error output for every new shell opened on machines without that tool.\n\n**Fix**:\n```fish\nif type -q starship\n    starship init fish | source\nend\n\nif type -q direnv\n    direnv hook fish | source\nen...",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        227,
+        236
+      ],
+      "block_text": "### \u274c Using `set -U` (Universal) in conf.d/ for Tool Paths\n\n**Detection**:\n```bash\ngrep -rn 'set -U\\|set --universal' --include=\"*.fish\" ~/.config/fish/conf.d/\nrg 'set -U ' --type-add 'fish:*.fish' --type fish ~/.config/fish/conf.d/\n```\n\n**What it looks like**:\n```fish",
+      "domain_hint": "fish-shell-config"
+    },
+    {
+      "file": "skills/fish-shell-config/references/fish-anti-patterns.md",
+      "line_range": [
+        237,
+        246
+      ],
+      "block_text": "# ~/.config/fish/conf.d/10-env.fish \u2014 WRONG\nset -U GOPATH ~/go\nset -U EDITOR nvim\nset -U JAVA_HOME /usr/lib/jvm/java-17-openjdk\n```\n\n**Why wrong**: Universal variables are stored in `fish_variables` and persist across all sessions. Setting them in `conf.d/` re-sets them on every shell start \u2014 harmless for idempotent values but causes subtle bugs when the value changes (e.g., different JAVA_HOME on different machines). Universal scope is for user preferences set interactively, not for environment...",
+      "domain_hint": "fish-shell-config"
     },
     {
       "file": "skills/gemini-image-generator/references/prompts.md",

--- a/scripts/detect-unpaired-antipatterns.py
+++ b/scripts/detect-unpaired-antipatterns.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Detect unpaired anti-pattern blocks across skills and agents.
+
+An anti-pattern block is "unpaired" when it contains a negative description
+(What it looks like / Why wrong) but has no matching positive counterpart
+("Do instead" / "Correct approach" / "Instead" variant).
+
+An annotated exception `<!-- no-pair-required: reason -->` suppresses the finding
+for that block.
+
+Usage:
+    python3 scripts/detect-unpaired-antipatterns.py
+    python3 scripts/detect-unpaired-antipatterns.py --json
+    python3 scripts/detect-unpaired-antipatterns.py --output artifacts/joy-check-sweep-backlog.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SCAN_PATTERNS = [
+    "skills/**/SKILL.md",
+    "skills/**/references/*.md",
+    "agents/**/*.md",
+    "agents/**/references/*.md",
+]
+
+# Files that are known non-content (index, template metadata)
+SKIP_FILES = {"INDEX.json", "README.md"}
+
+# Headings or bold markers that signal the start of an anti-pattern block
+ANTIPATTERN_START = re.compile(
+    r"(?:^#{1,4}\s+.*(?:anti.?pattern|bad\s+practice|wrong\s+way|avoid|don.t\s+do).*$"
+    r"|^\*\*(?:Anti.?[Pp]attern|What it looks like|Why wrong)\*\*"
+    r"|^##\s+.*(?:Anti.?[Pp]attern).*$"
+    r"|^-\s+\*\*(?:Anti.?[Pp]attern|What it looks like|Why wrong)\*\*)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Markers that indicate a positive counterpart is present
+DO_INSTEAD_MARKERS = re.compile(
+    r"(?:\*\*(?:do\s+instead|correct\s+approach|instead|do\s+this|right\s+way"
+    r"|preferred|recommended|use\s+instead|better\s+approach|solution|right)\*\*"
+    r"|^###?\s+.*(?:correct|preferred|instead|do\s+instead).*$"
+    r"|\u2705\s+(?:do\s+instead|correct|instead|right)"
+    r"|Do\s+instead:"
+    r"|Correct\s+approach:"
+    r"|Instead:"
+    r"|\*\*Right\*\*:"
+    r"|Right:)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Annotated exception suppresses the finding
+EXCEPTION_ANNOTATION = re.compile(r"<!--\s*no-pair-required\s*:", re.IGNORECASE)
+
+# Frontmatter name field for domain hint
+FRONTMATTER_NAME = re.compile(r"^name:\s*(.+)$", re.MULTILINE)
+
+
+def extract_domain_hint(file_path: Path, content: str) -> str:
+    """Infer domain hint from frontmatter name or file path."""
+    name_match = FRONTMATTER_NAME.search(content[:500])
+    if name_match:
+        name = name_match.group(1).strip().strip('"').strip("'")
+        parts = name.split("-")
+        if parts:
+            return parts[0]
+
+    parts = file_path.parts
+    for i, part in enumerate(parts):
+        if part in ("skills", "agents") and i + 1 < len(parts):
+            return parts[i + 1]
+
+    return file_path.stem
+
+
+def split_into_blocks(content: str) -> list[tuple[int, str]]:
+    """Split content into heading-delimited blocks. Returns (start_line, block_text) pairs."""
+    lines = content.splitlines()
+    blocks: list[tuple[int, str]] = []
+    current_start = 0
+    current_lines: list[str] = []
+
+    for i, line in enumerate(lines):
+        if re.match(r"^#{1,4}\s+", line) and current_lines:
+            blocks.append((current_start + 1, "\n".join(current_lines)))
+            current_start = i
+            current_lines = [line]
+        else:
+            current_lines.append(line)
+
+    if current_lines:
+        blocks.append((current_start + 1, "\n".join(current_lines)))
+
+    return blocks
+
+
+def block_is_antipattern(block_text: str) -> bool:
+    """Return True if this block describes an anti-pattern."""
+    return bool(ANTIPATTERN_START.search(block_text))
+
+
+def block_has_do_instead(block_text: str) -> bool:
+    """Return True if this block contains a positive counterpart."""
+    return bool(DO_INSTEAD_MARKERS.search(block_text))
+
+
+def block_has_exception(block_text: str) -> bool:
+    """Return True if this block has a no-pair-required annotation."""
+    return bool(EXCEPTION_ANNOTATION.search(block_text))
+
+
+@dataclass
+class UnpairedFinding:
+    file: str
+    line_range: list[int]
+    block_text: str
+    domain_hint: str
+
+
+def scan_file(file_path: Path) -> list[UnpairedFinding]:
+    """Scan a single file for unpaired anti-pattern blocks."""
+    if file_path.name in SKIP_FILES:
+        return []
+
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    # Skip pure YAML/JSON files
+    if not content.strip().startswith("#") and not content.strip().startswith("---"):
+        stripped = content.strip()
+        if stripped.startswith("{") or stripped.startswith("["):
+            return []
+
+    domain_hint = extract_domain_hint(file_path, content)
+    findings: list[UnpairedFinding] = []
+
+    blocks = split_into_blocks(content)
+    lines = content.splitlines()
+
+    for start_line, block_text in blocks:
+        if not block_is_antipattern(block_text):
+            continue
+        if block_has_do_instead(block_text):
+            continue
+        if block_has_exception(block_text):
+            continue
+
+        block_lines = block_text.splitlines()
+        end_line = start_line + len(block_lines) - 1
+
+        # Truncate block text for JSON output (avoid huge entries)
+        truncated = block_text[:500] + ("..." if len(block_text) > 500 else "")
+
+        findings.append(
+            UnpairedFinding(
+                file=str(file_path.relative_to(REPO_ROOT)),
+                line_range=[start_line, end_line],
+                block_text=truncated,
+                domain_hint=domain_hint,
+            )
+        )
+
+    return findings
+
+
+def collect_scan_targets() -> list[Path]:
+    """Expand glob patterns to file paths, deduplicating."""
+    seen: set[Path] = set()
+    targets: list[Path] = []
+
+    for pattern in SCAN_PATTERNS:
+        for path in sorted(REPO_ROOT.glob(pattern)):
+            if path.is_file() and path not in seen:
+                seen.add(path)
+                targets.append(path)
+
+    return targets
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Detect unpaired anti-pattern blocks across skills and agents")
+    parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Output JSON to stdout",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="PATH",
+        help="Write JSON output to this file (implies --json)",
+    )
+    args = parser.parse_args()
+
+    targets = collect_scan_targets()
+    all_findings: list[UnpairedFinding] = []
+
+    for path in targets:
+        all_findings.extend(scan_file(path))
+
+    output_data = {
+        "total": len(all_findings),
+        "findings": [asdict(f) for f in all_findings],
+    }
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(output_data, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote {len(all_findings)} finding(s) to {args.output}", file=sys.stderr)
+    elif args.json_output:
+        print(json.dumps(output_data, indent=2))
+    else:
+        # Human-readable summary
+        if not all_findings:
+            print("No unpaired anti-patterns found.")
+            return
+
+        print(f"Found {len(all_findings)} unpaired anti-pattern block(s):\n")
+        for f in all_findings:
+            print(f"  {f.file}:{f.line_range[0]}-{f.line_range[1]}  domain={f.domain_hint}")
+
+        domains: dict[str, int] = {}
+        for f in all_findings:
+            domains[f.domain_hint] = domains.get(f.domain_hint, 0) + 1
+        print("\nBy domain:")
+        for domain, count in sorted(domains.items(), key=lambda x: -x[1]):
+            print(f"  {domain}: {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_check_do_framing.py
+++ b/scripts/tests/test_check_do_framing.py
@@ -1,0 +1,161 @@
+"""Tests for validate-references.py --check-do-framing mode.
+
+Three core cases:
+1. Unpaired anti-pattern block fails validation (exit code 1, issue listed).
+2. Paired anti-pattern block passes validation (exit code 0, no issues).
+3. Annotated exception (no-pair-required) passes validation (exit code 0).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+# ─── Path setup ────────────────────────────────────────────────────────────────
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+for _p in [str(_SCRIPTS_DIR)]:
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+vr = importlib.import_module("validate-references")
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def tmp_md(tmp_path):
+    """Factory: write markdown content to a temp file and return its Path."""
+
+    def _write(content: str, name: str = "test-agent.md") -> Path:
+        f = tmp_path / name
+        f.write_text(content, encoding="utf-8")
+        return f
+
+    return _write
+
+
+# ---------------------------------------------------------------------------
+# Case 1: Unpaired anti-pattern — must fail
+# ---------------------------------------------------------------------------
+
+
+UNPAIRED_CONTENT = """\
+# Test Agent
+
+## Anti-Pattern: Bad Thing
+
+**What it looks like**: Someone does the bad thing.
+
+**Why wrong**: It causes problems.
+"""
+
+
+def test_unpaired_antipattern_fails(tmp_md):
+    """An anti-pattern block with no Do-instead counterpart produces an issue."""
+    path = tmp_md(UNPAIRED_CONTENT)
+    issues = vr.check_do_framing_in_file(path)
+    assert len(issues) == 1, f"Expected 1 issue, got {len(issues)}: {issues}"
+    assert issues[0].line_start >= 1
+
+
+# ---------------------------------------------------------------------------
+# Case 2: Paired anti-pattern — must pass
+# ---------------------------------------------------------------------------
+
+
+PAIRED_CONTENT = """\
+# Test Agent
+
+## Anti-Pattern: Bad Thing
+
+**What it looks like**: Someone does the bad thing.
+
+**Why wrong**: It causes problems.
+
+**Do instead**: Do the good thing instead.
+"""
+
+
+def test_paired_antipattern_passes(tmp_md):
+    """An anti-pattern block with a Do-instead counterpart produces no issues."""
+    path = tmp_md(PAIRED_CONTENT)
+    issues = vr.check_do_framing_in_file(path)
+    assert issues == [], f"Expected no issues, got: {issues}"
+
+
+# ---------------------------------------------------------------------------
+# Case 3: Annotated exception — must pass
+# ---------------------------------------------------------------------------
+
+
+ANNOTATED_CONTENT = """\
+# Test Agent
+
+<!-- no-pair-required: absolute prohibition, no safe alternative -->
+## Anti-Pattern: Never Do This
+
+**What it looks like**: Someone commits credentials.
+
+**Why wrong**: Security breach.
+"""
+
+
+def test_annotated_exception_passes(tmp_md):
+    """An anti-pattern block annotated with no-pair-required produces no issues."""
+    path = tmp_md(ANNOTATED_CONTENT)
+    issues = vr.check_do_framing_in_file(path)
+    assert issues == [], f"Expected no issues for annotated exception, got: {issues}"
+
+
+# ---------------------------------------------------------------------------
+# Case 4: Correct approach variant also counts as Do-instead
+# ---------------------------------------------------------------------------
+
+
+CORRECT_APPROACH_CONTENT = """\
+# Test Agent
+
+## Anti-Pattern: Wrong Way
+
+**What it looks like**: Bad code.
+
+**Why wrong**: It fails.
+
+**Correct approach**: Use the right pattern.
+"""
+
+
+def test_correct_approach_counts_as_do_instead(tmp_md):
+    """'Correct approach' is accepted as a Do-instead counterpart."""
+    path = tmp_md(CORRECT_APPROACH_CONTENT)
+    issues = vr.check_do_framing_in_file(path)
+    assert issues == [], f"Expected no issues for 'Correct approach' variant, got: {issues}"
+
+
+# ---------------------------------------------------------------------------
+# Case 5: File with no anti-patterns — must pass
+# ---------------------------------------------------------------------------
+
+
+NO_ANTIPATTERN_CONTENT = """\
+# Test Agent
+
+## Overview
+
+This agent does something useful.
+
+## Patterns
+
+Use this approach for best results.
+"""
+
+
+def test_no_antipatterns_passes(tmp_md):
+    """A file with no anti-pattern blocks produces no issues."""
+    path = tmp_md(NO_ANTIPATTERN_CONTENT)
+    issues = vr.check_do_framing_in_file(path)
+    assert issues == [], f"Expected no issues for file without anti-patterns, got: {issues}"

--- a/scripts/validate-references.py
+++ b/scripts/validate-references.py
@@ -9,6 +9,182 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 AGENTS_DIR = Path(__file__).parent.parent / "agents"
+REPO_ROOT = Path(__file__).parent.parent
+
+# ---------------------------------------------------------------------------
+# Do-framing validation
+# ---------------------------------------------------------------------------
+
+_DO_FRAMING_SCAN_PATTERNS = [
+    "agents/**/*.md",
+    "agents/**/references/*.md",
+    "skills/**/SKILL.md",
+    "skills/**/references/*.md",
+]
+
+_ANTIPATTERN_HEADING = re.compile(
+    r"(?:^#{1,4}\s+.*(?:anti.?pattern|bad\s+practice|wrong\s+way).*$"
+    r"|^\*\*(?:Anti.?[Pp]attern|What it looks like|Why wrong)\*\*"
+    r"|^##\s+.*(?:Anti.?[Pp]attern).*$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+_DO_INSTEAD = re.compile(
+    r"(?:\*\*(?:do\s+instead|correct\s+approach|instead|do\s+this|right\s+way"
+    r"|preferred|recommended|use\s+instead|better\s+approach|solution|right)\*\*"
+    r"|^###?\s+.*(?:correct|preferred|instead|do\s+instead).*$"
+    r"|\u2705\s+(?:do\s+instead|correct|instead|right)"
+    r"|Do\s+instead:"
+    r"|Correct\s+approach:"
+    r"|Instead:"
+    r"|\*\*Right\*\*:"
+    r"|Right:)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+_EXCEPTION_ANNOTATION = re.compile(r"<!--\s*no-pair-required\s*:", re.IGNORECASE)
+
+_SKIP_FILENAMES = {"INDEX.json", "README.md"}
+
+
+def _split_blocks(content: str) -> list[tuple[int, str]]:
+    """Split content by H1-H4 headings. Returns (start_line_1indexed, text) pairs."""
+    lines = content.splitlines()
+    blocks: list[tuple[int, str]] = []
+    start = 0
+    current: list[str] = []
+
+    for i, line in enumerate(lines):
+        if re.match(r"^#{1,4}\s+", line) and current:
+            blocks.append((start + 1, "\n".join(current)))
+            start = i
+            current = [line]
+        else:
+            current.append(line)
+
+    if current:
+        blocks.append((start + 1, "\n".join(current)))
+
+    return blocks
+
+
+@dataclass
+class DoFramingIssue:
+    file: str
+    line_start: int
+    line_end: int
+    snippet: str
+
+
+def check_do_framing_in_file(path: Path) -> list[DoFramingIssue]:
+    """Return unpaired anti-pattern blocks in a single file."""
+    if path.name in _SKIP_FILENAMES:
+        return []
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    issues: list[DoFramingIssue] = []
+    try:
+        rel = str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        rel = str(path)
+
+    all_lines = content.splitlines()
+
+    for start_line, block in _split_blocks(content):
+        if not _ANTIPATTERN_HEADING.search(block):
+            continue
+        if _DO_INSTEAD.search(block):
+            continue
+        if _EXCEPTION_ANNOTATION.search(block):
+            continue
+        # Also check up to 3 lines immediately before the block for an annotation.
+        # This handles the common pattern of placing <!-- no-pair-required: ... -->
+        # on the line just before the heading.
+        pre_start = max(0, start_line - 4)  # start_line is 1-indexed
+        pre_context = "\n".join(all_lines[pre_start : start_line - 1])
+        if _EXCEPTION_ANNOTATION.search(pre_context):
+            continue
+        end_line = start_line + len(block.splitlines()) - 1
+        snippet = block.splitlines()[0][:120]
+        issues.append(DoFramingIssue(file=rel, line_start=start_line, line_end=end_line, snippet=snippet))
+
+    return issues
+
+
+def _load_allowlist(allowlist_path: Path) -> set[tuple[str, int]]:
+    """Load a backlog JSON file and return a set of (file, line_start) keys to skip."""
+    if not allowlist_path.exists():
+        return set()
+    try:
+        data = json.loads(allowlist_path.read_text(encoding="utf-8"))
+        keys: set[tuple[str, int]] = set()
+        for entry in data.get("findings", []):
+            keys.add((entry["file"], entry["line_range"][0]))
+        return keys
+    except (OSError, KeyError, json.JSONDecodeError):
+        return set()
+
+
+_DEFAULT_ALLOWLIST = REPO_ROOT / "artifacts" / "joy-check-sweep-backlog.json"
+
+
+def run_check_do_framing(json_output: bool, allowlist_path: Path | None = None) -> int:
+    """Scan all skill and agent files for unpaired anti-pattern blocks.
+
+    Violations already listed in the allowlist (backlog) are skipped so that
+    pre-existing findings do not block CI while new violations do.
+    """
+    if allowlist_path is None:
+        allowlist_path = _DEFAULT_ALLOWLIST
+    known: set[tuple[str, int]] = _load_allowlist(allowlist_path)
+
+    seen: set[Path] = set()
+    targets: list[Path] = []
+    for pattern in _DO_FRAMING_SCAN_PATTERNS:
+        for p in sorted(REPO_ROOT.glob(pattern)):
+            if p.is_file() and p not in seen:
+                seen.add(p)
+                targets.append(p)
+
+    all_issues: list[DoFramingIssue] = []
+    skipped = 0
+    for target in targets:
+        for issue in check_do_framing_in_file(target):
+            if (issue.file, issue.line_start) in known:
+                skipped += 1
+            else:
+                all_issues.append(issue)
+
+    if json_output:
+        out = {
+            "total": len(all_issues),
+            "skipped_known": skipped,
+            "issues": [
+                {"file": i.file, "line_start": i.line_start, "line_end": i.line_end, "snippet": i.snippet}
+                for i in all_issues
+            ],
+            "exit_code": 1 if all_issues else 0,
+        }
+        print(json.dumps(out, indent=2))
+    else:
+        if all_issues:
+            print(f"DO-FRAMING: {len(all_issues)} NEW unpaired anti-pattern block(s) found\n")
+            for issue in all_issues:
+                print(f"  {issue.file}:{issue.line_start}-{issue.line_end}")
+                print(f"    {issue.snippet}")
+            print(
+                "\nFix: add a 'Do instead' / 'Correct approach' block, or annotate with"
+                " <!-- no-pair-required: reason -->"
+            )
+        else:
+            known_msg = f" ({skipped} known backlog item(s) skipped)" if skipped else ""
+            print(f"DO-FRAMING: no new unpaired anti-pattern blocks.{known_msg}")
+
+    return 1 if all_issues else 0
+
 
 VALID_IMPACT_LEVELS = {"CRITICAL", "HIGH", "MEDIUM-HIGH", "MEDIUM", "LOW-MEDIUM", "LOW"}
 
@@ -219,11 +395,21 @@ def main() -> None:
     parser.add_argument("--agent", help="Validate references for specific agent")
     parser.add_argument("--all", action="store_true", help="Validate all agents")
     parser.add_argument("--check-declared", action="store_true", help="Only check declared refs exist")
+    parser.add_argument("--check-do-framing", action="store_true", help="Check all files for unpaired anti-patterns")
+    parser.add_argument(
+        "--allowlist",
+        metavar="PATH",
+        help="Backlog JSON to skip known violations (default: artifacts/joy-check-sweep-backlog.json)",
+    )
     parser.add_argument("--json", dest="json_output", action="store_true", help="JSON output for CI")
     args = parser.parse_args()
 
+    if args.check_do_framing:
+        allowlist = Path(args.allowlist) if args.allowlist else None
+        sys.exit(run_check_do_framing(json_output=args.json_output, allowlist_path=allowlist))
+
     if not args.agent and not args.all:
-        parser.error("Specify --agent <name> or --all")
+        parser.error("Specify --agent <name>, --all, or --check-do-framing")
 
     check_structure = not args.check_declared
 

--- a/skills/reference-enrichment/SKILL.md
+++ b/skills/reference-enrichment/SKILL.md
@@ -152,10 +152,21 @@ For each gap, create one reference file following `references/reference-file-tem
   detection commands, error-fix mappings where applicable
 - Match the tone of existing Level 3 references: direct, concrete, no hedging
 
+**Do-pairing rule (mandatory):** Every anti-pattern block written during this phase must include
+a "Do instead" counterpart. If the retro learning or research does not carry enough information
+to write a concrete positive counterpart, omit the anti-pattern entirely rather than shipping it
+without the paired "Do instead". A bare negative block encodes no actionable knowledge and will
+fail structural validation. If a prohibition is a genuine absolute with no correct alternative,
+annotate it with `<!-- no-pair-required: reason -->` inline before the block.
+
 Write files to: `agents/{name}/references/` or `skills/{name}/references/`
 
-**Gate**: Each generated file is between 80-500 lines. Run
-`scripts/validate-references.py --agent {name}` if it exists.
+**Gate**: Each generated file is between 80-500 lines. Run both checks:
+```bash
+python3 scripts/validate-references.py --agent {name}
+python3 scripts/validate-references.py --check-do-framing
+```
+Both must exit 0 before proceeding to Phase 4.
 
 ---
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -123,6 +123,15 @@ The description is the primary triggering mechanism. Claude tends to undertrigge
 
 Constraints belong inline within the workflow step where they apply. Explain the reasoning behind constraints -- "Run with `-race` because race conditions are silent until production" generalizes; "ALWAYS run with -race" does not.
 
+**Do-pair validation** -- After writing any anti-pattern blocks, run:
+```bash
+python3 scripts/validate-references.py --check-do-framing
+```
+Every anti-pattern block must have a paired "Do instead" counterpart. Blocks
+without one fail the check. If a prohibition genuinely has no correct alternative,
+annotate it with `<!-- no-pair-required: reason -->` to pass validation without
+a "Do instead" block. Ship the skill only after this check exits 0.
+
 **Progressive disclosure** -- SKILL.md is the routing target, not the reference
 library. It stays lean so it loads fast when Claude considers invoking it, then
 reads `references/` on demand as phases execute. See

--- a/skills/skill-creator/references/skill-template.md
+++ b/skills/skill-creator/references/skill-template.md
@@ -262,7 +262,11 @@ Additional for this skill:
 
 ## Anti-Patterns Section (Medium+)
 
-For skills with significant complexity, include 3-6 anti-patterns:
+For skills with significant complexity, include 3-6 anti-patterns.
+
+**Do-pairing rule (mandatory):** Every anti-pattern block must include a "Do instead" counterpart that shows the correct approach. A bare negative ("don't do X") encodes no actionable knowledge. The positive counterpart is the actual learning. If a genuine absolute prohibition has no correct alternative (e.g., "never commit secrets"), annotate it with `<!-- no-pair-required: absolute prohibition, no safe alternative -->` to pass structural validation.
+
+Validation gate: `python3 scripts/validate-references.py --check-do-framing` rejects anti-pattern blocks without a paired "Do instead" or `<!-- no-pair-required: ... -->` annotation.
 
 ```markdown
 ### Anti-Pattern 1: [Pattern Name]
@@ -272,5 +276,5 @@ For skills with significant complexity, include 3-6 anti-patterns:
 
 **Why wrong:** [Consequence]
 
-**Do instead:** [Correct approach]
+**Do instead:** [Correct approach — this field is mandatory]
 ```


### PR DESCRIPTION
## Summary

Implements Parts 1, 2, and Part 3 foundation of the Do-framing enforcement ADR (`adr/joy-check-sweep-template-enforcement.md`).

- **Templates updated** so every anti-pattern block requires a paired "Do instead" counterpart at authoring time, with `<!-- no-pair-required: reason -->` as the annotated-exception escape hatch
- **reference-enrichment Phase 3** now requires every emitted anti-pattern to include a Do-instead block; omits the anti-pattern if the source learning cannot support one
- **`validate-references.py --check-do-framing`** scans all skill and agent files for unpaired blocks; uses `artifacts/joy-check-sweep-backlog.json` as allowlist so pre-existing violations skip while new ones fail CI
- **CI lint job** wires in the check so it runs on every push
- **`detect-unpaired-antipatterns.py`** scans the full repo and emits JSON with `{file, line_range, block_text, domain_hint}`; run once to produce `artifacts/joy-check-sweep-backlog.json` (932 findings) for future domain batch PRs to consume
- **pytest** covers all three required cases: unpaired fails, paired passes, annotated-exception passes

## What is NOT in this PR

- Domain batch sweeps (Go, Kubernetes, content) — those are multi-week per-domain PRs per the ADR
- PHILOSOPHY.md edits — the ADR notes the principle is already present implicitly
- Deletion of existing anti-pattern blocks — anti-patterns are information; the rule is pairing, not removal

## Test plan

- [ ] `ruff check scripts/ --config pyproject.toml` exits 0
- [ ] `ruff format --check scripts/ --config pyproject.toml` exits 0
- [ ] `python3 -m pytest scripts/tests/test_check_do_framing.py -v` passes (5 tests)
- [ ] `python3 scripts/validate-references.py --check-do-framing` exits 0
- [ ] `python3 scripts/detect-unpaired-antipatterns.py --json` produces valid JSON with total count
- [ ] CI Tests/lint and Tests/test pass