### PR TITLE
Severity matrix + scope clarification for reviewer skills

### DIFF
--- a/commands/pr-review.md
+++ b/commands/pr-review.md
@@ -11,6 +11,17 @@ Comprehensive PR review using specialized agents, with automatic knowledge captu
 This is a local fork of `pr-review-toolkit:review-pr` with a retro learning phase that
 records review patterns to the knowledge store.
 
+## Scope
+
+This command accepts either a PR reference or a local branch diff. You do not need an open PR to use it.
+
+| Invocation form | What it reviews |
+|----------------|-----------------|
+| `/pr-review` (no argument) | Uncommitted and committed local changes against the base branch (`HEAD` vs base) |
+| `/pr-review 123` or `/pr-review https://github.com/org/repo/pull/123` | The diff of the specified open PR |
+
+When no argument is provided, the command reads `git diff` to determine changed files. When a PR number or URL is provided, it fetches the PR diff via `gh pr view`. All review phases and retro learning apply in both cases.
+
 ## Usage
 
 ```

--- a/skills/parallel-code-review/SKILL.md
+++ b/skills/parallel-code-review/SKILL.md
@@ -134,6 +134,17 @@ Include this matrix in every report so stakeholders see the severity distributio
 ```markdown
 ## Parallel Review Complete
 
+### Severity Matrix
+
+| Severity | Count | Summary |
+|----------|-------|---------|
+| Critical | N | One-line aggregated summary |
+| High     | N | One-line aggregated summary |
+| Medium   | N | One-line aggregated summary |
+| Low      | N | One-line aggregated summary |
+
+Details by reviewer below.
+
 ### Combined Findings
 
 #### CRITICAL (Block Merge)


### PR DESCRIPTION
## Summary

- **parallel-code-review**: Adds a `### Severity Matrix` table as the opening section of the review output template. The matrix shows Critical/High/Medium/Low counts and a one-line summary per severity tier before the full reviewer-by-reviewer detail sections. Readers get the highest-priority signal immediately rather than having to scan through three reviewer sections to assemble the picture themselves.

- **pr-review**: Adds a `## Scope` subsection that documents the two supported invocation forms: running with no argument (reviews local `HEAD` vs base branch diff) and running with a PR number or URL (reviews the specified open PR). The underlying behavior already supports both forms; this makes the contract explicit so users know they can run the command before opening a PR.

## Test plan

- [ ] `python3 scripts/validate-references.py --all` passes with no new issues
- [ ] `python3 scripts/validate-references.py --check-do-framing` passes
- [ ] Severity matrix renders correctly as a markdown table in a review output
- [ ] Scope section reads naturally in context with the existing Usage section