### PR TITLE
docs(sqlite-peewee): pair anti-patterns with Do-instead blocks

### DIFF
--- a/agents/sqlite-peewee-engineer/references/peewee-migrations.md
+++ b/agents/sqlite-peewee-engineer/references/peewee-migrations.md
@@ -180,6 +180,7 @@ reads AND writes (default journal mode). Batching limits each lock window to `ba
 ---
 
 ## Anti-Pattern Catalog
+<!-- no-pair-required: section header with no content -->
 
 ### ❌ Manual SQL for Schema Changes
 
@@ -189,6 +190,8 @@ reads AND writes (default journal mode). Batching limits each lock window to `ba
 grep -rn 'execute_sql.*ALTER TABLE\|execute_sql.*CREATE TABLE\|execute_sql.*DROP TABLE' --include="*.py"
 rg 'execute_sql\([\'\"](ALTER|CREATE|DROP)' --type py
 ```
+
+**Do instead:** Use `playhouse.migrate` — see fix below.
 
 **What it looks like**:
 ```python
@@ -201,7 +204,11 @@ db.execute_sql("DROP TABLE IF EXISTS temp_data")
 exist?), produces no migration record, and on SQLite may silently succeed when the operation
 has unintended side effects (like dropping all triggers on a table).
 
-**Fix**:
+**Do instead:**
+
+Use `playhouse.migrate` for all schema changes so operations are tracked, pre-flight checked,
+and wrapped in a single atomic call:
+
 ```python
 from playhouse.migrate import SqliteMigrator, migrate
 from peewee import TextField
@@ -221,6 +228,8 @@ grep -rn 'add_column' --include="*.py" -A 2 | grep -v 'null=True\|default='
 rg 'add_column\([^)]*\)' --type py | grep -v 'null=True|default='
 ```
 
+**Do instead:** Add the column as `null=True` first, backfill existing rows, then constrain in a later migration.
+
 **What it looks like**:
 ```python
 # FAILS on any non-empty table — existing rows have no value for 'status'
@@ -231,7 +240,11 @@ migrate(migrator.add_column('post', 'status', CharField()))
 A non-null column with no default fails with `OperationalError: Cannot add a NOT NULL column
 with default value NULL`.
 
-**Fix**:
+**Do instead:**
+
+Add the column as nullable, backfill existing rows, then enforce the constraint via a table
+rebuild in a separate migration if strictly required:
+
 ```python
 # Step 1: Add as nullable
 migrate(migrator.add_column('post', 'status', CharField(null=True)))
@@ -253,6 +266,8 @@ grep -rn 'drop_column' --include="*.py"
 rg 'migrator\.drop_column\(' --type py
 ```
 
+**Do instead:** Guard with a SQLite version check and fall back to a table rebuild on older SQLite.
+
 **What it looks like**:
 ```python
 # Fails silently or errors on SQLite < 3.35
@@ -263,7 +278,11 @@ migrate(migrator.drop_column('user', 'legacy_field'))
 Many Linux distributions ship SQLite 3.31 or earlier. Calling `drop_column()` on older SQLite
 either raises `OperationalError` or does nothing depending on Playhouse version.
 
-**Fix**:
+**Do instead:**
+
+Check the SQLite version at migration time and either call `drop_column()` on 3.35+ or raise
+with a clear message directing the developer to implement a table rebuild:
+
 ```python
 import sqlite3
 
@@ -296,6 +315,8 @@ grep -rn 'migrate(' --include="*.py" -B 3 | grep -v 'atomic\|with db'
 rg 'migrate\(' --type py -B 3 | grep -v 'atomic'
 ```
 
+**Do instead:** Wrap all `migrate()` calls in a single `db.atomic()` block so they commit together or roll back together.
+
 **What it looks like**:
 ```python
 migrator = SqliteMigrator(db)
@@ -307,7 +328,11 @@ migrate(migrator.add_index('user', ('email',), False))               # Separate 
 **Why wrong**: Each `migrate()` call is its own implicit transaction. If the second call fails,
 the first is already committed. The schema is now partially updated with no clean rollback path.
 
-**Fix**:
+**Do instead:**
+
+Pass all related operations to a single `migrate()` call inside `db.atomic()` so they form
+one atomic unit:
+
 ```python
 with db.atomic():
     migrate(

--- a/agents/sqlite-peewee-engineer/references/peewee-query-patterns.md
+++ b/agents/sqlite-peewee-engineer/references/peewee-query-patterns.md
@@ -96,6 +96,7 @@ readers to continue while a write transaction is open, essential for web applica
 ---
 
 ### Targeted SELECT to Avoid Overfetch
+<!-- no-pair-required: positive pattern section, title contains 'avoid' triggering false positive -->
 
 Specify only needed columns — prevents loading TEXT/BLOB columns when only IDs or names needed.
 
@@ -116,6 +117,7 @@ for u in users:
 ---
 
 ## Anti-Pattern Catalog
+<!-- no-pair-required: section header with no content -->
 
 ### ❌ N+1 Queries via Loop Attribute Access
 
@@ -127,6 +129,8 @@ grep -rn '\.select()' --include="*.py" -A 10 | grep -B 5 'for .* in '
 rg 'for \w+ in \w+\.\w+:' --type py
 rg '\.select\(\)' --type py -A 5 | grep '\.\w+\.\w+'
 ```
+
+**Do instead:** Use `User.select().prefetch(Post)` to load all related data in 2 queries instead of N+1.
 
 **What it looks like**:
 ```python
@@ -141,7 +145,11 @@ for user in users:
 With 500 users this is 1001 queries. SQLite holds a read lock per query — accumulated latency
 grows linearly with row count.
 
-**Fix**:
+**Do instead:**
+
+Use `prefetch()` to load all related data in 2 queries, or annotate with a subquery to compute
+aggregates in a single SQL statement:
+
 ```python
 # Option 1: prefetch + Python aggregation
 users = User.select().prefetch(Post)
@@ -174,6 +182,8 @@ grep -rn 'ForeignKeyField' --include="*.py"
 rg 'ForeignKeyField\([^)]*\)' --type py | grep -v 'index=True'
 ```
 
+**Do instead:** Add `index=True` to every `ForeignKeyField` and declare composite indexes in `Meta.indexes` for multi-column query patterns.
+
 **What it looks like**:
 ```python
 class Post(Model):
@@ -185,7 +195,11 @@ class Post(Model):
 filtering on `Post.user == user_id` do a full table scan. At 10k rows this is noticeable; at
 100k rows it's a reported bug.
 
-**Fix**:
+**Do instead:**
+
+Declare `index=True` on every `ForeignKeyField` and add composite indexes in `Meta.indexes`
+for any query patterns that filter on multiple columns:
+
 ```python
 class Post(Model):
     user = ForeignKeyField(User, backref='posts', index=True)
@@ -211,6 +225,8 @@ rg '\.prefetch\(' --type py -A 2 | grep '\.join\('
 grep -rn 'prefetch' --include="*.py" -A 3 | grep 'join'
 ```
 
+**Do instead:** Use `join()` alone when filtering on a related field, or `prefetch()` alone when loading related data. Never combine both for the same model.
+
 **What it looks like**:
 ```python
 # BUG: join + prefetch on same model produces cartesian product rows
@@ -224,7 +240,11 @@ users = (User
 Using both causes Post rows to appear multiple times in `user.posts` after prefetch populates
 from the JOIN result set.
 
-**Fix**:
+**Do instead:**
+
+Pick one strategy per query: `join()` for filter/order operations, `prefetch()` for loading
+related objects into memory:
+
 ```python
 # For filtering: use join only, no prefetch
 users = User.select().join(Post).where(Post.status == 'published').distinct()
@@ -244,6 +264,8 @@ rg '\.select\(\s*\)' --type py
 grep -rn '\.select()' --include="*.py" | grep -v 'select(.*\.'
 ```
 
+**Do instead:** Specify only the columns you need: `Post.select(Post.id, Post.title, Post.created_at)`.
+
 **What it looks like**:
 ```python
 # Loads all columns including large TEXT/BLOB fields
@@ -255,7 +277,10 @@ for post in posts:
 **Why wrong**: SQLite reads entire row pages into cache. Loading unused large columns wastes
 cache and increases I/O, especially in list views rendering only titles or IDs.
 
-**Fix**:
+**Do instead:**
+
+Select only the columns required for the operation, keeping queries narrow and cache-efficient:
+
 ```python
 posts = Post.select(Post.id, Post.title, Post.created_at)
 ```

--- a/agents/sqlite-peewee-engineer/references/peewee-testing.md
+++ b/agents/sqlite-peewee-engineer/references/peewee-testing.md
@@ -185,6 +185,7 @@ def test_add_email_column_migration(pre_migration_db):
 ---
 
 ## Anti-Pattern Catalog
+<!-- no-pair-required: section header with no content -->
 
 ### ❌ Module-Level Database in Tests (State Leakage)
 
@@ -195,6 +196,8 @@ grep -rn 'db = SqliteDatabase' --include="test_*.py"
 grep -rn 'setUpClass\|setup_module' --include="test_*.py" -A 5 | grep 'create_tables'
 rg 'SqliteDatabase.*test' --type py | grep -v 'fixture\|conftest'
 ```
+
+**Do instead:** Use a per-test `db` fixture with `bind_ctx()` so each test gets a fresh in-memory database.
 
 **What it looks like**:
 ```python
@@ -215,7 +218,10 @@ def test_user_count():
 created in one test are visible to all subsequent tests. Test order determines results —
 passing locally but failing in CI (different ordering) is the common symptom.
 
-**Fix**:
+**Do instead:**
+
+Create a fresh `:memory:` database per test using a `pytest.fixture` with `bind_ctx()`:
+
 ```python
 # conftest.py — CORRECT: fresh database per test
 @pytest.fixture(autouse=True)
@@ -237,6 +243,8 @@ grep -rn 'SqliteDatabase(' --include="test_*.py" | grep -v ':memory:'
 rg 'SqliteDatabase\([^:)]' --type py --glob 'test_*'
 ```
 
+**Do instead:** Always use `SqliteDatabase(':memory:')` for unit tests, or a `tempfile.mkstemp()` path for integration tests with automatic cleanup.
+
 **What it looks like**:
 ```python
 # Uses real app.db in tests — modifies production data
@@ -251,8 +259,10 @@ def test_delete_user():
 the production database file. SQLite file databases have no transaction isolation between
 processes.
 
-**Fix**: Always use `SqliteDatabase(':memory:')` in tests. For integration tests that need
-a file, use `tempfile.mkstemp()` and clean up in fixture teardown.
+**Do instead:**
+
+Use `:memory:` for unit tests. For integration tests that genuinely require a file path, use
+`tempfile.mkstemp()` and delete the file in fixture teardown:
 
 ```python
 import tempfile
@@ -279,6 +289,8 @@ rg 'SqliteDatabase.*:memory:' --type py | grep -v 'foreign_keys'
 grep -rn "SqliteDatabase(':memory:')" --include="*.py" -A 3 | grep -v 'foreign_keys'
 ```
 
+**Do instead:** Always pass `pragmas={'foreign_keys': 1}` when creating the test database so FK violations surface in tests, not in production.
+
 **What it looks like**:
 ```python
 # SQLite disables FK checks by default — tests pass but prod fails
@@ -293,7 +305,11 @@ def test_post_without_user():
 **Why wrong**: SQLite disables foreign key constraints by default for backwards compatibility.
 Tests pass with invalid data that production rejects. The divergence is invisible until deploy.
 
-**Fix**:
+**Do instead:**
+
+Always enable FK enforcement in the test database pragma so tests catch the same integrity
+errors that production would raise:
+
 ```python
 db = SqliteDatabase(':memory:', pragmas={'foreign_keys': 1})
 ```


### PR DESCRIPTION
## Summary

- Added `**Do instead:**` counterparts to all 24 unpaired anti-pattern blocks across three `sqlite-peewee-engineer` reference files
- Annotated bare `## Anti-Pattern Catalog` section headers with `<!-- no-pair-required -->` to suppress false positives from empty heading blocks
- Regenerated `artifacts/joy-check-sweep-backlog.json`: 763 findings down to 723 (40 resolved: 24 content blocks + 16 section-header false positives)

## Files touched

| File | Unpaired blocks fixed |
|------|-----------------------|
| `agents/sqlite-peewee-engineer/references/peewee-migrations.md` | 9 |
| `agents/sqlite-peewee-engineer/references/peewee-query-patterns.md` | 8 |
| `agents/sqlite-peewee-engineer/references/peewee-testing.md` | 7 |
| `artifacts/joy-check-sweep-backlog.json` | regenerated |

## Acceptance checks (all local)

- `python3 scripts/detect-unpaired-antipatterns.py` — 0 sqlite-peewee-engineer findings
- `python3 scripts/validate-references.py --check-do-framing` — no new unpaired blocks (701 known backlog items skipped)
- `ruff check . --config pyproject.toml` — all checks passed
- `ruff format --check . --config pyproject.toml` — 298 files already formatted
- `python3 -m pytest scripts/tests/` — 2457 passed, 0 failed

## No file splits needed

All three files remain under 400 lines after additions (398 / 339 / 382 lines respectively).