### PR TITLE
docs(endpoint-validator): pair anti-patterns with Do-instead blocks

### DIFF
--- a/skills/endpoint-validator/references/auth-endpoint-patterns.md
+++ b/skills/endpoint-validator/references/auth-endpoint-patterns.md
@@ -128,7 +128,7 @@ rg '"Authorization".*"Bearer [A-Za-z0-9._-]{20,}"' --type json
 **Why wrong**: JWT tokens in config files get committed to git history. Even after rotation,
 the old token remains in every git clone. GitHub secret scanning flags base64-encoded JWTs.
 
-**Fix**: `{"headers": {"Authorization": "Bearer ${API_TOKEN}"}}`
+**Do instead**: `{"headers": {"Authorization": "Bearer ${API_TOKEN}"}}`
 
 ---
 
@@ -155,10 +155,10 @@ for ep in cfg.get('endpoints', []):
 ```
 
 **Why wrong**: Without explicit `expect_status`, default is 200. If the token expires or
-loses its scope, the endpoint returns 401 — the validator reports FAIL (expected 200, got 401)
+loses its scope, the endpoint returns 401. The validator reports FAIL (expected 200, got 401)
 with no context that it's an auth failure, not an API bug.
 
-**Fix**: Always set `expect_status: 200` explicitly on auth-protected endpoints so the
+**Do instead**: Always set `expect_status: 200` explicitly on auth-protected endpoints so the
 failure message reads "expected 200, got 401" and the auth header is visible in the config.
 
 ---
@@ -179,7 +179,7 @@ grep -rn "ADMIN\|ROOT\|MASTER\|SUPERUSER\|SUPER_" endpoints.json
 to production. Blast radius is maximum. Use read-only service account tokens scoped to
 the specific paths being validated.
 
-**Fix**: Create a dedicated `endpoint-validator` service account with read-only access.
+**Do instead**: Create a dedicated `endpoint-validator` service account with read-only access.
 Rotate its token independently of admin credentials.
 
 ---
@@ -204,7 +204,7 @@ grep -rn '"Cookie"' endpoints.json | grep -v '\${[A-Z_]'
 silently redirect to a login page (302), which the validator may follow and report 200
 (the login page), masking the auth failure entirely.
 
-**Fix**: Use env var for session token and add `expect_key` on JSON dashboard APIs:
+**Do instead**: Use env var for session token and add `expect_key` on JSON dashboard APIs:
 ```json
 {
   "path": "/api/dashboard",

--- a/skills/endpoint-validator/references/endpoint-config-anti-patterns.md
+++ b/skills/endpoint-validator/references/endpoint-config-anti-patterns.md
@@ -1,5 +1,7 @@
 # Endpoint Config Anti-Patterns Reference
 
+<!-- no-pair-required: document title block, not an anti-pattern description -->
+
 > **Scope**: Anti-patterns in `endpoints.json` configuration and common validation mistakes.
 > **Version range**: All versions of endpoint-validator
 > **Generated**: 2026-04-17
@@ -71,7 +73,7 @@ rg '"base_url".*[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' --type json
 **Why wrong**: IP addresses are machine-local. The config breaks on every other developer
 machine, in CI, and after any network reconfiguration.
 
-**Fix**:
+**Do instead**:
 ```json
 {"base_url": "http://localhost:8000"}
 ```
@@ -99,7 +101,7 @@ grep -rn '"method"' . --include="*.json" | grep -iE '"POST"|"PUT"|"DELETE"|"PATC
 **Why wrong**: POST/PUT/DELETE against a production URL creates/mutates/deletes real data.
 A smoke test that runs pre-deploy will insert test records, trigger webhooks, or bill users.
 
-**Fix**: Use staging for mutating endpoints. Reserve production config for GET-only health
+**Do instead**: Use staging for mutating endpoints. Reserve production config for GET-only health
 checks. The validator warns when it detects write methods with a non-localhost `base_url`.
 
 ---
@@ -118,11 +120,11 @@ grep -rn '"timeout"' . --include="*.json" | grep -E '"timeout":\s*[6-9][0-9]|[1-
 {"path": "/api/upload", "timeout": 300}
 ```
 
-**Why wrong**: `timeout: 0` means no timeout — a hung connection blocks the entire validation
+**Why wrong**: `timeout: 0` means no timeout. A hung connection blocks the entire validation
 suite forever. `timeout: 300` hides performance regressions; an endpoint that starts taking
 60 seconds is clearly degraded but passes validation.
 
-**Fix**: Use `timeout: 5` (default) for health checks. For legitimately slow endpoints, set
+**Do instead**: Use `timeout: 5` (default) for health checks. For legitimately slow endpoints, set
 `timeout: 15` and `max_time: 5.0` to distinguish "too slow" from "timed out completely":
 ```json
 {"path": "/api/report", "timeout": 15, "max_time": 5.0}
@@ -146,7 +148,7 @@ grep -B2 '"expect_key"' endpoints.json | grep -E '"path".*\.(html|xml|csv|txt|pd
 XML, HTML, and CSV responses will always fail JSON parsing, generating "Invalid JSON response"
 errors that obscure the real issue.
 
-**Fix**: For non-JSON endpoints, only check `expect_status`:
+**Do instead**: For non-JSON endpoints, only check `expect_status`:
 ```json
 {"path": "/sitemap.xml", "expect_status": 200}
 ```
@@ -176,7 +178,7 @@ for ep in cfg.get('endpoints', []):
 **Why wrong**: Default `expect_status` is 200. An endpoint that intentionally returns 404
 (e.g., validating your 404 handler) will report FAIL when it should PASS.
 
-**Fix**:
+**Do instead**:
 ```json
 {"path": "/api/v1/nonexistent-resource", "expect_status": 404}
 ```
@@ -200,7 +202,7 @@ rg '"Bearer [A-Za-z0-9+/=._-]{20,}"' --type json
 rotated, the old token may be valid elsewhere or extractable from history. GitHub secret
 scanning will flag this.
 
-**Fix**: Use environment variable interpolation:
+**Do instead**: Use environment variable interpolation:
 ```json
 {"headers": {"Authorization": "Bearer ${API_TOKEN}"}}
 ```

--- a/skills/endpoint-validator/references/security-headers.md
+++ b/skills/endpoint-validator/references/security-headers.md
@@ -110,7 +110,7 @@ grep -rn '"base_url".*localhost\|"base_url".*127\.0\.0\.1' endpoints.json
 **Why wrong**: Development servers don't set these headers. Running the check against localhost
 generates spurious WARNs on every local run, training developers to ignore warnings entirely.
 
-**Fix**: The validator skips security header checks when `base_url` contains `localhost` or
+**Do instead**: The validator skips security header checks when `base_url` contains `localhost` or
 `127.0.0.1` by default. Only override with `force_security_check: true` when explicitly needed.
 
 ---
@@ -131,7 +131,7 @@ grep -rn "|| true\|--allow-warn\|exit 0" .github/workflows/ .gitlab-ci.yml 2>/de
 CSP) pass CI silently. Use `--fail-on-warn` in production validation runs so header removal
 triggers a build failure.
 
-**Fix**:
+**Do instead**:
 ```yaml
 - run: endpoint-validator --base-url $PROD_URL --fail-on-warn
   env:
@@ -153,9 +153,9 @@ grep -rn '"base_url".*"http://' endpoints.json | grep -v "localhost\|127\.0\.0\.
 ```
 
 **Why wrong**: HSTS is only meaningful over HTTPS. Browsers ignore HSTS headers delivered
-over HTTP (per RFC 6797 §8.1). Checking for it on HTTP endpoints always generates misleading WARNs.
+over HTTP (per RFC 6797 section 8.1). Checking for it on HTTP endpoints always generates misleading WARNs.
 
-**Fix**: Use `https://` base_url for production validation, or the validator should auto-skip
+**Do instead**: Use `https://` base_url for production validation, or the validator should auto-skip
 HSTS checks when base_url starts with `http://`.
 
 ---


### PR DESCRIPTION
## Summary

- Replaced `**Fix**:` labels with `**Do instead**:` in all 13 anti-pattern blocks across the three endpoint-validator reference files, so the `detect-unpaired-antipatterns.py` detector recognizes the positive counterpart.
- Added `<!-- no-pair-required: document title block -->` annotation to the `endpoint-config-anti-patterns.md` H1 header, which was incorrectly flagged because the title and scope line both contain the word "Anti-patterns".

## Files changed

- `skills/endpoint-validator/references/auth-endpoint-patterns.md` (4 anti-patterns paired)
- `skills/endpoint-validator/references/endpoint-config-anti-patterns.md` (6 anti-patterns paired + 1 title annotated)
- `skills/endpoint-validator/references/security-headers.md` (3 anti-patterns paired)

## Test plan

- [ ] `python3 scripts/detect-unpaired-antipatterns.py` returns zero findings for `domain=endpoint-validator`
- [ ] `python3 scripts/validate-references.py --check-do-framing` passes
- [ ] All three files under 500 lines (259, 246, 192 respectively)
- [ ] CI green