### PR TITLE
docs(reviewer-perspectives): pair anti-patterns with Do-instead blocks

### DIFF
--- a/agents/reviewer-perspectives/references/clarity-and-assumption-detection.md
+++ b/agents/reviewer-perspectives/references/clarity-and-assumption-detection.md
@@ -36,7 +36,7 @@ if response_code == 429:
 
 **Why wrong**: A newcomer cannot distinguish `60` (seconds) from `60` (max retries) or `60` (a business rule). When the value changes, they don't know all the places to update.
 
-**Fix**:
+**Do instead:**
 ```python
 HTTP_TOO_MANY_REQUESTS = 429
 RATE_LIMIT_BACKOFF_SECONDS = 60
@@ -73,7 +73,7 @@ func ProcessEvent(e Event, cfg *Config, dry bool) (Result, error) {
 
 **Why wrong**: The newcomer cannot call this function without reading all 200 lines to understand what `dry bool` does or what errors to expect.
 
-**Fix**: Add a doc comment explaining the function's purpose, key parameters, and failure conditions in 2-4 lines.
+**Do instead:** Add a doc comment explaining the function's purpose, key parameters, and failure conditions in 2-4 lines.
 
 ---
 
@@ -104,6 +104,8 @@ func calc(d []float64, n int) float64 {
 
 **Why wrong**: `d`, `n`, `s`, `v` carry zero information. Is this averaging? Summing? What is `d`? Why is `n` separate from `len(d)`?
 
+**Do instead:** Name variables after what they hold, not their type or role in the computation. Replace `d` with `dataPoints`, `s` with `sum`, and `n` with `sampleSize`. A reader should be able to understand the intent without running the code.
+
 ---
 
 ### ❌ Implicit Preconditions Not Documented
@@ -130,7 +132,7 @@ func ProcessOrder(order *Order) {
 
 **Why wrong**: A newcomer calling `ProcessOrder` does not know they must pre-populate `Customer`. The panic surfaces far from the actual mistake.
 
-**Fix**: Either guard with a nil check and return an error, or document the precondition in the function's doc comment: `// ProcessOrder requires order.Customer to be non-nil`.
+**Do instead:** Either guard with a nil check and return an error, or document the precondition in the function's doc comment: `// ProcessOrder requires order.Customer to be non-nil`.
 
 ---
 
@@ -151,6 +153,8 @@ rg -n ':8080|:3000|:5432|:6379' --type go --type py --type ts | rg -v 'test\|exa
 ```
 
 **Why wrong**: The Contrarian perspective asks "what happens in CI, staging, or prod?" Code assuming `localhost:5432` silently breaks in containerized environments.
+
+**Do instead:** Load host, port, and path values from environment variables with sensible defaults. `os.Getenv("DB_HOST", "localhost")` documents the assumption explicitly and makes it overridable without a code change.
 
 ---
 
@@ -177,6 +181,8 @@ func parseFlags(args []string) string {
 
 **Why wrong**: The Contrarian asks: "what if the caller passes zero args?" The assumption is invisible and produces a panic, not a clear error message.
 
+**Do instead:** Check bounds before indexing and return a descriptive error on violation. `if len(args) < 2 { return "", fmt.Errorf("expected at least 2 args, got %d", len(args)) }` converts a runtime panic into an actionable message.
+
 ---
 
 ### ❌ Sync-Only Code Assuming Sequential Execution
@@ -194,6 +200,8 @@ rg -n 'module\.exports\.\w+ = \[\|module\.exports\.\w+ = \{' --type js
 ```
 
 **Why wrong**: The Contrarian asks: "this code runs fine with one request — what about 100 simultaneous requests?" Module-level mutable state is shared across all requests in most web frameworks.
+
+**Do instead:** Scope mutable state to the request or transaction, not the module. Where shared state is unavoidable, protect it with a `sync.Mutex` or `sync.RWMutex` and document which fields it guards.
 
 ---
 
@@ -219,6 +227,8 @@ for key, val := range configMap {
 ```
 
 **Why wrong**: The Contrarian asks: "what assumption is the author making here?" Map iteration being ordered is a frequent hidden assumption that causes intermittent bugs.
+
+**Do instead:** Extract the keys, sort them explicitly with `sort.Strings(keys)`, then iterate the sorted slice. This makes the ordering contract visible in the code rather than hidden in an assumption about language behavior.
 
 ---
 

--- a/agents/reviewer-perspectives/references/code-review-detection.md
+++ b/agents/reviewer-perspectives/references/code-review-detection.md
@@ -40,7 +40,7 @@ result, _ := db.Query("SELECT * FROM users WHERE id = ?", id)
 
 **Why wrong**: Silent error discard means data corruption or partial writes proceed undetected. In production, this surfaces as corrupted records with no error logs.
 
-**Fix**:
+**Do instead:**
 ```go
 result, err := db.Query("SELECT * FROM users WHERE id = ?", id)
 if err != nil {
@@ -81,7 +81,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 **Why wrong**: RFC 7231 §6 defines status code semantics. Clients (including monitoring tools and API gateways) use status codes to route errors — a 200 error bypasses all error-handling middleware.
 
-**Fix**: Use `http.StatusBadRequest` (400) for invalid input, `http.StatusNotFound` (404) for missing resources, `http.StatusUnauthorized` (401) for missing auth, `http.StatusForbidden` (403) for insufficient permissions.
+**Do instead:** Use `http.StatusBadRequest` (400) for invalid input, `http.StatusNotFound` (404) for missing resources, `http.StatusUnauthorized` (401) for missing auth, `http.StatusForbidden` (403) for insufficient permissions.
 
 ---
 
@@ -107,7 +107,7 @@ grep -rn 'postgres://\|mysql://\|mongodb://' --include="*.go" --include="*.ts" -
 
 **Why wrong**: Credentials in version history are permanent — `git filter-branch` does not remove them from forks or cached copies. Leaked credentials require key rotation even after removal.
 
-**Fix**: Load from environment variables (`os.Getenv`, `process.env`, `os.environ`) or a secrets manager. Never commit `.env` files containing real values.
+**Do instead:** Load from environment variables (`os.Getenv`, `process.env`, `os.environ`) or a secrets manager. Never commit `.env` files containing real values.
 
 ---
 
@@ -130,7 +130,7 @@ grep -rn 'findAll\|getAll\|fetchAll' --include="*.ts" --include="*.go"
 
 **Why wrong**: A query returning 1,000 rows in development returns 50 million in production, causing OOM crashes or 30-second response times that cascade into timeouts.
 
-**Fix**: Add `LIMIT`/`OFFSET` or cursor-based pagination. Default page size should be ≤ 100.
+**Do instead:** Add `LIMIT`/`OFFSET` or cursor-based pagination. Default page size should be 100 or fewer records.
 
 ---
 
@@ -159,7 +159,7 @@ if _, exists := cache[key]; !exists {
 
 **Why wrong**: Two goroutines can both pass the `!exists` check before either writes, causing double computation or overwriting a valid value.
 
-**Fix**: Use `sync.Map.LoadOrStore()`, a mutex-wrapped check-and-store, or database-level `INSERT ... ON CONFLICT DO NOTHING`.
+**Do instead:** Use `sync.Map.LoadOrStore()`, a mutex-wrapped check-and-store, or database-level `INSERT ... ON CONFLICT DO NOTHING`.
 
 ---
 
@@ -188,7 +188,7 @@ for post in posts:
 
 **Why wrong**: 100 posts = 101 queries. 10,000 posts = 10,001 queries. Degrades exponentially with data growth.
 
-**Fix**: Use `select_related`/`prefetch_related` (Django), `JOIN` (raw SQL), or batch fetch with `IN (...)`.
+**Do instead:** Use `select_related`/`prefetch_related` (Django), `JOIN` (raw SQL), or batch fetch with `IN (...)`.
 
 ---
 
@@ -210,7 +210,7 @@ rg -n 'router\.(get|post|put|delete)\(' --type ts -B2 | rg -v 'auth\|verify\|req
 
 **Why wrong**: Authenticated users can access other users' resources. Classic IDOR (Insecure Direct Object Reference) vulnerability — OWASP A01:2021.
 
-**Fix**: Always filter queries by the authenticated user's ID: `WHERE user_id = $currentUser`.
+**Do instead:** Always filter queries by the authenticated user's ID: `WHERE user_id = $currentUser`. For operations that modify resources, verify ownership before executing.
 
 ---
 

--- a/agents/reviewer-perspectives/references/review-detection-commands.md
+++ b/agents/reviewer-perspectives/references/review-detection-commands.md
@@ -353,7 +353,7 @@ grep -c 'File:\|Where:\|:\d\+:' review_output.md 2>/dev/null || echo "No line re
 
 **Why wrong**: Vague findings are unfalsifiable. The author cannot verify them, cannot rebut them, and cannot be sure what to fix. Evidence-free reviews waste everyone's time.
 
-**Fix**: Before writing any finding, run the relevant detection command above. If the finding cannot be grounded in a file:line reference, it does not meet the `Evidence-Based Critique` hardcoded behavior.
+**Do instead:** Before writing any finding, run the relevant detection command above. If the finding cannot be grounded in a file:line reference, it does not meet the `Evidence-Based Critique` hardcoded behavior.
 
 ---
 


### PR DESCRIPTION
## Summary

Pairs every unpaired anti-pattern block in the three reviewer-perspectives reference files with a `**Do instead:**` counterpart, satisfying `detect-unpaired-antipatterns.py` for the `reviewer-perspectives` domain.

**Blocks paired per file:**

### clarity-and-assumption-detection.md (8 blocks)
- Magic Numbers: renamed `**Fix**:` to `**Do instead:**`
- Missing Documentation on Public APIs: renamed `**Fix**:` to `**Do instead:**`
- Non-Obvious Variable Names: added `**Do instead:**` paragraph (no fix existed)
- Implicit Preconditions Not Documented: renamed `**Fix**:` to `**Do instead:**`
- Hardcoded Environment Assumptions: added `**Do instead:**` paragraph
- Unvalidated Assumption About Input Size: added `**Do instead:**` paragraph
- Sync-Only Code Assuming Sequential Execution: added `**Do instead:**` paragraph
- Implicit Ordering Assumption: added `**Do instead:**` paragraph

### code-review-detection.md (7 blocks)
- Ignored Errors, HTTP Status Code Misuse, Hardcoded Credentials, Missing Pagination, Race Condition Check-Then-Act, N+1 Query Pattern, Missing Authorization Check: renamed `**Fix**:` to `**Do instead:**` on each

### review-detection-commands.md (1 block)
- Running Perspective Without Detection Pass: renamed `**Fix**:` to `**Do instead:**`

## Validation

- `python3 scripts/detect-unpaired-antipatterns.py --json` filtered to `reviewer-perspectives`: 0 findings
- `python3 scripts/validate-references.py --check-do-framing`: passes ("no new unpaired anti-pattern blocks")
- All three files remain under 500 lines (275, 260, 365)
- No logic or detection commands changed — text additions and marker renames only
- `artifacts/joy-check-sweep-backlog.json` not regenerated (auto-resolved on rebase per `.gitattributes`)

## Test plan

- [ ] `Tests / lint` passes
- [ ] `Tests / test (3.10)` passes
- [ ] `Tests / test (3.12)` passes