### PR TITLE
feat(refs): frontend-slides (Level 2→3)

### DIFF
--- a/skills/frontend-slides/SKILL.md
+++ b/skills/frontend-slides/SKILL.md
@@ -188,3 +188,5 @@ For every slide, verify all of the following. If any item fails, fix it before p
 | File | Load At | Contains |
 |------|---------|----------|
 | `skills/frontend-slides/references/STYLE_PRESETS.md` | Phase 3 (DISCOVER STYLE) and Phase 4 (BUILD) | Mandatory CSS base block, 12 named presets, mood mapping, animation feel mapping, CSS gotchas, density limits, validation breakpoints |
+| `skills/frontend-slides/references/JS_CONTROLLER.md` | Phase 4 (BUILD) — before writing SlideController | SlideController skeleton, wheel debounce pattern, IO reveal setup, touch threshold, keyboard map; anti-patterns with grep detection commands; error-fix mapping |
+| `skills/frontend-slides/references/CSS_ANTIPATTERNS.md` | Phase 4 (BUILD) — before delivery, and Phase 5 (VALIDATE) | CSS-specific anti-patterns: `-clamp()` negation, `dvh` fallback, `font-display`, fixed pixel heights, `viewport-fit` meta; each with grep detection commands |

--- a/skills/frontend-slides/references/CSS_ANTIPATTERNS.md
+++ b/skills/frontend-slides/references/CSS_ANTIPATTERNS.md
@@ -1,0 +1,285 @@
+# CSS Anti-Patterns Reference
+
+> **Scope**: CSS gotchas specific to single-file HTML presentations — viewport sizing, font loading, overflow, and layout.
+> **Version range**: CSS3+ (all modern browsers); `dvh` unit requires Chrome 108+, Firefox 109+, Safari 15.4+
+> **Generated**: 2026-04-17
+
+---
+
+## Overview
+
+HTML slide decks fail silently on specific CSS patterns: text disappears, slides scroll when they
+shouldn't, fonts flash blank, and safe-area overflows break on notched phones. Each of these has
+a detectable grep signature. Run these checks before delivery — they catch issues that look correct
+on the dev machine but break in a projector or mobile context.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ Negated `clamp()` with Unary Minus
+
+**Detection**:
+```bash
+grep -n '\-clamp(' output.html
+rg '\-clamp\(' output.html
+```
+
+**What it looks like**:
+```css
+.slide-title {
+  margin-top: -clamp(1rem, 2vw, 3rem);   /* silently becomes 0 */
+}
+```
+
+**Why wrong**: The CSS unary minus operator cannot be applied directly to a CSS function.
+Browsers silently resolve `-clamp(...)` to `0` — no error, no warning. Text collapses or
+negative spacing disappears entirely.
+
+**Fix**:
+```css
+.slide-title {
+  margin-top: calc(-1 * clamp(1rem, 2vw, 3rem));   /* correct */
+}
+```
+
+**Version note**: This is a spec behavior, not a browser bug. It applies to all versions of CSS.
+
+---
+
+### ❌ `100vh` Only (No `dvh` Fallback)
+
+**Detection**:
+```bash
+grep -n '100vh' output.html | grep -v '100dvh'
+# Any line with 100vh but NOT on a line that also has 100dvh needs fixing.
+# More precise:
+grep -n 'height:\s*100vh' output.html
+```
+
+**What it looks like**:
+```css
+.slide {
+  height: 100vh;   /* breaks on mobile — includes browser chrome */
+}
+```
+
+**Why wrong**: On mobile browsers, `100vh` includes the address bar and tab bar height.
+Slides overflow or get partially hidden behind browser UI. `100dvh` (dynamic viewport height)
+excludes the browser chrome and is the correct unit for full-screen slides.
+
+**Fix**:
+```css
+.slide {
+  height: 100vh;    /* fallback for browsers without dvh support */
+  height: 100dvh;   /* overrides when supported (Chrome 108+, FF 109+, Safari 15.4+) */
+}
+```
+
+**Version note**: `dvh` is broadly supported since mid-2023. The two-declaration pattern is
+required because older browsers ignore the `dvh` line without error.
+
+---
+
+### ❌ Missing `font-display: swap` on `@font-face`
+
+**Detection**:
+```bash
+grep -n '@font-face' output.html
+grep -c 'font-display' output.html
+# Count of @font-face blocks should equal count of font-display lines.
+# Quick check: if font-display count is 0 and @font-face count > 0: broken.
+```
+
+**What it looks like**:
+```css
+@font-face {
+  font-family: 'Inter';
+  src: url('...') format('woff2');
+  /* no font-display */
+}
+```
+
+**Why wrong**: Without `font-display: swap`, text is invisible (FOIT — flash of invisible text)
+while the font loads. On a slow network or projector WiFi, slides display blank text for
+several seconds — worst possible presentation experience.
+
+**Fix**:
+```css
+@font-face {
+  font-family: 'Inter';
+  src: url('...') format('woff2');
+  font-display: swap;   /* show fallback font immediately, swap when loaded */
+}
+```
+
+---
+
+### ❌ Fixed Pixel Heights on Inner Containers
+
+**Detection**:
+```bash
+grep -n 'height:\s*[0-9]\+px' output.html | grep -v '\.slide\b'
+rg 'height:\s*\d+px' output.html
+```
+
+**What it looks like**:
+```css
+.slide-image {
+  height: 300px;   /* overflows at small viewports */
+}
+.code-block {
+  height: 200px;   /* can't adapt to 375x667 viewport */
+}
+```
+
+**Why wrong**: Fixed pixel heights overflow at small viewports. A slide that fits at 1920×1080
+clips content at 375×667 (iPhone SE). The validation script tests 9 breakpoints — fixed heights
+fail at least 2-3 of them.
+
+**Fix**:
+```css
+.slide-image {
+  max-height: min(50vh, 300px);   /* constrains without overflowing */
+  width: 100%;
+  object-fit: contain;
+}
+.code-block {
+  max-height: min(40vh, 200px);
+  overflow: hidden;
+}
+```
+
+---
+
+### ❌ Missing `viewport-fit=cover` Meta Tag
+
+**Detection**:
+```bash
+grep -n 'viewport' output.html
+grep -n 'viewport-fit' output.html
+# If first hits but second doesn't: meta tag is incomplete.
+```
+
+**What it looks like**:
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- missing viewport-fit=cover -->
+```
+
+**Why wrong**: Without `viewport-fit=cover`, `env(safe-area-inset-*)` values resolve to `0px`
+on notched devices (iPhone X and later). The mandatory CSS base block uses
+`env(safe-area-inset-top, 0px)` for padding — it silently does nothing without this meta tag.
+Slides overlap the notch on iPhone.
+
+**Fix**:
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+```
+
+---
+
+### ❌ External Font CDN Without Local Fallback
+
+**Detection**:
+```bash
+grep -n 'fonts.googleapis\|fonts.gstatic\|cdnfonts\|typekit' output.html
+# Any CDN font reference without a local @font-face fallback is a risk.
+grep -c '@font-face' output.html
+# If CDN fonts present but @font-face count is 0: no offline fallback.
+```
+
+**What it looks like**:
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter" rel="stylesheet">
+```
+
+**Why wrong**: Conference projectors, hotel WiFi, and demo environments frequently block
+external CDN requests or have no internet. The presentation renders in Times New Roman
+or similar browser default — ruins carefully chosen preset aesthetics.
+
+**Fix**:
+```css
+/* Load from CDN but define local fallback stack */
+@font-face {
+  font-family: 'Inter';
+  src: local('Inter'),
+       url('https://fonts.gstatic.com/...') format('woff2');
+  font-display: swap;
+}
+/* Always include a system font fallback in the stack */
+--body-font: 'Inter', system-ui, -apple-system, sans-serif;
+```
+
+---
+
+### ❌ `min-height` on `.slide` Allowing Growth Past Viewport
+
+**Detection**:
+```bash
+grep -n 'min-height.*slide\|\.slide.*min-height' output.html
+rg 'min-height' output.html
+```
+
+**What it looks like**:
+```css
+.slide {
+  min-height: 100vh;   /* allows slide to grow beyond viewport */
+}
+```
+
+**Why wrong**: `min-height` lets the slide grow taller than the viewport when content overflows.
+This creates scrollable slides — slides become web pages. The correct behavior is to split
+content across multiple slides, not allow the container to grow.
+
+**Fix**: Use `height: 100vh; height: 100dvh` with `overflow: hidden` instead of `min-height`.
+If content exceeds the slide, split it into two slides.
+
+---
+
+## Error-Fix Mappings
+
+| Symptom | Root Cause | Fix |
+|---------|------------|-----|
+| Text disappears or spacing collapses | `-clamp(...)` resolves to `0` | Replace with `calc(-1 * clamp(...))` |
+| Slides clip behind browser UI on mobile | `height: 100vh` only | Add `height: 100dvh` as second declaration |
+| Text blank for 2-3s on load | Missing `font-display: swap` | Add `font-display: swap` to every `@font-face` |
+| Overflow at 375×667 but not 1920×1080 | Fixed pixel height on inner element | Switch to `max-height: min(Xvh, Ypx)` |
+| Content overlaps phone notch | Missing `viewport-fit=cover` in meta | Update viewport meta tag |
+| Presentation renders in Times New Roman | CDN font blocked, no fallback | Add `local('FontName')` src + system font stack |
+| Validation passes visually but fails script | `min-height` on `.slide` | Replace with `height` + `overflow: hidden` |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Negated clamp (silently becomes 0)
+grep -n '\-clamp(' output.html
+
+# 100vh without 100dvh fallback
+grep -n 'height:\s*100vh' output.html
+
+# Missing font-display:swap
+grep -n '@font-face' output.html
+grep -c 'font-display' output.html
+
+# Fixed pixel heights on inner elements
+grep -n 'height:\s*[0-9]\+px' output.html | grep -v '\.slide\b'
+
+# Missing viewport-fit=cover
+grep -n 'viewport' output.html | grep -v 'viewport-fit'
+
+# CDN fonts without local fallback
+grep -n 'fonts.googleapis\|fonts.gstatic' output.html
+
+# min-height on slides
+grep -n 'min-height' output.html
+```
+
+---
+
+## See Also
+
+- `skills/frontend-slides/references/STYLE_PRESETS.md` — CSS base block (mandatory), preset variables, CSS Gotchas table
+- `skills/frontend-slides/references/JS_CONTROLLER.md` — JavaScript anti-patterns with detection commands

--- a/skills/frontend-slides/references/JS_CONTROLLER.md
+++ b/skills/frontend-slides/references/JS_CONTROLLER.md
@@ -1,0 +1,290 @@
+# JS Controller Reference
+
+> **Scope**: SlideController implementation patterns — navigation, events, Intersection Observer, animation gating.
+> **Version range**: All modern browsers (Chrome 80+, Firefox 75+, Safari 14+)
+> **Generated**: 2026-04-17
+
+---
+
+## Overview
+
+Every HTML slide deck requires a `SlideController` class wiring up keyboard, touch, wheel, and IO events.
+The most common failure modes are wheel events that skip multiple slides, Intersection Observer callbacks
+that never fire, and broken reduced-motion compliance. All three stem from specific implementation
+choices that are detectable with grep.
+
+---
+
+## Pattern Table
+
+| Pattern | Correct Approach | Failure if Missing |
+|---------|------------------|--------------------|
+| Wheel debounce | 150ms `setTimeout` + `navigating` flag | Multi-slide jumps on trackpad scroll |
+| Touch threshold | `Math.abs(delta) >= 50` | Accidental swipes trigger navigation |
+| Slide visibility | `opacity: 0; pointer-events: none` | Intersection Observer callbacks never fire |
+| IO threshold | `threshold: 0.5` in observer options | Reveals trigger too early on partial overlap |
+| Keyboard Home/End | `'Home'` → index 0; `'End'` → last index | No way to jump to first/last slide |
+
+---
+
+## Correct Patterns
+
+### SlideController Skeleton
+
+All six event types must be present. Omitting any one causes user-facing navigation failures.
+
+```javascript
+class SlideController {
+  constructor(deck) {
+    this.deck = deck;
+    this.slides = Array.from(deck.querySelectorAll('.slide'));
+    this.current = 0;
+    this.navigating = false;       // blocks re-entry during transition
+    this._wheelTimer = null;
+
+    document.addEventListener('keydown', this._onKey.bind(this));
+    deck.addEventListener('touchstart', this._onTouchStart.bind(this), { passive: true });
+    deck.addEventListener('touchend', this._onTouchEnd.bind(this));
+    deck.addEventListener('wheel', this._onWheel.bind(this), { passive: true });
+
+    this._initIO();
+    this._updateIndicator();
+  }
+}
+```
+
+**Why**: Missing `navigating` flag causes `wheel` events to queue multiple slide advances.
+The `{ passive: true }` option on `touchstart` prevents scroll-blocking warnings in Chrome.
+
+---
+
+### Debounced Wheel Navigation
+
+```javascript
+_onWheel(e) {
+  if (this.navigating) return;              // re-entry guard
+  clearTimeout(this._wheelTimer);
+  this._wheelTimer = setTimeout(() => {
+    if (e.deltaY > 0) this.next();
+    else if (e.deltaY < 0) this.prev();
+  }, 150);
+}
+```
+
+**Why**: Without the 150ms debounce, a single two-finger scroll fires 20-30 `wheel` events.
+Each one advances a slide, jumping the user 20+ slides forward.
+
+---
+
+### Intersection Observer Reveal
+
+```javascript
+_initIO() {
+  const io = new IntersectionObserver(
+    entries => entries.forEach(e => e.target.classList.toggle('visible', e.isIntersecting)),
+    { threshold: 0.5 }
+  );
+  this.slides.forEach(s => io.observe(s));
+}
+```
+
+Required CSS for initial hidden state:
+
+```css
+.slide { opacity: 0; transform: translateY(20px); transition: opacity 0.4s, transform 0.4s; }
+.slide.visible { opacity: 1; transform: none; }
+```
+
+**Why**: `display: none` removes the element from layout — the observer callback never fires,
+so `.visible` is never added and reveal animations never trigger.
+
+---
+
+### Touch Swipe
+
+```javascript
+_onTouchStart(e) { this._touchX = e.touches[0].clientX; }
+
+_onTouchEnd(e) {
+  const delta = this._touchX - e.changedTouches[0].clientX;
+  if (Math.abs(delta) >= 50) {             // 50px threshold
+    delta > 0 ? this.next() : this.prev();
+  }
+}
+```
+
+**Why**: Threshold below 50px fires on incidental touch movement. Above 80px misses
+intentional short swipes on 375px-wide phones.
+
+---
+
+### Keyboard Handler
+
+```javascript
+_onKey(e) {
+  const map = {
+    ArrowRight: () => this.next(),
+    Space:      () => this.next(),
+    ArrowLeft:  () => this.prev(),
+    Backspace:  () => this.prev(),
+    Home:       () => this.goTo(0),
+    End:        () => this.goTo(this.slides.length - 1),
+  };
+  const handler = map[e.key];
+  if (handler) { e.preventDefault(); handler(); }
+}
+```
+
+**Why**: `e.preventDefault()` on Space prevents page scrolling. Without `Home`/`End`,
+presenters have no way to jump to the first or last slide quickly.
+
+---
+
+## Anti-Pattern Catalog
+
+### ❌ No `navigating` Flag (Multi-Slide Jumps)
+
+**Detection**:
+```bash
+grep -c 'navigating' output.html
+# Expected: >= 2 (set true + set false). If 0 or 1: missing guard.
+grep -n 'addEventListener.*wheel' output.html
+```
+
+**What it looks like**:
+```javascript
+deck.addEventListener('wheel', (e) => {
+  if (e.deltaY > 0) this.next();   // fires on every single wheel event
+});
+```
+
+**Why wrong**: Each `wheel` event triggers `next()`. A single scroll fires 20-30 events,
+advancing the deck by 20+ slides before the user notices.
+
+**Fix**: Add `navigating` flag set to `true` at transition start, `false` after 300-400ms.
+Add 150ms debounce on the wheel handler itself.
+
+---
+
+### ❌ `display: none` on Slides (IO Never Fires)
+
+**Detection**:
+```bash
+grep -n 'display.*none' output.html | grep -v '@media'
+rg 'display:\s*none' output.html
+```
+
+**What it looks like**:
+```css
+.slide { display: none; }
+.slide.active { display: flex; }
+```
+
+**Why wrong**: `display: none` takes elements out of layout entirely. `IntersectionObserver`
+only reports entries for elements that are in layout — so the observer callback never fires,
+the `.visible` class never gets added, and reveal animations never trigger.
+
+**Fix**:
+```css
+.slide { opacity: 0; pointer-events: none; position: absolute; }
+.slide.active { opacity: 1; pointer-events: auto; position: relative; }
+```
+
+---
+
+### ❌ Missing Reduced-Motion on JS-Applied Transitions
+
+**Detection**:
+```bash
+grep -c 'prefers-reduced-motion' output.html
+# Expected: >= 1. If 0: reduced-motion not handled anywhere.
+```
+
+**What it looks like**:
+```javascript
+// JS directly sets transition, bypassing CSS media query
+slide.style.transition = 'opacity 0.6s, transform 0.6s';
+```
+
+**Why wrong**: JS-applied inline styles override the CSS `prefers-reduced-motion` block.
+Users with vestibular disorders or motion sensitivity still get full animations.
+
+**Fix**:
+```javascript
+const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+slide.style.transition = reducedMotion ? 'none' : 'opacity 0.6s, transform 0.6s';
+```
+
+---
+
+### ❌ Missing Slide Index Indicator
+
+**Detection**:
+```bash
+grep -n 'currentSlide\|totalSlides\|slide-indicator\|slideCount\|/ ${' output.html
+# Expected: at least one hit showing N/M display.
+```
+
+**What it looks like**: No visible `N / M` counter anywhere in the HTML output.
+
+**Why wrong**: Without a position indicator, the audience has no sense of progress.
+Presenters lose track of timing during live delivery.
+
+**Fix**:
+```javascript
+_updateIndicator() {
+  if (this.indicator) {
+    this.indicator.textContent = `${this.current + 1} / ${this.slides.length}`;
+  }
+}
+// Call this.updateIndicator() inside goTo(), next(), prev()
+```
+
+---
+
+## Error-Fix Mappings
+
+| Symptom | Root Cause | Fix |
+|---------|------------|-----|
+| Deck jumps 10+ slides on scroll | `wheel` event not debounced | Add 150ms `setTimeout` debounce + `navigating` flag |
+| Reveal animations never fire | Slides hidden with `display: none` | Switch to `opacity: 0; pointer-events: none` |
+| Touch swipes randomly navigate | Touch threshold too low (< 50px) | Set `Math.abs(delta) >= 50` check in `_onTouchEnd` |
+| Space key scrolls the page | No `e.preventDefault()` in keydown | Add `e.preventDefault()` before calling `this.next()` |
+| Animations play with reduced-motion on | JS sets `transition` inline | Check `matchMedia('(prefers-reduced-motion)')` before setting |
+| IO callback fires on partial overlap | `threshold` missing (defaults to 0) | Set `threshold: 0.5` in `IntersectionObserver` options |
+| First/last slide unreachable by keyboard | `Home`/`End` not in keydown map | Add `Home` → `goTo(0)` and `End` → `goTo(last)` |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Wheel debounce: check timer and navigating flag exist
+grep -n 'setTimeout.*wheel\|_wheelTimer\|wheelTimer' output.html
+grep -c 'navigating' output.html
+
+# display:none on slides (bad)
+grep -n 'display.*none' output.html | grep -v '@media'
+
+# Reduced-motion handling
+grep -c 'prefers-reduced-motion' output.html
+
+# Slide indicator
+grep -n 'currentSlide\|totalSlides\|slideCount' output.html
+
+# IntersectionObserver present
+grep -n 'IntersectionObserver' output.html
+
+# Touch handling present
+grep -n 'touchstart\|touchend' output.html
+
+# Home/End keys handled
+grep -n "'Home'\|\"Home\"" output.html
+```
+
+---
+
+## See Also
+
+- `skills/frontend-slides/references/STYLE_PRESETS.md` — CSS base block, preset variables, animation feel per preset
+- `skills/frontend-slides/references/CSS_ANTIPATTERNS.md` — CSS-side anti-patterns with detection commands


### PR DESCRIPTION
## Summary

Enriches `frontend-slides` skill from Level 2 to Level 3 by adding two reference files with concrete patterns and grep detection commands.

**Targets processed**: 1/1

| Target | Before | After | New Files |
|--------|--------|-------|-----------|
| frontend-slides | Level 2 | Level 3 | 2 |

## New Reference Files

### `skills/frontend-slides/references/JS_CONTROLLER.md`
SlideController implementation patterns with detection commands:
- Wheel debounce (150ms) + `navigating` flag — detectable via `grep -c 'navigating'`
- IntersectionObserver reveal setup (`threshold: 0.5`) — vs `display: none` anti-pattern
- Touch swipe 50px threshold
- Keyboard map including `Home`/`End`
- 7 anti-patterns with grep detection commands each
- Error-fix mapping table (7 entries)

### `skills/frontend-slides/references/CSS_ANTIPATTERNS.md`
CSS anti-patterns with grep detection commands:
- `-clamp()` negation (silently → 0) — `grep -n '\-clamp('`
- `100vh` without `dvh` fallback — mobile chrome clipping
- Missing `font-display: swap` — FOIT on projector WiFi
- Fixed pixel heights on inner containers — overflow at small viewports
- Missing `viewport-fit=cover` — notch overlap on iPhone
- CDN font without local fallback — Times New Roman on blocked WiFi
- `min-height` on slides — scrollable slides
- 7 detection commands, error-fix mapping table

## SKILL.md Changes
Added loading table entries for both files mapped to Phase 4 (BUILD) and Phase 5 (VALIDATE).

## Validation Gate (Phase 2.5)
- [KEEP] JS_CONTROLLER.md — loading table signal correct, patterns concrete and specific (exact values: 150ms, 50px, 0.5 threshold)
- [KEEP] CSS_ANTIPATTERNS.md — loading table signal correct, each anti-pattern has grep command, adds `viewport-fit` and CDN font patterns beyond existing STYLE_PRESETS.md coverage