### PR TITLE
docs(database-engineer): pair anti-patterns with Do-instead blocks

### DIFF
--- a/agents/database-engineer/references/performance.md
+++ b/agents/database-engineer/references/performance.md
@@ -180,7 +180,7 @@ CREATE INDEX idx_users_country ON users(country);
 
 **Why wrong**: Every index slows down writes (INSERT/UPDATE/DELETE must update all indexes). A table with 10 indexes has 10× write amplification. Index maintenance during VACUUM is slower. Buffer cache fills with index pages instead of table data.
 
-**Fix**: Check `pg_stat_user_indexes.idx_scan = 0` after running the application under production load for 1+ weeks. Drop indexes with zero usage. Keep only indexes that serve known query patterns.
+**Do instead:** Check `pg_stat_user_indexes.idx_scan = 0` after running the application under production load for 1+ weeks. Drop indexes with zero usage. Keep only indexes that serve known query patterns.
 
 ---
 
@@ -206,7 +206,7 @@ ALTER TABLE orders ADD COLUMN processed BOOLEAN NOT NULL DEFAULT false;
 
 **Why wrong**: On PostgreSQL < 11, adding a column with a default value requires rewriting the entire table. On a 500GB table, this takes hours with an ExclusiveLock that blocks ALL reads and writes.
 
-**Fix**:
+**Do instead:**
 ```sql
 -- PostgreSQL 11+: adding column with DEFAULT is safe (metadata only), do it directly
 
@@ -243,7 +243,7 @@ WHERE state = 'active'
 
 **Why wrong**: Long-running queries on PostgreSQL prevent autovacuum from cleaning dead rows (transaction ID wraparound risk), hold shared memory, and block DDL operations that need ExclusiveLock.
 
-**Fix**:
+**Do instead:**
 ```sql
 -- Set per-session timeout (application layer)
 SET statement_timeout = '30s';

--- a/agents/database-engineer/references/postgres.md
+++ b/agents/database-engineer/references/postgres.md
@@ -181,7 +181,7 @@ AND (tc.table_name, kcu.column_name) NOT IN (
 
 **Why wrong**: A JOIN on an unindexed foreign key does a sequential scan of the child table for every parent row. On a 1M row orders table with 100K users, that's 100K × 10ms sequential scans = 16 minutes for a simple user-orders join.
 
-**Fix**:
+**Do instead:**
 ```sql
 CREATE INDEX idx_orders_user_id ON orders(user_id);
 -- Verify with EXPLAIN that query now uses Index Scan instead of Seq Scan
@@ -205,7 +205,7 @@ SELECT * FROM products WHERE name ILIKE '%laptop%';
 
 **Why wrong**: B-tree indexes require a known prefix. `LIKE '%term%'` always does a full sequential scan regardless of indexes. On 100K products, this is 100K string comparisons per query.
 
-**Fix**:
+**Do instead:**
 ```sql
 -- Option 1: PostgreSQL full-text search (for natural language)
 ALTER TABLE products ADD COLUMN search_vector tsvector
@@ -250,7 +250,7 @@ ORDER BY n_live_tup DESC;
 
 **Why wrong**: PostgreSQL's query planner uses row count estimates to choose join strategies and index selection. Stale statistics (50x off) cause the planner to pick catastrophically wrong query plans.
 
-**Fix**:
+**Do instead:**
 ```sql
 -- After bulk loads, run ANALYZE immediately
 ANALYZE orders;

--- a/agents/database-engineer/references/sql.md
+++ b/agents/database-engineer/references/sql.md
@@ -166,7 +166,7 @@ cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))
 
 **Why wrong**: Retrieves all columns including large TEXT/BLOB fields even when only `name` and `email` are needed. Breaks when schema adds columns (new columns appear in API responses). Prevents index-only scans (which need only indexed columns).
 
-**Fix**:
+**Do instead:**
 ```python
 cursor.execute(
     "SELECT id, name, email, created_at FROM users WHERE id = %s",
@@ -202,7 +202,7 @@ SELECT * FROM users WHERE id = '12345';
 
 **Why wrong**: In MySQL, comparing an integer column to a string `'12345'` coerces the string to integer for comparison but may or may not use the index depending on the column type. PostgreSQL is stricter and often throws an error, but implicit casts in some cases bypass indexes.
 
-**Fix**: Pass the correct type from the application:
+**Do instead:** Pass the correct type from the application:
 ```python
 # Python: pass integer, not string
 cursor.execute("SELECT * FROM users WHERE id = %s", (int(user_id),))
@@ -231,7 +231,7 @@ cursor.execute(query)
 
 **Why wrong**: Attacker passes `id=1 OR 1=1` to dump all users, or `id=1; DROP TABLE users` to destroy data. This is OWASP Top 10 #3.
 
-**Fix**:
+**Do instead:**
 ```python
 # Always use parameterized queries
 cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))
@@ -262,7 +262,7 @@ SELECT * FROM users WHERE LOWER(email) = 'alice@example.com';
 
 **Why wrong**: Applying a function to an indexed column prevents index use. `DATE(created_at)` computes a new value for every row, forcing a full sequential scan. The index stores values of `created_at`, not values of `DATE(created_at)`.
 
-**Fix**:
+**Do instead:**
 ```sql
 -- Date range instead of function (uses index)
 SELECT * FROM orders


### PR DESCRIPTION
## Summary

- Renames `**Fix**:` to `**Do instead:**` in all three database-engineer reference files
- Fixes 10 unpaired anti-pattern findings (performance.md x3, postgres.md x3, sql.md x4)
- Label-only change: no technical content altered

## Verification

- `python3 scripts/detect-unpaired-antipatterns.py` reports 0 findings for `database-engineer`
- `python3 scripts/validate-references.py --check-do-framing` passes
- All three files remain under 500 lines (303 / 311 / 317)

## Test plan

- [ ] CI lint passes (ruff check + format)
- [ ] CI test passes
- [ ] Detector reports 0 new findings for database-engineer domain