### PR TITLE
docs(python-openstack): pair anti-patterns with Do-instead blocks

### DIFF
--- a/agents/python-openstack-engineer/references/hacking-rules.md
+++ b/agents/python-openstack-engineer/references/hacking-rules.md
@@ -124,7 +124,7 @@ except:   # H201 — catches SystemExit, KeyboardInterrupt, GeneratorExit
 
 **Why wrong**: Catches `SystemExit` and `KeyboardInterrupt`, preventing clean service shutdown. `tox -e pep8` hard blocks this.
 
-**Fix**:
+**Do instead:**
 ```python
 try:
     result = db.get_resource(context, resource_id)
@@ -151,7 +151,7 @@ from myservice.common import *
 
 **Why wrong**: Pollutes namespace, breaks introspection, makes `tox -e pep8` fail, and hides dependency chain from code review tools like Zuul.
 
-**Fix**: Import only what you use explicitly.
+**Do instead:** Import only what you use explicitly.
 
 ```python
 from oslo_config.cfg import CONF, StrOpt, IntOpt
@@ -175,7 +175,7 @@ from ..exception import ResourceNotFound
 
 **Why wrong**: OpenStack enforces absolute imports throughout. Relative imports break `oslo-config-generator`, tox environments, and Zuul dependency resolution.
 
-**Fix**:
+**Do instead:**
 ```python
 from myservice.common.utils import format_id
 from myservice import exception
@@ -199,7 +199,7 @@ LOG.debug('State: %(state)s timeout: %(timeout)s' % self.__dict__)
 
 **Why wrong**: `locals()` captures entire local scope including sensitive values (passwords, tokens). Implicit coupling makes refactoring silently break string formatting.
 
-**Fix**:
+**Do instead:**
 ```python
 msg = ('Creating %(resource_type)s for user %(user_id)s'
        % {'resource_type': resource_type, 'user_id': user_id})

--- a/agents/python-openstack-engineer/references/oslo-patterns.md
+++ b/agents/python-openstack-engineer/references/oslo-patterns.md
@@ -174,7 +174,7 @@ LOG = logging.getLogger(__name__)
 
 **Why wrong**: Bypasses `oslo.log` integration. Log messages won't carry Oslo context fields (`request_id`, `project_id`), and runtime log level changes via `CONF.debug` won't apply to this logger.
 
-**Fix**:
+**Do instead:**
 ```python
 from oslo_log import log as logging
 
@@ -198,7 +198,7 @@ transport = messaging.get_rpc_transport(
 
 **Why wrong**: Transport URL must come from oslo.config (`CONF.transport_url`) to be overridable in deployment configs and testable with `oslo_messaging.fake`.
 
-**Fix**:
+**Do instead:**
 ```python
 # In opts registration:
 cfg.StrOpt('transport_url', default='rabbit://', help='...')
@@ -228,7 +228,7 @@ session = Session()
 
 **Why wrong**: Bypasses oslo.db retry logic (deadlock retries via `@api.wrap_db_retry`), connection pool management, and the `sqlite+pysqlite:///:memory:` test override used in unit tests.
 
-**Fix**: Use `enginefacade.writer` / `enginefacade.reader` decorators as shown in the Correct Patterns section.
+**Do instead:** Use `enginefacade.writer` / `enginefacade.reader` decorators as shown in the Correct Patterns section.
 
 ---
 
@@ -248,7 +248,7 @@ def delete_resource(self, context, resource_id):
 
 **Why wrong**: All API operations must enforce oslo.policy rules. Missing enforcement silently bypasses RBAC — a security vulnerability that won't be caught by unit tests unless policy enforcement is explicitly tested.
 
-**Fix**:
+**Do instead:**
 ```python
 from oslo_policy import policy
 

--- a/agents/python-openstack-engineer/references/rpc-versioning.md
+++ b/agents/python-openstack-engineer/references/rpc-versioning.md
@@ -174,7 +174,7 @@ def create_resource(self, context, name, resource_type):  # Added required arg
 
 **Why wrong**: Old nodes calling `create_resource(ctx, name)` will crash with `TypeError` on the new server. Rolling upgrade fails.
 
-**Fix**: Bump `RPC_API_VERSION` to `'1.3'`, make `resource_type` optional with a default, and pin new client calls to `prepare(version='1.3')`.
+**Do instead:** Bump `RPC_API_VERSION` to `'1.3'`, make `resource_type` optional with a default, and pin new client calls to `prepare(version='1.3')`.
 
 ---
 
@@ -196,7 +196,7 @@ def resize_resource(self, context, resource_id, new_size):
 
 **Why wrong**: `_client.call()` without `.prepare(version=X)` sends no version requirement. If the server is on `1.3` and doesn't have `resize_resource`, the call fails with `MethodNotFound`.
 
-**Fix**: Always use `self._client.prepare(version='1.4').call(...)` before calls that require a specific version.
+**Do instead:** Always use `self._client.prepare(version='1.4').call(...)` before calls that require a specific version.
 
 ---
 
@@ -222,7 +222,7 @@ class MyServiceManager:
 
 **Why wrong**: Clients can't use `prepare(version=X)` to protect against calling new methods on old servers. Every caller must assume all methods exist on all server versions — breaks rolling upgrades.
 
-**Fix**: Audit when each method was added, assign retrospective version numbers, and update `RPC_API_VERSION` to reflect the current maximum.
+**Do instead:** Audit when each method was added, assign retrospective version numbers, and update `RPC_API_VERSION` to reflect the current maximum.
 
 ---
 


### PR DESCRIPTION
## Summary

- Renames every `**Fix**:` label to `**Do instead:**` across the three `python-openstack-engineer` reference files
- Clears all 11 unpaired anti-pattern findings reported by `detect-unpaired-antipatterns.py` for this domain
- No technical content changed — label rename only

## Files changed

- `agents/python-openstack-engineer/references/hacking-rules.md` (4 blocks: H201, H303, H304, H501)
- `agents/python-openstack-engineer/references/oslo-patterns.md` (4 blocks: direct import logging, hardcoded transport URL, raw SQLAlchemy, missing oslo.policy)
- `agents/python-openstack-engineer/references/rpc-versioning.md` (3 blocks: signature without version bump, new method without version pin, RPC_API_VERSION 1.0 forever)

## Verification

- `python3 scripts/detect-unpaired-antipatterns.py` — 0 new findings for python-openstack files
- `python3 scripts/validate-references.py --check-do-framing` — no new unpaired anti-patterns
- All files under 500 lines (248, 301, 261)

## Test plan

- [ ] `Tests / lint` passes
- [ ] `Tests / test (3.10)` passes
- [ ] `Tests / test (3.12)` passes
- [ ] `Tests / routing-benchmark` passes
- [ ] `Tests / routing-drift` passes