### PR TITLE
docs(testing-automation): pair anti-patterns with Do-instead blocks

### DIFF
--- a/agents/testing-automation-engineer/references/async-testing.md
+++ b/agents/testing-automation-engineer/references/async-testing.md
@@ -166,7 +166,7 @@ expect(await page.textContent('.result')).toBe('Done')
 
 **Why wrong**: Arbitrary delays make tests slow on fast machines and flaky on slow ones. If the operation takes 600ms instead of 500ms (CI under load), the test fails. These tests hide timing bugs rather than revealing them.
 
-**Fix**:
+**Do instead:**
 ```typescript
 // RTL — wait for actual DOM change
 await screen.findByText(/result/i)
@@ -198,7 +198,7 @@ expect(screen.getByText(/hello/i)).toBeInTheDocument()
 
 **Why wrong**: `userEvent.setup()` returns async methods in RTL 14+. Without `await`, the events fire but React state updates haven't processed before assertions run. Test passes inconsistently depending on microtask scheduling.
 
-**Fix**:
+**Do instead:**
 ```typescript
 const user = userEvent.setup()
 await user.click(button)
@@ -225,7 +225,7 @@ expect(screen.getByText(/saved/i)).toBeInTheDocument()  // may not exist yet
 
 **Why wrong**: `user.click` resolves after the event dispatches, not after React re-renders from async work (API calls, state transitions). The `getByText` assertion runs synchronously and finds the element absent.
 
-**Fix**:
+**Do instead:**
 ```typescript
 await user.click(screen.getByRole('button', { name: /save/i }))
 await screen.findByText(/saved/i)   // waits up to 1000ms by default
@@ -248,7 +248,7 @@ server.listen()  // no onUnhandledRequest — silent network failures
 
 **Why wrong**: When a component makes an unexpected API call (wrong path, URL typo), MSW passes it through or returns undefined without failing the test. The component renders broken UI, tests assert on something unrelated, and the bug is hidden until production.
 
-**Fix**:
+**Do instead:**
 ```typescript
 server.listen({ onUnhandledRequest: 'error' })
 // Unexpected requests now throw: "Error: No handler for GET /api/typo"

--- a/agents/testing-automation-engineer/references/mocking-patterns.md
+++ b/agents/testing-automation-engineer/references/mocking-patterns.md
@@ -151,7 +151,7 @@ it('displays total', () => {
 
 **Why wrong**: This test verifies that when `calculateTotal` returns `99.99`, the component displays it. It does NOT test whether `calculateTotal` returns the right value. A bug in the calculation is invisible to this test. Over-mocked tests pass while the real system is broken.
 
-**Fix**: Mock only the network boundary, let real internal logic run:
+**Do instead:** Mock only the network boundary, let real internal logic run:
 ```typescript
 server.use(
   http.get('/api/cart', () => HttpResponse.json({ items: [{ price: 99.99, qty: 1 }] }))
@@ -182,7 +182,7 @@ vi.mock('react-router-dom', () => ({
 
 **Why wrong**: When `react-router-dom` updates its API, the mock silently diverges. The test passes but the real component breaks in production. You're testing against a fake contract you wrote yourself.
 
-**Fix**: Use real providers in tests. For React Router v6+:
+**Do instead:** Use real providers in tests. For React Router v6+:
 ```typescript
 import { MemoryRouter } from 'react-router-dom'
 
@@ -221,7 +221,7 @@ it('saves user preferences', async () => {
 
 **Why wrong**: This test passes even if `savePreferences` is called but returns an error the component silently swallows. Or if the UI shows a stale state. It verifies that a function was invoked, not that the user got the right outcome.
 
-**Fix**: Assert on user-visible result first; use call assertions as secondary verification:
+**Do instead:** Assert on user-visible result first; use call assertions as secondary verification:
 ```typescript
 it('saves user preferences', async () => {
   server.use(http.post('/api/preferences', () => new HttpResponse(null, { status: 204 })))
@@ -254,7 +254,7 @@ beforeAll(() => {
 
 **Why wrong**: This suppresses all React prop-type warnings, act() warnings, and real errors. A broken component renders silently. Errors that should fail the test pass unnoticed.
 
-**Fix**: Suppress only the specific known warning; assert others still fire:
+**Do instead:** Suppress only the specific known warning; assert others still fire:
 ```typescript
 beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation((msg) => {

--- a/agents/testing-automation-engineer/references/vitest-patterns.md
+++ b/agents/testing-automation-engineer/references/vitest-patterns.md
@@ -152,7 +152,7 @@ jest.spyOn(console, 'error')
 
 **Why wrong**: Vitest does not polyfill the `jest` global by default. These calls throw `ReferenceError: jest is not defined` at runtime or produce silent `undefined` if `globals: true` is configured with a partial shim.
 
-**Fix**:
+**Do instead:**
 ```typescript
 import { vi } from 'vitest'
 const mockFn = vi.fn()
@@ -190,7 +190,7 @@ describe('Suite B', () => {
 
 **Why wrong**: Spy state persists across test files in the same worker thread. Tests in unrelated files fail with unexpected mock behavior. Produces order-dependent failures that are hard to reproduce.
 
-**Fix**: Always pair `vi.spyOn` with `afterEach(() => vi.restoreAllMocks())`. Or configure globally:
+**Do instead:** Always pair `vi.spyOn` with `afterEach(() => vi.restoreAllMocks())`. Or configure globally:
 ```typescript
 test: { restoreMocks: true }  // auto-restore after each test in vitest.config.ts
 ```
@@ -218,7 +218,7 @@ coverage: {
 
 **Why wrong**: A function with `if (user.isAdmin)` tested only with admin users shows 100% line coverage but 0% branch coverage. The non-admin code path is completely untested. CI passes, bugs ship.
 
-**Fix**: Always include `branches: 80` in thresholds (see Correct Patterns section above).
+**Do instead:** Always include `branches: 80` in thresholds (see Correct Patterns section above).
 
 ---
 
@@ -240,7 +240,7 @@ it('renders correctly', () => {
 
 **Why wrong**: External `.snap` files are updated with `--updateSnapshot` without review. Developers mindlessly accept them in CI, converting regression detectors into rubber stamps.
 
-**Fix**: Use inline snapshots or explicit behavioral assertions:
+**Do instead:** Use inline snapshots or explicit behavioral assertions:
 ```typescript
 // Inline snapshot — diff visible in the PR
 expect(button).toMatchInlineSnapshot(`<button class="btn">Click me</button>`)


### PR DESCRIPTION
## Summary

- Renames `**Fix**:` to `**Do instead:**` in all 11 anti-pattern blocks across three testing-automation-engineer reference files
- Fixes `detect-unpaired-antipatterns.py` reporting for this domain: 11 findings reduced to 0
- No content changes; label-only renames that satisfy the joy-check detector's `DO_INSTEAD_MARKERS` regex

## Files changed

- `agents/testing-automation-engineer/references/async-testing.md` (4 blocks)
- `agents/testing-automation-engineer/references/mocking-patterns.md` (4 blocks)
- `agents/testing-automation-engineer/references/vitest-patterns.md` (3 blocks)

## Validation

- `python3 scripts/detect-unpaired-antipatterns.py` — 0 new findings for testing-automation domain
- `python3 scripts/validate-references.py --check-do-framing` — no new unpaired anti-pattern blocks
- All three files remain under 500 lines (305 / 286 / 303)

## Test plan

- [ ] All 5 CI checks pass (lint, test, validate-references, detect-unpaired-antipatterns, ruff)