### PR TITLE
docs(pipeline-orchestrator): pair anti-patterns with Do-instead blocks

### DIFF
--- a/agents/pipeline-orchestrator-engineer/references/anti-patterns.md
+++ b/agents/pipeline-orchestrator-engineer/references/anti-patterns.md
@@ -1,5 +1,7 @@
 # Pipeline Orchestration — Anti-Patterns
 
+<!-- no-pair-required: section-header-only; document title for anti-patterns reference file -->
+
 > **Scope**: Common mistakes when creating, scaffolding, and routing toolkit pipelines. Does NOT cover general Go/Python anti-patterns — see those agents for language-specific issues.
 > **Version range**: claude-code-toolkit all versions
 > **Generated**: 2026-04-09 — verify detection commands against current repo structure
@@ -13,6 +15,8 @@ Pipeline creation mistakes compound: a missing discovery step leads to duplicate
 ---
 
 ## Anti-Pattern Catalog
+
+<!-- no-pair-required: section-header-only; individual anti-patterns below carry Do-instead blocks -->
 
 ### ❌ Dispatching Sub-Agents Without Context Package
 
@@ -29,7 +33,7 @@ Agent(description="Create skill", prompt="Create a skill for Prometheus alerting
 
 **Why wrong**: The sub-agent starts with no knowledge of existing components, naming conventions, or inter-component relationships. It will create components that conflict with or duplicate existing ones. The pipeline-creator A/B test validated this: agents dispatched without a Discovery Report produced orphaned components in 40% of runs.
 
-**Fix**:
+**Do instead**:
 ```
 Agent(
   description="Create Prometheus alerting skill",
@@ -62,7 +66,7 @@ ls agents/*.md | wc -l
 
 **Why wrong**: Creates a duplicate routing entry. Two agents with overlapping triggers produce non-deterministic routing — `/do` will route to whichever appears first in the routing table. Users get inconsistent behavior. The duplicate is harder to merge later than to prevent now.
 
-**Fix**: Always run Phase 1 before Phase 3:
+**Do instead**: Always run Phase 1 before Phase 3:
 ```bash
 # In Phase 1
 python3 scripts/artifact-utils.py discover --domain prometheus
@@ -89,7 +93,7 @@ description: "Prometheus: metrics, alerting, dashboards, operations, performance
 
 **Why wrong**: Each subdomain has different task types needing different pipeline chains. A skill handling 5 subdomains dilutes expertise, overloads context, and can't be routed independently. The A/B test on parallel dispatch showed sequential single-skill approaches lose 1.40 points on Examples quality vs. parallel N-skill approaches.
 
-**Fix**: Decompose into N skills per domain:
+**Do instead**: Decompose into N skills per domain:
 ```
 prometheus-metrics-skill.md        — authoring and querying metrics
 prometheus-alerting-skill.md       — alert rules, inhibition, routing
@@ -114,7 +118,7 @@ grep -rn 'validate-chain\|chain.*pass\|chain.*valid' adr/ --include="*.md"
 
 **Why wrong**: Type incompatibilities surface at runtime, not during scaffolding. A `research` step produces a `ResearchReport` artifact; a `review` step expects `DraftContent`. Connecting them directly produces a type mismatch that silently produces empty or malformed output.
 
-**Fix**:
+**Do instead**:
 ```bash
 python3 scripts/artifact-utils.py validate-chain \
   --chain "research,draft,review,publish" \
@@ -139,7 +143,7 @@ comm -23 \
 
 **Why wrong**: An unrouted pipeline is invisible. No trigger phrase reaches it. It exists as a file but is dead code — users get no error, just wrong routing to an unrelated agent. Routing integration takes 2 minutes; recovering user trust in the routing system takes longer.
 
-**Fix**: Phase 4 INTEGRATE is not optional. Run `routing-table-updater` in the same session as Phase 3 SCAFFOLD. Gate: all components routable via `/do` before task is marked complete.
+**Do instead**: Phase 4 INTEGRATE is not optional. Run `routing-table-updater` in the same session as Phase 3 SCAFFOLD. Gate: all components routable via `/do` before task is marked complete.
 
 ---
 
@@ -164,7 +168,7 @@ description: "..."
 
 **Why wrong**: Agents without `allowed-tools` get the full tool set regardless of their role. A read-only reviewer agent that can Edit/Write/Bash can silently modify files during review — a violation of the reviewer role. ADR-063 mandates tool restriction by role type.
 
-**Fix**: Match tools to role:
+**Do instead**: Match tools to role:
 ```yaml
 allowed-tools:  # for reviewers / research agents
   - Read

--- a/agents/pipeline-orchestrator-engineer/references/orchestration-patterns.md
+++ b/agents/pipeline-orchestrator-engineer/references/orchestration-patterns.md
@@ -159,7 +159,7 @@ grep -rn 'integrate\|routing-table' agents/pipeline-orchestrator-engineer.md | h
 
 **Why wrong**: Partial integration produces inconsistent routing. An agent registered in INDEX.json that doesn't yet exist on disk will cause Agent tool failures. A skill registered in routing-tables.md whose agent isn't created yet produces "unknown agent" errors at dispatch time.
 
-**Fix**: Hard gate — `wait for ALL dispatched agents to complete` before any integration step. There is no acceptable partial state.
+**Do instead**: Hard gate — `wait for ALL dispatched agents to complete` before any integration step. There is no acceptable partial state.
 
 ---
 
@@ -176,7 +176,7 @@ ls adr/pipeline-*.md 2>/dev/null | wc -l
 
 **Why wrong**: Without an ADR, context drifts across phases. Phase 3 sub-agents don't know the Phase 2 decisions. The component manifest from Phase 1 gets lost between phases. In sessions longer than 30 minutes, orchestrators re-derive decisions already made in earlier phases — wasting context and sometimes reversing earlier conclusions.
 
-**Fix**: Phase 0 is always Phase 0. Create the ADR file, register the session:
+**Do instead**: Phase 0 is always Phase 0. Create the ADR file, register the session:
 ```bash
 python3 ~/.claude/scripts/adr-query.py register --adr adr/{pipeline-name}.md
 ```
@@ -197,7 +197,7 @@ python3 scripts/artifact-utils.py discover --domain {name} 2>/dev/null | grep "s
 
 **Why wrong**: Over-decomposition creates maintenance overhead. Each component needs its own routing entry, its own template compliance check, its own reference files. A pipeline with 8 components for a 2-component problem adds 6 units of maintenance debt with zero user benefit.
 
-**Fix**: Apply the 80% coverage rule — if an existing agent covers 80%+ of the request, bind new skills to it rather than creating new agents. Three reused components beat one new monolithic agent.
+**Do instead**: Apply the 80% coverage rule — if an existing agent covers 80%+ of the request, bind new skills to it rather than creating new agents. Three reused components beat one new monolithic agent.
 
 ---
 


### PR DESCRIPTION
## Summary

- Renames `**Fix**:` to `**Do instead**:` in all anti-pattern blocks across `anti-patterns.md` (6 blocks) and `orchestration-patterns.md` (3 blocks) — the detector recognises `**Do instead**:` but not `**Fix**:`
- Adds `<!-- no-pair-required: ... -->` to the H1 document title and `## Anti-Pattern Catalog` section header in `anti-patterns.md`, both of which triggered the detector due to the word "anti-pattern" appearing in surrounding body text

## Verification

- `python3 scripts/detect-unpaired-antipatterns.py`: 0 findings for pipeline-orchestrator-engineer domain
- `python3 scripts/validate-references.py --check-do-framing`: no new unpaired blocks
- Both files under 500 lines (anti-patterns.md: 269, orchestration-patterns.md: 356)

## Test plan

- [ ] All 5 CI checks pass (lint, test, validate-references, detect-unpaired-antipatterns, line-count)
- [ ] No changes to scripts, hooks, or backlog JSON