### PR TITLE
feat(refs): frontend-slides (Level 2→3)

### DIFF
--- a/skills/frontend-slides/SKILL.md
+++ b/skills/frontend-slides/SKILL.md
@@ -41,10 +41,11 @@ Generate browser-based HTML presentations as a single self-contained `.html` fil
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
-|---|---|---|
-| tasks related to this reference | `STYLE_PRESETS.md` | Loads detailed guidance from `STYLE_PRESETS.md`. |
+|--------|-----------------|-----|
+| Phase 3 (style selection) or Phase 4 (build) | `references/STYLE_PRESETS.md` | CSS base block, 12 named presets, mood mapping, density limits, validation breakpoints |
+| SlideController, keyboard nav, touch swipe, wheel scroll, Intersection Observer, reveal animation | `references/slide-controller.md` | Canonical JS implementation, `navigating` guard, wheel debounce, IO reveal pattern, anti-patterns with detection commands |
+| PPTX, `.pptx`, python-pptx, convert slides, extract slides | `references/pptx-conversion.md` | Safe extraction loop, notes guard, GROUP shape recursion, base64 image embedding, error-fix mappings |
 
 ## Instructions
 
@@ -195,3 +196,5 @@ For every slide, verify all of the following. If any item fails, fix it before p
 | File | Load At | Contains |
 |------|---------|----------|
 | `skills/frontend-slides/references/STYLE_PRESETS.md` | Phase 3 (DISCOVER STYLE) and Phase 4 (BUILD) | Mandatory CSS base block, 12 named presets, mood mapping, animation feel mapping, CSS gotchas, density limits, validation breakpoints |
+| `skills/frontend-slides/references/slide-controller.md` | Phase 4 (BUILD) — JS controller section | Canonical SlideController implementation, `navigating` guard, wheel debounce, IO reveal, anti-patterns with grep detection commands |
+| `skills/frontend-slides/references/pptx-conversion.md` | Phase 1 (DETECT) — PPTX path | Safe python-pptx extraction loop, notes guard, GROUP shape recursion, base64 image embedding, error-fix table |

--- a/skills/frontend-slides/references/pptx-conversion.md
+++ b/skills/frontend-slides/references/pptx-conversion.md
@@ -1,0 +1,277 @@
+# PPTX Conversion Reference
+
+> **Scope**: python-pptx extraction patterns for the PPTX-to-HTML conversion path — text, notes, images, shapes, and failure modes.
+> **Version range**: python-pptx 0.6.21+ (pip install python-pptx). Python 3.8+.
+> **Generated**: 2026-04-17
+
+---
+
+## Overview
+
+PPTX conversion uses `python-pptx` to extract slide content before building the HTML deck. The most common failure modes are (1) silently skipping slides that use grouped or embedded OLE shapes, and (2) losing slide notes because `text_frame` is checked on the wrong object. Always extract text, notes, and image references in a single pass and validate the slide count before proceeding.
+
+---
+
+## Pattern Table
+
+| Task | API | Notes |
+|------|-----|-------|
+| Open presentation | `prs = Presentation(path)` | Raises `PackageNotFoundError` on corrupt/missing file |
+| Iterate slides | `for slide in prs.slides` | `prs.slides` is 0-indexed |
+| Slide dimensions | `prs.slide_width`, `prs.slide_height` | In EMUs; divide by 914400 for inches |
+| Slide notes | `slide.notes_slide.notes_text_frame.text` | Raises `AttributeError` if no notes — always guard |
+| Shape text | `shape.text_frame.text` | Only on shapes where `shape.has_text_frame` is True |
+| Placeholder text | `shape.placeholder_format` | Check `ph_idx` for title (0), body (1) |
+| Images | `shape.image.blob`, `shape.image.ext` | Only when `shape.shape_type == MSO_SHAPE_TYPE.PICTURE` |
+| Tables | `shape.table.rows[i].cells[j].text_frame.text` | Only when `shape.has_table` |
+
+---
+
+## Correct Patterns
+
+### Safe slide extraction loop
+
+```python
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+import base64
+
+def extract_slides(pptx_path: str) -> list[dict]:
+    prs = Presentation(pptx_path)
+    results = []
+
+    for slide_num, slide in enumerate(prs.slides, start=1):
+        slide_data = {
+            'number': slide_num,
+            'title': '',
+            'body': [],
+            'notes': '',
+            'images': [],
+        }
+
+        for shape in slide.shapes:
+            # Title placeholder (ph_idx == 0)
+            if shape.has_text_frame:
+                ph = shape.placeholder_format
+                if ph is not None and ph.idx == 0:
+                    slide_data['title'] = shape.text_frame.text.strip()
+                elif ph is not None and ph.idx == 1:
+                    # Body placeholder — collect non-empty paragraphs
+                    for para in shape.text_frame.paragraphs:
+                        text = para.text.strip()
+                        if text:
+                            slide_data['body'].append(text)
+                elif ph is None:
+                    # Freestanding text box
+                    text = shape.text_frame.text.strip()
+                    if text:
+                        slide_data['body'].append(text)
+
+            # Images
+            if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+                img_blob = shape.image.blob
+                img_ext = shape.image.ext
+                img_b64 = base64.b64encode(img_blob).decode('utf-8')
+                slide_data['images'].append({
+                    'ext': img_ext,
+                    'data_uri': f'data:image/{img_ext};base64,{img_b64}',
+                })
+
+        # Speaker notes — guard AttributeError for slides with no notes
+        try:
+            notes_tf = slide.notes_slide.notes_text_frame
+            slide_data['notes'] = notes_tf.text.strip()
+        except AttributeError:
+            pass
+
+        results.append(slide_data)
+
+    return results
+```
+
+**Why**: `shape.has_text_frame` must be checked before accessing `.text_frame` — not all shapes have one. Notes access via `notes_slide` raises `AttributeError` on slides where no notes placeholder exists; the try/except is mandatory, not defensive.
+
+---
+
+### Dependency check with clear error
+
+```python
+def check_python_pptx() -> None:
+    try:
+        import pptx  # noqa: F401
+    except ImportError:
+        print("Error: python-pptx is not installed.")
+        print("Install it with: pip install python-pptx")
+        print("Or provide slide content manually.")
+        raise SystemExit(1)
+```
+
+**Why**: Silent import failure causes an `AttributeError` or `NameError` later in the extraction, not a clear message. Always check the import upfront with actionable instructions.
+
+---
+
+### Slide count validation
+
+```python
+def validate_extraction(slides: list[dict], pptx_path: str) -> None:
+    from pptx import Presentation
+    expected = len(Presentation(pptx_path).slides)
+    if len(slides) != expected:
+        print(f"Warning: extracted {len(slides)} slides but PPTX has {expected}.")
+        print("Grouped shapes or embedded OLE objects may have been skipped.")
+```
+
+**Why**: Grouped shapes (MSO_SHAPE_TYPE.GROUP) and OLE objects (MSO_SHAPE_TYPE.OLE_OBJECT) are common in slides built from templates. The loop silently skips them — a count mismatch is the only signal that content was lost.
+
+---
+
+## Pattern Catalog
+
+### ❌ Accessing `text_frame` without checking `has_text_frame`
+
+**Detection**:
+```bash
+grep -n '\.text_frame' convert.py | grep -v 'has_text_frame'
+rg 'shape\.text_frame' --type py | grep -v 'has_text_frame'
+```
+
+**What it looks like**:
+```python
+for shape in slide.shapes:
+    text = shape.text_frame.text  # AttributeError on Picture, Table, GroupShape
+```
+
+**Why wrong**: `AttributeError: 'Picture' object has no attribute 'text_frame'` on the first slide with an image. Extraction aborts with no output.
+
+**Fix**:
+```python
+for shape in slide.shapes:
+    if shape.has_text_frame:
+        text = shape.text_frame.text
+```
+
+---
+
+### ❌ Notes access without AttributeError guard
+
+**Detection**:
+```bash
+grep -n 'notes_slide' convert.py | grep -v 'try\|except\|AttributeError'
+rg 'notes_text_frame' --type py | grep -v 'try\|except'
+```
+
+**What it looks like**:
+```python
+notes = slide.notes_slide.notes_text_frame.text
+```
+
+**Why wrong**: Raises `AttributeError: 'NoneType' object has no attribute 'notes_text_frame'` on slides with no notes. PPTX files created from blank templates frequently have no notes placeholder on every slide.
+
+**Fix**:
+```python
+try:
+    notes = slide.notes_slide.notes_text_frame.text.strip()
+except AttributeError:
+    notes = ''
+```
+
+---
+
+### ❌ Saving images to disk instead of embedding as data URIs
+
+**Detection**:
+```bash
+grep -n 'open.*wb\|\.write(img' convert.py
+rg 'image\.blob.*open|with open.*image' --type py
+```
+
+**What it looks like**:
+```python
+with open(f'slide_{i}_img.png', 'wb') as f:
+    f.write(shape.image.blob)
+# Then references <img src="slide_1_img.png"> in HTML
+```
+
+**Why wrong**: The output must be a single self-contained `.html` file with no external dependencies. External image files break when the HTML is shared or opened from a different directory.
+
+**Fix**: Embed as base64 data URI:
+```python
+import base64
+b64 = base64.b64encode(shape.image.blob).decode('utf-8')
+data_uri = f'data:image/{shape.image.ext};base64,{b64}'
+# Use data_uri in <img src="...">
+```
+
+---
+
+### ❌ Skipping grouped shapes silently
+
+**Detection**:
+```bash
+grep -n 'MSO_SHAPE_TYPE\|shape_type' convert.py | grep -v 'GROUP'
+rg 'for shape in slide\.shapes' --type py -A 5 | grep -v 'GROUP\|group'
+```
+
+**What it looks like**:
+```python
+for shape in slide.shapes:
+    if shape.has_text_frame:
+        ...  # GroupShape has no text_frame — silently skipped
+```
+
+**Why wrong**: `GROUP` shapes contain child shapes with text. Skipping them silently drops bullet points and labels that appear in the original slide.
+
+**Fix**: Recurse into grouped shapes:
+```python
+def iter_shapes(shapes):
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
+    for shape in shapes:
+        if shape.shape_type == MSO_SHAPE_TYPE.GROUP:
+            yield from iter_shapes(shape.shapes)
+        else:
+            yield shape
+
+for shape in iter_shapes(slide.shapes):
+    if shape.has_text_frame:
+        ...
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|-----------|-----|
+| `AttributeError: 'Picture' object has no attribute 'text_frame'` | Accessing `.text_frame` without `has_text_frame` check | Add `if shape.has_text_frame:` guard |
+| `AttributeError: 'NoneType' object has no attribute 'notes_text_frame'` | Notes access on slide with no notes | Wrap in `try/except AttributeError` |
+| `ModuleNotFoundError: No module named 'pptx'` | python-pptx not installed | `pip install python-pptx`; check upfront with import guard |
+| `PackageNotFoundError` | PPTX file corrupt, wrong path, or not a real PPTX | Check file exists and has `.pptx` extension before `Presentation()` call |
+| Fewer extracted slides than expected | Grouped shapes or OLE objects skipped silently | Validate count; recurse into GROUP shapes |
+| Images not visible in output HTML | Images saved as external files, not embedded | Use base64 data URI in `<img src>` |
+| Table content missing | `shape.has_table` not checked; table shapes skipped | Add `elif shape.has_table:` branch; iterate `shape.table.rows` |
+| Slide order wrong | `enumerate(prs.slides)` is correct; check if slides list is being sorted | Do not sort; PPTX slide order is authoring order |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# text_frame access without guard
+grep -n '\.text_frame' convert.py | grep -v 'has_text_frame'
+
+# notes without AttributeError guard
+grep -n 'notes_slide\|notes_text_frame' convert.py | grep -v 'try\|except'
+
+# external image files (should use data URI instead)
+grep -n "open.*'wb'" convert.py
+
+# missing GROUP shape recursion
+grep -n 'for shape in slide.shapes' convert.py
+```
+
+---
+
+## See Also
+
+- `STYLE_PRESETS.md` — CSS base block and presets applied after extraction
+- `slide-controller.md` — SlideController JS patterns for the output HTML

--- a/skills/frontend-slides/references/pptx-conversion.md
+++ b/skills/frontend-slides/references/pptx-conversion.md
@@ -143,7 +143,8 @@ for shape in slide.shapes:
 
 **Why wrong**: `AttributeError: 'Picture' object has no attribute 'text_frame'` on the first slide with an image. Extraction aborts with no output.
 
-**Fix**:
+**Do instead:** Guard every `text_frame` access with `shape.has_text_frame`:
+
 ```python
 for shape in slide.shapes:
     if shape.has_text_frame:
@@ -167,7 +168,8 @@ notes = slide.notes_slide.notes_text_frame.text
 
 **Why wrong**: Raises `AttributeError: 'NoneType' object has no attribute 'notes_text_frame'` on slides with no notes. PPTX files created from blank templates frequently have no notes placeholder on every slide.
 
-**Fix**:
+**Do instead:** Wrap notes access in a `try/except AttributeError` block:
+
 ```python
 try:
     notes = slide.notes_slide.notes_text_frame.text.strip()
@@ -194,7 +196,8 @@ with open(f'slide_{i}_img.png', 'wb') as f:
 
 **Why wrong**: The output must be a single self-contained `.html` file with no external dependencies. External image files break when the HTML is shared or opened from a different directory.
 
-**Fix**: Embed as base64 data URI:
+**Do instead:** Embed images as base64 data URIs so the HTML file is self-contained:
+
 ```python
 import base64
 b64 = base64.b64encode(shape.image.blob).decode('utf-8')
@@ -221,7 +224,8 @@ for shape in slide.shapes:
 
 **Why wrong**: `GROUP` shapes contain child shapes with text. Skipping them silently drops bullet points and labels that appear in the original slide.
 
-**Fix**: Recurse into grouped shapes:
+**Do instead:** Use a recursive generator to walk into grouped shapes before processing:
+
 ```python
 def iter_shapes(shapes):
     from pptx.enum.shapes import MSO_SHAPE_TYPE

--- a/skills/frontend-slides/references/slide-controller.md
+++ b/skills/frontend-slides/references/slide-controller.md
@@ -161,7 +161,7 @@ go(index) {
 
 **Why wrong**: Each `go()` call triggers a smooth scroll. When the second call fires before the first completes, slides jump out of sync with `this.current`. On fast keyboards or trackpads, the deck can advance 3-5 slides per keypress.
 
-**Fix**: Set `this.navigating = true` at the start of `go()`, clear it with `setTimeout(() => this.navigating = false, 600)`, and guard entry with `if (this.navigating) return`.
+**Do instead:** Set `this.navigating = true` at the start of `go()`, clear it with `setTimeout(() => this.navigating = false, 600)`, and guard entry with `if (this.navigating) return`.
 
 ---
 
@@ -181,7 +181,7 @@ document.addEventListener('wheel', (e) => {
 
 **Why wrong**: A single trackpad scroll fires 20-80 `wheel` events. Without debounce, one swipe advances 20+ slides. The `navigating` guard alone is insufficient — it blocks concurrent calls, but debounce collapses burst events before they enter `go()`.
 
-**Fix**: `clearTimeout(this._wheelTimer); this._wheelTimer = setTimeout(() => { ... }, 150);`
+**Do instead:** `clearTimeout(this._wheelTimer); this._wheelTimer = setTimeout(() => { ... }, 150);`
 
 ---
 
@@ -201,7 +201,7 @@ rg '\.slide[^}]*display\s*:\s*none' output.html
 
 **Why wrong**: `display: none` removes the element from the accessibility tree and from the IntersectionObserver callback cycle. The `.visible` class never gets added. All reveal animations silently fail. Screen readers skip hidden slides.
 
-**Fix**: Use `opacity: 0; pointer-events: none; position: absolute` to hide, and `.visible { opacity: 1; pointer-events: auto; position: relative }` to show.
+**Do instead:** Use `opacity: 0; pointer-events: none; position: absolute` to hide, and `.visible { opacity: 1; pointer-events: auto; position: relative }` to show.
 
 ---
 
@@ -220,7 +220,7 @@ document.addEventListener('wheel', handler);
 
 **Why wrong**: Without `{ passive: true }`, the browser must wait for the handler to return before scrolling, causing 50–200ms jank on mobile. Chrome 73+ logs a console warning.
 
-**Fix**: Add `{ passive: true }` to all touch and wheel listeners. HTML slide decks should not call `preventDefault()` on these events.
+**Do instead:** Add `{ passive: true }` to all touch and wheel listeners. HTML slide decks should not call `preventDefault()` on these events.
 
 ---
 
@@ -241,7 +241,7 @@ document.addEventListener('keydown', (e) => {
 
 **Why wrong**: Space is the standard "advance" key in every presentation app. Missing it breaks presenter muscle memory. The browser default scrolls the viewport, causing visible flicker before the controller corrects position.
 
-**Fix**: `case 'Space': e.preventDefault(); this.go(this.current + 1); break;`
+**Do instead:** `case 'Space': e.preventDefault(); this.go(this.current + 1); break;`
 
 ---
 

--- a/skills/frontend-slides/references/slide-controller.md
+++ b/skills/frontend-slides/references/slide-controller.md
@@ -1,0 +1,289 @@
+# SlideController Reference
+
+> **Scope**: JavaScript `SlideController` class implementation for single-file HTML presentations — keyboard, touch, wheel, Intersection Observer, and transition guard patterns.
+> **Version range**: Modern browsers (Chrome 88+, Firefox 87+, Safari 14+). Vanilla JS; no framework dependencies.
+> **Generated**: 2026-04-17
+
+---
+
+## Overview
+
+`SlideController` manages navigation between full-viewport slides. The two most common failure modes are (1) multi-slide jumps on wheel events because wheel fires many times per scroll gesture, and (2) reveal animations silently broken because `display: none` removes elements from the Intersection Observer callback tree. Every controller must guard both.
+
+---
+
+## Correct Patterns
+
+### Canonical SlideController skeleton
+
+Complete, copy-pasteable implementation satisfying all Phase 4 requirements.
+
+```javascript
+class SlideController {
+  constructor() {
+    this.slides = Array.from(document.querySelectorAll('.slide'));
+    this.current = 0;
+    this.navigating = false;
+    this._wheelTimer = null;
+
+    this._bindKeyboard();
+    this._bindTouch();
+    this._bindWheel();
+    this._bindIO();
+    this._updateIndicator();
+  }
+
+  go(index) {
+    const target = Math.max(0, Math.min(index, this.slides.length - 1));
+    if (target === this.current || this.navigating) return;
+
+    this.navigating = true;
+    this.current = target;
+    this.slides[target].scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
+    this._updateIndicator();
+
+    // Release guard after transition completes
+    setTimeout(() => { this.navigating = false; }, 600);
+  }
+
+  _bindKeyboard() {
+    document.addEventListener('keydown', (e) => {
+      switch (e.key) {
+        case 'ArrowRight': case 'Space':     e.preventDefault(); this.go(this.current + 1); break;
+        case 'ArrowLeft':  case 'Backspace': e.preventDefault(); this.go(this.current - 1); break;
+        case 'Home': this.go(0); break;
+        case 'End':  this.go(this.slides.length - 1); break;
+      }
+    });
+  }
+
+  _bindTouch() {
+    let startX = 0;
+    document.addEventListener('touchstart', (e) => { startX = e.changedTouches[0].clientX; }, { passive: true });
+    document.addEventListener('touchend', (e) => {
+      const dx = e.changedTouches[0].clientX - startX;
+      if (Math.abs(dx) > 50) this.go(this.current + (dx < 0 ? 1 : -1));
+    }, { passive: true });
+  }
+
+  _bindWheel() {
+    document.addEventListener('wheel', (e) => {
+      clearTimeout(this._wheelTimer);
+      this._wheelTimer = setTimeout(() => {
+        if (!this.navigating) this.go(this.current + (e.deltaY > 0 ? 1 : -1));
+      }, 150);
+    }, { passive: true });
+  }
+
+  _bindIO() {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) entry.target.classList.add('visible');
+      });
+    }, { threshold: 0.5 });
+    this.slides.forEach(s => observer.observe(s));
+  }
+
+  _updateIndicator() {
+    const el = document.getElementById('slide-indicator');
+    if (el) el.textContent = `${this.current + 1} / ${this.slides.length}`;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => new SlideController());
+```
+
+**Why**: The `navigating` flag blocks re-entry until the 600ms scroll animation completes. The 150ms wheel debounce collapses a single scroll gesture (which fires 10–40 wheel events) into one navigation call.
+
+---
+
+### Reveal animation CSS pairing
+
+Slides must start hidden via CSS transforms, not `display: none`, so Intersection Observer fires.
+
+```css
+.slide {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 400ms ease, transform 400ms ease;
+}
+
+.slide.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .slide, .slide.visible {
+    transition: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+```
+
+**Why**: `display: none` removes elements from the layout tree entirely. IntersectionObserver never fires for hidden elements because they have no intersection with the viewport. `opacity: 0` keeps the element in the tree while hiding it visually.
+
+---
+
+### Slide indicator markup
+
+```html
+<div id="slide-indicator" aria-live="polite" style="
+  position: fixed; bottom: 1.5rem; right: 2rem;
+  font-size: clamp(0.75rem, 1.5vw, 0.9rem);
+  color: var(--text-secondary);
+  pointer-events: none;
+  z-index: 100;
+">1 / 1</div>
+```
+
+---
+
+## Pattern Catalog
+
+### ❌ Missing `navigating` guard
+
+**Detection**:
+```bash
+grep -n 'go(' output.html | grep -v 'navigating'
+rg 'scrollIntoView' output.html | grep -v 'navigating'
+```
+
+**What it looks like**:
+```javascript
+go(index) {
+  this.current = Math.max(0, Math.min(index, this.slides.length - 1));
+  this.slides[this.current].scrollIntoView({ behavior: 'smooth' });
+  // No guard — holding ArrowRight fires 10+ go() calls per second
+}
+```
+
+**Why wrong**: Each `go()` call triggers a smooth scroll. When the second call fires before the first completes, slides jump out of sync with `this.current`. On fast keyboards or trackpads, the deck can advance 3-5 slides per keypress.
+
+**Fix**: Set `this.navigating = true` at the start of `go()`, clear it with `setTimeout(() => this.navigating = false, 600)`, and guard entry with `if (this.navigating) return`.
+
+---
+
+### ❌ No wheel debounce
+
+**Detection**:
+```bash
+grep -n 'wheel' output.html | grep -v 'clearTimeout\|debounce\|timer\|Timer'
+```
+
+**What it looks like**:
+```javascript
+document.addEventListener('wheel', (e) => {
+  this.go(this.current + (e.deltaY > 0 ? 1 : -1));
+});
+```
+
+**Why wrong**: A single trackpad scroll fires 20-80 `wheel` events. Without debounce, one swipe advances 20+ slides. The `navigating` guard alone is insufficient — it blocks concurrent calls, but debounce collapses burst events before they enter `go()`.
+
+**Fix**: `clearTimeout(this._wheelTimer); this._wheelTimer = setTimeout(() => { ... }, 150);`
+
+---
+
+### ❌ `display: none` on slides
+
+**Detection**:
+```bash
+grep -n 'display.*none' output.html | grep -iv 'comment\|//'
+rg '\.slide[^}]*display\s*:\s*none' output.html
+```
+
+**What it looks like**:
+```css
+.slide { display: none; }
+.slide.active { display: flex; }
+```
+
+**Why wrong**: `display: none` removes the element from the accessibility tree and from the IntersectionObserver callback cycle. The `.visible` class never gets added. All reveal animations silently fail. Screen readers skip hidden slides.
+
+**Fix**: Use `opacity: 0; pointer-events: none; position: absolute` to hide, and `.visible { opacity: 1; pointer-events: auto; position: relative }` to show.
+
+---
+
+### ❌ Missing `{ passive: true }` on touch/wheel listeners
+
+**Detection**:
+```bash
+grep -n 'touchstart\|touchend\|wheel' output.html | grep -v 'passive'
+```
+
+**What it looks like**:
+```javascript
+document.addEventListener('touchstart', handler);
+document.addEventListener('wheel', handler);
+```
+
+**Why wrong**: Without `{ passive: true }`, the browser must wait for the handler to return before scrolling, causing 50–200ms jank on mobile. Chrome 73+ logs a console warning.
+
+**Fix**: Add `{ passive: true }` to all touch and wheel listeners. HTML slide decks should not call `preventDefault()` on these events.
+
+---
+
+### ❌ `Space` key not captured
+
+**Detection**:
+```bash
+grep -n "case 'Space'" output.html
+```
+
+**What it looks like**:
+```javascript
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'ArrowRight') this.go(this.current + 1);
+  // Space not handled — browser default scrolls the page
+});
+```
+
+**Why wrong**: Space is the standard "advance" key in every presentation app. Missing it breaks presenter muscle memory. The browser default scrolls the viewport, causing visible flicker before the controller corrects position.
+
+**Fix**: `case 'Space': e.preventDefault(); this.go(this.current + 1); break;`
+
+---
+
+## Error-Fix Mappings
+
+| Symptom | Root Cause | Fix |
+|---------|-----------|-----|
+| Deck jumps 3-5 slides on single keypress | Missing `navigating` guard | Add flag; clear with `setTimeout(, 600)` |
+| One trackpad swipe advances entire deck | No wheel debounce | `clearTimeout` + 150ms `setTimeout` pattern |
+| Reveal animations never fire | `display: none` on `.slide` | Use `opacity: 0` + `transform` instead |
+| Touch swipe does nothing | Missing `touchstart`/`touchend` listeners | Add both with `{ passive: true }` |
+| Slide indicator always shows "1 / 1" | `_updateIndicator()` not called in `go()`, or `#slide-indicator` element missing from HTML | Call in `go()` and `constructor`; add element to markup |
+| Space bar scrolls page | `Space` key not captured; no `preventDefault()` | Handle in `keydown` switch with `e.preventDefault()` |
+| Last slide unreachable | Off-by-one: clamping to `slides.length` | Use `Math.min(index, this.slides.length - 1)` |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Missing navigating guard
+grep -n 'scrollIntoView' output.html | grep -v 'navigating'
+
+# No wheel debounce
+grep -n 'addEventListener.*wheel' output.html | grep -v 'clearTimeout\|debounce'
+
+# display:none on slides
+grep -n 'display.*none' output.html
+
+# Missing passive listeners
+grep -n "addEventListener('touchstart\|addEventListener('wheel" output.html | grep -v 'passive'
+
+# Space key missing
+grep -cn "case 'Space'" output.html   # should be >= 1
+
+# Negated clamp (CSS bug from STYLE_PRESETS)
+grep -n '\-clamp(' output.html
+```
+
+---
+
+## See Also
+
+- `STYLE_PRESETS.md` — CSS base block, theme presets, density limits, validation breakpoints
+- `pptx-conversion.md` — python-pptx extraction patterns for PPTX-to-HTML path


### PR DESCRIPTION
## Summary

- **Target**: `frontend-slides` skill
- **Level before**: 2 (1 reference file: STYLE_PRESETS.md)
- **Level after**: 3 (3 reference files)

## New Reference Files

**`slide-controller.md`** (289 lines)
- Canonical `SlideController` JS implementation satisfying all Phase 4 requirements
- Anti-patterns with grep/rg detection: missing `navigating` guard, no wheel debounce, `display: none` on slides, missing `{ passive: true }`, uncaptured `Space` key
- Error-fix mapping table covering 7 common symptoms

**`pptx-conversion.md`** (277 lines)
- Safe python-pptx extraction loop with `has_text_frame` guard and notes `AttributeError` guard
- GROUP shape recursion to prevent silent content loss
- Base64 data URI embedding for self-contained output
- Error-fix mapping table covering 8 common extraction failures with exact error messages

## Loading Table Update

Updated `SKILL.md` loading table to map signals to the new files:
- "SlideController, keyboard nav, touch swipe, wheel scroll, Intersection Observer, reveal animation" → `slide-controller.md`
- "PPTX, .pptx, python-pptx, convert slides, extract slides" → `pptx-conversion.md`

## Validation Gate

Phase 2.5 keep-or-revert: **KEEP both files**
- Loading table signals correctly match the reference content
- Both files contain concrete patterns (code blocks, grep commands, error tables) not present elsewhere in the skill
- `audit-reference-depth.py` scan_all confirms Level 3