### PR TITLE
fix: remove double blank lines, fix system-upgrade-engineer, add whitespace validator

### DIFF
--- a/agents/ansible-automation-engineer.md
+++ b/agents/ansible-automation-engineer.md
@@ -140,7 +140,6 @@ Testing Strategy: [How to validate]
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Vault encryption, secrets, credentials, `no_log`, privilege escalation | `security.md` | Routes to the matching deep reference |

--- a/agents/ansible-automation-engineer/references/modules.md
+++ b/agents/ansible-automation-engineer/references/modules.md
@@ -201,7 +201,7 @@ rg -t yaml '(command|shell):.*systemctl' roles/ playbooks/
 ```bash
 # Find copy tasks that use variables in src
 grep -rn -A5 "ansible.builtin.copy:\|^  copy:" roles/ playbooks/ \
-  | grep "content:.*{{" 
+  | grep "content:.*{{"
 
 # Find hardcoded config files that should be templates
 grep -rn "copy:" roles/ playbooks/ -A3 \

--- a/agents/combat-effects-upgrade/references/css-particle-migration.md
+++ b/agents/combat-effects-upgrade/references/css-particle-migration.md
@@ -177,7 +177,6 @@ export function createImpactBurst(x: number, y: number, type: 'strike' | 'grappl
 }
 ```
 
-
 ---
 
 ## CSS @keyframes: Complete Definitions

--- a/agents/data-engineer.md
+++ b/agents/data-engineer.md
@@ -77,7 +77,6 @@ This agent operates as an operator for data engineering, configuring Claude's be
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Expertise, default/optional behaviors, capabilities, output format | `expertise.md` | Routes to the matching deep reference |

--- a/agents/database-engineer.md
+++ b/agents/database-engineer.md
@@ -147,7 +147,6 @@ Performance Needs: [SLAs, scale requirements]
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | PostgreSQL index types, EXPLAIN analysis, JSONB, isolation levels, pg_stat | `postgres.md` | Routes to the matching deep reference |

--- a/agents/github-profile-rules-engineer.md
+++ b/agents/github-profile-rules-engineer.md
@@ -97,7 +97,6 @@ This agent operates as an operator for GitHub profile analysis, configuring Clau
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Rule taxonomy, confidence scoring, CLAUDE.md output format | `rule-categories.md` | Category taxonomy, confidence model, evidence requirements |

--- a/agents/github-profile-rules-engineer/references/github-api-patterns.md
+++ b/agents/github-profile-rules-engineer/references/github-api-patterns.md
@@ -51,7 +51,7 @@ def check_rate_limit(headers: dict) -> None:
     """Raise if fewer than 10 requests remaining."""
     remaining = int(headers.get("X-RateLimit-Remaining", 0))
     reset_time = int(headers.get("X-RateLimit-Reset", 0))
-    
+
     if remaining < 10:
         wait_seconds = reset_time - time.time()
         raise RateLimitError(
@@ -71,14 +71,14 @@ def get_file_tree(owner: str, repo: str, branch: str = "HEAD") -> list[str]:
     # First get the commit SHA for branch
     resp = github_get(f"/repos/{owner}/{repo}/commits/{branch}")
     tree_sha = resp["commit"]["tree"]["sha"]
-    
+
     # Fetch entire tree recursively
     resp = github_get(f"/repos/{owner}/{repo}/git/trees/{tree_sha}?recursive=1")
-    
+
     if resp.get("truncated"):
         # Repo has >100k files — fall back to directory-by-directory
         return get_file_tree_paged(owner, repo, tree_sha)
-    
+
     return [item["path"] for item in resp["tree"] if item["type"] == "blob"]
 ```
 
@@ -94,10 +94,10 @@ import base64
 def get_file_content(owner: str, repo: str, path: str) -> str:
     """Fetch and decode file content from GitHub API."""
     resp = github_get(f"/repos/{owner}/{repo}/contents/{path}")
-    
+
     if resp.get("encoding") != "base64":
         raise ValueError(f"Unexpected encoding: {resp.get('encoding')}")
-    
+
     # Content has newlines inserted by GitHub — strip before decoding
     return base64.b64decode(resp["content"].replace("\n", "")).decode("utf-8", errors="replace")
 ```
@@ -112,11 +112,11 @@ def get_file_content(owner: str, repo: str, path: str) -> str:
 def get_analysis_repos(username: str, max_repos: int = 5) -> list[dict]:
     """Return repos sorted by relevance: stars + recent activity, excluding forks."""
     repos = github_get(f"/users/{username}/repos?sort=pushed&per_page=20&type=owner")
-    
+
     # Sort by stars (strongest signal), filter forks (project-specific style)
     owned = [r for r in repos if not r["fork"]]
     owned.sort(key=lambda r: r["stargazers_count"], reverse=True)
-    
+
     return owned[:max_repos]
 ```
 

--- a/agents/golang-general-engineer-compact.md
+++ b/agents/golang-general-engineer-compact.md
@@ -296,7 +296,6 @@ STOP and ask when:
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Idiom upgrade, version compatibility, `any` vs `interface{}` | `go-patterns.md` | Version table Go 1.18–1.26, error wrapping, functional options |

--- a/agents/hook-development-engineer/references/code-examples.md
+++ b/agents/hook-development-engineer/references/code-examples.md
@@ -18,7 +18,6 @@ import traceback
 from pathlib import Path
 from datetime import datetime
 
-
 def debug_log(message):
     """Log debug information without blocking execution."""
     try:
@@ -26,7 +25,6 @@ def debug_log(message):
             f.write(f"[{datetime.now().isoformat()}] {message}\n")
     except Exception:
         pass  # Never let logging block execution
-
 
 def process_event(event_data):
     """
@@ -51,7 +49,6 @@ def process_event(event_data):
 
     return None
 
-
 def main():
     """Main hook execution with comprehensive error handling."""
     try:
@@ -72,7 +69,6 @@ def main():
     finally:
         # CRITICAL: Always exit 0 to prevent blocking Claude Code
         sys.exit(0)
-
 
 if __name__ == "__main__":
     main()
@@ -97,10 +93,8 @@ import hashlib
 from pathlib import Path
 from datetime import datetime
 
-
 LEARNING_DB = Path.home() / '.claude' / 'learnings' / 'error_patterns.json'
 DEBUG_LOG = Path('/tmp/claude_hook_debug.log')
-
 
 def debug_log(message):
     """Non-blocking debug logging."""
@@ -109,7 +103,6 @@ def debug_log(message):
             f.write(f"[{datetime.now().isoformat()}] {message}\\n")
     except Exception:
         pass
-
 
 def classify_error(tool_name, error_output):
     """
@@ -138,7 +131,6 @@ def classify_error(tool_name, error_output):
     else:
         return 'unknown'
 
-
 def generate_signature(tool_name, error_type, error_message):
     """
     Generate unique signature for error pattern.
@@ -155,7 +147,6 @@ def generate_signature(tool_name, error_type, error_message):
     message_snippet = error_message[:200]
     signature_input = f"{tool_name}:{error_type}:{message_snippet}"
     return hashlib.md5(signature_input.encode()).hexdigest()
-
 
 def query_learning_db(signature):
     """
@@ -186,7 +177,6 @@ def query_learning_db(signature):
 
     return None
 
-
 def inject_solution(solution_data, event_name: str) -> None:
     """
     Inject solution into Claude Code context via stdout.
@@ -205,7 +195,6 @@ def inject_solution(solution_data, event_name: str) -> None:
         context_output(event_name, text).print_and_exit()
     except Exception as e:
         debug_log(f"Context injection error: {e}")
-
 
 def main():
     """Main error detection logic."""
@@ -244,7 +233,6 @@ def main():
     finally:
         sys.exit(0)
 
-
 if __name__ == "__main__":
     main()
 ```
@@ -266,10 +254,8 @@ import sys
 from pathlib import Path
 from datetime import datetime
 
-
 LEARNING_DB = Path.home() / '.claude' / 'learnings' / 'error_patterns.json'
 DEBUG_LOG = Path('/tmp/claude_hook_debug.log')
-
 
 def debug_log(message):
     """Non-blocking debug logging."""
@@ -278,7 +264,6 @@ def debug_log(message):
             f.write(f"[{datetime.now().isoformat()}] {message}\\n")
     except Exception:
         pass
-
 
 def load_learning_db():
     """Load learning database with error handling."""
@@ -291,7 +276,6 @@ def load_learning_db():
 
     # Return empty structure if load fails
     return {'patterns': [], 'metadata': {'version': '1.0'}}
-
 
 def save_learning_db(data):
     """Save learning database with atomic operations."""
@@ -309,7 +293,6 @@ def save_learning_db(data):
 
     except Exception as e:
         debug_log(f"DB save error: {e}")
-
 
 def update_confidence(pattern_id, success):
     """
@@ -339,7 +322,6 @@ def update_confidence(pattern_id, success):
             break
 
     save_learning_db(db)
-
 
 def store_new_pattern(tool_name, error_type, signature, solution):
     """
@@ -376,7 +358,6 @@ def store_new_pattern(tool_name, error_type, signature, solution):
 
     debug_log(f"Stored new pattern: {new_pattern['id']}")
 
-
 def main():
     """Main learning update logic."""
     try:
@@ -402,7 +383,6 @@ def main():
     finally:
         sys.exit(0)
 
-
 if __name__ == "__main__":
     main()
 ```
@@ -423,9 +403,7 @@ import json
 import sys
 from pathlib import Path
 
-
 LEARNING_DB = Path.home() / '.claude' / 'learnings' / 'error_patterns.json'
-
 
 def find_pattern_lazy(signature, confidence_threshold=0.7):
     """
@@ -460,7 +438,6 @@ def find_pattern_lazy(signature, confidence_threshold=0.7):
 
     return None
 
-
 def main():
     """Optimized pattern matching."""
     try:
@@ -476,7 +453,6 @@ def main():
         pass
     finally:
         sys.exit(0)
-
 
 if __name__ == "__main__":
     main()

--- a/agents/kotlin-general-engineer.md
+++ b/agents/kotlin-general-engineer.md
@@ -213,7 +213,6 @@ See [references/kotlin-security-testing.md](references/kotlin-security-testing.m
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | [`references/kotlin-patterns.md`](references/kotlin-patterns.md) | `kotlin-patterns.md)` | Null safety (`!!` alternatives, Java interop), coroutines/Flow (structured concurrency, dispatchers, StateFlow, `runTest`), sealed classes/enums/data classes, Koin DI |

--- a/agents/kubernetes-helm-engineer.md
+++ b/agents/kubernetes-helm-engineer.md
@@ -146,7 +146,6 @@ Safety Checks: [Dry-run, context verification]
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Pod failures, CrashLoopBackOff, OOMKilled, Pending, ImagePullBackOff | `kubernetes-troubleshooting.md` | Diagnostic commands, pod state table, error-fix mappings |

--- a/agents/kubernetes-helm-engineer/references/kubernetes-troubleshooting.md
+++ b/agents/kubernetes-helm-engineer/references/kubernetes-troubleshooting.md
@@ -49,7 +49,7 @@ kubectl get events -n <namespace> --sort-by='.lastTimestamp' | tail -20
 ```bash
 # Find pods with OOM kills
 kubectl get pods --all-namespaces -o json | \
-  jq '.items[] | select(.status.containerStatuses[]?.lastState.terminated.reason == "OOMKilled") | 
+  jq '.items[] | select(.status.containerStatuses[]?.lastState.terminated.reason == "OOMKilled") |
   {name: .metadata.name, ns: .metadata.namespace}'
 
 # Check actual vs requested memory for a pod
@@ -86,7 +86,7 @@ kubectl get secret <secret-name> -n <namespace> \
 ```bash
 # Find deployments with containers missing resource limits
 kubectl get deployments --all-namespaces -o json | \
-  jq '.items[] | select(.spec.template.spec.containers[] | .resources.limits == null) | 
+  jq '.items[] | select(.spec.template.spec.containers[] | .resources.limits == null) |
   {name: .metadata.name, ns: .metadata.namespace}'
 
 # Find pods currently running without resource limits
@@ -128,8 +128,8 @@ containers:
 ```bash
 # Find deployments using :latest tag
 kubectl get deployments --all-namespaces -o json | \
-  jq '.items[] | select(.spec.template.spec.containers[].image | endswith(":latest")) | 
-  {name: .metadata.name, namespace: .metadata.namespace, 
+  jq '.items[] | select(.spec.template.spec.containers[].image | endswith(":latest")) |
+  {name: .metadata.name, namespace: .metadata.namespace,
    image: .spec.template.spec.containers[].image}'
 
 # Check in manifests/helm values
@@ -149,7 +149,7 @@ rg ':latest' --type yaml
 ```bash
 # Find pods with short liveness probe timeouts
 kubectl get pods --all-namespaces -o json | \
-  jq '.items[] | select(.spec.containers[].livenessProbe.failureThreshold <= 2) | 
+  jq '.items[] | select(.spec.containers[].livenessProbe.failureThreshold <= 2) |
   {name: .metadata.name, threshold: .spec.containers[].livenessProbe.failureThreshold}'
 
 grep -rn 'failureThreshold: [12]$' --include="*.yaml" .

--- a/agents/nextjs-ecommerce-engineer.md
+++ b/agents/nextjs-ecommerce-engineer.md
@@ -59,7 +59,6 @@ This agent operates as an operator for Next.js e-commerce development, configuri
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Expertise, default/optional behaviors, capabilities, output format | `expertise.md` | Routes to the matching deep reference |

--- a/agents/perses-engineer.md
+++ b/agents/perses-engineer.md
@@ -75,7 +75,6 @@ After making changes to CRDs, Helm values, or operator configuration, STOP and a
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `core.md` | Loads detailed guidance from `core.md`. |

--- a/agents/php-general-engineer.md
+++ b/agents/php-general-engineer.md
@@ -187,7 +187,6 @@ Deep-dive material loaded on demand.
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | [`references/hooks-and-behaviors.md`](php-general-engineer/references/hooks-and-behaviors.md) | `hooks-and-behaviors.md)` | PostToolUse hook command block (full), PHP version table, framework variants, static analysis tier, hardcoded/default/optional behaviors, companion skills, core expertise table, capabilities & limitations, Implementation Schema |

--- a/agents/project-coordinator-engineer/references/parallel-execution-patterns.md
+++ b/agents/project-coordinator-engineer/references/parallel-execution-patterns.md
@@ -79,7 +79,7 @@ After parallel streams, hold integration until ALL streams complete.
 
 Wait conditions:
 - [ ] STREAM A: golang-general-engineer — src/api/ complete
-- [ ] STREAM B: typescript-frontend-engineer — src/ui/ complete  
+- [ ] STREAM B: typescript-frontend-engineer — src/ui/ complete
 - [ ] STREAM C: database-engineer — migrations/ complete
 
 BLOCKED: Do not dispatch integration agent until all 3 boxes checked.

--- a/agents/prometheus-grafana-engineer.md
+++ b/agents/prometheus-grafana-engineer.md
@@ -141,7 +141,6 @@ Cardinality Check: [Label cardinality analysis]
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Writing or debugging PromQL — `rate()`, `irate()`, `histogram_quantile()`, recording rules, subqueries | `promql-patterns.md` | Routes to the matching deep reference |

--- a/agents/python-general-engineer.md
+++ b/agents/python-general-engineer.md
@@ -147,7 +147,6 @@ See `agents/python-general-engineer/references/capabilities.md` for full CAN/CAN
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | errors | `python-errors.md` | Loads detailed guidance from `python-errors.md`. |

--- a/agents/python-openstack-engineer.md
+++ b/agents/python-openstack-engineer.md
@@ -121,7 +121,6 @@ See `python-openstack-engineer/references/openstack-patterns.md` for oslo.config
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | oslo.config option registration, oslo.log setup, oslo.messaging transport, oslo.db sessions, oslo.policy enforcement, `CONF.register_opts`, `enginefacade`, `get_rpc_transport` | `oslo-patterns.md` | Routes to the matching deep reference |

--- a/agents/react-portfolio-engineer.md
+++ b/agents/react-portfolio-engineer.md
@@ -156,7 +156,6 @@ This agent uses the **Implementation Schema**.
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Gallery component, filtering, image patterns, anti-rationalization table | `gallery-patterns.md` | Routes to the matching deep reference |

--- a/agents/research-coordinator-engineer.md
+++ b/agents/research-coordinator-engineer.md
@@ -215,7 +215,6 @@ See [references/delegation-patterns.md](references/delegation-patterns.md) for t
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Query type, depth-first, breadth-first, straightforward, classify, subagent count | `query-classification.md` | Routes to the matching deep reference |

--- a/agents/research-subagent-executor.md
+++ b/agents/research-subagent-executor.md
@@ -148,7 +148,6 @@ STOP and ask the user when:
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Budget calculation, OODA structure, tool selection, query optimization, diminishing returns | `research-execution-patterns.md` | Routes to the matching deep reference |

--- a/agents/reviewer-code.md
+++ b/agents/reviewer-code.md
@@ -136,7 +136,6 @@ Rules:
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Convention compliance, style, CLAUDE.md | `code-quality.md` | "code quality", "style review", "convention check" |

--- a/agents/reviewer-domain.md
+++ b/agents/reviewer-domain.md
@@ -191,7 +191,6 @@ STOP and ask the user when:
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | **ADR Compliance** | `adr-compliance.md` | Decision mapping, contradiction detection, scope creep analysis |

--- a/agents/reviewer-perspectives.md
+++ b/agents/reviewer-perspectives.md
@@ -189,7 +189,6 @@ See [shared-patterns/anti-rationalization-review.md](../skills/shared-patterns/a
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | **Newcomer** | `newcomer.md` | Fresh-eyes critique: documentation gaps, confusing code, accessibility |

--- a/agents/reviewer-system.md
+++ b/agents/reviewer-system.md
@@ -168,7 +168,6 @@ Each finding must follow this structure:
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Security | `security.md` | OWASP, auth, injection, XSS, CSRF, secrets, vulnerabilities |

--- a/agents/sqlite-peewee-engineer.md
+++ b/agents/sqlite-peewee-engineer.md
@@ -144,7 +144,6 @@ SQLite Constraints: [Limitations to work within]
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | N+1, prefetch, join, slow query, index, WAL, EXPLAIN | `peewee-query-patterns.md` | Query optimization, N+1 prevention, index strategy, SQLite pragmas |

--- a/agents/swift-general-engineer.md
+++ b/agents/swift-general-engineer.md
@@ -182,7 +182,6 @@ See [references/swift-security-testing.md](swift-general-engineer/references/swi
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | implementation patterns | `swift-patterns.md` | Loads detailed guidance from `swift-patterns.md`. |

--- a/agents/system-upgrade-engineer.md
+++ b/agents/system-upgrade-engineer.md
@@ -121,7 +121,6 @@ When asked to perform unavailable actions, explain the limitation and suggest th
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Parsing release notes, extracting signals, building Change Manifest, retro graduation signals | `upgrade-signal-parsing.md` | Routes to the matching deep reference |
@@ -177,17 +176,17 @@ Solution: Manual copy to `~/.claude/`. Report the broken sync path.
 
 ## Patterns to Detect and Fix
 
-### Anti-Pattern 1: Implementing Without Plan Approval
+### Pattern 1: Skipping Plan Approval
 **What it looks like**: Moving directly from AUDIT to IMPLEMENT
 **Why wrong**: User loses control of what changes in their system
 **Do instead**: Always present Phase 3 plan and wait for approval
 
-### Anti-Pattern 2: Making All Changes Directly
+### Pattern 2: Making All Changes Directly
 **What it looks like**: Editing hook files inline instead of dispatching hook-development-engineer
 **Why wrong**: Bypasses the specialist's domain knowledge (event structure, performance requirements, template conventions)
 **Do instead**: Route to domain specialists for any non-trivial change
 
-### Anti-Pattern 3: Not Scoping the Audit
+### Pattern 3: Unscoped Audit
 **What it looks like**: Running comprehensive audit for every trigger
 **Why wrong**: Auditing 120+ skills for a 2-hook change wastes time and creates noise
 **Do instead**: Scope audit to the change signals. Comprehensive is opt-in.
@@ -219,7 +218,7 @@ Load these reference files when the task type matches:
 
 ## References
 
-- **Skill**: [skills/workflow/references/system-upgrade.md](..skills/workflow/references/system-upgrade.md)
+- **Skill**: [skills/workflow/references/system-upgrade.md](../skills/workflow/references/system-upgrade.md)
 - **Agent Evaluation**: [skills/agent-evaluation/SKILL.md](../skills/agent-evaluation/SKILL.md)
 - **Learning DB**: [scripts/learning-db.py](../scripts/learning-db.py)
 - **Routing Table Updater**: [skills/routing-table-updater/SKILL.md](../skills/routing-table-updater/SKILL.md)

--- a/agents/technical-documentation-engineer.md
+++ b/agents/technical-documentation-engineer.md
@@ -160,7 +160,6 @@ Load `documentation-templates.md` plus the relevant domain file when writing doc
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Writing docs from scratch, API endpoint template, integration guide, verification workflow, adversarial self-check | `documentation-templates.md` | Templates, 4-phase workflow, preferred patterns with before/after |

--- a/agents/technical-journalist-writer.md
+++ b/agents/technical-journalist-writer.md
@@ -151,7 +151,6 @@ STOP and ask the user when:
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | implementation patterns | `article-structure-patterns.md` | Loads detailed guidance from `article-structure-patterns.md`. |

--- a/agents/toolkit-governance-engineer.md
+++ b/agents/toolkit-governance-engineer.md
@@ -181,7 +181,6 @@ Use this format for consistency checks, audits, and multi-file operations. Singl
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `adr-lifecycle.md` | Loads detailed guidance from `adr-lifecycle.md`. |

--- a/agents/typescript-debugging-engineer.md
+++ b/agents/typescript-debugging-engineer.md
@@ -137,7 +137,6 @@ Test Plan: [How to reproduce]
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | workflow steps | `debugging-workflows.md` | Race conditions, type errors, production debugging, async issues, git bisect, memory leaks |

--- a/agents/typescript-frontend-engineer.md
+++ b/agents/typescript-frontend-engineer.md
@@ -129,7 +129,6 @@ Load [typescript-frontend-engineer/references/engineering-rules.md](typescript-f
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | type error, build error, tsc, tsconfig, compilation | `typescript-errors.md` | Routes to the matching deep reference |

--- a/agents/ui-design-engineer.md
+++ b/agents/ui-design-engineer.md
@@ -156,7 +156,6 @@ Uses the **Implementation Schema**: ANALYZE (surface type, narrative brief, cont
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | implement, scaffold, output format, code example | `implementation-patterns.md` | Output format checklist, Tailwind theme example, accessible button, responsive grid, animation code |

--- a/scripts/check-whitespace.py
+++ b/scripts/check-whitespace.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Check agent and skill markdown files for blank lines and trailing spaces that inflate token counts."""
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
+
+REPO_ROOT = Path(__file__).parent.parent
+
+_DEFAULT_PATTERNS = [
+    "agents/**/*.md",
+    "skills/**/*.md",
+]
+
+
+@dataclass
+class Violation:
+    path: str
+    line_no: int
+    kind: str
+    detail: str
+
+
+def check_file(path: Path) -> list[Violation]:
+    """Return all whitespace violations in a single file. Pure check, no side effects."""
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    try:
+        rel = str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        rel = str(path)
+
+    violations: list[Violation] = []
+    lines = content.splitlines(keepends=False)
+
+    i = 0
+    in_fence = False
+    while i < len(lines):
+        # Track code fence state — skip structural checks inside fences
+        if _FENCE_RE.match(lines[i]):
+            in_fence = not in_fence
+            i += 1
+            continue
+
+        # Consecutive blank lines: count run of empty lines (skip inside fences)
+        if lines[i] == "" and not in_fence:
+            run = 0
+            j = i
+            while j < len(lines) and lines[j] == "":
+                run += 1
+                j += 1
+            if run >= 2:
+                violations.append(
+                    Violation(
+                        path=rel,
+                        line_no=i + 1,
+                        kind="consecutive_blank_lines",
+                        detail=f"{run} consecutive blank lines",
+                    )
+                )
+            i = j
+            continue
+
+        # Trailing whitespace
+        stripped = lines[i].rstrip(" \t")
+        if len(stripped) < len(lines[i]):
+            trailing = len(lines[i]) - len(stripped)
+            violations.append(
+                Violation(
+                    path=rel,
+                    line_no=i + 1,
+                    kind="trailing_whitespace",
+                    detail=f"{trailing} trailing char(s)",
+                )
+            )
+
+        i += 1
+
+    return violations
+
+
+def fix_file(path: Path) -> int:
+    """Fix trailing whitespace and consecutive blank lines in place.
+
+    Returns the count of fixes applied. Does NOT fix indented headers.
+    """
+    try:
+        original = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return 0
+
+    lines = original.splitlines(keepends=False)
+    fixed_lines: list[str] = []
+    fixes = 0
+
+    i = 0
+    in_fence = False
+    while i < len(lines):
+        line = lines[i]
+
+        # Track code fence state — preserve blank lines inside fences
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            fixed_lines.append(line)
+            i += 1
+            continue
+
+        # Collapse runs of 2+ blank lines into a single blank line (outside fences only)
+        if line == "" and not in_fence:
+            run = 0
+            j = i
+            while j < len(lines) and lines[j] == "":
+                run += 1
+                j += 1
+            fixed_lines.append("")
+            if run >= 2:
+                fixes += run - 1
+            i = j
+            continue
+
+        # Strip trailing whitespace
+        stripped = line.rstrip(" \t")
+        if len(stripped) < len(line):
+            fixes += 1
+            line = stripped
+
+        fixed_lines.append(line)
+        i += 1
+
+    result = "\n".join(fixed_lines)
+
+    # Preserve original trailing newline behaviour
+    if original.endswith("\n"):
+        result += "\n"
+
+    if result != original:
+        path.write_text(result, encoding="utf-8")
+
+    return fixes
+
+
+def _collect_paths(path_args: list[str]) -> list[Path]:
+    """Resolve CLI path arguments to a list of Path objects."""
+    paths: list[Path] = []
+    seen: set[Path] = set()
+    for arg in path_args:
+        p = Path(arg)
+        if p.is_file():
+            if p not in seen:
+                seen.add(p)
+                paths.append(p)
+        elif p.is_dir():
+            for candidate in sorted(p.rglob("*.md")):
+                if candidate not in seen:
+                    seen.add(candidate)
+                    paths.append(candidate)
+        else:
+            print(f"WARNING: path not found: {arg}", file=sys.stderr)
+    return paths
+
+
+def _collect_default_paths() -> list[Path]:
+    """Collect all agent and skill markdown files from repo root."""
+    seen: set[Path] = set()
+    paths: list[Path] = []
+    for pattern in _DEFAULT_PATTERNS:
+        for p in sorted(REPO_ROOT.glob(pattern)):
+            if p.is_file() and p not in seen:
+                seen.add(p)
+                paths.append(p)
+    return paths
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Check agent/skill markdown files for blank lines and trailing spaces that inflate Opus token counts.",
+        epilog="Exit codes: 0=clean, 1=violations found, 2=usage error. --fix auto-corrects violations in place.",
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Auto-fix trailing whitespace and consecutive blank lines in place",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        metavar="PATH",
+        help="Files or directories to scan (default: agents/**/*.md and skills/**/*.md)",
+    )
+    args = parser.parse_args()
+
+    if args.paths:
+        targets = _collect_paths(args.paths)
+    else:
+        targets = _collect_default_paths()
+
+    if not targets:
+        print("No files to scan.", file=sys.stderr)
+        sys.exit(2)
+
+    if args.fix:
+        total_fixes = 0
+        for target in targets:
+            n = fix_file(target)
+            if n:
+                print(f"fixed {target}: {n} fix(es) applied")
+                total_fixes += n
+        if total_fixes:
+            print(f"\nTotal fixes applied: {total_fixes}")
+        else:
+            print("No fixes needed.")
+        sys.exit(0)
+
+    all_violations: list[Violation] = []
+    for target in targets:
+        all_violations.extend(check_file(target))
+
+    if all_violations:
+        for v in all_violations:
+            print(f"{v.path}:{v.line_no}: {v.kind} ({v.detail})")
+        print(f"\n{len(all_violations)} violation(s) found in {len(targets)} file(s) scanned.")
+        sys.exit(1)
+    else:
+        print(f"clean — {len(targets)} file(s) scanned, no violations.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_check_whitespace.py
+++ b/scripts/tests/test_check_whitespace.py
@@ -1,0 +1,294 @@
+"""Tests for scripts/check-whitespace.py."""
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the hyphen-named module via importlib
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH = Path(__file__).parent.parent / "check-whitespace.py"
+_spec = importlib.util.spec_from_file_location("check_whitespace", _SCRIPT_PATH)
+_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+sys.modules["check_whitespace"] = _mod
+
+Violation = _mod.Violation
+check_file = _mod.check_file
+fix_file = _mod.fix_file
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def write(tmp_path: Path, name: str, content: str) -> Path:
+    """Write content to a named file inside tmp_path and return the Path."""
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# check_file — consecutive blank lines
+# ---------------------------------------------------------------------------
+
+
+def test_check_consecutive_blank_lines(tmp_path: Path) -> None:
+    p = write(
+        tmp_path,
+        "a.md",
+        textwrap.dedent(
+            """\
+            # Heading
+
+            First paragraph.
+
+
+            Second paragraph after two blank lines.
+            """
+        ),
+    )
+    violations = check_file(p)
+    kinds = [v.kind for v in violations]
+    assert "consecutive_blank_lines" in kinds
+
+
+def test_check_single_blank_line_is_clean(tmp_path: Path) -> None:
+    p = write(
+        tmp_path,
+        "clean.md",
+        textwrap.dedent(
+            """\
+            # Heading
+
+            Paragraph one.
+
+            Paragraph two.
+            """
+        ),
+    )
+    violations = check_file(p)
+    assert violations == []
+
+
+def test_check_triple_blank_lines_reports_line_number(tmp_path: Path) -> None:
+    content = "line one\n\n\n\nline after three blanks\n"
+    p = write(tmp_path, "b.md", content)
+    violations = check_file(p)
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.kind == "consecutive_blank_lines"
+    assert v.line_no == 2  # first blank line is line 2
+    assert "3" in v.detail  # 3 consecutive blank lines
+
+
+# ---------------------------------------------------------------------------
+# check_file — trailing whitespace
+# ---------------------------------------------------------------------------
+
+
+def test_check_trailing_whitespace(tmp_path: Path) -> None:
+    p = write(tmp_path, "c.md", "# Heading  \nclean line\n")
+    violations = check_file(p)
+    assert any(v.kind == "trailing_whitespace" for v in violations)
+
+
+def test_check_trailing_tab(tmp_path: Path) -> None:
+    p = write(tmp_path, "d.md", "line with tab\t\nclean\n")
+    violations = check_file(p)
+    assert any(v.kind == "trailing_whitespace" for v in violations)
+
+
+def test_check_no_trailing_whitespace_is_clean(tmp_path: Path) -> None:
+    p = write(tmp_path, "e.md", "# Heading\nclean line\n")
+    violations = check_file(p)
+    assert not any(v.kind == "trailing_whitespace" for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# check_file — clean file
+# ---------------------------------------------------------------------------
+
+
+def test_check_completely_clean_file(tmp_path: Path) -> None:
+    p = write(
+        tmp_path,
+        "clean_full.md",
+        textwrap.dedent(
+            """\
+            ---
+            name: test-agent
+            ---
+
+            ## Section One
+
+            Some content here.
+
+            ## Section Two
+
+            More content.
+            """
+        ),
+    )
+    assert check_file(p) == []
+
+
+# ---------------------------------------------------------------------------
+# fix_file — consecutive blank lines
+# ---------------------------------------------------------------------------
+
+
+def test_fix_consecutive_blank_lines(tmp_path: Path) -> None:
+    content = "line one\n\n\nline after two blanks\n"
+    p = write(tmp_path, "h.md", content)
+    n = fix_file(p)
+    assert n >= 1
+    result = p.read_text(encoding="utf-8")
+    assert "\n\n\n" not in result
+    assert "line one" in result
+    assert "line after two blanks" in result
+
+
+def test_fix_trailing_whitespace(tmp_path: Path) -> None:
+    content = "line one   \nline two\t\nline three\n"
+    p = write(tmp_path, "i.md", content)
+    n = fix_file(p)
+    assert n == 2
+    result = p.read_text(encoding="utf-8")
+    for line in result.splitlines():
+        assert line == line.rstrip(), f"trailing whitespace remains: {line!r}"
+
+
+def test_fix_returns_zero_for_clean_file(tmp_path: Path) -> None:
+    content = "# Clean\n\nAll good here.\n"
+    p = write(tmp_path, "j.md", content)
+    n = fix_file(p)
+    assert n == 0
+
+
+def test_fix_clears_violations(tmp_path: Path) -> None:
+    content = "# Head\n\n\ntext trailing   \nmore\n"
+    p = write(tmp_path, "k.md", content)
+    fix_file(p)
+    violations = check_file(p)
+    remaining_kinds = {v.kind for v in violations}
+    assert "consecutive_blank_lines" not in remaining_kinds
+    assert "trailing_whitespace" not in remaining_kinds
+
+
+# ---------------------------------------------------------------------------
+# fix_file — preserves trailing newline
+# ---------------------------------------------------------------------------
+
+
+def test_fix_preserves_trailing_newline(tmp_path: Path) -> None:
+    content = "line one\n\n\nline two\n"
+    p = write(tmp_path, "m.md", content)
+    fix_file(p)
+    result = p.read_text(encoding="utf-8")
+    assert result.endswith("\n")
+
+
+def test_fix_preserves_no_trailing_newline(tmp_path: Path) -> None:
+    content = "line one\n\n\nline two"
+    p = write(tmp_path, "n.md", content)
+    fix_file(p)
+    result = p.read_text(encoding="utf-8")
+    assert not result.endswith("\n")
+
+
+# ---------------------------------------------------------------------------
+# Violation dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_violation_fields() -> None:
+    v = Violation(path="foo.md", line_no=5, kind="trailing_whitespace", detail="2 trailing char(s)")
+    assert v.path == "foo.md"
+    assert v.line_no == 5
+    assert v.kind == "trailing_whitespace"
+    assert v.detail == "2 trailing char(s)"
+
+
+# ---------------------------------------------------------------------------
+# Multiple violations in one file
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_violations_reported(tmp_path: Path) -> None:
+    content = "# Head  \n\n\nmore   \n"
+    p = write(tmp_path, "multi.md", content)
+    violations = check_file(p)
+    kinds = {v.kind for v in violations}
+    assert "trailing_whitespace" in kinds
+    assert "consecutive_blank_lines" in kinds
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_file_is_clean(tmp_path: Path) -> None:
+    p = write(tmp_path, "empty.md", "")
+    assert check_file(p) == []
+
+
+def test_single_line_no_newline(tmp_path: Path) -> None:
+    p = write(tmp_path, "single.md", "just a line")
+    assert check_file(p) == []
+
+
+@pytest.mark.parametrize("run_len", [2, 3, 5])
+def test_various_blank_line_run_lengths(tmp_path: Path, run_len: int) -> None:
+    content = "before\n" + ("\n" * run_len) + "after\n"
+    p = write(tmp_path, f"run{run_len}.md", content)
+    violations = check_file(p)
+    assert any(v.kind == "consecutive_blank_lines" for v in violations)
+    assert any(str(run_len) in v.detail for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# Code fence handling — structural checks must not fire inside fences
+# ---------------------------------------------------------------------------
+
+
+def test_consecutive_blank_lines_inside_fence_not_flagged(tmp_path: Path) -> None:
+    content = textwrap.dedent(
+        """\
+        ## Section
+
+        ```bash
+        # part one
+
+        # part two after intentional blank
+        ```
+
+        After fence.
+        """
+    )
+    p = write(tmp_path, "blank_in_fence.md", content)
+    violations = check_file(p)
+    assert not any(v.kind == "consecutive_blank_lines" for v in violations)
+
+
+def test_fix_preserves_blank_lines_inside_fence(tmp_path: Path) -> None:
+    content = "before\n\n```\n\n\ncode with blanks\n```\nafter\n"
+    p = write(tmp_path, "preserve_fence.md", content)
+    fix_file(p)
+    result = p.read_text(encoding="utf-8")
+    # The two blank lines inside the fence must survive
+    assert "```\n\n\ncode" in result
+
+
+def test_tilde_fence_blank_lines_not_flagged(tmp_path: Path) -> None:
+    content = "## Heading\n~~~python\ncode\n\n\nmore code\n~~~\nafter\n"
+    p = write(tmp_path, "tilde.md", content)
+    violations = check_file(p)
+    assert not any(v.kind == "consecutive_blank_lines" for v in violations)

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-04-17T03:24:23Z",
+  "generated": "2026-04-17T20:49:52Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
     "adr-consultation": {
@@ -590,7 +590,7 @@
       "pairs_with": [
         "comprehensive-review"
       ],
-      "model": "opus"
+      "model": "sonnet"
     },
     "game-asset-generator": {
       "file": "skills/game-asset-generator/SKILL.md",
@@ -1467,7 +1467,7 @@
         "workflow"
       ],
       "agent": "research-coordinator-engineer",
-      "model": "opus"
+      "model": "sonnet"
     },
     "research-pipeline": {
       "file": "skills/research-pipeline/SKILL.md",
@@ -1565,7 +1565,7 @@
         "sapcc-audit"
       ],
       "agent": "golang-general-engineer",
-      "model": "opus"
+      "model": "sonnet"
     },
     "security-threat-model": {
       "file": "skills/security-threat-model/SKILL.md",
@@ -1587,7 +1587,7 @@
       "pairs_with": [
         "python-general-engineer"
       ],
-      "model": "opus"
+      "model": "sonnet"
     },
     "series-planner": {
       "file": "skills/series-planner/SKILL.md",

--- a/skills/adr-consultation/SKILL.md
+++ b/skills/adr-consultation/SKILL.md
@@ -31,7 +31,6 @@ Multi-agent architecture consultation that dispatches 3 specialized reviewers in
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `agent-prompts.md` | Loads detailed guidance from `agent-prompts.md`. |

--- a/skills/agent-comparison/SKILL.md
+++ b/skills/agent-comparison/SKILL.md
@@ -27,7 +27,6 @@ Compare agent variants through controlled A/B benchmarks. Runs identical tasks o
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `benchmark-tasks.md` | Loads detailed guidance from `benchmark-tasks.md`. |

--- a/skills/agent-evaluation/SKILL.md
+++ b/skills/agent-evaluation/SKILL.md
@@ -25,7 +25,6 @@ Objective, evidence-based quality assessment for agents and skills. Implements a
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `batch-evaluation.md` | Loads detailed guidance from `batch-evaluation.md`. |

--- a/skills/anti-ai-editor/SKILL.md
+++ b/skills/anti-ai-editor/SKILL.md
@@ -28,7 +28,6 @@ Detect and remove AI-generated writing patterns through targeted, minimal edits.
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | AI Cliches | `cliche-replacements.md` | "delve", "leverage", "utilize", "robust" |

--- a/skills/anti-ai-editor/references/detection-patterns.md
+++ b/skills/anti-ai-editor/references/detection-patterns.md
@@ -240,8 +240,6 @@ AI tells the reader to feel something instead of presenting facts that create th
 
 **Fix strategy:** If you need to tell the reader something matters, the preceding facts didn't do their job. Fix the facts, then delete the emphasis.
 
-
-
 ```regex
 # Absolute adjectives with modifiers
 \bvery unique\b

--- a/skills/auto-dream/SKILL.md
+++ b/skills/auto-dream/SKILL.md
@@ -36,7 +36,6 @@ Background memory consolidation cycle. Scans memory files, finds stale/duplicate
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Debugging failed cron run, silent failure, empty log, wrong exit code | `headless-cron-patterns.md` | Routes to the matching deep reference |

--- a/skills/bluesky-reader/SKILL.md
+++ b/skills/bluesky-reader/SKILL.md
@@ -67,7 +67,6 @@ python3 ~/.claude/scripts/bluesky_reader.py feed --handle HANDLE --cursor CURSOR
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Endpoint details, data shapes, pagination | `at-protocol-api.md` | Routes to the matching deep reference |

--- a/skills/code-cleanup/SKILL.md
+++ b/skills/code-cleanup/SKILL.md
@@ -49,7 +49,6 @@ Scan repositories for 9 categories of technical debt (TODOs, unused imports, dea
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `report-template.md` | Loads detailed guidance from `report-template.md`. |

--- a/skills/code-linting/SKILL.md
+++ b/skills/code-linting/SKILL.md
@@ -25,7 +25,6 @@ Unified linting workflow for Python (ruff) and JavaScript (Biome). Covers check,
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Python violations, ruff rules, F401/E711/B006/UP errors | `ruff-rules-reference.md` | Routes to the matching deep reference |

--- a/skills/codebase-analyzer/SKILL.md
+++ b/skills/codebase-analyzer/SKILL.md
@@ -39,7 +39,6 @@ Load these files when the corresponding signals appear:
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |

--- a/skills/codebase-overview/SKILL.md
+++ b/skills/codebase-overview/SKILL.md
@@ -29,7 +29,6 @@ Systematic 4-phase codebase exploration that produces an evidence-backed onboard
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | example-driven tasks, errors | `examples-and-errors.md` | Loads detailed guidance from `examples-and-errors.md`. |

--- a/skills/condition-based-waiting/SKILL.md
+++ b/skills/condition-based-waiting/SKILL.md
@@ -35,7 +35,6 @@ Implement condition-based polling and retry patterns with bounded timeouts, jitt
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | implementation patterns | `anti-patterns.md` | Loads detailed guidance from `anti-patterns.md`. |

--- a/skills/content-calendar/SKILL.md
+++ b/skills/content-calendar/SKILL.md
@@ -25,7 +25,6 @@ Manage editorial content through 6 pipeline stages: Ideas, Outlined, Drafted, Ed
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `calendar-format.md` | Loads detailed guidance from `calendar-format.md`. |

--- a/skills/content-calendar/references/metrics.md
+++ b/skills/content-calendar/references/metrics.md
@@ -34,7 +34,7 @@ Content stuck in a stage for more than 14 days signals a bottleneck.
 # Outlined entries older than 14 days
 grep -E "\(outline: [0-9]{4}-[0-9]{2}-[0-9]{2}\)" content-calendar.md
 
-# Drafted entries older than 14 days  
+# Drafted entries older than 14 days
 grep -E "\(draft: [0-9]{4}-[0-9]{2}-[0-9]{2}\)" content-calendar.md
 
 # Editing entries older than 14 days

--- a/skills/content-engine/SKILL.md
+++ b/skills/content-engine/SKILL.md
@@ -38,7 +38,6 @@ Platform-native means each variant is written from scratch for its target platfo
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |

--- a/skills/create-voice/SKILL.md
+++ b/skills/create-voice/SKILL.md
@@ -40,7 +40,6 @@ Create a complete voice profile from writing samples through a 7-phase pipeline.
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |

--- a/skills/cron-job-auditor/SKILL.md
+++ b/skills/cron-job-auditor/SKILL.md
@@ -23,7 +23,6 @@ Static analysis of cron and scheduled job scripts against a 9-point reliability 
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Checking error handling, `set -e`, `pipefail`, `trap`, exit codes | `shell-error-handling.md` | Routes to the matching deep reference |

--- a/skills/csuite/references/migration-planning.md
+++ b/skills/csuite/references/migration-planning.md
@@ -296,7 +296,7 @@ def save_record(data):
         log_error('dual-write-shadow-failure', e, data)
         # Do NOT fail the request — old system is primary
         return old_result
-    
+
     compare_results(old_result, new_result)  # Log divergences
     return old_result                         # Return old system result during shadow phase
 

--- a/skills/data-analysis/SKILL.md
+++ b/skills/data-analysis/SKILL.md
@@ -46,7 +46,6 @@ Every analysis begins with the decision being supported, works backward to the e
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | implementation patterns | `anti-patterns.md` | Loads detailed guidance from `anti-patterns.md`. |

--- a/skills/distinctive-frontend-design/SKILL.md
+++ b/skills/distinctive-frontend-design/SKILL.md
@@ -29,7 +29,6 @@ Optional capabilities (off unless explicitly enabled by the user): design system
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | implementation patterns | `animation-patterns.md` | Loads detailed guidance from `animation-patterns.md`. |

--- a/skills/docs-sync-checker/SKILL.md
+++ b/skills/docs-sync-checker/SKILL.md
@@ -32,7 +32,6 @@ Optional flags: `--auto-fix` (experimental, requires explicit opt-in), `--strict
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | documentation work | `documentation-structure.md` | Loads detailed guidance from `documentation-structure.md`. |

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -36,7 +36,6 @@ Playwright-based E2E testing across four phases: Scaffold, Build, Run, Validate.
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | async, Promise.all, race condition, waitForTimeout, fixture teardown | `async.md` | Routes to the matching deep reference |

--- a/skills/endpoint-validator/SKILL.md
+++ b/skills/endpoint-validator/SKILL.md
@@ -25,7 +25,6 @@ Deterministic HTTP endpoint validation following a **Discover, Validate, Report*
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Security header WARNs, HSTS/CSP/X-Frame issues | `security-headers.md` | Routes to the matching deep reference |

--- a/skills/feature-lifecycle/SKILL.md
+++ b/skills/feature-lifecycle/SKILL.md
@@ -105,7 +105,6 @@ Each phase produces an artifact consumed by the next. Skipping phases is not sup
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `design.md` | Loads detailed guidance from `design.md`. |

--- a/skills/fish-shell-config/SKILL.md
+++ b/skills/fish-shell-config/SKILL.md
@@ -36,7 +36,6 @@ Fish is not POSIX. Every pattern here targets Fish 3.0+ (supports `$()`, `&&`, `
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | migrations | `bash-migration.md` | Loads detailed guidance from `bash-migration.md`. |

--- a/skills/forensics/SKILL.md
+++ b/skills/forensics/SKILL.md
@@ -46,7 +46,6 @@ Investigate failed or stuck workflows through post-mortem analysis of git histor
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `detectors.md` | Loads detailed guidance from `detectors.md`. |

--- a/skills/frontend-slides/SKILL.md
+++ b/skills/frontend-slides/SKILL.md
@@ -41,7 +41,6 @@ Generate browser-based HTML presentations as a single self-contained `.html` fil
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `STYLE_PRESETS.md` | Loads detailed guidance from `STYLE_PRESETS.md`. |

--- a/skills/full-repo-review/SKILL.md
+++ b/skills/full-repo-review/SKILL.md
@@ -46,7 +46,6 @@ identical.
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `report-template.md` | Loads detailed guidance from `report-template.md`. |

--- a/skills/game-asset-generator/SKILL.md
+++ b/skills/game-asset-generator/SKILL.md
@@ -161,7 +161,6 @@ mixer.update(deltaTime);
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | "3D model", "character model", "generate model", GLB, mesh, rig, animate, humanoid | `meshyai.md` | **3D Model** |

--- a/skills/game-pipeline/SKILL.md
+++ b/skills/game-pipeline/SKILL.md
@@ -47,7 +47,6 @@ This skill orchestrates the full game development lifecycle: SCAFFOLD → ASSETS
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | `references/game-audio.md` | `game-audio.md` | AUDIO |

--- a/skills/gemini-image-generator/SKILL.md
+++ b/skills/gemini-image-generator/SKILL.md
@@ -32,7 +32,6 @@ Generate images from text prompts via CLI using Google Gemini APIs. Supports mod
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `prompts.md` | Loads detailed guidance from `prompts.md`. |

--- a/skills/generate-claudemd/SKILL.md
+++ b/skills/generate-claudemd/SKILL.md
@@ -34,7 +34,6 @@ This skill does not use `context: fork` because it requires interactive user gat
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `CLAUDEMD_TEMPLATE.md` | Loads detailed guidance from `CLAUDEMD_TEMPLATE.md`. |

--- a/skills/go-patterns/SKILL.md
+++ b/skills/go-patterns/SKILL.md
@@ -79,7 +79,6 @@ based on the Go task at hand.
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Testing | `testing.md` | Writing, fixing, or reviewing Go tests |

--- a/skills/image-to-video/SKILL.md
+++ b/skills/image-to-video/SKILL.md
@@ -34,7 +34,6 @@ Combine a static image with an audio file to produce an MP4 video using FFmpeg. 
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `ffmpeg-filters.md` | Loads detailed guidance from `ffmpeg-filters.md`. |

--- a/skills/integration-checker/SKILL.md
+++ b/skills/integration-checker/SKILL.md
@@ -36,7 +36,6 @@ This is a read-only analysis skill -- it reads and reports but does not fix wiri
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `wiring-checks.md` | Loads detailed guidance from `wiring-checks.md`. |

--- a/skills/joy-check/SKILL.md
+++ b/skills/joy-check/SKILL.md
@@ -44,7 +44,6 @@ This skill checks *framing*, not *topic* and not *voice*. Voice fidelity belongs
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `instruction-rubric.md` | Loads detailed guidance from `instruction-rubric.md`. |

--- a/skills/kb/SKILL.md
+++ b/skills/kb/SKILL.md
@@ -52,7 +52,6 @@ Detect the user's intent and load the appropriate reference file:
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | "kb compile", "compile wiki", "build knowledge base", "compile raw sources" | `compile.md` | **Compile** |

--- a/skills/kotlin-coroutines/SKILL.md
+++ b/skills/kotlin-coroutines/SKILL.md
@@ -23,7 +23,6 @@ the correct reference based on the task at hand.
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Concurrency | `concurrency-patterns.md` | Scopes, cancellation, dispatchers, exception handling |

--- a/skills/multi-persona-critique/SKILL.md
+++ b/skills/multi-persona-critique/SKILL.md
@@ -51,7 +51,6 @@ This skill takes a set of proposals — feature ideas, architectural decisions, 
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | example-driven tasks, errors | `examples-and-errors.md` | Loads detailed guidance from `examples-and-errors.md`. |

--- a/skills/perses/SKILL.md
+++ b/skills/perses/SKILL.md
@@ -65,7 +65,6 @@ Umbrella skill for all Perses platform operations.
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | First-time setup, server deployment | `onboard-deploy.md` | New Perses installation or server configuration |

--- a/skills/phaser-gamedev/SKILL.md
+++ b/skills/phaser-gamedev/SKILL.md
@@ -38,7 +38,6 @@ This skill builds complete Phaser 3 2D games using a **Phased Construction** pat
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | `references/core-patterns.md` | `core-patterns.md` | Always |

--- a/skills/php-testing/SKILL.md
+++ b/skills/php-testing/SKILL.md
@@ -23,7 +23,6 @@ Apply PHPUnit testing patterns for PHP projects: unit tests with data providers,
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | implementation patterns | `patterns.md` | Loads detailed guidance from `patterns.md`. |

--- a/skills/planning/SKILL.md
+++ b/skills/planning/SKILL.md
@@ -92,7 +92,6 @@ Detect the user's intent and load the appropriate reference file:
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | "write spec", "user stories", "define requirements", "scope this", "acceptance criteria", "define scope", "spec out" | `spec.md` | **Spec** |

--- a/skills/pptx-generator/SKILL.md
+++ b/skills/pptx-generator/SKILL.md
@@ -41,7 +41,6 @@ This separation prevents the common failure mode where the generator rationalize
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `anti-ai-slide-rules.md` | Loads detailed guidance from `anti-ai-slide-rules.md`. |

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -98,7 +98,6 @@ Detect the user's intent and load the appropriate reference file:
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | "push", "create PR", "sync", "ship this" | `sync.md` | **Sync** (default) |

--- a/skills/pr-workflow/references/miner.md
+++ b/skills/pr-workflow/references/miner.md
@@ -246,7 +246,6 @@ Solution:
 - `${CLAUDE_SKILL_DIR}/scripts/miner.py`: Main mining script (GitHub API extraction)
 - `${CLAUDE_SKILL_DIR}/scripts/validate.py`: Output validation script
 
-
 ---
 
 # Part 2: PR Mining Coordinator (Workflow Coordination and Rule Generation)

--- a/skills/pr-workflow/references/pipeline.md
+++ b/skills/pr-workflow/references/pipeline.md
@@ -395,7 +395,6 @@ Solution:
 3. Suggest: `gh run watch [run-id]` for manual monitoring
 4. Mark pipeline as complete with "CI pending" status
 
-
 ---
 
 # Appendix: Reference Details
@@ -470,7 +469,6 @@ echo "Preflight checklist PASSED."
 
 This is context-dependent. If the project has a test suite (`go test`, `npm test`, `pytest`, etc.), look for evidence that tests were run recently (e.g., verification report files, recent test output in the session). If no test infrastructure exists, this check passes by default. The goal is to prevent submitting code that was never tested, not to block projects without tests.
 
-
 ---
 
 # Review-Fix Loop
@@ -531,7 +529,6 @@ REVIEW-FIX ITERATION [N/3]
   Remaining: [Z issues]
   Status: [CLEAN | FIXING | MAX ITERATIONS REACHED]
 ```
-
 
 ---
 
@@ -641,7 +638,6 @@ python3 ~/.claude/scripts/adr-status.py status
 ```
 
 Include the status summary in the PR body if the PR touches any `adr/*.md` files. This gives reviewers an at-a-glance view of ADR state.
-
 
 ---
 

--- a/skills/professional-communication/SKILL.md
+++ b/skills/professional-communication/SKILL.md
@@ -30,7 +30,6 @@ This skill transforms dense technical communication into clear, structured busin
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -93,7 +93,6 @@ Detect the user's intent and load the appropriate reference file:
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | "outline post", "blog structure", "content blueprint", "article outline", "content structure" | `outline.md` | **Outline** |

--- a/skills/python-quality-gate/SKILL.md
+++ b/skills/python-quality-gate/SKILL.md
@@ -32,7 +32,6 @@ Run four quality tools in deterministic order -- ruff, pytest, mypy, bandit -- a
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `report-template.md` | Loads detailed guidance from `report-template.md`. |

--- a/skills/quick/SKILL.md
+++ b/skills/quick/SKILL.md
@@ -53,7 +53,6 @@ Quick covers the full lightweight tier from zero-ceremony inline fixes (≤3 edi
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |

--- a/skills/reddit-moderate/SKILL.md
+++ b/skills/reddit-moderate/SKILL.md
@@ -33,7 +33,6 @@ report classification, and executes mod actions you confirm.
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | Classifying items, category definitions, confidence thresholds | `classification-prompt.md` | Routes to the matching deep reference |

--- a/skills/reference-enrichment/SKILL.md
+++ b/skills/reference-enrichment/SKILL.md
@@ -229,7 +229,6 @@ Load when the task type matches:
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `quality-rubric.md` | Loads detailed guidance from `quality-rubric.md`. |

--- a/skills/repo-value-analysis/SKILL.md
+++ b/skills/repo-value-analysis/SKILL.md
@@ -38,7 +38,6 @@ The pipeline enforces **full file reading** (not sampling), **parallel execution
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |

--- a/skills/roast/SKILL.md
+++ b/skills/roast/SKILL.md
@@ -42,7 +42,6 @@ This skill produces evidence-based constructive critique through 5 specialized H
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `personas.md` | Loads detailed guidance from `personas.md`. |

--- a/skills/routing-table-updater/SKILL.md
+++ b/skills/routing-table-updater/SKILL.md
@@ -33,7 +33,6 @@ The skill reads metadata from all skills and agents (never modifies them) and sa
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `batch-mode.md` | Loads detailed guidance from `batch-mode.md`. |

--- a/skills/sapcc-review/SKILL.md
+++ b/skills/sapcc-review/SKILL.md
@@ -53,7 +53,6 @@ Each specialist loads only its domain-specific reference file to keep context ti
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `agent-dispatch-prompts.md` | Loads detailed guidance from `agent-dispatch-prompts.md`. |

--- a/skills/security-threat-model/SKILL.md
+++ b/skills/security-threat-model/SKILL.md
@@ -275,7 +275,6 @@ These are not error conditions. Re-run with `--verbose` for detail on missing pa
 
 ---
 
-
 ## References
 
 - [ADR-102: Security Threat Model Skill](../../adr/ADR-102-security-threat-model.md)

--- a/skills/series-planner/SKILL.md
+++ b/skills/series-planner/SKILL.md
@@ -31,7 +31,6 @@ This skill plans multi-part content series with proper structure, cross-linking,
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `cadence-guidelines.md` | Loads detailed guidance from `cadence-guidelines.md`. |

--- a/skills/skill-composer/SKILL.md
+++ b/skills/skill-composer/SKILL.md
@@ -31,7 +31,6 @@ Orchestrate complex workflows by chaining multiple skills into validated executi
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `compatibility-matrix.md` | Loads detailed guidance from `compatibility-matrix.md`. |

--- a/skills/skill-composer/references/examples.md
+++ b/skills/skill-composer/references/examples.md
@@ -514,7 +514,6 @@ Task Analysis:
   Quality requirements: quality_checks
   Domain hints: golang
 
-
 Execution Plan:
 
 Phase 1:

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -360,7 +360,6 @@ but only if the queries are well-designed.
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | implementation patterns | `anti-patterns.md` | Loads detailed guidance from `anti-patterns.md`. |

--- a/skills/skill-eval/SKILL.md
+++ b/skills/skill-eval/SKILL.md
@@ -34,7 +34,6 @@ Measure and improve skill quality through empirical testing — because structur
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `schemas.md` | Loads detailed guidance from `schemas.md`. |

--- a/skills/skill-eval/references/self-improve-loop.md
+++ b/skills/skill-eval/references/self-improve-loop.md
@@ -106,11 +106,11 @@ Each hypothesis must:
 Format each hypothesis:
 
 ```
-Hypothesis A: Moving the error-handling constraint from the preamble to Phase 2 
+Hypothesis A: Moving the error-handling constraint from the preamble to Phase 2
   (where errors actually occur) should improve error-handling quality in outputs
   because constraints at point-of-use are more effective than front-loaded rules.
 
-Hypothesis B: Replacing the vague anti-pattern "don't over-engineer" with a 
+Hypothesis B: Replacing the vague anti-pattern "don't over-engineer" with a
   concrete before/after example should reduce over-engineering in outputs because
   specific examples are more actionable than abstract warnings.
 ```
@@ -118,8 +118,8 @@ Hypothesis B: Replacing the vague anti-pattern "don't over-engineer" with a
 **Example using a real toolkit skill** — improving the `fast` skill's description:
 
 ```
-Hypothesis A: Shortening the description from "Zero-ceremony inline execution 
-  for 3 or fewer file edits" to "Quick inline edits, 1-3 files, no ceremony" 
+Hypothesis A: Shortening the description from "Zero-ceremony inline execution
+  for 3 or fewer file edits" to "Quick inline edits, 1-3 files, no ceremony"
   should improve trigger rate for casual phrasing ("just fix this quick") because
   the shorter form matches how users actually talk.
 ```

--- a/skills/systematic-code-review/SKILL.md
+++ b/skills/systematic-code-review/SKILL.md
@@ -24,7 +24,6 @@ Systematic 4-phase code review: UNDERSTAND changes, VERIFY claims against actual
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | implementation patterns | `go-review-patterns.md` | Loads detailed guidance from `go-review-patterns.md`. |

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -30,7 +30,6 @@ Enforce the RED-GREEN-REFACTOR cycle for all code changes. Tests are written bef
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |

--- a/skills/testing-agents-with-subagents/SKILL.md
+++ b/skills/testing-agents-with-subagents/SKILL.md
@@ -36,7 +36,6 @@ Each test runs in a fresh subagent to avoid context pollution. After any fix, re
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | example-driven tasks, errors | `examples-and-errors.md` | Loads detailed guidance from `examples-and-errors.md`. |

--- a/skills/testing-anti-patterns/SKILL.md
+++ b/skills/testing-anti-patterns/SKILL.md
@@ -44,7 +44,6 @@ This skill identifies and fixes common testing mistakes across unit, integration
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | implementation patterns | `anti-pattern-catalog.md` | Loads detailed guidance from `anti-pattern-catalog.md`. |

--- a/skills/threejs-builder/SKILL.md
+++ b/skills/threejs-builder/SKILL.md
@@ -59,7 +59,6 @@ This skill builds complete Three.js web applications using a **Phased Constructi
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | `@react-three/fiber`, `r3f`, `drei`, `useFrame`, `<Canvas>`, `<mesh>`, React project with 3D | `react-three-fiber.md` | **React Three Fiber** |

--- a/skills/toolkit-evolution/SKILL.md
+++ b/skills/toolkit-evolution/SKILL.md
@@ -42,7 +42,6 @@ Invoke: `/evolve`, `/evolve routing`, `/evolve hooks`, `/evolve --discover`. Cro
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `diagnose-scripts.md` | Loads detailed guidance from `diagnose-scripts.md`. |

--- a/skills/topic-brainstormer/SKILL.md
+++ b/skills/topic-brainstormer/SKILL.md
@@ -32,7 +32,6 @@ Core principle: **Assess-Decide-Generate with Domain Intelligence**. Gather sign
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `content-filter.md` | Loads detailed guidance from `content-filter.md`. |

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -33,7 +33,6 @@ This skill prevents the most common form of premature completion: claiming succe
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `adversarial-methodology.md` | Loads detailed guidance from `adversarial-methodology.md`. |

--- a/skills/video-editing/SKILL.md
+++ b/skills/video-editing/SKILL.md
@@ -50,7 +50,6 @@ This skill implements a **6-layer pipeline** where AI handles judgment tasks (wh
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | `references/preflight.md` | `preflight.md` | Before Phase 1 |

--- a/skills/wordpress-live-validation/SKILL.md
+++ b/skills/wordpress-live-validation/SKILL.md
@@ -49,7 +49,6 @@ This skill loads a real WordPress post in a Playwright headless browser and veri
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | tasks related to this reference | `validation-checks.md` | Loads detailed guidance from `validation-checks.md`. |

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -79,7 +79,6 @@ If the task spans multiple workflows (e.g., research then write), load each refe
 
 ## Reference Loading Table
 
-
 | Signal | Load These Files | Why |
 |---|---|---|
 | **Code Review** | `comprehensive-review.md` | Comprehensive multi-wave review |

--- a/skills/workflow/references/mcp-pipeline-builder/references/python-scaffold-template.md
+++ b/skills/workflow/references/mcp-pipeline-builder/references/python-scaffold-template.md
@@ -87,7 +87,6 @@ mcp = FastMCP("{service}-mcp-server")
 # Initialize shared client
 _client = ServiceClient(api_key=_API_KEY)
 
-
 # --- Tool parameter models (Pydantic v2) ---
 
 class GetIssueParams(BaseModel):
@@ -95,13 +94,11 @@ class GetIssueParams(BaseModel):
     repo: str = Field(description="Repository name")
     issue_number: int = Field(description="Issue number", gt=0)
 
-
 class ListIssuesParams(BaseModel):
     owner: str = Field(description="Repository owner or organization name")
     repo: str = Field(description="Repository name")
     state: str = Field(default="open", description="Filter by state: open, closed, all")
     limit: int = Field(default=20, ge=1, le=100, description="Maximum results. Default: 20")
-
 
 # --- Tools ---
 
@@ -117,7 +114,6 @@ def service_get_issue(params: GetIssueParams) -> str:
         # Raise with a clear message — FastMCP converts this to an MCP error response
         raise ValueError(f"Error fetching issue {params.issue_number}: {e}") from e
 
-
 @mcp.tool(
     description="List issues with optional state filter. Returns a JSON array of matching issues."
 )
@@ -128,7 +124,6 @@ def service_list_issues(params: ListIssuesParams) -> str:
         return json.dumps(issues, indent=2)
     except Exception as e:
         raise ValueError(f"Error listing issues: {e}") from e
-
 
 # --- Entry point ---
 
@@ -149,7 +144,6 @@ The shared client class. Adapt to the target service's protocol.
 
 import httpx
 from typing import Any
-
 
 class ServiceClient:
     def __init__(self, api_key: str, base_url: str = "https://api.example.com"):
@@ -190,7 +184,6 @@ import subprocess
 import json
 import os
 
-
 class CliClient:
     def __init__(self, executable: str, env: dict[str, str] | None = None):
         self._executable = executable
@@ -226,7 +219,6 @@ When the target is an installable Python package:
 
 # Install the target: pip install {service-package}
 from {service_package} import SomeClient, Config
-
 
 class ImportClient:
     def __init__(self, api_key: str):

--- a/skills/workflow/references/systematic-refactoring.md
+++ b/skills/workflow/references/systematic-refactoring.md
@@ -38,7 +38,6 @@ routing:
 
 Safe, verifiable refactoring through 5 explicit phases with mandatory gates. Each phase has gates that prevent common refactoring mistakes: breaking behavior, incomplete migrations, or orphaned code.
 
-
 ---
 
 ## Instructions
@@ -330,7 +329,6 @@ Phase 3:
 Phase 4: Verify all callers use new signature
 Phase 5: Record migration pattern
 ```
-
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary

- **113 agent/skill files**: Removed double blank lines left by the `a21f535` comment-removal pass (161 total fixes). Each extra blank line is tokenized on every agent dispatch.
- **agents/system-upgrade-engineer.md**: Renamed `Anti-Pattern 1/2/3` subsection headers to `Pattern 1/2/3` — the section was already renamed to "Patterns to Detect and Fix" in `a21f535` but the subsections were missed.
- **agents/system-upgrade-engineer.md:221**: Fixed broken relative link `..skills/` → `../skills/`.
- **scripts/check-whitespace.py**: New deterministic validator for consecutive blank lines and trailing whitespace in agent/skill markdown files. Supports `--fix` for in-place correction. Code-fence aware (backtick and tilde fences both handled).
- **scripts/tests/test_check_whitespace.py**: 23 tests covering all violation types, fix idempotency, fence handling, and edge cases.

## Test plan

- [ ] `ruff check . --config pyproject.toml` passes
- [ ] `ruff format --check . --config pyproject.toml` passes
- [ ] `python3 -m pytest scripts/tests/ -q` passes (2588 passed, 1 skipped, 178 xfailed)
- [ ] `python3 scripts/check-whitespace.py` reports `clean — 904 file(s) scanned, no violations`