### PR TITLE
feat(refs): frontend-slides (Level 2→3)

### DIFF
--- a/skills/frontend-slides/references/js-controller-patterns.md
+++ b/skills/frontend-slides/references/js-controller-patterns.md
@@ -102,9 +102,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
 ---
 
+<!-- no-pair-required: section heading — each Anti-Pattern block below has its own Do-instead -->
 ## Anti-Pattern Catalog
 
 ### Anti-Pattern 1: Missing `navigating` flag
+
+Do instead: add `if (this.navigating) return;` as the first line of `go()` and reset it via `setTimeout`.
 
 **Detection**:
 ```bash
@@ -127,9 +130,25 @@ first scroll animation completes, causing the deck to skip 2-3 slides.
 **Fix**: `if (this.navigating) return;` as first line in `go()`. Set `navigating = false`
 in a `setTimeout` matching the slide transition duration (typically 400-600ms).
 
+**Do instead**
+
+```javascript
+go(index) {
+  if (this.navigating) return;          // guard: reject re-entrant calls
+  if (index < 0 || index >= this.total) return;
+  this.navigating = true;
+  this.current = index;
+  this.deck.scrollTo({ left: index * this.deck.offsetWidth, behavior: 'smooth' });
+  this._updateIndicator();
+  setTimeout(() => { this.navigating = false; }, 500);
+}
+```
+
 ---
 
 ### Anti-Pattern 2: Wheel without debounce
+
+Do instead: wrap the `wheel` handler body in `clearTimeout` + `setTimeout(() => { ... }, 150)` to collapse burst events.
 
 **Detection**:
 ```bash
@@ -150,6 +169,20 @@ deck advances to the last slide in under a second.
 
 **Fix**: Use `clearTimeout(this.wheelTimer)` + `setTimeout(() => { ... }, 150)` pattern from
 the canonical implementation above. The 150ms window collapses burst events into one action.
+
+**Do instead**
+
+```javascript
+_initWheel() {
+  this.deck.addEventListener('wheel', e => {
+    e.preventDefault();
+    clearTimeout(this.wheelTimer);
+    this.wheelTimer = setTimeout(() => {
+      e.deltaY > 0 ? this.next() : this.prev();
+    }, 150); // collapses burst events into a single slide advance
+  }, { passive: false });
+}
+```
 
 ---
 
@@ -174,9 +207,25 @@ callbacks never fire. Reveal animations (`opacity: 0 → 1`) silently break for 
 always "display: flex". No manual show/hide is needed. If you must hide off-screen slides,
 use `opacity: 0; pointer-events: none; position: absolute` instead.
 
+**Do instead**
+
+```css
+/* All slides remain in DOM flow — no display toggling */
+.slide {
+  display: flex;
+  flex: 0 0 100%;         /* each slide occupies exactly one viewport width */
+  scroll-snap-align: start;
+}
+/* Use IntersectionObserver to trigger reveal animations, not display toggling */
+.slide { opacity: 0; transition: opacity 0.4s ease; }
+.slide.visible { opacity: 1; }
+```
+
 ---
 
 ### Anti-Pattern 4: Touch swipe fires on vertical scroll
+
+Do instead: record `screenY` on `touchstart` and reject gestures where `Math.abs(dy) > Math.abs(dx)`.
 
 **Detection**:
 ```bash
@@ -198,9 +247,29 @@ trying to scroll content on a mobile slide accidentally navigate.
 **Fix**: Record `screenY` on `touchstart`. On `touchend`, reject if `Math.abs(dy) > Math.abs(dx)`
 (gesture is more vertical than horizontal). See canonical implementation.
 
+**Do instead**
+
+```javascript
+_initTouch() {
+  this.deck.addEventListener('touchstart', e => {
+    this.touchStartX = e.changedTouches[0].screenX;
+    this.touchStartY = e.changedTouches[0].screenY;  // record Y to detect vertical gestures
+  }, { passive: true });
+
+  this.deck.addEventListener('touchend', e => {
+    const dx = e.changedTouches[0].screenX - this.touchStartX;
+    const dy = e.changedTouches[0].screenY - this.touchStartY;
+    if (Math.abs(dx) < 50 || Math.abs(dy) > Math.abs(dx)) return; // reject vertical-dominant gestures
+    dx < 0 ? this.next() : this.prev();
+  }, { passive: true });
+}
+```
+
 ---
 
 ### Anti-Pattern 5: `Space` key not prevented from scrolling page
+
+Do instead: call `e.preventDefault()` before `this.next()` on every navigation key including Space.
 
 **Detection**:
 ```bash
@@ -217,6 +286,20 @@ if (e.key === 'Space') this.next();
 both slide advance and page scroll fire simultaneously, causing a jarring visible jump.
 
 **Fix**: `if (e.key === 'Space') { e.preventDefault(); this.next(); }`
+
+**Do instead**
+
+```javascript
+_initKeyboard() {
+  document.addEventListener('keydown', e => {
+    // e.preventDefault() called before this.next()/prev() on every navigation key
+    if (e.key === 'ArrowRight' || e.key === 'Space') { e.preventDefault(); this.next(); }
+    if (e.key === 'ArrowLeft'  || e.key === 'Backspace') { e.preventDefault(); this.prev(); }
+    if (e.key === 'Home') { e.preventDefault(); this.go(0); }
+    if (e.key === 'End')  { e.preventDefault(); this.go(this.total - 1); }
+  });
+}
+```
 
 ---
 

--- a/skills/frontend-slides/references/js-controller-patterns.md
+++ b/skills/frontend-slides/references/js-controller-patterns.md
@@ -1,0 +1,321 @@
+# JS Controller Patterns — Frontend Slides Reference
+
+> **Load this file during Phase 4 (BUILD) when implementing SlideController.**
+
+---
+
+## Canonical SlideController Implementation
+
+The full class below satisfies all requirements in Phase 4 rule 6. Use it verbatim and extend
+with preset-specific animation logic — do not rewrite from scratch.
+
+```javascript
+class SlideController {
+  constructor(deck) {
+    this.deck = deck;
+    this.slides = Array.from(deck.querySelectorAll('.slide'));
+    this.current = 0;
+    this.total = this.slides.length;
+    this.navigating = false;       // blocks re-entry during transition
+    this.wheelTimer = null;        // debounce handle
+    this.touchStartX = 0;
+    this.touchStartY = 0;
+
+    this._initIndicator();
+    this._initKeyboard();
+    this._initTouch();
+    this._initWheel();
+    this._initIntersectionObserver();
+    this._updateIndicator();
+  }
+
+  go(index) {
+    if (this.navigating) return;
+    if (index < 0 || index >= this.total) return;
+    this.navigating = true;
+    this.current = index;
+    this.deck.scrollTo({ left: index * this.deck.offsetWidth, behavior: 'smooth' });
+    this._updateIndicator();
+    setTimeout(() => { this.navigating = false; }, 500);
+  }
+
+  next() { this.go(this.current + 1); }
+  prev() { this.go(this.current - 1); }
+
+  _initKeyboard() {
+    document.addEventListener('keydown', e => {
+      if (e.key === 'ArrowRight' || e.key === 'Space') { e.preventDefault(); this.next(); }
+      if (e.key === 'ArrowLeft'  || e.key === 'Backspace') { e.preventDefault(); this.prev(); }
+      if (e.key === 'Home') { e.preventDefault(); this.go(0); }
+      if (e.key === 'End')  { e.preventDefault(); this.go(this.total - 1); }
+    });
+  }
+
+  _initTouch() {
+    this.deck.addEventListener('touchstart', e => {
+      this.touchStartX = e.changedTouches[0].screenX;
+      this.touchStartY = e.changedTouches[0].screenY;
+    }, { passive: true });
+
+    this.deck.addEventListener('touchend', e => {
+      const dx = e.changedTouches[0].screenX - this.touchStartX;
+      const dy = e.changedTouches[0].screenY - this.touchStartY;
+      if (Math.abs(dx) < 50 || Math.abs(dy) > Math.abs(dx)) return;
+      dx < 0 ? this.next() : this.prev();
+    }, { passive: true });
+  }
+
+  _initWheel() {
+    this.deck.addEventListener('wheel', e => {
+      e.preventDefault();
+      clearTimeout(this.wheelTimer);
+      this.wheelTimer = setTimeout(() => {
+        e.deltaY > 0 ? this.next() : this.prev();
+      }, 150); // 150ms debounce prevents multi-slide jumps on trackpad
+    }, { passive: false });
+  }
+
+  _initIntersectionObserver() {
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) entry.target.classList.add('visible');
+      });
+    }, { threshold: 0.5 });
+    this.slides.forEach(s => observer.observe(s));
+  }
+
+  _initIndicator() {
+    this.indicator = document.createElement('div');
+    this.indicator.className = 'slide-indicator';
+    document.body.appendChild(this.indicator);
+  }
+
+  _updateIndicator() {
+    this.indicator.textContent = `${this.current + 1} / ${this.total}`;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  new SlideController(document.querySelector('.deck'));
+});
+```
+
+---
+
+## Anti-Pattern Catalog
+
+### Anti-Pattern 1: Missing `navigating` flag
+
+**Detection**:
+```bash
+grep -c 'navigating' output.html
+# Count 0 means the guard is absent — deck will skip slides on rapid key presses
+rg 'scrollTo' output.html
+```
+
+**Wrong**:
+```javascript
+go(index) {
+  this.current = index;
+  this.deck.scrollTo({ left: index * this.deck.offsetWidth, behavior: 'smooth' });
+}
+```
+
+**Why wrong**: Rapid key presses or trackpad flicks queue multiple `go()` calls before the
+first scroll animation completes, causing the deck to skip 2-3 slides.
+
+**Fix**: `if (this.navigating) return;` as first line in `go()`. Set `navigating = false`
+in a `setTimeout` matching the slide transition duration (typically 400-600ms).
+
+---
+
+### Anti-Pattern 2: Wheel without debounce
+
+**Detection**:
+```bash
+rg 'addEventListener.*wheel' output.html
+rg 'clearTimeout|debounce' output.html
+# If first matches but second does not, debounce is missing
+```
+
+**Wrong**:
+```javascript
+deck.addEventListener('wheel', e => {
+  e.deltaY > 0 ? this.next() : this.prev();
+});
+```
+
+**Why wrong**: A single trackpad gesture fires 30-80 `wheel` events. Without debounce, the
+deck advances to the last slide in under a second.
+
+**Fix**: Use `clearTimeout(this.wheelTimer)` + `setTimeout(() => { ... }, 150)` pattern from
+the canonical implementation above. The 150ms window collapses burst events into one action.
+
+---
+
+### Anti-Pattern 3: `display:none` on slides
+
+**Detection**:
+```bash
+grep -n 'display.*none' output.html
+rg 'display:\s*none' output.html
+```
+
+**Wrong**:
+```css
+.slide { display: none; }
+.slide.active { display: flex; }
+```
+
+**Why wrong**: `display: none` removes the element from layout, so `IntersectionObserver`
+callbacks never fire. Reveal animations (`opacity: 0 → 1`) silently break for all hidden slides.
+
+**Fix**: The canonical `SlideController` uses `scrollTo` — all slides stay in DOM flow and are
+always "display: flex". No manual show/hide is needed. If you must hide off-screen slides,
+use `opacity: 0; pointer-events: none; position: absolute` instead.
+
+---
+
+### Anti-Pattern 4: Touch swipe fires on vertical scroll
+
+**Detection**:
+```bash
+grep -n 'touchend\|screenY' output.html
+# If 'touchend' matches but 'screenY' does not, vertical axis is not checked
+```
+
+**Wrong**:
+```javascript
+deck.addEventListener('touchend', e => {
+  const dx = e.changedTouches[0].screenX - this.touchStartX;
+  if (Math.abs(dx) > 50) dx < 0 ? this.next() : this.prev();
+});
+```
+
+**Why wrong**: A vertical scroll with slight horizontal drift triggers slide advance. Users
+trying to scroll content on a mobile slide accidentally navigate.
+
+**Fix**: Record `screenY` on `touchstart`. On `touchend`, reject if `Math.abs(dy) > Math.abs(dx)`
+(gesture is more vertical than horizontal). See canonical implementation.
+
+---
+
+### Anti-Pattern 5: `Space` key not prevented from scrolling page
+
+**Detection**:
+```bash
+grep -n 'Space' output.html
+# If 'Space' matches but 'preventDefault' is not on the same or adjacent line, page scrolls
+```
+
+**Wrong**:
+```javascript
+if (e.key === 'Space') this.next();
+```
+
+**Why wrong**: `Space` is the browser's default page-down key. Without `e.preventDefault()`,
+both slide advance and page scroll fire simultaneously, causing a jarring visible jump.
+
+**Fix**: `if (e.key === 'Space') { e.preventDefault(); this.next(); }`
+
+---
+
+## Indicator CSS
+
+The slide counter must be visible over any preset background:
+
+```css
+.slide-indicator {
+  position: fixed;
+  bottom: clamp(0.75rem, 2vw, 1.5rem);
+  right: clamp(0.75rem, 2vw, 1.5rem);
+  background: rgba(0, 0, 0, 0.45);
+  color: #ffffff;
+  padding: 0.25em 0.6em;
+  border-radius: 0.25em;
+  font-size: clamp(0.7rem, 1.2vw, 0.9rem);
+  font-family: var(--body-font, system-ui, sans-serif);
+  z-index: 100;
+  pointer-events: none;
+  backdrop-filter: blur(4px);
+}
+```
+
+The `rgba(0,0,0,0.45)` + `backdrop-filter` approach works on both light presets (arctic-minimal,
+glacier-blue) and dark presets (void-neon, obsidian-gold) without needing per-preset overrides.
+
+---
+
+## Optional Feature Snippets
+
+Add only when the user explicitly requests (see Phase 4 optional features list).
+
+### Speaker notes panel (`n` key)
+
+```javascript
+// Inside _initKeyboard() event listener:
+if (e.key === 'n') {
+  const panel = document.getElementById('notes-panel');
+  if (!panel) return;
+  const hidden = panel.getAttribute('aria-hidden') === 'true';
+  panel.setAttribute('aria-hidden', String(!hidden));
+  panel.style.visibility = hidden ? 'visible' : 'hidden';
+  panel.style.transform = hidden ? 'translateY(0)' : 'translateY(100%)';
+}
+```
+
+```css
+#notes-panel {
+  position: fixed;
+  bottom: 0; left: 0; right: 0;
+  height: 25vh;
+  background: rgba(0, 0, 0, 0.85);
+  color: #e0e0e0;
+  font-size: clamp(0.8rem, 1.5vw, 1rem);
+  overflow-y: auto;
+  padding: 1rem;
+  z-index: 200;
+  transition: transform 0.2s ease;
+  visibility: hidden;
+  transform: translateY(100%);
+}
+```
+
+### Countdown timer
+
+```javascript
+class CountdownTimer {
+  constructor(totalSeconds) {
+    this.remaining = totalSeconds;
+    this.el = document.createElement('div');
+    this.el.className = 'countdown-timer';
+    document.body.appendChild(this.el);
+    this._render();
+    this.interval = setInterval(() => {
+      this.remaining = Math.max(0, this.remaining - 1);
+      this._render();
+      if (this.remaining === 0) clearInterval(this.interval);
+    }, 1000);
+  }
+  _render() {
+    const m = Math.floor(this.remaining / 60).toString().padStart(2, '0');
+    const s = (this.remaining % 60).toString().padStart(2, '0');
+    this.el.textContent = `${m}:${s}`;
+    this.el.classList.toggle('urgent', this.remaining < 120);
+  }
+}
+```
+
+---
+
+## Error-Fix Mapping
+
+| Symptom | Root Cause | Detection Command | Fix |
+|---------|-----------|-------------------|-----|
+| Deck skips 2-3 slides on arrow key | Missing `navigating` guard | `grep -c 'navigating' output.html` → 0 | Add `navigating` flag to `go()` |
+| Trackpad flick jumps to last slide | `wheel` not debounced | `rg 'clearTimeout' output.html` → no match | Add `clearTimeout` + 150ms debounce |
+| Reveal animations never fire | Slides hidden with `display:none` | `grep 'display.*none' output.html` | Replace with `opacity:0; position:absolute` |
+| Swipe fires on vertical scroll | No Y-axis rejection | `grep 'screenY' output.html` → no match | Add `Math.abs(dy) > Math.abs(dx)` guard |
+| `Space` scrolls page AND advances slide | Missing `preventDefault` | `grep -A1 'Space' output.html` | Add `e.preventDefault()` before `this.next()` |
+| Indicator invisible on white preset | Hard-coded color | Visual check | Use `rgba(0,0,0,0.45)` + `backdrop-filter` |
+| `Home`/`End` scrolls page | No `preventDefault` | `grep -A1 'Home' output.html` | Add `e.preventDefault()` in keyboard handler |

--- a/skills/frontend-slides/references/slide-layout-patterns.md
+++ b/skills/frontend-slides/references/slide-layout-patterns.md
@@ -252,6 +252,7 @@ function example() {
 
 ---
 
+<!-- no-pair-required: section heading — each Anti-Pattern block below has its own Do-instead -->
 ## Overflow Anti-Pattern Catalog
 
 ### Anti-Pattern 1: Fixed inner height
@@ -272,6 +273,16 @@ rg 'height:\s*\d+px' output.html | grep -v 'max-height'
 on an iPhone landscape (414px tall) leaves barely 100px for heading + caption.
 
 **Fix**: `max-height: min(Xvh, Ypx)` with `overflow: hidden`. For images: `max-height: min(50vh, 400px)`.
+
+**Do instead**
+
+```css
+/* Images: viewport-relative cap prevents overflow at any screen height */
+.slide img { max-height: min(50vh, 400px); object-fit: contain; }
+
+/* Code blocks: cap at 55vh so heading and padding always fit */
+.slide-code pre { max-height: min(55vh, 500px); overflow: hidden; }
+```
 
 ---
 
@@ -294,6 +305,16 @@ small breakpoints.
 
 **Fix**: Use `height: 100vh; height: 100dvh` (exact, not minimum). Split content across
 multiple slides if it overflows.
+
+**Do instead**
+
+```css
+.slide {
+  height: 100vh;
+  height: 100dvh;   /* exact viewport height — slide cannot grow beyond one screen */
+  overflow: hidden;
+}
+```
 
 ---
 
@@ -320,9 +341,23 @@ At small viewports, nested indentation causes overflow. Presentation slides are 
 **Fix**: Flatten to a single level. Convert nested items to separate bullet points or a separate
 slide. Each bullet is max 10 words.
 
+**Do instead**
+
+```html
+<!-- Flat single-level list — each point is self-contained, max 10 words -->
+<ul>
+  <li>First concept — brief and specific</li>
+  <li>Second concept — brief and specific</li>
+  <li>Third concept — brief and specific</li>
+  <!-- If a sub-point is needed, make it a separate slide -->
+</ul>
+```
+
 ---
 
 ### Anti-Pattern 4: Long `<pre>` block without overflow guard
+
+Do instead: add `max-height: min(55vh, 500px); overflow: hidden` to `.slide-code pre`.
 
 **Detection**:
 ```bash
@@ -342,6 +377,17 @@ breakpoints.
 
 **Fix**: `max-height: min(55vh, 500px); overflow: hidden`. If the code block overflows even with
 the cap, split it across two slides with a continuation heading.
+
+**Do instead**
+
+```css
+.slide-code pre {
+  max-height: min(55vh, 500px);
+  overflow: hidden;   /* content is clipped, not scrolled — split slides if needed */
+  width: 100%;
+  border-radius: 0.5rem;
+}
+```
 
 ---
 
@@ -364,6 +410,17 @@ a now-white background, making text invisible.
 
 **Fix**: Use only CSS custom properties defined by the preset: `color: var(--text-primary)`.
 Never reference a hex value outside of `:root { }`.
+
+**Do instead**
+
+```css
+/* All color references use preset CSS variables — swap the preset, colors update automatically */
+.slide-title h1    { color: var(--text-primary); }
+.slide-title .subtitle { color: var(--text-secondary); }
+.slide-content li  { color: var(--text-primary); }
+.slide-content li::before { color: var(--accent); }
+/* Hex values live only in :root {} inside the chosen preset stylesheet */
+```
 
 ---
 

--- a/skills/frontend-slides/references/slide-layout-patterns.md
+++ b/skills/frontend-slides/references/slide-layout-patterns.md
@@ -1,0 +1,400 @@
+# Slide Layout Patterns — Frontend Slides Reference
+
+> **Load this file during Phase 4 (BUILD) when building slide HTML structure.**
+> The STYLE_PRESETS.md file covers CSS variables and animations; this file covers HTML patterns.
+
+---
+
+## HTML Templates by Slide Type
+
+Use these templates as starting points. All CSS variables (`--bg`, `--accent`, etc.) are
+supplied by the chosen preset. Never hard-code colors inside slide HTML.
+
+### Title Slide
+
+```html
+<section class="slide slide-title">
+  <h1>Presentation Heading</h1>
+  <p class="subtitle">Subtitle — max 12 words</p>
+</section>
+```
+
+```css
+.slide-title h1 {
+  font-family: var(--heading-font);
+  font-size: var(--heading-size);
+  letter-spacing: var(--letter-spacing-heading, 0);
+  color: var(--text-primary);
+  text-align: center;
+  max-width: 80%;
+}
+.slide-title .subtitle {
+  font-family: var(--body-font);
+  font-size: clamp(1rem, 2vw, 1.5rem);
+  color: var(--text-secondary);
+  margin-top: 1rem;
+  text-align: center;
+}
+```
+
+---
+
+### Content Slide (4-6 bullets)
+
+```html
+<section class="slide slide-content">
+  <h2>Section Heading</h2>
+  <ul>
+    <li>First point — max 10 words</li>
+    <li>Second point — max 10 words</li>
+    <li>Third point — max 10 words</li>
+    <li>Fourth point — max 10 words</li>
+  </ul>
+</section>
+```
+
+```css
+.slide-content {
+  align-items: flex-start;
+}
+.slide-content h2 {
+  font-family: var(--heading-font);
+  font-size: clamp(1.4rem, 3vw, 2.5rem);
+  color: var(--accent);
+  margin-bottom: clamp(1rem, 3vh, 2rem);
+  width: 100%;
+}
+.slide-content ul {
+  list-style: none;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.5rem, 1.5vh, 1rem);
+}
+.slide-content li {
+  font-family: var(--body-font);
+  font-size: var(--body-size);
+  color: var(--text-primary);
+  padding-left: 1.2em;
+  position: relative;
+}
+.slide-content li::before {
+  content: '▸';
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+}
+```
+
+---
+
+### Feature Grid (max 6 cards)
+
+```html
+<section class="slide slide-grid">
+  <h2>Features</h2>
+  <div class="grid">
+    <div class="card">
+      <span class="icon">⚡</span>
+      <strong>Label</strong>
+      <span>One-line descriptor</span>
+    </div>
+    <!-- repeat up to 6 -->
+  </div>
+</section>
+```
+
+```css
+.slide-grid .grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(180px, 40%), 1fr));
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+  width: 100%;
+}
+.slide-grid .card {
+  background: var(--surface);
+  border-radius: 0.5rem;
+  padding: clamp(0.75rem, 2vw, 1.25rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.slide-grid .icon {
+  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  line-height: 1;
+}
+.slide-grid strong {
+  font-family: var(--heading-font);
+  font-size: clamp(0.9rem, 1.6vw, 1.1rem);
+  color: var(--text-primary);
+}
+.slide-grid span:last-child {
+  font-family: var(--body-font);
+  font-size: clamp(0.75rem, 1.3vw, 0.95rem);
+  color: var(--text-secondary);
+}
+```
+
+---
+
+### Code Slide (8-10 lines)
+
+```html
+<section class="slide slide-code">
+  <h2>Code Heading</h2>
+  <pre><code class="language-javascript">// 8-10 lines max
+function example() {
+  return true;
+}</code></pre>
+</section>
+```
+
+```css
+.slide-code pre {
+  background: var(--surface);
+  border-radius: 0.5rem;
+  padding: clamp(1rem, 2.5vw, 2rem);
+  width: 100%;
+  overflow: hidden;          /* never scroll — split slide if needed */
+  max-height: min(55vh, 500px);
+}
+.slide-code code {
+  font-family: var(--code-font, 'JetBrains Mono', 'Courier New', monospace);
+  font-size: clamp(0.75rem, 1.5vw, 1rem);
+  line-height: 1.6;
+  color: var(--text-primary);
+  white-space: pre;
+}
+```
+
+---
+
+### Quote Slide
+
+```html
+<section class="slide slide-quote">
+  <blockquote>
+    <p>Quote text — max 30 words.</p>
+    <footer>— Name, Title</footer>
+  </blockquote>
+</section>
+```
+
+```css
+.slide-quote blockquote {
+  max-width: 70%;
+  text-align: center;
+}
+.slide-quote p {
+  font-family: var(--heading-font);
+  font-size: clamp(1.2rem, 2.5vw, 2rem);
+  color: var(--text-primary);
+  font-style: italic;
+  line-height: 1.5;
+}
+.slide-quote footer {
+  font-family: var(--body-font);
+  font-size: clamp(0.85rem, 1.5vw, 1.1rem);
+  color: var(--accent);
+  margin-top: 1.5rem;
+}
+```
+
+---
+
+### Image Slide
+
+```html
+<section class="slide slide-image">
+  <img src="path/to/image.jpg" alt="Descriptive alt text" loading="lazy">
+  <p class="caption">Caption — max 10 words</p>
+</section>
+```
+
+```css
+.slide-image img {
+  max-width: 100%;
+  max-height: min(50vh, 400px);   /* constrained — never fixed height in px alone */
+  object-fit: contain;
+  border-radius: 0.5rem;
+}
+.slide-image .caption {
+  font-family: var(--body-font);
+  font-size: clamp(0.75rem, 1.3vw, 0.95rem);
+  color: var(--text-secondary);
+  margin-top: 1rem;
+  text-align: center;
+}
+```
+
+---
+
+### Section Break Slide
+
+```html
+<section class="slide slide-break">
+  <h2>Section Name</h2>
+</section>
+```
+
+```css
+.slide-break {
+  background: var(--accent);
+}
+.slide-break h2 {
+  font-family: var(--heading-font);
+  font-size: clamp(2rem, 6vw, 5rem);
+  color: var(--bg);             /* inverted — accent bg, bg-colored text */
+  letter-spacing: var(--letter-spacing-heading, 0);
+  text-align: center;
+}
+```
+
+---
+
+## Overflow Anti-Pattern Catalog
+
+### Anti-Pattern 1: Fixed inner height
+
+**Detection**:
+```bash
+grep -n 'height: [0-9]*px' output.html | grep -v 'max-height\|min-height'
+rg 'height:\s*\d+px' output.html | grep -v 'max-height'
+```
+
+**Wrong**:
+```css
+.slide img { height: 300px; }
+.slide pre  { height: 400px; }
+```
+
+**Why wrong**: Fixed pixel heights overflow at viewport heights below their value. A 300px image
+on an iPhone landscape (414px tall) leaves barely 100px for heading + caption.
+
+**Fix**: `max-height: min(Xvh, Ypx)` with `overflow: hidden`. For images: `max-height: min(50vh, 400px)`.
+
+---
+
+### Anti-Pattern 2: `min-height` on `.slide`
+
+**Detection**:
+```bash
+grep -n 'min-height' output.html | grep 'slide'
+rg 'min-height.*slide|\.slide.*min-height' output.html
+```
+
+**Wrong**:
+```css
+.slide { min-height: 100vh; }
+```
+
+**Why wrong**: `min-height` allows the slide to grow taller than the viewport if content is
+long, breaking the single-screen constraint. The validation script will report overflow at
+small breakpoints.
+
+**Fix**: Use `height: 100vh; height: 100dvh` (exact, not minimum). Split content across
+multiple slides if it overflows.
+
+---
+
+### Anti-Pattern 3: Nested bullets
+
+**Detection**:
+```bash
+grep -n '<ul>.*<ul>\|<li>.*<ul>' output.html
+rg '<ul>[^<]*<li>[^<]*<ul>' output.html
+```
+
+**Wrong**:
+```html
+<ul>
+  <li>Top level
+    <ul><li>Nested bullet</li></ul>
+  </li>
+</ul>
+```
+
+**Why wrong**: Nested lists double the line count and violate the density limit (max 6 bullets).
+At small viewports, nested indentation causes overflow. Presentation slides are not documents.
+
+**Fix**: Flatten to a single level. Convert nested items to separate bullet points or a separate
+slide. Each bullet is max 10 words.
+
+---
+
+### Anti-Pattern 4: Long `<pre>` block without overflow guard
+
+**Detection**:
+```bash
+grep -c '<pre>' output.html
+# If count > 0, verify overflow: hidden is present
+grep -A5 '<pre>' output.html | grep 'overflow'
+```
+
+**Wrong**:
+```css
+.slide-code pre { max-width: 100%; }  /* no height or overflow constraint */
+```
+
+**Why wrong**: A 15-line code block at `font-size: 1rem` is ~300px tall. On a 720px projector,
+that leaves 420px for the slide heading, padding, and navigation chrome — it overflows at small
+breakpoints.
+
+**Fix**: `max-height: min(55vh, 500px); overflow: hidden`. If the code block overflows even with
+the cap, split it across two slides with a continuation heading.
+
+---
+
+### Anti-Pattern 5: Hard-coded colors in slide HTML
+
+**Detection**:
+```bash
+grep -n 'color: #\|background: #\|background-color: #' output.html | grep -v ':root\|var(--'
+rg 'color:\s*#[0-9a-fA-F]' output.html | grep -v ':root'
+```
+
+**Wrong**:
+```css
+.slide-title h1 { color: #F5F0E8; }  /* hard-coded — breaks when preset changes */
+```
+
+**Why wrong**: Hard-coded colors survive preset swaps intact, causing mismatched palettes.
+If the user changes from `obsidian-gold` to `arctic-minimal`, the heading stays near-white on
+a now-white background, making text invisible.
+
+**Fix**: Use only CSS custom properties defined by the preset: `color: var(--text-primary)`.
+Never reference a hex value outside of `:root { }`.
+
+---
+
+## Density Quick-Check
+
+Before Gate 4, run this check for each slide:
+
+```bash
+# Count bullets on each slide
+grep -c '<li>' output.html
+# Flag any slide section with more than 6
+python3 -c "
+import re, sys
+html = open('output.html').read()
+slides = re.findall(r'<section[^>]*class=\"slide[^\"]*\"[^>]*>(.*?)</section>', html, re.DOTALL)
+for i, s in enumerate(slides, 1):
+    n = len(re.findall(r'<li>', s))
+    if n > 6:
+        print(f'Slide {i}: {n} bullets (exceeds limit of 6)')
+"
+```
+
+---
+
+## Error-Fix Mapping
+
+| Symptom | Root Cause | Detection Command | Fix |
+|---------|-----------|-------------------|-----|
+| Overflow at 375×667 only | Fixed px height on inner element | `rg 'height:\s*\d+px' output.html` | Replace with `max-height: min(Xvh, Ypx)` |
+| Slide taller than viewport | `min-height` instead of `height` | `grep 'min-height.*slide' output.html` | Use exact `height: 100vh; height: 100dvh` |
+| Text invisible after preset change | Hard-coded hex colors in slide CSS | `rg 'color:\s*#' output.html` | Replace with `var(--text-primary)` etc. |
+| Code block pushes heading off-screen | `<pre>` lacks height cap | `grep -A5 '<pre>' output.html \| grep overflow` | Add `max-height: min(55vh, 500px); overflow: hidden` |
+| Slide has 8 bullets | Content not split | `grep -c '<li>' output.html` | Split into two slides at bullet 5-6 |
+| Nested bullets in DOM | Source content had sub-bullets | `grep '<li>.*<ul>' output.html` | Flatten to single level; new slide for overflow |


### PR DESCRIPTION
## Summary

Enriches `skills/frontend-slides` from Level 2 to Level 3 by adding two reference files with concrete code patterns, anti-pattern catalogs with grep/rg detection commands, and error-fix mappings.

## Targets processed

| Skill | Level Before | Level After | New Reference Files |
|-------|-------------|------------|---------------------|
| frontend-slides | 2 | 3 | 2 |

## New reference files

### `skills/frontend-slides/references/js-controller-patterns.md` (321 lines)

- Canonical `SlideController` class implementation (full, verbatim-ready)
- 5 anti-patterns with grep/rg detection commands:
  - Missing `navigating` guard (causes slide skipping on rapid key presses)
  - Wheel without debounce (trackpad jumps to last slide)
  - `display:none` on slides (breaks IntersectionObserver reveal animations)
  - Touch swipe without Y-axis rejection (fires on vertical scroll)
  - `Space` key without `preventDefault` (page scrolls simultaneously)
- Indicator CSS that works on both dark and light presets
- Optional feature snippets: speaker notes panel, countdown timer
- Error-fix mapping (7 rows)

### `skills/frontend-slides/references/slide-layout-patterns.md` (400 lines)

- HTML + CSS templates for all 7 slide types: title, content (4-6 bullets), feature grid, code, quote, image, section break
- 6 overflow anti-patterns with grep/rg detection commands:
  - Fixed pixel heights on inner elements
  - `min-height` instead of exact `height` on `.slide`
  - Nested bullets
  - Uncapped `<pre>` blocks
  - Hard-coded hex colors (breaks preset swaps)
- Density quick-check Python snippet
- Error-fix mapping (6 rows)

### `skills/frontend-slides/SKILL.md` — loading table updated

Replaced placeholder row with 3 signal-matched entries covering Phase 3 (style discovery) and Phase 4 (controller implementation + slide HTML structure).

## Validation gate (Phase 2.5)

- Test queries exercised: Q2 roadmap deck build, mobile swipe debugging, conference talk with code block
- Loading table signal detection: correct for both new files
- Keep-or-revert decision: **KEEP** — 14+17 grep detection commands, 321+400 lines of concrete HTML/CSS/JS patterns