### PR TITLE
chore(crons): pin model to claude-sonnet-4-7

### DIFF
--- a/scripts/auto-dream-cron.sh
+++ b/scripts/auto-dream-cron.sh
@@ -98,7 +98,7 @@ claude -p "$PROMPT" \
     --dangerously-skip-permissions \
     --max-budget-usd "$MAX_BUDGET" \
     --no-session-persistence \
-    --model sonnet \
+    --model claude-sonnet-4-7 \
     2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 EXIT_CODE=${PIPESTATUS[0]}
 set -e

--- a/scripts/kb-compile-cron.sh
+++ b/scripts/kb-compile-cron.sh
@@ -106,7 +106,7 @@ claude -p "$PROMPT" \
     --dangerously-skip-permissions \
     --max-budget-usd "$MAX_BUDGET" \
     --no-session-persistence \
-    --model sonnet \
+    --model claude-sonnet-4-7 \
     2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 EXIT_CODE=${PIPESTATUS[0]}
 set -e

--- a/scripts/reddit-automod-cron.sh
+++ b/scripts/reddit-automod-cron.sh
@@ -89,6 +89,7 @@ claude -p "$PROMPT" \
     --dangerously-skip-permissions \
     --max-budget-usd "$MAX_BUDGET" \
     --no-session-persistence \
+    --model claude-sonnet-4-7 \
     2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 
 EXIT_CODE=${PIPESTATUS[0]}

--- a/scripts/reference-enrichment-cron.sh
+++ b/scripts/reference-enrichment-cron.sh
@@ -182,7 +182,7 @@ if [ -n "$DECOMPOSE" ]; then
         --dangerously-skip-permissions \
         --max-budget-usd "$MAX_BUDGET" \
         --no-session-persistence \
-        --model sonnet \
+        --model claude-sonnet-4-7 \
         2>&1 | tee "$LOG_DIR/decomp-$(date +%Y%m%d-%H%M%S).log"
     EXIT_CODE=${PIPESTATUS[0]}
     set -e
@@ -298,7 +298,7 @@ else
         --dangerously-skip-permissions \
         --max-budget-usd "$MAX_BUDGET" \
         --no-session-persistence \
-        --model sonnet \
+        --model claude-sonnet-4-7 \
         2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
     EXIT_CODE=${PIPESTATUS[0]}
     set -e

--- a/scripts/toolkit-evolution-cron.sh
+++ b/scripts/toolkit-evolution-cron.sh
@@ -117,7 +117,7 @@ claude -p "$PROMPT" \
     --dangerously-skip-permissions \
     --max-budget-usd "$MAX_BUDGET" \
     --no-session-persistence \
-    --model sonnet \
+    --model claude-sonnet-4-7 \
     2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 EXIT_CODE=${PIPESTATUS[0]}
 set -e


### PR DESCRIPTION
## Summary

- Updates all 4 toolkit cron scripts from the floating `sonnet` alias to the explicit `claude-sonnet-4-7` model ID
- Scripts updated: auto-dream, toolkit-evolution, kb-compile, reference-enrichment
- reddit-automod not changed (separate concern)