### PR TITLE
fix(crons): correct model pin to claude-sonnet-4-6

### DIFF
--- a/scripts/auto-dream-cron.sh
+++ b/scripts/auto-dream-cron.sh
@@ -98,7 +98,7 @@ claude -p "$PROMPT" \
     --dangerously-skip-permissions \
     --max-budget-usd "$MAX_BUDGET" \
     --no-session-persistence \
-    --model claude-sonnet-4-7 \
+    --model claude-sonnet-4-6 \
     2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 EXIT_CODE=${PIPESTATUS[0]}
 set -e

--- a/scripts/kb-compile-cron.sh
+++ b/scripts/kb-compile-cron.sh
@@ -106,7 +106,7 @@ claude -p "$PROMPT" \
     --dangerously-skip-permissions \
     --max-budget-usd "$MAX_BUDGET" \
     --no-session-persistence \
-    --model claude-sonnet-4-7 \
+    --model claude-sonnet-4-6 \
     2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 EXIT_CODE=${PIPESTATUS[0]}
 set -e

--- a/scripts/reddit-automod-cron.sh
+++ b/scripts/reddit-automod-cron.sh
@@ -89,7 +89,7 @@ claude -p "$PROMPT" \
     --dangerously-skip-permissions \
     --max-budget-usd "$MAX_BUDGET" \
     --no-session-persistence \
-    --model claude-sonnet-4-7 \
+    --model claude-sonnet-4-6 \
     2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 
 EXIT_CODE=${PIPESTATUS[0]}

--- a/scripts/reference-enrichment-cron.sh
+++ b/scripts/reference-enrichment-cron.sh
@@ -182,7 +182,7 @@ if [ -n "$DECOMPOSE" ]; then
         --dangerously-skip-permissions \
         --max-budget-usd "$MAX_BUDGET" \
         --no-session-persistence \
-        --model claude-sonnet-4-7 \
+        --model claude-sonnet-4-6 \
         2>&1 | tee "$LOG_DIR/decomp-$(date +%Y%m%d-%H%M%S).log"
     EXIT_CODE=${PIPESTATUS[0]}
     set -e
@@ -298,7 +298,7 @@ else
         --dangerously-skip-permissions \
         --max-budget-usd "$MAX_BUDGET" \
         --no-session-persistence \
-        --model claude-sonnet-4-7 \
+        --model claude-sonnet-4-6 \
         2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
     EXIT_CODE=${PIPESTATUS[0]}
     set -e

--- a/scripts/toolkit-evolution-cron.sh
+++ b/scripts/toolkit-evolution-cron.sh
@@ -117,7 +117,7 @@ claude -p "$PROMPT" \
     --dangerously-skip-permissions \
     --max-budget-usd "$MAX_BUDGET" \
     --no-session-persistence \
-    --model claude-sonnet-4-7 \
+    --model claude-sonnet-4-6 \
     2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 EXIT_CODE=${PIPESTATUS[0]}
 set -e


### PR DESCRIPTION
Brain flub on the version number — pinned to `claude-sonnet-4-7` instead of `claude-sonnet-4-6` in the previous commit. This corrects it across all 5 cron scripts (6 total occurrences).