### PR TITLE
feat(adr-195): create ~/.toolkit/ namespace for domain skills and agents

### DIFF
--- a/agents/pipeline-orchestrator-engineer/references/orchestration-patterns.md
+++ b/agents/pipeline-orchestrator-engineer/references/orchestration-patterns.md
@@ -332,7 +332,7 @@ This agent uses the **Planning Schema**.
 
 ```
 SESSION RESTART REQUIRED
-New agent '{agent-name}' was created and synced to ~/.claude/agents/.
+New agent '{agent-name}' was created and synced to ~/.toolkit/agents/.
 Claude Code compiles available subagent types at session startup:
 agents added during a session are NOT available as subagent_type
 until the next session.

--- a/agents/project-coordinator-engineer/references/agent-capability-map.md
+++ b/agents/project-coordinator-engineer/references/agent-capability-map.md
@@ -37,7 +37,7 @@ The coordinator's primary routing decision is which agent to dispatch for a give
 
 **Detection** — verify agent exists before dispatching:
 ```
-ls ~/.claude/agents/ | grep {agent-name}
+ls ~/.toolkit/agents/ | grep {agent-name}
 ```
 
 ---

--- a/docs/for-claude-code.md
+++ b/docs/for-claude-code.md
@@ -113,7 +113,7 @@ Trivial = reading a file the user named by exact path. Everything else routes th
 
 | Hook | Event | Purpose |
 |------|-------|---------|
-| `sync-to-user-claude.py` | SessionStart | Sync repo to `~/.claude/` |
+| `sync-to-user-claude.py` | SessionStart | Sync repo to `~/.claude/` (hooks/scripts/do) and `~/.toolkit/` (domain skills/agents) |
 | `session-context.py` | SessionStart | Load learned patterns from learning.db |
 | `cross-repo-agents.py` | SessionStart | Discover `.claude/agents/` in other repos |
 | `fish-shell-detector.py` | SessionStart | Detect fish shell, inject bash workarounds |
@@ -150,14 +150,15 @@ Trivial = reading a file the user named by exact path. Everything else routes th
 
 ## Sync Lifecycle
 
-`hooks/sync-to-user-claude.py` fires on `SessionStart` when cwd is this repo. It copies the repo into `~/.claude/` so that Claude Code instances in *other* repos get access to agents, skills, hooks, and scripts.
+`hooks/sync-to-user-claude.py` fires on `SessionStart` when cwd is this repo. It copies hooks, scripts, commands, and the `/do` skill into `~/.claude/`, and copies domain skills and agents into `~/.toolkit/` (ADR-195). Claude Code instances in other repos get access to the full toolkit via both locations.
 
 **What gets synced:**
 
 | Source | Destination | Sync Mode |
 |--------|-------------|-----------|
-| `agents/` | `~/.claude/agents/` | File-by-file copy, stale files removed |
-| `skills/` | `~/.claude/skills/` | File-by-file copy, stale files removed |
+| `agents/` | `~/.toolkit/agents/` + symlinks in `~/.claude/agents/` | Full copy to toolkit; symlinks for `subagent_type` dispatch |
+| `skills/do/` | `~/.claude/skills/do/` | Orchestration entry point (harness-visible) |
+| `skills/{domain}/` | `~/.toolkit/skills/{domain}/` | Domain skills (router-managed, not harness-injected) |
 | `hooks/` | `~/.claude/hooks/` | File-by-file copy, stale files removed |
 | `scripts/` | `~/.claude/scripts/` | File-by-file copy, stale files removed |
 | `commands/` | `~/.claude/commands/` | Additive only (never removes) |

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -39,7 +39,7 @@ Task completes: TaskCompleted
 | `rules-distill-injector` | Injects pending rules-distillation candidates from `learning/rules-distill-pending.json` |
 | `sapcc-go-detector` | Detects SAP Converged Cloud Go projects and injects `go-patterns` skill |
 | `session-context` | Loads high-confidence learned patterns (>0.7) from the learning DB and auto-dream payload into context |
-| `sync-to-user-claude` | Syncs agents, skills, hooks, commands, and scripts from the repo to `~/.claude/` |
+| `sync-to-user-claude` | Syncs hooks, scripts, commands, and `/do` skill to `~/.claude/`; domain skills and agents to `~/.toolkit/` (ADR-195) |
 | `team-config-loader` | Discovers `team-config.yaml` from priority-ordered locations and injects team configuration into context |
 
 ---
@@ -203,7 +203,7 @@ The sections below cover the learning system internals, shared library API, and 
 
 | Hook | Event | Purpose |
 |------|-------|---------|
-| [`sync-to-user-claude.py`](#sync-hook) | SessionStart | Sync repo to ~/.claude (bootstrap) |
+| [`sync-to-user-claude.py`](#sync-hook) | SessionStart | Sync repo to ~/.claude (hooks/do) and ~/.toolkit (domain skills/agents) |
 | [`error-learner.py`](#error-learning-system) | PostToolUse | Learn from errors, suggest fixes |
 | [`instruction-reminder.py`](#instruction-reminder) | UserPromptSubmit | Stub — previously re-injected CLAUDE.md (now handled natively) |
 | [`skill-evaluator.py`](#skill-evaluation) | UserPromptSubmit | Inject skill/agent evaluation |
@@ -216,7 +216,7 @@ The sections below cover the learning system internals, shared library API, and 
 
 ## Sync Hook
 
-The `sync-to-user-claude.py` hook is responsible for bootstrapping the hooks system. It copies agents, skills, hooks, and commands from the repo to `~/.claude/` for global access.
+The `sync-to-user-claude.py` hook is responsible for bootstrapping the hooks system. It copies hooks, scripts, commands, and the `/do` skill to `~/.claude/` for global access. Domain skills and agents go to `~/.toolkit/` (ADR-195), with symlinks from `~/.claude/agents/` for `subagent_type` dispatch.
 
 ### Bootstrap Requirement
 
@@ -242,8 +242,9 @@ claude
 
 | Source | Destination | Description |
 |--------|-------------|-------------|
-| `agents/` | `~/.claude/agents/` | Agent definitions |
-| `skills/` | `~/.claude/skills/` | Skill methodologies |
+| `agents/` | `~/.toolkit/agents/` + symlinks in `~/.claude/agents/` | Full copy to toolkit; symlinks for `subagent_type` dispatch |
+| `skills/do/` | `~/.claude/skills/do/` | Orchestration entry point (harness-visible only) |
+| `skills/{domain}/` | `~/.toolkit/skills/{domain}/` | Domain skills (router-managed, not harness-injected) |
 | `hooks/` | `~/.claude/hooks/` | Hook scripts |
 | `.claude/settings.json` | `~/.claude/settings.json` | Hook registrations (merged) |
 

--- a/hooks/adr-enforcement.py
+++ b/hooks/adr-enforcement.py
@@ -46,8 +46,8 @@ _EXCLUDE_PATTERNS = [
 ]
 
 # Reference files used by adr-compliance.py
-__STEP_MENU = "~/.claude/skills/pipeline-scaffolder/references/step-menu.md"
-__SPEC_FORMAT = "~/.claude/skills/pipeline-scaffolder/references/pipeline-spec-format.md"
+__STEP_MENU = "~/.toolkit/skills/pipeline-scaffolder/references/step-menu.md"
+__SPEC_FORMAT = "~/.toolkit/skills/pipeline-scaffolder/references/pipeline-spec-format.md"
 
 
 def is_pipeline_component(file_path: str) -> bool:

--- a/hooks/precompact-archive.py
+++ b/hooks/precompact-archive.py
@@ -79,9 +79,9 @@ def inject_adr_anchor(event: dict) -> None:
         print("[precompact-adr]")
         print("[precompact-adr] COMPLIANCE CHECK FOR ANY COMPONENT FILE:")
         print("[precompact-adr]   python3 ~/.claude/scripts/adr-compliance.py check --file {file} \\")
-        print("[precompact-adr]     --step-menu ~/.claude/skills/pipeline-scaffolder/references/step-menu.md \\")
+        print("[precompact-adr]     --step-menu ~/.toolkit/skills/pipeline-scaffolder/references/step-menu.md \\")
         print(
-            "[precompact-adr]     --spec-format ~/.claude/skills/pipeline-scaffolder/references/pipeline-spec-format.md"
+            "[precompact-adr]     --spec-format ~/.toolkit/skills/pipeline-scaffolder/references/pipeline-spec-format.md"
         )
         print("[precompact-adr] ==========================================")
 

--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -242,6 +242,53 @@ def _backup_settings_json(settings_path: Path, keep: int = 3) -> None:
                 pass
 
 
+def _sync_dir(src: Path, dst: Path, src_relative_paths: set, use_merge: bool, errors: list) -> tuple[int, int]:
+    """Copy files from src to dst, returning (count, merge_count).
+
+    Skips unchanged files via content comparison. Merges retro markdown files
+    at the ### heading level when use_merge is True.
+    """
+    count = 0
+    merge_count = 0
+    for item in src.rglob("*"):
+        if item.is_file():
+            rel = item.relative_to(src)
+            src_relative_paths.add(rel)
+            target = dst / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if use_merge and item.suffix == ".md" and item.name != "L1.md":
+                merge_retro_file(item, target)
+                merge_count += 1
+            elif use_merge and item.name == "L1.md":
+                pass  # Skip L1 — regenerated below
+            elif target.exists() and filecmp.cmp(item, target, shallow=False):
+                pass  # Unchanged — skip copy
+            else:
+                shutil.copy2(item, target)
+            count += 1
+    return count, merge_count
+
+
+def _stale_cleanup(dst: Path, all_paths: set, errors: list, label: str) -> None:
+    """Remove files from dst that are no longer in all_paths, then prune empty dirs."""
+    if not dst.is_dir():
+        return
+    try:
+        for item in dst.rglob("*"):
+            if item.is_file():
+                rel = item.relative_to(dst)
+                if rel not in all_paths:
+                    try:
+                        item.unlink()
+                    except OSError:
+                        pass
+        for dirpath in sorted(dst.rglob("*"), reverse=True):
+            if dirpath.is_dir() and not any(dirpath.iterdir()):
+                dirpath.rmdir()
+    except Exception as e:
+        errors.append(f"stale-cleanup-{label}: {e}")
+
+
 def main():
     # Only run when in the agents repo
     cwd = Path.cwd()
@@ -254,11 +301,13 @@ def main():
     # Paths - use CWD as repo root (not script location, since script may be in ~/.claude/hooks/)
     repo_root = cwd
     user_claude = Path.home() / ".claude"
+    # ~/.toolkit/ is the router-managed namespace for domain skills and agents.
+    # Neither the Claude Code harness nor the Codex CLI auto-scan this path.
+    # Only /do and dispatched agents read from it (ADR-195).
+    user_toolkit = Path.home() / ".toolkit"
 
-    # Components to sync (directories)
+    # Non-skill/agent components sync to ~/.claude/ as before
     components = [
-        ("agents", "agents"),
-        ("skills", "skills"),
         ("hooks", "hooks"),
         ("commands", "commands"),  # Still needed for slash menu discovery
         ("retro", "retro"),  # Knowledge store for retro-knowledge-injector hook
@@ -279,10 +328,6 @@ def main():
     errors = []
 
     # Track all source-relative paths per destination for deferred stale cleanup.
-    # Multiple sources can map to the same destination (e.g., skills/ and pipelines/
-    # both sync to ~/.claude/skills/). Stale cleanup must see the UNION of all
-    # source paths before deleting, otherwise the second sync deletes files from
-    # the first sync.
     dst_all_paths: dict[str, set] = {}
 
     for src_name, dst_name in components:
@@ -299,29 +344,9 @@ def main():
 
             dst.mkdir(parents=True, exist_ok=True)
 
-            # Additive sync: copy individual files, never nuke the directory.
-            # This is safe even if interrupted — each file copy is independent.
-            # Files with identical content are skipped to reduce I/O.
-            count = 0
-            merge_count = 0
-            src_relative_paths = set()
+            src_relative_paths: set = set()
             use_merge = src_name in merge_components
-            for item in src.rglob("*"):
-                if item.is_file():
-                    rel = item.relative_to(src)
-                    src_relative_paths.add(rel)
-                    target = dst / rel
-                    target.parent.mkdir(parents=True, exist_ok=True)
-                    if use_merge and item.suffix == ".md" and item.name != "L1.md":
-                        merge_retro_file(item, target)
-                        merge_count += 1
-                    elif use_merge and item.name == "L1.md":
-                        pass  # Skip L1 — regenerated below
-                    elif target.exists() and filecmp.cmp(item, target, shallow=False):
-                        pass  # Unchanged — skip copy
-                    else:
-                        shutil.copy2(item, target)
-                    count += 1
+            count, merge_count = _sync_dir(src, dst, src_relative_paths, use_merge, errors)
 
             # Accumulate paths per destination for deferred stale cleanup
             if src_name not in additive_only:
@@ -338,28 +363,177 @@ def main():
         except Exception as e:
             errors.append(f"{dst_name}: {e}")
 
-    # Deferred stale cleanup: remove files from destinations that no longer
-    # exist in ANY source mapping to that destination. This must run AFTER
-    # all sources have been synced.
+    # Deferred stale cleanup for ~/.claude/ non-skill/agent components
     for dst_name, all_paths in dst_all_paths.items():
-        dst = user_claude / dst_name
-        if not dst.is_dir():
-            continue
+        _stale_cleanup(user_claude / dst_name, all_paths, errors, dst_name)
+
+    # -------------------------------------------------------------------------
+    # Skills: two-layer model (ADR-195)
+    #
+    # ~/.claude/skills/do/        — orchestration entry point (harness discovers)
+    # ~/.claude/skills/voice-*/   — private voices (harness discovers; loaded by /do)
+    # ~/.toolkit/skills/          — all other domain skills (router-managed)
+    #
+    # The harness auto-scans ~/.claude/skills/ for SKILL.md files. Domain skills
+    # must NOT live there — they would be injected into every session's context,
+    # costing ~4k tokens per turn. Only /do needs harness visibility.
+    # -------------------------------------------------------------------------
+    repo_skills = repo_root / "skills"
+    claude_skills = user_claude / "skills"
+    toolkit_skills = user_toolkit / "skills"
+    do_src = repo_skills / "do"  # defined here for use in both skills and Codex sections
+
+    if repo_skills.is_dir():
+        # 1. Sync /do to ~/.claude/skills/do/ (orchestration entry point)
+        do_dst = claude_skills / "do"
+        if do_src.is_dir():
+            try:
+                do_dst.mkdir(parents=True, exist_ok=True)
+                do_paths: set = set()
+                count, _ = _sync_dir(do_src, do_dst, do_paths, False, errors)
+                synced.append(f"skills/do({count})")
+                _stale_cleanup(do_dst, do_paths, errors, "skills/do")
+            except Exception as e:
+                errors.append(f"skills/do: {e}")
+
+        # 2. Sync all domain skills (everything except do/) to ~/.toolkit/skills/
+        #    This includes skills like go-patterns, publish, planning, etc.
         try:
-            for item in dst.rglob("*"):
-                if item.is_file():
-                    rel = item.relative_to(dst)
-                    if rel not in all_paths:
+            toolkit_skills.mkdir(parents=True, exist_ok=True)
+            toolkit_paths: set = set()
+            toolkit_count = 0
+            for skill_dir in sorted(repo_skills.iterdir()):
+                if not skill_dir.is_dir():
+                    continue
+                if skill_dir.name == "do":
+                    continue  # Already handled above
+                dst_skill = toolkit_skills / skill_dir.name
+                dst_skill.mkdir(parents=True, exist_ok=True)
+                skill_paths: set = set()
+                count, _ = _sync_dir(skill_dir, dst_skill, skill_paths, False, errors)
+                # Remap relative paths to be under the skill subdirectory
+                for p in skill_paths:
+                    toolkit_paths.add(Path(skill_dir.name) / p)
+                toolkit_count += count
+            synced.append(f"~/.toolkit/skills({toolkit_count})")
+            _stale_cleanup(toolkit_skills, toolkit_paths, errors, "toolkit/skills")
+        except Exception as e:
+            errors.append(f"toolkit/skills: {e}")
+
+        # 3. Remove stale domain skills from ~/.claude/skills/ (keep only do/ and voice-*)
+        #    These were copied there by previous sync runs before ADR-195.
+        try:
+            if claude_skills.is_dir():
+                for item in sorted(claude_skills.iterdir()):
+                    if not item.is_dir():
+                        continue
+                    if item.name == "do":
+                        continue  # Orchestration entry point — keep
+                    if item.name.startswith("voice-"):
+                        continue  # Private voices — keep (harness needs them for /do)
+                    # Domain skill that should now live in ~/.toolkit/skills/ — remove
+                    try:
+                        shutil.rmtree(item)
+                    except OSError:
+                        pass
+        except Exception as e:
+            errors.append(f"stale-cleanup-claude-skills: {e}")
+
+    # -------------------------------------------------------------------------
+    # Agents: symlink model (ADR-195)
+    #
+    # ~/.toolkit/agents/          — canonical location (router-managed)
+    # ~/.claude/agents/{name}.md  — symlinks to ~/.toolkit/agents/{name}.md
+    #
+    # The Claude Code subagent_type parameter discovers agents from ~/.claude/agents/.
+    # We keep symlinks there so dispatch works, but the real files are in ~/.toolkit/.
+    # This means agents are never injected into the orchestrator's session context.
+    # -------------------------------------------------------------------------
+    repo_agents = repo_root / "agents"
+    claude_agents = user_claude / "agents"
+    toolkit_agents = user_toolkit / "agents"
+
+    if repo_agents.is_dir():
+        try:
+            toolkit_agents.mkdir(parents=True, exist_ok=True)
+            toolkit_agent_paths: set = set()
+            count, _ = _sync_dir(repo_agents, toolkit_agents, toolkit_agent_paths, False, errors)
+            synced.append(f"~/.toolkit/agents({count})")
+            _stale_cleanup(toolkit_agents, toolkit_agent_paths, errors, "toolkit/agents")
+        except Exception as e:
+            errors.append(f"toolkit/agents: {e}")
+
+        # Private agents: sync to ~/.toolkit/agents/ alongside public agents
+        private_agents_dir = repo_root / "private-agents"
+        if private_agents_dir.is_dir():
+            try:
+                priv_paths: set = set()
+                count, _ = _sync_dir(private_agents_dir, toolkit_agents, priv_paths, False, errors)
+                if count:
+                    synced.append(f"~/.toolkit/agents/private({count})")
+            except Exception as e:
+                errors.append(f"toolkit/agents/private: {e}")
+
+        # Create symlinks in ~/.claude/agents/ pointing to ~/.toolkit/agents/
+        # for each top-level .md file. This enables subagent_type dispatch.
+        try:
+            claude_agents.mkdir(parents=True, exist_ok=True)
+            symlink_count = 0
+            agent_md_files: set[str] = set()
+
+            # Collect all .md agent files from ~/.toolkit/agents/
+            if toolkit_agents.is_dir():
+                for item in toolkit_agents.rglob("*.md"):
+                    # Only top-level .md files are agent definitions; subdirs are references
+                    if item.parent == toolkit_agents:
+                        agent_md_files.add(item.name)
+
+            # Create or update symlinks
+            for name in agent_md_files:
+                link = claude_agents / name
+                target = toolkit_agents / name
+                if link.is_symlink():
+                    if link.resolve() == target.resolve():
+                        continue  # Already correct
+                    link.unlink()
+                elif link.exists():
+                    # A real file exists — replace with symlink only if it's
+                    # identical to the toolkit version (was copied by old sync)
+                    if target.exists() and filecmp.cmp(link, target, shallow=False):
+                        link.unlink()
+                    else:
+                        continue  # User-owned file, don't replace
+                try:
+                    link.symlink_to(target)
+                    symlink_count += 1
+                except OSError:
+                    pass
+
+            # Remove stale symlinks in ~/.claude/agents/ that point to toolkit
+            # agents no longer in the source. Leave non-symlink files untouched.
+            for item in claude_agents.iterdir():
+                if item.is_symlink():
+                    # Only remove symlinks that point into ~/.toolkit/agents/
+                    try:
+                        resolved = item.resolve()
+                        if str(resolved).startswith(str(toolkit_agents)):
+                            if item.name not in agent_md_files:
+                                item.unlink()
+                    except OSError:
+                        pass
+                elif item.is_dir():
+                    # Agent reference subdirectories: remove if they mirror toolkit
+                    toolkit_counterpart = toolkit_agents / item.name
+                    if toolkit_counterpart.is_dir():
                         try:
-                            item.unlink()
+                            shutil.rmtree(item)
                         except OSError:
                             pass
-            # Clean up empty directories left behind
-            for dirpath in sorted(dst.rglob("*"), reverse=True):
-                if dirpath.is_dir() and not any(dirpath.iterdir()):
-                    dirpath.rmdir()
+
+            if symlink_count:
+                synced.append(f"~/.claude/agents(symlinks: {symlink_count})")
         except Exception as e:
-            errors.append(f"stale-cleanup-{dst_name}: {e}")
+            errors.append(f"agent-symlinks: {e}")
 
     # Sync settings.json — repo hooks replace global hooks
     repo_settings_path = repo_root / ".claude" / "settings.json"
@@ -474,6 +648,8 @@ def main():
     # Private voices are gitignored — they contain personal writing patterns.
     # Each voice dir may contain: samples/, profile.json, config.json, skill/SKILL.md
     # Only the skill/ subdirectory is synced to ~/.claude/skills/ for orchestrator access.
+    # Private voices stay in ~/.claude/skills/ (not ~/.toolkit/) because the harness
+    # must be able to discover them — /do loads them during voice routing.
     private_voices_dir = repo_root / "private-voices"
     if private_voices_dir.is_dir():
         voice_count = 0
@@ -488,111 +664,90 @@ def main():
             skill_dst = user_claude / "skills" / f"voice-{voice_name}"
             try:
                 skill_dst.mkdir(parents=True, exist_ok=True)
-                for item in skill_src.rglob("*"):
-                    if item.is_file():
-                        rel = item.relative_to(skill_src)
-                        target = skill_dst / rel
-                        target.parent.mkdir(parents=True, exist_ok=True)
-                        if target.exists() and filecmp.cmp(item, target, shallow=False):
-                            continue
-                        shutil.copy2(item, target)
+                voice_paths: set = set()
+                count, _ = _sync_dir(skill_src, skill_dst, voice_paths, False, errors)
                 voice_count += 1
             except Exception as e:
                 errors.append(f"voice-{voice_name}: {e}")
         if voice_count > 0:
             synced.append(f"private-voices({voice_count})")
 
-    # Sync skills and agents to ~/.codex/ for OpenAI Codex CLI.
-    # Codex natively supports skills; agents are mirrored as reference
-    # material so Codex sessions can Read the same domain expertise that
-    # Claude Code sessions dispatch via subagent_type.
+    # -------------------------------------------------------------------------
+    # Codex CLI sync (ADR-195 updated)
+    #
+    # Codex gets only /do (orchestration entry point) and private voices.
+    # Domain skills now live in ~/.toolkit/, which neither harness scans.
+    # Stale domain skills are removed from ~/.codex/skills/ (keep only do/ and voice-*).
+    # Codex agents mirror the same copy that went to ~/.toolkit/agents/.
+    # -------------------------------------------------------------------------
     codex_skills_dst = Path.home() / ".codex" / "skills"
-    codex_sources = [("skills", repo_root / "skills")]
-    codex_count = 0
-    for label, src in codex_sources:
-        if not src.is_dir():
-            continue
+
+    # Sync /do to ~/.codex/skills/do/
+    if do_src.is_dir():
+        codex_do_dst = codex_skills_dst / "do"
         try:
-            codex_skills_dst.mkdir(parents=True, exist_ok=True)
-            for item in src.rglob("*"):
-                if item.is_file():
-                    rel = item.relative_to(src)
-                    target = codex_skills_dst / rel
-                    target.parent.mkdir(parents=True, exist_ok=True)
-                    if target.exists() and filecmp.cmp(item, target, shallow=False):
-                        continue
-                    shutil.copy2(item, target)
-                    codex_count += 1
+            codex_do_dst.mkdir(parents=True, exist_ok=True)
+            codex_do_paths: set = set()
+            count, _ = _sync_dir(do_src, codex_do_dst, codex_do_paths, False, errors)
+            synced.append(f".codex/skills/do({count})")
+            _stale_cleanup(codex_do_dst, codex_do_paths, errors, "codex/skills/do")
         except Exception as e:
-            errors.append(f"codex-{label}: {e}")
-    # Also sync private voices to Codex
+            errors.append(f"codex-skills/do: {e}")
+
+    # Remove stale domain skills from ~/.codex/skills/ (keep only do/ and voice-*)
+    try:
+        if codex_skills_dst.is_dir():
+            for item in sorted(codex_skills_dst.iterdir()):
+                if not item.is_dir():
+                    continue
+                if item.name == "do":
+                    continue
+                if item.name.startswith("voice-"):
+                    continue
+                # Domain skill that no longer belongs in Codex harness path
+                try:
+                    shutil.rmtree(item)
+                except OSError:
+                    pass
+    except Exception as e:
+        errors.append(f"stale-cleanup-codex-skills: {e}")
+
+    # Also sync private voices to Codex (harness needs them for /do voice routing)
     if private_voices_dir.is_dir():
         for voice_dir in sorted(private_voices_dir.iterdir()):
             if not voice_dir.is_dir():
                 continue
-            skill_src = voice_dir / "skill"
-            if not skill_src.is_dir():
+            skill_src_v = voice_dir / "skill"
+            if not skill_src_v.is_dir():
                 continue
             voice_name = voice_dir.name
             codex_voice_dst = codex_skills_dst / f"voice-{voice_name}"
             try:
                 codex_voice_dst.mkdir(parents=True, exist_ok=True)
-                for item in skill_src.rglob("*"):
-                    if item.is_file():
-                        rel = item.relative_to(skill_src)
-                        target = codex_voice_dst / rel
-                        target.parent.mkdir(parents=True, exist_ok=True)
-                        if target.exists() and filecmp.cmp(item, target, shallow=False):
-                            continue
-                        shutil.copy2(item, target)
-                        codex_count += 1
+                cv_paths: set = set()
+                _sync_dir(skill_src_v, codex_voice_dst, cv_paths, False, errors)
             except Exception as e:
                 errors.append(f"codex-voice-{voice_name}: {e}")
-    # No stale cleanup for Codex — additive only. Users or Codex itself may
-    # create skills in ~/.codex/skills/ that we don't own. We only copy ours in;
-    # we never delete theirs.
-    if codex_count > 0:
-        synced.append(f".codex/skills({codex_count} updated)")
-    elif codex_skills_dst.is_dir():
-        total = sum(1 for _ in codex_skills_dst.rglob("*") if _.is_file())
-        synced.append(f".codex/skills({total} current)")
 
-    # Sync agents to ~/.codex/agents/ — parallel mirror to skills.
-    # Agents carry domain expertise (Go, Python, K8s, TypeScript, etc.)
-    # and their reference subdirectories. Codex can Read them even though
-    # it has no native subagent_type dispatch.
+    # Sync agents to ~/.codex/agents/ — Codex can Read domain expertise even
+    # though it has no native subagent_type dispatch. Mirror from ~/.toolkit/agents/.
     codex_agents_dst = Path.home() / ".codex" / "agents"
-    codex_agent_sources = [("agents", repo_root / "agents")]
-    private_agents_dir = repo_root / "private-agents"
-    if private_agents_dir.is_dir():
-        codex_agent_sources.append(("private-agents", private_agents_dir))
-    codex_agent_count = 0
-    for label, src in codex_agent_sources:
-        if not src.is_dir():
-            continue
+    if toolkit_agents.is_dir():
         try:
             codex_agents_dst.mkdir(parents=True, exist_ok=True)
-            for item in src.rglob("*"):
-                if item.is_file():
-                    rel = item.relative_to(src)
-                    target = codex_agents_dst / rel
-                    target.parent.mkdir(parents=True, exist_ok=True)
-                    if target.exists() and filecmp.cmp(item, target, shallow=False):
-                        continue
-                    shutil.copy2(item, target)
-                    codex_agent_count += 1
+            codex_agent_paths: set = set()
+            count, _ = _sync_dir(toolkit_agents, codex_agents_dst, codex_agent_paths, False, errors)
+            if count:
+                synced.append(f".codex/agents({count} updated)")
+            elif codex_agents_dst.is_dir():
+                total = sum(1 for _ in codex_agents_dst.rglob("*") if _.is_file())
+                synced.append(f".codex/agents({total} current)")
         except Exception as e:
-            errors.append(f"codex-{label}: {e}")
-    # No stale cleanup for Codex agents — additive only, same rationale as skills.
-    if codex_agent_count > 0:
-        synced.append(f".codex/agents({codex_agent_count} updated)")
-    elif codex_agents_dst.is_dir():
-        total = sum(1 for _ in codex_agents_dst.rglob("*") if _.is_file())
-        synced.append(f".codex/agents({total} current)")
+            errors.append(f"codex-agents: {e}")
 
     # Output for hook feedback
     if synced:
-        print(f"[sync] Updated ~/.claude: {', '.join(synced)}")
+        print(f"[sync] Updated ~/.claude + ~/.toolkit: {', '.join(synced)}")
     if errors:
         print(f"[sync] Errors: {', '.join(errors)}", file=sys.stderr)
 

--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -459,7 +459,6 @@ def main():
             toolkit_agent_paths: set = set()
             count, _ = _sync_dir(repo_agents, toolkit_agents, toolkit_agent_paths, False, errors)
             synced.append(f"~/.toolkit/agents({count})")
-            _stale_cleanup(toolkit_agents, toolkit_agent_paths, errors, "toolkit/agents")
         except Exception as e:
             errors.append(f"toolkit/agents: {e}")
 
@@ -471,8 +470,14 @@ def main():
                 count, _ = _sync_dir(private_agents_dir, toolkit_agents, priv_paths, False, errors)
                 if count:
                     synced.append(f"~/.toolkit/agents/private({count})")
+                toolkit_agent_paths.update(priv_paths)
             except Exception as e:
                 errors.append(f"toolkit/agents/private: {e}")
+
+        try:
+            _stale_cleanup(toolkit_agents, toolkit_agent_paths, errors, "toolkit/agents")
+        except Exception as e:
+            errors.append(f"toolkit/agents/stale: {e}")
 
         # Create symlinks in ~/.claude/agents/ pointing to ~/.toolkit/agents/
         # for each top-level .md file. This enables subagent_type dispatch.
@@ -521,6 +526,15 @@ def main():
                                 item.unlink()
                     except OSError:
                         pass
+                elif item.is_file():
+                    # Regular files (e.g. README.md, INDEX.json) copied by old sync
+                    # runs: remove if the toolkit has a canonical copy.
+                    toolkit_counterpart = toolkit_agents / item.name
+                    if toolkit_counterpart.exists():
+                        try:
+                            item.unlink()
+                        except OSError:
+                            pass
                 elif item.is_dir():
                     # Agent reference subdirectories: remove if they mirror toolkit
                     toolkit_counterpart = toolkit_agents / item.name
@@ -742,6 +756,7 @@ def main():
             elif codex_agents_dst.is_dir():
                 total = sum(1 for _ in codex_agents_dst.rglob("*") if _.is_file())
                 synced.append(f".codex/agents({total} current)")
+            _stale_cleanup(codex_agents_dst, codex_agent_paths, errors, "codex/agents")
         except Exception as e:
             errors.append(f"codex-agents: {e}")
 

--- a/scripts/tests/test_reviewer_ab.py
+++ b/scripts/tests/test_reviewer_ab.py
@@ -28,12 +28,12 @@ from pathlib import Path
 AGENT_A = "agents/reviewer-code.md"
 AGENT_B = "agents/reviewer-code-playbook.md"
 
-# Also check ~/.claude/agents/ as fallback
+# Also check ~/.toolkit/agents/ as fallback
 HOME_AGENTS = Path.home() / ".claude" / "agents"
 
 
 def resolve_agent_path(relative: str) -> Path:
-    """Resolve agent path, checking repo first then ~/.claude/agents/."""
+    """Resolve agent path, checking repo first then ~/.toolkit/agents/."""
     repo_root = Path(__file__).resolve().parent.parent.parent
     repo_path = repo_root / relative
     if repo_path.is_file():

--- a/skills/auto-dream/dream-prompt.md
+++ b/skills/auto-dream/dream-prompt.md
@@ -248,7 +248,7 @@ Steps:
 
 3. For each accepted candidate, determine where to insert it:
    - If topic starts with `skill:` → target is `${DREAM_REPO_DIR}/skills/{skill_name}/SKILL.md`
-   - If topic starts with `agent:` → target is the agent's markdown file (search `${DREAM_REPO_DIR}/agents/` for it, or check `~/.claude/agents/`)
+   - If topic starts with `agent:` → target is the agent's markdown file (search `${DREAM_REPO_DIR}/agents/` for it, or check `~/.toolkit/agents/`)
    - Read the target file. Find an appropriate insertion point:
      - If an "Anti-Patterns" or "Common Mistakes" section exists, add there
      - If an "Error Handling" section exists, add there

--- a/skills/codebase-analyzer/references/examples.md
+++ b/skills/codebase-analyzer/references/examples.md
@@ -9,7 +9,7 @@ You want to understand the error handling standards in a Go service before submi
 
 ### Command
 ```bash
-cd ~/.claude/skills/codebase-analyzer
+cd ~/.toolkit/skills/codebase-analyzer
 python3 ~/.claude/scripts/analyzer.py ~/repos/api-server --output analysis_data/api_server_analysis.json
 ```
 
@@ -69,7 +69,7 @@ CODEBASE ANALYSIS SUMMARY
 
 ```bash
 # Check if reviewers also mention error wrapping
-cd ~/.claude/skills/pr-workflow
+cd ~/.toolkit/skills/pr-workflow
 grep -i "while.*%w" mined_data/senior-reviewer_go_all_2025-11-20.json
 ```
 
@@ -86,7 +86,7 @@ You're new to the team and want to understand team-wide patterns across api-serv
 
 ### Commands
 ```bash
-cd ~/.claude/skills/codebase-analyzer
+cd ~/.toolkit/skills/codebase-analyzer
 
 # Analyze each repo
 python3 ~/.claude/scripts/analyzer.py ~/repos/api-server --output analysis_data/api-server.json
@@ -341,7 +341,7 @@ func (d *Database) Query(ctx context.Context) error {
 
 **Step 1**: Mine PR reviews (explicit rules)
 ```bash
-cd ~/.claude/skills/pr-workflow
+cd ~/.toolkit/skills/pr-workflow
 ./venv/bin/python3 scripts/miner.py your-org/your-repo \
   mined_data/project_reviews.json \
   --limit 100 --all-comments
@@ -349,7 +349,7 @@ cd ~/.claude/skills/pr-workflow
 
 **Step 2**: Analyze codebase (implicit rules)
 ```bash
-cd ~/.claude/skills/codebase-analyzer
+cd ~/.toolkit/skills/codebase-analyzer
 python3 ~/.claude/scripts/analyzer.py ~/repos/your-project \
   --output analysis_data/project_stats.json
 ```
@@ -407,7 +407,7 @@ New developer joins the team. Instead of vague "read the code", give them concre
 # Welcome to the team!
 # This script generates your coding standards cheat sheet.
 
-cd ~/.claude/skills/codebase-analyzer
+cd ~/.toolkit/skills/codebase-analyzer
 
 echo "Analyzing api-server..."
 python3 ~/.claude/scripts/analyzer.py ~/repos/api-server --output /tmp/api-server.json

--- a/skills/do/references/repo-architecture.md
+++ b/skills/do/references/repo-architecture.md
@@ -12,7 +12,7 @@ This repository contains agents, skills, and hooks for Claude Code.
 | **Hook** | `hooks/*.py` | Event-driven automation | Python script |
 | **Script** | `scripts/*.py`, `scripts/*.sh` | Deterministic operations | Python or shell script |
 
-> **Note**: Pipelines are skills with explicit numbered phases and gates. They live in `skills/workflow/references/` for organizational clarity but are synced to `~/.claude/skills/` at install time, so Claude Code discovers them as regular skills.
+> **Note**: Pipelines are skills with explicit numbered phases and gates. They live in `skills/workflow/references/` for organizational clarity but are synced to `~/.toolkit/skills/` at install time (ADR-195). The `/do` skill reads them from `~/.toolkit/` via the routing manifest; they are not harness-injected.
 
 ## Key Frontmatter Fields
 

--- a/skills/go-patterns/references/quality-gate.md
+++ b/skills/go-patterns/references/quality-gate.md
@@ -15,7 +15,7 @@ Never skip validation, even if you think you know what the error is -- assumptio
 
 Run the validation script to check prerequisites:
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --validate-only
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --validate-only
 ```
 
 The repository needs:
@@ -47,7 +47,7 @@ Always use `make check` through the script -- never bypass it by running golangc
 
 Execute the quality gate:
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py
 ```
 
 The script will:
@@ -58,7 +58,7 @@ The script will:
 
 For verbose progress output:
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --verbose
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --verbose
 ```
 
 ### Step 4: Interpret Results
@@ -153,17 +153,17 @@ Only use individual make targets for focused investigation after `make check` ha
 
 Custom coverage threshold enforcement:
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --min-coverage 80.0
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --min-coverage 80.0
 ```
 
 JSON output for automation pipelines:
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --format json
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --format json
 ```
 
 Combined options for thorough debugging:
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --min-coverage 80.0 --verbose
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --min-coverage 80.0 --verbose
 ```
 
 ### Cleanup

--- a/skills/go-patterns/references/quality-gate/examples.md
+++ b/skills/go-patterns/references/quality-gate/examples.md
@@ -10,7 +10,7 @@ All quality checks pass with good coverage.
 ### Command
 ```bash
 cd /path/to/go-project
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --verbose
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --verbose
 ```
 
 ### Expected Output (JSON)
@@ -49,7 +49,7 @@ Code has unchecked error returns.
 ### Command
 ```bash
 cd /path/to/go-project
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py
 ```
 
 ### Expected Output (JSON)
@@ -109,7 +109,7 @@ Imports are not properly formatted.
 
 ### Command
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py
 ```
 
 ### Expected Output (JSON)
@@ -141,7 +141,7 @@ python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py
 ```bash
 fish -c "make goimports"
 # Re-run checks
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py
 ```
 
 ---
@@ -153,7 +153,7 @@ Unit tests are failing.
 
 ### Command
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --verbose
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --verbose
 ```
 
 ### Expected Output (JSON)
@@ -201,7 +201,7 @@ Mix of linting errors, test failures, and license issues.
 
 ### Command
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --verbose
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --verbose
 ```
 
 ### Expected Output (JSON)
@@ -277,7 +277,7 @@ Check if coverage meets minimum threshold.
 
 ### Command
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --min-coverage 80.0
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --min-coverage 80.0
 ```
 
 ### Expected Output (coverage below threshold)
@@ -314,7 +314,7 @@ Human-readable text output instead of JSON.
 
 ### Command
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --format text
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --format text
 ```
 
 ### Expected Output (success)
@@ -357,7 +357,7 @@ Running in non-Go directory.
 ### Command
 ```bash
 cd /tmp
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py
 ```
 
 ### Expected Output (JSON to stderr)
@@ -383,7 +383,7 @@ python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py
 **Claude**: "I'll run the Go PR quality gate to check your code."
 
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --verbose
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --verbose
 ```
 
 **Output** (failure scenario):
@@ -451,27 +451,27 @@ h := sha256.New()
 ### Check Specific Repository
 ```bash
 cd /path/to/go-project
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py
 ```
 
 ### Verbose Mode for Debugging
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --verbose
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --verbose
 ```
 
 ### Validate Only (No Checks)
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --validate-only
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --validate-only
 ```
 
 ### Enforce Coverage Threshold
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py --min-coverage 85.0
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py --min-coverage 85.0
 ```
 
 ### Combine Options
 ```bash
-python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py \
+python3 ~/.toolkit/skills/go-patterns/scripts/quality_checker.py \
   --min-coverage 80.0 \
   --format text \
   --verbose
@@ -488,7 +488,7 @@ python3 ~/.claude/skills/go-patterns/scripts/quality_checker.py \
 **Solution**: Install via Homebrew: `fish -c "brew install golangci-lint"`
 
 ### Issue: Permission denied
-**Solution**: Ensure scripts are executable: `fish -c "chmod +x ~/.claude/skills/go-patterns/scripts/*.py"`
+**Solution**: Ensure scripts are executable: `fish -c "chmod +x ~/.toolkit/skills/go-patterns/scripts/*.py"`
 
 ### Issue: Coverage not detected
 **Solution**: Verify `make check` includes test coverage, check for `build/cover.out` file

--- a/skills/pr-workflow/references/miner.md
+++ b/skills/pr-workflow/references/miner.md
@@ -267,7 +267,7 @@ This skill coordinates PR mining workflows to extract tribal knowledge and codin
 **Step 1: Check miner script exists**
 
 ```bash
-fish -c "ls ~/.claude/skills/pr-workflow/scripts/miner.py"
+fish -c "ls ~/.toolkit/skills/pr-workflow/scripts/miner.py"
 ```
 
 Expected: File exists at path.
@@ -304,7 +304,7 @@ Expected: PR results confirm username is valid and active.
 
 ```bash
 fish -c "set -x GITHUB_TOKEN (security find-internet-password -s github.com -w 2>/dev/null) && \
-  cd ~/.claude/skills/pr-workflow && \
+  cd ~/.toolkit/skills/pr-workflow && \
   ./venv/bin/python3 scripts/miner.py {repos} mined_data/{output}.json {flags} --summary" &
 ```
 
@@ -337,7 +337,7 @@ Run jobs sequentially. Wait for each to complete before starting next. Wait for 
 **Step 1: Check output file exists and has content**
 
 ```bash
-fish -c "cat ~/.claude/skills/pr-workflow/mined_data/{output}.json | head -50"
+fish -c "cat ~/.toolkit/skills/pr-workflow/mined_data/{output}.json | head -50"
 ```
 
 **Step 2: Validate structure**
@@ -425,7 +425,7 @@ Follow this structure for each pattern:
 **Step 4: Save rules**
 
 ```bash
-fish -c "cat > ~/.claude/skills/pr-workflow/rules/{repos}_coding_rules.md"
+fish -c "cat > ~/.toolkit/skills/pr-workflow/rules/{repos}_coding_rules.md"
 ```
 
 **Constraint - Cleanup Behavior**: After saving rules to disk, remove temporary coordination files (PIDs, debug logs, intermediate JSON). Keep ONLY the final mining result JSON (for future reference) and generated rules markdown (for user consumption).
@@ -444,7 +444,7 @@ Provide:
 - List of top 3-5 HIGH confidence patterns with occurrence counts
 - Summary of MEDIUM and LOW confidence pattern distribution
 
-**Constraint - Report Clarity**: Show actual numbers and paths, not generic summaries. Example good report: "Analyzed 150 PRs, extracted 42 interactions. HIGH confidence (12 patterns): Error handling (5), Testing (4), Naming (3). MEDIUM confidence: 18 patterns. LOW confidence: 12 patterns. Rules: ~/.claude/skills/pr-workflow/rules/myrepo_coding_rules.md"
+**Constraint - Report Clarity**: Show actual numbers and paths, not generic summaries. Example good report: "Analyzed 150 PRs, extracted 42 interactions. HIGH confidence (12 patterns): Error handling (5), Testing (4), Naming (3). MEDIUM confidence: 18 patterns. LOW confidence: 12 patterns. Rules: ~/.toolkit/skills/pr-workflow/rules/myrepo_coding_rules.md"
 
 **Constraint - Communication Style**: Report facts without self-congratulation. Show what happened and where the output is. Report facts directly: "Mined 42 interactions from 150 PRs" — keep the tone factual.
 

--- a/skills/pr-workflow/references/mining-commands.md
+++ b/skills/pr-workflow/references/mining-commands.md
@@ -5,7 +5,7 @@
 ### Mine Last 100 PRs from Single Repo
 ```bash
 fish -c "set -x GITHUB_TOKEN (security find-internet-password -s github.com -w 2>/dev/null) && \
-  cd ~/.claude/skills/pr-miner && \
+  cd ~/.toolkit/skills/pr-miner && \
   ./venv/bin/python3 scripts/miner.py \
     your-org/go-libs \
     mined_data/go_bits_all_2025-11-29.json \
@@ -15,7 +15,7 @@ fish -c "set -x GITHUB_TOKEN (security find-internet-password -s github.com -w 2
 ### Mine Specific Reviewer
 ```bash
 fish -c "set -x GITHUB_TOKEN (security find-internet-password -s github.com -w 2>/dev/null) && \
-  cd ~/.claude/skills/pr-miner && \
+  cd ~/.toolkit/skills/pr-miner && \
   ./venv/bin/python3 scripts/miner.py \
     your-org/go-libs \
     mined_data/senior-reviewer_go_bits_2025-11-29.json \
@@ -25,7 +25,7 @@ fish -c "set -x GITHUB_TOKEN (security find-internet-password -s github.com -w 2
 ### Mine Multiple Repos
 ```bash
 fish -c "set -x GITHUB_TOKEN (security find-internet-password -s github.com -w 2>/dev/null) && \
-  cd ~/.claude/skills/pr-miner && \
+  cd ~/.toolkit/skills/pr-miner && \
   ./venv/bin/python3 scripts/miner.py \
     your-org/go-libs,your-org/service-a,your-org/service-b \
     mined_data/go_repos_all_2025-11-29.json \
@@ -37,7 +37,7 @@ fish -c "set -x GITHUB_TOKEN (security find-internet-password -s github.com -w 2
 ### Date Range Mining
 ```bash
 fish -c "set -x GITHUB_TOKEN (security find-internet-password -s github.com -w 2>/dev/null) && \
-  cd ~/.claude/skills/pr-miner && \
+  cd ~/.toolkit/skills/pr-miner && \
   ./venv/bin/python3 scripts/miner.py \
     your-org/service-a \
     mined_data/api_server_2025_q4.json \
@@ -47,7 +47,7 @@ fish -c "set -x GITHUB_TOKEN (security find-internet-password -s github.com -w 2
 ### Comprehensive Team Analysis (All Reviewers, Multiple Repos)
 ```bash
 fish -c "set -x GITHUB_TOKEN (security find-internet-password -s github.com -w 2>/dev/null) && \
-  cd ~/.claude/skills/pr-miner && \
+  cd ~/.toolkit/skills/pr-miner && \
   ./venv/bin/python3 scripts/miner.py \
     your-org/go-libs,your-org/service-a,your-org/service-b,your-org/service-c \
     mined_data/go_team_2025-11-29.json \
@@ -57,7 +57,7 @@ fish -c "set -x GITHUB_TOKEN (security find-internet-password -s github.com -w 2
 ### Senior Reviewer Deep Dive (All Comments, Multiple Repos)
 ```bash
 fish -c "set -x GITHUB_TOKEN (security find-internet-password -s github.com -w 2>/dev/null) && \
-  cd ~/.claude/skills/pr-miner && \
+  cd ~/.toolkit/skills/pr-miner && \
   ./venv/bin/python3 scripts/miner.py \
     your-org/go-libs,your-org/service-a \
     mined_data/senior-reviewer_patterns_2025-11-29.json \
@@ -108,10 +108,10 @@ Use descriptive date names for periodic analysis:
 
 ## Directory Structure
 
-All mining operations use fixed paths under `~/.claude/skills/pr-miner/`:
+All mining operations use fixed paths under `~/.toolkit/skills/pr-miner/`:
 
 ```
-~/.claude/skills/pr-miner/
+~/.toolkit/skills/pr-miner/
   scripts/miner.py          # Mining tool
   venv/                     # Python virtual environment
   mined_data/               # Mining output (JSON)

--- a/skills/reference-enrichment/SKILL.md
+++ b/skills/reference-enrichment/SKILL.md
@@ -237,7 +237,7 @@ Load when the task type matches:
 ## Error Handling
 
 **Gap analyzer fails**: The component may not exist in expected paths. Check both `agents/` and
-`skills/` directories, and `~/.claude/agents/` for deployed copies.
+`skills/` directories, and `~/.toolkit/agents/` for deployed copies.
 
 **Phase 2 gate fails** (fewer than 10 concrete findings): The domain may be too narrow or already
 well-documented upstream. Flag and suggest manual enrichment with project-specific production

--- a/skills/reference-enrichment/enrichment-prompt.md
+++ b/skills/reference-enrichment/enrichment-prompt.md
@@ -43,7 +43,7 @@ For each target name in the targets list:
 
 1. **Audit before:** Run `python3 scripts/audit-reference-depth.py --agent {name} --verbose` to record the starting level
 2. **Gap analysis:** Run `python3 skills/reference-enrichment/scripts/gap-analyzer.py --agent {name}` to identify specific knowledge gaps
-3. **Read exemplars:** Read one high-quality reference file as a model (e.g., `~/.claude/agents/golang-general-engineer/references/go-anti-patterns.md`). This shows what Level 3 depth looks like.
+3. **Read exemplars:** Read one high-quality reference file as a model (e.g., `~/.toolkit/agents/golang-general-engineer/references/go-anti-patterns.md`). This shows what Level 3 depth looks like.
 4. **Read the quality rubric:** Read `skills/reference-enrichment/references/quality-rubric.md` for Level classification criteria
 5. **Read the template:** Read `skills/reference-enrichment/references/reference-file-template.md` for the standard structure
 6. **Generate reference files:** For the top 2-3 gaps identified, create reference files that include:

--- a/skills/routing-table-updater/SKILL.md
+++ b/skills/routing-table-updater/SKILL.md
@@ -54,7 +54,7 @@ The skill reads metadata from all skills and agents (never modifies them) and sa
 **Step 1: Run scan script**
 
 ```bash
-python3 ~/.claude/skills/routing-table-updater/scripts/scan.py --repo $HOME/claude-code-toolkit
+python3 ~/.toolkit/skills/routing-table-updater/scripts/scan.py --repo $HOME/claude-code-toolkit
 ```
 
 **Step 2: Validate scan output**
@@ -78,7 +78,7 @@ Compare discovered count against expected. If missing, check directory naming, a
 **Step 1: Run extraction script**
 
 ```bash
-python3 ~/.claude/skills/routing-table-updater/scripts/extract_metadata.py --input scan_results.json --output metadata.json
+python3 ~/.toolkit/skills/routing-table-updater/scripts/extract_metadata.py --input scan_results.json --output metadata.json
 ```
 
 **Step 2: Verify extraction completeness**
@@ -102,7 +102,7 @@ Review against `references/extraction-patterns.md`. Patterns must be specific en
 **Step 1: Run generation script**
 
 ```bash
-python3 ~/.claude/skills/routing-table-updater/scripts/generate_routes.py --input metadata.json --output routing_entries.json
+python3 ~/.toolkit/skills/routing-table-updater/scripts/generate_routes.py --input metadata.json --output routing_entries.json
 ```
 
 **Step 2: Understand the generation process**
@@ -130,7 +130,7 @@ Low-severity conflicts: script applies specificity rules automatically. High-sev
 **Step 1: Run update script with backup**
 
 ```bash
-python3 ~/.claude/skills/routing-table-updater/scripts/update_routing.py --input routing_entries.json --target $HOME/claude-code-toolkit/commands/do.md --backup
+python3 ~/.toolkit/skills/routing-table-updater/scripts/update_routing.py --input routing_entries.json --target $HOME/claude-code-toolkit/commands/do.md --backup
 ```
 
 **Step 2: Verify backup exists**
@@ -162,7 +162,7 @@ The script validates pipe alignment, header separator rows, consistent column co
 **Step 1: Run update script with backup**
 
 ```bash
-python3 ~/.claude/skills/routing-table-updater/scripts/update_commands.py --commands-dir $HOME/claude-code-toolkit/commands --metadata metadata.json --backup
+python3 ~/.toolkit/skills/routing-table-updater/scripts/update_commands.py --commands-dir $HOME/claude-code-toolkit/commands --metadata metadata.json --backup
 ```
 
 **Step 2: Understand the update process**
@@ -186,7 +186,7 @@ python3 ~/.claude/skills/routing-table-updater/scripts/update_commands.py --comm
 **Step 1: Run validation script**
 
 ```bash
-python3 ~/.claude/skills/routing-table-updater/scripts/validate.py --target $HOME/claude-code-toolkit/commands/do.md
+python3 ~/.toolkit/skills/routing-table-updater/scripts/validate.py --target $HOME/claude-code-toolkit/commands/do.md
 ```
 
 **Step 2: Understand verification checks**

--- a/skills/sapcc-review/SKILL.md
+++ b/skills/sapcc-review/SKILL.md
@@ -263,6 +263,6 @@ Update `sapcc-review-report.md` with:
 
 **Integration notes**:
 - Complements `/sapcc-audit` (package-level generalist) — use both for maximum coverage
-- Prerequisite: go-patterns skill must be installed at `~/.claude/skills/go-patterns/`
-- Sync: After creating, run `cp -r skills/sapcc-review ~/.claude/skills/sapcc-review` for global access
+- Prerequisite: go-patterns skill must be installed at `~/.toolkit/skills/go-patterns/`
+- Sync: After creating, run `cp -r skills/sapcc-review ~/.toolkit/skills/sapcc-review` for global access
 - Router: `/do` routes via "sapcc review", "sapcc lead review", "comprehensive sapcc audit"

--- a/skills/sapcc-review/references/agent-dispatch-prompts.md
+++ b/skills/sapcc-review/references/agent-dispatch-prompts.md
@@ -10,7 +10,7 @@ Include this block in every agent prompt:
 
 ```
 REFERENCE FILES TO READ FIRST (mandatory):
-1. Read ~/.claude/skills/go-patterns/references/sapcc-conventions/sapcc-code-patterns.md
+1. Read ~/.toolkit/skills/go-patterns/references/sapcc-conventions/sapcc-code-patterns.md
    (Focus on sections listed below, but skim all for context)
 2. Read [domain-specific reference file]
 

--- a/skills/universal-quality-gate/SKILL.md
+++ b/skills/universal-quality-gate/SKILL.md
@@ -59,7 +59,7 @@ This skill implements a **Detect, Check, Report** pattern for multi-language cod
 Run the quality gate check against the current project:
 
 ```bash
-python3 ~/.claude/skills/universal-quality-gate/scripts/run_quality_gate.py
+python3 ~/.toolkit/skills/universal-quality-gate/scripts/run_quality_gate.py
 ```
 
 This command automatically:
@@ -72,25 +72,25 @@ This command automatically:
 
 **For pre-commit validation** (fastest):
 ```bash
-python3 ~/.claude/skills/universal-quality-gate/scripts/run_quality_gate.py --staged
+python3 ~/.toolkit/skills/universal-quality-gate/scripts/run_quality_gate.py --staged
 ```
 Checks only git-staged files, enabling rapid feedback on recent changes.
 
 **For auto-fixing** (when issues are found):
 ```bash
-python3 ~/.claude/skills/universal-quality-gate/scripts/run_quality_gate.py --fix
+python3 ~/.toolkit/skills/universal-quality-gate/scripts/run_quality_gate.py --fix
 ```
 Auto-corrects fixable issues (formatting, imports, etc.), then re-run Step 1 to verify.
 
 **For focused checking** (single language):
 ```bash
-python3 ~/.claude/skills/universal-quality-gate/scripts/run_quality_gate.py --lang python
+python3 ~/.toolkit/skills/universal-quality-gate/scripts/run_quality_gate.py --lang python
 ```
 Narrows scope when debugging language-specific issues.
 
 **For verbose details**:
 ```bash
-python3 ~/.claude/skills/universal-quality-gate/scripts/run_quality_gate.py -v
+python3 ~/.toolkit/skills/universal-quality-gate/scripts/run_quality_gate.py -v
 ```
 Shows expanded diagnostic output for troubleshooting.
 
@@ -144,7 +144,7 @@ Review marked failures [X] first. Pattern matches [WARNING] are informational.
 ### Step 4: Resolve Issues
 
 **For auto-fixable issues:**
-1. Run `python3 ~/.claude/skills/universal-quality-gate/scripts/run_quality_gate.py --fix`
+1. Run `python3 ~/.toolkit/skills/universal-quality-gate/scripts/run_quality_gate.py --fix`
 2. Review changes with `git diff` to verify correctness
 3. Re-run Step 1 to confirm all checks pass
 4. Commit with message documenting the fixes
@@ -168,14 +168,14 @@ Once quality gate passes with zero required-tool failures:
 
 **Pre-commit validation (fastest path):**
 ```bash
-python3 ~/.claude/skills/universal-quality-gate/scripts/run_quality_gate.py --staged
+python3 ~/.toolkit/skills/universal-quality-gate/scripts/run_quality_gate.py --staged
 # If fails → fix issues → re-run
 # If passes → git commit
 ```
 
 **Full repo audit:**
 ```bash
-python3 ~/.claude/skills/universal-quality-gate/scripts/run_quality_gate.py
+python3 ~/.toolkit/skills/universal-quality-gate/scripts/run_quality_gate.py
 # Review all findings by language
 # Fix by category: required failures → warnings → patterns
 # Re-run after each batch of fixes
@@ -183,7 +183,7 @@ python3 ~/.claude/skills/universal-quality-gate/scripts/run_quality_gate.py
 
 **Language-specific validation:**
 ```bash
-python3 ~/.claude/skills/universal-quality-gate/scripts/run_quality_gate.py --lang python
+python3 ~/.toolkit/skills/universal-quality-gate/scripts/run_quality_gate.py --lang python
 # Use when debugging a specific language's toolchain
 # Narrows output and speeds iteration
 ```

--- a/skills/workflow/references/auto-pipeline.md
+++ b/skills/workflow/references/auto-pipeline.md
@@ -46,7 +46,7 @@ This pipeline operates as the automatic fallback for `/do` when no existing rout
 
 **Step 1**: Run task type classification:
 ```bash
-python3 ~/.claude/scripts/task-type-classifier.py --request "{user_request}" --check-catalog ~/.claude/skills/auto-pipeline/references/pipeline-catalog.json --json
+python3 ~/.claude/scripts/task-type-classifier.py --request "{user_request}" --check-catalog ~/.toolkit/skills/auto-pipeline/references/pipeline-catalog.json --json
 ```
 
 **Step 2**: If the classifier returns `existing_pipeline`, STOP. Route to that pipeline instead. Display:


### PR DESCRIPTION
## Summary
- Creates `~/.toolkit/` as the router-managed namespace for domain skills and agents (ADR-195)
- Updates `sync-to-user-claude.py` to deploy domain skills to `~/.toolkit/skills/` and agents to `~/.toolkit/agents/`
- Only `/do` (orchestration) and private voices remain in `~/.claude/skills/` for harness discovery
- Agent `.md` files get symlinks in `~/.claude/agents/` pointing to `~/.toolkit/agents/` for `subagent_type` dispatch
- Updates 22 files with path references from `~/.claude/skills/{domain}/` to `~/.toolkit/skills/{domain}/`
- Codex CLI gets only `/do` + private voices (domain skills removed from `~/.codex/skills/`)

**Token savings:** ~5.8k tokens per orchestrator turn (skills listing + agent listing no longer injected by harness)

## Test plan
- [ ] Run `python3 scripts/routing-manifest.py` and verify all agents/skills present
- [ ] Start a new session in the toolkit repo and verify sync output shows `~/.toolkit/` paths
- [ ] Dispatch a `/do` task and verify agent receives correct skill paths
- [ ] Verify `~/.claude/skills/` contains only `do/` after sync
- [ ] Verify `~/.claude/agents/*.md` are symlinks to `~/.toolkit/agents/`
- [ ] Verify `ruff check . && ruff format --check .` passes
- [ ] Run 10 representative tasks through `/do` to validate routing accuracy