### PR TITLE
feat(do): extract agent model from frontmatter and pass through dispatch

### DIFF
--- a/scripts/resolve-dispatch.py
+++ b/scripts/resolve-dispatch.py
@@ -28,6 +28,21 @@ SKILLS_DIR = TOOLKIT_DIR / "skills"
 SHARED_PATTERNS_DIR = SKILLS_DIR / "shared-patterns"
 
 
+def extract_model(path: Path) -> str | None:
+    """Extract model field from YAML frontmatter."""
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return None
+    end = text.find("---", 3)
+    if end == -1:
+        return None
+    for line in text[3:end].split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("model:"):
+            return stripped.split(":", 1)[1].strip().strip("\"'")
+    return None
+
+
 def resolve_agent(name: str) -> Path | None:
     path = AGENTS_DIR / f"{name}.md"
     return path if path.exists() else None
@@ -57,6 +72,7 @@ def list_references(base_dir: Path, name: str) -> list[Path]:
 
 def format_dispatch(
     agent_path: Path | None,
+    agent_model: str | None,
     skill_paths: list[tuple[str, Path]],
     inject_paths: list[tuple[str, Path]],
     agent_refs: list[Path],
@@ -66,6 +82,8 @@ def format_dispatch(
 
     if agent_path:
         lines.append(f"**Agent:** `{agent_path}`")
+    if agent_model:
+        lines.append(f"**Model:** `{agent_model}`")
 
     for name, path in skill_paths:
         lines.append(f"**Skill ({name}):** `{path}`")
@@ -104,6 +122,8 @@ def main() -> int:
         print(f"Agent not found: {args.agent}", file=sys.stderr)
         return 1
 
+    agent_model = extract_model(agent_path) if agent_path else None
+
     skill_paths = []
     skill_refs: list[tuple[str, list[Path]]] = []
     for skill_name in args.skill:
@@ -122,7 +142,7 @@ def main() -> int:
 
     agent_refs = list_references(AGENTS_DIR, args.agent)
 
-    dispatch = format_dispatch(agent_path, skill_paths, inject_paths, agent_refs, skill_refs)
+    dispatch = format_dispatch(agent_path, agent_model, skill_paths, inject_paths, agent_refs, skill_refs)
     print(dispatch)
     return 0
 

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -119,7 +119,9 @@ python3 ~/.claude/scripts/resolve-dispatch.py \
     --request "{user_request}"
 ```
 
-Prepend the Dispatch Package output to the agent prompt. For Medium+ tasks, also prepend:
+Prepend the Dispatch Package output to the agent prompt. Pass the **Model** value from the Dispatch Package as the `model` parameter on the Agent tool call. If no model is specified, omit the parameter (session default applies).
+
+For Medium+ tasks, also prepend:
 
 ```
 ## Task Specification


### PR DESCRIPTION
## Summary
- `resolve-dispatch.py` now extracts the `model:` field from agent .md frontmatter and includes `**Model:** \`{value}\`` in the Dispatch Package output
- SKILL.md Phase 4 instructs the main thread to pass the Model value as the `model` parameter on the Agent tool call
- Agents without a `model:` field get no override (session default applies)

This ensures 44 sonnet agents and 1 opus agent run on their declared models instead of always inheriting the session default (Opus).

## Test plan
- [x] 2594 tests pass, lint clean
- [x] Verified: `golang-general-engineer` outputs `Model: sonnet`
- [x] Verified: `wrestlejoy-news-producer` outputs `Model: opus`
- [x] Verified: `wrestlejoy-amy-writer` (no model field) omits Model line
- [ ] End-to-end: `/do` dispatches domain agent with correct model parameter