### PR TITLE
refactor: strip model frontmatter from agents and skills

### DIFF
--- a/agents/INDEX.json
+++ b/agents/INDEX.json
@@ -5,7 +5,6 @@
     "ansible-automation-engineer": {
       "file": "agents/ansible-automation-engineer.md",
       "short_description": "Ansible automation: playbooks, roles, collections, Molecule testing, Vault security",
-      "model": "sonnet",
       "triggers": [
         "ansible",
         "playbook",
@@ -24,7 +23,6 @@
     "combat-effects-upgrade": {
       "file": "agents/combat-effects-upgrade.md",
       "short_description": "Zero-dependency combat visual upgrades: CSS particle replacement, Framer Motion combat juice, CSS 3D card transforms",
-      "model": "sonnet",
       "triggers": [
         "combat effects",
         "CSS particles",
@@ -49,7 +47,6 @@
     "data-engineer": {
       "file": "agents/data-engineer.md",
       "short_description": "Data pipelines, ETL/ELT, warehouse design, dimensional modeling, stream processing",
-      "model": "sonnet",
       "triggers": [
         "data pipeline",
         "ETL",
@@ -88,7 +85,6 @@
     "database-engineer": {
       "file": "agents/database-engineer.md",
       "short_description": "Database design, optimization, query performance, migrations, indexing strategies",
-      "model": "sonnet",
       "triggers": [
         "database",
         "schema",
@@ -109,7 +105,6 @@
     "github-profile-rules-engineer": {
       "file": "agents/github-profile-rules-engineer.md",
       "short_description": "Extract coding conventions and style rules from GitHub user profiles via API",
-      "model": "sonnet",
       "triggers": [
         "github rules",
         "profile analysis",
@@ -126,7 +121,6 @@
     "golang-general-engineer-compact": {
       "file": "agents/golang-general-engineer-compact.md",
       "short_description": "Compact Go development for tight context budgets",
-      "model": "sonnet",
       "triggers": [
         "go",
         "golang",
@@ -144,7 +138,6 @@
     "golang-general-engineer": {
       "file": "agents/golang-general-engineer.md",
       "short_description": "Go development: features, debugging, code review, performance",
-      "model": "sonnet",
       "triggers": [
         "go",
         "golang",
@@ -164,7 +157,6 @@
     "hook-development-engineer": {
       "file": "agents/hook-development-engineer.md",
       "short_description": "Python hook development for Claude Code event-driven system and learning database",
-      "model": "sonnet",
       "triggers": [
         "create hook",
         "hook development",
@@ -185,7 +177,6 @@
     "kotlin-general-engineer": {
       "file": "agents/kotlin-general-engineer.md",
       "short_description": "Kotlin development: features, coroutines, debugging, code quality, multiplatform",
-      "model": "sonnet",
       "triggers": [
         "kotlin",
         "ktor",
@@ -214,7 +205,6 @@
     "kubernetes-helm-engineer": {
       "file": "agents/kubernetes-helm-engineer.md",
       "short_description": "Kubernetes and Helm: deployments, troubleshooting, cloud-native infrastructure",
-      "model": "sonnet",
       "triggers": [
         "kubernetes",
         "helm",
@@ -234,7 +224,6 @@
     "mcp-local-docs-engineer": {
       "file": "agents/mcp-local-docs-engineer.md",
       "short_description": "MCP server development for local documentation access in TypeScript/Node",
-      "model": "sonnet",
       "triggers": [
         "MCP",
         "docs server",
@@ -250,7 +239,6 @@
     "nextjs-ecommerce-engineer": {
       "file": "agents/nextjs-ecommerce-engineer.md",
       "short_description": "Use this agent when building a NextJS e-commerce site: shopping cart, Stripe payments, product catalogs, order management, and checkout flows",
-      "model": "sonnet",
       "triggers": [
         "next.js e-commerce",
         "nextjs ecommerce",
@@ -270,7 +258,6 @@
     "nodejs-api-engineer": {
       "file": "agents/nodejs-api-engineer.md",
       "short_description": "Use this agent when you need expert assistance with NodeJS backend API development: REST endpoints, authentication, file uploads, webhooks, middleware, and database integration",
-      "model": "sonnet",
       "triggers": [
         "node.js",
         "nodejs",
@@ -290,7 +277,6 @@
     "opensearch-elasticsearch-engineer": {
       "file": "agents/opensearch-elasticsearch-engineer.md",
       "short_description": "OpenSearch/Elasticsearch: cluster management, performance tuning, index optimization",
-      "model": "sonnet",
       "triggers": [
         "opensearch",
         "elasticsearch",
@@ -308,7 +294,6 @@
     "performance-optimization-engineer": {
       "file": "agents/performance-optimization-engineer.md",
       "short_description": "Web performance optimization: Core Web Vitals, rendering, bundle analysis, monitoring",
-      "model": "sonnet",
       "triggers": [
         "performance",
         "optimization",
@@ -324,7 +309,6 @@
     "perses-engineer": {
       "file": "agents/perses-engineer.md",
       "short_description": "Perses observability platform: dashboards, plugins, operator, core development",
-      "model": "sonnet",
       "triggers": [
         "perses",
         "perses dashboard",
@@ -369,7 +353,6 @@
     "php-general-engineer": {
       "file": "agents/php-general-engineer.md",
       "short_description": "PHP development: features, debugging, code quality, security, modern PHP 8",
-      "model": "sonnet",
       "triggers": [
         "php",
         "laravel",
@@ -402,7 +385,6 @@
     "pipeline-orchestrator-engineer": {
       "file": "agents/pipeline-orchestrator-engineer.md",
       "short_description": "Pipeline orchestration: scaffold multi-component workflows, fan-out/fan-in patterns",
-      "model": "sonnet",
       "triggers": [
         "create pipeline",
         "new pipeline",
@@ -421,7 +403,6 @@
     "pixijs-combat-renderer": {
       "file": "agents/pixijs-combat-renderer.md",
       "short_description": "PixiJS v8 2D WebGL combat rendering: @pixi/react hybrid canvas, normal maps, GPU particles, post-processing",
-      "model": "sonnet",
       "triggers": [
         "pixijs",
         "pixi.js",
@@ -445,7 +426,6 @@
     "project-coordinator-engineer": {
       "file": "agents/project-coordinator-engineer.md",
       "short_description": "Multi-agent project coordination: task breakdown, dependency management, progress tracking",
-      "model": "sonnet",
       "triggers": [
         "coordinate",
         "multi-agent",
@@ -464,7 +444,6 @@
     "prometheus-grafana-engineer": {
       "file": "agents/prometheus-grafana-engineer.md",
       "short_description": "Prometheus and Grafana: monitoring, alerting, dashboard design, PromQL optimization",
-      "model": "sonnet",
       "triggers": [
         "prometheus",
         "grafana",
@@ -484,7 +463,6 @@
     "python-general-engineer": {
       "file": "agents/python-general-engineer.md",
       "short_description": "Python development: features, debugging, code review, performance",
-      "model": "sonnet",
       "triggers": [
         "python",
         ".py files",
@@ -504,7 +482,6 @@
     "python-openstack-engineer": {
       "file": "agents/python-openstack-engineer.md",
       "short_description": "OpenStack Python development: Nova, Neutron, Cinder, Oslo libraries, WSGI middleware",
-      "model": "sonnet",
       "triggers": [
         "openstack",
         "oslo",
@@ -525,7 +502,6 @@
     "rabbitmq-messaging-engineer": {
       "file": "agents/rabbitmq-messaging-engineer.md",
       "short_description": "RabbitMQ: message queue architecture, clustering, high-availability, routing patterns",
-      "model": "sonnet",
       "triggers": [
         "rabbitmq",
         "messaging",
@@ -542,7 +518,6 @@
     "react-native-engineer": {
       "file": "agents/react-native-engineer.md",
       "short_description": "React Native and Expo development: performance, animations, navigation, native UI patterns",
-      "model": "sonnet",
       "triggers": [
         "react native",
         "expo",
@@ -562,7 +537,6 @@
     "react-portfolio-engineer": {
       "file": "agents/react-portfolio-engineer.md",
       "short_description": "React portfolio/gallery sites for creatives: React 18+, Next",
-      "model": "sonnet",
       "triggers": [
         "portfolio",
         "gallery",
@@ -581,7 +555,6 @@
     "research-coordinator-engineer": {
       "file": "agents/research-coordinator-engineer.md",
       "short_description": "Research coordination: systematic investigation, multi-source analysis, synthesis",
-      "model": "sonnet",
       "triggers": [
         "research",
         "investigate",
@@ -601,7 +574,6 @@
     "research-subagent-executor": {
       "file": "agents/research-subagent-executor.md",
       "short_description": "Research subagent execution: OODA-loop investigation, intelligence gathering, source evaluation",
-      "model": "sonnet",
       "triggers": [
         "research subtask",
         "delegated research"
@@ -615,7 +587,6 @@
     "reviewer-code": {
       "file": "agents/reviewer-code.md",
       "short_description": "Code quality review: conventions, naming, dead code, performance, test coverage",
-      "model": "sonnet",
       "triggers": [
         "code review",
         "review code quality",
@@ -638,7 +609,6 @@
     "reviewer-domain": {
       "file": "agents/reviewer-domain.md",
       "short_description": "Domain-specific review: ADR compliance, business logic, SAP CC structural, pragmatic builder",
-      "model": "sonnet",
       "triggers": [
         "adr compliance",
         "adr review",
@@ -674,7 +644,6 @@
     "reviewer-perspectives": {
       "file": "agents/reviewer-perspectives.md",
       "short_description": "Multi-perspective review: newcomer, senior, pedant, contrarian, user advocate, meta-process",
-      "model": "sonnet",
       "triggers": [
         "newcomer perspective",
         "fresh eyes review",
@@ -715,7 +684,6 @@
     "reviewer-system": {
       "file": "agents/reviewer-system.md",
       "short_description": "System-level review: security, concurrency, error handling, observability, API contracts",
-      "model": "sonnet",
       "triggers": [
         "system review",
         "security review",
@@ -739,7 +707,6 @@
     "rive-skeletal-animator": {
       "file": "agents/rive-skeletal-animator.md",
       "short_description": "Rive skeletal animation: @rive-app/react-canvas, state machines, character pipelines, combat integration",
-      "model": "sonnet",
       "triggers": [
         "rive",
         "rive-app",
@@ -763,7 +730,6 @@
     "sqlite-peewee-engineer": {
       "file": "agents/sqlite-peewee-engineer.md",
       "short_description": "SQLite with Peewee ORM: model definition, query optimization, migrations, transactions",
-      "model": "sonnet",
       "triggers": [
         "peewee",
         "sqlite",
@@ -781,7 +747,6 @@
     "swift-general-engineer": {
       "file": "agents/swift-general-engineer.md",
       "short_description": "Swift development: iOS, macOS, server-side Swift, SwiftUI, concurrency, testing",
-      "model": "sonnet",
       "triggers": [
         "swift",
         "ios",
@@ -817,7 +782,6 @@
     "system-upgrade-engineer": {
       "file": "agents/system-upgrade-engineer.md",
       "short_description": "Systematic toolkit upgrades: adapt agents, skills, hooks when Claude Code ships updates",
-      "model": "sonnet",
       "triggers": [
         "upgrade agents",
         "system upgrade",
@@ -844,7 +808,6 @@
     "technical-documentation-engineer": {
       "file": "agents/technical-documentation-engineer.md",
       "short_description": "Technical documentation: API docs, system architecture, runbooks, enterprise standards",
-      "model": "sonnet",
       "triggers": [
         "API documentation",
         "technical docs",
@@ -860,7 +823,6 @@
     "technical-journalist-writer": {
       "file": "agents/technical-journalist-writer.md",
       "short_description": "Technical journalism: explainers, opinion pieces, analysis articles, long-form content",
-      "model": "sonnet",
       "triggers": [
         "technical article",
         "technical writing",
@@ -877,7 +839,6 @@
     "testing-automation-engineer": {
       "file": "agents/testing-automation-engineer.md",
       "short_description": "Testing automation: Vitest, Playwright, E2E, coverage enforcement, CI/CD integration",
-      "model": "sonnet",
       "triggers": [
         "testing",
         "E2E",
@@ -896,7 +857,6 @@
     "toolkit-governance-engineer": {
       "file": "agents/toolkit-governance-engineer.md",
       "short_description": "Toolkit governance: edit skills, update routing tables, manage ADR lifecycle, enforce standards",
-      "model": "sonnet",
       "triggers": [
         "edit skill",
         "update routing",
@@ -919,7 +879,6 @@
     "typescript-debugging-engineer": {
       "file": "agents/typescript-debugging-engineer.md",
       "short_description": "TypeScript debugging: race conditions, async/await issues, type errors, runtime exceptions",
-      "model": "sonnet",
       "triggers": [
         "typescript debug",
         "async bug",
@@ -938,7 +897,6 @@
     "typescript-frontend-engineer": {
       "file": "agents/typescript-frontend-engineer.md",
       "short_description": "TypeScript frontend architecture: type-safe components, state management, build optimization",
-      "model": "sonnet",
       "triggers": [
         "typescript",
         "react",
@@ -958,7 +916,6 @@
     "ui-design-engineer": {
       "file": "agents/ui-design-engineer.md",
       "short_description": "UI/UX design: design systems, responsive layouts, accessibility, animations",
-      "model": "sonnet",
       "triggers": [
         "UI",
         "design",

--- a/scripts/generate-agent-index.py
+++ b/scripts/generate-agent-index.py
@@ -167,9 +167,6 @@ def generate_index(
             "short_description": extract_short_description(frontmatter.get("description", "")),
         }
 
-        if "model" in frontmatter:
-            agent_entry["model"] = frontmatter["model"]
-
         # Add routing metadata if present
         if "routing" in frontmatter:
             routing = frontmatter["routing"]

--- a/scripts/resolve-dispatch.py
+++ b/scripts/resolve-dispatch.py
@@ -28,21 +28,6 @@ SKILLS_DIR = TOOLKIT_DIR / "skills"
 SHARED_PATTERNS_DIR = SKILLS_DIR / "shared-patterns"
 
 
-def extract_model(path: Path) -> str | None:
-    """Extract model field from YAML frontmatter."""
-    text = path.read_text(encoding="utf-8")
-    if not text.startswith("---"):
-        return None
-    end = text.find("---", 3)
-    if end == -1:
-        return None
-    for line in text[3:end].split("\n"):
-        stripped = line.strip()
-        if stripped.startswith("model:"):
-            return stripped.split(":", 1)[1].strip().strip("\"'")
-    return None
-
-
 def resolve_agent(name: str) -> Path | None:
     path = AGENTS_DIR / f"{name}.md"
     return path if path.exists() else None
@@ -72,7 +57,6 @@ def list_references(base_dir: Path, name: str) -> list[Path]:
 
 def format_dispatch(
     agent_path: Path | None,
-    agent_model: str | None,
     skill_paths: list[tuple[str, Path]],
     inject_paths: list[tuple[str, Path]],
     agent_refs: list[Path],
@@ -82,8 +66,6 @@ def format_dispatch(
 
     if agent_path:
         lines.append(f"**Agent:** `{agent_path}`")
-    if agent_model:
-        lines.append(f"**Model:** `{agent_model}`")
 
     for name, path in skill_paths:
         lines.append(f"**Skill ({name}):** `{path}`")
@@ -122,8 +104,6 @@ def main() -> int:
         print(f"Agent not found: {args.agent}", file=sys.stderr)
         return 1
 
-    agent_model = extract_model(agent_path) if agent_path else None
-
     skill_paths = []
     skill_refs: list[tuple[str, list[Path]]] = []
     for skill_name in args.skill:
@@ -142,7 +122,7 @@ def main() -> int:
 
     agent_refs = list_references(AGENTS_DIR, args.agent)
 
-    dispatch = format_dispatch(agent_path, agent_model, skill_paths, inject_paths, agent_refs, skill_refs)
+    dispatch = format_dispatch(agent_path, skill_paths, inject_paths, agent_refs, skill_refs)
     print(dispatch)
     return 0
 

--- a/scripts/routing-manifest.py
+++ b/scripts/routing-manifest.py
@@ -89,8 +89,7 @@ def format_compact(entries: list[dict]) -> str:
 
         if e["type"] == "agent":
             pairs_str = f" [{pairs}]" if pairs else ""
-            model_str = f" model={e['model']}" if e.get("model") else ""
-            agents.append(f"  {name}{model_str}{pairs_str} — {desc}")
+            agents.append(f"  {name}{pairs_str} — {desc}")
         else:
             force_str = " FORCE" if e.get("force_route") else ""
             agent_str = f" agent={e['agent']}" if e.get("agent") else ""

--- a/scripts/strip-model-frontmatter.py
+++ b/scripts/strip-model-frontmatter.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Strip model: lines from YAML frontmatter in agent and skill files.
+
+Removes the model: field from YAML frontmatter in .md files. The model
+field is redundant context: 44/49 agents specify 'sonnet' (the default),
+and the field doesn't work in Codex. The only model override that
+matters is the Haiku one in /do's SKILL.md instruction.
+
+Usage:
+    python3 scripts/strip-model-frontmatter.py                    # dry run
+    python3 scripts/strip-model-frontmatter.py --apply            # apply changes
+    python3 scripts/strip-model-frontmatter.py --path ~/custom    # custom path
+
+Exit codes:
+    0 — Success
+    1 — No files found
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+TOOLKIT_DIR = Path.home() / ".toolkit"
+
+
+def strip_model_from_frontmatter(text: str) -> tuple[str, str | None]:
+    """Remove model: line from YAML frontmatter. Returns (new_text, old_model)."""
+    if not text.startswith("---"):
+        return text, None
+
+    end = text.find("\n---", 3)
+    if end == -1:
+        return text, None
+
+    frontmatter = text[3:end]
+    match = re.search(r"\n\s*model:\s*(.+)", frontmatter)
+    if not match:
+        return text, None
+
+    old_model = match.group(1).strip().strip("\"'")
+    new_frontmatter = frontmatter[: match.start()] + frontmatter[match.end() :]
+    return "---" + new_frontmatter + text[end:], old_model
+
+
+def find_files(base: Path) -> list[Path]:
+    """Find agent .md files and skill SKILL.md files."""
+    files = []
+
+    agents_dir = base / "agents"
+    if agents_dir.exists():
+        for f in sorted(agents_dir.glob("*.md")):
+            if f.name == "README.md":
+                continue
+            files.append(f.resolve())
+
+    skills_dir = base / "skills"
+    if skills_dir.exists():
+        for f in sorted(skills_dir.glob("*/SKILL.md")):
+            files.append(f.resolve())
+
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Strip model: from frontmatter.")
+    parser.add_argument("--apply", action="store_true", help="Apply changes (default: dry run)")
+    parser.add_argument("--path", type=Path, default=TOOLKIT_DIR, help="Base path to scan")
+    args = parser.parse_args()
+
+    files = find_files(args.path)
+    if not files:
+        print(f"No files found under {args.path}")
+        return 1
+
+    changed = 0
+    skipped = 0
+
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        new_text, old_model = strip_model_from_frontmatter(text)
+        if old_model is None:
+            skipped += 1
+            continue
+
+        rel = path.relative_to(args.path) if str(path).startswith(str(args.path)) else path
+        action = "stripped" if args.apply else "would strip"
+        print(f"  {action} model={old_model} from {rel}")
+
+        if args.apply:
+            path.write_text(new_text, encoding="utf-8")
+
+        changed += 1
+
+    mode = "Applied" if args.apply else "Dry run"
+    print(f"\n{mode}: {changed} files changed, {skipped} files without model field")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-04-18T19:13:29Z",
+  "generated": "2026-04-18T19:37:16Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
     "adr-consultation": {

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -67,13 +67,12 @@ USER REQUEST: {user_request}
 ROUTING MANIFEST:
 {manifest_output}
 
-Return JSON: {"agent": "name or null", "skill": "name or null", "model": "model from agent entry or null", "reasoning": "one sentence", "confidence": "high/medium/low"}
+Return JSON: {"agent": "name or null", "skill": "name or null", "reasoning": "one sentence", "confidence": "high/medium/low"}
 
 Rules:
 - Pick the most specific match. Agent handles domain, skill handles methodology.
 - FORCE entries must be selected when intent clearly matches (semantic, not keyword).
 - Git operations (push, commit, PR, merge) always get pr-workflow skill.
-- Copy the agent's model= value into the response. If no model is listed, return null.
 - If nothing matches, return nulls.
 ```
 
@@ -120,7 +119,7 @@ python3 ~/.claude/scripts/resolve-dispatch.py \
     --request "{user_request}"
 ```
 
-Prepend the Dispatch Package output to the agent prompt. Pass the `model` value from the Haiku routing response (or from the Dispatch Package **Model** line) as the `model` parameter on the Agent tool call. If no model is specified, omit the parameter (session default applies).
+Prepend the Dispatch Package output to the agent prompt.
 
 For Medium+ tasks, also prepend:
 


### PR DESCRIPTION
## Summary
- Strips `model:` from 62 agent/skill frontmatter files (61 sonnet, 1 opus) via new `scripts/strip-model-frontmatter.py`
- Reverts model passthrough infrastructure from #512 and #513: removes model extraction from `resolve-dispatch.py`, model output from `routing-manifest.py`, and model field from `generate-agent-index.py`
- The only model override that matters is `model: "haiku"` for the /do routing subagent, specified in the SKILL.md instruction

The field was wasted context: nearly all agents specified the default, and it doesn't work in Codex.

## Test plan
- [x] 2594 tests pass, lint clean
- [x] Dry run confirms 0 model fields remain across 160 files
- [x] Dispatch Package output verified: no Model line
- [x] Manifest output verified: no model= in agent entries