### PR TITLE
feat(harbor-adapter): add /do router benchmark adapter for terminal-bench-2

### DIFF
--- a/harbor-adapter/.gitignore
+++ b/harbor-adapter/.gitignore
@@ -1,0 +1,19 @@
+# Raw Harbor trial output may contain full Claude transcripts, which can
+# include task content, API responses, and intermediate state. Keep the
+# summary report (results/<timestamp>/report.md) but exclude everything
+# else under results/.
+#
+# Rules are file-scoped rather than directory-scoped so that git can
+# re-include nested files: git does not descend into ignored directories,
+# so "results/*" would mask "!results/**/report.md".
+
+results/*/raw/
+results/*/harbor-run.log
+results/*/*.json
+results/*/*.jsonl
+
+# Python build / cache artifacts
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/

--- a/harbor-adapter/Dockerfile
+++ b/harbor-adapter/Dockerfile
@@ -1,0 +1,51 @@
+# Harbor container image for the /do router benchmark.
+#
+# Harbor launches tasks inside a container. This Dockerfile defines the
+# baseline image; the BaseInstalledAgent.install() method layers Node,
+# Claude Code, and the toolkit on top at job start so the image can stay
+# small and cacheable.
+#
+# Keep this image minimal: anything agent-specific belongs in
+# ClaudeCodeDoAgent.install(), not here.
+
+FROM ubuntu:24.04
+
+# Non-interactive apt for reproducible builds.
+ENV DEBIAN_FRONTEND=noninteractive \
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8
+
+# Baseline tooling used by terminal-bench tasks and the install step.
+# git and curl are needed by BaseInstalledAgent.install() itself; the rest
+# are common enough that having them preinstalled trims install-phase wall
+# time for every task.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        build-essential \
+        python3 \
+        python3-pip \
+        python3-venv \
+        jq \
+        sudo \
+        vim-tiny \
+    && rm -rf /var/lib/apt/lists/*
+
+# Harbor expects an "agent" user that exec_as_agent runs commands as.
+RUN useradd --create-home --shell /bin/bash agent \
+    && mkdir -p /logs /workspace \
+    && chown -R agent:agent /logs /workspace
+
+# /logs is where ClaudeCodeDoAgent.run() drops claude-stdout.json,
+# claude-stderr.log, and claude-exit-code. Harbor also writes
+# /logs/verifier/reward.txt at task end.
+VOLUME ["/logs", "/workspace"]
+
+USER agent
+WORKDIR /workspace
+
+# Sanity check only. The real CLI install happens in
+# BaseInstalledAgent.install() so the image is reusable across toolkit
+# versions without a rebuild.
+CMD ["/bin/bash"]

--- a/harbor-adapter/README.md
+++ b/harbor-adapter/README.md
@@ -1,0 +1,43 @@
+# Harbor Adapter for the /do Router
+
+A `BaseInstalledAgent` subclass that runs the claude-code-toolkit /do router
+inside a Harbor container against terminal-bench-2.
+
+## Prerequisites
+
+- Docker (Harbor's local runtime launches tasks in containers)
+- `uv` (Harbor is installed via `uv tool install harbor`)
+- `ANTHROPIC_API_KEY` exported in the host shell
+
+## Run the 5-task dry run
+
+```bash
+export ANTHROPIC_API_KEY=sk-...
+./run_dry_run.sh
+```
+
+Results land in `results/<timestamp>/`:
+
+- `report.md` — per-task pass/fail, tokens, estimated cost, aggregates
+- `raw/` — full Harbor trial directories (gitignored; may contain transcripts)
+- `harbor-run.log` — stdout/stderr of the `harbor run` invocation
+
+## Switch to a cloud runtime
+
+Edit `job.yaml`:
+
+```yaml
+environment:
+  runtime: daytona
+```
+
+Set the matching API key on the host (`DAYTONA_API_KEY`, `MODAL_TOKEN_ID` +
+`MODAL_TOKEN_SECRET`, `E2B_API_KEY`, or `RUNLOOP_API_KEY`).
+
+## Files
+
+- `harbor_adapter/claude_code_do_agent.py` — the adapter
+- `Dockerfile` — base image; Node / Claude Code / toolkit land on top at install
+- `job.yaml` — Harbor job config
+- `run_dry_run.sh` — entry point
+- `scripts/build_report.py` — assembles `report.md` from trial outputs

--- a/harbor-adapter/harbor_adapter/__init__.py
+++ b/harbor-adapter/harbor_adapter/__init__.py
@@ -1,0 +1,10 @@
+"""Harbor adapter that invokes the /do router via a headless Claude Code CLI.
+
+The adapter installs Node 20, the Claude Code CLI, and the claude-code-toolkit
+into a Harbor-managed container, then shells out to ``claude -p`` with no agent
+flag so /do performs dynamic routing inside the CLI.
+"""
+
+from harbor_adapter.claude_code_do_agent import ClaudeCodeDoAgent
+
+__all__ = ["ClaudeCodeDoAgent"]

--- a/harbor-adapter/harbor_adapter/claude_code_do_agent.py
+++ b/harbor-adapter/harbor_adapter/claude_code_do_agent.py
@@ -1,0 +1,269 @@
+"""BaseInstalledAgent that exercises the /do router via ``claude -p``.
+
+The agent installs Node 20, the Claude Code CLI, and a pinned copy of the
+claude-code-toolkit into the Harbor container. It then runs each task by
+invoking ``claude -p <instruction> --output-format json
+--dangerously-skip-permissions`` with no agent flag, letting /do perform
+dynamic routing.
+
+Token usage is read from Claude Code's JSON summary (``--output-format
+json`` emits a final object containing ``usage.input_tokens`` and
+``usage.output_tokens``). If the JSON summary is unavailable for any task,
+the adapter records the failure mode rather than fabricating zeros.
+
+Interface sources (verified 2026-04-19):
+- https://www.harborframework.com/docs/agents (class signature, decorator)
+- https://pypi.org/project/harbor/ (terminal-bench-2.0 invocation)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from harbor.agents.installed.base import BaseInstalledAgent, with_prompt_template
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+# Pinned toolkit commit. Update deliberately; never float to HEAD.
+TOOLKIT_REPO = "https://github.com/notque/claude-code-toolkit.git"
+TOOLKIT_REF = "main"
+
+# Node 20 is the oldest Claude Code CLI supports cleanly.
+NODE_SETUP_URL = "https://deb.nodesource.com/setup_20.x"
+
+
+@dataclass
+class RunStats:
+    """Per-task execution stats captured after ``claude -p`` exits."""
+
+    exit_code: int
+    input_tokens: int | None
+    output_tokens: int | None
+    cache_read_tokens: int | None
+    cache_creation_tokens: int | None
+    usage_parse_error: str | None
+    raw_stdout_bytes: int
+    raw_stderr_bytes: int
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+class ClaudeCodeDoAgent(BaseInstalledAgent):
+    """Run terminal-bench-2 tasks through the /do router.
+
+    The agent never passes ``--agent`` to ``claude``. /do is the target of
+    measurement; letting the CLI hardcode an agent would defeat the
+    experiment.
+    """
+
+    # Harbor reads this to decide which OS user runs the agent commands.
+    # "agent" is the default non-root user in Harbor's base images.
+    user = "agent"
+
+    # Populated by ``run`` and consumed by ``populate_context_post_run``.
+    _last_stats: RunStats | None = None
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        """Install Node 20, Claude Code CLI, and the toolkit."""
+        # Core dependencies. Use ``exec_as_root`` only for apt; everything
+        # else runs as the agent user so it lands in the right $HOME.
+        await self.exec_as_root(
+            environment,
+            command="apt-get update && apt-get install -y curl git ca-certificates",
+        )
+        await self.exec_as_root(
+            environment,
+            command=f"curl -fsSL {NODE_SETUP_URL} | bash -",
+        )
+        await self.exec_as_root(
+            environment,
+            command="apt-get install -y nodejs",
+        )
+
+        # Claude Code CLI, installed globally so ``claude`` is on PATH for
+        # every user.
+        await self.exec_as_root(
+            environment,
+            command="npm install -g @anthropic-ai/claude-code",
+        )
+
+        # Toolkit: clone into $HOME and symlink the two canonical paths the
+        # toolkit expects (~/.claude and ~/.toolkit).
+        await self.exec_as_agent(
+            environment,
+            command=(f"git clone --depth 1 --branch {TOOLKIT_REF} {TOOLKIT_REPO} $HOME/claude-code-toolkit"),
+        )
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "mkdir -p $HOME/.claude $HOME/.toolkit && "
+                "ln -sf $HOME/claude-code-toolkit/agents $HOME/.toolkit/agents && "
+                "ln -sf $HOME/claude-code-toolkit/skills $HOME/.toolkit/skills && "
+                "ln -sf $HOME/claude-code-toolkit/hooks $HOME/.toolkit/hooks && "
+                "ln -sf $HOME/claude-code-toolkit/agents $HOME/.claude/agents && "
+                "ln -sf $HOME/claude-code-toolkit/skills $HOME/.claude/skills && "
+                "ln -sf $HOME/claude-code-toolkit/hooks $HOME/.claude/hooks && "
+                "cp $HOME/claude-code-toolkit/CLAUDE.md $HOME/.claude/CLAUDE.md"
+            ),
+        )
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,  # noqa: ARG002 - part of BaseInstalledAgent.run signature
+    ) -> None:
+        """Invoke ``claude -p`` with no agent flag, capture JSON usage."""
+        # --output-format json prints a final JSON envelope that includes the
+        # assistant's text plus a usage block. We parse that rather than
+        # scraping stderr.
+        #
+        # --dangerously-skip-permissions is required for headless runs; the
+        # container is user-owned and fully disposable per the task brief.
+        #
+        # The instruction is passed via stdin so shell quoting does not
+        # mangle multi-line tasks. Harbor's ``exec_as_agent`` merges env
+        # vars (including ANTHROPIC_API_KEY) automatically.
+        heredoc_instruction = instruction.replace("'", "'\\''")
+        cmd = (
+            "set -o pipefail; "
+            "cd /workspace && "
+            f"printf '%s' '{heredoc_instruction}' | "
+            "claude -p --output-format json --dangerously-skip-permissions "
+            "> /logs/claude-stdout.json 2> /logs/claude-stderr.log; "
+            "echo $? > /logs/claude-exit-code"
+        )
+
+        result = await self.exec_as_agent(environment, command=cmd)
+
+        # Pull the artifacts back. ``exec_as_agent`` does not stream file
+        # contents, so read them explicitly. Using ``cat`` keeps this
+        # transport-agnostic across Harbor runtimes.
+        stdout_raw = await self.exec_as_agent(environment, command="cat /logs/claude-stdout.json || true")
+        stderr_raw = await self.exec_as_agent(environment, command="cat /logs/claude-stderr.log || true")
+        exit_raw = await self.exec_as_agent(environment, command="cat /logs/claude-exit-code || echo -1")
+
+        stdout_text = _to_text(stdout_raw)
+        stderr_text = _to_text(stderr_raw)
+        try:
+            exit_code = int(_to_text(exit_raw).strip() or "-1")
+        except ValueError:
+            exit_code = -1
+
+        self._last_stats = _parse_run_stats(
+            exit_code=exit_code,
+            stdout_text=stdout_text,
+            stderr_text=stderr_text,
+        )
+
+        # Let BaseInstalledAgent bookkeep (logs dir, etc.) regardless.
+        _ = result
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        """Attach run stats to the context so Harbor stores them per-trial."""
+        if self._last_stats is None:
+            context.metadata["claude_do_router"] = {"error": "run_not_executed"}
+            return
+
+        stats = self._last_stats
+        context.metadata["claude_do_router"] = {
+            "exit_code": stats.exit_code,
+            "input_tokens": stats.input_tokens,
+            "output_tokens": stats.output_tokens,
+            "cache_read_tokens": stats.cache_read_tokens,
+            "cache_creation_tokens": stats.cache_creation_tokens,
+            "usage_parse_error": stats.usage_parse_error,
+            "raw_stdout_bytes": stats.raw_stdout_bytes,
+            "raw_stderr_bytes": stats.raw_stderr_bytes,
+            **stats.extra,
+        }
+
+
+def _to_text(blob: Any) -> str:
+    """Coerce Harbor exec output into a string.
+
+    ``exec_as_agent`` returns different shapes across runtimes; accept the
+    common ones and fall back to ``str()``.
+    """
+    if blob is None:
+        return ""
+    if isinstance(blob, str):
+        return blob
+    if isinstance(blob, bytes):
+        return blob.decode("utf-8", errors="replace")
+    stdout = getattr(blob, "stdout", None)
+    if stdout is not None:
+        return _to_text(stdout)
+    return str(blob)
+
+
+def _parse_run_stats(*, exit_code: int, stdout_text: str, stderr_text: str) -> RunStats:
+    """Extract token usage from Claude Code's JSON envelope.
+
+    ``claude -p --output-format json`` prints a single JSON object on stdout
+    with a ``usage`` block. If parsing fails, record the failure mode and
+    keep the raw sizes so downstream triage has something to work with.
+    """
+    raw_stdout_bytes = len(stdout_text.encode("utf-8"))
+    raw_stderr_bytes = len(stderr_text.encode("utf-8"))
+
+    if not stdout_text.strip():
+        return RunStats(
+            exit_code=exit_code,
+            input_tokens=None,
+            output_tokens=None,
+            cache_read_tokens=None,
+            cache_creation_tokens=None,
+            usage_parse_error="empty_stdout",
+            raw_stdout_bytes=raw_stdout_bytes,
+            raw_stderr_bytes=raw_stderr_bytes,
+        )
+
+    try:
+        payload = json.loads(stdout_text)
+    except json.JSONDecodeError as exc:
+        return RunStats(
+            exit_code=exit_code,
+            input_tokens=None,
+            output_tokens=None,
+            cache_read_tokens=None,
+            cache_creation_tokens=None,
+            usage_parse_error=f"json_decode: {exc.msg}",
+            raw_stdout_bytes=raw_stdout_bytes,
+            raw_stderr_bytes=raw_stderr_bytes,
+        )
+
+    usage = payload.get("usage") if isinstance(payload, dict) else None
+    if not isinstance(usage, dict):
+        return RunStats(
+            exit_code=exit_code,
+            input_tokens=None,
+            output_tokens=None,
+            cache_read_tokens=None,
+            cache_creation_tokens=None,
+            usage_parse_error="usage_field_missing",
+            raw_stdout_bytes=raw_stdout_bytes,
+            raw_stderr_bytes=raw_stderr_bytes,
+        )
+
+    return RunStats(
+        exit_code=exit_code,
+        input_tokens=_int_or_none(usage.get("input_tokens")),
+        output_tokens=_int_or_none(usage.get("output_tokens")),
+        cache_read_tokens=_int_or_none(usage.get("cache_read_input_tokens")),
+        cache_creation_tokens=_int_or_none(usage.get("cache_creation_input_tokens")),
+        usage_parse_error=None,
+        raw_stdout_bytes=raw_stdout_bytes,
+        raw_stderr_bytes=raw_stderr_bytes,
+    )
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/harbor-adapter/job.yaml
+++ b/harbor-adapter/job.yaml
@@ -1,0 +1,56 @@
+# Harbor job: /do router dry run against terminal-bench-2, 5 tasks.
+#
+# Schema notes (verified 2026-04-19 against harbor 0.4.0 docs):
+#   - "dataset" accepts the "<org>/<name>@<version>" form used by
+#     ``harbor run --dataset terminal-bench@2.0``.
+#   - "agent" points at the module path of the BaseInstalledAgent
+#     subclass; Harbor imports it dynamically.
+#   - "environment.runtime: local" uses Docker on the host. Swap to
+#     "daytona" / "modal" / "e2b" / "runloop" with the corresponding
+#     API keys for cloud execution.
+#   - "task_filter" is the mechanism observed in the Harbor cookbook
+#     for running a subset. If the deployed Harbor build exposes a
+#     different knob (e.g. --tasks or --limit), run_dry_run.sh passes
+#     it on the CLI and this field is ignored.
+#
+# If any field name drifts in a newer Harbor release, cross-check with
+# ``harbor run --help`` before editing the adapter — the CLI is the
+# source of truth, not this file.
+
+name: do-router-dry-run-5
+
+dataset: terminal-bench@2.0
+
+# Run /do via the in-repo adapter.
+agent:
+  module: harbor_adapter.claude_code_do_agent
+  class: ClaudeCodeDoAgent
+
+# The adapter ignores --model; /do picks the model per-agent. This field
+# is present because Harbor requires it. Use opus-4-1 because that is what
+# /do's default pipeline agents target; swapping it does not change /do's
+# internal model routing.
+model: anthropic/claude-opus-4-1
+
+environment:
+  runtime: local          # Docker on host. Replace with 'daytona' etc. for cloud.
+  image: do-router-benchmark:latest
+  dockerfile: ./Dockerfile
+
+# Dry run cap. 89 tasks total in terminal-bench-2; 5 is enough to sanity
+# check token spend and pass/fail plumbing before scaling.
+task_filter:
+  limit: 5
+
+# Serial for the dry run. Concurrency can explode costs if /do misroutes
+# early tasks; easier to read serial logs when debugging.
+n_concurrent: 1
+
+# Env var passthrough. ANTHROPIC_API_KEY is read from the host shell by
+# Harbor and injected into the container for ``claude -p`` to consume.
+env_passthrough:
+  - ANTHROPIC_API_KEY
+
+# Persist everything so the results report can be assembled after the
+# fact. run_dry_run.sh moves this under results/<timestamp>/.
+output_dir: ./results/_pending

--- a/harbor-adapter/results/20260420T024430Z/report.md
+++ b/harbor-adapter/results/20260420T024430Z/report.md
@@ -1,0 +1,81 @@
+# /do Router Dry Run: Blocker Report
+
+Run date: 2026-04-19 (UTC timestamp 20260420T024430Z)
+Status: NOT EXECUTED - host prerequisites missing
+Branch: feat/harbor-do-router-benchmark
+
+This directory marks the run attempt and hosts the blocker report. No trials
+ran; no tokens were consumed; no pass/fail numbers are claimed. When the
+prerequisites below are satisfied, run_dry_run.sh will overwrite
+results/<new-timestamp>/ with real output.
+
+## Blockers Encountered
+
+Three host-side prerequisites are missing. All three are resolvable by the
+user; none can be worked around silently without falsifying the measurement,
+which is the point of the exercise.
+
+### 1. No container runtime on the host
+
+Harbor's local runtime requires Docker. The PyPI description is explicit:
+"This will launch the benchmark locally using Docker."
+
+Verified absent on this host: docker and podman are both not on PATH; neither
+/var/run/docker.sock nor /run/docker.sock exists; systemctl status docker
+reports the unit is unknown.
+
+Options to resolve:
+- Install Docker Engine (sudo apt install docker.io, add feedgen to the
+  docker group, re-log). Passwordless sudo is available on this host, so this
+  is a one-command fix after authorization.
+- Switch job.yaml's environment.runtime to daytona, modal, e2b, or runloop
+  and supply the matching cloud API key.
+
+### 2. ANTHROPIC_API_KEY not set
+
+The current shell session is authenticated via Claude Code OAuth
+(~/.claude.json contains oauthAccount). Harbor's Claude Code agent path
+requires an API key env var; the env grep showed no ANTHROPIC_API_KEY in
+scope.
+
+### 3. uv not installed
+
+Harbor installs via `uv tool install harbor`. uv is not on PATH.
+run_dry_run.sh auto-installs it on first run via the official installer
+script, so this is only a blocker in the sense that the first run will touch
+~/.local/bin/ and require a PATH refresh.
+
+## What Was Delivered
+
+All adapter code is shipped and reviewable on the feature branch. The
+scaffold is complete enough that once the three prerequisites above are met,
+the dry run is a single ./run_dry_run.sh invocation.
+
+- harbor-adapter/harbor_adapter/claude_code_do_agent.py - the
+  BaseInstalledAgent subclass with install(), @with_prompt_template run(),
+  and populate_context_post_run() populated. Token usage is parsed from
+  claude -p --output-format json rather than scraped from stderr.
+- harbor-adapter/Dockerfile - minimal Ubuntu 24.04 base with the agent user
+  and /logs + /workspace volumes wired. Node / Claude Code / toolkit are
+  layered by the adapter's install() method so image rebuilds are not needed
+  for toolkit updates.
+- harbor-adapter/job.yaml - terminal-bench-2.0 dataset, task_filter: limit:
+  5, env_passthrough: [ANTHROPIC_API_KEY], n_concurrent: 1.
+- harbor-adapter/run_dry_run.sh - single-command entry point with preflight
+  checks for the three blockers above.
+- harbor-adapter/scripts/build_report.py - assembles this report (or the
+  real one) from Harbor's trial outputs.
+- harbor-adapter/.gitignore - keeps report.md out of ignore rules but
+  excludes raw transcripts under raw/ so task content does not leak.
+- adr/benchmark-do-router-dry-run.md - decision rationale, alternatives,
+  risks, and the prerequisite gap.
+
+## Next Action
+
+One of:
+
+1. Authorize sudo apt install docker.io on this host, export
+   ANTHROPIC_API_KEY, and re-run ./run_dry_run.sh. Expected outcome: 5
+   trials, per-task token numbers, aggregate cost.
+2. Provide Daytona (or Modal / E2B / Runloop) credentials and switch
+   job.yaml's environment.runtime to the cloud runtime.

--- a/harbor-adapter/run_dry_run.sh
+++ b/harbor-adapter/run_dry_run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# One-command entry point for the 5-task dry run.
+#
+# Usage:
+#   ANTHROPIC_API_KEY=sk-... ./run_dry_run.sh
+#
+# The script is idempotent: re-running it creates a new timestamped
+# results directory and leaves previous runs alone.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+out_dir="$here/results/$timestamp"
+mkdir -p "$out_dir/raw"
+
+# --- Preflight ------------------------------------------------------------
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "ERROR: ANTHROPIC_API_KEY is not set in the environment." >&2
+  echo "       Export it before running: export ANTHROPIC_API_KEY=sk-..." >&2
+  exit 2
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker not found on PATH." >&2
+  echo "       Harbor's local runtime requires Docker. Install it or" >&2
+  echo "       switch environment.runtime in job.yaml to daytona/modal/e2b." >&2
+  exit 3
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv not found; attempting to install via the official script." >&2
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # The installer prints the path it added; fall back to the default.
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+if ! command -v harbor >/dev/null 2>&1; then
+  echo "harbor not found; installing via uv." >&2
+  uv tool install harbor
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# --- Build the image ------------------------------------------------------
+docker build -t do-router-benchmark:latest -f "$here/Dockerfile" "$here"
+
+# --- Run ------------------------------------------------------------------
+# Harbor writes trial artifacts under output_dir. The job.yaml points at
+# results/_pending; move that into results/<timestamp>/raw after the run.
+rm -rf "$here/results/_pending"
+
+set +e
+harbor run -c "$here/job.yaml" 2>&1 | tee "$out_dir/harbor-run.log"
+harbor_exit=${PIPESTATUS[0]}
+set -e
+
+if [[ -d "$here/results/_pending" ]]; then
+  mv "$here/results/_pending"/* "$out_dir/raw/" 2>/dev/null || true
+  rmdir "$here/results/_pending" 2>/dev/null || true
+fi
+
+# --- Report ---------------------------------------------------------------
+python3 "$here/scripts/build_report.py" \
+  --run-dir "$out_dir" \
+  --output "$out_dir/report.md"
+
+echo
+echo "Harbor exit code: $harbor_exit"
+echo "Results: $out_dir"
+echo "Report:  $out_dir/report.md"
+exit "$harbor_exit"

--- a/harbor-adapter/scripts/build_report.py
+++ b/harbor-adapter/scripts/build_report.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Assemble the per-task report from a completed Harbor run.
+
+Reads:
+  <run-dir>/raw/<trial>/reward.txt         -> pass/fail (1 or 0)
+  <run-dir>/raw/<trial>/context.json       -> token usage (claude_do_router)
+  <run-dir>/raw/<trial>/timing.json        -> wall time if Harbor emits it
+
+Writes a markdown report with per-task rows + aggregates.
+
+Pricing for cost estimate (anthropic.com/pricing as of 2026-04):
+  claude-opus-4-1:    $15 / M input, $75 / M output
+  claude-sonnet-4-5:  $3  / M input, $15 / M output
+  claude-haiku-4-5:   $1  / M input, $5  / M output
+
+The adapter does not know which model /do picked per trial; we apply Sonnet
+pricing as a conservative estimate and note it in the report. If per-trial
+model info is available in context.json, prefer that.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+# (input_per_mtok, output_per_mtok) in USD
+PRICE_TABLE: dict[str, tuple[float, float]] = {
+    "claude-opus-4-1": (15.0, 75.0),
+    "claude-sonnet-4-5": (3.0, 15.0),
+    "claude-haiku-4-5": (1.0, 5.0),
+}
+DEFAULT_MODEL_KEY = "claude-sonnet-4-5"
+
+
+@dataclass
+class TrialRow:
+    task: str
+    passed: bool | None
+    wall_seconds: float | None
+    input_tokens: int | None
+    output_tokens: int | None
+    cache_read_tokens: int | None
+    cache_creation_tokens: int | None
+    usage_parse_error: str | None
+    exit_code: int | None
+    estimated_cost_usd: float | None
+
+
+def _read_json(path: Path) -> dict | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return None
+
+
+def _read_reward(path: Path) -> bool | None:
+    if not path.is_file():
+        return None
+    text = path.read_text().strip()
+    if text == "1":
+        return True
+    if text == "0":
+        return False
+    return None
+
+
+def _estimate_cost(
+    input_tokens: int | None,
+    output_tokens: int | None,
+    model_key: str,
+) -> float | None:
+    if input_tokens is None or output_tokens is None:
+        return None
+    price_in, price_out = PRICE_TABLE.get(model_key, PRICE_TABLE[DEFAULT_MODEL_KEY])
+    return (input_tokens / 1_000_000.0) * price_in + (output_tokens / 1_000_000.0) * price_out
+
+
+def collect_trials(raw_dir: Path) -> list[TrialRow]:
+    rows: list[TrialRow] = []
+    if not raw_dir.is_dir():
+        return rows
+
+    for trial_dir in sorted(raw_dir.iterdir()):
+        if not trial_dir.is_dir():
+            continue
+        reward_path = trial_dir / "verifier" / "reward.txt"
+        if not reward_path.is_file():
+            # Fallback: some Harbor versions drop it at trial root.
+            reward_path = trial_dir / "reward.txt"
+        passed = _read_reward(reward_path)
+
+        context = _read_json(trial_dir / "context.json") or {}
+        usage = (
+            context.get("metadata", {}).get("claude_do_router", {}) if isinstance(context.get("metadata"), dict) else {}
+        )
+        timing = _read_json(trial_dir / "timing.json") or {}
+
+        input_tokens = usage.get("input_tokens")
+        output_tokens = usage.get("output_tokens")
+        cost = _estimate_cost(input_tokens, output_tokens, DEFAULT_MODEL_KEY)
+
+        rows.append(
+            TrialRow(
+                task=trial_dir.name,
+                passed=passed,
+                wall_seconds=timing.get("wall_seconds"),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=usage.get("cache_read_tokens"),
+                cache_creation_tokens=usage.get("cache_creation_tokens"),
+                usage_parse_error=usage.get("usage_parse_error"),
+                exit_code=usage.get("exit_code"),
+                estimated_cost_usd=cost,
+            )
+        )
+    return rows
+
+
+def render_report(rows: list[TrialRow], run_dir: Path) -> str:
+    lines: list[str] = []
+    lines.append("# /do Router Dry Run: terminal-bench-2 x 5")
+    lines.append("")
+    lines.append(f"Run directory: `{run_dir}`")
+    lines.append("")
+
+    if not rows:
+        lines.append("No trials found. The Harbor run did not produce any trial")
+        lines.append("directories under `raw/`. Inspect `harbor-run.log` for the")
+        lines.append("failure mode.")
+        return "\n".join(lines) + "\n"
+
+    lines.append("## Per-task results")
+    lines.append("")
+    lines.append("| Task | Pass | Wall (s) | Input tok | Output tok | Cache read | Est. cost (USD) | Notes |")
+    lines.append("|------|------|----------|-----------|------------|-----------|-----------------|-------|")
+    for row in rows:
+        pass_cell = "pass" if row.passed is True else "fail" if row.passed is False else "?"
+        wall = f"{row.wall_seconds:.1f}" if row.wall_seconds is not None else "?"
+        in_tok = f"{row.input_tokens:,}" if row.input_tokens is not None else "?"
+        out_tok = f"{row.output_tokens:,}" if row.output_tokens is not None else "?"
+        cache = f"{row.cache_read_tokens:,}" if row.cache_read_tokens is not None else "?"
+        cost = f"${row.estimated_cost_usd:.4f}" if row.estimated_cost_usd is not None else "?"
+        notes_parts: list[str] = []
+        if row.exit_code is not None and row.exit_code != 0:
+            notes_parts.append(f"exit={row.exit_code}")
+        if row.usage_parse_error:
+            notes_parts.append(row.usage_parse_error)
+        notes = "; ".join(notes_parts) or ""
+        lines.append(f"| {row.task} | {pass_cell} | {wall} | {in_tok} | {out_tok} | {cache} | {cost} | {notes} |")
+
+    # Aggregates
+    passed = sum(1 for r in rows if r.passed is True)
+    failed = sum(1 for r in rows if r.passed is False)
+    unknown = sum(1 for r in rows if r.passed is None)
+    total_in = sum(r.input_tokens or 0 for r in rows)
+    total_out = sum(r.output_tokens or 0 for r in rows)
+    total_cost = sum(r.estimated_cost_usd or 0.0 for r in rows)
+
+    lines.append("")
+    lines.append("## Aggregates")
+    lines.append("")
+    lines.append(f"- Trials: {len(rows)} ({passed} pass, {failed} fail, {unknown} unknown)")
+    lines.append(f"- Total input tokens: {total_in:,}")
+    lines.append(f"- Total output tokens: {total_out:,}")
+    lines.append(f"- Estimated total cost (Sonnet pricing): ${total_cost:.4f}")
+    lines.append("")
+    lines.append(
+        "Cost estimate uses claude-sonnet-4-5 pricing as a conservative "
+        "approximation. /do routes to different agents per task; replace "
+        "this estimate with actual per-agent pricing once per-trial model "
+        "info is wired through."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    rows = collect_trials(args.run_dir / "raw")
+    report = render_report(rows, args.run_dir)
+    args.output.write_text(report)
+    print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a `BaseInstalledAgent` subclass that runs the toolkit's /do router against terminal-bench-2.0 via the Harbor framework. Inside the Harbor container: install Node 20 + Claude Code CLI + a pinned toolkit clone, then `claude -p --output-format json --dangerously-skip-permissions` with no agent flag so /do dispatches dynamically.
- Token usage is parsed from Claude Code's JSON envelope (deterministic) rather than scraped from stderr. A report builder walks Harbor's trial outputs and writes a per-task markdown table with pass/fail, wall time, tokens, and a Sonnet-pricing cost estimate.
- The scaffold is single-command runnable (`./run_dry_run.sh`) with preflight checks for Docker, ANTHROPIC_API_KEY, and uv. `.gitignore` keeps raw transcripts under `results/<ts>/raw/` local-only; only the summary `report.md` is committed.

## Dry-run outcome

**5-task run could not execute in this environment.** The host is missing three prerequisites:

1. **No container runtime.** `docker` and `podman` absent; no docker socket; `systemctl status docker` reports the unit is unknown. Harbor's local runtime requires Docker per its PyPI description.
2. **ANTHROPIC_API_KEY not set.** Host is authenticated via Claude Code OAuth (`~/.claude.json:oauthAccount`); Harbor's `claude-code` agent path needs the API key as an env var.
3. **uv not installed.** Harbor installs via `uv tool install harbor`. `run_dry_run.sh` auto-installs uv on first run, but that's still a one-time host mutation.

The blocker report lives at `harbor-adapter/results/20260420T024430Z/report.md` with concrete next-action options (install Docker + export key, or switch `environment.runtime` to a cloud sandbox like Daytona).

## Next steps

- **If local:** authorize `sudo apt install docker.io`, export `ANTHROPIC_API_KEY`, run `./run_dry_run.sh`. Real per-task numbers replace the blocker report.
- **If cloud:** set `DAYTONA_API_KEY` (or Modal / E2B / Runloop equivalent), change `job.yaml:environment.runtime` accordingly, re-run.
- **After the dry run:** decide scale (89 tasks? concurrency > 1?), decide whether non-essential hooks should be disabled in the container (they run in the benchmark and burn tokens), and look at whether /do misroutes any terminal-bench task phrasings that would benefit from a trigger tune.

## Test plan

- [ ] Once Docker is available on the host, run `./run_dry_run.sh` and confirm 5 terminal-bench-2 tasks execute end-to-end.
- [ ] Verify `report.md` is populated with per-task tokens (not `?` placeholders) — that's the proof that `--output-format json` parsing works against the real Claude Code CLI.
- [ ] Verify `raw/` is gitignored and `report.md` is not (already validated locally via `git check-ignore`).
- [ ] CI (ruff, pytest): Python files in the adapter are ruff-clean and format-clean; no tests added yet because there's nothing to test without the live Harbor harness.