### PR TITLE
fix(do): restore resolve-dispatch validation after Haiku routes

### DIFF
--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -80,6 +80,32 @@ def cmd_record(args):
     )
 
 
+def cmd_record_invalid_route(args: argparse.Namespace) -> None:
+    """Record that the router picked a name that did not resolve to a real file.
+
+    Called from the /do Phase 2.5 validation failure branch so we can track
+    how often the router returns names outside the canonical agent/skill lists.
+    """
+    value = f"router picked invalid {args.kind}: {args.name}"
+    if args.reason:
+        value = f"{value} | reason: {args.reason}"
+
+    key = f"{args.kind}:{args.name}"
+    result = record_learning(
+        topic="invalid-route",
+        key=key,
+        value=value,
+        category="effectiveness",
+        tags=["invalid-route", "routing-feedback", args.kind],
+        source="hook:resolve-dispatch",
+    )
+    action = "Updated" if not result["is_new"] else "Recorded"
+    print(
+        f"{action}: [invalid-route] {key} "
+        f"(confidence: {result['confidence']:.2f}, observations: {result['observation_count']})"
+    )
+
+
 def cmd_query(args):
     results = query_learnings(
         topic=args.topic,
@@ -740,6 +766,29 @@ def main():
     p_record.add_argument("--source-detail", help="Additional source context")
     p_record.add_argument("--project-path", help="Project path")
     p_record.set_defaults(func=cmd_record)
+
+    # record-invalid-route — log when resolve-dispatch rejects a router pick
+    p_rec_invalid = subparsers.add_parser(
+        "record-invalid-route",
+        help="Record that the router picked a name that does not resolve to a real file",
+    )
+    p_rec_invalid.add_argument(
+        "--kind",
+        required=True,
+        choices=["agent", "skill"],
+        help="Which kind of name the router got wrong",
+    )
+    p_rec_invalid.add_argument(
+        "--name",
+        required=True,
+        help="The invalid name the router returned",
+    )
+    p_rec_invalid.add_argument(
+        "--reason",
+        default="",
+        help="Optional context (e.g. closest-match suggestions from resolve-dispatch)",
+    )
+    p_rec_invalid.set_defaults(func=cmd_record_invalid_route)
 
     # query
     p_query = subparsers.add_parser("query", help="Query learnings")

--- a/scripts/resolve-dispatch.py
+++ b/scripts/resolve-dispatch.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Validate that a Haiku routing decision names real agent and skill files.
+
+The Haiku router returns ``agent`` and ``skill`` names. Before the parent
+dispatches work, this script confirms those names resolve to files on disk.
+If the router picks a name that does not exist, we surface the invalid name
+and the three closest matches so the user can narrow their request.
+
+Canonical sources:
+
+- Agents: ``~/.toolkit/agents/INDEX.json`` lists every toolkit agent by name.
+  A repo-local ``.claude/agents/<name>.md`` in the current working directory
+  overrides the toolkit entry of the same name.
+- Skills: globbed from ``~/.toolkit/skills/*/SKILL.md``. A repo-local
+  ``.claude/skills/<name>/SKILL.md`` in the current working directory
+  overrides the toolkit entry.
+
+Usage:
+    python3 scripts/resolve-dispatch.py --agent golang-general-engineer --skill go-patterns
+    python3 scripts/resolve-dispatch.py --agent python-general-engineer --skill ""
+    python3 scripts/resolve-dispatch.py --agent "" --skill pr-workflow
+
+Exit codes:
+    0 — Every non-empty argument resolves to an existing file.
+    2 — At least one argument does not resolve. Stderr names the invalid
+        value and lists the three closest matches from the canonical lists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+TOOLKIT_DIR = Path.home() / ".toolkit"
+AGENTS_DIR = TOOLKIT_DIR / "agents"
+SKILLS_DIR = TOOLKIT_DIR / "skills"
+AGENTS_INDEX = AGENTS_DIR / "INDEX.json"
+
+
+def levenshtein(a: str, b: str) -> int:
+    """Compute the Levenshtein edit distance between two strings.
+
+    Pure-Python implementation with O(len(a) * len(b)) time and
+    O(min(len(a), len(b))) memory. Used to rank close-match suggestions.
+    """
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    # Keep the shorter string as the inner loop for memory efficiency.
+    if len(a) < len(b):
+        a, b = b, a
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        current = [i] + [0] * len(b)
+        for j, cb in enumerate(b, start=1):
+            cost = 0 if ca == cb else 1
+            current[j] = min(
+                current[j - 1] + 1,  # insertion
+                previous[j] + 1,  # deletion
+                previous[j - 1] + cost,  # substitution
+            )
+        previous = current
+    return previous[-1]
+
+
+def load_canonical_agents() -> set[str]:
+    """Return the set of canonical agent names.
+
+    Reads ``~/.toolkit/agents/INDEX.json`` and unions any repo-local agent
+    files under ``./.claude/agents/*.md``. Repo-local overrides add names
+    that exist locally but not in the toolkit index.
+    """
+    names: set[str] = set()
+
+    try:
+        payload = json.loads(AGENTS_INDEX.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        payload = {}
+    agents = payload.get("agents", {}) if isinstance(payload, dict) else {}
+    if isinstance(agents, dict):
+        names.update(agents.keys())
+
+    local_dir = Path.cwd() / ".claude" / "agents"
+    if local_dir.is_dir():
+        for md in local_dir.glob("*.md"):
+            names.add(md.stem)
+
+    return names
+
+
+def load_canonical_skills() -> set[str]:
+    """Return the set of canonical skill names.
+
+    Globs ``~/.toolkit/skills/*/SKILL.md`` and unions repo-local skill
+    directories under ``./.claude/skills/*/SKILL.md``. Repo-local overrides
+    add names that exist locally but not in the toolkit.
+    """
+    names: set[str] = set()
+
+    if SKILLS_DIR.is_dir():
+        for skill_md in SKILLS_DIR.glob("*/SKILL.md"):
+            names.add(skill_md.parent.name)
+
+    local_dir = Path.cwd() / ".claude" / "skills"
+    if local_dir.is_dir():
+        for skill_md in local_dir.glob("*/SKILL.md"):
+            names.add(skill_md.parent.name)
+
+    return names
+
+
+def resolve_agent(name: str) -> Path | None:
+    """Return the resolved path for an agent name, or None if missing.
+
+    Repo-local ``./.claude/agents/<name>.md`` wins over the toolkit copy
+    when both exist.
+    """
+    local = Path.cwd() / ".claude" / "agents" / f"{name}.md"
+    if local.is_file():
+        return local
+    toolkit = AGENTS_DIR / f"{name}.md"
+    if toolkit.is_file():
+        return toolkit
+    # Fall back to the INDEX.json pointer when the file is not at the
+    # default location (the index records the canonical ``file`` path).
+    try:
+        payload = json.loads(AGENTS_INDEX.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    agents = payload.get("agents", {}) if isinstance(payload, dict) else {}
+    entry = agents.get(name) if isinstance(agents, dict) else None
+    if isinstance(entry, dict):
+        file_ref = entry.get("file")
+        if isinstance(file_ref, str):
+            # Index paths are repo-relative; map them under ~/.toolkit.
+            indexed = TOOLKIT_DIR / file_ref
+            if indexed.is_file():
+                return indexed
+    return None
+
+
+def resolve_skill(name: str) -> Path | None:
+    """Return the resolved path for a skill name, or None if missing."""
+    local = Path.cwd() / ".claude" / "skills" / name / "SKILL.md"
+    if local.is_file():
+        return local
+    toolkit = SKILLS_DIR / name / "SKILL.md"
+    if toolkit.is_file():
+        return toolkit
+    return None
+
+
+def closest_matches(needle: str, haystack: set[str], limit: int = 3) -> list[str]:
+    """Return up to ``limit`` closest names to ``needle`` by edit distance."""
+    if not haystack:
+        return []
+    scored = sorted(haystack, key=lambda n: (levenshtein(needle, n), n))
+    return scored[:limit]
+
+
+def validate(kind: str, name: str, canonical: set[str], resolver) -> str | None:
+    """Return an error string if ``name`` does not resolve, else None.
+
+    ``kind`` is "agent" or "skill" for the error message. ``resolver`` is
+    the function that maps a name to a Path or None.
+    """
+    if resolver(name) is not None:
+        return None
+    matches = closest_matches(name, canonical)
+    if matches:
+        suggestion = ", ".join(matches)
+    else:
+        suggestion = "(no close matches found)"
+    return f"router picked invalid {kind}: {name}. closest matches: {suggestion}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a Haiku routing decision against the canonical agent and skill lists."
+    )
+    parser.add_argument(
+        "--agent",
+        default="",
+        help="Agent name from the router, or empty string when the router returned null.",
+    )
+    parser.add_argument(
+        "--skill",
+        default="",
+        help="Skill name from the router, or empty string when the router returned null.",
+    )
+    args = parser.parse_args(argv)
+
+    agent = args.agent.strip()
+    skill = args.skill.strip()
+
+    if not agent and not skill:
+        print(
+            "resolve-dispatch: at least one of --agent or --skill must be non-empty.",
+            file=sys.stderr,
+        )
+        return 2
+
+    errors: list[str] = []
+
+    if agent:
+        canonical_agents = load_canonical_agents()
+        err = validate("agent", agent, canonical_agents, resolve_agent)
+        if err:
+            errors.append(err)
+
+    if skill:
+        canonical_skills = load_canonical_skills()
+        err = validate("skill", skill, canonical_skills, resolve_skill)
+        if err:
+            errors.append(err)
+
+    if errors:
+        for msg in errors:
+            print(msg, file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_learning_db_invalid_route.py
+++ b/scripts/tests/test_learning_db_invalid_route.py
@@ -1,0 +1,135 @@
+"""Tests for the learning-db.py ``record-invalid-route`` subcommand.
+
+Covers:
+- A new invalid-route record is inserted with the correct topic/key/category.
+- Repeated calls with the same kind+name increment observation_count.
+- Different names produce distinct rows.
+- Missing --kind or --name fails argparse validation.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repo hooks/lib is on the path for learning_db_v2.
+_repo_root = Path(__file__).resolve().parent.parent.parent
+_repo_hooks_lib = str(_repo_root / "hooks" / "lib")
+if _repo_hooks_lib not in sys.path:
+    sys.path.insert(0, _repo_hooks_lib)
+
+_SCRIPT_PATH = _repo_root / "scripts" / "learning-db.py"
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the learning DB at a temp directory so tests never touch production data."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+
+    import learning_db_v2
+
+    monkeypatch.setattr(learning_db_v2, "_initialized", False)
+    if "learning_db_v2" in sys.modules:
+        importlib.reload(sys.modules["learning_db_v2"])
+    return db_dir
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    """Invoke the learning-db.py CLI as a subprocess with CLAUDE_LEARNING_DIR honored."""
+    import os
+
+    env = os.environ.copy()
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT_PATH), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_record_invalid_route_creates_row(isolated_db: Path) -> None:
+    """The first call inserts a fresh invalid-route row."""
+    result = _run_cli("record-invalid-route", "--kind", "agent", "--name", "benchmark")
+    assert result.returncode == 0, result.stderr
+    assert "Recorded: [invalid-route]" in result.stdout
+
+    # Verify the row landed in the DB with the expected shape.
+    import learning_db_v2
+
+    rows = learning_db_v2.query_learnings(topic="invalid-route")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["topic"] == "invalid-route"
+    assert row["key"] == "agent:benchmark"
+    assert row["category"] == "effectiveness"
+    assert "router picked invalid agent: benchmark" in row["value"]
+    assert row["observation_count"] == 1
+
+
+def test_record_invalid_route_increments_observation_count(isolated_db: Path) -> None:
+    """Calling twice with the same kind+name updates the existing row."""
+    r1 = _run_cli("record-invalid-route", "--kind", "agent", "--name", "benchmark")
+    assert r1.returncode == 0, r1.stderr
+    r2 = _run_cli("record-invalid-route", "--kind", "agent", "--name", "benchmark")
+    assert r2.returncode == 0, r2.stderr
+
+    import learning_db_v2
+
+    rows = learning_db_v2.query_learnings(topic="invalid-route")
+    assert len(rows) == 1
+    assert rows[0]["observation_count"] == 2
+
+
+def test_record_invalid_route_distinguishes_kind_and_name(isolated_db: Path) -> None:
+    """Different kinds or names create distinct rows."""
+    _run_cli("record-invalid-route", "--kind", "agent", "--name", "benchmark")
+    _run_cli("record-invalid-route", "--kind", "skill", "--name", "benchmark")
+    _run_cli("record-invalid-route", "--kind", "agent", "--name", "fake-other")
+
+    import learning_db_v2
+
+    rows = learning_db_v2.query_learnings(topic="invalid-route", limit=10)
+    keys = {r["key"] for r in rows}
+    assert keys == {"agent:benchmark", "skill:benchmark", "agent:fake-other"}
+
+
+def test_record_invalid_route_with_reason(isolated_db: Path) -> None:
+    """The --reason flag appends context to the stored value."""
+    result = _run_cli(
+        "record-invalid-route",
+        "--kind",
+        "agent",
+        "--name",
+        "benchmark",
+        "--reason",
+        "closest matches: code-reviewer, python-general-engineer",
+    )
+    assert result.returncode == 0, result.stderr
+
+    import learning_db_v2
+
+    rows = learning_db_v2.query_learnings(topic="invalid-route")
+    assert len(rows) == 1
+    assert "closest matches: code-reviewer" in rows[0]["value"]
+
+
+def test_record_invalid_route_rejects_missing_kind(isolated_db: Path) -> None:
+    """Argparse rejects invocation without --kind."""
+    result = _run_cli("record-invalid-route", "--name", "benchmark")
+    assert result.returncode != 0
+    assert "required" in result.stderr.lower() or "--kind" in result.stderr
+
+
+def test_record_invalid_route_rejects_invalid_kind(isolated_db: Path) -> None:
+    """Argparse rejects kinds outside {agent, skill}."""
+    result = _run_cli("record-invalid-route", "--kind", "other", "--name", "benchmark")
+    assert result.returncode != 0
+    assert "invalid choice" in result.stderr.lower()

--- a/scripts/tests/test_resolve_dispatch.py
+++ b/scripts/tests/test_resolve_dispatch.py
@@ -1,0 +1,285 @@
+"""Tests for scripts/resolve-dispatch.py.
+
+Covers:
+- Valid agent and valid skill exit 0 with no stderr.
+- Invalid agent with close match exits 2 with a "closest matches" message.
+- Invalid skill with no close match exits 2 and still reports.
+- Both arguments empty exits 2 with an explanatory stderr line.
+- Repo-local ``.claude/agents/<name>.md`` overrides a missing toolkit entry.
+- Repo-local ``.claude/skills/<name>/SKILL.md`` overrides a missing toolkit entry.
+- Levenshtein ranking returns the expected close matches.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the hyphen-named module via importlib
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH = Path(__file__).parent.parent / "resolve-dispatch.py"
+_spec = importlib.util.spec_from_file_location("resolve_dispatch", _SCRIPT_PATH)
+_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+sys.modules["resolve_dispatch"] = _mod
+
+levenshtein = _mod.levenshtein
+closest_matches = _mod.closest_matches
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: build a fake ~/.toolkit tree so tests never touch real files
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_toolkit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a fake ~/.toolkit with INDEX.json and skills glob targets.
+
+    Contains three agents (golang-general-engineer, python-general-engineer,
+    code-reviewer) and three skills (go-patterns, pr-workflow, systematic-debugging).
+    """
+    toolkit = tmp_path / "toolkit"
+    agents_dir = toolkit / "agents"
+    skills_dir = toolkit / "skills"
+    agents_dir.mkdir(parents=True)
+    skills_dir.mkdir(parents=True)
+
+    # Agent markdown files.
+    for name in ("golang-general-engineer", "python-general-engineer", "code-reviewer"):
+        (agents_dir / f"{name}.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    # INDEX.json recording the canonical agent set.
+    index_payload = {
+        "version": "1.0",
+        "agents": {
+            "golang-general-engineer": {
+                "file": "agents/golang-general-engineer.md",
+                "short_description": "Go",
+                "triggers": ["go", "golang"],
+            },
+            "python-general-engineer": {
+                "file": "agents/python-general-engineer.md",
+                "short_description": "Python",
+                "triggers": ["python"],
+            },
+            "code-reviewer": {
+                "file": "agents/code-reviewer.md",
+                "short_description": "Review",
+                "triggers": ["review"],
+            },
+        },
+    }
+    (agents_dir / "INDEX.json").write_text(json.dumps(index_payload), encoding="utf-8")
+
+    # Skill directories, each with a SKILL.md.
+    for skill_name in ("go-patterns", "pr-workflow", "systematic-debugging"):
+        sdir = skills_dir / skill_name
+        sdir.mkdir()
+        (sdir / "SKILL.md").write_text(f"# {skill_name}\n", encoding="utf-8")
+
+    # Redirect Path.home() at the module level so the resolver reads our fake tree.
+    monkeypatch.setattr(_mod, "TOOLKIT_DIR", toolkit)
+    monkeypatch.setattr(_mod, "AGENTS_DIR", toolkit / "agents")
+    monkeypatch.setattr(_mod, "SKILLS_DIR", toolkit / "skills")
+    monkeypatch.setattr(_mod, "AGENTS_INDEX", toolkit / "agents" / "INDEX.json")
+
+    return toolkit
+
+
+@pytest.fixture
+def isolated_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Change into a scratch directory so repo-local .claude/* lookups start empty."""
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+    return work
+
+
+# ---------------------------------------------------------------------------
+# levenshtein + closest_matches
+# ---------------------------------------------------------------------------
+
+
+def test_levenshtein_identical_is_zero() -> None:
+    assert levenshtein("abc", "abc") == 0
+
+
+def test_levenshtein_one_char_edit() -> None:
+    assert levenshtein("cat", "cut") == 1
+    assert levenshtein("benchmark", "benchmarks") == 1
+
+
+def test_levenshtein_handles_empty() -> None:
+    assert levenshtein("", "abc") == 3
+    assert levenshtein("abc", "") == 3
+    assert levenshtein("", "") == 0
+
+
+def test_closest_matches_ranks_by_distance() -> None:
+    haystack = {"golang-general-engineer", "python-general-engineer", "code-reviewer"}
+    matches = closest_matches("golang-gen-engineer", haystack, limit=3)
+    # Closest match must be the golang agent.
+    assert matches[0] == "golang-general-engineer"
+    assert len(matches) == 3
+
+
+def test_closest_matches_empty_haystack() -> None:
+    assert closest_matches("anything", set()) == []
+
+
+# ---------------------------------------------------------------------------
+# main() — direct function call (fast, no subprocess)
+# ---------------------------------------------------------------------------
+
+
+def test_valid_agent_and_skill_exit_zero(fake_toolkit: Path, isolated_cwd: Path, capsys: pytest.CaptureFixture) -> None:
+    rc = _mod.main(["--agent", "golang-general-engineer", "--skill", "go-patterns"])
+    out = capsys.readouterr()
+    assert rc == 0
+    assert out.err == ""
+
+
+def test_valid_agent_only(fake_toolkit: Path, isolated_cwd: Path, capsys: pytest.CaptureFixture) -> None:
+    rc = _mod.main(["--agent", "python-general-engineer", "--skill", ""])
+    out = capsys.readouterr()
+    assert rc == 0
+    assert out.err == ""
+
+
+def test_valid_skill_only(fake_toolkit: Path, isolated_cwd: Path, capsys: pytest.CaptureFixture) -> None:
+    rc = _mod.main(["--agent", "", "--skill", "pr-workflow"])
+    out = capsys.readouterr()
+    assert rc == 0
+    assert out.err == ""
+
+
+def test_invalid_agent_with_close_match(fake_toolkit: Path, isolated_cwd: Path, capsys: pytest.CaptureFixture) -> None:
+    # "benchmark" does not exist; the real fake agents are far away but
+    # closest_matches still returns a ranked list of three names.
+    rc = _mod.main(["--agent", "benchmark", "--skill", ""])
+    out = capsys.readouterr()
+    assert rc == 2
+    assert "router picked invalid agent: benchmark" in out.err
+    assert "closest matches:" in out.err
+
+
+def test_invalid_agent_typo_suggests_real_agent(
+    fake_toolkit: Path, isolated_cwd: Path, capsys: pytest.CaptureFixture
+) -> None:
+    # Typo of "python-general-engineer".
+    rc = _mod.main(["--agent", "python-general-enginer", "--skill", ""])
+    out = capsys.readouterr()
+    assert rc == 2
+    assert "python-general-engineer" in out.err
+
+
+def test_invalid_skill_still_reports(fake_toolkit: Path, isolated_cwd: Path, capsys: pytest.CaptureFixture) -> None:
+    rc = _mod.main(["--agent", "", "--skill", "totally-made-up-skill"])
+    out = capsys.readouterr()
+    assert rc == 2
+    assert "router picked invalid skill: totally-made-up-skill" in out.err
+    # Three skills in the fake toolkit, so we always get a ranked list.
+    assert "closest matches:" in out.err
+
+
+def test_both_empty_is_error(fake_toolkit: Path, isolated_cwd: Path, capsys: pytest.CaptureFixture) -> None:
+    rc = _mod.main(["--agent", "", "--skill", ""])
+    out = capsys.readouterr()
+    assert rc == 2
+    assert "at least one of --agent or --skill must be non-empty" in out.err
+
+
+def test_both_invalid_reports_both(fake_toolkit: Path, isolated_cwd: Path, capsys: pytest.CaptureFixture) -> None:
+    rc = _mod.main(["--agent", "not-an-agent", "--skill", "not-a-skill"])
+    out = capsys.readouterr()
+    assert rc == 2
+    assert "router picked invalid agent: not-an-agent" in out.err
+    assert "router picked invalid skill: not-a-skill" in out.err
+
+
+# ---------------------------------------------------------------------------
+# Repo-local overrides
+# ---------------------------------------------------------------------------
+
+
+def test_repo_local_agent_override_wins(fake_toolkit: Path, isolated_cwd: Path, capsys: pytest.CaptureFixture) -> None:
+    """A repo-local .claude/agents/<name>.md adds an agent not in the toolkit."""
+    local_agents = isolated_cwd / ".claude" / "agents"
+    local_agents.mkdir(parents=True)
+    (local_agents / "local-only-agent.md").write_text("# local-only-agent\n", encoding="utf-8")
+
+    rc = _mod.main(["--agent", "local-only-agent", "--skill", ""])
+    out = capsys.readouterr()
+    assert rc == 0
+    assert out.err == ""
+
+
+def test_repo_local_skill_override_wins(fake_toolkit: Path, isolated_cwd: Path, capsys: pytest.CaptureFixture) -> None:
+    """A repo-local .claude/skills/<name>/SKILL.md adds a skill not in the toolkit."""
+    local_skill_dir = isolated_cwd / ".claude" / "skills" / "local-only-skill"
+    local_skill_dir.mkdir(parents=True)
+    (local_skill_dir / "SKILL.md").write_text("# local-only-skill\n", encoding="utf-8")
+
+    rc = _mod.main(["--agent", "", "--skill", "local-only-skill"])
+    out = capsys.readouterr()
+    assert rc == 0
+    assert out.err == ""
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: run the real script as a subprocess to exercise argparse + exit
+# ---------------------------------------------------------------------------
+
+
+def test_script_subprocess_exit_code(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invoke the script directly to confirm the CLI wiring and exit codes."""
+    # Build a fake toolkit the subprocess will see via HOME.
+    home = tmp_path / "home"
+    home.mkdir()
+    agents_dir = home / ".toolkit" / "agents"
+    skills_dir = home / ".toolkit" / "skills"
+    agents_dir.mkdir(parents=True)
+    skills_dir.mkdir(parents=True)
+    (agents_dir / "only-agent.md").write_text("# only-agent\n", encoding="utf-8")
+    (agents_dir / "INDEX.json").write_text(
+        json.dumps({"agents": {"only-agent": {"file": "agents/only-agent.md"}}}),
+        encoding="utf-8",
+    )
+    (skills_dir / "only-skill").mkdir()
+    (skills_dir / "only-skill" / "SKILL.md").write_text("# only-skill\n", encoding="utf-8")
+
+    env = {"HOME": str(home), "PATH": "/usr/bin:/bin"}
+    work = tmp_path / "cwd"
+    work.mkdir()
+
+    # Valid invocation -> exit 0.
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT_PATH), "--agent", "only-agent", "--skill", "only-skill"],
+        env=env,
+        cwd=str(work),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+
+    # Invalid invocation -> exit 2 with stderr.
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT_PATH), "--agent", "not-real", "--skill", ""],
+        env=env,
+        cwd=str(work),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "router picked invalid agent: not-real" in result.stderr

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -82,6 +82,46 @@ invent a fallback.
 
 ---
 
+## Phase 2.5: VALIDATE
+
+Before printing the banner or dispatching the worker, confirm Haiku's chosen
+`agent` and `skill` actually exist on disk. This catches the case where the
+router returns a name that is not in the canonical toolkit (`INDEX.json` and
+`~/.toolkit/skills/*/SKILL.md`).
+
+If either `agent` or `skill` is non-null, run:
+
+```bash
+python3 ~/.claude/scripts/resolve-dispatch.py \
+    --agent "<agent-or-empty>" \
+    --skill "<skill-or-empty>"
+```
+
+Substitute empty strings for any field Haiku returned as null.
+
+- **Exit 0**: both resolved. Proceed to Phase 3 unchanged.
+- **Exit 2**: at least one name does not exist. The script prints
+  "router picked invalid <kind>: <name>. closest matches: ..." on stderr.
+  Do the following:
+  1. Record the failure so we can measure how often the router picks
+     nonexistent names over time. Run this once per invalid name reported:
+
+     ```bash
+     python3 ~/.claude/scripts/learning-db.py record-invalid-route \
+         --kind "<agent|skill>" \
+         --name "<name-the-router-returned>" \
+         --reason "<resolve-dispatch stderr line for this name>"
+     ```
+
+  2. Surface the stderr back to the user with this framing:
+
+     > Router picked an invalid name: `<stderr>`. Please narrow your request.
+
+  3. Stop. Do NOT retry Haiku (retries waste tokens chasing the same mistake).
+     Do NOT invent a fallback agent or skill.
+
+---
+
 ## Phase 3: DISPATCH
 
 1. Print the routing banner exactly as Haiku provided it:
@@ -128,4 +168,7 @@ Use the values from Haiku's JSON verbatim. Do not add commentary.
 - `~/.claude/skills/do/haiku-router-prompt.md`: self-contained routing prompt
   Haiku executes. All routing knowledge (agent names, skill names, triggers,
   routing tables) lives behind this file and is never loaded into the parent.
-- `~/.claude/scripts/learning-db.py`: routing outcome recorder (optional).
+- `~/.claude/scripts/resolve-dispatch.py`: Phase 2.5 validator. Exits 0 when
+  every non-null name resolves; exits 2 with a stderr suggestion line otherwise.
+- `~/.claude/scripts/learning-db.py`: routing outcome recorder (Phase 4) and
+  invalid-route logger (Phase 2.5 failure branch).

--- a/skills/do/haiku-router-prompt.md
+++ b/skills/do/haiku-router-prompt.md
@@ -116,4 +116,10 @@ No markdown fences. No explanation of your reasoning outside the JSON.
 }
 ```
 
-Do not add extra fields. Do not wrap in markdown. Do not narrate.
+- Do not invent agent or skill names. If your chosen name is not in the
+  `INDEX.json` you read or the `~/.toolkit/skills/*/SKILL.md` glob result
+  you saw, return `agent: null`, `skill: null`, `confidence: "low"`, and
+  explain the miss in `reasoning`. A downstream validator rejects any
+  name that does not resolve to a real file and wastes a round trip on
+  every invented name.
+- Do not add extra fields. Do not wrap in markdown. Do not narrate.


### PR DESCRIPTION
## Summary

- Restores `scripts/resolve-dispatch.py` as a Phase 2.5 validator between the Haiku router and worker dispatch. The script reads `~/.toolkit/agents/INDEX.json` and globs `~/.toolkit/skills/*/SKILL.md` (with repo-local `.claude/agents` and `.claude/skills` overrides), confirms the router's names resolve, and prints three closest matches by Levenshtein distance on a miss.
- Adds `learning-db.py record-invalid-route` so the failure branch logs every name the router returns that is not on disk. Data lands under topic `invalid-route`, category `effectiveness`, keyed by `<kind>:<name>` so repeated observations increment in place.
- Wires Phase 2.5 into `skills/do/SKILL.md`: exit 0 flows to Phase 3 unchanged; exit 2 records the miss, surfaces stderr to the user, and stops without retrying Haiku or inventing a fallback.
- Adds a hardening bullet to `skills/do/haiku-router-prompt.md` Step 6 telling Haiku to return `null`/`low` when its chosen name is not in the sources it read.

PR #517 removed the pre-Haiku validation scripts; this restores the layer at the correct place in the new two-stage pipeline (after Haiku's pick, before dispatch).

## Files changed

- `scripts/resolve-dispatch.py` (new)
- `scripts/learning-db.py` — `record-invalid-route` subcommand
- `scripts/tests/test_resolve_dispatch.py` (new, 16 tests)
- `scripts/tests/test_learning_db_invalid_route.py` (new, 6 tests)
- `skills/do/SKILL.md` — Phase 2.5 block + Files list
- `skills/do/haiku-router-prompt.md` — Step 6 hardening bullet

## Test plan

- [x] `python3 -m pytest scripts/tests/test_resolve_dispatch.py scripts/tests/test_learning_db_invalid_route.py` — 22 passed
- [x] `python3 -m pytest` — 3204 passed, 1 skipped, 180 xfailed
- [x] `ruff check . --config pyproject.toml` — all checks passed
- [x] `ruff format --check . --config pyproject.toml` — 322 files already formatted
- [x] End-to-end: `python3 ~/.claude/scripts/resolve-dispatch.py --agent benchmark --skill ""` prints `router picked invalid agent: benchmark. closest matches: data-engineer, reviewer-code, reviewer-domain` and exits 2
- [x] End-to-end: `learning-db.py record-invalid-route --kind agent --name benchmark` persists to the DB and increments on repeat