### PR TITLE
chore(agents): remove model pinning from all agents and references

### DIFF
--- a/AGENT_TEMPLATE_V2.md
+++ b/AGENT_TEMPLATE_V2.md
@@ -50,7 +50,6 @@ Bad: `description: "Use this agent when working with Go files, .go extensions, o
 ```yaml
 ---
 name: {domain}-{function}-engineer
-model: sonnet
 description: "{60-100 char single-line description of domain expertise}"
 
 color: blue | green | orange | red | purple | teal | cyan | yellow

--- a/agents/ansible-automation-engineer.md
+++ b/agents/ansible-automation-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: ansible-automation-engineer
-model: sonnet
 description: "Ansible automation: playbooks, roles, collections, Molecule testing, Vault security."
 color: orange
 routing:

--- a/agents/combat-effects-upgrade.md
+++ b/agents/combat-effects-upgrade.md
@@ -1,6 +1,5 @@
 ---
 name: combat-effects-upgrade
-model: sonnet
 description: "Zero-dependency combat visual upgrades: CSS particle replacement, Framer Motion combat juice, CSS 3D card transforms."
 color: orange
 routing:

--- a/agents/data-engineer.md
+++ b/agents/data-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: data-engineer
-model: sonnet
 description: "Data pipelines, ETL/ELT, warehouse design, dimensional modeling, stream processing."
 color: cyan
 memory: project

--- a/agents/database-engineer.md
+++ b/agents/database-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: database-engineer
-model: sonnet
 description: "Database design, optimization, query performance, migrations, indexing strategies."
 color: purple
 memory: project

--- a/agents/github-profile-rules-engineer.md
+++ b/agents/github-profile-rules-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: github-profile-rules-engineer
-model: sonnet
 description: "Extract coding conventions and style rules from GitHub user profiles via API."
 color: blue
 routing:

--- a/agents/golang-general-engineer-compact.md
+++ b/agents/golang-general-engineer-compact.md
@@ -1,6 +1,5 @@
 ---
 name: golang-general-engineer-compact
-model: sonnet
 description: "Compact Go development for tight context budgets. Modern Go 1.26+ patterns."
 color: blue
 memory: project

--- a/agents/golang-general-engineer.md
+++ b/agents/golang-general-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: golang-general-engineer
-model: sonnet
 description: "Go development: features, debugging, code review, performance. Modern Go 1.26+ patterns."
 color: blue
 hooks:

--- a/agents/hook-development-engineer.md
+++ b/agents/hook-development-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: hook-development-engineer
-model: sonnet
 description: "Python hook development for Claude Code event-driven system and learning database."
 color: purple
 routing:

--- a/agents/kotlin-general-engineer.md
+++ b/agents/kotlin-general-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: kotlin-general-engineer
-model: sonnet
 description: "Kotlin development: features, coroutines, debugging, code quality, multiplatform."
 color: purple
 hooks:

--- a/agents/kubernetes-helm-engineer.md
+++ b/agents/kubernetes-helm-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: kubernetes-helm-engineer
-model: sonnet
 description: "Kubernetes and Helm: deployments, troubleshooting, cloud-native infrastructure."
 color: green
 memory: project

--- a/agents/mcp-local-docs-engineer.md
+++ b/agents/mcp-local-docs-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: mcp-local-docs-engineer
-model: sonnet
 description: "MCP server development for local documentation access in TypeScript/Node.js and Go."
 color: teal
 routing:

--- a/agents/nextjs-ecommerce-engineer.md
+++ b/agents/nextjs-ecommerce-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: nextjs-ecommerce-engineer
-model: sonnet
 description: "Use this agent when building a NextJS e-commerce site: shopping cart, Stripe payments, product catalogs, order management, and checkout flows"
 color: green
 routing:

--- a/agents/nodejs-api-engineer.md
+++ b/agents/nodejs-api-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: nodejs-api-engineer
-model: sonnet
 description: "Use this agent when you need expert assistance with NodeJS backend API development: REST endpoints, authentication, file uploads, webhooks, middleware, and database integration"
 color: red
 memory: project

--- a/agents/opensearch-elasticsearch-engineer.md
+++ b/agents/opensearch-elasticsearch-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: opensearch-elasticsearch-engineer
-model: sonnet
 description: "OpenSearch/Elasticsearch: cluster management, performance tuning, index optimization."
 color: teal
 routing:

--- a/agents/performance-optimization-engineer.md
+++ b/agents/performance-optimization-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: performance-optimization-engineer
-model: sonnet
 description: "Web performance optimization: Core Web Vitals, rendering, bundle analysis, monitoring."
 color: yellow
 routing:

--- a/agents/perses-engineer.md
+++ b/agents/perses-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: perses-engineer
-model: sonnet
 description: "Perses observability platform: dashboards, plugins, operator, core development."
 color: green
 routing:

--- a/agents/php-general-engineer.md
+++ b/agents/php-general-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: php-general-engineer
-model: sonnet
 description: "PHP development: features, debugging, code quality, security, modern PHP 8.x patterns."
 color: purple
 hooks:

--- a/agents/pipeline-orchestrator-engineer.md
+++ b/agents/pipeline-orchestrator-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: pipeline-orchestrator-engineer
-model: sonnet
 description: "Pipeline orchestration: scaffold multi-component workflows, fan-out/fan-in patterns."
 color: purple
 routing:

--- a/agents/pipeline-orchestrator-engineer/references/anti-patterns.md
+++ b/agents/pipeline-orchestrator-engineer/references/anti-patterns.md
@@ -161,7 +161,6 @@ grep -rL 'allowed-tools' agents/*.md
 ```yaml
 ---
 name: my-new-agent
-model: sonnet
 description: "..."
 ---
 ```

--- a/agents/pixijs-combat-renderer.md
+++ b/agents/pixijs-combat-renderer.md
@@ -1,6 +1,5 @@
 ---
 name: pixijs-combat-renderer
-model: sonnet
 description: "PixiJS v8 2D WebGL combat rendering: @pixi/react hybrid canvas, normal maps, GPU particles, post-processing."
 color: cyan
 routing:

--- a/agents/project-coordinator-engineer.md
+++ b/agents/project-coordinator-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: project-coordinator-engineer
-model: sonnet
 description: "Multi-agent project coordination: task breakdown, dependency management, progress tracking."
 color: teal
 routing:

--- a/agents/prometheus-grafana-engineer.md
+++ b/agents/prometheus-grafana-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: prometheus-grafana-engineer
-model: sonnet
 description: "Prometheus and Grafana: monitoring, alerting, dashboard design, PromQL optimization."
 color: red
 routing:

--- a/agents/python-general-engineer.md
+++ b/agents/python-general-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: python-general-engineer
-model: sonnet
 description: "Python development: features, debugging, code review, performance. Modern Python 3.12+ patterns."
 color: green
 hooks:

--- a/agents/python-openstack-engineer.md
+++ b/agents/python-openstack-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: python-openstack-engineer
-model: sonnet
 description: "OpenStack Python development: Nova, Neutron, Cinder, Oslo libraries, WSGI middleware."
 color: red
 memory: project

--- a/agents/rabbitmq-messaging-engineer.md
+++ b/agents/rabbitmq-messaging-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: rabbitmq-messaging-engineer
-model: sonnet
 description: "RabbitMQ: message queue architecture, clustering, high-availability, routing patterns."
 color: orange
 routing:

--- a/agents/react-native-engineer.md
+++ b/agents/react-native-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: react-native-engineer
-model: sonnet
 description: "React Native and Expo development: performance, animations, navigation, native UI patterns."
 color: green
 routing:

--- a/agents/react-portfolio-engineer.md
+++ b/agents/react-portfolio-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: react-portfolio-engineer
-model: sonnet
 description: "React portfolio/gallery sites for creatives: React 18+, Next.js App Router, image optimization."
 color: purple
 routing:

--- a/agents/research-coordinator-engineer.md
+++ b/agents/research-coordinator-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: research-coordinator-engineer
-model: sonnet
 description: "Research coordination: systematic investigation, multi-source analysis, synthesis."
 color: purple
 background: true

--- a/agents/research-subagent-executor.md
+++ b/agents/research-subagent-executor.md
@@ -1,6 +1,5 @@
 ---
 name: research-subagent-executor
-model: sonnet
 description: "Research subagent execution: OODA-loop investigation, intelligence gathering, source evaluation."
 color: purple
 background: true

--- a/agents/reviewer-code.md
+++ b/agents/reviewer-code.md
@@ -1,6 +1,5 @@
 ---
 name: reviewer-code
-model: sonnet
 description: "Code quality review: conventions, naming, dead code, performance, test coverage"
 color: green
 routing:

--- a/agents/reviewer-domain.md
+++ b/agents/reviewer-domain.md
@@ -1,6 +1,5 @@
 ---
 name: reviewer-domain
-model: sonnet
 description: "Domain-specific review: ADR compliance, business logic, SAP CC structural, pragmatic builder."
 color: orange
 isolation: worktree

--- a/agents/reviewer-perspectives.md
+++ b/agents/reviewer-perspectives.md
@@ -1,6 +1,5 @@
 ---
 name: reviewer-perspectives
-model: sonnet
 description: "Multi-perspective review: newcomer, senior, pedant, contrarian, user advocate, meta-process."
 color: purple
 routing:

--- a/agents/reviewer-system.md
+++ b/agents/reviewer-system.md
@@ -1,6 +1,5 @@
 ---
 name: reviewer-system
-model: sonnet
 description: "System-level review: security, concurrency, error handling, observability, API contracts"
 color: red
 routing:

--- a/agents/rive-skeletal-animator.md
+++ b/agents/rive-skeletal-animator.md
@@ -1,6 +1,5 @@
 ---
 name: rive-skeletal-animator
-model: sonnet
 description: "Rive skeletal animation: @rive-app/react-canvas, state machines, character pipelines, combat integration."
 color: emerald
 routing:

--- a/agents/sqlite-peewee-engineer.md
+++ b/agents/sqlite-peewee-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: sqlite-peewee-engineer
-model: sonnet
 description: "SQLite with Peewee ORM: model definition, query optimization, migrations, transactions."
 color: green
 routing:

--- a/agents/swift-general-engineer.md
+++ b/agents/swift-general-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: swift-general-engineer
-model: sonnet
 description: "Swift development: iOS, macOS, server-side Swift, SwiftUI, concurrency, testing."
 color: orange
 hooks:

--- a/agents/system-upgrade-engineer.md
+++ b/agents/system-upgrade-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: system-upgrade-engineer
-model: sonnet
 description: "Systematic toolkit upgrades: adapt agents, skills, hooks when Claude Code ships updates."
 color: orange
 routing:

--- a/agents/technical-documentation-engineer.md
+++ b/agents/technical-documentation-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: technical-documentation-engineer
-model: sonnet
 description: "Technical documentation: API docs, system architecture, runbooks, enterprise standards"
 color: blue
 routing:

--- a/agents/technical-journalist-writer.md
+++ b/agents/technical-journalist-writer.md
@@ -1,6 +1,5 @@
 ---
 name: technical-journalist-writer
-model: sonnet
 description: "Technical journalism: explainers, opinion pieces, analysis articles, long-form content."
 color: blue
 routing:

--- a/agents/testing-automation-engineer.md
+++ b/agents/testing-automation-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: testing-automation-engineer
-model: sonnet
 description: "Testing automation: Vitest, Playwright, E2E, coverage enforcement, CI/CD integration"
 color: yellow
 routing:

--- a/agents/toolkit-governance-engineer.md
+++ b/agents/toolkit-governance-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: toolkit-governance-engineer
-model: sonnet
 description: "Toolkit governance: edit skills, update routing tables, manage ADR lifecycle, enforce standards."
 color: blue
 routing:

--- a/agents/toolkit-governance-engineer/references/frontmatter-compliance.md
+++ b/agents/toolkit-governance-engineer/references/frontmatter-compliance.md
@@ -105,7 +105,6 @@ rg -L 'allowed-tools' --glob 'agents/*.md'
 ```yaml
 ---
 name: my-agent
-model: sonnet
 description: "Does something"
 routing:
   triggers: [do thing]

--- a/agents/typescript-debugging-engineer.md
+++ b/agents/typescript-debugging-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: typescript-debugging-engineer
-model: sonnet
 description: "TypeScript debugging: race conditions, async/await issues, type errors, runtime exceptions."
 color: blue
 memory: project

--- a/agents/typescript-frontend-engineer.md
+++ b/agents/typescript-frontend-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: typescript-frontend-engineer
-model: sonnet
 description: "TypeScript frontend architecture: type-safe components, state management, build optimization."
 color: blue
 memory: project

--- a/agents/ui-design-engineer.md
+++ b/agents/ui-design-engineer.md
@@ -1,6 +1,5 @@
 ---
 name: ui-design-engineer
-model: sonnet
 description: "UI/UX design: design systems, responsive layouts, accessibility, animations."
 color: orange
 routing:

--- a/scripts/validate-references.py
+++ b/scripts/validate-references.py
@@ -47,6 +47,31 @@ _EXCEPTION_ANNOTATION = re.compile(r"<!--\s*no-pair-required\s*:", re.IGNORECASE
 _SKIP_FILENAMES = {"INDEX.json", "README.md"}
 
 
+def _strip_fenced_blocks(content: str) -> str:
+    """Replace content inside fenced code blocks with empty lines, preserving line count."""
+    lines = content.splitlines()
+    out: list[str] = []
+    in_fence = False
+    fence_marker = ""
+    for line in lines:
+        stripped = line.strip()
+        if not in_fence:
+            m = re.match(r"^(`{3,}|~{3,})", stripped)
+            if m:
+                in_fence = True
+                fence_marker = m.group(1)[0] * len(m.group(1))
+                out.append(line)
+            else:
+                out.append(line)
+        else:
+            if re.match(r"^" + re.escape(fence_marker) + r"[\s]*$", stripped):
+                in_fence = False
+                out.append(line)
+            else:
+                out.append("")  # blank out code content, preserve line count
+    return "\n".join(out)
+
+
 def _split_blocks(content: str) -> list[tuple[int, str]]:
     """Split content by H1-H4 headings. Returns (start_line_1indexed, text) pairs."""
     lines = content.splitlines()
@@ -92,9 +117,11 @@ def check_do_framing_in_file(path: Path) -> list[DoFramingIssue]:
         rel = str(path)
 
     all_lines = content.splitlines()
+    stripped_content = _strip_fenced_blocks(content)
 
-    for start_line, block in _split_blocks(content):
-        if not _ANTIPATTERN_HEADING.search(block):
+    for start_line, block in _split_blocks(stripped_content):
+        heading_line = block.splitlines()[0] if block.splitlines() else ""
+        if not _ANTIPATTERN_HEADING.search(heading_line):
             continue
         if _DO_INSTEAD.search(block):
             continue

--- a/skills/adr-consultation/SKILL.md
+++ b/skills/adr-consultation/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: adr-consultation
 description: "Multi-agent consultation for architecture decisions."
-model: sonnet
 user-invocable: false
 allowed-tools:
   - Read

--- a/skills/auto-dream/SKILL.md
+++ b/skills/auto-dream/SKILL.md
@@ -4,7 +4,6 @@ description: Background memory consolidation and learning graduation — overnig
 user-invocable: true
 command: dream
 context: fork
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/content-engine/SKILL.md
+++ b/skills/content-engine/SKILL.md
@@ -2,7 +2,6 @@
 name: content-engine
 description: "Repurpose source assets into platform-native social content."
 user-invocable: false
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -3,7 +3,6 @@ name: e2e-testing
 description: "Playwright-based end-to-end testing workflow."
 user-invocable: false
 agent: testing-automation-engineer
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/frontend-slides/SKILL.md
+++ b/skills/frontend-slides/SKILL.md
@@ -3,7 +3,6 @@ name: frontend-slides
 description: "Browser-based HTML presentation generation."
 user-invocable: false
 agent: typescript-frontend-engineer
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/full-repo-review/SKILL.md
+++ b/skills/full-repo-review/SKILL.md
@@ -4,7 +4,6 @@ description: "Comprehensive 3-wave review of all repo source files, producing a 
 user-invocable: true
 command: full-repo-review
 context: fork
-model: sonnet
 allowed-tools:
   - Agent
   - Bash

--- a/skills/github-notification-triage/SKILL.md
+++ b/skills/github-notification-triage/SKILL.md
@@ -3,7 +3,6 @@ name: github-notification-triage
 description: "Triage GitHub notifications and report actions needed."
 user-invocable: false
 context: fork
-model: sonnet
 allowed-tools:
   - Bash
   - Read

--- a/skills/kairos-lite/SKILL.md
+++ b/skills/kairos-lite/SKILL.md
@@ -4,7 +4,6 @@ description: Proactive monitoring — checks GitHub, CI, and toolkit health, pro
 user-invocable: true
 command: kairos
 context: fork
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/perses/SKILL.md
+++ b/skills/perses/SKILL.md
@@ -3,7 +3,6 @@ name: perses
 description: "Perses platform operations: dashboards, plugins, deployment, migration, and quality."
 context: fork
 agent: perses-engineer
-model: sonnet
 allowed-tools:
   - Read
   - Edit

--- a/skills/repo-value-analysis/SKILL.md
+++ b/skills/repo-value-analysis/SKILL.md
@@ -4,7 +4,6 @@ description: "Analyze external repositories for adoptable ideas and patterns."
 user-invocable: false
 argument-hint: "<repo-url-or-path>"
 agent: research-coordinator-engineer
-model: sonnet
 allowed-tools:
   - Agent
   - Read

--- a/skills/research-pipeline/SKILL.md
+++ b/skills/research-pipeline/SKILL.md
@@ -9,7 +9,6 @@ user-invocable: true
 argument-hint: "<research topic>"
 agent: research-coordinator-engineer
 context: fork
-model: sonnet
 allowed-tools:
   - Read
   - Bash

--- a/skills/sapcc-review/SKILL.md
+++ b/skills/sapcc-review/SKILL.md
@@ -4,7 +4,6 @@ description: "Gold-standard SAP CC Go code review: 10 parallel domain specialist
 user-invocable: false
 argument-hint: "[--fix]"
 command: /sapcc-review
-model: sonnet
 agent: golang-general-engineer
 allowed-tools:
   - Agent

--- a/skills/security-threat-model/SKILL.md
+++ b/skills/security-threat-model/SKILL.md
@@ -3,7 +3,6 @@ name: security-threat-model
 description: "Security threat model: scan toolkit for attack surface, supply-chain risks."
 effort: high
 user-invocable: false
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/video-editing/SKILL.md
+++ b/skills/video-editing/SKILL.md
@@ -3,7 +3,6 @@ name: video-editing
 description: "Video editing pipeline: cut footage, assemble clips via FFmpeg and Remotion."
 user-invocable: false
 agent: python-general-engineer
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/voice-writer/SKILL.md
+++ b/skills/voice-writer/SKILL.md
@@ -10,7 +10,6 @@ user-invocable: true
 argument-hint: "<topic or title>"
 command: /voice-writer
 context: fork
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -3,7 +3,6 @@ name: workflow
 description: "Structured multi-phase workflows: review, debug, refactor, deploy, create, research, and more."
 user-invocable: false
 context: fork
-model: sonnet
 routing:
   category: meta-tooling
   triggers:

--- a/skills/workflow/references/chain-composer.md
+++ b/skills/workflow/references/chain-composer.md
@@ -3,7 +3,6 @@ name: chain-composer
 description: "Compose valid pipeline chains from the step menu per subdomain."
 user-invocable: false
 agent: pipeline-orchestrator-engineer
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/workflow/references/comprehensive-review.md
+++ b/skills/workflow/references/comprehensive-review.md
@@ -4,7 +4,6 @@ description: "Four-wave code review pipeline for large or high-risk changes."
 effort: high
 user-invocable: false
 command: /comprehensive-review
-model: sonnet
 allowed-tools:
   - Agent
   - Read

--- a/skills/workflow/references/domain-research.md
+++ b/skills/workflow/references/domain-research.md
@@ -3,7 +3,6 @@ name: domain-research
 description: "Discover and classify subdomains for pipeline generation."
 user-invocable: false
 agent: pipeline-orchestrator-engineer
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/workflow/references/github-profile-rules.md
+++ b/skills/workflow/references/github-profile-rules.md
@@ -4,7 +4,6 @@ description: "Extract coding conventions from a GitHub user's public profile."
 user-invocable: false
 argument-hint: "<github-username>"
 agent: github-profile-rules-engineer
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/workflow/references/pipeline-retro.md
+++ b/skills/workflow/references/pipeline-retro.md
@@ -3,7 +3,6 @@ name: pipeline-retro
 description: "Trace pipeline test failures to generator root causes."
 user-invocable: false
 agent: pipeline-orchestrator-engineer
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/workflow/references/pipeline-scaffolder.md
+++ b/skills/workflow/references/pipeline-scaffolder.md
@@ -3,7 +3,6 @@ name: pipeline-scaffolder
 description: "Scaffold pipeline components from a Pipeline Spec JSON."
 user-invocable: false
 agent: pipeline-orchestrator-engineer
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/workflow/references/pipeline-scaffolder/references/generated-skill-template.md
+++ b/skills/workflow/references/pipeline-scaffolder/references/generated-skill-template.md
@@ -60,7 +60,6 @@ description: |
   Use for {{trigger_keywords}} inside the {{subdomain_name}} subdomain.
 user-invocable: true
 agent: {{agent_name}}
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/workflow/references/pipeline-test-runner.md
+++ b/skills/workflow/references/pipeline-test-runner.md
@@ -3,7 +3,6 @@ name: pipeline-test-runner
 description: "Test generated pipeline skills against real targets."
 user-invocable: false
 agent: pipeline-orchestrator-engineer
-model: sonnet
 allowed-tools:
   - Read
   - Write

--- a/skills/workflow/references/toolkit-improvement.md
+++ b/skills/workflow/references/toolkit-improvement.md
@@ -2,7 +2,6 @@
 name: toolkit-improvement
 description: "Multi-angle toolkit evaluation, ADR creation, and fix pipeline."
 effort: high
-model: sonnet
 context: fork
 allowed-tools:
   - Agent

--- a/skills/x-api/SKILL.md
+++ b/skills/x-api/SKILL.md
@@ -3,7 +3,6 @@ name: x-api
 description: "Post tweets, build threads, upload media via the X API."
 user-invocable: false
 agent: python-general-engineer
-model: sonnet
 allowed-tools:
   - Read
   - Write


### PR DESCRIPTION
## Summary
- Removes `model: sonnet` frontmatter from all 43 agent files
- Removes same from 27 skill/reference files that had it in frontmatter positions
- Agents and skills now inherit the session model rather than being pinned to sonnet

## Test plan
- [ ] CI lint and tests pass