### PR TITLE
docs(readme): document --system-prompt "." pattern for toolkit users

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ There is no opt-out flag. The mirror is harmless when Codex CLI is not installed
 
 **Reference**: [`adr/182-codex-hooks-mirror.md`](adr/182-codex-hooks-mirror.md). Upstream Phase 2 tracker: [openai/codex#16732](https://github.com/openai/codex/issues/16732).
 
+## Running Claude Code with the toolkit
+
+The toolkit already supplies routing (`/do`), domain knowledge (agents), methodology (skills), and enforcement (hooks, CLAUDE.md). The shipped Claude Code system prompt, which is several thousand tokens, largely duplicates that structure for toolkit users. Override it to shrink per-request token cost:
+
+```bash
+claude --system-prompt "."
+```
+
+The `.` is just a non-empty placeholder (some shells reject an empty string). This is a token-economy and architectural-fit pattern, not a claim about output quality.
+
+Trade-off: overriding the default strips Claude Code's built-in tool-use instructions and style guidance. That context comes back through the toolkit's own agents, skills, hooks, and CLAUDE.md, which is why the pattern fits here. On a bare Claude Code install without the toolkit, use `--append-system-prompt "..."` instead so the default guidance stays in place.
+
 ## The Core Workflow
 
 1. **Routing.** You type a request. The router entry point is `/do` in Claude Code and `$do` in Codex. It classifies intent, selects a domain agent and a workflow skill, and dispatches. No menus, no configuration.


### PR DESCRIPTION
## Summary

- Adds a short "Running Claude Code with the toolkit" section to `README.md` describing the `claude --system-prompt "."` invocation pattern.
- Frames the benefit as token economy (the shipped system prompt is multi-thousand tokens) and architectural fit (the toolkit already provides routing, domain knowledge, methodology, and enforcement through agents, skills, hooks, and CLAUDE.md).
- Includes an honest caveat: overriding the default strips Claude Code's built-in tool-use instructions and style guidance, so this is a toolkit-user pattern. Bare-install users are directed to `--append-system-prompt` instead.

## Scope

- No quality claims ("works better", "produces better output") are made. The framing is strictly token cost + architectural duplication.
- Section is 11 lines, placed between `Codex CLI Parity` and `The Core Workflow` where running/usage concerns cluster.

## Test plan

- [ ] CI `Tests / lint` passes
- [ ] CI `Tests / test` passes
- [ ] README renders correctly on GitHub (code fence, section heading, list of trade-offs)