### PR TITLE
chore: disable auto-memory for toolkit repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "effortLevel": "max",
+  "autoMemoryEnabled": false,
   "env": {
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
     "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000"

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -60,6 +60,8 @@ Three mechanisms enforce this:
 
 **Memory corollary:** if it can be re-derived from a source of truth, do not save it to memory. Git log, the file system, and running queries are always available. Memory should capture what cannot be derived: feedback about working style, project context that lives outside the codebase, references to external systems the model cannot introspect. Saving derivable facts to memory turns it into a noisy cache that drifts out of sync with reality. Save human judgment, not machine-readable state.
 
+**Auto-memory is disabled in this repo** (`.claude/settings.json` sets `autoMemoryEnabled: false`). Claude Code's auto-memory feature surfaces an index of session-level fragments (feedback snippets, parallel project names, insight entries) at the top of every conversation. That index is useful as a lookup target but wrong as a constant context injection: it loads granular state at the wrong level of abstraction, on every turn, regardless of task relevance. The toolkit already has better homes for each fragment type. User feedback belongs in hooks and skill instructions where it becomes an enforced rule rather than a reminder. Project state lives in `adr/`, the codebase itself, and git history. Session insights belong in `learning.db`, where retro-knowledge injection can surface only the entries relevant to the current task. Loading all of it every turn violates the progressive context principle this toolkit is built on. Off by default, retrieved on demand.
+
 ## Tokens Are Expensive, Use Progressive Context
 
 Spending tokens on the right context ensures correctness. Spending tokens on unfocused context adds cost without improving quality.


### PR DESCRIPTION
## Summary

- Set `autoMemoryEnabled: false` in project `.claude/settings.json` so the setting ships with the repo for anyone who clones it.
- Document the rationale in `docs/PHILOSOPHY.md` under the existing "Load Only What You Need" section, just after the Memory corollary and before "Tokens Are Expensive, Use Progressive Context".

## Why

Claude Code's auto-memory feature surfaces an index of session-level fragments (feedback snippets, parallel project names, insight entries) at the top of every conversation. That index is useful as a lookup target but wrong as a constant context injection. It loads granular state at the wrong level of abstraction, on every turn, regardless of task relevance.

The toolkit already has better homes for each fragment type:

- User feedback belongs in hooks and skill instructions, where it becomes an enforced rule rather than a reminder.
- Project state lives in `adr/`, the codebase itself, and git history.
- Session insights belong in `learning.db`, where retro-knowledge injection can surface only the entries relevant to the current task.

Loading all of it every turn violates the progressive context principle the toolkit is built on. Off by default, retrieved on demand.

## Test plan

- [ ] `python3 -c "import json; json.load(open('.claude/settings.json'))"` parses cleanly with the new key present.
- [ ] `docs/PHILOSOPHY.md` renders with the new paragraph in place; no broken cross-references.
- [ ] CI passes (ruff check + ruff format on Python; this change is JSON + markdown only).