### PR TITLE
refactor(references): normalize frontmatter across reference files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "effortLevel": "max",
+  "autoMemoryEnabled": false,
   "env": {
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
     "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000"

--- a/agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md
+++ b/agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: MCP Server Anti-Patterns
 description: Common MCP server mistakes with detection commands and fixes — front matter parsing, caching failures, protocol violations
 ---
 

--- a/agents/mcp-local-docs-engineer/references/mcp-patterns.md
+++ b/agents/mcp-local-docs-engineer/references/mcp-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: MCP Server Development Patterns
 description: Core MCP SDK patterns for TypeScript/Node.js server implementation, tool registration, and resource handling
 ---
 

--- a/agents/mcp-local-docs-engineer/references/typescript-async-patterns.md
+++ b/agents/mcp-local-docs-engineer/references/typescript-async-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: TypeScript Async Patterns for MCP Servers
 description: Async/await, concurrency control, and error propagation patterns for MCP documentation server performance
 ---
 

--- a/agents/nodejs-api-engineer/references/auth-patterns.md
+++ b/agents/nodejs-api-engineer/references/auth-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: Authentication Patterns for Node.js APIs
 description: JWT, OAuth, session management, and token refresh implementations with security-correct patterns
 ---
 

--- a/agents/nodejs-api-engineer/references/middleware-patterns.md
+++ b/agents/nodejs-api-engineer/references/middleware-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: Express/Next.js Middleware Patterns
 description: Error handling middleware, validation, rate limiting, and security header patterns for Node.js APIs
 ---
 

--- a/agents/nodejs-api-engineer/references/webhook-patterns.md
+++ b/agents/nodejs-api-engineer/references/webhook-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: Webhook Patterns for Node.js APIs
 description: Webhook processing patterns — signature verification, idempotency, retry handling, and queue integration
 ---
 

--- a/agents/opensearch-elasticsearch-engineer/references/cluster-operations.md
+++ b/agents/opensearch-elasticsearch-engineer/references/cluster-operations.md
@@ -1,5 +1,4 @@
 ---
-name: OpenSearch/Elasticsearch Cluster Operations
 description: Cluster health, shard allocation, capacity planning, rolling upgrades, and snapshot/restore operations
 ---
 

--- a/agents/opensearch-elasticsearch-engineer/references/index-management.md
+++ b/agents/opensearch-elasticsearch-engineer/references/index-management.md
@@ -1,5 +1,4 @@
 ---
-name: OpenSearch/Elasticsearch Index Management
 description: Mapping design, ILM policies, index templates, and reindexing strategies with anti-pattern detection
 ---
 

--- a/agents/opensearch-elasticsearch-engineer/references/query-optimization.md
+++ b/agents/opensearch-elasticsearch-engineer/references/query-optimization.md
@@ -1,5 +1,4 @@
 ---
-name: OpenSearch/Elasticsearch Query Optimization
 description: Query DSL patterns, aggregation optimization, caching strategies, and search profiling for performance tuning
 ---
 

--- a/agents/pixijs-combat-renderer/references/combat-visual-effects.md
+++ b/agents/pixijs-combat-renderer/references/combat-visual-effects.md
@@ -1,5 +1,4 @@
 ---
-name: PixiJS Combat Visual Effects
 description: Custom GLSL filters for hit effects, glow chaining, DisplacementFilter shockwaves, Spine integration, particle emitter combat patterns, z-ordering, and alpha masking in PixiJS v8+
 agent: pixijs-combat-renderer
 category: visual-techniques

--- a/agents/pixijs-combat-renderer/references/pixi-performance.md
+++ b/agents/pixijs-combat-renderer/references/pixi-performance.md
@@ -1,5 +1,4 @@
 ---
-name: PixiJS Rendering Performance
 description: Sprite batching, texture atlases, RenderTexture caching, off-screen culling, object pooling, ParticleContainer vs Container, and anti-patterns that break GPU batching in PixiJS v8+
 agent: pixijs-combat-renderer
 category: performance

--- a/artifacts/joy-check-sweep-backlog.json
+++ b/artifacts/joy-check-sweep-backlog.json
@@ -43,7 +43,7 @@
         67,
         78
       ],
-      "block_text": "## How to Use (MANDATORY)\n\n**You MUST load the reference file before executing any workflow phase.** The table above is a routing index \u2014 the actual methodology, phases, gates, and instructions are in the reference files.\n\n1. **Identify** the workflow category from the user's task using the table above\n2. **Load** the matching reference file using `Read` tool on `${CLAUDE_SKILL_DIR}/references/<name>.md`\n3. **Follow** the phases and gates defined in that reference exactly \u2014 do not improvise phas...",
+      "block_text": "## How to Use (MANDATORY)\n\n**You MUST load the reference file before executing any workflow phase.** The table above is a routing index — the actual methodology, phases, gates, and instructions are in the reference files.\n\n1. **Identify** the workflow category from the user's task using the table above\n2. **Load** the matching reference file using `Read` tool on `${CLAUDE_SKILL_DIR}/references/<name>.md`\n3. **Follow** the phases and gates defined in that reference exactly — do not improvise phas...",
       "domain_hint": "workflow"
     },
     {
@@ -52,7 +52,7 @@
         1,
         8
       ],
-      "block_text": "# ADR Consultation \u2014 Anti-Patterns\n\n> **Scope**: Common failures in ADR consultation orchestration and synthesis. Covers what goes wrong\n> and how to detect and fix it. Does NOT cover ADR authoring style or implementation quality.\n> **Version range**: Standard mode (3 agents), Complex mode (5 agents)\n> **Generated**: 2026-04-15\n\n---\n",
+      "block_text": "# ADR Consultation — Anti-Patterns\n\n> **Scope**: Common failures in ADR consultation orchestration and synthesis. Covers what goes wrong\n> and how to detect and fix it. Does NOT cover ADR authoring style or implementation quality.\n> **Version range**: Standard mode (3 agents), Complex mode (5 agents)\n> **Generated**: 2026-04-15\n\n---\n",
       "domain_hint": "adr-consultation"
     },
     {
@@ -88,7 +88,7 @@
         61,
         72
       ],
-      "block_text": "## Verdict: PROCEED\n[Based on what the agents reported in this session...]\n```\n\n**Why wrong**: Task return context disappears when context is cleared or a new session starts.\nSynthesis built from context cannot be re-read, audited, or resumed. If the session drops\nmid-consultation, the entire analysis is lost. File-based artifacts are the permanent record.\n\n**Fix**: After all agents complete, explicitly read each `adr/{name}/reviewer-perspectives-*.md`\nfile before synthesizing \u2014 even if Task ret...",
+      "block_text": "## Verdict: PROCEED\n[Based on what the agents reported in this session...]\n```\n\n**Why wrong**: Task return context disappears when context is cleared or a new session starts.\nSynthesis built from context cannot be re-read, audited, or resumed. If the session drops\nmid-consultation, the entire analysis is lost. File-based artifacts are the permanent record.\n\n**Fix**: After all agents complete, explicitly read each `adr/{name}/reviewer-perspectives-*.md`\nfile before synthesizing — even if Task ret...",
       "domain_hint": "adr-consultation"
     },
     {
@@ -124,7 +124,7 @@
         138,
         152
       ],
-      "block_text": "# If files exist with recent timestamps, this is prior work \u2014 confirm before overwriting\n```\n\n**What it looks like**: Re-running consultation on an ADR that already has consultation\nartifacts without acknowledging or showing the existing results.\n\n**Why wrong**: Silently overwriting prior consultation destroys the audit trail. The prior\nconsultation may have reached a BLOCKED verdict that was intentionally deferred, or may\ncontain concerns that were addressed in the ADR revision \u2014 losing this hi...",
+      "block_text": "# If files exist with recent timestamps, this is prior work — confirm before overwriting\n```\n\n**What it looks like**: Re-running consultation on an ADR that already has consultation\nartifacts without acknowledging or showing the existing results.\n\n**Why wrong**: Silently overwriting prior consultation destroys the audit trail. The prior\nconsultation may have reached a BLOCKED verdict that was intentionally deferred, or may\ncontain concerns that were addressed in the ADR revision — losing this hi...",
       "domain_hint": "adr-consultation"
     },
     {
@@ -151,7 +151,7 @@
         193,
         206
       ],
-      "block_text": "## Verdict: PROCEED\nTwo reviewers had minor concerns but overall the approach is sound.\n```\n\n**Why wrong**: Two NEEDS_CHANGES verdicts mean two independent reviewers identified specific\nthings that must change. Aggregating this to PROCEED discards both sets of concerns. The\nsynthesis verdict table is not a voting system \u2014 it is a concern aggregator. Multiple\nNEEDS_CHANGES is a signal that the ADR needs revision before proceeding.\n\n**Fix**: When multiple agents return NEEDS_CHANGES, treat as BLOC...",
+      "block_text": "## Verdict: PROCEED\nTwo reviewers had minor concerns but overall the approach is sound.\n```\n\n**Why wrong**: Two NEEDS_CHANGES verdicts mean two independent reviewers identified specific\nthings that must change. Aggregating this to PROCEED discards both sets of concerns. The\nsynthesis verdict table is not a voting system — it is a concern aggregator. Multiple\nNEEDS_CHANGES is a signal that the ADR needs revision before proceeding.\n\n**Fix**: When multiple agents return NEEDS_CHANGES, treat as BLOC...",
       "domain_hint": "adr-consultation"
     },
     {
@@ -205,7 +205,7 @@
         347,
         348
       ],
-      "block_text": "# \"Is/are\" avoidance \u2014 substituting complex verbs for simple copulas\n\\b(serves|stands|functions|acts)\\s+as\\s+(a|an|the)\\b\n",
+      "block_text": "# \"Is/are\" avoidance — substituting complex verbs for simple copulas\n\\b(serves|stands|functions|acts)\\s+as\\s+(a|an|the)\\b\n",
       "domain_hint": "anti-ai-editor"
     },
     {
@@ -214,7 +214,7 @@
         350,
         365
       ],
-      "block_text": "# \"Has\" avoidance \u2014 inflated verbs replacing \"has\"\n\\b(boasts|features|offers)\\s+(a|an|the)\\b\n```\n\n**Before/After Examples:**\n\n| AI Pattern | Human Version |\n|-----------|---------------|\n| \"The library **serves as a** bridge between APIs\" | \"The library **is a** bridge between APIs\" |\n| \"The framework **stands as a** testament to good design\" | \"The framework **is** a testament to good design\" |\n| \"The package **functions as a** wrapper\" | \"The package **is** a wrapper\" |\n| \"The city **boasts a*...",
+      "block_text": "# \"Has\" avoidance — inflated verbs replacing \"has\"\n\\b(boasts|features|offers)\\s+(a|an|the)\\b\n```\n\n**Before/After Examples:**\n\n| AI Pattern | Human Version |\n|-----------|---------------|\n| \"The library **serves as a** bridge between APIs\" | \"The library **is a** bridge between APIs\" |\n| \"The framework **stands as a** testament to good design\" | \"The framework **is** a testament to good design\" |\n| \"The package **functions as a** wrapper\" | \"The package **is** a wrapper\" |\n| \"The city **boasts a*...",
       "domain_hint": "anti-ai-editor"
     },
     {
@@ -259,7 +259,7 @@
         30,
         39
       ],
-      "block_text": "# Wrong \u2014 bsky.social requires auth for most endpoints\nurl = f\"https://bsky.social/xrpc/app.bsky.feed.getAuthorFeed?actor={handle}\"\n```\n\n**Why wrong**: `bsky.social` is a PDS (Personal Data Server) that requires JWT authentication\nfor most endpoints. Unauthenticated requests return `HTTP 401: AuthRequired`. The public app\nview (`public.api.bsky.app`) is purpose-built for unauthenticated reads.\n\n**Fix**:\n```python",
+      "block_text": "# Wrong — bsky.social requires auth for most endpoints\nurl = f\"https://bsky.social/xrpc/app.bsky.feed.getAuthorFeed?actor={handle}\"\n```\n\n**Why wrong**: `bsky.social` is a PDS (Personal Data Server) that requires JWT authentication\nfor most endpoints. Unauthenticated requests return `HTTP 401: AuthRequired`. The public app\nview (`public.api.bsky.app`) is purpose-built for unauthenticated reads.\n\n**Fix**:\n```python",
       "domain_hint": "bluesky-reader"
     },
     {
@@ -268,7 +268,7 @@
         56,
         66
       ],
-      "block_text": "# Wrong \u2014 AT Protocol has no offset parameter\nfor page in range(10):\n    url = f\"{BASE}/app.bsky.feed.getAuthorFeed?actor={handle}&limit=100&offset={page * 100}\"\n    data = fetch_json(url)\n```\n\n**Why wrong**: The AT Protocol lexicon has no `offset` parameter \u2014 the API ignores it silently.\nAll pagination is cursor-based. Passing `offset` fetches the same first page on every iteration.\n\n**Fix**:\n```python",
+      "block_text": "# Wrong — AT Protocol has no offset parameter\nfor page in range(10):\n    url = f\"{BASE}/app.bsky.feed.getAuthorFeed?actor={handle}&limit=100&offset={page * 100}\"\n    data = fetch_json(url)\n```\n\n**Why wrong**: The AT Protocol lexicon has no `offset` parameter — the API ignores it silently.\nAll pagination is cursor-based. Passing `offset` fetches the same first page on every iteration.\n\n**Fix**:\n```python",
       "domain_hint": "bluesky-reader"
     },
     {
@@ -286,7 +286,7 @@
         94,
         103
       ],
-      "block_text": "# Wrong \u2014 getAuthorFeed uses \"feed\" key, not \"posts\"\ndata = fetch_json(url)\nposts = data[\"posts\"]  # KeyError or empty list\n```\n\n**Why wrong**: `getAuthorFeed` returns `{\"feed\": [...], \"cursor\": \"...\"}`. The `posts` key\nis only used by `searchPosts`. Confusing the two silently returns nothing.\n\n**Fix**:\n```python",
+      "block_text": "# Wrong — getAuthorFeed uses \"feed\" key, not \"posts\"\ndata = fetch_json(url)\nposts = data[\"posts\"]  # KeyError or empty list\n```\n\n**Why wrong**: `getAuthorFeed` returns `{\"feed\": [...], \"cursor\": \"...\"}`. The `posts` key\nis only used by `searchPosts`. Confusing the two silently returns nothing.\n\n**Fix**:\n```python",
       "domain_hint": "bluesky-reader"
     },
     {
@@ -304,7 +304,7 @@
         125,
         144
       ],
-      "block_text": "# Wrong \u2014 feed items wrap the post data, text is nested\nfor item in data[\"feed\"]:\n    text = item[\"text\"]  # KeyError \u2014 text lives at item[\"post\"][\"record\"][\"text\"]\n```\n\n**Why wrong**: `getAuthorFeed` returns `FeedViewPost` objects, not raw posts. The actual post\nrecord is nested at `item[\"post\"][\"record\"]`. The outer `item` holds `post`, `reason`, and\n`reply` sub-keys.\n\n**Fix**:\n```python\nfor item in data.get(\"feed\", []):\n    post_data = item.get(\"post\", {})\n    record = post_data.get(\"record\",...",
+      "block_text": "# Wrong — feed items wrap the post data, text is nested\nfor item in data[\"feed\"]:\n    text = item[\"text\"]  # KeyError — text lives at item[\"post\"][\"record\"][\"text\"]\n```\n\n**Why wrong**: `getAuthorFeed` returns `FeedViewPost` objects, not raw posts. The actual post\nrecord is nested at `item[\"post\"][\"record\"]`. The outer `item` holds `post`, `reason`, and\n`reply` sub-keys.\n\n**Fix**:\n```python\nfor item in data.get(\"feed\", []):\n    post_data = item.get(\"post\", {})\n    record = post_data.get(\"record\",...",
       "domain_hint": "bluesky-reader"
     },
     {
@@ -322,7 +322,7 @@
         156,
         184
       ],
-      "block_text": "# Wrong \u2014 treats reposts as original posts by the feed owner\nfor item in data[\"feed\"]:\n    handle = item[\"post\"][\"author\"][\"handle\"]  # This is the ORIGINAL author, not reposter\n    print(f\"@{handle}: {item['post']['record']['text']}\")\n```\n\n**Why wrong**: When a user reposts, `item[\"reason\"][\"$type\"]` is\n`\"app.bsky.feed.defs#reasonRepost\"` and `item[\"reason\"][\"by\"]` holds the reposter's info.\nThe `item[\"post\"][\"author\"]` is always the original author. Without checking `reason`, every\nrepost is p...",
+      "block_text": "# Wrong — treats reposts as original posts by the feed owner\nfor item in data[\"feed\"]:\n    handle = item[\"post\"][\"author\"][\"handle\"]  # This is the ORIGINAL author, not reposter\n    print(f\"@{handle}: {item['post']['record']['text']}\")\n```\n\n**Why wrong**: When a user reposts, `item[\"reason\"][\"$type\"]` is\n`\"app.bsky.feed.defs#reasonRepost\"` and `item[\"reason\"][\"by\"]` holds the reposter's info.\nThe `item[\"post\"][\"author\"]` is always the original author. Without checking `reason`, every\nrepost is p...",
       "domain_hint": "bluesky-reader"
     },
     {
@@ -358,7 +358,7 @@
         228,
         237
       ],
-      "block_text": "# Wrong \u2014 no timeout, hangs indefinitely on network stall\nwith urllib.request.urlopen(req) as resp:\n    return json.loads(resp.read())\n```\n\n**Why wrong**: The Bluesky public API can stall under load. Without a timeout, the script\nhangs until the OS TCP timeout (often 2+ minutes), making the tool appear frozen.\n\n**Fix**:\n```python",
+      "block_text": "# Wrong — no timeout, hangs indefinitely on network stall\nwith urllib.request.urlopen(req) as resp:\n    return json.loads(resp.read())\n```\n\n**Why wrong**: The Bluesky public API can stall under load. Without a timeout, the script\nhangs until the OS TCP timeout (often 2+ minutes), making the tool appear frozen.\n\n**Fix**:\n```python",
       "domain_hint": "bluesky-reader"
     },
     {
@@ -376,7 +376,7 @@
         134,
         152
       ],
-      "block_text": "# Find goroutine launches \u2014 review each for semaphore acquire\nrg 'go func\\(' --type go internal/\ngrep -rn 'go func(' --include=\"*.go\" internal/\n```\n\n**What it looks like**:\n```go\nfor _, domain := range domains {\n    go func(d libvirt.Domain) {\n        collectDomain(ctx, d, ch) // no semaphore\n    }(domain)\n}\n```\n\n**Why wrong**: On a hypervisor with 500 VMs, this launches 500 goroutines simultaneously. Each goroutine makes libvirt RPC calls over the same Unix socket. libvirt queues drop, connecti...",
+      "block_text": "# Find goroutine launches — review each for semaphore acquire\nrg 'go func\\(' --type go internal/\ngrep -rn 'go func(' --include=\"*.go\" internal/\n```\n\n**What it looks like**:\n```go\nfor _, domain := range domains {\n    go func(d libvirt.Domain) {\n        collectDomain(ctx, d, ch) // no semaphore\n    }(domain)\n}\n```\n\n**Why wrong**: On a hypervisor with 500 VMs, this launches 500 goroutines simultaneously. Each goroutine makes libvirt RPC calls over the same Unix socket. libvirt queues drop, connecti...",
       "domain_hint": "cobalt-core"
     },
     {
@@ -385,7 +385,7 @@
         154,
         178
       ],
-      "block_text": "### \u274c Blocking Lock in Prometheus Collect Path\n\n**Detection**:\n```bash\nrg '\\.Lock\\(\\)' --type go internal/libvirt/\ngrep -n \"\\.Lock()\" internal/libvirt/*.go\n```\nReview if `Lock()` appears in any `Collect()` or `Describe()` method.\n\n**What it looks like**:\n```go\nfunc (s *ServiceImpl) Collect(ch chan<- prometheus.Metric) {\n    s.mu.Lock()         // blocks if previous scrape running\n    defer s.mu.Unlock()\n    s.retrieveMetrics(ctx, ch)\n}\n```\n\n**Why wrong**: Prometheus's default scrape timeout is 1...",
+      "block_text": "### ❌ Blocking Lock in Prometheus Collect Path\n\n**Detection**:\n```bash\nrg '\\.Lock\\(\\)' --type go internal/libvirt/\ngrep -n \"\\.Lock()\" internal/libvirt/*.go\n```\nReview if `Lock()` appears in any `Collect()` or `Describe()` method.\n\n**What it looks like**:\n```go\nfunc (s *ServiceImpl) Collect(ch chan<- prometheus.Metric) {\n    s.mu.Lock()         // blocks if previous scrape running\n    defer s.mu.Unlock()\n    s.retrieveMetrics(ctx, ch)\n}\n```\n\n**Why wrong**: Prometheus's default scrape timeout is 1...",
       "domain_hint": "cobalt-core"
     },
     {
@@ -394,7 +394,7 @@
         180,
         205
       ],
-      "block_text": "### \u274c Skipping ClearScrapeCache() on Error Exit\n\n**Detection**:\n```bash\nrg 'ClearScrapeCache' --type go\ngrep -rn 'ClearScrapeCache' --include=\"*.go\" .\n```\nConfirm it is called in `defer` or in all exit paths of `retrieveMetrics`.\n\n**What it looks like**:\n```go\nfunc (s *ServiceImpl) retrieveMetrics(ctx context.Context, ch chan<- prometheus.Metric) {\n    if err := s.connectLibvirt(); err != nil {\n        log.Errorf(\"connect: %v\", err)\n        return // scrape cache NOT cleared \u2014 stale data persist...",
+      "block_text": "### ❌ Skipping ClearScrapeCache() on Error Exit\n\n**Detection**:\n```bash\nrg 'ClearScrapeCache' --type go\ngrep -rn 'ClearScrapeCache' --include=\"*.go\" .\n```\nConfirm it is called in `defer` or in all exit paths of `retrieveMetrics`.\n\n**What it looks like**:\n```go\nfunc (s *ServiceImpl) retrieveMetrics(ctx context.Context, ch chan<- prometheus.Metric) {\n    if err := s.connectLibvirt(); err != nil {\n        log.Errorf(\"connect: %v\", err)\n        return // scrape cache NOT cleared — stale data persist...",
       "domain_hint": "cobalt-core"
     },
     {
@@ -403,7 +403,7 @@
         207,
         231
       ],
-      "block_text": "### \u274c Plain map for Concurrent Domain State\n\n**Detection**:\n```bash\nrg 'map\\[string\\]' --type go internal/libvirt/\ngrep -n \"map\\[string\\]\" internal/libvirt/*.go\n```\nAny `map[string]` accessed from goroutines without a wrapping mutex is a data race.\n\n**What it looks like**:\n```go\nvar history = map[string]uint64{} // shared, no mutex\n\nfunc updateHistory(key string, val uint64) uint64 {\n    prev := history[key]  // concurrent read \u2014 data race\n    history[key] = val    // concurrent write \u2014 data rac...",
+      "block_text": "### ❌ Plain map for Concurrent Domain State\n\n**Detection**:\n```bash\nrg 'map\\[string\\]' --type go internal/libvirt/\ngrep -n \"map\\[string\\]\" internal/libvirt/*.go\n```\nAny `map[string]` accessed from goroutines without a wrapping mutex is a data race.\n\n**What it looks like**:\n```go\nvar history = map[string]uint64{} // shared, no mutex\n\nfunc updateHistory(key string, val uint64) uint64 {\n    prev := history[key]  // concurrent read — data race\n    history[key] = val    // concurrent write — data rac...",
       "domain_hint": "cobalt-core"
     },
     {
@@ -421,7 +421,7 @@
         132,
         155
       ],
-      "block_text": "### \u274c Hand-Editing interface_mock_gen.go\n\n**Detection**:\n```bash\ngit log --oneline internal/libvirt/interface_mock_gen.go\ngrep -n \"hand\" internal/libvirt/interface_mock_gen.go\nrg 'interface_mock_gen' --type go\n```\nCheck if the file has commits that don't come from `make generate`.\n\n**What it looks like**:\n```go\n// In interface_mock_gen.go \u2014 manually added method:\nfunc (m *LibVirtMock) NewMethod(ctx context.Context) error {\n    // hand-written \u2014 not from moq\n    return nil\n}\n```\n\n**Why wrong**: T...",
+      "block_text": "### ❌ Hand-Editing interface_mock_gen.go\n\n**Detection**:\n```bash\ngit log --oneline internal/libvirt/interface_mock_gen.go\ngrep -n \"hand\" internal/libvirt/interface_mock_gen.go\nrg 'interface_mock_gen' --type go\n```\nCheck if the file has commits that don't come from `make generate`.\n\n**What it looks like**:\n```go\n// In interface_mock_gen.go — manually added method:\nfunc (m *LibVirtMock) NewMethod(ctx context.Context) error {\n    // hand-written — not from moq\n    return nil\n}\n```\n\n**Why wrong**: T...",
       "domain_hint": "cobalt-core"
     },
     {
@@ -430,7 +430,7 @@
         157,
         182
       ],
-      "block_text": "### \u274c Skipping Race Detector in Tests with Goroutines\n\n**Detection**:\n```bash\nrg 'go test' Makefile\ngrep -n \"go test\" Makefile\n```\nCheck that all `go test` invocations in Makefile include `-race`.\n\n**What it looks like**:\n```makefile\ntest:\n    go test ./internal/...   # no -race\n```\n\n**Why wrong**: kvm-exporter's domain collection is concurrent. Tests that exercise collection without `-race` can pass even with data races \u2014 the race detector is not enabled by default. Race conditions surface only...",
+      "block_text": "### ❌ Skipping Race Detector in Tests with Goroutines\n\n**Detection**:\n```bash\nrg 'go test' Makefile\ngrep -n \"go test\" Makefile\n```\nCheck that all `go test` invocations in Makefile include `-race`.\n\n**What it looks like**:\n```makefile\ntest:\n    go test ./internal/...   # no -race\n```\n\n**Why wrong**: kvm-exporter's domain collection is concurrent. Tests that exercise collection without `-race` can pass even with data races — the race detector is not enabled by default. Race conditions surface only...",
       "domain_hint": "cobalt-core"
     },
     {
@@ -457,7 +457,7 @@
         166,
         191
       ],
-      "block_text": "### \u274c Using `let` when `const` suffices (useConst)\n\n**Detection**:\n```bash\nruff check --select UP .  # Python only \u2014 for JS/TS use Biome directly\nnpx @biomejs/biome check --reporter=json src/ | python3 -c \"\nimport json,sys; data=json.load(sys.stdin)\n[print(d['location']['path']['file'], d['rule_name']) for d in data.get('diagnostics',[]) if 'useConst' in d.get('rule_name','')]\n\"\n```\n\n**What it looks like**:\n```typescript\nlet name = \"Alice\";   // never reassigned below\nlet config = { debug: false...",
+      "block_text": "### ❌ Using `let` when `const` suffices (useConst)\n\n**Detection**:\n```bash\nruff check --select UP .  # Python only — for JS/TS use Biome directly\nnpx @biomejs/biome check --reporter=json src/ | python3 -c \"\nimport json,sys; data=json.load(sys.stdin)\n[print(d['location']['path']['file'], d['rule_name']) for d in data.get('diagnostics',[]) if 'useConst' in d.get('rule_name','')]\n\"\n```\n\n**What it looks like**:\n```typescript\nlet name = \"Alice\";   // never reassigned below\nlet config = { debug: false...",
       "domain_hint": "code-linting"
     },
     {
@@ -466,7 +466,7 @@
         193,
         222
       ],
-      "block_text": "### \u274c TypeScript `any` type annotation (noExplicitAny)\n\n**Detection**:\n```bash\ngrep -rn ': any\\b\\|as any\\b' --include=\"*.ts\" --include=\"*.tsx\"\nrg ':\\s*any\\b|as any\\b' --type ts\n```\n\n**What it looks like**:\n```typescript\nfunction process(data: any): any {\n    return data.value;\n}\nconst result = response as any;\n```\n\n**Why wrong**: `any` disables TypeScript's type checker for that value. Errors that TypeScript would catch at compile time become runtime crashes. Propagates through the codebase \u2014 on...",
+      "block_text": "### ❌ TypeScript `any` type annotation (noExplicitAny)\n\n**Detection**:\n```bash\ngrep -rn ': any\\b\\|as any\\b' --include=\"*.ts\" --include=\"*.tsx\"\nrg ':\\s*any\\b|as any\\b' --type ts\n```\n\n**What it looks like**:\n```typescript\nfunction process(data: any): any {\n    return data.value;\n}\nconst result = response as any;\n```\n\n**Why wrong**: `any` disables TypeScript's type checker for that value. Errors that TypeScript would catch at compile time become runtime crashes. Propagates through the codebase — on...",
       "domain_hint": "code-linting"
     },
     {
@@ -475,7 +475,7 @@
         250,
         276
       ],
-      "block_text": "### \u274c Optional chain avoidance (useOptionalChain)\n\n**Detection**:\n```bash\ngrep -rn '&& .*\\.' --include=\"*.ts\" --include=\"*.tsx\"\nrg '\\w+\\s*&&\\s*\\w+\\.' --type ts\n```\n\n**What it looks like**:\n```typescript\nconst city = user && user.address && user.address.city;\nconst len = arr && arr.length;\nconst name = response && response.data && response.data.user && response.data.user.name;\n```\n\n**Why wrong**: Manual null checks via `&&` chains are verbose and easy to get wrong (short-circuits at wrong level)....",
+      "block_text": "### ❌ Optional chain avoidance (useOptionalChain)\n\n**Detection**:\n```bash\ngrep -rn '&& .*\\.' --include=\"*.ts\" --include=\"*.tsx\"\nrg '\\w+\\s*&&\\s*\\w+\\.' --type ts\n```\n\n**What it looks like**:\n```typescript\nconst city = user && user.address && user.address.city;\nconst len = arr && arr.length;\nconst name = response && response.data && response.data.user && response.data.user.name;\n```\n\n**Why wrong**: Manual null checks via `&&` chains are verbose and easy to get wrong (short-circuits at wrong level)....",
       "domain_hint": "code-linting"
     },
     {
@@ -493,7 +493,7 @@
         84,
         114
       ],
-      "block_text": "### \u274c Using `== None` / `== True` / `== False` (E711/E712)\n\n**Detection**:\n```bash\ngrep -rn '== None\\|== True\\|== False\\|!= None' --include=\"*.py\"\nrg '(==|!=)\\s+(None|True|False)' --type py\n```\n\n**What it looks like**:\n```python\nif result == None:\n    return\nif flag == True:\n    process()\nif items != None and len(items) == 0:\n    return []\n```\n\n**Why wrong**: `== None` uses equality comparison for an identity check. Works in CPython but `is None` is correct and triggers no E711. `== True` trigge...",
+      "block_text": "### ❌ Using `== None` / `== True` / `== False` (E711/E712)\n\n**Detection**:\n```bash\ngrep -rn '== None\\|== True\\|== False\\|!= None' --include=\"*.py\"\nrg '(==|!=)\\s+(None|True|False)' --type py\n```\n\n**What it looks like**:\n```python\nif result == None:\n    return\nif flag == True:\n    process()\nif items != None and len(items) == 0:\n    return []\n```\n\n**Why wrong**: `== None` uses equality comparison for an identity check. Works in CPython but `is None` is correct and triggers no E711. `== True` trigge...",
       "domain_hint": "code-linting"
     },
     {
@@ -502,7 +502,7 @@
         116,
         146
       ],
-      "block_text": "### \u274c Mutable default argument (B006)\n\n**Detection**:\n```bash\nrg 'def \\w+\\([^)]*=\\s*(\\[\\]|\\{\\}|\\(\\))' --type py\ngrep -rn 'def .*=\\s*\\[\\|def .*=\\s*{' --include=\"*.py\"\n```\n\n**What it looks like**:\n```python\ndef append_item(item, container=[]):   # B006\n    container.append(item)\n    return container\n\ndef merge_config(opts={}):  # B006\n    opts.update({\"debug\": False})\n    return opts\n```\n\n**Why wrong**: Default argument is evaluated once at function definition time. All callers share the same list...",
+      "block_text": "### ❌ Mutable default argument (B006)\n\n**Detection**:\n```bash\nrg 'def \\w+\\([^)]*=\\s*(\\[\\]|\\{\\}|\\(\\))' --type py\ngrep -rn 'def .*=\\s*\\[\\|def .*=\\s*{' --include=\"*.py\"\n```\n\n**What it looks like**:\n```python\ndef append_item(item, container=[]):   # B006\n    container.append(item)\n    return container\n\ndef merge_config(opts={}):  # B006\n    opts.update({\"debug\": False})\n    return opts\n```\n\n**Why wrong**: Default argument is evaluated once at function definition time. All callers share the same list...",
       "domain_hint": "code-linting"
     },
     {
@@ -511,7 +511,7 @@
         148,
         167
       ],
-      "block_text": "### \u274c Deprecated typing generics (UP006/UP007/UP035)\n\n**Detection**:\n```bash\ngrep -rn 'from typing import.*List\\|from typing import.*Dict\\|from typing import.*Optional' --include=\"*.py\"\nrg 'typing\\.(List|Dict|Optional|Tuple|Set|FrozenSet)\\[' --type py\n```\n\n**What it looks like**:\n```python\nfrom typing import List, Dict, Optional, Tuple\n\ndef process(items: List[str], config: Dict[str, int]) -> Optional[Tuple[int, str]]:\n    ...\n```\n\n**Why wrong**: Python 3.9+ supports `list[str]`, `dict[str, int]...",
+      "block_text": "### ❌ Deprecated typing generics (UP006/UP007/UP035)\n\n**Detection**:\n```bash\ngrep -rn 'from typing import.*List\\|from typing import.*Dict\\|from typing import.*Optional' --include=\"*.py\"\nrg 'typing\\.(List|Dict|Optional|Tuple|Set|FrozenSet)\\[' --type py\n```\n\n**What it looks like**:\n```python\nfrom typing import List, Dict, Optional, Tuple\n\ndef process(items: List[str], config: Dict[str, int]) -> Optional[Tuple[int, str]]:\n    ...\n```\n\n**Why wrong**: Python 3.9+ supports `list[str]`, `dict[str, int]...",
       "domain_hint": "code-linting"
     },
     {
@@ -520,7 +520,7 @@
         183,
         209
       ],
-      "block_text": "### \u274c Lambda capturing loop variable (B023)\n\n**Detection**:\n```bash\nrg 'lambda.*:\\s*.*\\b\\w+\\b' --type py -A2 | grep -B2 'for .* in'\ngrep -rn 'lambda' --include=\"*.py\"\n```\n\n**What it looks like**:\n```python\nhandlers = [lambda x: x + i for i in range(5)]   # all lambdas use i=4\ncallbacks = []\nfor name in names:\n    callbacks.append(lambda: process(name))  # all use final name\n```\n\n**Why wrong**: Lambda captures the variable by reference, not value. By execution time, the loop variable holds its fi...",
+      "block_text": "### ❌ Lambda capturing loop variable (B023)\n\n**Detection**:\n```bash\nrg 'lambda.*:\\s*.*\\b\\w+\\b' --type py -A2 | grep -B2 'for .* in'\ngrep -rn 'lambda' --include=\"*.py\"\n```\n\n**What it looks like**:\n```python\nhandlers = [lambda x: x + i for i in range(5)]   # all lambdas use i=4\ncallbacks = []\nfor name in names:\n    callbacks.append(lambda: process(name))  # all use final name\n```\n\n**Why wrong**: Lambda captures the variable by reference, not value. By execution time, the loop variable holds its fi...",
       "domain_hint": "code-linting"
     },
     {
@@ -529,7 +529,7 @@
         211,
         236
       ],
-      "block_text": "### \u274c Unused imports not cleaned up (F401)\n\n**Detection**:\n```bash\nruff check --select F401 . --config pyproject.toml\nrg '^import |^from .* import' --type py\n```\n\n**What it looks like**:\n```python\nimport os       # never used below\nimport sys      # never used below\nfrom pathlib import Path  # used\n```\n\n**Why wrong**: Dead imports slow startup, confuse readers, and fail CI. Common culprit: imports used in removed code, or imports that were only in type comments.\n\n**Fix**:\n```bash\nruff check --fi...",
+      "block_text": "### ❌ Unused imports not cleaned up (F401)\n\n**Detection**:\n```bash\nruff check --select F401 . --config pyproject.toml\nrg '^import |^from .* import' --type py\n```\n\n**What it looks like**:\n```python\nimport os       # never used below\nimport sys      # never used below\nfrom pathlib import Path  # used\n```\n\n**Why wrong**: Dead imports slow startup, confuse readers, and fail CI. Common culprit: imports used in removed code, or imports that were only in type comments.\n\n**Fix**:\n```bash\nruff check --fi...",
       "domain_hint": "code-linting"
     },
     {
@@ -547,7 +547,7 @@
         1,
         7
       ],
-      "block_text": "# Wait/Retry Anti-Patterns\n\n> **Scope**: Common mistakes in polling, retry, and backoff code \u2014 detection commands and fixes.\n> **Version range**: Python 3.8+, Bash (any POSIX)\n> **Generated**: 2026-04-16\n\n---\n",
+      "block_text": "# Wait/Retry Anti-Patterns\n\n> **Scope**: Common mistakes in polling, retry, and backoff code — detection commands and fixes.\n> **Version range**: Python 3.8+, Bash (any POSIX)\n> **Generated**: 2026-04-16\n\n---\n",
       "domain_hint": "condition-based-waiting"
     },
     {
@@ -565,7 +565,7 @@
         17,
         44
       ],
-      "block_text": "### \u274c Hardcoded `time.sleep()` Without Condition Check\n\n**Detection**:\n```bash\ngrep -rn 'time\\.sleep(' --include=\"*.py\" | grep -v 'poll_interval\\|wait_for\\|retry\\|backoff'\nrg 'time\\.sleep\\(\\d' --type py\n```\n\n**What it looks like**:\n```python\ndef wait_for_db():\n    time.sleep(5)  # Hope the DB is ready by now\n    return connect()\n```\n\n**Why wrong**: The sleep duration is a guess. If the DB starts in 1s you wasted 4s; if it takes 6s you got a connection error. There is no feedback \u2014 the code never...",
+      "block_text": "### ❌ Hardcoded `time.sleep()` Without Condition Check\n\n**Detection**:\n```bash\ngrep -rn 'time\\.sleep(' --include=\"*.py\" | grep -v 'poll_interval\\|wait_for\\|retry\\|backoff'\nrg 'time\\.sleep\\(\\d' --type py\n```\n\n**What it looks like**:\n```python\ndef wait_for_db():\n    time.sleep(5)  # Hope the DB is ready by now\n    return connect()\n```\n\n**Why wrong**: The sleep duration is a guess. If the DB starts in 1s you wasted 4s; if it takes 6s you got a connection error. There is no feedback — the code never...",
       "domain_hint": "condition-based-waiting"
     },
     {
@@ -574,7 +574,7 @@
         46,
         59
       ],
-      "block_text": "### \u274c Infinite Loop Without Timeout\n\n**Detection**:\n```bash\ngrep -rn 'while True' --include=\"*.py\" | grep -v 'timeout\\|deadline\\|monotonic'\nrg 'while True:' --type py -A 5 | grep -v 'break\\|timeout\\|deadline'\n```\n\n**What it looks like**:\n```python\nwhile True:\n    if service_ready():\n        break\n    time.sleep(1)",
+      "block_text": "### ❌ Infinite Loop Without Timeout\n\n**Detection**:\n```bash\ngrep -rn 'while True' --include=\"*.py\" | grep -v 'timeout\\|deadline\\|monotonic'\nrg 'while True:' --type py -A 5 | grep -v 'break\\|timeout\\|deadline'\n```\n\n**What it looks like**:\n```python\nwhile True:\n    if service_ready():\n        break\n    time.sleep(1)",
       "domain_hint": "condition-based-waiting"
     },
     {
@@ -592,7 +592,7 @@
         78,
         106
       ],
-      "block_text": "### \u274c Using `time.time()` for Elapsed Time Measurement\n\n**Detection**:\n```bash\nrg 'start\\s*=\\s*time\\.time\\(\\)' --type py\ngrep -rn 'time\\.time()' --include=\"*.py\" | grep -E 'deadline|elapsed|timeout'\n```\n\n**What it looks like**:\n```python\nstart = time.time()\ndeadline = start + timeout\nwhile time.time() < deadline:\n    ...\n```\n\n**Why wrong**: `time.time()` is wall-clock time and jumps backward on NTP sync or DST changes. A 1-second backward jump can cause the loop to run `timeout` extra seconds pa...",
+      "block_text": "### ❌ Using `time.time()` for Elapsed Time Measurement\n\n**Detection**:\n```bash\nrg 'start\\s*=\\s*time\\.time\\(\\)' --type py\ngrep -rn 'time\\.time()' --include=\"*.py\" | grep -E 'deadline|elapsed|timeout'\n```\n\n**What it looks like**:\n```python\nstart = time.time()\ndeadline = start + timeout\nwhile time.time() < deadline:\n    ...\n```\n\n**Why wrong**: `time.time()` is wall-clock time and jumps backward on NTP sync or DST changes. A 1-second backward jump can cause the loop to run `timeout` extra seconds pa...",
       "domain_hint": "condition-based-waiting"
     },
     {
@@ -601,7 +601,7 @@
         108,
         135
       ],
-      "block_text": "### \u274c Retry Without Jitter (Thundering Herd)\n\n**Detection**:\n```bash\ngrep -rn 'sleep.*delay\\|sleep.*backoff' --include=\"*.py\" | grep -v 'jitter\\|random\\|uniform'\nrg 'time\\.sleep\\(delay\\)' --type py\n```\n\n**What it looks like**:\n```python\nfor attempt in range(max_retries):\n    try:\n        return call_api()\n    except RequestException:\n        time.sleep(delay)\n        delay *= 2  # No jitter \u2014 all clients wake up simultaneously\n```\n\n**Why wrong**: After an outage, all clients waiting with the sam...",
+      "block_text": "### ❌ Retry Without Jitter (Thundering Herd)\n\n**Detection**:\n```bash\ngrep -rn 'sleep.*delay\\|sleep.*backoff' --include=\"*.py\" | grep -v 'jitter\\|random\\|uniform'\nrg 'time\\.sleep\\(delay\\)' --type py\n```\n\n**What it looks like**:\n```python\nfor attempt in range(max_retries):\n    try:\n        return call_api()\n    except RequestException:\n        time.sleep(delay)\n        delay *= 2  # No jitter — all clients wake up simultaneously\n```\n\n**Why wrong**: After an outage, all clients waiting with the sam...",
       "domain_hint": "condition-based-waiting"
     },
     {
@@ -610,7 +610,7 @@
         137,
         174
       ],
-      "block_text": "### \u274c Retrying Non-Retryable Errors\n\n**Detection**:\n```bash\ngrep -rn 'except Exception' --include=\"*.py\" -B2 | grep -E 'retry|attempt|backoff'\nrg 'retryable_exceptions.*=.*Exception\\b' --type py\n```\n\n**What it looks like**:\n```python\nfor attempt in range(5):\n    try:\n        return api_call()\n    except Exception:  # Retries 401, 404, validation errors too\n        time.sleep(delay)\n```\n\n**Why wrong**: A 401 Unauthorized will never succeed on retry \u2014 you're burning quota and delaying the inevitab...",
+      "block_text": "### ❌ Retrying Non-Retryable Errors\n\n**Detection**:\n```bash\ngrep -rn 'except Exception' --include=\"*.py\" -B2 | grep -E 'retry|attempt|backoff'\nrg 'retryable_exceptions.*=.*Exception\\b' --type py\n```\n\n**What it looks like**:\n```python\nfor attempt in range(5):\n    try:\n        return api_call()\n    except Exception:  # Retries 401, 404, validation errors too\n        time.sleep(delay)\n```\n\n**Why wrong**: A 401 Unauthorized will never succeed on retry — you're burning quota and delaying the inevitab...",
       "domain_hint": "condition-based-waiting"
     },
     {
@@ -619,7 +619,7 @@
         176,
         188
       ],
-      "block_text": "### \u274c Busy-Wait (No Sleep in Poll Loop)\n\n**Detection**:\n```bash\ngrep -rn -A 8 'while.*monotonic\\(\\)' --include=\"*.py\" | grep -v 'sleep'\nrg 'while time\\.monotonic' --type py -A 6 | grep -c 'sleep'\n```\n\n**What it looks like**:\n```python\nwhile time.monotonic() < deadline:\n    if condition():\n        return True",
+      "block_text": "### ❌ Busy-Wait (No Sleep in Poll Loop)\n\n**Detection**:\n```bash\ngrep -rn -A 8 'while.*monotonic\\(\\)' --include=\"*.py\" | grep -v 'sleep'\nrg 'while time\\.monotonic' --type py -A 6 | grep -c 'sleep'\n```\n\n**What it looks like**:\n```python\nwhile time.monotonic() < deadline:\n    if condition():\n        return True",
       "domain_hint": "condition-based-waiting"
     },
     {
@@ -628,7 +628,7 @@
         189,
         202
       ],
-      "block_text": "# No sleep \u2014 spins at 100% CPU until timeout\n```\n\n**Why wrong**: A tight poll loop consumes 100% of one CPU core, starves other threads/processes, and triggers thermal throttling on laptops.\n\n**Fix**:\n```python\nwhile time.monotonic() < deadline:\n    if condition():\n        return True\n    time.sleep(poll_interval)  # min 0.01s in-process; 0.5s+ for external services\n```\n\n---\n",
+      "block_text": "# No sleep — spins at 100% CPU until timeout\n```\n\n**Why wrong**: A tight poll loop consumes 100% of one CPU core, starves other threads/processes, and triggers thermal throttling on laptops.\n\n**Fix**:\n```python\nwhile time.monotonic() < deadline:\n    if condition():\n        return True\n    time.sleep(poll_interval)  # min 0.01s in-process; 0.5s+ for external services\n```\n\n---\n",
       "domain_hint": "condition-based-waiting"
     },
     {
@@ -637,7 +637,7 @@
         204,
         216
       ],
-      "block_text": "### \u274c Bash Loop Without Timeout\n\n**Detection**:\n```bash\ngrep -rn 'while.*sleep' --include=\"*.sh\" | grep -v 'deadline\\|SECONDS\\|timeout\\|end_time'\ngrep -rn 'while true' --include=\"*.sh\" -i | grep -v 'deadline\\|SECONDS'\n```\n\n**What it looks like**:\n```bash\nwhile ! pg_isready -h localhost; do\n    sleep 2\ndone",
+      "block_text": "### ❌ Bash Loop Without Timeout\n\n**Detection**:\n```bash\ngrep -rn 'while.*sleep' --include=\"*.sh\" | grep -v 'deadline\\|SECONDS\\|timeout\\|end_time'\ngrep -rn 'while true' --include=\"*.sh\" -i | grep -v 'deadline\\|SECONDS'\n```\n\n**What it looks like**:\n```bash\nwhile ! pg_isready -h localhost; do\n    sleep 2\ndone",
       "domain_hint": "condition-based-waiting"
     },
     {
@@ -646,7 +646,7 @@
         217,
         237
       ],
-      "block_text": "# Hangs indefinitely if postgres never starts\n```\n\n**Why wrong**: No bound means this script hangs in CI until the job times out, with no diagnostic about what failed or how long it waited.\n\n**Fix**:\n```bash\ndeadline=$((SECONDS + 60))\nwhile [ $SECONDS -lt $deadline ]; do\n    if pg_isready -h localhost; then\n        exit 0\n    fi\n    sleep 2\ndone\necho \"Timeout: postgres not ready after 60s\" >&2\nexit 1\n```\n\n**Note**: `$SECONDS` is a bash built-in counting seconds since shell started \u2014 no `date` su...",
+      "block_text": "# Hangs indefinitely if postgres never starts\n```\n\n**Why wrong**: No bound means this script hangs in CI until the job times out, with no diagnostic about what failed or how long it waited.\n\n**Fix**:\n```bash\ndeadline=$((SECONDS + 60))\nwhile [ $SECONDS -lt $deadline ]; do\n    if pg_isready -h localhost; then\n        exit 0\n    fi\n    sleep 2\ndone\necho \"Timeout: postgres not ready after 60s\" >&2\nexit 1\n```\n\n**Note**: `$SECONDS` is a bash built-in counting seconds since shell started — no `date` su...",
       "domain_hint": "condition-based-waiting"
     },
     {
@@ -655,7 +655,7 @@
         228,
         249
       ],
-      "block_text": "## Anti-Pattern: Using `time.sleep` in Tests Directly\n\n**Detection**:\n```bash\ngrep -rn 'time\\.sleep' --include=\"test_*.py\"\nrg 'time\\.sleep\\(\\d' --type py -g 'test_*'\n```\n\n**What it looks like**:\n```python\ndef test_retry_waits():\n    # Slow test \u2014 waits real time\n    start = time.time()\n    retry_with_backoff(flaky_op, \"test\", initial_delay_seconds=1.0)\n    assert time.time() - start >= 1.0\n```\n\n**Why wrong**: This makes the test suite slow. A 3-retry test with 1s initial delay takes 7+ real seco...",
+      "block_text": "## Anti-Pattern: Using `time.sleep` in Tests Directly\n\n**Detection**:\n```bash\ngrep -rn 'time\\.sleep' --include=\"test_*.py\"\nrg 'time\\.sleep\\(\\d' --type py -g 'test_*'\n```\n\n**What it looks like**:\n```python\ndef test_retry_waits():\n    # Slow test — waits real time\n    start = time.time()\n    retry_with_backoff(flaky_op, \"test\", initial_delay_seconds=1.0)\n    assert time.time() - start >= 1.0\n```\n\n**Why wrong**: This makes the test suite slow. A 3-retry test with 1s initial delay takes 7+ real seco...",
       "domain_hint": "condition-based-waiting"
     },
     {
@@ -682,7 +682,7 @@
         81,
         87
       ],
-      "block_text": "# Error: topic not found\n```\n\n**Why wrong**: Users type partial titles or wrong case. \"Hugo caching\" and \"Hugo partial caching issues\" \u2014 the latter is the real entry. Hard stop wastes user time when a partial match could resolve it.\n\n**Fix**:\n```bash",
+      "block_text": "# Error: topic not found\n```\n\n**Why wrong**: Users type partial titles or wrong case. \"Hugo caching\" and \"Hugo partial caching issues\" — the latter is the real entry. Hard stop wastes user time when a partial match could resolve it.\n\n**Fix**:\n```bash",
       "domain_hint": "content-calendar"
     },
     {
@@ -691,7 +691,7 @@
         103,
         108
       ],
-      "block_text": "# ... write operation ...\nwc -l content-calendar.md  # after \u2014 should be >= before for add/move\n```\n\n**What it looks like**:\n```",
+      "block_text": "# ... write operation ...\nwc -l content-calendar.md  # after — should be >= before for add/move\n```\n\n**What it looks like**:\n```",
       "domain_hint": "content-calendar"
     },
     {
@@ -718,7 +718,7 @@
         130,
         138
       ],
-      "block_text": "## Ready\n- [ ] **Hugo build errors** (ready: 2025-01-14)  <!-- should be [x] -->\n```\n\n**Why wrong**: Checkbox state `[x]` must flip at the Editing\u2192Ready transition. If a topic lands in Ready as `- [ ]`, the Published and Historical sections will contain unchecked items, making the file unreadable as a kanban board.\n\n**Fix**: Enforce checkbox flip during move-to-ready. If a topic arrives in Ready with `[ ]`, convert to `[x]` before writing.\n\n---\n",
+      "block_text": "## Ready\n- [ ] **Hugo build errors** (ready: 2025-01-14)  <!-- should be [x] -->\n```\n\n**Why wrong**: Checkbox state `[x]` must flip at the Editing→Ready transition. If a topic lands in Ready as `- [ ]`, the Published and Historical sections will contain unchecked items, making the file unreadable as a kanban board.\n\n**Fix**: Enforce checkbox flip during move-to-ready. If a topic arrives in Ready with `[ ]`, convert to `[x]` before writing.\n\n---\n",
       "domain_hint": "content-calendar"
     },
     {
@@ -736,7 +736,7 @@
         165,
         173
       ],
-      "block_text": "### \u274c Duplicate Section Headers\n\n**Detection**:\n```bash\ngrep -n \"^## Ideas\\|^## Outlined\\|^## Drafted\\|^## Editing\\|^## Ready\\|^## Published\" content-calendar.md | sort | uniq -d\n```\n\n**What it looks like**:\n```markdown",
+      "block_text": "### ❌ Duplicate Section Headers\n\n**Detection**:\n```bash\ngrep -n \"^## Ideas\\|^## Outlined\\|^## Drafted\\|^## Editing\\|^## Ready\\|^## Published\" content-calendar.md | sort | uniq -d\n```\n\n**What it looks like**:\n```markdown",
       "domain_hint": "content-calendar"
     },
     {
@@ -745,7 +745,7 @@
         180,
         188
       ],
-      "block_text": "## Ideas        <!-- duplicate \u2014 botched merge or manual edit -->\n- [ ] Topic B\n```\n\n**Why wrong**: Only the first `## Ideas` section is parsed. Topic B is silently invisible to all operations and the count table is wrong.\n\n**Fix**: On load, detect duplicate section headers. Merge content from all instances into one section and warn the user before proceeding.\n\n---\n",
+      "block_text": "## Ideas        <!-- duplicate — botched merge or manual edit -->\n- [ ] Topic B\n```\n\n**Why wrong**: Only the first `## Ideas` section is parsed. Topic B is silently invisible to all operations and the count table is wrong.\n\n**Fix**: On load, detect duplicate section headers. Merge content from all instances into one section and warn the user before proceeding.\n\n---\n",
       "domain_hint": "content-calendar"
     },
     {
@@ -763,7 +763,7 @@
         82,
         104
       ],
-      "block_text": "# Find editing entries older than threshold (14 days back)\nCUTOFF=$(python3 -c \"from datetime import date, timedelta; print((date.today() - timedelta(days=14)).isoformat())\")\ngrep -E \"\\(editing: [0-9]{4}-[0-9]{2}-[0-9]{2}\\)\" content-calendar.md | \\\n  awk -F'editing: ' '{print $2}' | tr -d ')' | awk -v c=\"$CUTOFF\" '$1 < c'\n```\n\n**What it looks like**:\n```\nIN PROGRESS:\n  -> \"Hugo debugging guide\" (editing)     \u2190 no age shown\n  -> \"Image optimization\" (drafted)       \u2190 no age shown\n```\n\n**Why wrong...",
+      "block_text": "# Find editing entries older than threshold (14 days back)\nCUTOFF=$(python3 -c \"from datetime import date, timedelta; print((date.today() - timedelta(days=14)).isoformat())\")\ngrep -E \"\\(editing: [0-9]{4}-[0-9]{2}-[0-9]{2}\\)\" content-calendar.md | \\\n  awk -F'editing: ' '{print $2}' | tr -d ')' | awk -v c=\"$CUTOFF\" '$1 < c'\n```\n\n**What it looks like**:\n```\nIN PROGRESS:\n  -> \"Hugo debugging guide\" (editing)     ← no age shown\n  -> \"Image optimization\" (drafted)       ← no age shown\n```\n\n**Why wrong...",
       "domain_hint": "content-calendar"
     },
     {
@@ -772,7 +772,7 @@
         112,
         128
       ],
-      "block_text": "# Compare to sum of active stages\ngrep -E \"^\\| (Outlined|Drafted|Editing|Ready)\" content-calendar.md\n```\n\n**What it looks like**:\n```\nPipeline Overview:\n| Ideas    | 23 |\n| Outlined |  1 |\n| Drafted  |  0 |\n```\n\n**Why wrong**: 23 ideas with 1 outlined means idea generation is not bottlenecked \u2014 advancement is. Reporting a \"full\" pipeline when Ideas=23 gives false confidence. Ideas are potential, not velocity.\n\n**Fix**: When displaying pipeline health, separate \"idea backlog depth\" from \"active p...",
+      "block_text": "# Compare to sum of active stages\ngrep -E \"^\\| (Outlined|Drafted|Editing|Ready)\" content-calendar.md\n```\n\n**What it looks like**:\n```\nPipeline Overview:\n| Ideas    | 23 |\n| Outlined |  1 |\n| Drafted  |  0 |\n```\n\n**Why wrong**: 23 ideas with 1 outlined means idea generation is not bottlenecked — advancement is. Reporting a \"full\" pipeline when Ideas=23 gives false confidence. Ideas are potential, not velocity.\n\n**Fix**: When displaying pipeline health, separate \"idea backlog depth\" from \"active p...",
       "domain_hint": "content-calendar"
     },
     {
@@ -790,7 +790,7 @@
         144,
         153
       ],
-      "block_text": "## Ready\n- [x] **Hugo build errors** (ready: 2025-01-14)\n<!-- no Scheduled: line \u2014 when does this publish? -->\n```\n\n**Why wrong**: Content without a scheduled date clogs the Ready stage indefinitely. A 3-month-old \"Ready\" item is effectively abandoned, but looks like active work.\n\n**Fix**: Block the move-to-ready operation from completing until a publication date is provided. Show: \"When should this be published? (YYYY-MM-DD or 'tbd' to skip)\".\n\n---\n",
+      "block_text": "## Ready\n- [x] **Hugo build errors** (ready: 2025-01-14)\n<!-- no Scheduled: line — when does this publish? -->\n```\n\n**Why wrong**: Content without a scheduled date clogs the Ready stage indefinitely. A 3-month-old \"Ready\" item is effectively abandoned, but looks like active work.\n\n**Fix**: Block the move-to-ready operation from completing until a publication date is provided. Show: \"When should this be published? (YYYY-MM-DD or 'tbd' to skip)\".\n\n---\n",
       "domain_hint": "content-calendar"
     },
     {
@@ -808,7 +808,7 @@
         168,
         175
       ],
-      "block_text": "# December and January posts remain in Published \u2014 not moved to Historical\n```\n\n**Why wrong**: The Published section grows unbounded. A 6-month-old pipeline will have dozens of entries in Published, making counts misleading and dashboard output unreadable.\n\n**Fix**: Run archive check on every `view` operation (warn-only) and require explicit user confirmation before moving to Historical on `archive` operation.\n\n---\n",
+      "block_text": "# December and January posts remain in Published — not moved to Historical\n```\n\n**Why wrong**: The Published section grows unbounded. A 6-month-old pipeline will have dozens of entries in Published, making counts misleading and dashboard output unreadable.\n\n**Fix**: Run archive check on every `view` operation (warn-only) and require explicit user confirmation before moving to Historical on `archive` operation.\n\n---\n",
       "domain_hint": "content-calendar"
     },
     {
@@ -826,7 +826,7 @@
         21,
         31
       ],
-      "block_text": "# Repeated Phase headers in session artifacts signal a full restart occurred\ngrep -c \"## Atomic Ideas\" content_ideas.md\n```\n\n**What it looks like**: Deleting `content_ideas.md` and `content_drafts.md` and starting over when Phase 4 flags a single hype phrase.\n\n**Why wrong**: Gate failures are surgical \u2014 one phrase in one draft. Restarting discards clean work from passing sections. The gate exists to target the failure, not trigger a full rewrite.\n\n**Fix**: Identify the flagged section, rewrite o...",
+      "block_text": "# Repeated Phase headers in session artifacts signal a full restart occurred\ngrep -c \"## Atomic Ideas\" content_ideas.md\n```\n\n**What it looks like**: Deleting `content_ideas.md` and `content_drafts.md` and starting over when Phase 4 flags a single hype phrase.\n\n**Why wrong**: Gate failures are surgical — one phrase in one draft. Restarting discards clean work from passing sections. The gate exists to target the failure, not trigger a full rewrite.\n\n**Fix**: Identify the flagged section, rewrite o...",
       "domain_hint": "content-engine"
     },
     {
@@ -835,7 +835,7 @@
         39,
         48
       ],
-      "block_text": "# \"DRAFT \u2014 pending Phase 4 gate\" means gate was never run\n```\n\n**What it looks like**: \"I've reviewed the drafts carefully and they look clean. Proceeding to Phase 5.\"\n\n**Why wrong**: Self-assessment misses hype phrases embedded in context and cannot reliably detect verbatim cross-platform sentences. The scripts use exact string matching; LLMs use paraphrase matching \u2014 these produce different results.\n\n**Fix**: Always run both script checks before Phase 5. If scripts are unavailable, use the man...",
+      "block_text": "# \"DRAFT — pending Phase 4 gate\" means gate was never run\n```\n\n**What it looks like**: \"I've reviewed the drafts carefully and they look clean. Proceeding to Phase 5.\"\n\n**Why wrong**: Self-assessment misses hype phrases embedded in context and cannot reliably detect verbatim cross-platform sentences. The scripts use exact string matching; LLMs use paraphrase matching — these produce different results.\n\n**Fix**: Always run both script checks before Phase 5. If scripts are unavailable, use the man...",
       "domain_hint": "content-engine"
     },
     {
@@ -871,7 +871,7 @@
         86,
         106
       ],
-      "block_text": "### \u274c No concurrency protection at all\n\n**Detection**:\n```bash\ngrep -rL \"flock\\|\\.lock\\|\\.pid\\|lockrun\" --include=\"*.sh\" scripts/ cron/ jobs/\nrg -L 'flock|\\.lock|\\.pid' --type sh\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -euo pipefail\ncd /var/data\npython3 process_all_records.py   # runs for 45 min, cron fires again at minute 0\n```\n\n**Why wrong**: If the job takes longer than its interval, two instances run simultaneously. Both read the same input, both write to the same output, both u...",
+      "block_text": "### ❌ No concurrency protection at all\n\n**Detection**:\n```bash\ngrep -rL \"flock\\|\\.lock\\|\\.pid\\|lockrun\" --include=\"*.sh\" scripts/ cron/ jobs/\nrg -L 'flock|\\.lock|\\.pid' --type sh\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -euo pipefail\ncd /var/data\npython3 process_all_records.py   # runs for 45 min, cron fires again at minute 0\n```\n\n**Why wrong**: If the job takes longer than its interval, two instances run simultaneously. Both read the same input, both write to the same output, both u...",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -880,7 +880,7 @@
         108,
         136
       ],
-      "block_text": "### \u274c Testing lock file existence without flock (TOCTOU race)\n\n**Detection**:\n```bash\ngrep -rn \"if \\[ -f.*lock\\|test -f.*lock\" --include=\"*.sh\" scripts/ cron/\nrg 'if \\[ -f.*lock' --type sh\n```\n\n**What it looks like**:\n```bash\nLOCK=\"/tmp/myjob.lock\"\nif [ -f \"$LOCK\" ]; then\n    echo \"Running, exit\"\n    exit 0\nfi\ntouch \"$LOCK\"    # race window between [ -f ] check and touch\ntrap 'rm -f $LOCK' EXIT\n```\n\n**Why wrong**: There is a TOCTOU race: two instances can both pass `[ -f \"$LOCK\" ]` before either...",
+      "block_text": "### ❌ Testing lock file existence without flock (TOCTOU race)\n\n**Detection**:\n```bash\ngrep -rn \"if \\[ -f.*lock\\|test -f.*lock\" --include=\"*.sh\" scripts/ cron/\nrg 'if \\[ -f.*lock' --type sh\n```\n\n**What it looks like**:\n```bash\nLOCK=\"/tmp/myjob.lock\"\nif [ -f \"$LOCK\" ]; then\n    echo \"Running, exit\"\n    exit 0\nfi\ntouch \"$LOCK\"    # race window between [ -f ] check and touch\ntrap 'rm -f $LOCK' EXIT\n```\n\n**Why wrong**: There is a TOCTOU race: two instances can both pass `[ -f \"$LOCK\" ]` before either...",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -889,7 +889,7 @@
         138,
         151
       ],
-      "block_text": "### \u274c Using sleep-retry as a \"lock\"\n\n**Detection**:\n```bash\ngrep -rn \"while.*lock\\|sleep.*lock\" --include=\"*.sh\" scripts/ cron/\nrg 'while.*lock' --type sh\n```\n\n**What it looks like**:\n```bash\nwhile [ -f /tmp/myjob.lock ]; do\n    sleep 5\ndone\ntouch /tmp/myjob.lock",
+      "block_text": "### ❌ Using sleep-retry as a \"lock\"\n\n**Detection**:\n```bash\ngrep -rn \"while.*lock\\|sleep.*lock\" --include=\"*.sh\" scripts/ cron/\nrg 'while.*lock' --type sh\n```\n\n**What it looks like**:\n```bash\nwhile [ -f /tmp/myjob.lock ]; do\n    sleep 5\ndone\ntouch /tmp/myjob.lock",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -907,7 +907,7 @@
         171,
         187
       ],
-      "block_text": "# Files that mention lock but not trap\ngrep -rl \"lock\\|\\.pid\" --include=\"*.sh\" scripts/ cron/ | xargs grep -L \"trap\"\nrg -l 'lock|\\.pid' --type sh | xargs rg -L 'trap'\n```\n\n**What it looks like**:\n```bash\ntouch /tmp/myjob.lock\ndo_work\nrm /tmp/myjob.lock   # only runs on success; if set -e fires, lock is never removed\n```\n\n**Why wrong**: With `set -e`, any failure exits the script immediately \u2014 `rm` never runs. The lock file persists. All future runs think a job is still running and exit immediate...",
+      "block_text": "# Files that mention lock but not trap\ngrep -rl \"lock\\|\\.pid\" --include=\"*.sh\" scripts/ cron/ | xargs grep -L \"trap\"\nrg -l 'lock|\\.pid' --type sh | xargs rg -L 'trap'\n```\n\n**What it looks like**:\n```bash\ntouch /tmp/myjob.lock\ndo_work\nrm /tmp/myjob.lock   # only runs on success; if set -e fires, lock is never removed\n```\n\n**Why wrong**: With `set -e`, any failure exits the script immediately — `rm` never runs. The lock file persists. All future runs think a job is still running and exit immediate...",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -925,7 +925,7 @@
         92,
         113
       ],
-      "block_text": "### \u274c No logging at all (relying on cron email)\n\n**Detection**:\n```bash\ngrep -rL '>> .*log\\|tee.*log\\|LOG=' --include=\"*.sh\" scripts/ cron/ jobs/\nrg -L '>> .*\\.log|tee .*\\.log|LOG=' --type sh\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -e\ncd /var/data\npython3 process.py\nrsync -avz output/ backup/\n```\n\n**Why wrong**: All output goes to cron's mail system (usually `nobody@localhost`, usually discarded). When the job fails, there is no record of what was running, what the error was, or whe...",
+      "block_text": "### ❌ No logging at all (relying on cron email)\n\n**Detection**:\n```bash\ngrep -rL '>> .*log\\|tee.*log\\|LOG=' --include=\"*.sh\" scripts/ cron/ jobs/\nrg -L '>> .*\\.log|tee .*\\.log|LOG=' --type sh\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -e\ncd /var/data\npython3 process.py\nrsync -avz output/ backup/\n```\n\n**Why wrong**: All output goes to cron's mail system (usually `nobody@localhost`, usually discarded). When the job fails, there is no record of what was running, what the error was, or whe...",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -943,7 +943,7 @@
         129,
         137
       ],
-      "block_text": "# or locale-dependent:\necho \"$(date): Starting\"  # Thu Apr 16 20:07:00 UTC 2026 \u2014 hard to sort/grep\n```\n\n**Why wrong**: Without timestamps, log lines from different runs blend together. Locale-dependent `date` output sorts lexicographically wrong and is hard to parse programmatically. In a post-incident review, \"which run caused this?\" becomes guesswork.\n\n**Fix**:\n```bash\necho \"$(date '+%Y-%m-%d %H:%M:%S'): Starting job\"",
+      "block_text": "# or locale-dependent:\necho \"$(date): Starting\"  # Thu Apr 16 20:07:00 UTC 2026 — hard to sort/grep\n```\n\n**Why wrong**: Without timestamps, log lines from different runs blend together. Locale-dependent `date` output sorts lexicographically wrong and is hard to parse programmatically. In a post-incident review, \"which run caused this?\" becomes guesswork.\n\n**Fix**:\n```bash\necho \"$(date '+%Y-%m-%d %H:%M:%S'): Starting job\"",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -952,7 +952,7 @@
         143,
         155
       ],
-      "block_text": "### \u274c No log rotation (unbounded growth)\n\n**Detection**:\n```bash\ngrep -rl \"\\.log\" --include=\"*.sh\" scripts/ | xargs grep -L \"mtime\\|logrotate\\|rotate\"\nrg -l '\\.log' --type sh | xargs rg -L 'mtime|logrotate|rotate'\n```\n\n**What it looks like**:\n```bash\nLOG=\"/var/log/myjob.log\"\nexec >> \"$LOG\" 2>&1\necho \"$(date): Starting\"",
+      "block_text": "### ❌ No log rotation (unbounded growth)\n\n**Detection**:\n```bash\ngrep -rl \"\\.log\" --include=\"*.sh\" scripts/ | xargs grep -L \"mtime\\|logrotate\\|rotate\"\nrg -l '\\.log' --type sh | xargs rg -L 'mtime|logrotate|rotate'\n```\n\n**What it looks like**:\n```bash\nLOG=\"/var/log/myjob.log\"\nexec >> \"$LOG\" 2>&1\necho \"$(date): Starting\"",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -961,7 +961,7 @@
         156,
         162
       ],
-      "block_text": "# ... no rotation, this file grows forever ...\n```\n\n**Why wrong**: A daily cron job writing 1 MB of output fills 365 MB/year into a single file. On a VPS with a small `/var` partition, this causes disk-full failures in other services (nginx, postgres, syslog) \u2014 usually noticed at 3am when cron itself fails to write.\n\n**Fix**:\n```bash",
+      "block_text": "# ... no rotation, this file grows forever ...\n```\n\n**Why wrong**: A daily cron job writing 1 MB of output fills 365 MB/year into a single file. On a VPS with a small `/var` partition, this causes disk-full failures in other services (nginx, postgres, syslog) — usually noticed at 3am when cron itself fails to write.\n\n**Fix**:\n```bash",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -970,7 +970,7 @@
         173,
         187
       ],
-      "block_text": "### \u274c Logging to stdout only (lost in cron daemon)\n\n**Detection**:\n```bash\ngrep -rL \">>\" --include=\"*.sh\" scripts/ cron/ | xargs grep -l \"echo\\|printf\" 2>/dev/null\nrg -L '>>' --type sh | xargs rg -l 'echo|printf' 2>/dev/null\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -e\necho \"Starting at $(date)\"\ndo_work\necho \"Done\"",
+      "block_text": "### ❌ Logging to stdout only (lost in cron daemon)\n\n**Detection**:\n```bash\ngrep -rL \">>\" --include=\"*.sh\" scripts/ cron/ | xargs grep -l \"echo\\|printf\" 2>/dev/null\nrg -L '>>' --type sh | xargs rg -l 'echo|printf' 2>/dev/null\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -e\necho \"Starting at $(date)\"\ndo_work\necho \"Done\"",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -979,7 +979,7 @@
         188,
         198
       ],
-      "block_text": "# All output captured by cron daemon, usually discarded or emailed to root\n```\n\n**Why wrong**: Cron captures stdout/stderr and emails them. Most systems have cron email disabled or pointing to an unread mailbox. Even when email works, you lose historical logs \u2014 only the most recent run's output is potentially available.\n\n**Fix**:\n```bash\nexec >> \"/var/log/myjob_$(date +%Y%m%d).log\" 2>&1\n```\n\n---\n",
+      "block_text": "# All output captured by cron daemon, usually discarded or emailed to root\n```\n\n**Why wrong**: Cron captures stdout/stderr and emails them. Most systems have cron email disabled or pointing to an unread mailbox. Even when email works, you lose historical logs — only the most recent run's output is potentially available.\n\n**Fix**:\n```bash\nexec >> \"/var/log/myjob_$(date +%Y%m%d).log\" 2>&1\n```\n\n---\n",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -997,7 +997,7 @@
         87,
         112
       ],
-      "block_text": "### \u274c Missing set -e / no error handling\n\n**Detection**:\n```bash\ngrep -rL \"set -e\" --include=\"*.sh\" scripts/ cron/ jobs/ bin/\nrg -L \"set -e\" --type sh\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\ncd /var/data\nrm -rf old_files/\nprocess_data.py input.csv > output.csv\nmv output.csv /var/reports/\n```\n\n**Why wrong**: If `process_data.py` fails (non-zero exit), `mv` still runs, overwriting `/var/reports/` with an empty or corrupt file. The failure is invisible \u2014 cron marks the job as succeeded.\n\n*...",
+      "block_text": "### ❌ Missing set -e / no error handling\n\n**Detection**:\n```bash\ngrep -rL \"set -e\" --include=\"*.sh\" scripts/ cron/ jobs/ bin/\nrg -L \"set -e\" --type sh\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\ncd /var/data\nrm -rf old_files/\nprocess_data.py input.csv > output.csv\nmv output.csv /var/reports/\n```\n\n**Why wrong**: If `process_data.py` fails (non-zero exit), `mv` still runs, overwriting `/var/reports/` with an empty or corrupt file. The failure is invisible — cron marks the job as succeeded.\n\n*...",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -1006,7 +1006,7 @@
         114,
         141
       ],
-      "block_text": "### \u274c Piped commands ignoring pipeline failures\n\n**Detection**:\n```bash\ngrep -rl \"\\|\" --include=\"*.sh\" scripts/ cron/ | xargs grep -L \"pipefail\"\nrg '\\|\\s+\\w+' --type sh -l | xargs rg -L 'pipefail'\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -e  # but no pipefail!\npg_dump mydb | gzip > backup.sql.gz    # if pg_dump fails, gzip writes a 0-byte gz file\nfind /data -name \"*.log\" | xargs gzip  # if find fails, gzip still runs on partial list\n```\n\n**Why wrong**: Without `pipefail`, the exit co...",
+      "block_text": "### ❌ Piped commands ignoring pipeline failures\n\n**Detection**:\n```bash\ngrep -rl \"\\|\" --include=\"*.sh\" scripts/ cron/ | xargs grep -L \"pipefail\"\nrg '\\|\\s+\\w+' --type sh -l | xargs rg -L 'pipefail'\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -e  # but no pipefail!\npg_dump mydb | gzip > backup.sql.gz    # if pg_dump fails, gzip writes a 0-byte gz file\nfind /data -name \"*.log\" | xargs gzip  # if find fails, gzip still runs on partial list\n```\n\n**Why wrong**: Without `pipefail`, the exit co...",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -1015,7 +1015,7 @@
         143,
         163
       ],
-      "block_text": "### \u274c Undefined variable silently expanding to empty string\n\n**Detection**:\n```bash\ngrep -rL \"set -u\\|set -euo\\|nounset\" --include=\"*.sh\" scripts/ cron/\ngrep -rn 'rm -rf.*\\$' --include=\"*.sh\" scripts/\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -e\nrm -rf \"$BACKUP_DIR/\"    # if BACKUP_DIR is unset, expands to \"rm -rf /\"\nrsync -avz \"$SRC_PATH/\" \"$DEST/\"   # silently copies nothing if SRC_PATH unset\n```\n\n**Why wrong**: Without `set -u`, unset variables expand to empty string. `rm -rf \"$BAC...",
+      "block_text": "### ❌ Undefined variable silently expanding to empty string\n\n**Detection**:\n```bash\ngrep -rL \"set -u\\|set -euo\\|nounset\" --include=\"*.sh\" scripts/ cron/\ngrep -rn 'rm -rf.*\\$' --include=\"*.sh\" scripts/\n```\n\n**What it looks like**:\n```bash\n#!/bin/bash\nset -e\nrm -rf \"$BACKUP_DIR/\"    # if BACKUP_DIR is unset, expands to \"rm -rf /\"\nrsync -avz \"$SRC_PATH/\" \"$DEST/\"   # silently copies nothing if SRC_PATH unset\n```\n\n**Why wrong**: Without `set -u`, unset variables expand to empty string. `rm -rf \"$BAC...",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -1024,7 +1024,7 @@
         170,
         187
       ],
-      "block_text": "### \u274c Swallowing errors with bare || true\n\n**Detection**:\n```bash\ngrep -rn \"|| true\" --include=\"*.sh\" scripts/ cron/ jobs/\nrg '\\|\\|\\s*true' --type sh\n```\n\n**What it looks like**:\n```bash\ncreate_schema.sql || true    # if schema creation fails, continue anyway\nvalidate_data.py || true     # silently ignores validation failures\n```\n\n**Why wrong**: `|| true` converts any failure into success. Combined with `set -e`, it suppresses the exit but also suppresses the failure signal \u2014 the script continue...",
+      "block_text": "### ❌ Swallowing errors with bare || true\n\n**Detection**:\n```bash\ngrep -rn \"|| true\" --include=\"*.sh\" scripts/ cron/ jobs/\nrg '\\|\\|\\s*true' --type sh\n```\n\n**What it looks like**:\n```bash\ncreate_schema.sql || true    # if schema creation fails, continue anyway\nvalidate_data.py || true     # silently ignores validation failures\n```\n\n**Why wrong**: `|| true` converts any failure into success. Combined with `set -e`, it suppresses the exit but also suppresses the failure signal — the script continue...",
       "domain_hint": "cron-job-auditor"
     },
     {
@@ -1105,7 +1105,7 @@
         17,
         35
       ],
-      "block_text": "### \u274c Confirmation Bias via Post-Hoc Weight Adjustment\n\n**Detection signal**: User adjusts weights AFTER seeing the scored matrix, specifically to change the winner.\n\n```\n\"Actually, I think Familiarity should be weight 4, not 2.\"  [after seeing their preferred option lost on Familiarity]\n\"Can we lower Risk? I don't think it's that important here.\" [after seeing their preferred option scored badly on Risk]\n```\n\n**Why wrong**: Weights represent what matters for this decision. If weights were set c...",
+      "block_text": "### ❌ Confirmation Bias via Post-Hoc Weight Adjustment\n\n**Detection signal**: User adjusts weights AFTER seeing the scored matrix, specifically to change the winner.\n\n```\n\"Actually, I think Familiarity should be weight 4, not 2.\"  [after seeing their preferred option lost on Familiarity]\n\"Can we lower Risk? I don't think it's that important here.\" [after seeing their preferred option scored badly on Risk]\n```\n\n**Why wrong**: Weights represent what matters for this decision. If weights were set c...",
       "domain_hint": "decision-helper"
     },
     {
@@ -1114,7 +1114,7 @@
         37,
         56
       ],
-      "block_text": "### \u274c Analysis Paralysis via Option Proliferation\n\n**Detection signal**: User presents 5+ options, or keeps adding options mid-scoring.\n\n```\n\"We're also considering Option D, and actually Option E is worth looking at...\"\n\"Before we score, what if we added the hybrid approach as Option F?\"\n```\n\n**Why wrong**: Scoring more than 4 options dilutes focus and invites false precision. A 6-option matrix signals the decision hasn't been framed yet \u2014 it's research, not decision-making. The math becomes me...",
+      "block_text": "### ❌ Analysis Paralysis via Option Proliferation\n\n**Detection signal**: User presents 5+ options, or keeps adding options mid-scoring.\n\n```\n\"We're also considering Option D, and actually Option E is worth looking at...\"\n\"Before we score, what if we added the hybrid approach as Option F?\"\n```\n\n**Why wrong**: Scoring more than 4 options dilutes focus and invites false precision. A 6-option matrix signals the decision hasn't been framed yet — it's research, not decision-making. The math becomes me...",
       "domain_hint": "decision-helper"
     },
     {
@@ -1123,7 +1123,7 @@
         58,
         72
       ],
-      "block_text": "### \u274c Anchoring to the First Option\n\n**Detection signal**: First option stated gets systematically higher scores across criteria, even weak ones, or other options are evaluated relative to the first rather than absolutely.\n\n```\n\"Option A does X well. Option B doesn't do X as well as A.\" [A becomes the reference point]\n```\n\n**Why wrong**: Scores should be absolute (1-10 on the criterion itself), not relative to another option. When the first option anchors scoring, the matrix measures \"distance f...",
+      "block_text": "### ❌ Anchoring to the First Option\n\n**Detection signal**: First option stated gets systematically higher scores across criteria, even weak ones, or other options are evaluated relative to the first rather than absolutely.\n\n```\n\"Option A does X well. Option B doesn't do X as well as A.\" [A becomes the reference point]\n```\n\n**Why wrong**: Scores should be absolute (1-10 on the criterion itself), not relative to another option. When the first option anchors scoring, the matrix measures \"distance f...",
       "domain_hint": "decision-helper"
     },
     {
@@ -1132,7 +1132,7 @@
         74,
         96
       ],
-      "block_text": "### \u274c False Precision on Tied Scores\n\n**Detection signal**: User treats a 0.1 or 0.2 weighted score difference as a meaningful recommendation.\n\n```\nOption A: 6.89\nOption B: 6.71\n\"So we should go with Option A.\"\n```\n\n**Why wrong**: Individual scores are subjective 1-10 estimates. A score of 7 vs 8 on Complexity is not a measurement \u2014 it's an opinion. Weighted differences below 0.5 are noise, not signal. Treating them as decisive ignores the uncertainty in every input score.\n\n**Fix**: Apply the cl...",
+      "block_text": "### ❌ False Precision on Tied Scores\n\n**Detection signal**: User treats a 0.1 or 0.2 weighted score difference as a meaningful recommendation.\n\n```\nOption A: 6.89\nOption B: 6.71\n\"So we should go with Option A.\"\n```\n\n**Why wrong**: Individual scores are subjective 1-10 estimates. A score of 7 vs 8 on Complexity is not a measurement — it's an opinion. Weighted differences below 0.5 are noise, not signal. Treating them as decisive ignores the uncertainty in every input score.\n\n**Fix**: Apply the cl...",
       "domain_hint": "decision-helper"
     },
     {
@@ -1141,7 +1141,7 @@
         98,
         117
       ],
-      "block_text": "### \u274c Criteria Scope Creep Mid-Scoring\n\n**Detection signal**: New criteria added after scoring has started, especially if the new criterion favors a particular option that was losing.\n\n```\n\"Actually, we should add 'Vendor Support' as a criterion.\"  [halfway through scoring]\n\"I forgot to include 'Team Learning Opportunity.'\"  [after Option A is clearly losing]\n```\n\n**Why wrong**: Adding criteria after partial scoring means earlier options were scored on a different basis than later ones. The matr...",
+      "block_text": "### ❌ Criteria Scope Creep Mid-Scoring\n\n**Detection signal**: New criteria added after scoring has started, especially if the new criterion favors a particular option that was losing.\n\n```\n\"Actually, we should add 'Vendor Support' as a criterion.\"  [halfway through scoring]\n\"I forgot to include 'Team Learning Opportunity.'\"  [after Option A is clearly losing]\n```\n\n**Why wrong**: Adding criteria after partial scoring means earlier options were scored on a different basis than later ones. The matr...",
       "domain_hint": "decision-helper"
     },
     {
@@ -1150,7 +1150,7 @@
         119,
         132
       ],
-      "block_text": "### \u274c Skipping Hard Constraint Elimination\n\n**Detection signal**: Options with obvious eliminators still make it into the scoring matrix.\n\n```\nScoring a vendor that doesn't support the required data residency region.\nScoring an open-source library with a GPL license for a commercial product.\nScoring a framework whose last commit was 4 years ago.\n```\n\n**Why wrong**: Hard constraints are binary eliminators, not scored criteria. Including non-starters in the matrix wastes time and creates noise. Wo...",
+      "block_text": "### ❌ Skipping Hard Constraint Elimination\n\n**Detection signal**: Options with obvious eliminators still make it into the scoring matrix.\n\n```\nScoring a vendor that doesn't support the required data residency region.\nScoring an open-source library with a GPL license for a commercial product.\nScoring a framework whose last commit was 4 years ago.\n```\n\n**Why wrong**: Hard constraints are binary eliminators, not scored criteria. Including non-starters in the matrix wastes time and creates noise. Wo...",
       "domain_hint": "decision-helper"
     },
     {
@@ -1159,7 +1159,7 @@
         147,
         162
       ],
-      "block_text": "### \u274c No Hard Criteria for \"Scores Feel Wrong\"\n\n**Detection signal**: User repeatedly adjusts scores without reasoning, or says \"something feels off.\"\n\n```\n\"I think Risk should be 9, not 7.\" [no explanation]\n\"Let's change Maintainability to 5.\" [changing a score without new information]\n```\n\n**Why wrong**: Score changes without justification are gut feelings overriding the framework. The framework's value is making implicit reasoning explicit. Unexplained score changes re-obscure the reasoning.\n...",
+      "block_text": "### ❌ No Hard Criteria for \"Scores Feel Wrong\"\n\n**Detection signal**: User repeatedly adjusts scores without reasoning, or says \"something feels off.\"\n\n```\n\"I think Risk should be 9, not 7.\" [no explanation]\n\"Let's change Maintainability to 5.\" [changing a score without new information]\n```\n\n**Why wrong**: Score changes without justification are gut feelings overriding the framework. The framework's value is making implicit reasoning explicit. Unexplained score changes re-obscure the reasoning.\n...",
       "domain_hint": "decision-helper"
     },
     {
@@ -1186,7 +1186,7 @@
         70,
         96
       ],
-      "block_text": "# Find Tailwind arbitrary color values (should use CSS vars via theme config instead)\nrg 'text-\\[#[0-9a-fA-F]+\\]|bg-\\[#[0-9a-fA-F]+\\]|border-\\[#[0-9a-fA-F]+\\]' -g \"*.tsx\" -g \"*.jsx\"\n```\n\n**What it looks like**:\n```css\n.hero-title {\n  color: #1a1a2e;           /* hardcoded \u2014 bypasses token system */\n  background: #4a90e2;      /* hardcoded \u2014 impossible to audit ratio */\n}\n```\n\n**Why wrong**: Hardcoded colors scattered across files break the 60/30/10 dominance ratio audit \u2014 you cannot verify palet...",
+      "block_text": "# Find Tailwind arbitrary color values (should use CSS vars via theme config instead)\nrg 'text-\\[#[0-9a-fA-F]+\\]|bg-\\[#[0-9a-fA-F]+\\]|border-\\[#[0-9a-fA-F]+\\]' -g \"*.tsx\" -g \"*.jsx\"\n```\n\n**What it looks like**:\n```css\n.hero-title {\n  color: #1a1a2e;           /* hardcoded — bypasses token system */\n  background: #4a90e2;      /* hardcoded — impossible to audit ratio */\n}\n```\n\n**Why wrong**: Hardcoded colors scattered across files break the 60/30/10 dominance ratio audit — you cannot verify palet...",
       "domain_hint": "distinctive-frontend-design"
     },
     {
@@ -1195,7 +1195,7 @@
         111,
         140
       ],
-      "block_text": "# Find blanket transition (anti-pattern: animating everything with *)\ngrep -rn '\\*\\s*{[^}]*transition' --include=\"*.css\" --include=\"*.scss\"\ngrep -rn 'transition:\\s*all' --include=\"*.css\" --include=\"*.scss\"\n```\n\n**What it looks like**:\n```css\n/* Animating everything \u2014 loses impact */\n.hero         { animation: fade-in 0.4s ease; }\n.hero-title   { animation: slide-up 0.5s ease 0.1s; }\n.hero-subtitle{ animation: slide-up 0.5s ease 0.2s; }\n.hero-cta     { animation: slide-up 0.5s ease 0.3s; }\n.nav  ...",
+      "block_text": "# Find blanket transition (anti-pattern: animating everything with *)\ngrep -rn '\\*\\s*{[^}]*transition' --include=\"*.css\" --include=\"*.scss\"\ngrep -rn 'transition:\\s*all' --include=\"*.css\" --include=\"*.scss\"\n```\n\n**What it looks like**:\n```css\n/* Animating everything — loses impact */\n.hero         { animation: fade-in 0.4s ease; }\n.hero-title   { animation: slide-up 0.5s ease 0.1s; }\n.hero-subtitle{ animation: slide-up 0.5s ease 0.2s; }\n.hero-cta     { animation: slide-up 0.5s ease 0.3s; }\n.nav  ...",
       "domain_hint": "distinctive-frontend-design"
     },
     {
@@ -1204,7 +1204,7 @@
         150,
         176
       ],
-      "block_text": "# Verify hero/section elements have gradient layers (count should be > 0)\ngrep -rn '\\.hero\\b\\|\\.landing\\b\\|\\.page-hero\\b' --include=\"*.css\" -A 8 | grep -c 'gradient'\n```\n\n**What it looks like**:\n```css\n.hero {\n  background-color: #0a0a1a; /* flat \u2014 fails the 2-layer Phase 5 gate */\n}\n.landing-section {\n  background: #f5f5f0;       /* single value \u2014 no atmospheric depth */\n}\n```\n\n**Why wrong**: A flat background creates no visual depth, no focal point, no mood. It is the visual equivalent of sayi...",
+      "block_text": "# Verify hero/section elements have gradient layers (count should be > 0)\ngrep -rn '\\.hero\\b\\|\\.landing\\b\\|\\.page-hero\\b' --include=\"*.css\" -A 8 | grep -c 'gradient'\n```\n\n**What it looks like**:\n```css\n.hero {\n  background-color: #0a0a1a; /* flat — fails the 2-layer Phase 5 gate */\n}\n.landing-section {\n  background: #f5f5f0;       /* single value — no atmospheric depth */\n}\n```\n\n**Why wrong**: A flat background creates no visual depth, no focal point, no mood. It is the visual equivalent of sayi...",
       "domain_hint": "distinctive-frontend-design"
     },
     {
@@ -1213,7 +1213,7 @@
         186,
         204
       ],
-      "block_text": "# Find missing fallback (only one font in stack, no comma)\ngrep -rn \"font-family:\\s*'[^']*'\" --include=\"*.css\" | grep -v ','\n```\n\n**What it looks like**:\n```css\nbody { font-family: sans-serif; }        /* OS default \u2014 different on every platform */\nh1   { font-family: 'Outfit'; }          /* no fallback \u2014 FOUT on slow connections */\n```\n\n**Why wrong**: `sans-serif` alone renders as Helvetica (macOS), Arial (Windows), or Liberation Sans (Linux) \u2014 three different pages. A missing fallback causes F...",
+      "block_text": "# Find missing fallback (only one font in stack, no comma)\ngrep -rn \"font-family:\\s*'[^']*'\" --include=\"*.css\" | grep -v ','\n```\n\n**What it looks like**:\n```css\nbody { font-family: sans-serif; }        /* OS default — different on every platform */\nh1   { font-family: 'Outfit'; }          /* no fallback — FOUT on slow connections */\n```\n\n**Why wrong**: `sans-serif` alone renders as Helvetica (macOS), Arial (Windows), or Liberation Sans (Linux) — three different pages. A missing fallback causes F...",
       "domain_hint": "distinctive-frontend-design"
     },
     {
@@ -1240,7 +1240,7 @@
         131,
         160
       ],
-      "block_text": "# Find transition on layout properties\ngrep -rn 'transition:.*\\(width\\|height\\|top\\|left\\|margin\\)' --include=\"*.css\" --include=\"*.scss\"\nrg 'transition-property:\\s*(width|height|top|left|margin)' --type css\n```\n\n**What it looks like**:\n```css\n@keyframes expand {\n  from { width: 0; height: 0; }\n  to   { width: 200px; height: 200px; }\n}\n.card {\n  transition: margin-top 0.3s ease; /* layout shift on hover */\n}\n```\n\n**Why wrong**: Layout properties trigger the full pipeline (Layout \u2192 Paint \u2192 Composi...",
+      "block_text": "# Find transition on layout properties\ngrep -rn 'transition:.*\\(width\\|height\\|top\\|left\\|margin\\)' --include=\"*.css\" --include=\"*.scss\"\nrg 'transition-property:\\s*(width|height|top|left|margin)' --type css\n```\n\n**What it looks like**:\n```css\n@keyframes expand {\n  from { width: 0; height: 0; }\n  to   { width: 200px; height: 200px; }\n}\n.card {\n  transition: margin-top 0.3s ease; /* layout shift on hover */\n}\n```\n\n**Why wrong**: Layout properties trigger the full pipeline (Layout → Paint → Composi...",
       "domain_hint": "distinctive-frontend-design"
     },
     {
@@ -1267,7 +1267,7 @@
         234,
         249
       ],
-      "block_text": "# Find will-change declarations\ngrep -rn 'will-change:' --include=\"*.css\" --include=\"*.scss\" --include=\"*.module.css\"\nrg 'will-change:' --type css\n```\n\n**What it looks like**:\n```css\n* { will-change: transform; }  /* nuclear option \u2014 crashes low-end devices */\n.card { will-change: transform, opacity, filter; } /* too many properties */\n```\n\n**Why wrong**: Each `will-change` layer consumes GPU memory. Blanket use exhausts VRAM on low-end mobile (typically 512MB\u20131GB GPU memory budget), causing the...",
+      "block_text": "# Find will-change declarations\ngrep -rn 'will-change:' --include=\"*.css\" --include=\"*.scss\" --include=\"*.module.css\"\nrg 'will-change:' --type css\n```\n\n**What it looks like**:\n```css\n* { will-change: transform; }  /* nuclear option — crashes low-end devices */\n.card { will-change: transform, opacity, filter; } /* too many properties */\n```\n\n**Why wrong**: Each `will-change` layer consumes GPU memory. Blanket use exhausts VRAM on low-end mobile (typically 512MB–1GB GPU memory budget), causing the...",
       "domain_hint": "distinctive-frontend-design"
     },
     {
@@ -1321,7 +1321,7 @@
         109,
         137
       ],
-      "block_text": "### \u274c `waitForTimeout` as a Timing Fix\n\n**Detection**:\n```bash\ngrep -rn 'waitForTimeout' --include=\"*.ts\" --include=\"*.spec.ts\"\nrg 'waitForTimeout\\(' --type ts\n```\n\n**What it looks like**:\n```typescript\nawait page.getByTestId('save-button').click();\nawait page.waitForTimeout(2000); // \"give it time to save\"\nawait expect(page.getByTestId('success-banner')).toBeVisible();\n```\n\n**Why wrong**: Hard-coded delays fail silently on slow CI (timeout too short) or waste time on fast machines (timeout too ...",
+      "block_text": "### ❌ `waitForTimeout` as a Timing Fix\n\n**Detection**:\n```bash\ngrep -rn 'waitForTimeout' --include=\"*.ts\" --include=\"*.spec.ts\"\nrg 'waitForTimeout\\(' --type ts\n```\n\n**What it looks like**:\n```typescript\nawait page.getByTestId('save-button').click();\nawait page.waitForTimeout(2000); // \"give it time to save\"\nawait expect(page.getByTestId('success-banner')).toBeVisible();\n```\n\n**Why wrong**: Hard-coded delays fail silently on slow CI (timeout too short) or waste time on fast machines (timeout too ...",
       "domain_hint": "e2e-testing"
     },
     {
@@ -1330,7 +1330,7 @@
         139,
         163
       ],
-      "block_text": "### \u274c Fire-and-Forget Click (Missing Await on Navigation)\n\n**Detection**:\n```bash\ngrep -rn '\\.click()$' --include=\"*.spec.ts\"\nrg '\\.click\\(\\)[^;]' --type ts\n```\n\n**What it looks like**:\n```typescript\npage.getByTestId('submit').click(); // missing await\nawait expect(page).toHaveURL('/confirmation'); // races with navigation\n```\n\n**Why wrong**: Without `await`, the click fires but the test proceeds immediately. If the URL check runs before navigation completes, it sees the old URL and fails interm...",
+      "block_text": "### ❌ Fire-and-Forget Click (Missing Await on Navigation)\n\n**Detection**:\n```bash\ngrep -rn '\\.click()$' --include=\"*.spec.ts\"\nrg '\\.click\\(\\)[^;]' --type ts\n```\n\n**What it looks like**:\n```typescript\npage.getByTestId('submit').click(); // missing await\nawait expect(page).toHaveURL('/confirmation'); // races with navigation\n```\n\n**Why wrong**: Without `await`, the click fires but the test proceeds immediately. If the URL check runs before navigation completes, it sees the old URL and fails interm...",
       "domain_hint": "e2e-testing"
     },
     {
@@ -1339,7 +1339,7 @@
         165,
         200
       ],
-      "block_text": "### \u274c Async Fixture Without Teardown\n\n**Detection**:\n```bash\ngrep -rn \"test\\.extend\" --include=\"*.ts\" -A 10\nrg 'test\\.extend\\b' --type ts -A 10\n```\n\n**What it looks like**:\n```typescript\nexport const test = base.extend<{ db: Database }>({\n  db: async ({}, use) => {\n    const db = await Database.connect();\n    await use(db);\n    // Missing: await db.disconnect();  \u2014 resource leak\n  },\n});\n```\n\n**Why wrong**: Leaked connections accumulate across the test suite. In CI with 100 tests, this exhausts ...",
+      "block_text": "### ❌ Async Fixture Without Teardown\n\n**Detection**:\n```bash\ngrep -rn \"test\\.extend\" --include=\"*.ts\" -A 10\nrg 'test\\.extend\\b' --type ts -A 10\n```\n\n**What it looks like**:\n```typescript\nexport const test = base.extend<{ db: Database }>({\n  db: async ({}, use) => {\n    const db = await Database.connect();\n    await use(db);\n    // Missing: await db.disconnect();  — resource leak\n  },\n});\n```\n\n**Why wrong**: Leaked connections accumulate across the test suite. In CI with 100 tests, this exhausts ...",
       "domain_hint": "e2e-testing"
     },
     {
@@ -1348,7 +1348,7 @@
         202,
         228
       ],
-      "block_text": "### \u274c Sequential Waits for Independent Elements\n\n**Detection**:\n```bash\ngrep -rn '\\.waitFor(' --include=\"*.spec.ts\" -A 1\nrg 'waitFor\\(' --type ts --include=\"*.spec.ts\"\n```\n\n**What it looks like**:\n```typescript\nawait page.getByTestId('widget-a').waitFor({ state: 'visible' });\nawait page.getByTestId('widget-b').waitFor({ state: 'visible' });\nawait page.getByTestId('widget-c').waitFor({ state: 'visible' });\n```\n\n**Why wrong**: Each wait is sequential. If each element takes 500ms to render, this ad...",
+      "block_text": "### ❌ Sequential Waits for Independent Elements\n\n**Detection**:\n```bash\ngrep -rn '\\.waitFor(' --include=\"*.spec.ts\" -A 1\nrg 'waitFor\\(' --type ts --include=\"*.spec.ts\"\n```\n\n**What it looks like**:\n```typescript\nawait page.getByTestId('widget-a').waitFor({ state: 'visible' });\nawait page.getByTestId('widget-b').waitFor({ state: 'visible' });\nawait page.getByTestId('widget-c').waitFor({ state: 'visible' });\n```\n\n**Why wrong**: Each wait is sequential. If each element takes 500ms to render, this ad...",
       "domain_hint": "e2e-testing"
     },
     {
@@ -1366,7 +1366,7 @@
         186,
         209
       ],
-      "block_text": "### \u274c UI Login in Every Test\n\n**Detection**:\n```bash\ngrep -rn 'getByTestId.*login\\|getByTestId.*password\\|getByTestId.*signin' --include=\"*.spec.ts\"\nrg '(login-email|login-password|login-submit)' --type ts --include=\"*.spec.ts\" -l\n```\n\n**What it looks like**:\n```typescript\ntest.beforeEach(async ({ page }) => {\n  await page.goto('/login');\n  await page.getByTestId('login-email').fill('user@test.com');\n  await page.getByTestId('login-password').fill('password');\n  await page.getByTestId('login-sub...",
+      "block_text": "### ❌ UI Login in Every Test\n\n**Detection**:\n```bash\ngrep -rn 'getByTestId.*login\\|getByTestId.*password\\|getByTestId.*signin' --include=\"*.spec.ts\"\nrg '(login-email|login-password|login-submit)' --type ts --include=\"*.spec.ts\" -l\n```\n\n**What it looks like**:\n```typescript\ntest.beforeEach(async ({ page }) => {\n  await page.goto('/login');\n  await page.getByTestId('login-email').fill('user@test.com');\n  await page.getByTestId('login-password').fill('password');\n  await page.getByTestId('login-sub...",
       "domain_hint": "e2e-testing"
     },
     {
@@ -1375,7 +1375,7 @@
         211,
         238
       ],
-      "block_text": "### \u274c Sharing Auth Context Between Roles\n\n**Detection**:\n```bash\ngrep -rn 'storageState' --include=\"playwright.config.ts\" -A 5\nrg 'storageState.*admin.*viewer|storageState.*viewer.*admin' --type ts\n```\n\n**What it looks like**:\n```typescript\n// playwright.config.ts \u2014 wrong: one storageState for all tests\nuse: {\n  storageState: 'playwright/.auth/user.json', // which user? admin or viewer?\n},\n```\n\n**Why wrong**: When tests for different roles share one auth file, they run with the same permissions....",
+      "block_text": "### ❌ Sharing Auth Context Between Roles\n\n**Detection**:\n```bash\ngrep -rn 'storageState' --include=\"playwright.config.ts\" -A 5\nrg 'storageState.*admin.*viewer|storageState.*viewer.*admin' --type ts\n```\n\n**What it looks like**:\n```typescript\n// playwright.config.ts — wrong: one storageState for all tests\nuse: {\n  storageState: 'playwright/.auth/user.json', // which user? admin or viewer?\n},\n```\n\n**Why wrong**: When tests for different roles share one auth file, they run with the same permissions....",
       "domain_hint": "e2e-testing"
     },
     {
@@ -1384,7 +1384,7 @@
         240,
         261
       ],
-      "block_text": "### \u274c Hardcoded Credentials in Spec Files\n\n**Detection**:\n```bash\ngrep -rn 'password.*:.*\"[^\"]\\+\"\\|fill.*\"password[^\"]*\"' --include=\"*.spec.ts\"\nrg '(password|secret|token)\\s*[:=]\\s*[\"'\"'\"'][^\"'\"'\"']+[\"'\"'\"']' --type ts --include=\"*.spec.ts\"\n```\n\n**What it looks like**:\n```typescript\nawait page.getByTestId('login-password').fill('MyP@ssw0rd123'); // hardcoded\n```\n\n**Why wrong**: Credentials in source code appear in git history permanently. They also break when rotated.\n\n**Fix**:\n```typescript\nawa...",
+      "block_text": "### ❌ Hardcoded Credentials in Spec Files\n\n**Detection**:\n```bash\ngrep -rn 'password.*:.*\"[^\"]\\+\"\\|fill.*\"password[^\"]*\"' --include=\"*.spec.ts\"\nrg '(password|secret|token)\\s*[:=]\\s*[\"'\"'\"'][^\"'\"'\"']+[\"'\"'\"']' --type ts --include=\"*.spec.ts\"\n```\n\n**What it looks like**:\n```typescript\nawait page.getByTestId('login-password').fill('MyP@ssw0rd123'); // hardcoded\n```\n\n**Why wrong**: Credentials in source code appear in git history permanently. They also break when rotated.\n\n**Fix**:\n```typescript\nawa...",
       "domain_hint": "e2e-testing"
     },
     {
@@ -1393,7 +1393,7 @@
         263,
         281
       ],
-      "block_text": "### \u274c Testing Real OAuth Provider Endpoints\n\n**Detection**:\n```bash\ngrep -rn 'accounts\\.google\\.com\\|github\\.com/login/oauth\\|login\\.microsoftonline' --include=\"*.spec.ts\"\nrg '(google|github|microsoft|auth0)\\.com' --type ts --include=\"*.spec.ts\"\n```\n\n**What it looks like**:\n```typescript\nawait page.goto('https://accounts.google.com/o/oauth2/auth?...');\nawait page.getByLabel('Email').fill(process.env.GOOGLE_TEST_EMAIL!);\n```\n\n**Why wrong**: Hits a live external service. Flaky on network issues. R...",
+      "block_text": "### ❌ Testing Real OAuth Provider Endpoints\n\n**Detection**:\n```bash\ngrep -rn 'accounts\\.google\\.com\\|github\\.com/login/oauth\\|login\\.microsoftonline' --include=\"*.spec.ts\"\nrg '(google|github|microsoft|auth0)\\.com' --type ts --include=\"*.spec.ts\"\n```\n\n**What it looks like**:\n```typescript\nawait page.goto('https://accounts.google.com/o/oauth2/auth?...');\nawait page.getByLabel('Email').fill(process.env.GOOGLE_TEST_EMAIL!);\n```\n\n**Why wrong**: Hits a live external service. Flaky on network issues. R...",
       "domain_hint": "e2e-testing"
     },
     {
@@ -1411,7 +1411,7 @@
         115,
         133
       ],
-      "block_text": "### \u274c Hardcoded Bearer Token in Config\n\n**Detection**:\n```bash\ngrep -rn '\"Authorization\"' endpoints.json | grep -v '\\${[A-Z_]'\nrg '\"Authorization\".*\"Bearer [A-Za-z0-9._-]{20,}\"' --type json\n```\n\n**What it looks like**:\n```json\n{\"headers\": {\"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.actual.token\"}}\n```\n\n**Why wrong**: JWT tokens in config files get committed to git history. Even after rotation,\nthe old token remains in every git clone. GitHub secret scanning flags base64-encode...",
+      "block_text": "### ❌ Hardcoded Bearer Token in Config\n\n**Detection**:\n```bash\ngrep -rn '\"Authorization\"' endpoints.json | grep -v '\\${[A-Z_]'\nrg '\"Authorization\".*\"Bearer [A-Za-z0-9._-]{20,}\"' --type json\n```\n\n**What it looks like**:\n```json\n{\"headers\": {\"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.actual.token\"}}\n```\n\n**Why wrong**: JWT tokens in config files get committed to git history. Even after rotation,\nthe old token remains in every git clone. GitHub secret scanning flags base64-encode...",
       "domain_hint": "endpoint-validator"
     },
     {
@@ -1420,7 +1420,7 @@
         135,
         164
       ],
-      "block_text": "### \u274c Skipping expect_status on Protected Endpoint\n\n**Detection**:\n```bash\npython3 -c \"\nimport json\ncfg = json.load(open('endpoints.json'))\nfor ep in cfg.get('endpoints', []):\n    if 'Authorization' in str(ep.get('headers', {})):\n        if 'expect_status' not in ep:\n            print('WARN no expect_status on auth endpoint:', ep['path'])\n\"\n```\n\n**What it looks like**:\n```json\n{\n  \"path\": \"/api/v1/admin/users\",\n  \"headers\": {\"Authorization\": \"Bearer ${TOKEN}\"}\n}\n```\n\n**Why wrong**: Without expli...",
+      "block_text": "### ❌ Skipping expect_status on Protected Endpoint\n\n**Detection**:\n```bash\npython3 -c \"\nimport json\ncfg = json.load(open('endpoints.json'))\nfor ep in cfg.get('endpoints', []):\n    if 'Authorization' in str(ep.get('headers', {})):\n        if 'expect_status' not in ep:\n            print('WARN no expect_status on auth endpoint:', ep['path'])\n\"\n```\n\n**What it looks like**:\n```json\n{\n  \"path\": \"/api/v1/admin/users\",\n  \"headers\": {\"Authorization\": \"Bearer ${TOKEN}\"}\n}\n```\n\n**Why wrong**: Without expli...",
       "domain_hint": "endpoint-validator"
     },
     {
@@ -1429,7 +1429,7 @@
         166,
         185
       ],
-      "block_text": "### \u274c Using Admin Credentials for Smoke Tests\n\n**Detection**:\n```bash\ngrep -rn \"ADMIN\\|ROOT\\|MASTER\\|SUPERUSER\\|SUPER_\" endpoints.json\n```\n\n**What it looks like**:\n```json\n{\"headers\": {\"Authorization\": \"Bearer ${PROD_ADMIN_TOKEN}\"}}\n```\n\n**Why wrong**: A validation run with a compromised CI environment gets full admin access\nto production. Blast radius is maximum. Use read-only service account tokens scoped to\nthe specific paths being validated.\n\n**Fix**: Create a dedicated `endpoint-validator` ...",
+      "block_text": "### ❌ Using Admin Credentials for Smoke Tests\n\n**Detection**:\n```bash\ngrep -rn \"ADMIN\\|ROOT\\|MASTER\\|SUPERUSER\\|SUPER_\" endpoints.json\n```\n\n**What it looks like**:\n```json\n{\"headers\": {\"Authorization\": \"Bearer ${PROD_ADMIN_TOKEN}\"}}\n```\n\n**Why wrong**: A validation run with a compromised CI environment gets full admin access\nto production. Blast radius is maximum. Use read-only service account tokens scoped to\nthe specific paths being validated.\n\n**Fix**: Create a dedicated `endpoint-validator` ...",
       "domain_hint": "endpoint-validator"
     },
     {
@@ -1438,7 +1438,7 @@
         187,
         217
       ],
-      "block_text": "### \u274c Session Cookie Validation Without Expiry Handling\n\n**Detection**:\n```bash\ngrep -rn '\"Cookie\"' endpoints.json | grep -v '\\${[A-Z_]'\n```\n\n**What it looks like**:\n```json\n{\n  \"path\": \"/dashboard\",\n  \"headers\": {\"Cookie\": \"session=abc123fixed\"},\n  \"expect_status\": 200\n}\n```\n\n**Why wrong**: Sessions expire. A hardcoded session value that worked during setup will\nsilently redirect to a login page (302), which the validator may follow and report 200\n(the login page), masking the auth failure enti...",
+      "block_text": "### ❌ Session Cookie Validation Without Expiry Handling\n\n**Detection**:\n```bash\ngrep -rn '\"Cookie\"' endpoints.json | grep -v '\\${[A-Z_]'\n```\n\n**What it looks like**:\n```json\n{\n  \"path\": \"/dashboard\",\n  \"headers\": {\"Cookie\": \"session=abc123fixed\"},\n  \"expect_status\": 200\n}\n```\n\n**Why wrong**: Sessions expire. A hardcoded session value that worked during setup will\nsilently redirect to a login page (302), which the validator may follow and report 200\n(the login page), masking the auth failure enti...",
       "domain_hint": "endpoint-validator"
     },
     {
@@ -1465,7 +1465,7 @@
         58,
         80
       ],
-      "block_text": "### \u274c Hardcoded IP Address in base_url\n\n**Detection**:\n```bash\ngrep -rn '\"base_url\"' . --include=\"*.json\" | grep -E '\"[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+'\nrg '\"base_url\".*[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}' --type json\n```\n\n**What it looks like**:\n```json\n{\"base_url\": \"http://192.168.1.42:8000\"}\n```\n\n**Why wrong**: IP addresses are machine-local. The config breaks on every other developer\nmachine, in CI, and after any network reconfiguration.\n\n**Fix**:\n```json\n{\"base_url\": \"http://localho...",
+      "block_text": "### ❌ Hardcoded IP Address in base_url\n\n**Detection**:\n```bash\ngrep -rn '\"base_url\"' . --include=\"*.json\" | grep -E '\"[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+'\nrg '\"base_url\".*[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}' --type json\n```\n\n**What it looks like**:\n```json\n{\"base_url\": \"http://192.168.1.42:8000\"}\n```\n\n**Why wrong**: IP addresses are machine-local. The config breaks on every other developer\nmachine, in CI, and after any network reconfiguration.\n\n**Fix**:\n```json\n{\"base_url\": \"http://localho...",
       "domain_hint": "endpoint-validator"
     },
     {
@@ -1474,7 +1474,7 @@
         82,
         105
       ],
-      "block_text": "### \u274c Write Endpoints Against Production base_url\n\n**Detection**:\n```bash\ngrep -rn '\"method\"' . --include=\"*.json\" | grep -iE '\"POST\"|\"PUT\"|\"DELETE\"|\"PATCH\"'\n```\n\n**What it looks like**:\n```json\n{\n  \"base_url\": \"https://api.example.com\",\n  \"endpoints\": [\n    {\"path\": \"/api/v1/users\", \"method\": \"POST\", \"body\": {\"name\": \"test\"}}\n  ]\n}\n```\n\n**Why wrong**: POST/PUT/DELETE against a production URL creates/mutates/deletes real data.\nA smoke test that runs pre-deploy will insert test records, trigger w...",
+      "block_text": "### ❌ Write Endpoints Against Production base_url\n\n**Detection**:\n```bash\ngrep -rn '\"method\"' . --include=\"*.json\" | grep -iE '\"POST\"|\"PUT\"|\"DELETE\"|\"PATCH\"'\n```\n\n**What it looks like**:\n```json\n{\n  \"base_url\": \"https://api.example.com\",\n  \"endpoints\": [\n    {\"path\": \"/api/v1/users\", \"method\": \"POST\", \"body\": {\"name\": \"test\"}}\n  ]\n}\n```\n\n**Why wrong**: POST/PUT/DELETE against a production URL creates/mutates/deletes real data.\nA smoke test that runs pre-deploy will insert test records, trigger w...",
       "domain_hint": "endpoint-validator"
     },
     {
@@ -1483,7 +1483,7 @@
         107,
         131
       ],
-      "block_text": "### \u274c Zero or Very High Timeout\n\n**Detection**:\n```bash\ngrep -rn '\"timeout\"' . --include=\"*.json\" | grep -E '\"timeout\":\\s*0\\b'\ngrep -rn '\"timeout\"' . --include=\"*.json\" | grep -E '\"timeout\":\\s*[6-9][0-9]|[1-9][0-9]{2,}'\n```\n\n**What it looks like**:\n```json\n{\"path\": \"/api/slow\", \"timeout\": 0}\n{\"path\": \"/api/upload\", \"timeout\": 300}\n```\n\n**Why wrong**: `timeout: 0` means no timeout \u2014 a hung connection blocks the entire validation\nsuite forever. `timeout: 300` hides performance regressions; an endp...",
+      "block_text": "### ❌ Zero or Very High Timeout\n\n**Detection**:\n```bash\ngrep -rn '\"timeout\"' . --include=\"*.json\" | grep -E '\"timeout\":\\s*0\\b'\ngrep -rn '\"timeout\"' . --include=\"*.json\" | grep -E '\"timeout\":\\s*[6-9][0-9]|[1-9][0-9]{2,}'\n```\n\n**What it looks like**:\n```json\n{\"path\": \"/api/slow\", \"timeout\": 0}\n{\"path\": \"/api/upload\", \"timeout\": 300}\n```\n\n**Why wrong**: `timeout: 0` means no timeout — a hung connection blocks the entire validation\nsuite forever. `timeout: 300` hides performance regressions; an endp...",
       "domain_hint": "endpoint-validator"
     },
     {
@@ -1492,7 +1492,7 @@
         133,
         154
       ],
-      "block_text": "### \u274c expect_key on Non-JSON Endpoint\n\n**Detection**:\n```bash\ngrep -B2 '\"expect_key\"' endpoints.json | grep -E '\"path\".*\\.(html|xml|csv|txt|pdf)'\n```\n\n**What it looks like**:\n```json\n{\"path\": \"/sitemap.xml\", \"expect_key\": \"urlset\"}\n```\n\n**Why wrong**: `expect_key` parses the response as JSON and checks for a top-level key.\nXML, HTML, and CSV responses will always fail JSON parsing, generating \"Invalid JSON response\"\nerrors that obscure the real issue.\n\n**Fix**: For non-JSON endpoints, only check...",
+      "block_text": "### ❌ expect_key on Non-JSON Endpoint\n\n**Detection**:\n```bash\ngrep -B2 '\"expect_key\"' endpoints.json | grep -E '\"path\".*\\.(html|xml|csv|txt|pdf)'\n```\n\n**What it looks like**:\n```json\n{\"path\": \"/sitemap.xml\", \"expect_key\": \"urlset\"}\n```\n\n**Why wrong**: `expect_key` parses the response as JSON and checks for a top-level key.\nXML, HTML, and CSV responses will always fail JSON parsing, generating \"Invalid JSON response\"\nerrors that obscure the real issue.\n\n**Fix**: For non-JSON endpoints, only check...",
       "domain_hint": "endpoint-validator"
     },
     {
@@ -1501,7 +1501,7 @@
         156,
         184
       ],
-      "block_text": "### \u274c Missing expect_status on Non-200 Endpoints\n\n**Detection**:\n```bash\npython3 -c \"\nimport json\nwith open('endpoints.json') as f: cfg = json.load(f)\nfor ep in cfg.get('endpoints', []):\n    path = ep.get('path', '')\n    if ('404' in path or 'error' in path.lower() or 'missing' in path.lower()):\n        if 'expect_status' not in ep:\n            print('WARN missing expect_status:', path)\n\"\n```\n\n**What it looks like**:\n```json\n{\"path\": \"/api/v1/nonexistent-resource\"}\n```\n\n**Why wrong**: Default `e...",
+      "block_text": "### ❌ Missing expect_status on Non-200 Endpoints\n\n**Detection**:\n```bash\npython3 -c \"\nimport json\nwith open('endpoints.json') as f: cfg = json.load(f)\nfor ep in cfg.get('endpoints', []):\n    path = ep.get('path', '')\n    if ('404' in path or 'error' in path.lower() or 'missing' in path.lower()):\n        if 'expect_status' not in ep:\n            print('WARN missing expect_status:', path)\n\"\n```\n\n**What it looks like**:\n```json\n{\"path\": \"/api/v1/nonexistent-resource\"}\n```\n\n**Why wrong**: Default `e...",
       "domain_hint": "endpoint-validator"
     },
     {
@@ -1510,7 +1510,7 @@
         186,
         208
       ],
-      "block_text": "### \u274c Credentials in Config File\n\n**Detection**:\n```bash\ngrep -rn '\"Authorization\"\\|\"X-Api-Key\"\\|\"api_key\"\\|\"token\"' endpoints.json | grep -v '\\${[A-Z_]*}'\nrg '\"Bearer [A-Za-z0-9+/=._-]{20,}\"' --type json\n```\n\n**What it looks like**:\n```json\n{\"headers\": {\"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiJ9.actual-token-here\"}}\n```\n\n**Why wrong**: Tokens committed to config files end up in git history permanently. Even if\nrotated, the old token may be valid elsewhere or extractable from history. GitHub ...",
+      "block_text": "### ❌ Credentials in Config File\n\n**Detection**:\n```bash\ngrep -rn '\"Authorization\"\\|\"X-Api-Key\"\\|\"api_key\"\\|\"token\"' endpoints.json | grep -v '\\${[A-Z_]*}'\nrg '\"Bearer [A-Za-z0-9+/=._-]{20,}\"' --type json\n```\n\n**What it looks like**:\n```json\n{\"headers\": {\"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiJ9.actual-token-here\"}}\n```\n\n**Why wrong**: Tokens committed to config files end up in git history permanently. Even if\nrotated, the old token may be valid elsewhere or extractable from history. GitHub ...",
       "domain_hint": "endpoint-validator"
     },
     {
@@ -1528,7 +1528,7 @@
         95,
         116
       ],
-      "block_text": "### \u274c Checking Security Headers on localhost\n\n**Detection**:\n```bash\ngrep -rn '\"base_url\".*localhost\\|\"base_url\".*127\\.0\\.0\\.1' endpoints.json\n```\n\n**What it looks like**:\n```json\n{\n  \"base_url\": \"http://localhost:8000\",\n  \"check_security_headers\": true\n}\n```\n\n**Why wrong**: Development servers don't set these headers. Running the check against localhost\ngenerates spurious WARNs on every local run, training developers to ignore warnings entirely.\n\n**Fix**: The validator skips security header che...",
+      "block_text": "### ❌ Checking Security Headers on localhost\n\n**Detection**:\n```bash\ngrep -rn '\"base_url\".*localhost\\|\"base_url\".*127\\.0\\.0\\.1' endpoints.json\n```\n\n**What it looks like**:\n```json\n{\n  \"base_url\": \"http://localhost:8000\",\n  \"check_security_headers\": true\n}\n```\n\n**Why wrong**: Development servers don't set these headers. Running the check against localhost\ngenerates spurious WARNs on every local run, training developers to ignore warnings entirely.\n\n**Fix**: The validator skips security header che...",
       "domain_hint": "endpoint-validator"
     },
     {
@@ -1537,7 +1537,7 @@
         118,
         141
       ],
-      "block_text": "### \u274c Treating WARN as PASS in CI\n\n**Detection**:\n```bash\ngrep -rn \"|| true\\|--allow-warn\\|exit 0\" .github/workflows/ .gitlab-ci.yml 2>/dev/null\n```\n\n**What it looks like**:\n```yaml\n- run: endpoint-validator || true  # suppress all failures\n```\n\n**Why wrong**: Suppressing exit codes means security header regressions (a deploy that removes\nCSP) pass CI silently. Use `--fail-on-warn` in production validation runs so header removal\ntriggers a build failure.\n\n**Fix**:\n```yaml\n- run: endpoint-validat...",
+      "block_text": "### ❌ Treating WARN as PASS in CI\n\n**Detection**:\n```bash\ngrep -rn \"|| true\\|--allow-warn\\|exit 0\" .github/workflows/ .gitlab-ci.yml 2>/dev/null\n```\n\n**What it looks like**:\n```yaml\n- run: endpoint-validator || true  # suppress all failures\n```\n\n**Why wrong**: Suppressing exit codes means security header regressions (a deploy that removes\nCSP) pass CI silently. Use `--fail-on-warn` in production validation runs so header removal\ntriggers a build failure.\n\n**Fix**:\n```yaml\n- run: endpoint-validat...",
       "domain_hint": "endpoint-validator"
     },
     {
@@ -1546,7 +1546,7 @@
         143,
         161
       ],
-      "block_text": "### \u274c HSTS Expected on HTTP Endpoint\n\n**Detection**:\n```bash\ngrep -rn '\"base_url\".*\"http://' endpoints.json | grep -v \"localhost\\|127\\.0\\.0\\.1\"\n```\n\n**What it looks like**:\n```json\n{\"base_url\": \"http://api.example.com\"}\n```\n\n**Why wrong**: HSTS is only meaningful over HTTPS. Browsers ignore HSTS headers delivered\nover HTTP (per RFC 6797 \u00a78.1). Checking for it on HTTP endpoints always generates misleading WARNs.\n\n**Fix**: Use `https://` base_url for production validation, or the validator should ...",
+      "block_text": "### ❌ HSTS Expected on HTTP Endpoint\n\n**Detection**:\n```bash\ngrep -rn '\"base_url\".*\"http://' endpoints.json | grep -v \"localhost\\|127\\.0\\.0\\.1\"\n```\n\n**What it looks like**:\n```json\n{\"base_url\": \"http://api.example.com\"}\n```\n\n**Why wrong**: HSTS is only meaningful over HTTPS. Browsers ignore HSTS headers delivered\nover HTTP (per RFC 6797 §8.1). Checking for it on HTTP endpoints always generates misleading WARNs.\n\n**Fix**: Use `https://` base_url for production validation, or the validator should ...",
       "domain_hint": "endpoint-validator"
     },
     {
@@ -1555,7 +1555,7 @@
         1,
         6
       ],
-      "block_text": "# Explanation Traces \u2014 Anti-Patterns\n\nAnti-patterns for both trace producers (hooks that write session-trace.json) and trace\nconsumers (this skill reading it). Organized by who makes the mistake.\n\n---\n",
+      "block_text": "# Explanation Traces — Anti-Patterns\n\nAnti-patterns for both trace producers (hooks that write session-trace.json) and trace\nconsumers (this skill reading it). Organized by who makes the mistake.\n\n---\n",
       "domain_hint": "explanation-traces"
     },
     {
@@ -1600,7 +1600,7 @@
         97,
         124
       ],
-      "block_text": "# Check evidence length \u2014 short evidence is usually vague:\npython3 -c \"\nimport json\ndata = json.load(open('session-trace.json'))\nshort = [(i, d['evidence']) for i, d in enumerate(data['decisions'])\n         if len(d.get('evidence', '')) < 20]\nfor i, ev in short: print(f'[{i}] Short evidence: {repr(ev)}')\n\"\n```\n\n**What it looks like**:\n```json\n{ \"evidence\": \"seemed like the right choice\" }\n{ \"evidence\": \"best match\" }\n{ \"evidence\": \"\" }\n```\n\n**Why wrong**: These evidence strings tell the user not...",
+      "block_text": "# Check evidence length — short evidence is usually vague:\npython3 -c \"\nimport json\ndata = json.load(open('session-trace.json'))\nshort = [(i, d['evidence']) for i, d in enumerate(data['decisions'])\n         if len(d.get('evidence', '')) < 20]\nfor i, ev in short: print(f'[{i}] Short evidence: {repr(ev)}')\n\"\n```\n\n**What it looks like**:\n```json\n{ \"evidence\": \"seemed like the right choice\" }\n{ \"evidence\": \"best match\" }\n{ \"evidence\": \"\" }\n```\n\n**Why wrong**: These evidence strings tell the user not...",
       "domain_hint": "explanation-traces"
     },
     {
@@ -1645,7 +1645,7 @@
         189,
         202
       ],
-      "block_text": "### AP-6: Reconstructing Decisions from Conversation History\n\n**What it looks like** (incorrect skill behavior):\n> \"The trace file doesn't exist, but based on the conversation I can tell the router\n> probably chose the golang agent because the user mentioned Go...\"\n\n**Why wrong**: This is exactly the rationalization the skill exists to prevent. If no\ntrace file exists, the correct answer is \"no trace file found\" \u2014 not an inference from\nmemory or conversation history.\n\n**Correct behavior**: Repor...",
+      "block_text": "### AP-6: Reconstructing Decisions from Conversation History\n\n**What it looks like** (incorrect skill behavior):\n> \"The trace file doesn't exist, but based on the conversation I can tell the router\n> probably chose the golang agent because the user mentioned Go...\"\n\n**Why wrong**: This is exactly the rationalization the skill exists to prevent. If no\ntrace file exists, the correct answer is \"no trace file found\" — not an inference from\nmemory or conversation history.\n\n**Correct behavior**: Repor...",
       "domain_hint": "explanation-traces"
     },
     {
@@ -1663,7 +1663,7 @@
         218,
         230
       ],
-      "block_text": "### AP-8: Treating Incomplete Traces as Complete\n\n**What it looks like**: Presenting a timeline without flagging that several decisions have\nempty `evidence` fields.\n\n**Why wrong**: The user assumes the explanation is authoritative. Missing evidence means\nthe \"why\" for those decisions is unknown \u2014 presenting them without a caveat creates false\nconfidence in the explanation.\n\n**Correct behavior**: Flag incomplete entries explicitly (SKILL.md Phase 3 Step 3).\nReport count of entries with missing/e...",
+      "block_text": "### AP-8: Treating Incomplete Traces as Complete\n\n**What it looks like**: Presenting a timeline without flagging that several decisions have\nempty `evidence` fields.\n\n**Why wrong**: The user assumes the explanation is authoritative. Missing evidence means\nthe \"why\" for those decisions is unknown — presenting them without a caveat creates false\nconfidence in the explanation.\n\n**Correct behavior**: Flag incomplete entries explicitly (SKILL.md Phase 3 Step 3).\nReport count of entries with missing/e...",
       "domain_hint": "explanation-traces"
     },
     {
@@ -1699,7 +1699,7 @@
         106,
         134
       ],
-      "block_text": "### \u274c Retrying a Failed Agent More Than Three Times\n\n**Detection**:\n```bash\ngrep -rn 'Attempt [4-9]\\|Attempt [0-9][0-9]' .feature/state/implement/\nrg 'retry.*attempt|attempt.*[4-9]' .feature/ --ignore-case\n```\n\n**What it looks like**:\n```\nAttempt 1: Agent dispatch failed (no output)\nAttempt 2: Agent dispatch failed (timeout)\nAttempt 3: Agent dispatch failed (malformed response)\nAttempt 4: Retrying with more context...  \u2190 wrong\n```\n\n**Why wrong**: Three consecutive failures signal a structural pr...",
+      "block_text": "### ❌ Retrying a Failed Agent More Than Three Times\n\n**Detection**:\n```bash\ngrep -rn 'Attempt [4-9]\\|Attempt [0-9][0-9]' .feature/state/implement/\nrg 'retry.*attempt|attempt.*[4-9]' .feature/ --ignore-case\n```\n\n**What it looks like**:\n```\nAttempt 1: Agent dispatch failed (no output)\nAttempt 2: Agent dispatch failed (timeout)\nAttempt 3: Agent dispatch failed (malformed response)\nAttempt 4: Retrying with more context...  ← wrong\n```\n\n**Why wrong**: Three consecutive failures signal a structural pr...",
       "domain_hint": "feature-lifecycle"
     },
     {
@@ -1708,7 +1708,7 @@
         136,
         160
       ],
-      "block_text": "### \u274c Proceeding Past a Gate Failure\n\n**Detection**:\n```bash\ngrep -rn 'gate.*fail\\|BLOCKED.*proceed\\|proceeding.*fail' .feature/state/ --ignore-case\nrg 'minor failure|appears minor|otherwise complete' .feature/\n```\n\n**What it looks like**:\n```\nGate: Validate failed (2 tests failing), but proceeding to release because\n      failures appear minor and the feature is otherwise complete.\n```\n\n**Why wrong**: Gates are binary. Downstream phases depend on upstream correctness \u2014 releasing with failing va...",
+      "block_text": "### ❌ Proceeding Past a Gate Failure\n\n**Detection**:\n```bash\ngrep -rn 'gate.*fail\\|BLOCKED.*proceed\\|proceeding.*fail' .feature/state/ --ignore-case\nrg 'minor failure|appears minor|otherwise complete' .feature/\n```\n\n**What it looks like**:\n```\nGate: Validate failed (2 tests failing), but proceeding to release because\n      failures appear minor and the feature is otherwise complete.\n```\n\n**Why wrong**: Gates are binary. Downstream phases depend on upstream correctness — releasing with failing va...",
       "domain_hint": "feature-lifecycle"
     },
     {
@@ -1717,7 +1717,7 @@
         166,
         181
       ],
-      "block_text": "# Find scripts opening the state JSON directly instead of via CLI\nrg '\\.feature/state.*\\.json' . --type py\ngrep -rn 'open.*feature.*state' . --include=\"*.py\"\n```\n\n**What it looks like**:\n```python\nimport json\nwith open('.feature/state/my-feature.json', 'w') as f:\n    json.dump({'phase': 'validate', ...}, f)  # direct write \u2014 wrong\n```\n\n**Why wrong**: The state file format is an implementation detail of `feature-state.py`. Direct writes bypass validation, lock acquisition, and event recording. Th...",
+      "block_text": "# Find scripts opening the state JSON directly instead of via CLI\nrg '\\.feature/state.*\\.json' . --type py\ngrep -rn 'open.*feature.*state' . --include=\"*.py\"\n```\n\n**What it looks like**:\n```python\nimport json\nwith open('.feature/state/my-feature.json', 'w') as f:\n    json.dump({'phase': 'validate', ...}, f)  # direct write — wrong\n```\n\n**Why wrong**: The state file format is an implementation detail of `feature-state.py`. Direct writes bypass validation, lock acquisition, and event recording. Th...",
       "domain_hint": "feature-lifecycle"
     },
     {
@@ -1753,7 +1753,7 @@
         17,
         26
       ],
-      "block_text": "### \u274c Bash-Style Variable Assignment\n\n**Detection**:\n```bash\ngrep -rn '^[A-Z_]*=[^=]' --include=\"*.fish\" ~/.config/fish/\nrg '^\\s*[A-Z_a-z]+=[^=]' --type-add 'fish:*.fish' --type fish ~/.config/fish/\n```\n\n**What it looks like**:\n```fish",
+      "block_text": "### ❌ Bash-Style Variable Assignment\n\n**Detection**:\n```bash\ngrep -rn '^[A-Z_]*=[^=]' --include=\"*.fish\" ~/.config/fish/\nrg '^\\s*[A-Z_a-z]+=[^=]' --type-add 'fish:*.fish' --type fish ~/.config/fish/\n```\n\n**What it looks like**:\n```fish",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1762,7 +1762,7 @@
         27,
         42
       ],
-      "block_text": "# WRONG \u2014 syntax error in Fish\nGOPATH=~/go\nMY_VAR=hello\n```\n\n**Why wrong**: `VAR=value` is a syntax error in Fish (not silently ignored). Fish rejects it at parse time, causing the entire conf.d file to fail to load \u2014 all subsequent lines in that file are skipped.\n\n**Fix**:\n```fish\nset -gx GOPATH ~/go\nset -g MY_VAR hello\n```\n\n**Version note**: No version where this worked. Fish has never supported `VAR=value` assignment syntax.\n\n---\n",
+      "block_text": "# WRONG — syntax error in Fish\nGOPATH=~/go\nMY_VAR=hello\n```\n\n**Why wrong**: `VAR=value` is a syntax error in Fish (not silently ignored). Fish rejects it at parse time, causing the entire conf.d file to fail to load — all subsequent lines in that file are skipped.\n\n**Fix**:\n```fish\nset -gx GOPATH ~/go\nset -g MY_VAR hello\n```\n\n**Version note**: No version where this worked. Fish has never supported `VAR=value` assignment syntax.\n\n---\n",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1771,7 +1771,7 @@
         44,
         53
       ],
-      "block_text": "### \u274c `export VAR=value` (Bash Export Syntax)\n\n**Detection**:\n```bash\ngrep -rn 'export ' --include=\"*.fish\" ~/.config/fish/\nrg 'export \\w+=' --type-add 'fish:*.fish' --type fish ~/.config/fish/\n```\n\n**What it looks like**:\n```fish",
+      "block_text": "### ❌ `export VAR=value` (Bash Export Syntax)\n\n**Detection**:\n```bash\ngrep -rn 'export ' --include=\"*.fish\" ~/.config/fish/\nrg 'export \\w+=' --type-add 'fish:*.fish' --type fish ~/.config/fish/\n```\n\n**What it looks like**:\n```fish",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1780,7 +1780,7 @@
         54,
         67
       ],
-      "block_text": "# WRONG \u2014 syntax error in Fish\nexport PATH=\"$PATH:~/.local/bin\"\nexport EDITOR=nvim\n```\n\n**Why wrong**: `export` is not a Fish builtin for variable assignment. The syntax `export VAR=value` is a parse error. Even `export EDITOR nvim` (space-separated) calls the external `export` binary, sets nothing in Fish scope, and is immediately discarded.\n\n**Fix**:\n```fish\nfish_add_path ~/.local/bin\nset -gx EDITOR nvim\n```\n\n---\n",
+      "block_text": "# WRONG — syntax error in Fish\nexport PATH=\"$PATH:~/.local/bin\"\nexport EDITOR=nvim\n```\n\n**Why wrong**: `export` is not a Fish builtin for variable assignment. The syntax `export VAR=value` is a parse error. Even `export EDITOR nvim` (space-separated) calls the external `export` binary, sets nothing in Fish scope, and is immediately discarded.\n\n**Fix**:\n```fish\nfish_add_path ~/.local/bin\nset -gx EDITOR nvim\n```\n\n---\n",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1789,7 +1789,7 @@
         69,
         78
       ],
-      "block_text": "### \u274c Colon-Separated PATH Manipulation\n\n**Detection**:\n```bash\ngrep -rn 'PATH.*:.*PATH\\|\"\\$PATH:' --include=\"*.fish\" ~/.config/fish/\nrg 'set.*PATH.*\"\\$PATH:' --type-add 'fish:*.fish' --type fish ~/.config/fish/\n```\n\n**What it looks like**:\n```fish",
+      "block_text": "### ❌ Colon-Separated PATH Manipulation\n\n**Detection**:\n```bash\ngrep -rn 'PATH.*:.*PATH\\|\"\\$PATH:' --include=\"*.fish\" ~/.config/fish/\nrg 'set.*PATH.*\"\\$PATH:' --type-add 'fish:*.fish' --type fish ~/.config/fish/\n```\n\n**What it looks like**:\n```fish",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1798,7 +1798,7 @@
         79,
         93
       ],
-      "block_text": "# WRONG \u2014 creates a single malformed string element\nset -gx PATH \"$PATH:$HOME/.local/bin\"\nset -gx PATH \"$HOME/.local/bin:$PATH\"\n```\n\n**Why wrong**: Fish PATH is a list variable. Each element is a separate string. String-concatenating with colons creates a single element containing the literal colon \u2014 e.g., `\"/home/user/.local/bin:/usr/bin\"` becomes one list entry, not two PATH components. Commands in the new directory become unfindable.\n\n**Fix**:\n```fish\nfish_add_path ~/.local/bin        # Prepe...",
+      "block_text": "# WRONG — creates a single malformed string element\nset -gx PATH \"$PATH:$HOME/.local/bin\"\nset -gx PATH \"$HOME/.local/bin:$PATH\"\n```\n\n**Why wrong**: Fish PATH is a list variable. Each element is a separate string. String-concatenating with colons creates a single element containing the literal colon — e.g., `\"/home/user/.local/bin:/usr/bin\"` becomes one list entry, not two PATH components. Commands in the new directory become unfindable.\n\n**Fix**:\n```fish\nfish_add_path ~/.local/bin        # Prepe...",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1807,7 +1807,7 @@
         95,
         104
       ],
-      "block_text": "### \u274c Unguarded Abbreviations in conf.d/\n\n**Detection**:\n```bash\ngrep -rn '^abbr ' --include=\"*.fish\" ~/.config/fish/conf.d/\nrg '^abbr ' --type-add 'fish:*.fish' --type fish ~/.config/fish/conf.d/\n```\n\n**What it looks like**:\n```fish",
+      "block_text": "### ❌ Unguarded Abbreviations in conf.d/\n\n**Detection**:\n```bash\ngrep -rn '^abbr ' --include=\"*.fish\" ~/.config/fish/conf.d/\nrg '^abbr ' --type-add 'fish:*.fish' --type fish ~/.config/fish/conf.d/\n```\n\n**What it looks like**:\n```fish",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1816,7 +1816,7 @@
         105,
         113
       ],
-      "block_text": "# ~/.config/fish/conf.d/20-abbreviations.fish \u2014 WRONG\nabbr -a g git\nabbr -a gst \"git status\"\n```\n\n**Why wrong**: Abbreviations are interactive-only. When Fish sources `conf.d/` in non-interactive mode (scripts, CI, cron, `fish -c \"...\"`), `abbr -a` emits a warning and is a no-op. More critically, they never expand in scripts regardless \u2014 so logic depending on abbreviation expansion in `.fish` scripts will silently fail.\n\n**Fix**:\n```fish",
+      "block_text": "# ~/.config/fish/conf.d/20-abbreviations.fish — WRONG\nabbr -a g git\nabbr -a gst \"git status\"\n```\n\n**Why wrong**: Abbreviations are interactive-only. When Fish sources `conf.d/` in non-interactive mode (scripts, CI, cron, `fish -c \"...\"`), `abbr -a` emits a warning and is a no-op. More critically, they never expand in scripts regardless — so logic depending on abbreviation expansion in `.fish` scripts will silently fail.\n\n**Fix**:\n```fish",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1825,7 +1825,7 @@
         124,
         133
       ],
-      "block_text": "### \u274c Bash Double-Bracket Conditionals\n\n**Detection**:\n```bash\ngrep -rn '\\[\\[' --include=\"*.fish\" ~/.config/fish/\ngrep -rn 'if \\[' --include=\"*.fish\" ~/.config/fish/\n```\n\n**What it looks like**:\n```fish",
+      "block_text": "### ❌ Bash Double-Bracket Conditionals\n\n**Detection**:\n```bash\ngrep -rn '\\[\\[' --include=\"*.fish\" ~/.config/fish/\ngrep -rn 'if \\[' --include=\"*.fish\" ~/.config/fish/\n```\n\n**What it looks like**:\n```fish",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1834,7 +1834,7 @@
         134,
         157
       ],
-      "block_text": "# WRONG \u2014 syntax error in Fish\nif [[ -f ~/.config/fish/local.fish ]]\n    source ~/.config/fish/local.fish\nend\n\nif [ -z \"$TMUX\" ]\n    echo \"not in tmux\"\nend\n```\n\n**Why wrong**: `[[` is not recognized by Fish \u2014 it is a Bash/Zsh construct and causes a parse error. `[ ]` calls the external `/bin/[` binary which has slightly different behavior from the Fish `test` builtin and incurs a fork/exec overhead.\n\n**Fix**:\n```fish\nif test -f ~/.config/fish/local.fish\n    source ~/.config/fish/local.fish\nend\n\n...",
+      "block_text": "# WRONG — syntax error in Fish\nif [[ -f ~/.config/fish/local.fish ]]\n    source ~/.config/fish/local.fish\nend\n\nif [ -z \"$TMUX\" ]\n    echo \"not in tmux\"\nend\n```\n\n**Why wrong**: `[[` is not recognized by Fish — it is a Bash/Zsh construct and causes a parse error. `[ ]` calls the external `/bin/[` binary which has slightly different behavior from the Fish `test` builtin and incurs a fork/exec overhead.\n\n**Fix**:\n```fish\nif test -f ~/.config/fish/local.fish\n    source ~/.config/fish/local.fish\nend\n\n...",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1852,7 +1852,7 @@
         172,
         182
       ],
-      "block_text": "# File: ~/.config/fish/functions/mkcd.fish\nfunction make_directory_and_cd    # WRONG \u2014 name doesn't match file\n    mkdir -p $argv[1]\n    and cd $argv[1]\nend\n```\n\n**Why wrong**: Fish autoloads functions by filename. When `mkcd` is called, Fish looks for `~/.config/fish/functions/mkcd.fish`. If that file exists but defines `function make_directory_and_cd`, calling `mkcd` fails with \"Unknown command: mkcd\". The file loads but the desired name never registers.\n\n**Fix**:\n```fish",
+      "block_text": "# File: ~/.config/fish/functions/mkcd.fish\nfunction make_directory_and_cd    # WRONG — name doesn't match file\n    mkdir -p $argv[1]\n    and cd $argv[1]\nend\n```\n\n**Why wrong**: Fish autoloads functions by filename. When `mkcd` is called, Fish looks for `~/.config/fish/functions/mkcd.fish`. If that file exists but defines `function make_directory_and_cd`, calling `mkcd` fails with \"Unknown command: mkcd\". The file loads but the desired name never registers.\n\n**Fix**:\n```fish",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1861,7 +1861,7 @@
         192,
         201
       ],
-      "block_text": "### \u274c Tool Integration Without Availability Guard\n\n**Detection**:\n```bash\ngrep -rn 'init fish | source\\|hook fish | source' --include=\"*.fish\" ~/.config/fish/conf.d/\nrg '(starship|direnv|fnm|zoxide|mise|pyenv) (init|hook)' --type-add 'fish:*.fish' --type fish ~/.config/fish/conf.d/\n```\n\n**What it looks like**:\n```fish",
+      "block_text": "### ❌ Tool Integration Without Availability Guard\n\n**Detection**:\n```bash\ngrep -rn 'init fish | source\\|hook fish | source' --include=\"*.fish\" ~/.config/fish/conf.d/\nrg '(starship|direnv|fnm|zoxide|mise|pyenv) (init|hook)' --type-add 'fish:*.fish' --type fish ~/.config/fish/conf.d/\n```\n\n**What it looks like**:\n```fish",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1870,7 +1870,7 @@
         202,
         225
       ],
-      "block_text": "# WRONG \u2014 breaks on machines where tool is not installed\nstarship init fish | source\ndirenv hook fish | source\nfnm env --use-on-cd | source\n```\n\n**Why wrong**: If the tool is not installed, the command fails with \"command not found: starship\". This error may stop further `conf.d/` processing, producing error output for every new shell opened on machines without that tool.\n\n**Fix**:\n```fish\nif type -q starship\n    starship init fish | source\nend\n\nif type -q direnv\n    direnv hook fish | source\nen...",
+      "block_text": "# WRONG — breaks on machines where tool is not installed\nstarship init fish | source\ndirenv hook fish | source\nfnm env --use-on-cd | source\n```\n\n**Why wrong**: If the tool is not installed, the command fails with \"command not found: starship\". This error may stop further `conf.d/` processing, producing error output for every new shell opened on machines without that tool.\n\n**Fix**:\n```fish\nif type -q starship\n    starship init fish | source\nend\n\nif type -q direnv\n    direnv hook fish | source\nen...",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1879,7 +1879,7 @@
         227,
         236
       ],
-      "block_text": "### \u274c Using `set -U` (Universal) in conf.d/ for Tool Paths\n\n**Detection**:\n```bash\ngrep -rn 'set -U\\|set --universal' --include=\"*.fish\" ~/.config/fish/conf.d/\nrg 'set -U ' --type-add 'fish:*.fish' --type fish ~/.config/fish/conf.d/\n```\n\n**What it looks like**:\n```fish",
+      "block_text": "### ❌ Using `set -U` (Universal) in conf.d/ for Tool Paths\n\n**Detection**:\n```bash\ngrep -rn 'set -U\\|set --universal' --include=\"*.fish\" ~/.config/fish/conf.d/\nrg 'set -U ' --type-add 'fish:*.fish' --type fish ~/.config/fish/conf.d/\n```\n\n**What it looks like**:\n```fish",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1888,7 +1888,7 @@
         237,
         246
       ],
-      "block_text": "# ~/.config/fish/conf.d/10-env.fish \u2014 WRONG\nset -U GOPATH ~/go\nset -U EDITOR nvim\nset -U JAVA_HOME /usr/lib/jvm/java-17-openjdk\n```\n\n**Why wrong**: Universal variables are stored in `fish_variables` and persist across all sessions. Setting them in `conf.d/` re-sets them on every shell start \u2014 harmless for idempotent values but causes subtle bugs when the value changes (e.g., different JAVA_HOME on different machines). Universal scope is for user preferences set interactively, not for environment...",
+      "block_text": "# ~/.config/fish/conf.d/10-env.fish — WRONG\nset -U GOPATH ~/go\nset -U EDITOR nvim\nset -U JAVA_HOME /usr/lib/jvm/java-17-openjdk\n```\n\n**Why wrong**: Universal variables are stored in `fish_variables` and persist across all sessions. Setting them in `conf.d/` re-sets them on every shell start — harmless for idempotent values but causes subtle bugs when the value changes (e.g., different JAVA_HOME on different machines). Universal scope is for user preferences set interactively, not for environment...",
       "domain_hint": "fish-shell-config"
     },
     {
@@ -1951,7 +1951,7 @@
         97,
         103
       ],
-      "block_text": "## Anti-patterns\n\n- Do NOT fix issues silently \u2014 always report before fixing\n- Do NOT suggest concepts for every minor term \u2014 only significant gaps (max 5)\n- Do NOT report passing checks \u2014 only failures and suggestions\n- Do NOT read every raw source during lint \u2014 structural checks use wiki files only\n- Do NOT treat missing `research/{topic}/` as a lint failure \u2014 exit with a clear error message before phase 1",
+      "block_text": "## Anti-patterns\n\n- Do NOT fix issues silently — always report before fixing\n- Do NOT suggest concepts for every minor term — only significant gaps (max 5)\n- Do NOT report passing checks — only failures and suggestions\n- Do NOT read every raw source during lint — structural checks use wiki files only\n- Do NOT treat missing `research/{topic}/` as a lint failure — exit with a clear error message before phase 1",
       "domain_hint": "kb"
     },
     {
@@ -1966,8 +1966,8 @@
     {
       "file": "skills/kotlin-coroutines/references/anti-patterns.md",
       "line_range": [
-        7,
-        7
+        6,
+        6
       ],
       "block_text": "# Kotlin Coroutine Anti-Patterns\n",
       "domain_hint": "anti"
@@ -1987,7 +1987,7 @@
         1,
         1
       ],
-      "block_text": "# Multi-Persona Critique \u2014 Templates, Examples, Anti-Patterns, and Error Handling\n",
+      "block_text": "# Multi-Persona Critique — Templates, Examples, Anti-Patterns, and Error Handling\n",
       "domain_hint": "multi-persona-critique"
     },
     {
@@ -2002,8 +2002,8 @@
     {
       "file": "skills/phaser-gamedev/references/game-feel-patterns.md",
       "line_range": [
-        295,
-        295
+        294,
+        294
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "Phaser Game Feel Patterns"
@@ -2011,19 +2011,19 @@
     {
       "file": "skills/phaser-gamedev/references/game-feel-patterns.md",
       "line_range": [
-        334,
-        373
+        333,
+        372
       ],
-      "block_text": "### \u274c Creating Physics Bodies Inside update()\n\n**Detection**:\n```bash\ngrep -rn \"physics\\.add\\.\\(sprite\\|image\\|existing\\)\\|add\\.group\" --include=\"*.ts\" --include=\"*.js\"\nrg \"update\\(.*delta\\)\" --type ts -A 30 | grep \"physics\\.add\"\n```\n\n**What it looks like**:\n```typescript\nupdate(_time: number, _delta: number): void {\n  if (this.fireButton.isDown) {\n    // BAD: new physics sprite every frame the button is held\n    const bullet = this.physics.add.image(this.player.x, this.player.y, 'bullet');\n    ...",
+      "block_text": "### ❌ Creating Physics Bodies Inside update()\n\n**Detection**:\n```bash\ngrep -rn \"physics\\.add\\.\\(sprite\\|image\\|existing\\)\\|add\\.group\" --include=\"*.ts\" --include=\"*.js\"\nrg \"update\\(.*delta\\)\" --type ts -A 30 | grep \"physics\\.add\"\n```\n\n**What it looks like**:\n```typescript\nupdate(_time: number, _delta: number): void {\n  if (this.fireButton.isDown) {\n    // BAD: new physics sprite every frame the button is held\n    const bullet = this.physics.add.image(this.player.x, this.player.y, 'bullet');\n    ...",
       "domain_hint": "Phaser Game Feel Patterns"
     },
     {
       "file": "skills/phaser-gamedev/references/game-feel-patterns.md",
       "line_range": [
-        375,
-        398
+        374,
+        397
       ],
-      "block_text": "### \u274c Camera Shake Without Bounds\n\n**Detection**:\n```bash\ngrep -rn \"camera\\.shake\\|cameras\\.main\\.shake\" --include=\"*.ts\" --include=\"*.js\"\nrg \"cameras\\.main\" --type ts | grep -v \"bounds\\|follow\\|setZoom\"\n```\n\n**What it looks like**:\n```typescript\n// BAD: camera shakes past world edge, revealing void outside the map\nthis.cameras.main.shake(300, 0.05); // no world bounds set\n```\n\n**Why wrong**: Camera shake pans the camera. Without bounds, the camera reveals empty space outside the tilemap, breaki...",
+      "block_text": "### ❌ Camera Shake Without Bounds\n\n**Detection**:\n```bash\ngrep -rn \"camera\\.shake\\|cameras\\.main\\.shake\" --include=\"*.ts\" --include=\"*.js\"\nrg \"cameras\\.main\" --type ts | grep -v \"bounds\\|follow\\|setZoom\"\n```\n\n**What it looks like**:\n```typescript\n// BAD: camera shakes past world edge, revealing void outside the map\nthis.cameras.main.shake(300, 0.05); // no world bounds set\n```\n\n**Why wrong**: Camera shake pans the camera. Without bounds, the camera reveals empty space outside the tilemap, breaki...",
       "domain_hint": "Phaser Game Feel Patterns"
     },
     {
@@ -2032,14 +2032,14 @@
         99,
         140
       ],
-      "block_text": "## GC Optimization \u2014 Avoid Allocations in update()\n\nEvery object created in `update()` becomes garbage. Garbage collection pauses manifest as micro-stutters.\n\n**Patterns to eliminate from `update()`:**\n\n```typescript\n// BAD \u2014 allocates a new Vector2 every frame (60 allocs/sec)\nupdate(): void {\n  const dir = new Phaser.Math.Vector2(this.target.x - this.x, this.target.y - this.y);\n  dir.normalize();\n}\n\n// GOOD \u2014 reuse a pre-allocated vector\nprivate _dir = new Phaser.Math.Vector2();\n\nupdate(): void...",
+      "block_text": "## GC Optimization — Avoid Allocations in update()\n\nEvery object created in `update()` becomes garbage. Garbage collection pauses manifest as micro-stutters.\n\n**Patterns to eliminate from `update()`:**\n\n```typescript\n// BAD — allocates a new Vector2 every frame (60 allocs/sec)\nupdate(): void {\n  const dir = new Phaser.Math.Vector2(this.target.x - this.x, this.target.y - this.y);\n  dir.normalize();\n}\n\n// GOOD — reuse a pre-allocated vector\nprivate _dir = new Phaser.Math.Vector2();\n\nupdate(): void...",
       "domain_hint": "phaser-gamedev"
     },
     {
       "file": "skills/phaser-gamedev/references/tilemaps-and-physics.md",
       "line_range": [
-        259,
-        259
+        258,
+        258
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "Phaser Tilemaps and Physics"
@@ -2047,19 +2047,19 @@
     {
       "file": "skills/phaser-gamedev/references/tilemaps-and-physics.md",
       "line_range": [
-        261,
-        284
+        260,
+        283
       ],
-      "block_text": "### \u274c Calling setCollisionByProperty After Layer Already Has Colliders\n\n**Detection**:\n```bash\ngrep -rn \"setCollisionByProperty\\|setCollision\\b\" --include=\"*.ts\" --include=\"*.js\"\nrg \"setCollision\" --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: setting collision after a Matter tilemapLayer already generated bodies\nthis.matter.add.tilemapLayer(groundLayer, { isStatic: true });\ngroundLayer.setCollisionByProperty({ collides: true }); // no effect \u2014 Matter ignores this\n```\n\n**Why wrong*...",
+      "block_text": "### ❌ Calling setCollisionByProperty After Layer Already Has Colliders\n\n**Detection**:\n```bash\ngrep -rn \"setCollisionByProperty\\|setCollision\\b\" --include=\"*.ts\" --include=\"*.js\"\nrg \"setCollision\" --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: setting collision after a Matter tilemapLayer already generated bodies\nthis.matter.add.tilemapLayer(groundLayer, { isStatic: true });\ngroundLayer.setCollisionByProperty({ collides: true }); // no effect — Matter ignores this\n```\n\n**Why wrong*...",
       "domain_hint": "Phaser Tilemaps and Physics"
     },
     {
       "file": "skills/phaser-gamedev/references/tilemaps-and-physics.md",
       "line_range": [
-        286,
-        315
+        285,
+        314
       ],
-      "block_text": "### \u274c Creating Physics Bodies Inside update()\n\n**Detection**:\n```bash\ngrep -rn \"matter\\.add\\.\\(sprite\\|image\\|circle\\|rectangle\\)\" --include=\"*.ts\" --include=\"*.js\"\nrg \"update\\b\" --type ts -A 40 | grep \"matter\\.add\\|physics\\.add\\.sprite\"\n```\n\n**What it looks like**:\n```typescript\nupdate(_time: number, delta: number): void {\n  if (this.fireButton.isDown) {\n    // BAD: creates a new Matter body every frame\n    const bullet = this.matter.add.image(this.player.x, this.player.y, 'bullet');\n    bullet...",
+      "block_text": "### ❌ Creating Physics Bodies Inside update()\n\n**Detection**:\n```bash\ngrep -rn \"matter\\.add\\.\\(sprite\\|image\\|circle\\|rectangle\\)\" --include=\"*.ts\" --include=\"*.js\"\nrg \"update\\b\" --type ts -A 40 | grep \"matter\\.add\\|physics\\.add\\.sprite\"\n```\n\n**What it looks like**:\n```typescript\nupdate(_time: number, delta: number): void {\n  if (this.fireButton.isDown) {\n    // BAD: creates a new Matter body every frame\n    const bullet = this.matter.add.image(this.player.x, this.player.y, 'bullet');\n    bullet...",
       "domain_hint": "Phaser Tilemaps and Physics"
     },
     {
@@ -2149,7 +2149,7 @@
         63,
         86
       ],
-      "block_text": "### \u274c {{Anti-Pattern Name}}\n\n**Detection**:\n```bash\ngrep -rn '{{pattern}}' --include=\"*.{{ext}}\"\nrg '{{pattern}}' --type {{lang}}\n```\n\n**What it looks like**:\n```{{language}}\n{{bad code example \u2014 should be something grep above would find}}\n```\n\n**Why wrong**: {{Behavioral consequence \u2014 what actually breaks, not just \"it's bad practice\".\nMention the specific failure mode: data loss, silent error, performance degradation, etc.}}\n\n**Fix**:\n```{{language}}\n{{corrected code example}}\n```\n\n**Version n...",
+      "block_text": "### ❌ {{Anti-Pattern Name}}\n\n**Detection**:\n```bash\ngrep -rn '{{pattern}}' --include=\"*.{{ext}}\"\nrg '{{pattern}}' --type {{lang}}\n```\n\n**What it looks like**:\n```{{language}}\n{{bad code example — should be something grep above would find}}\n```\n\n**Why wrong**: {{Behavioral consequence — what actually breaks, not just \"it's bad practice\".\nMention the specific failure mode: data loss, silent error, performance degradation, etc.}}\n\n**Fix**:\n```{{language}}\n{{corrected code example}}\n```\n\n**Version n...",
       "domain_hint": "reference-enrichment"
     },
     {
@@ -2158,7 +2158,7 @@
         88,
         107
       ],
-      "block_text": "### \u274c {{Anti-Pattern Name}}\n\n**Detection**:\n```bash\ngrep -rn '{{pattern}}' --include=\"*.{{ext}}\"\n```\n\n**What it looks like**:\n```{{language}}\n{{bad code}}\n```\n\n**Why wrong**: {{Consequence.}}\n\n**Fix**:\n```{{language}}\n{{fix}}\n```\n\n---\n",
+      "block_text": "### ❌ {{Anti-Pattern Name}}\n\n**Detection**:\n```bash\ngrep -rn '{{pattern}}' --include=\"*.{{ext}}\"\n```\n\n**What it looks like**:\n```{{language}}\n{{bad code}}\n```\n\n**Why wrong**: {{Consequence.}}\n\n**Fix**:\n```{{language}}\n{{fix}}\n```\n\n---\n",
       "domain_hint": "reference-enrichment"
     },
     {
@@ -2185,7 +2185,7 @@
         215,
         238
       ],
-      "block_text": "## Agent 10: Anti-Patterns, LLM Tells, Community Divergences\n\n**Sections**: \u00a722 (Divergences), \u00a724 (Anti-Patterns), \u00a725 (LLM Code Feedback), \u00a733 (Portunus Architecture), \u00a735 (Reinforcement Table)\n**Extra Reference**: `anti-patterns.md`\n\n**This is the highest-value agent.** It checks for patterns that LLMs generate by default but the project explicitly rejects:\n\n- Functional options pattern (project convention: positional params)\n- Table-driven tests (project convention: sequential scenario narra...",
+      "block_text": "## Agent 10: Anti-Patterns, LLM Tells, Community Divergences\n\n**Sections**: §22 (Divergences), §24 (Anti-Patterns), §25 (LLM Code Feedback), §33 (Portunus Architecture), §35 (Reinforcement Table)\n**Extra Reference**: `anti-patterns.md`\n\n**This is the highest-value agent.** It checks for patterns that LLMs generate by default but the project explicitly rejects:\n\n- Functional options pattern (project convention: positional params)\n- Table-driven tests (project convention: sequential scenario narra...",
       "domain_hint": "sapcc-review"
     },
     {
@@ -2230,7 +2230,7 @@
         30,
         33
       ],
-      "block_text": "## \u274c Anti-Pattern: Phases Without Gates\n\n**What it looks like**:\n```markdown",
+      "block_text": "## ❌ Anti-Pattern: Phases Without Gates\n\n**What it looks like**:\n```markdown",
       "domain_hint": "skill-creator"
     },
     {
@@ -2239,7 +2239,7 @@
         201,
         204
       ],
-      "block_text": "## \u274c Anti-Pattern: Infinite Retry Loops\n\n**What it looks like**:\n```markdown",
+      "block_text": "## ❌ Anti-Pattern: Infinite Retry Loops\n\n**What it looks like**:\n```markdown",
       "domain_hint": "skill-creator"
     },
     {
@@ -2248,7 +2248,7 @@
         231,
         234
       ],
-      "block_text": "## \u274c Anti-Pattern: Hardcoded Secrets\n\n**What it looks like**:\n```python",
+      "block_text": "## ❌ Anti-Pattern: Hardcoded Secrets\n\n**What it looks like**:\n```python",
       "domain_hint": "skill-creator"
     },
     {
@@ -2257,7 +2257,7 @@
         271,
         274
       ],
-      "block_text": "## \u274c Anti-Pattern: No Error Handling\n\n**What it looks like**:\n```markdown",
+      "block_text": "## ❌ Anti-Pattern: No Error Handling\n\n**What it looks like**:\n```markdown",
       "domain_hint": "skill-creator"
     },
     {
@@ -2266,7 +2266,7 @@
         382,
         385
       ],
-      "block_text": "## \u274c Anti-Pattern: Mandates Without Motivation\n\n**What it looks like**:\n```markdown",
+      "block_text": "## ❌ Anti-Pattern: Mandates Without Motivation\n\n**What it looks like**:\n```markdown",
       "domain_hint": "skill-creator"
     },
     {
@@ -2284,7 +2284,7 @@
         261,
         268
       ],
-      "block_text": "### \u274c Over-Tiering\n**What it looks like**: Simple workflow (pr-workflow (cleanup)) implemented as Complex tier with references/, death loop prevention, 10+ error cases\n\n**Why wrong**: Creates maintenance burden, confuses users, violates Over-Engineering Prevention\n\n**Fix**: Reduce to appropriate tier - Simple workflows stay Simple\n\n---\n",
+      "block_text": "### ❌ Over-Tiering\n**What it looks like**: Simple workflow (pr-workflow (cleanup)) implemented as Complex tier with references/, death loop prevention, 10+ error cases\n\n**Why wrong**: Creates maintenance burden, confuses users, violates Over-Engineering Prevention\n\n**Fix**: Reduce to appropriate tier - Simple workflows stay Simple\n\n---\n",
       "domain_hint": "skill-creator"
     },
     {
@@ -2293,7 +2293,7 @@
         270,
         277
       ],
-      "block_text": "### \u274c Under-Tiering\n**What it looks like**: Multi-agent orchestration skill (parallel-code-review) implemented as Medium tier with no death loop prevention\n\n**Why wrong**: Missing critical patterns, will fail in production, no scaling considerations\n\n**Fix**: Upgrade to Complex tier, add death loop prevention, create references/\n\n---\n",
+      "block_text": "### ❌ Under-Tiering\n**What it looks like**: Multi-agent orchestration skill (parallel-code-review) implemented as Medium tier with no death loop prevention\n\n**Why wrong**: Missing critical patterns, will fail in production, no scaling considerations\n\n**Fix**: Upgrade to Complex tier, add death loop prevention, create references/\n\n---\n",
       "domain_hint": "skill-creator"
     },
     {
@@ -2302,7 +2302,7 @@
         279,
         284
       ],
-      "block_text": "### \u274c Tier Drift\n**What it looks like**: Skill starts as Simple (400 lines), grows to 2000 lines over time without restructuring\n\n**Why wrong**: Violates progressive disclosure, bloats context, makes skill hard to maintain\n\n**Fix**: Promote to appropriate tier, extract references/, apply progressive disclosure",
+      "block_text": "### ❌ Tier Drift\n**What it looks like**: Skill starts as Simple (400 lines), grows to 2000 lines over time without restructuring\n\n**Why wrong**: Violates progressive disclosure, bloats context, makes skill hard to maintain\n\n**Fix**: Promote to appropriate tier, extract references/, apply progressive disclosure",
       "domain_hint": "skill-creator"
     },
     {
@@ -2311,7 +2311,7 @@
         160,
         182
       ],
-      "block_text": "## Testing (test-driven-development, testing-anti-patterns, e2e-testing)\n\n**Primary sources**\n- [Playwright docs](https://playwright.dev/docs/intro) \u2014 extract: Page Object Model\n  structure, locator best practices, network interception patterns\n- [pytest docs](https://docs.pytest.org) \u2014 extract: fixture patterns, parametrize,\n  conftest scope decisions\n\n**Secondary sources**\n- Kent C. Dodds \u2014 Testing Trophy and [testing-library principles](https://testing-library.com/docs/guiding-principles)\n  \u2014...",
+      "block_text": "## Testing (test-driven-development, testing-anti-patterns, e2e-testing)\n\n**Primary sources**\n- [Playwright docs](https://playwright.dev/docs/intro) — extract: Page Object Model\n  structure, locator best practices, network interception patterns\n- [pytest docs](https://docs.pytest.org) — extract: fixture patterns, parametrize,\n  conftest scope decisions\n\n**Secondary sources**\n- Kent C. Dodds — Testing Trophy and [testing-library principles](https://testing-library.com/docs/guiding-principles)\n  —...",
       "domain_hint": "skill-creator"
     },
     {
@@ -2326,8 +2326,8 @@
     {
       "file": "skills/swift-concurrency/references/anti-patterns.md",
       "line_range": [
-        7,
-        7
+        6,
+        6
       ],
       "block_text": "# Common Anti-Patterns\n",
       "domain_hint": "swift"
@@ -2362,8 +2362,8 @@
     {
       "file": "skills/threejs-builder/references/advanced-animation.md",
       "line_range": [
-        333,
-        333
+        332,
+        332
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "Three.js Advanced Animation"
@@ -2371,35 +2371,35 @@
     {
       "file": "skills/threejs-builder/references/advanced-animation.md",
       "line_range": [
-        335,
-        362
+        334,
+        361
       ],
-      "block_text": "### \u274c Calling mixer.update() with Raw Timestamp (Not Delta)\n\n**Detection**:\n```bash\ngrep -rn \"mixer\\.update\" --include=\"*.js\" --include=\"*.ts\"\nrg \"mixer\\.update\\(time\\)\" --type js\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop((time) => {\n  mixer.update(time); // BAD: time is ms since page load (~120000ms after 2 minutes)\n});\n```\n\n**Why wrong**: `mixer.update()` expects elapsed seconds since last frame (delta), not absolute timestamp. Passing raw `time` makes animations pla...",
+      "block_text": "### ❌ Calling mixer.update() with Raw Timestamp (Not Delta)\n\n**Detection**:\n```bash\ngrep -rn \"mixer\\.update\" --include=\"*.js\" --include=\"*.ts\"\nrg \"mixer\\.update\\(time\\)\" --type js\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop((time) => {\n  mixer.update(time); // BAD: time is ms since page load (~120000ms after 2 minutes)\n});\n```\n\n**Why wrong**: `mixer.update()` expects elapsed seconds since last frame (delta), not absolute timestamp. Passing raw `time` makes animations pla...",
       "domain_hint": "Three.js Advanced Animation"
     },
     {
       "file": "skills/threejs-builder/references/advanced-animation.md",
       "line_range": [
-        364,
-        391
+        363,
+        390
       ],
-      "block_text": "### \u274c Applying Bone Rotation After mixer.update()\n\n**Detection**:\n```bash\ngrep -rn \"bone\\.rotation\\|bone\\.quaternion\" --include=\"*.js\" --include=\"*.ts\"\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop(() => {\n  mixer.update(delta); // sets bone transforms from keyframe data\n  headBone.rotation.y = mouseTargetY; // immediately overwritten \u2014 no effect seen\n});\n```\n\n**Why wrong**: `mixer.update()` overwrites bone transforms from animation keyframes on the same frame tick. Manual...",
+      "block_text": "### ❌ Applying Bone Rotation After mixer.update()\n\n**Detection**:\n```bash\ngrep -rn \"bone\\.rotation\\|bone\\.quaternion\" --include=\"*.js\" --include=\"*.ts\"\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop(() => {\n  mixer.update(delta); // sets bone transforms from keyframe data\n  headBone.rotation.y = mouseTargetY; // immediately overwritten — no effect seen\n});\n```\n\n**Why wrong**: `mixer.update()` overwrites bone transforms from animation keyframes on the same frame tick. Manual...",
       "domain_hint": "Three.js Advanced Animation"
     },
     {
       "file": "skills/threejs-builder/references/advanced-animation.md",
       "line_range": [
-        393,
-        426
+        392,
+        425
       ],
-      "block_text": "### \u274c Not Disposing Mixer on Component Unmount\n\n**Detection**:\n```bash\ngrep -rn \"AnimationMixer\" --include=\"*.js\" --include=\"*.ts\"\nrg \"mixer\\.\" --type js | grep -v \"dispose\\|update\\|stopAll\"\n```\n\n**What it looks like**:\n```javascript\n// In a React Three Fiber component:\nuseEffect(() => {\n  const mixer = new THREE.AnimationMixer(scene);\n  // No cleanup\n}, []);\n```\n\n**Why wrong**: `AnimationMixer` holds references to scene objects, preventing GC. Multiple mixers accumulate on route changes.\n\n**Fix...",
+      "block_text": "### ❌ Not Disposing Mixer on Component Unmount\n\n**Detection**:\n```bash\ngrep -rn \"AnimationMixer\" --include=\"*.js\" --include=\"*.ts\"\nrg \"mixer\\.\" --type js | grep -v \"dispose\\|update\\|stopAll\"\n```\n\n**What it looks like**:\n```javascript\n// In a React Three Fiber component:\nuseEffect(() => {\n  const mixer = new THREE.AnimationMixer(scene);\n  // No cleanup\n}, []);\n```\n\n**Why wrong**: `AnimationMixer` holds references to scene objects, preventing GC. Multiple mixers accumulate on route changes.\n\n**Fix...",
       "domain_hint": "Three.js Advanced Animation"
     },
     {
       "file": "skills/threejs-builder/references/performance-patterns.md",
       "line_range": [
-        276,
-        276
+        275,
+        275
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "Three.js Performance Patterns"
@@ -2407,28 +2407,28 @@
     {
       "file": "skills/threejs-builder/references/performance-patterns.md",
       "line_range": [
-        278,
-        311
+        277,
+        310
       ],
-      "block_text": "### \u274c Creating Geometry in the Animation Loop\n\n**Detection**:\n```bash\ngrep -rn \"new THREE\\.\\(Box\\|Sphere\\|Plane\\|Cylinder\\)Geometry\" --include=\"*.js\" --include=\"*.ts\"\nrg \"setAnimationLoop|useFrame\" --type js -A 20 | grep \"new THREE\\.\"\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop((time) => {\n  // BAD: allocates new geometry every frame at 60fps\n  const geo = new THREE.SphereGeometry(Math.sin(time * 0.001), 32, 32);\n  mesh.geometry = geo;\n  renderer.render(scene, camera);\n}...",
+      "block_text": "### ❌ Creating Geometry in the Animation Loop\n\n**Detection**:\n```bash\ngrep -rn \"new THREE\\.\\(Box\\|Sphere\\|Plane\\|Cylinder\\)Geometry\" --include=\"*.js\" --include=\"*.ts\"\nrg \"setAnimationLoop|useFrame\" --type js -A 20 | grep \"new THREE\\.\"\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop((time) => {\n  // BAD: allocates new geometry every frame at 60fps\n  const geo = new THREE.SphereGeometry(Math.sin(time * 0.001), 32, 32);\n  mesh.geometry = geo;\n  renderer.render(scene, camera);\n}...",
       "domain_hint": "Three.js Performance Patterns"
     },
     {
       "file": "skills/threejs-builder/references/performance-patterns.md",
       "line_range": [
-        313,
-        346
+        312,
+        345
       ],
-      "block_text": "### \u274c `new THREE.Vector3()` Inside render Loop\n\n**Detection**:\n```bash\ngrep -rn \"new THREE\\.Vector3\\|new THREE\\.Color\\|new THREE\\.Matrix4\" --include=\"*.js\" --include=\"*.ts\"\nrg \"setAnimationLoop|useFrame\" --type js -A 30 | grep \"new THREE\\.\"\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop(() => {\n  // BAD: 3 allocations per frame = 10,800 objects/min of GC pressure\n  const pos = new THREE.Vector3(mesh.position);\n  const dir = new THREE.Vector3(0, 1, 0);\n  const target = new T...",
+      "block_text": "### ❌ `new THREE.Vector3()` Inside render Loop\n\n**Detection**:\n```bash\ngrep -rn \"new THREE\\.Vector3\\|new THREE\\.Color\\|new THREE\\.Matrix4\" --include=\"*.js\" --include=\"*.ts\"\nrg \"setAnimationLoop|useFrame\" --type js -A 30 | grep \"new THREE\\.\"\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop(() => {\n  // BAD: 3 allocations per frame = 10,800 objects/min of GC pressure\n  const pos = new THREE.Vector3(mesh.position);\n  const dir = new THREE.Vector3(0, 1, 0);\n  const target = new T...",
       "domain_hint": "Three.js Performance Patterns"
     },
     {
       "file": "skills/threejs-builder/references/performance-patterns.md",
       "line_range": [
-        348,
-        369
+        347,
+        368
       ],
-      "block_text": "### \u274c Using `renderer.render()` with EffectComposer\n\n**Detection**:\n```bash\ngrep -rn \"renderer\\.render\\|composer\\.render\" --include=\"*.js\" --include=\"*.ts\"\n```\n\n**What it looks like**:\n```javascript\nconst composer = new EffectComposer(renderer);\n// ...\n\nrenderer.setAnimationLoop(() => {\n  renderer.render(scene, camera); // BAD when composer is active \u2014 skips postprocessing\n});\n```\n\n**Why wrong**: `renderer.render()` writes directly to the canvas, bypassing the composer's pass chain. Postprocessi...",
+      "block_text": "### ❌ Using `renderer.render()` with EffectComposer\n\n**Detection**:\n```bash\ngrep -rn \"renderer\\.render\\|composer\\.render\" --include=\"*.js\" --include=\"*.ts\"\n```\n\n**What it looks like**:\n```javascript\nconst composer = new EffectComposer(renderer);\n// ...\n\nrenderer.setAnimationLoop(() => {\n  renderer.render(scene, camera); // BAD when composer is active — skips postprocessing\n});\n```\n\n**Why wrong**: `renderer.render()` writes directly to the canvas, bypassing the composer's pass chain. Postprocessi...",
       "domain_hint": "Three.js Performance Patterns"
     },
     {
@@ -2443,8 +2443,8 @@
     {
       "file": "skills/threejs-builder/references/shader-patterns.md",
       "line_range": [
-        397,
-        397
+        396,
+        396
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "Three.js Shader Patterns"
@@ -2452,28 +2452,28 @@
     {
       "file": "skills/threejs-builder/references/shader-patterns.md",
       "line_range": [
-        399,
-        433
+        398,
+        432
       ],
-      "block_text": "### \u274c Recreating ShaderMaterial in Animation Loop\n\n**Detection**:\n```bash\ngrep -rn \"new THREE.ShaderMaterial\" --include=\"*.js\" --include=\"*.ts\"\nrg \"new THREE\\.ShaderMaterial\" --type js\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop((time) => {\n  // BAD: creates new material every frame \u2014 leaks GPU memory\n  mesh.material = new THREE.ShaderMaterial({\n    uniforms: { uTime: { value: time } },\n    ...\n  });\n  renderer.render(scene, camera);\n});\n```\n\n**Why wrong**: GPU memory le...",
+      "block_text": "### ❌ Recreating ShaderMaterial in Animation Loop\n\n**Detection**:\n```bash\ngrep -rn \"new THREE.ShaderMaterial\" --include=\"*.js\" --include=\"*.ts\"\nrg \"new THREE\\.ShaderMaterial\" --type js\n```\n\n**What it looks like**:\n```javascript\nrenderer.setAnimationLoop((time) => {\n  // BAD: creates new material every frame — leaks GPU memory\n  mesh.material = new THREE.ShaderMaterial({\n    uniforms: { uTime: { value: time } },\n    ...\n  });\n  renderer.render(scene, camera);\n});\n```\n\n**Why wrong**: GPU memory le...",
       "domain_hint": "Three.js Shader Patterns"
     },
     {
       "file": "skills/threejs-builder/references/shader-patterns.md",
       "line_range": [
-        435,
-        459
+        434,
+        458
       ],
-      "block_text": "### \u274c Forgetting OutputPass (Washed-Out Colors in r150+)\n\n**Detection**:\n```bash\ngrep -rn \"EffectComposer\" --include=\"*.js\" --include=\"*.ts\" -l\nrg \"GammaCorrectionShader\" --type js\n```\n\n**What it looks like**:\n```javascript\n// r150+ \u2014 GammaCorrectionShader is deprecated, OutputPass is required\nimport { GammaCorrectionShader } from 'three/addons/shaders/GammaCorrectionShader.js'; // deprecated r154+\n```\n\n**Why wrong**: In Three.js r150+, `renderer.outputColorSpace` defaults to `SRGBColorSpace`. W...",
+      "block_text": "### ❌ Forgetting OutputPass (Washed-Out Colors in r150+)\n\n**Detection**:\n```bash\ngrep -rn \"EffectComposer\" --include=\"*.js\" --include=\"*.ts\" -l\nrg \"GammaCorrectionShader\" --type js\n```\n\n**What it looks like**:\n```javascript\n// r150+ — GammaCorrectionShader is deprecated, OutputPass is required\nimport { GammaCorrectionShader } from 'three/addons/shaders/GammaCorrectionShader.js'; // deprecated r154+\n```\n\n**Why wrong**: In Three.js r150+, `renderer.outputColorSpace` defaults to `SRGBColorSpace`. W...",
       "domain_hint": "Three.js Shader Patterns"
     },
     {
       "file": "skills/threejs-builder/references/shader-patterns.md",
       "line_range": [
-        461,
-        483
+        460,
+        482
       ],
-      "block_text": "### \u274c Using ShaderChunk Injection Without Understanding Side Effects\n\n**Detection**:\n```bash\ngrep -rn \"onBeforeCompile\" --include=\"*.js\" --include=\"*.ts\"\nrg \"shader\\.vertexShader\\.replace\" --type js\n```\n\n**What it looks like**:\n```javascript\nmaterial.onBeforeCompile = (shader) => {\n  shader.vertexShader = shader.vertexShader.replace(\n    '#include <begin_vertex>',\n    `vec3 transformed = position + vec3(sin(uTime), 0.0, 0.0);`\n  );\n};\n```\n\n**Why wrong**: `#include` tokens change between Three.js...",
+      "block_text": "### ❌ Using ShaderChunk Injection Without Understanding Side Effects\n\n**Detection**:\n```bash\ngrep -rn \"onBeforeCompile\" --include=\"*.js\" --include=\"*.ts\"\nrg \"shader\\.vertexShader\\.replace\" --type js\n```\n\n**What it looks like**:\n```javascript\nmaterial.onBeforeCompile = (shader) => {\n  shader.vertexShader = shader.vertexShader.replace(\n    '#include <begin_vertex>',\n    `vec3 transformed = position + vec3(sin(uTime), 0.0, 0.0);`\n  );\n};\n```\n\n**Why wrong**: `#include` tokens change between Three.js...",
       "domain_hint": "Three.js Shader Patterns"
     },
     {
@@ -2491,7 +2491,7 @@
         1,
         5
       ],
-      "block_text": "# Toolkit Evolution \u2014 Anti-Patterns, Errors, and Cost\n\nReference for Phase 3 CRITIQUE (fallback), anti-patterns, error handling, and cost estimates.\n\n---\n",
+      "block_text": "# Toolkit Evolution — Anti-Patterns, Errors, and Cost\n\nReference for Phase 3 CRITIQUE (fallback), anti-patterns, error handling, and cost estimates.\n\n---\n",
       "domain_hint": "toolkit-evolution"
     },
     {
@@ -2527,7 +2527,7 @@
         331,
         343
       ],
-      "block_text": "## Anti-Patterns\n\n**Animating hue at full time speed**: `hue = fract(uv.x + u_time)` cycles through the full rainbow every second. Real holo foil shifts hue based on viewing angle, not time \u2014 it doesn't pulse like a disco ball. Use mouse position as the primary hue driver; time should only add a slow ambient drift.\n\n**Skipping the distortion field for performance**: Without UV distortion, the rainbow bands are perfectly straight lines. Real holo foil has organic, slightly random banding. Even 2 ...",
+      "block_text": "## Anti-Patterns\n\n**Animating hue at full time speed**: `hue = fract(uv.x + u_time)` cycles through the full rainbow every second. Real holo foil shifts hue based on viewing angle, not time — it doesn't pulse like a disco ball. Use mouse position as the primary hue driver; time should only add a slow ambient drift.\n\n**Skipping the distortion field for performance**: Without UV distortion, the rainbow bands are perfectly straight lines. Real holo foil has organic, slightly random banding. Even 2 ...",
       "domain_hint": "webgl-card-effects"
     },
     {
@@ -2545,7 +2545,7 @@
         530,
         542
       ],
-      "block_text": "## Anti-Patterns\n\n**Creating a new WebGL2 context per card instance**: Browsers cap at 8\u201316 total contexts. With a hand of 8+ cards, you will hit this limit. The singleton pattern above is non-negotiable.\n\n**Running RAF at 60fps for card shimmer**: Card shimmer doesn't need 60fps. The 30fps throttle (`TARGET_FRAME_MS = 1000 / 30`) halves GPU load with no perceptible quality difference for a slow organic shimmer.\n\n**Skipping IntersectionObserver**: Cards not in the viewport still consume RAF budg...",
+      "block_text": "## Anti-Patterns\n\n**Creating a new WebGL2 context per card instance**: Browsers cap at 8–16 total contexts. With a hand of 8+ cards, you will hit this limit. The singleton pattern above is non-negotiable.\n\n**Running RAF at 60fps for card shimmer**: Card shimmer doesn't need 60fps. The 30fps throttle (`TARGET_FRAME_MS = 1000 / 30`) halves GPU load with no perceptible quality difference for a slow organic shimmer.\n\n**Skipping IntersectionObserver**: Cards not in the viewport still consume RAF budg...",
       "domain_hint": "webgl-card-effects"
     },
     {
@@ -2554,7 +2554,7 @@
         248,
         256
       ],
-      "block_text": "### Anti-Pattern: Single-Threaded Research\n\n**BANNED**: Research phases that use sequential `grep` or `search` commands without dispatching parallel agents.\n\n**Why wrong**: Sequential search is narrow by construction \u2014 each search informs the next, creating tunnel vision. Parallel agents explore independently, producing broader coverage.\n\n**Exception**: If the pipeline's research phase takes <30 seconds total (e.g., single file lookup), sequential is acceptable. But any research involving \"find ...",
+      "block_text": "### Anti-Pattern: Single-Threaded Research\n\n**BANNED**: Research phases that use sequential `grep` or `search` commands without dispatching parallel agents.\n\n**Why wrong**: Sequential search is narrow by construction — each search informs the next, creating tunnel vision. Parallel agents explore independently, producing broader coverage.\n\n**Exception**: If the pipeline's research phase takes <30 seconds total (e.g., single file lookup), sequential is acceptable. But any research involving \"find ...",
       "domain_hint": "workflow"
     },
     {
@@ -2608,7 +2608,7 @@
         206,
         234
       ],
-      "block_text": "# Find hardcoded config files that should be templates\ngrep -rn \"copy:\" roles/ playbooks/ -A3 \\\n  | grep \"src:.*\\.conf\\|src:.*\\.cfg\\|src:.*\\.ini\"\n```\n\n**What it looks like**:\n```yaml\n- name: Copy nginx config\n  ansible.builtin.copy:\n    src: files/nginx.conf  # Static file, no variable substitution\n    dest: /etc/nginx/nginx.conf\n    # But the file contains: listen {{ nginx_port }};  \u2190 variable!\n```\n\n**Why wrong**: `copy` sends the file verbatim \u2014 Jinja2 variables are NOT evaluated. The destinat...",
+      "block_text": "# Find hardcoded config files that should be templates\ngrep -rn \"copy:\" roles/ playbooks/ -A3 \\\n  | grep \"src:.*\\.conf\\|src:.*\\.cfg\\|src:.*\\.ini\"\n```\n\n**What it looks like**:\n```yaml\n- name: Copy nginx config\n  ansible.builtin.copy:\n    src: files/nginx.conf  # Static file, no variable substitution\n    dest: /etc/nginx/nginx.conf\n    # But the file contains: listen {{ nginx_port }};  ← variable!\n```\n\n**Why wrong**: `copy` sends the file verbatim — Jinja2 variables are NOT evaluated. The destinat...",
       "domain_hint": "ansible-automation-engineer"
     },
     {
@@ -2635,7 +2635,7 @@
         123,
         132
       ],
-      "block_text": "# vars/main.yml \u2014 NEVER DO THIS\ndb_password: MyS3cr3tP@ssword!\naws_access_key: AKIAIOSFODNN7EXAMPLE\naws_secret_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n```\n\n**Why wrong**: Plaintext secrets in any file will eventually reach git history. Git history is permanent \u2014 even after deletion, the secret exists in every clone and every CI artifact that ran during that period. Rotation requires assuming full compromise.\n\n**Fix**:\n```bash",
+      "block_text": "# vars/main.yml — NEVER DO THIS\ndb_password: MyS3cr3tP@ssword!\naws_access_key: AKIAIOSFODNN7EXAMPLE\naws_secret_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n```\n\n**Why wrong**: Plaintext secrets in any file will eventually reach git history. Git history is permanent — even after deletion, the secret exists in every clone and every CI artifact that ran during that period. Rotation requires assuming full compromise.\n\n**Fix**:\n```bash",
       "domain_hint": "ansible-automation-engineer"
     },
     {
@@ -2653,7 +2653,7 @@
         157,
         165
       ],
-      "block_text": "# inventory/hosts.ini \u2014 NEVER DO THIS\n[webservers]\nweb01 ansible_ssh_private_key_file=keys/deploy_key.pem\n```\n\n**Why wrong**: Private keys committed to a repository expose root access to every server in the inventory. Even with a gitignore rule added later, the key exists in git history.\n\n**Fix**:\n```yaml",
+      "block_text": "# inventory/hosts.ini — NEVER DO THIS\n[webservers]\nweb01 ansible_ssh_private_key_file=keys/deploy_key.pem\n```\n\n**Why wrong**: Private keys committed to a repository expose root access to every server in the inventory. Even with a gitignore rule added later, the key exists in git history.\n\n**Fix**:\n```yaml",
       "domain_hint": "ansible-automation-engineer"
     },
     {
@@ -2707,7 +2707,7 @@
         193,
         232
       ],
-      "block_text": "# molecule/default/verify.yml \u2014 provides zero value\n---\n- name: Verify\n  hosts: all\n  tasks:\n    - name: Check connectivity\n      ping:\n```\n\n**Why wrong**: Ping passing means the container is alive, not that the role worked. A role that fails to install nginx will still pass this verify.\n\n**Fix**:\n```yaml\n---\n- name: Verify\n  hosts: all\n  gather_facts: false\n  tasks:\n    - name: Check nginx listening on port 80\n      wait_for:\n        port: 80\n        timeout: 5\n\n    - name: Check nginx config s...",
+      "block_text": "# molecule/default/verify.yml — provides zero value\n---\n- name: Verify\n  hosts: all\n  tasks:\n    - name: Check connectivity\n      ping:\n```\n\n**Why wrong**: Ping passing means the container is alive, not that the role worked. A role that fails to install nginx will still pass this verify.\n\n**Fix**:\n```yaml\n---\n- name: Verify\n  hosts: all\n  gather_facts: false\n  tasks:\n    - name: Check nginx listening on port 80\n      wait_for:\n        port: 80\n        timeout: 5\n\n    - name: Check nginx config s...",
       "domain_hint": "ansible-automation-engineer"
     },
     {
@@ -2761,7 +2761,7 @@
         206,
         230
       ],
-      "block_text": "# In BigQuery console: Query Plan tab \u2192 look for large \"Write\" steps\n```\n\n**What it looks like**:\n```sql\n-- fact_orders (1B rows) joined to dim_customer (10M rows)\n-- Neither table clustered on customer_id\nSELECT fo.*, dc.segment\nFROM fact_orders fo\nJOIN dim_customer dc ON fo.customer_id = dc.customer_id\nWHERE fo.order_date = CURRENT_DATE\n```\n\n**Why wrong**: Without clustering on `customer_id`, the join shuffles all data across nodes to co-locate matching rows. On 1B rows, this is a multi-minute...",
+      "block_text": "# In BigQuery console: Query Plan tab → look for large \"Write\" steps\n```\n\n**What it looks like**:\n```sql\n-- fact_orders (1B rows) joined to dim_customer (10M rows)\n-- Neither table clustered on customer_id\nSELECT fo.*, dc.segment\nFROM fact_orders fo\nJOIN dim_customer dc ON fo.customer_id = dc.customer_id\nWHERE fo.order_date = CURRENT_DATE\n```\n\n**Why wrong**: Without clustering on `customer_id`, the join shuffles all data across nodes to co-locate matching rows. On 1B rows, this is a multi-minute...",
       "domain_hint": "data-engineer"
     },
     {
@@ -2779,7 +2779,7 @@
         246,
         256
       ],
-      "block_text": "# Airflow DAG that runs at 9 AM \u2014 peak dashboard hour\nrefresh_mv = PostgresOperator(\n    sql=\"REFRESH MATERIALIZED VIEW daily_revenue_by_segment;\",\n    schedule_interval=\"0 9 * * *\",  # 9 AM = peak load\n)\n```\n\n**Why wrong**: `REFRESH MATERIALIZED VIEW` (non-CONCURRENT) takes an exclusive lock that blocks all queries to the view. Running during 9 AM peak hour blocks dashboards for the duration of the refresh (potentially minutes on large datasets).\n\n**Fix**:\n```python",
+      "block_text": "# Airflow DAG that runs at 9 AM — peak dashboard hour\nrefresh_mv = PostgresOperator(\n    sql=\"REFRESH MATERIALIZED VIEW daily_revenue_by_segment;\",\n    schedule_interval=\"0 9 * * *\",  # 9 AM = peak load\n)\n```\n\n**Why wrong**: `REFRESH MATERIALIZED VIEW` (non-CONCURRENT) takes an exclusive lock that blocks all queries to the view. Running during 9 AM peak hour blocks dashboards for the duration of the refresh (potentially minutes on large datasets).\n\n**Fix**:\n```python",
       "domain_hint": "data-engineer"
     },
     {
@@ -2815,7 +2815,7 @@
         189,
         220
       ],
-      "block_text": "### \u274c SELECT * in Pipeline Transforms\n\n**Detection**:\n```bash\ngrep -rn \"SELECT \\*\" models/ pipelines/ sql/ --include=\"*.sql\"\nrg 'SELECT \\*' --type sql\n```\n\n**What it looks like**:\n```sql\n-- Staging model that passes through everything\nSELECT * FROM raw.orders\n```\n\n**Why wrong**: When the source schema adds a column, the staging model now passes that column downstream \u2014 potentially breaking downstream models that don't expect it, or silently including PII that shouldn't flow through the pipeline....",
+      "block_text": "### ❌ SELECT * in Pipeline Transforms\n\n**Detection**:\n```bash\ngrep -rn \"SELECT \\*\" models/ pipelines/ sql/ --include=\"*.sql\"\nrg 'SELECT \\*' --type sql\n```\n\n**What it looks like**:\n```sql\n-- Staging model that passes through everything\nSELECT * FROM raw.orders\n```\n\n**Why wrong**: When the source schema adds a column, the staging model now passes that column downstream — potentially breaking downstream models that don't expect it, or silently including PII that shouldn't flow through the pipeline....",
       "domain_hint": "data-engineer"
     },
     {
@@ -2878,7 +2878,7 @@
         143,
         185
       ],
-      "block_text": "### \u274c Over-Indexing (Index on Every Column)\n\n**Detection**:\n```sql\n-- Find tables with unusually high index count\nSELECT\n  schemaname,\n  tablename,\n  COUNT(*) AS index_count\nFROM pg_indexes\nWHERE schemaname = 'public'\nGROUP BY schemaname, tablename\nHAVING COUNT(*) > 8\nORDER BY index_count DESC;\n\n-- Find unused indexes (no scans since last statistics reset)\nSELECT\n  schemaname,\n  tablename,\n  indexname,\n  idx_scan AS times_used\nFROM pg_stat_user_indexes\nWHERE idx_scan = 0\n  AND indexname NOT LIKE...",
+      "block_text": "### ❌ Over-Indexing (Index on Every Column)\n\n**Detection**:\n```sql\n-- Find tables with unusually high index count\nSELECT\n  schemaname,\n  tablename,\n  COUNT(*) AS index_count\nFROM pg_indexes\nWHERE schemaname = 'public'\nGROUP BY schemaname, tablename\nHAVING COUNT(*) > 8\nORDER BY index_count DESC;\n\n-- Find unused indexes (no scans since last statistics reset)\nSELECT\n  schemaname,\n  tablename,\n  indexname,\n  idx_scan AS times_used\nFROM pg_stat_user_indexes\nWHERE idx_scan = 0\n  AND indexname NOT LIKE...",
       "domain_hint": "database-engineer"
     },
     {
@@ -2887,7 +2887,7 @@
         195,
         229
       ],
-      "block_text": "# Check table size before running migration\npsql -c \"SELECT pg_size_pretty(pg_total_relation_size('orders'));\"\n```\n\n**What it looks like**:\n```sql\n-- This takes an ExclusiveLock for the duration on a 500GB table\nALTER TABLE orders ADD COLUMN processed BOOLEAN NOT NULL DEFAULT false;\n-- PostgreSQL 11+: default value is safe \u2014 metadata-only change\n-- PostgreSQL < 11: rewrites entire table with new column!\n```\n\n**Why wrong**: On PostgreSQL < 11, adding a column with a default value requires rewriti...",
+      "block_text": "# Check table size before running migration\npsql -c \"SELECT pg_size_pretty(pg_total_relation_size('orders'));\"\n```\n\n**What it looks like**:\n```sql\n-- This takes an ExclusiveLock for the duration on a 500GB table\nALTER TABLE orders ADD COLUMN processed BOOLEAN NOT NULL DEFAULT false;\n-- PostgreSQL 11+: default value is safe — metadata-only change\n-- PostgreSQL < 11: rewrites entire table with new column!\n```\n\n**Why wrong**: On PostgreSQL < 11, adding a column with a default value requires rewriti...",
       "domain_hint": "database-engineer"
     },
     {
@@ -2896,7 +2896,7 @@
         231,
         258
       ],
-      "block_text": "### \u274c No Query Timeout Set (Runaway Queries)\n\n**Detection**:\n```sql\n-- Find queries running longer than 5 minutes\nSELECT pid, now() - query_start AS duration, query\nFROM pg_stat_activity\nWHERE state = 'active'\n  AND query_start < NOW() - INTERVAL '5 minutes';\n```\n\n**What it looks like**: Application has no statement timeout configured. A user runs `SELECT * FROM orders` (full table scan, no WHERE clause) that runs for 30 minutes and holds shared locks.\n\n**Why wrong**: Long-running queries on Pos...",
+      "block_text": "### ❌ No Query Timeout Set (Runaway Queries)\n\n**Detection**:\n```sql\n-- Find queries running longer than 5 minutes\nSELECT pid, now() - query_start AS duration, query\nFROM pg_stat_activity\nWHERE state = 'active'\n  AND query_start < NOW() - INTERVAL '5 minutes';\n```\n\n**What it looks like**: Application has no statement timeout configured. A user runs `SELECT * FROM orders` (full table scan, no WHERE clause) that runs for 30 minutes and holds shared locks.\n\n**Why wrong**: Long-running queries on Pos...",
       "domain_hint": "database-engineer"
     },
     {
@@ -2914,7 +2914,7 @@
         155,
         190
       ],
-      "block_text": "### \u274c Unindexed Foreign Key Column\n\n**Detection**:\n```sql\n-- Find all foreign keys without corresponding indexes (PostgreSQL)\nSELECT\n  tc.table_name,\n  kcu.column_name,\n  ccu.table_name AS references_table\nFROM information_schema.table_constraints AS tc\nJOIN information_schema.key_column_usage AS kcu\n  ON tc.constraint_name = kcu.constraint_name\nJOIN information_schema.referential_constraints AS rc\n  ON tc.constraint_name = rc.constraint_name\nJOIN information_schema.key_column_usage AS ccu\n  ON ...",
+      "block_text": "### ❌ Unindexed Foreign Key Column\n\n**Detection**:\n```sql\n-- Find all foreign keys without corresponding indexes (PostgreSQL)\nSELECT\n  tc.table_name,\n  kcu.column_name,\n  ccu.table_name AS references_table\nFROM information_schema.table_constraints AS tc\nJOIN information_schema.key_column_usage AS kcu\n  ON tc.constraint_name = kcu.constraint_name\nJOIN information_schema.referential_constraints AS rc\n  ON tc.constraint_name = rc.constraint_name\nJOIN information_schema.key_column_usage AS ccu\n  ON ...",
       "domain_hint": "database-engineer"
     },
     {
@@ -2923,7 +2923,7 @@
         196,
         229
       ],
-      "block_text": "# Find LIKE patterns with leading wildcards in application queries\ngrep -rn \"LIKE '%\\|ilike '%\\|SIMILAR TO '%\" src/ --include=\"*.py\" --include=\"*.go\" --include=\"*.ts\"\n```\n\n**What it looks like**:\n```sql\n-- Scans entire table \u2014 no index can help with leading wildcard\nSELECT * FROM products WHERE name ILIKE '%laptop%';\n```\n\n**Why wrong**: B-tree indexes require a known prefix. `LIKE '%term%'` always does a full sequential scan regardless of indexes. On 100K products, this is 100K string comparison...",
+      "block_text": "# Find LIKE patterns with leading wildcards in application queries\ngrep -rn \"LIKE '%\\|ilike '%\\|SIMILAR TO '%\" src/ --include=\"*.py\" --include=\"*.go\" --include=\"*.ts\"\n```\n\n**What it looks like**:\n```sql\n-- Scans entire table — no index can help with leading wildcard\nSELECT * FROM products WHERE name ILIKE '%laptop%';\n```\n\n**Why wrong**: B-tree indexes require a known prefix. `LIKE '%term%'` always does a full sequential scan regardless of indexes. On 100K products, this is 100K string comparison...",
       "domain_hint": "database-engineer"
     },
     {
@@ -2932,7 +2932,7 @@
         231,
         268
       ],
-      "block_text": "### \u274c Not Updating Table Statistics After Bulk Loads\n\n**Detection**:\n```sql\n-- Find tables with stale statistics (last analyzed > 7 days for busy tables)\nSELECT\n  schemaname,\n  tablename,\n  n_live_tup,\n  last_analyze,\n  last_autoanalyze,\n  now() - last_analyze AS time_since_analyze\nFROM pg_stat_user_tables\nWHERE (last_analyze < NOW() - INTERVAL '7 days' OR last_analyze IS NULL)\n  AND n_live_tup > 10000\nORDER BY n_live_tup DESC;\n```\n\n**What it looks like**: After a bulk insert of 500K rows into a...",
+      "block_text": "### ❌ Not Updating Table Statistics After Bulk Loads\n\n**Detection**:\n```sql\n-- Find tables with stale statistics (last analyzed > 7 days for busy tables)\nSELECT\n  schemaname,\n  tablename,\n  n_live_tup,\n  last_analyze,\n  last_autoanalyze,\n  now() - last_analyze AS time_since_analyze\nFROM pg_stat_user_tables\nWHERE (last_analyze < NOW() - INTERVAL '7 days' OR last_analyze IS NULL)\n  AND n_live_tup > 10000\nORDER BY n_live_tup DESC;\n```\n\n**What it looks like**: After a bulk insert of 500K rows into a...",
       "domain_hint": "database-engineer"
     },
     {
@@ -3013,7 +3013,7 @@
         129,
         137
       ],
-      "block_text": "### \u274c Fetching Files One by One Without Tree\n\n**Detection** (in your own code pattern):\n```bash\ngrep -rn 'GET /repos.*contents' scripts/ | grep -v 'tree'\n```\n\n**What it looks like**:\n```python",
+      "block_text": "### ❌ Fetching Files One by One Without Tree\n\n**Detection** (in your own code pattern):\n```bash\ngrep -rn 'GET /repos.*contents' scripts/ | grep -v 'tree'\n```\n\n**What it looks like**:\n```python",
       "domain_hint": "github-profile-rules-engineer"
     },
     {
@@ -3031,7 +3031,7 @@
         154,
         163
       ],
-      "block_text": "### \u274c Not Checking Pagination\n\n**Detection**:\n```bash\ngrep -rn 'per_page' scripts/ | grep -v 'pagination\\|next\\|link'\n```\n\n**What it looks like**:\n```python\nrepos = github_get(f\"/users/{username}/repos?per_page=100\")",
+      "block_text": "### ❌ Not Checking Pagination\n\n**Detection**:\n```bash\ngrep -rn 'per_page' scripts/ | grep -v 'pagination\\|next\\|link'\n```\n\n**What it looks like**:\n```python\nrepos = github_get(f\"/users/{username}/repos?per_page=100\")",
       "domain_hint": "github-profile-rules-engineer"
     },
     {
@@ -3040,7 +3040,7 @@
         164,
         181
       ],
-      "block_text": "# Assumes all repos fit in one page \u2014 fails for users with 100+ repos\n```\n\n**Why wrong**: GitHub API returns max 100 items per page. Users with 100+ repos silently get incomplete data. The API includes a `Link` header with `rel=\"next\"` for pagination.\n\n**Fix**:\n```python\ndef paginate(url: str) -> list:\n    results = []\n    while url:\n        resp = requests.get(url, headers=auth_headers)\n        results.extend(resp.json())\n        # GitHub uses Link header for pagination\n        url = resp.links...",
+      "block_text": "# Assumes all repos fit in one page — fails for users with 100+ repos\n```\n\n**Why wrong**: GitHub API returns max 100 items per page. Users with 100+ repos silently get incomplete data. The API includes a `Link` header with `rel=\"next\"` for pagination.\n\n**Fix**:\n```python\ndef paginate(url: str) -> list:\n    results = []\n    while url:\n        resp = requests.get(url, headers=auth_headers)\n        results.extend(resp.json())\n        # GitHub uses Link header for pagination\n        url = resp.links...",
       "domain_hint": "github-profile-rules-engineer"
     },
     {
@@ -3049,7 +3049,7 @@
         183,
         192
       ],
-      "block_text": "### \u274c Using Unauthenticated Requests for Full Analysis\n\n**Detection**:\n```bash\ngrep -rn 'github_get\\|requests.get' scripts/ | grep -v 'Authorization\\|token'\n```\n\n**What it looks like**:\n```python\nheaders = {\"Accept\": \"application/vnd.github.v3+json\"}",
+      "block_text": "### ❌ Using Unauthenticated Requests for Full Analysis\n\n**Detection**:\n```bash\ngrep -rn 'github_get\\|requests.get' scripts/ | grep -v 'Authorization\\|token'\n```\n\n**What it looks like**:\n```python\nheaders = {\"Accept\": \"application/vnd.github.v3+json\"}",
       "domain_hint": "github-profile-rules-engineer"
     },
     {
@@ -3058,7 +3058,7 @@
         193,
         208
       ],
-      "block_text": "# Missing: Authorization header \u2014 capped at 60 req/hr\n```\n\n**Why wrong**: 60 requests/hr is exhausted by analyzing 2-3 repos. Profile analysis needs 50-200 requests minimum.\n\n**Fix**: Accept `--token` CLI flag; check for `GITHUB_TOKEN` env var:\n```python\nimport os\ntoken = args.token or os.environ.get(\"GITHUB_TOKEN\")\nheaders = {\n    \"Accept\": \"application/vnd.github.v3+json\",\n    **({\"Authorization\": f\"token {token}\"} if token else {})\n}\n```\n\n---\n",
+      "block_text": "# Missing: Authorization header — capped at 60 req/hr\n```\n\n**Why wrong**: 60 requests/hr is exhausted by analyzing 2-3 repos. Profile analysis needs 50-200 requests minimum.\n\n**Fix**: Accept `--token` CLI flag; check for `GITHUB_TOKEN` env var:\n```python\nimport os\ntoken = args.token or os.environ.get(\"GITHUB_TOKEN\")\nheaders = {\n    \"Accept\": \"application/vnd.github.v3+json\",\n    **({\"Authorization\": f\"token {token}\"} if token else {})\n}\n```\n\n---\n",
       "domain_hint": "github-profile-rules-engineer"
     },
     {
@@ -3076,7 +3076,7 @@
         83,
         99
       ],
-      "block_text": "### \u274c Extracting Universal Patterns\n\n**Detection** (in your own rule output \u2014 review before emitting):\nLook for rules that would appear in any developer's CLAUDE.md:\n- \"Use meaningful variable names\"\n- \"Write tests for your code\"\n- \"Handle errors appropriately\"\n- \"Use consistent formatting\"\n\n**Why wrong**: Universal patterns add no value. The user already knows these. The value of extraction is finding *this developer's* specific choices that differ from the default.\n\n**Fix**: Only emit rules wh...",
+      "block_text": "### ❌ Extracting Universal Patterns\n\n**Detection** (in your own rule output — review before emitting):\nLook for rules that would appear in any developer's CLAUDE.md:\n- \"Use meaningful variable names\"\n- \"Write tests for your code\"\n- \"Handle errors appropriately\"\n- \"Use consistent formatting\"\n\n**Why wrong**: Universal patterns add no value. The user already knows these. The value of extraction is finding *this developer's* specific choices that differ from the default.\n\n**Fix**: Only emit rules wh...",
       "domain_hint": "github-profile-rules-engineer"
     },
     {
@@ -3085,7 +3085,7 @@
         101,
         116
       ],
-      "block_text": "### \u274c Rules Without Repo + File Evidence\n\n**Detection** (in your rule generation):\n```\nRule: \"Always wrap errors with context\"\nEvidence: [none cited]\n```\n\n**Why wrong**: Without evidence, the rule is a guess. The user can't verify it, and it may conflict with their actual preference.\n\n**Fix**: Every rule must cite at minimum:\n- Which repo the pattern was observed in\n- Which file (or file pattern) contains the example\n- Optionally: the specific line or code snippet\n\n---\n",
+      "block_text": "### ❌ Rules Without Repo + File Evidence\n\n**Detection** (in your rule generation):\n```\nRule: \"Always wrap errors with context\"\nEvidence: [none cited]\n```\n\n**Why wrong**: Without evidence, the rule is a guess. The user can't verify it, and it may conflict with their actual preference.\n\n**Fix**: Every rule must cite at minimum:\n- Which repo the pattern was observed in\n- Which file (or file pattern) contains the example\n- Optionally: the specific line or code snippet\n\n---\n",
       "domain_hint": "github-profile-rules-engineer"
     },
     {
@@ -3094,7 +3094,7 @@
         118,
         128
       ],
-      "block_text": "### \u274c Confusing Project Convention with Personal Style\n\n**Detection**: When a pattern appears in only one repo, check if that repo has a contributing guide, linter config, or external style guide that explains it.\n\n**What it looks like**: Extracting \"Always use 2-space indentation in Python\" from one repo \u2014 but the repo is a web framework with enforced formatter config.\n\n**Why wrong**: The developer may be following the project's style, not their own preference. They may write 4-space indentatio...",
+      "block_text": "### ❌ Confusing Project Convention with Personal Style\n\n**Detection**: When a pattern appears in only one repo, check if that repo has a contributing guide, linter config, or external style guide that explains it.\n\n**What it looks like**: Extracting \"Always use 2-space indentation in Python\" from one repo — but the repo is a web framework with enforced formatter config.\n\n**Why wrong**: The developer may be following the project's style, not their own preference. They may write 4-space indentatio...",
       "domain_hint": "github-profile-rules-engineer"
     },
     {
@@ -3103,7 +3103,7 @@
         130,
         142
       ],
-      "block_text": "### \u274c Over-Weighting Authored Code vs Review Comments\n\n**Detection**: If rule extraction only reads authored code files without checking PR reviews, it misses preference signals.\n\n**Why wrong**: PR review comments reveal what the developer considers important enough to enforce on *others*. A developer who writes sloppy error handling in their own draft PRs but consistently requests proper error wrapping in reviews is showing you their real standard.\n\n**Correct priority order**:\n1. PR review comm...",
+      "block_text": "### ❌ Over-Weighting Authored Code vs Review Comments\n\n**Detection**: If rule extraction only reads authored code files without checking PR reviews, it misses preference signals.\n\n**Why wrong**: PR review comments reveal what the developer considers important enough to enforce on *others*. A developer who writes sloppy error handling in their own draft PRs but consistently requests proper error wrapping in reviews is showing you their real standard.\n\n**Correct priority order**:\n1. PR review comm...",
       "domain_hint": "github-profile-rules-engineer"
     },
     {
@@ -3139,7 +3139,7 @@
         94,
         133
       ],
-      "block_text": "### \u274c Goroutine Without Exit Strategy\n\n**Detection**:\n```bash\ngrep -rn 'go func()' --include=\"*.go\" | grep -v \"_test.go\"\nrg 'go func\\(\\)' --type go -l\n```\n\n**What it looks like**:\n```go\nfunc startBackgroundJob() {\n    go func() {\n        for {\n            doWork() // No ctx.Done(), no stop channel\n        }\n    }()\n}\n```\n\n**Why wrong**: The goroutine runs until process exit. If called repeatedly (e.g., in tests), goroutines accumulate. `goleak` in tests will catch this; production just slowly ru...",
+      "block_text": "### ❌ Goroutine Without Exit Strategy\n\n**Detection**:\n```bash\ngrep -rn 'go func()' --include=\"*.go\" | grep -v \"_test.go\"\nrg 'go func\\(\\)' --type go -l\n```\n\n**What it looks like**:\n```go\nfunc startBackgroundJob() {\n    go func() {\n        for {\n            doWork() // No ctx.Done(), no stop channel\n        }\n    }()\n}\n```\n\n**Why wrong**: The goroutine runs until process exit. If called repeatedly (e.g., in tests), goroutines accumulate. `goleak` in tests will catch this; production just slowly ru...",
       "domain_hint": "golang-general-engineer-compact"
     },
     {
@@ -3148,7 +3148,7 @@
         135,
         178
       ],
-      "block_text": "### \u274c WaitGroup Add Inside Goroutine (Pre-1.25)\n\n**Detection**:\n```bash\ngrep -A2 'go func' --include=\"*.go\" -rn . | grep 'wg.Add'\nrg 'go func.*\\{' --type go -A 3 | grep 'wg\\.Add'\n```\n\n**What it looks like**:\n```go\nfor _, item := range items {\n    go func(i Item) {\n        wg.Add(1) // Race: Wait() can return before Add() runs\n        defer wg.Done()\n        process(i)\n    }(item)\n}\nwg.Wait()\n```\n\n**Why wrong**: `wg.Wait()` may return before some goroutines call `wg.Add(1)`. This is a race condit...",
+      "block_text": "### ❌ WaitGroup Add Inside Goroutine (Pre-1.25)\n\n**Detection**:\n```bash\ngrep -A2 'go func' --include=\"*.go\" -rn . | grep 'wg.Add'\nrg 'go func.*\\{' --type go -A 3 | grep 'wg\\.Add'\n```\n\n**What it looks like**:\n```go\nfor _, item := range items {\n    go func(i Item) {\n        wg.Add(1) // Race: Wait() can return before Add() runs\n        defer wg.Done()\n        process(i)\n    }(item)\n}\nwg.Wait()\n```\n\n**Why wrong**: `wg.Wait()` may return before some goroutines call `wg.Add(1)`. This is a race condit...",
       "domain_hint": "golang-general-engineer-compact"
     },
     {
@@ -3157,7 +3157,7 @@
         180,
         215
       ],
-      "block_text": "### \u274c Closing Channel from Multiple Writers\n\n**Detection**:\n```bash\ngrep -rn 'close(' --include=\"*.go\" | grep -v \"_test.go\"\nrg 'close\\(ch\\)' --type go\n```\n\n**What it looks like**:\n```go\nfor _, worker := range workers {\n    go func(w Worker) {\n        result := w.Compute()\n        results <- result\n        close(results) // Panic: multiple goroutines close same channel\n    }(worker)\n}\n```\n\n**Why wrong**: Only one goroutine should close a channel. Multiple goroutines closing the same channel cause...",
+      "block_text": "### ❌ Closing Channel from Multiple Writers\n\n**Detection**:\n```bash\ngrep -rn 'close(' --include=\"*.go\" | grep -v \"_test.go\"\nrg 'close\\(ch\\)' --type go\n```\n\n**What it looks like**:\n```go\nfor _, worker := range workers {\n    go func(w Worker) {\n        result := w.Compute()\n        results <- result\n        close(results) // Panic: multiple goroutines close same channel\n    }(worker)\n}\n```\n\n**Why wrong**: Only one goroutine should close a channel. Multiple goroutines closing the same channel cause...",
       "domain_hint": "golang-general-engineer-compact"
     },
     {
@@ -3166,7 +3166,7 @@
         217,
         245
       ],
-      "block_text": "### \u274c Benchmark Using b.N Loop (Pre-1.24)\n\n**Detection**:\n```bash\ngrep -rn 'for i := 0; i < b.N' --include=\"*_test.go\"\nrg 'i < b\\.N' --type go\n```\n\n**What it looks like**:\n```go\nfunc BenchmarkOp(b *testing.B) {\n    for i := 0; i < b.N; i++ { // Old idiom, still works but verbose\n        op()\n    }\n}\n```\n\n**Fix** (Go 1.24+):\n```go\nfunc BenchmarkOp(b *testing.B) {\n    for b.Loop() { // b.Loop() is idiomatic Go 1.24+\n        op()\n    }\n}\n```\n\n**Version note**: `b.Loop()` was added in Go 1.24. It al...",
+      "block_text": "### ❌ Benchmark Using b.N Loop (Pre-1.24)\n\n**Detection**:\n```bash\ngrep -rn 'for i := 0; i < b.N' --include=\"*_test.go\"\nrg 'i < b\\.N' --type go\n```\n\n**What it looks like**:\n```go\nfunc BenchmarkOp(b *testing.B) {\n    for i := 0; i < b.N; i++ { // Old idiom, still works but verbose\n        op()\n    }\n}\n```\n\n**Fix** (Go 1.24+):\n```go\nfunc BenchmarkOp(b *testing.B) {\n    for b.Loop() { // b.Loop() is idiomatic Go 1.24+\n        op()\n    }\n}\n```\n\n**Version note**: `b.Loop()` was added in Go 1.24. It al...",
       "domain_hint": "golang-general-engineer-compact"
     },
     {
@@ -3184,7 +3184,7 @@
         155,
         187
       ],
-      "block_text": "### \u274c Bare Error Return (No Context)\n\n**Detection**:\n```bash\ngrep -rn 'return err$' --include=\"*.go\" | grep -v \"_test.go\"\nrg 'return nil, err$' --type go | grep -v '_test.go'\n```\n\n**What it looks like**:\n```go\nfunc getConfig(path string) (*Config, error) {\n    data, err := os.ReadFile(path)\n    if err != nil {\n        return nil, err // Loses call context\n    }\n    ...\n}\n```\n\n**Why wrong**: Caller receives `open /etc/config: no such file or directory` with no indication that `getConfig` was the ...",
+      "block_text": "### ❌ Bare Error Return (No Context)\n\n**Detection**:\n```bash\ngrep -rn 'return err$' --include=\"*.go\" | grep -v \"_test.go\"\nrg 'return nil, err$' --type go | grep -v '_test.go'\n```\n\n**What it looks like**:\n```go\nfunc getConfig(path string) (*Config, error) {\n    data, err := os.ReadFile(path)\n    if err != nil {\n        return nil, err // Loses call context\n    }\n    ...\n}\n```\n\n**Why wrong**: Caller receives `open /etc/config: no such file or directory` with no indication that `getConfig` was the ...",
       "domain_hint": "golang-general-engineer-compact"
     },
     {
@@ -3211,7 +3211,7 @@
         121,
         144
       ],
-      "block_text": "### \u274c Missing t.Parallel() in Subtests\n\n**Detection**:\n```bash\ngrep -A5 't.Run(' --include=\"*_test.go\" -rn . | grep -v 't.Parallel'\nrg 't\\.Run\\(' --type go -A 3 | grep -v 't\\.Parallel'\n```\n\n**What it looks like**:\n```go\nfor _, tt := range tests {\n    t.Run(tt.name, func(t *testing.T) {\n        // No t.Parallel() \u2014 runs sequentially\n        result := expensiveCompute(tt.input)\n        ...\n    })\n}\n```\n\n**Why wrong**: Sequential subtests are 10-100x slower on multi-core machines. `go test -count=1...",
+      "block_text": "### ❌ Missing t.Parallel() in Subtests\n\n**Detection**:\n```bash\ngrep -A5 't.Run(' --include=\"*_test.go\" -rn . | grep -v 't.Parallel'\nrg 't\\.Run\\(' --type go -A 3 | grep -v 't\\.Parallel'\n```\n\n**What it looks like**:\n```go\nfor _, tt := range tests {\n    t.Run(tt.name, func(t *testing.T) {\n        // No t.Parallel() — runs sequentially\n        result := expensiveCompute(tt.input)\n        ...\n    })\n}\n```\n\n**Why wrong**: Sequential subtests are 10-100x slower on multi-core machines. `go test -count=1...",
       "domain_hint": "golang-general-engineer-compact"
     },
     {
@@ -3220,7 +3220,7 @@
         177,
         215
       ],
-      "block_text": "### \u274c Context Not Canceled in Test Goroutines\n\n**Detection**:\n```bash\ngrep -rn 'context.Background()' --include=\"*_test.go\"\nrg 'context\\.Background\\(\\)' --type go --glob '*_test.go'\n```\n\n**What it looks like**:\n```go\nfunc TestServer(t *testing.T) {\n    ctx := context.Background() // Never canceled \u2014 goroutines may outlive test\n    go startServer(ctx)\n    ...\n}\n```\n\n**Why wrong**: Goroutines started with `context.Background()` in tests run until process exit, causing goroutine leaks detected by `...",
+      "block_text": "### ❌ Context Not Canceled in Test Goroutines\n\n**Detection**:\n```bash\ngrep -rn 'context.Background()' --include=\"*_test.go\"\nrg 'context\\.Background\\(\\)' --type go --glob '*_test.go'\n```\n\n**What it looks like**:\n```go\nfunc TestServer(t *testing.T) {\n    ctx := context.Background() // Never canceled — goroutines may outlive test\n    go startServer(ctx)\n    ...\n}\n```\n\n**Why wrong**: Goroutines started with `context.Background()` in tests run until process exit, causing goroutine leaks detected by `...",
       "domain_hint": "golang-general-engineer-compact"
     },
     {
@@ -3229,7 +3229,7 @@
         217,
         248
       ],
-      "block_text": "### \u274c Benchmark Without Reset or Skip Setup\n\n**Detection**:\n```bash\ngrep -B5 'for.*b\\.N' --include=\"*_test.go\" -rn . | grep -v 'b.ResetTimer'\nrg 'for i := 0.*b\\.N' --type go --glob '*_test.go'\n```\n\n**What it looks like**:\n```go\nfunc BenchmarkProcess(b *testing.B) {\n    data := loadLargeDataset() // Counted in benchmark time!\n    for i := 0; i < b.N; i++ {\n        process(data)\n    }\n}\n```\n\n**Why wrong**: `loadLargeDataset()` runs once but the time is counted in benchmark initialization, skewing ...",
+      "block_text": "### ❌ Benchmark Without Reset or Skip Setup\n\n**Detection**:\n```bash\ngrep -B5 'for.*b\\.N' --include=\"*_test.go\" -rn . | grep -v 'b.ResetTimer'\nrg 'for i := 0.*b\\.N' --type go --glob '*_test.go'\n```\n\n**What it looks like**:\n```go\nfunc BenchmarkProcess(b *testing.B) {\n    data := loadLargeDataset() // Counted in benchmark time!\n    for i := 0; i < b.N; i++ {\n        process(data)\n    }\n}\n```\n\n**Why wrong**: `loadLargeDataset()` runs once but the time is counted in benchmark initialization, skewing ...",
       "domain_hint": "golang-general-engineer-compact"
     },
     {
@@ -3256,7 +3256,7 @@
         134,
         143
       ],
-      "block_text": "### \u274c Hardcoded Secrets in Values Files\n\n**Detection**:\n```bash\ngrep -rn 'password\\|secret\\|token\\|apiKey\\|api_key' --include=\"values*.yaml\" .\nrg '(password|secret|token|apiKey|api_key): ' --type yaml\n```\n\n**What it looks like**:\n```yaml",
+      "block_text": "### ❌ Hardcoded Secrets in Values Files\n\n**Detection**:\n```bash\ngrep -rn 'password\\|secret\\|token\\|apiKey\\|api_key' --include=\"values*.yaml\" .\nrg '(password|secret|token|apiKey|api_key): ' --type yaml\n```\n\n**What it looks like**:\n```yaml",
       "domain_hint": "kubernetes-helm-engineer"
     },
     {
@@ -3265,7 +3265,7 @@
         144,
         153
       ],
-      "block_text": "# values-prod.yaml \u2014 NEVER DO THIS\ndatabase:\n  password: \"mysecretpassword\"   # Exposed in git history\n  connectionString: \"postgres://user:pass@host/db\"\n```\n\n**Why wrong**: Values files are checked into git. Secrets in git history persist forever even after deletion. CI logs, PR previews, and `helm get values` all expose them.\n\n**Fix**: Use external secret management:\n```yaml",
+      "block_text": "# values-prod.yaml — NEVER DO THIS\ndatabase:\n  password: \"mysecretpassword\"   # Exposed in git history\n  connectionString: \"postgres://user:pass@host/db\"\n```\n\n**Why wrong**: Values files are checked into git. Secrets in git history persist forever even after deletion. CI logs, PR previews, and `helm get values` all expose them.\n\n**Fix**: Use external secret management:\n```yaml",
       "domain_hint": "kubernetes-helm-engineer"
     },
     {
@@ -3274,7 +3274,7 @@
         172,
         180
       ],
-      "block_text": "### \u274c Not Using `required` for Mandatory Values\n\n**Detection**:\n```bash\ngrep -rn '\\.Values\\.' --include=\"*.yaml\" charts/*/templates/ | grep -v 'default\\|required' | head -20\n```\n\n**What it looks like**:\n```yaml",
+      "block_text": "### ❌ Not Using `required` for Mandatory Values\n\n**Detection**:\n```bash\ngrep -rn '\\.Values\\.' --include=\"*.yaml\" charts/*/templates/ | grep -v 'default\\|required' | head -20\n```\n\n**What it looks like**:\n```yaml",
       "domain_hint": "kubernetes-helm-engineer"
     },
     {
@@ -3283,7 +3283,7 @@
         183,
         193
       ],
-      "block_text": "# If image.tag is missing: renders as \"myapp:<no value>\" \u2014 deploys broken pod\n```\n\n**Why wrong**: Missing values render as `<no value>` or empty string. The chart deploys without error, but the pod fails at runtime with a confusing image pull error.\n\n**Fix**:\n```yaml\nimage: {{ .Values.image.repository }}:{{ required \"image.tag is required\" .Values.image.tag }}\n```\n\n---\n",
+      "block_text": "# If image.tag is missing: renders as \"myapp:<no value>\" — deploys broken pod\n```\n\n**Why wrong**: Missing values render as `<no value>` or empty string. The chart deploys without error, but the pod fails at runtime with a confusing image pull error.\n\n**Fix**:\n```yaml\nimage: {{ .Values.image.repository }}:{{ required \"image.tag is required\" .Values.image.tag }}\n```\n\n---\n",
       "domain_hint": "kubernetes-helm-engineer"
     },
     {
@@ -3301,7 +3301,7 @@
         221,
         234
       ],
-      "block_text": "### \u274c No Chart Tests\n\n**Detection**:\n```bash\nls charts/*/templates/tests/ 2>/dev/null || echo \"No test directory found\"\nfind charts/ -name \"*test*\" -path \"*/templates/*\"\n```\n\n**What it looks like**: A chart with no `templates/tests/` directory and no `helm.sh/hook: test` annotated pods.\n\n**Why wrong**: `helm install` can succeed with pods in Pending/Unready state. Without tests, there's no way to verify the chart actually works.\n\n**Fix**:\n```yaml",
+      "block_text": "### ❌ No Chart Tests\n\n**Detection**:\n```bash\nls charts/*/templates/tests/ 2>/dev/null || echo \"No test directory found\"\nfind charts/ -name \"*test*\" -path \"*/templates/*\"\n```\n\n**What it looks like**: A chart with no `templates/tests/` directory and no `helm.sh/hook: test` annotated pods.\n\n**Why wrong**: `helm install` can succeed with pods in Pending/Unready state. Without tests, there's no way to verify the chart actually works.\n\n**Fix**:\n```yaml",
       "domain_hint": "kubernetes-helm-engineer"
     },
     {
@@ -3328,7 +3328,7 @@
         135,
         144
       ],
-      "block_text": "# Check in manifests/helm values\ngrep -rn ':latest' --include=\"*.yaml\" --include=\"*.yml\" .\nrg ':latest' --type yaml\n```\n\n**Why wrong**: `:latest` is pulled differently based on `imagePullPolicy`. `Always` causes unnecessary registry calls; `IfNotPresent` means different nodes run different versions silently. Rollbacks are impossible \u2014 you can't pin `:latest` to a previous image.\n\n**Fix**: Use immutable tags: `image: myapp:v1.2.3` or `image: myapp:$(git rev-parse --short HEAD)`.\n\n---\n",
+      "block_text": "# Check in manifests/helm values\ngrep -rn ':latest' --include=\"*.yaml\" --include=\"*.yml\" .\nrg ':latest' --type yaml\n```\n\n**Why wrong**: `:latest` is pulled differently based on `imagePullPolicy`. `Always` causes unnecessary registry calls; `IfNotPresent` means different nodes run different versions silently. Rollbacks are impossible — you can't pin `:latest` to a previous image.\n\n**Fix**: Use immutable tags: `image: myapp:v1.2.3` or `image: myapp:$(git rev-parse --short HEAD)`.\n\n---\n",
       "domain_hint": "kubernetes-helm-engineer"
     },
     {
@@ -3361,17 +3361,17 @@
     {
       "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
       "line_range": [
-        6,
-        12
+        5,
+        11
       ],
-      "block_text": "# MCP Server Anti-Patterns\n\n> **Scope**: Anti-patterns specific to MCP documentation servers in TypeScript/Node.js. Covers front matter parsing failures, indexing bugs, and protocol misuse.\n> **Version range**: `@modelcontextprotocol/sdk` 0.5.0+, Node.js 18+\n> **Generated**: 2026-04-08 \u2014 verify against current MCP spec\n\n---\n",
+      "block_text": "# MCP Server Anti-Patterns\n\n> **Scope**: Anti-patterns specific to MCP documentation servers in TypeScript/Node.js. Covers front matter parsing failures, indexing bugs, and protocol misuse.\n> **Version range**: `@modelcontextprotocol/sdk` 0.5.0+, Node.js 18+\n> **Generated**: 2026-04-08 — verify against current MCP spec\n\n---\n",
       "domain_hint": "MCP Server Anti"
     },
     {
       "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
       "line_range": [
-        20,
-        20
+        19,
+        19
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "MCP Server Anti"
@@ -3379,17 +3379,17 @@
     {
       "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
       "line_range": [
-        28,
-        70
+        27,
+        69
       ],
-      "block_text": "# Check if they're wrapped in try/catch\ngrep -B5 'yaml\\.parse\\|yaml\\.load' --include=\"*.ts\" -rn src/\n```\n\n**What it looks like**:\n```typescript\nfunction parseFrontMatter(content: string): DocMetadata {\n  const parts = content.split('---');\n  // Crashes if YAML is malformed \u2014 kills entire server\n  const metadata = yaml.parse(parts[1]);\n  return metadata as DocMetadata;\n}\n```\n\n**Why wrong**: A single documentation file with a tab in YAML (invalid) or an unclosed quote crashes `yaml.parse()` and pr...",
+      "block_text": "# Check if they're wrapped in try/catch\ngrep -B5 'yaml\\.parse\\|yaml\\.load' --include=\"*.ts\" -rn src/\n```\n\n**What it looks like**:\n```typescript\nfunction parseFrontMatter(content: string): DocMetadata {\n  const parts = content.split('---');\n  // Crashes if YAML is malformed — kills entire server\n  const metadata = yaml.parse(parts[1]);\n  return metadata as DocMetadata;\n}\n```\n\n**Why wrong**: A single documentation file with a tab in YAML (invalid) or an unclosed quote crashes `yaml.parse()` and pr...",
       "domain_hint": "MCP Server Anti"
     },
     {
       "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
       "line_range": [
-        78,
-        108
+        77,
+        107
       ],
       "block_text": "# Check if server strips them\ngrep -rn 'shortcode\\|{{%\\|{{<' --include=\"*.ts\" src/\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ReadResourceRequestSchema, async (request) => {\n  const doc = this.docsIndex.get(request.params.uri);\n  // Returns raw markdown with Hugo shortcodes intact\n  return { contents: [{ uri: doc.uri, mimeType: 'text/markdown', text: doc.content }] };\n});\n```\n\n**Why wrong**: Hugo shortcodes like `{{< youtube abc123 >}}` or `{{% notice warning %}}` are no...",
       "domain_hint": "MCP Server Anti"
@@ -3397,35 +3397,35 @@
     {
       "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
       "line_range": [
-        115,
-        146
+        114,
+        145
       ],
-      "block_text": "# Must include capabilities matching registered handlers\n```\n\n**What it looks like**:\n```typescript\nthis.server = new Server(\n  { name: 'local-docs', version: '1.0.0' },\n  { capabilities: {} }  // Empty \u2014 client won't discover tools or resources\n);\n```\n\n**Why wrong**: MCP clients negotiate capabilities during the `initialize` handshake. If `capabilities.resources` is absent, clients skip the `resources/list` call entirely and never discover documents. If `capabilities.tools` is absent, the `sear...",
+      "block_text": "# Must include capabilities matching registered handlers\n```\n\n**What it looks like**:\n```typescript\nthis.server = new Server(\n  { name: 'local-docs', version: '1.0.0' },\n  { capabilities: {} }  // Empty — client won't discover tools or resources\n);\n```\n\n**Why wrong**: MCP clients negotiate capabilities during the `initialize` handshake. If `capabilities.resources` is absent, clients skip the `resources/list` call entirely and never discover documents. If `capabilities.tools` is absent, the `sear...",
       "domain_hint": "MCP Server Anti"
     },
     {
       "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
       "line_range": [
-        152,
-        185
+        151,
+        184
       ],
-      "block_text": "# Find URI-to-path conversion without traversal check\ngrep -rn 'uriToPath\\|path\\.join.*params\\.uri\\|path\\.resolve.*params' --include=\"*.ts\" src/\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ReadResourceRequestSchema, async (request) => {\n  // URI: docs://../../../etc/passwd \u2014 traverses out of docs root!\n  const filePath = path.join(this.docsRoot, request.params.uri.slice('docs://'.length));\n  const content = await fs.promises.readFile(filePath, 'utf-8');\n  return { content...",
+      "block_text": "# Find URI-to-path conversion without traversal check\ngrep -rn 'uriToPath\\|path\\.join.*params\\.uri\\|path\\.resolve.*params' --include=\"*.ts\" src/\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ReadResourceRequestSchema, async (request) => {\n  // URI: docs://../../../etc/passwd — traverses out of docs root!\n  const filePath = path.join(this.docsRoot, request.params.uri.slice('docs://'.length));\n  const content = await fs.promises.readFile(filePath, 'utf-8');\n  return { content...",
       "domain_hint": "MCP Server Anti"
     },
     {
       "file": "agents/mcp-local-docs-engineer/references/mcp-anti-patterns.md",
       "line_range": [
-        193,
-        222
+        192,
+        221
       ],
-      "block_text": "# Check Hugo content for draft: true documents\ngrep -rn '^draft: true\\|^draft: \"true\"' --include=\"*.md\" content/\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ListResourcesRequestSchema, async () => {\n  const resources = Array.from(this.docsIndex.values()).map((doc) => ({\n    uri: doc.uri,\n    name: doc.metadata.title ?? 'Untitled',\n  }));\n  return { resources }; // Includes draft: true documents\n});\n```\n\n**Why wrong**: Hugo draft documents are unpublished content \u2014 WIP, in...",
+      "block_text": "# Check Hugo content for draft: true documents\ngrep -rn '^draft: true\\|^draft: \"true\"' --include=\"*.md\" content/\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ListResourcesRequestSchema, async () => {\n  const resources = Array.from(this.docsIndex.values()).map((doc) => ({\n    uri: doc.uri,\n    name: doc.metadata.title ?? 'Untitled',\n  }));\n  return { resources }; // Includes draft: true documents\n});\n```\n\n**Why wrong**: Hugo draft documents are unpublished content — WIP, in...",
       "domain_hint": "MCP Server Anti"
     },
     {
       "file": "agents/mcp-local-docs-engineer/references/mcp-patterns.md",
       "line_range": [
-        135,
-        135
+        134,
+        134
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "MCP Server Development Patterns"
@@ -3433,26 +3433,26 @@
     {
       "file": "agents/mcp-local-docs-engineer/references/mcp-patterns.md",
       "line_range": [
-        137,
-        165
+        136,
+        164
       ],
-      "block_text": "### \u274c Synchronous File I/O in Request Handlers\n\n**Detection**:\n```bash\ngrep -rn 'readFileSync\\|existsSync\\|readdirSync' --include=\"*.ts\" src/\nrg 'Sync\\(' --type ts src/\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ReadResourceRequestSchema, (request) => {\n  // NOT async \u2014 blocks the entire Node.js event loop\n  const content = fs.readFileSync(uriToPath(request.params.uri), 'utf-8');\n  return { contents: [{ uri: request.params.uri, text: content }] };\n});\n```\n\n**Why wrong**:...",
+      "block_text": "### ❌ Synchronous File I/O in Request Handlers\n\n**Detection**:\n```bash\ngrep -rn 'readFileSync\\|existsSync\\|readdirSync' --include=\"*.ts\" src/\nrg 'Sync\\(' --type ts src/\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ReadResourceRequestSchema, (request) => {\n  // NOT async — blocks the entire Node.js event loop\n  const content = fs.readFileSync(uriToPath(request.params.uri), 'utf-8');\n  return { contents: [{ uri: request.params.uri, text: content }] };\n});\n```\n\n**Why wrong**:...",
       "domain_hint": "MCP Server Development Patterns"
     },
     {
       "file": "agents/mcp-local-docs-engineer/references/mcp-patterns.md",
       "line_range": [
-        172,
-        207
+        171,
+        206
       ],
-      "block_text": "# Flag if found inside a setRequestHandler callback\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ListResourcesRequestSchema, async () => {\n  // Re-parses all markdown files on every list call \u2014 seconds of delay\n  const docs = await this.indexDocs();\n  return { resources: docs.map((d) => ({ uri: d.uri, name: d.metadata.title })) };\n});\n```\n\n**Why wrong**: Claude calls `resources/list` repeatedly during a session. Re-parsing 1000 files takes 3-10 seconds each time. The LLM c...",
+      "block_text": "# Flag if found inside a setRequestHandler callback\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ListResourcesRequestSchema, async () => {\n  // Re-parses all markdown files on every list call — seconds of delay\n  const docs = await this.indexDocs();\n  return { resources: docs.map((d) => ({ uri: d.uri, name: d.metadata.title })) };\n});\n```\n\n**Why wrong**: Claude calls `resources/list` repeatedly during a session. Re-parsing 1000 files takes 3-10 seconds each time. The LLM c...",
       "domain_hint": "MCP Server Development Patterns"
     },
     {
       "file": "agents/mcp-local-docs-engineer/references/mcp-patterns.md",
       "line_range": [
-        214,
-        244
+        213,
+        243
       ],
       "block_text": "# Should be McpError for protocol failures\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(ReadResourceRequestSchema, async (request) => {\n  const doc = this.docsIndex.get(request.params.uri);\n  if (!doc) {\n    throw new Error(`Not found: ${request.params.uri}`); // Generic JS error\n  }\n  return { contents: [{ uri: doc.uri, text: doc.content }] };\n});\n```\n\n**Why wrong**: Generic `Error` objects get wrapped in an internal error JSON-RPC response with code `-32603`. MCP clients...",
       "domain_hint": "MCP Server Development Patterns"
@@ -3460,8 +3460,8 @@
     {
       "file": "agents/mcp-local-docs-engineer/references/typescript-async-patterns.md",
       "line_range": [
-        146,
-        146
+        145,
+        145
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "TypeScript Async Patterns for MCP Servers"
@@ -3469,17 +3469,17 @@
     {
       "file": "agents/mcp-local-docs-engineer/references/typescript-async-patterns.md",
       "line_range": [
-        152,
-        177
+        151,
+        176
       ],
-      "block_text": "# Find Promise.all with .map() on potentially large arrays\ngrep -rn 'Promise\\.all.*\\.map' --include=\"*.ts\" src/\nrg 'Promise\\.all\\(' --type ts src/ -A2 | grep '\\.map'\n```\n\n**What it looks like**:\n```typescript\n// Reads ALL files simultaneously \u2014 EMFILE on large repos\nconst docs = await Promise.all(\n  allFiles.map((f) => fs.promises.readFile(f, 'utf-8'))\n);\n```\n\n**Why wrong**: `EMFILE: too many open files` at runtime. Default ulimit is 1024 file descriptors on Linux. A repo with 2000 markdown file...",
+      "block_text": "# Find Promise.all with .map() on potentially large arrays\ngrep -rn 'Promise\\.all.*\\.map' --include=\"*.ts\" src/\nrg 'Promise\\.all\\(' --type ts src/ -A2 | grep '\\.map'\n```\n\n**What it looks like**:\n```typescript\n// Reads ALL files simultaneously — EMFILE on large repos\nconst docs = await Promise.all(\n  allFiles.map((f) => fs.promises.readFile(f, 'utf-8'))\n);\n```\n\n**Why wrong**: `EMFILE: too many open files` at runtime. Default ulimit is 1024 file descriptors on Linux. A repo with 2000 markdown file...",
       "domain_hint": "TypeScript Async Patterns for MCP Servers"
     },
     {
       "file": "agents/mcp-local-docs-engineer/references/typescript-async-patterns.md",
       "line_range": [
-        184,
-        209
+        183,
+        208
       ],
       "block_text": "# More specifically: promises not awaited inside handlers\nrg 'setRequestHandler.*\\{' --type ts src/ -A5 | grep '^\\s*[a-zA-Z].*\\(\\)' | grep -v 'await'\n```\n\n**What it looks like**:\n```typescript\nserver.setRequestHandler(CallToolRequestSchema, (request) => {\n  // Not async, not returning promise properly\n  this.searchIndex(request.params.arguments?.query).then((results) => {\n    return { content: [{ type: 'text', text: JSON.stringify(results) }] };\n  });\n  // Returns undefined! Handler completes be...",
       "domain_hint": "TypeScript Async Patterns for MCP Servers"
@@ -3487,10 +3487,10 @@
     {
       "file": "agents/mcp-local-docs-engineer/references/typescript-async-patterns.md",
       "line_range": [
-        211,
-        251
+        210,
+        250
       ],
-      "block_text": "### \u274c Swallowing Errors in indexDocs\n\n**Detection**:\n```bash\ngrep -rn 'catch.*{}' --include=\"*.ts\" src/\ngrep -rn 'catch.*return\\s*$\\|catch.*return;\\s*$' --include=\"*.ts\" src/\n```\n\n**What it looks like**:\n```typescript\nasync indexDocs(): Promise<void> {\n  const files = await glob('**/*.md', { cwd: this.docsPath });\n  await Promise.all(files.map(async (f) => {\n    try {\n      await this.parseAndCache(f);\n    } catch {\n      // Silently swallow \u2014 no log, no counter\n    }\n  }));\n}\n```\n\n**Why wrong**...",
+      "block_text": "### ❌ Swallowing Errors in indexDocs\n\n**Detection**:\n```bash\ngrep -rn 'catch.*{}' --include=\"*.ts\" src/\ngrep -rn 'catch.*return\\s*$\\|catch.*return;\\s*$' --include=\"*.ts\" src/\n```\n\n**What it looks like**:\n```typescript\nasync indexDocs(): Promise<void> {\n  const files = await glob('**/*.md', { cwd: this.docsPath });\n  await Promise.all(files.map(async (f) => {\n    try {\n      await this.parseAndCache(f);\n    } catch {\n      // Silently swallow — no log, no counter\n    }\n  }));\n}\n```\n\n**Why wrong**...",
       "domain_hint": "TypeScript Async Patterns for MCP Servers"
     },
     {
@@ -3499,14 +3499,14 @@
         1,
         4
       ],
-      "block_text": "# Anti-Patterns Reference\n<!-- Loaded by nextjs-ecommerce-engineer when reviewing e-commerce code for security, correctness, or reliability issues -->\n\nThese are the e-commerce mistakes that cause real damage \u2014 lost revenue, security incidents, overselling, and data corruption. Each one has a canonical fix.\n",
+      "block_text": "# Anti-Patterns Reference\n<!-- Loaded by nextjs-ecommerce-engineer when reviewing e-commerce code for security, correctness, or reliability issues -->\n\nThese are the e-commerce mistakes that cause real damage — lost revenue, security incidents, overselling, and data corruption. Each one has a canonical fix.\n",
       "domain_hint": "nextjs-ecommerce-engineer"
     },
     {
       "file": "agents/nodejs-api-engineer/references/auth-patterns.md",
       "line_range": [
-        149,
-        149
+        148,
+        148
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "Authentication Patterns for Node.js APIs"
@@ -3514,17 +3514,17 @@
     {
       "file": "agents/nodejs-api-engineer/references/auth-patterns.md",
       "line_range": [
-        180,
-        220
+        179,
+        219
       ],
-      "block_text": "# Look for early returns before bcrypt.compare\ngrep -rn 'findUser\\|findByEmail' --include=\"*.ts\" src/ -A10 | grep -v 'compare\\|bcrypt'\n```\n\n**What it looks like**:\n```typescript\nasync function login(email: string, password: string) {\n  const user = await db.users.findByEmail(email);\n  if (!user) {\n    return { error: 'User not found' }; // Responds fast \u2014 user doesn't exist\n  }\n  const valid = await bcrypt.compare(password, user.passwordHash); // Responds slow\n  if (!valid) {\n    return { error:...",
+      "block_text": "# Look for early returns before bcrypt.compare\ngrep -rn 'findUser\\|findByEmail' --include=\"*.ts\" src/ -A10 | grep -v 'compare\\|bcrypt'\n```\n\n**What it looks like**:\n```typescript\nasync function login(email: string, password: string) {\n  const user = await db.users.findByEmail(email);\n  if (!user) {\n    return { error: 'User not found' }; // Responds fast — user doesn't exist\n  }\n  const valid = await bcrypt.compare(password, user.passwordHash); // Responds slow\n  if (!valid) {\n    return { error:...",
       "domain_hint": "Authentication Patterns for Node.js APIs"
     },
     {
       "file": "agents/nodejs-api-engineer/references/auth-patterns.md",
       "line_range": [
-        227,
-        244
+        226,
+        243
       ],
       "block_text": "# Flag anything longer than 1 hour\ngrep -rn \"expiresIn.*['\\\"].*[0-9][dw]\\|expiresIn.*3600[0-9]\" --include=\"*.ts\" src/\n```\n\n**What it looks like**:\n```typescript\nconst token = jwt.sign(\n  { sub: userId },\n  process.env.JWT_SECRET!,\n  { expiresIn: '7d' } // 7-day access token\n);\n```\n\n**Why wrong**: A 7-day access token means a stolen token gives 7 days of unauthorized access. With no server-side revocation on logout, all active sessions for a user remain valid even after a password change.\n\n**Fix*...",
       "domain_hint": "Authentication Patterns for Node.js APIs"
@@ -3532,17 +3532,17 @@
     {
       "file": "agents/nodejs-api-engineer/references/auth-patterns.md",
       "line_range": [
-        246,
-        266
+        245,
+        265
       ],
-      "block_text": "### \u274c Storing Refresh Tokens in localStorage\n\n**Detection**: This is a frontend anti-pattern but confirm with client team.\n```bash\ngrep -rn 'localStorage.*refresh\\|localStorage.*token' --include=\"*.ts\" --include=\"*.tsx\" src/\n```\n\n**Why wrong**: `localStorage` is accessible to any JavaScript running on the page, including XSS-injected scripts. Refresh tokens in localStorage are stolen by any XSS vulnerability.\n\n**Fix**: `httpOnly` cookies for refresh tokens \u2014 inaccessible to JavaScript:\n```typesc...",
+      "block_text": "### ❌ Storing Refresh Tokens in localStorage\n\n**Detection**: This is a frontend anti-pattern but confirm with client team.\n```bash\ngrep -rn 'localStorage.*refresh\\|localStorage.*token' --include=\"*.ts\" --include=\"*.tsx\" src/\n```\n\n**Why wrong**: `localStorage` is accessible to any JavaScript running on the page, including XSS-injected scripts. Refresh tokens in localStorage are stolen by any XSS vulnerability.\n\n**Fix**: `httpOnly` cookies for refresh tokens — inaccessible to JavaScript:\n```typesc...",
       "domain_hint": "Authentication Patterns for Node.js APIs"
     },
     {
       "file": "agents/nodejs-api-engineer/references/middleware-patterns.md",
       "line_range": [
-        223,
-        223
+        222,
+        222
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "Express/Next.js Middleware Patterns"
@@ -3550,26 +3550,26 @@
     {
       "file": "agents/nodejs-api-engineer/references/middleware-patterns.md",
       "line_range": [
-        230,
-        247
+        229,
+        246
       ],
-      "block_text": "# Find error handlers with only 3 params\ngrep -rn 'function.*err.*req.*res\\b' --include=\"*.ts\" src/\nrg '\\(err,\\s*req,\\s*res\\)' --type ts src/\n```\n\n**What it looks like**:\n```typescript\n// 3 args \u2014 Express treats this as REGULAR middleware, not error middleware\napp.use((err: Error, req: Request, res: Response) => {\n  res.status(500).json({ error: err.message });\n});\n```\n\n**Why wrong**: Express identifies error-handling middleware by arity (argument count). A 3-argument function is a regular middl...",
+      "block_text": "# Find error handlers with only 3 params\ngrep -rn 'function.*err.*req.*res\\b' --include=\"*.ts\" src/\nrg '\\(err,\\s*req,\\s*res\\)' --type ts src/\n```\n\n**What it looks like**:\n```typescript\n// 3 args — Express treats this as REGULAR middleware, not error middleware\napp.use((err: Error, req: Request, res: Response) => {\n  res.status(500).json({ error: err.message });\n});\n```\n\n**Why wrong**: Express identifies error-handling middleware by arity (argument count). A 3-argument function is a regular middl...",
       "domain_hint": "Express/Next.js Middleware Patterns"
     },
     {
       "file": "agents/nodejs-api-engineer/references/middleware-patterns.md",
       "line_range": [
-        249,
-        266
+        248,
+        265
       ],
-      "block_text": "### \u274c Wildcard CORS Origin\n\n**Detection**:\n```bash\ngrep -rn \"origin.*'\\*'\\|origin.*\\\"\\\\*\\\"\" --include=\"*.ts\" src/\nrg \"cors\\(\\{.*origin.*\\*\" --type ts src/\n```\n\n**What it looks like**:\n```typescript\napp.use(cors({ origin: '*', credentials: true }));\n```\n\n**Why wrong**: `origin: '*'` with `credentials: true` is rejected by browsers (CORS spec prohibits it), but `origin: '*'` without credentials still allows any malicious site to read API responses. Attack: attacker hosts `evil.com`, victim visits ...",
+      "block_text": "### ❌ Wildcard CORS Origin\n\n**Detection**:\n```bash\ngrep -rn \"origin.*'\\*'\\|origin.*\\\"\\\\*\\\"\" --include=\"*.ts\" src/\nrg \"cors\\(\\{.*origin.*\\*\" --type ts src/\n```\n\n**What it looks like**:\n```typescript\napp.use(cors({ origin: '*', credentials: true }));\n```\n\n**Why wrong**: `origin: '*'` with `credentials: true` is rejected by browsers (CORS spec prohibits it), but `origin: '*'` without credentials still allows any malicious site to read API responses. Attack: attacker hosts `evil.com`, victim visits ...",
       "domain_hint": "Express/Next.js Middleware Patterns"
     },
     {
       "file": "agents/nodejs-api-engineer/references/middleware-patterns.md",
       "line_range": [
-        272,
-        293
+        271,
+        292
       ],
       "block_text": "# Find validation that comes after DB calls or side effects\ngrep -rn 'parse\\|safeParse\\|validate' --include=\"*.ts\" src/ -B10 | grep -E 'await.*db|await.*createUser|sendEmail'\n```\n\n**What it looks like**:\n```typescript\napp.post('/users', async (req, res) => {\n  // Creates user BEFORE validating input\n  const user = await db.users.create({ data: req.body });\n  const validated = UserSchema.safeParse(req.body);\n  if (!validated.success) {\n    res.status(422).json({ error: 'Invalid' });\n  }\n  res.jso...",
       "domain_hint": "Express/Next.js Middleware Patterns"
@@ -3577,8 +3577,8 @@
     {
       "file": "agents/nodejs-api-engineer/references/webhook-patterns.md",
       "line_range": [
-        163,
-        163
+        162,
+        162
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "Webhook Patterns for Node.js APIs"
@@ -3586,8 +3586,8 @@
     {
       "file": "agents/nodejs-api-engineer/references/webhook-patterns.md",
       "line_range": [
-        170,
-        189
+        169,
+        188
       ],
       "block_text": "# Check if webhook routes are registered after app.use(express.json())\ngrep -rn 'app\\.post.*webhook' --include=\"*.ts\" src/ -B20 | grep 'express\\.json'\n```\n\n**What it looks like**:\n```typescript\napp.use(express.json()); // Parses ALL bodies first\n\napp.post('/webhooks/stripe', (req, res) => {\n  // req.body is now a JS object, not the original bytes\n  const sig = req.headers['stripe-signature'];\n  stripe.webhooks.constructEvent(req.body, sig, secret); // Always fails!\n});\n```\n\n**Why wrong**: `expre...",
       "domain_hint": "Webhook Patterns for Node.js APIs"
@@ -3595,26 +3595,26 @@
     {
       "file": "agents/nodejs-api-engineer/references/webhook-patterns.md",
       "line_range": [
-        195,
-        219
+        194,
+        218
       ],
-      "block_text": "# Look for awaited DB calls or email sends inside webhook handlers\ngrep -rn 'app\\.post.*webhook' --include=\"*.ts\" src/ -A30 | grep -E 'await.*db|await.*email|await.*stripe|sendMail'\n```\n\n**What it looks like**:\n```typescript\napp.post('/webhooks/stripe', async (req, res) => {\n  const event = JSON.parse(req.body.toString());\n\n  if (event.type === 'payment_intent.succeeded') {\n    // Doing heavy work before responding \u2014 may exceed 30s timeout\n    await db.orders.update({ where: { paymentId: event.d...",
+      "block_text": "# Look for awaited DB calls or email sends inside webhook handlers\ngrep -rn 'app\\.post.*webhook' --include=\"*.ts\" src/ -A30 | grep -E 'await.*db|await.*email|await.*stripe|sendMail'\n```\n\n**What it looks like**:\n```typescript\napp.post('/webhooks/stripe', async (req, res) => {\n  const event = JSON.parse(req.body.toString());\n\n  if (event.type === 'payment_intent.succeeded') {\n    // Doing heavy work before responding — may exceed 30s timeout\n    await db.orders.update({ where: { paymentId: event.d...",
       "domain_hint": "Webhook Patterns for Node.js APIs"
     },
     {
       "file": "agents/nodejs-api-engineer/references/webhook-patterns.md",
       "line_range": [
-        226,
-        250
+        225,
+        249
       ],
-      "block_text": "# Queue push before res.status(200) \u2014 blocks acknowledgment\ngrep -rn 'queue\\.add' --include=\"*.ts\" src/ -A5 | grep 'res\\.status'\n```\n\n**What it looks like**:\n```typescript\napp.post('/webhooks', async (req, res) => {\n  await webhookQueue.add('event', req.body); // Blocks if Redis is slow\n  res.status(200).json({ received: true }); // Only after queue push\n});\n```\n\n**Why wrong**: If Redis is slow or down, the queue push blocks and may exceed the webhook sender's timeout. The sender retries, causin...",
+      "block_text": "# Queue push before res.status(200) — blocks acknowledgment\ngrep -rn 'queue\\.add' --include=\"*.ts\" src/ -A5 | grep 'res\\.status'\n```\n\n**What it looks like**:\n```typescript\napp.post('/webhooks', async (req, res) => {\n  await webhookQueue.add('event', req.body); // Blocks if Redis is slow\n  res.status(200).json({ received: true }); // Only after queue push\n});\n```\n\n**Why wrong**: If Redis is slow or down, the queue push blocks and may exceed the webhook sender's timeout. The sender retries, causin...",
       "domain_hint": "Webhook Patterns for Node.js APIs"
     },
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
       "line_range": [
-        174,
-        174
+        173,
+        173
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
@@ -3622,8 +3622,8 @@
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
       "line_range": [
-        182,
-        194
+        181,
+        193
       ],
       "block_text": "# Convert bytes to GB and flag if > 31GB\ncurl -s \"$ES_HOST/_nodes/stats/jvm\" | python3 -c \"\nimport json, sys\ndata = json.load(sys.stdin)\nfor nid, n in data['nodes'].items():\n    heap_gb = n['jvm']['mem']['heap_max_in_bytes'] / (1024**3)\n    flag = ' *** ABOVE 31GB ***' if heap_gb > 31 else ''\n    print(f\\\"{n['name']}: {heap_gb:.1f}GB{flag}\\\")\n\"\n```\n\n**What it looks like**:\n```bash",
       "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
@@ -3631,17 +3631,17 @@
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
       "line_range": [
-        195,
-        204
+        194,
+        203
       ],
-      "block_text": "# jvm.options\n-Xms64g\n-Xmx64g  # 64GB \u2014 loses compressed OOPs\n```\n\n**Why wrong**: Above ~31GB, JVM object pointers are 64-bit instead of 32-bit compressed. Memory per object increases significantly. The JVM now needs a larger heap to hold the same amount of data. A 64GB heap may hold less effective data than a properly configured 31GB heap. GC pauses also increase with heap size.\n\n**Fix**: Split heap across two nodes rather than increase past 31GB. Two nodes with 15GB heap each outperform one no...",
+      "block_text": "# jvm.options\n-Xms64g\n-Xmx64g  # 64GB — loses compressed OOPs\n```\n\n**Why wrong**: Above ~31GB, JVM object pointers are 64-bit instead of 32-bit compressed. Memory per object increases significantly. The JVM now needs a larger heap to hold the same amount of data. A 64GB heap may hold less effective data than a properly configured 31GB heap. GC pauses also increase with heap size.\n\n**Fix**: Split heap across two nodes rather than increase past 31GB. Two nodes with 15GB heap each outperform one no...",
       "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
     },
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
       "line_range": [
-        212,
-        216
+        211,
+        215
       ],
       "block_text": "# Anything other than 'all' or null is suspect\n```\n\n**What it looks like**:\n```bash",
       "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
@@ -3649,17 +3649,17 @@
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
       "line_range": [
-        224,
-        235
+        223,
+        234
       ],
-      "block_text": "# Maintenance completes, engineer leaves \u2014 setting persists\n```\n\n**Why wrong**: With `allocation.enable: none`, no new shard assignments occur. Adding a new node does nothing \u2014 no shards migrate to it. A data node failure causes replicas to become unassigned but not recovered. The cluster silently degrades toward red status.\n\n**Fix**: After every maintenance operation, verify allocation is re-enabled:\n```bash\nPUT /_cluster/settings { \"transient\": { \"cluster.routing.allocation.enable\": null } }\nG...",
+      "block_text": "# Maintenance completes, engineer leaves — setting persists\n```\n\n**Why wrong**: With `allocation.enable: none`, no new shard assignments occur. Adding a new node does nothing — no shards migrate to it. A data node failure causes replicas to become unassigned but not recovered. The cluster silently degrades toward red status.\n\n**Fix**: After every maintenance operation, verify allocation is re-enabled:\n```bash\nPUT /_cluster/settings { \"transient\": { \"cluster.routing.allocation.enable\": null } }\nG...",
       "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
     },
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
       "line_range": [
-        245,
-        263
+        244,
+        262
       ],
       "block_text": "# Verify via settings\nGET /_all/_settings?filter_path=*.settings.index.number_of_replicas\n```\n\n**What it looks like**:\n```json\nPUT /logs-2024-01\n{\n  \"settings\": {\n    \"number_of_replicas\": 0\n  }\n}\n```\n\n**Why wrong**: A node failure with 0 replicas causes data loss for all primary shards on that node. Cluster status goes RED. Documents indexed after the last snapshot are permanently lost.\n\n**Fix**: `number_of_replicas: 1` minimum in production. Even for a single-node dev cluster, set to 0 explici...",
       "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
@@ -3667,8 +3667,8 @@
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
       "line_range": [
-        275,
-        279
+        274,
+        278
       ],
       "block_text": "# Target: 20-50GB per shard\n```\n\n**What it looks like**:\n```bash",
       "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
@@ -3676,17 +3676,17 @@
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/cluster-operations.md",
       "line_range": [
-        285,
-        292
+        284,
+        291
       ],
-      "block_text": "# 5 shards of 100MB each \u2014 massive overhead for tiny data\n```\n\n**Why wrong**: Each shard has overhead: file descriptors, JVM memory in the shard metadata, cluster state size. 1000 shards of 1MB each consume as much overhead as 1000 shards of 50GB each \u2014 but the 1MB shards return results 100x slower due to cross-shard coordination cost on empty shards.\n\n**Fix**: `number_of_shards: 1` for indices < 5GB. Use rollover for growing indices rather than pre-allocating many shards.\n\n---\n",
+      "block_text": "# 5 shards of 100MB each — massive overhead for tiny data\n```\n\n**Why wrong**: Each shard has overhead: file descriptors, JVM memory in the shard metadata, cluster state size. 1000 shards of 1MB each consume as much overhead as 1000 shards of 50GB each — but the 1MB shards return results 100x slower due to cross-shard coordination cost on empty shards.\n\n**Fix**: `number_of_shards: 1` for indices < 5GB. Use rollover for growing indices rather than pre-allocating many shards.\n\n---\n",
       "domain_hint": "OpenSearch/Elasticsearch Cluster Operations"
     },
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/index-management.md",
       "line_range": [
-        191,
-        191
+        190,
+        190
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "OpenSearch/Elasticsearch Index Management"
@@ -3694,8 +3694,8 @@
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/index-management.md",
       "line_range": [
-        206,
-        244
+        205,
+        243
       ],
       "block_text": "# Check all indices for field counts\nGET /_cat/indices?v&h=index,docs.count\nGET /your-index/_mapping | jq '.[] | .mappings.properties | keys | length'\n```\n\n**What it looks like**:\n```json\n{\n  \"mappings\": {\n    \"dynamic\": true,\n    \"properties\": {\n      \"event_data\": {\n        \"properties\": {\n          \"user_pref_color\": { \"type\": \"text\" },\n          \"user_pref_font_size\": { \"type\": \"long\" },\n          \"experiment_ab_1234_variant\": { \"type\": \"text\" },\n          \"experiment_ab_5678_variant\": { \"ty...",
       "domain_hint": "OpenSearch/Elasticsearch Index Management"
@@ -3703,17 +3703,17 @@
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/index-management.md",
       "line_range": [
-        252,
-        276
+        251,
+        275
       ],
-      "block_text": "# Check mapping for fields used in term queries\nGET /your-index/_mapping\n```\n\n**What it looks like**:\n```json\n{\n  \"mappings\": {\n    \"properties\": {\n      \"status\": { \"type\": \"text\" }\n    }\n  }\n}\n\n// Query that silently fails:\n{\n  \"query\": { \"term\": { \"status\": \"active\" } }\n}\n```\n\n**Why wrong**: `text` fields are analyzed \u2014 `\"active\"` is tokenized and lowercased. A `term` query for `\"active\"` works, but `\"Active\"` misses. `\"IS_ACTIVE\"` gets tokenized to `[\"is\", \"active\"]` \u2014 `term` query on `\"IS_A...",
+      "block_text": "# Check mapping for fields used in term queries\nGET /your-index/_mapping\n```\n\n**What it looks like**:\n```json\n{\n  \"mappings\": {\n    \"properties\": {\n      \"status\": { \"type\": \"text\" }\n    }\n  }\n}\n\n// Query that silently fails:\n{\n  \"query\": { \"term\": { \"status\": \"active\" } }\n}\n```\n\n**Why wrong**: `text` fields are analyzed — `\"active\"` is tokenized and lowercased. A `term` query for `\"active\"` works, but `\"Active\"` misses. `\"IS_ACTIVE\"` gets tokenized to `[\"is\", \"active\"]` — `term` query on `\"IS_A...",
       "domain_hint": "OpenSearch/Elasticsearch Index Management"
     },
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/index-management.md",
       "line_range": [
-        285,
-        289
+        284,
+        288
       ],
       "block_text": "# Check for type conflicts\n```\n\n**What it looks like**:\n```bash",
       "domain_hint": "OpenSearch/Elasticsearch Index Management"
@@ -3721,8 +3721,8 @@
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/index-management.md",
       "line_range": [
-        296,
-        303
+        295,
+        302
       ],
       "block_text": "# Then discover v2 has \"date\" field mapped as \"text\" in v1\n```\n\n**Why wrong**: If `published_at` is `text` in v1 and `date` in v2, reindex fails on any document where `published_at` doesn't parse as a date. `_reindex` continues by default, silently skipping failed documents. The result is an incomplete index with no clear indication of what was dropped.\n\n**Fix**: Use `\"conflicts\": \"proceed\"` only intentionally, and check task results for failures:\n```bash\nGET _tasks/{taskId}",
       "domain_hint": "OpenSearch/Elasticsearch Index Management"
@@ -3730,8 +3730,8 @@
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/query-optimization.md",
       "line_range": [
-        148,
-        148
+        147,
+        147
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "OpenSearch/Elasticsearch Query Optimization"
@@ -3739,35 +3739,35 @@
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/query-optimization.md",
       "line_range": [
-        156,
-        188
+        155,
+        187
       ],
-      "block_text": "# Also check application code\nrg '\"wildcard\"' --type json queries/\ngrep -rn 'wildcard.*\\*.*value\\|value.*\\*.*wild' --include=\"*.py\" --include=\"*.ts\" --include=\"*.go\" src/\n```\n\n**What it looks like**:\n```json\n{\n  \"query\": {\n    \"wildcard\": {\n      \"username\": {\n        \"value\": \"*smith*\"\n      }\n    }\n  }\n}\n```\n\n**Why wrong**: Leading wildcards (`*smith`) force a full index scan \u2014 every term in the inverted index must be checked. On a 10M document index with 500K unique usernames, this scans 500K...",
+      "block_text": "# Also check application code\nrg '\"wildcard\"' --type json queries/\ngrep -rn 'wildcard.*\\*.*value\\|value.*\\*.*wild' --include=\"*.py\" --include=\"*.ts\" --include=\"*.go\" src/\n```\n\n**What it looks like**:\n```json\n{\n  \"query\": {\n    \"wildcard\": {\n      \"username\": {\n        \"value\": \"*smith*\"\n      }\n    }\n  }\n}\n```\n\n**Why wrong**: Leading wildcards (`*smith`) force a full index scan — every term in the inverted index must be checked. On a 10M document index with 500K unique usernames, this scans 500K...",
       "domain_hint": "OpenSearch/Elasticsearch Query Optimization"
     },
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/query-optimization.md",
       "line_range": [
-        195,
-        221
+        194,
+        220
       ],
-      "block_text": "# Find large from values\nrg '\"from\":\\s*[0-9]{4,}' --type json\n```\n\n**What it looks like**:\n```json\n{\n  \"from\": 10000,\n  \"size\": 20,\n  \"query\": { \"match_all\": {} }\n}\n```\n\n**Why wrong**: `from: 10000` fetches 10,020 documents per shard, discards 10,000, returns 20. On a 5-shard index: 50,100 documents fetched, 50,080 discarded. Memory and CPU scale linearly with `from` value. Default limit is `index.max_result_window: 10000` \u2014 exceeding it throws an exception.\n\n**Fix**: Use search_after for deep p...",
+      "block_text": "# Find large from values\nrg '\"from\":\\s*[0-9]{4,}' --type json\n```\n\n**What it looks like**:\n```json\n{\n  \"from\": 10000,\n  \"size\": 20,\n  \"query\": { \"match_all\": {} }\n}\n```\n\n**Why wrong**: `from: 10000` fetches 10,020 documents per shard, discards 10,000, returns 20. On a 5-shard index: 50,100 documents fetched, 50,080 discarded. Memory and CPU scale linearly with `from` value. Default limit is `index.max_result_window: 10000` — exceeding it throws an exception.\n\n**Fix**: Use search_after for deep p...",
       "domain_hint": "OpenSearch/Elasticsearch Query Optimization"
     },
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/query-optimization.md",
       "line_range": [
-        227,
-        250
+        226,
+        249
       ],
-      "block_text": "# Find terms aggregations without explicit size\ngrep -rn '\"terms\"' --include=\"*.json\" queries/ -A5 | grep -v '\"size\"'\nrg '\"terms\"' --type json queries/ -A5 | grep -B3 '\"field\"' | grep -v size\n```\n\n**What it looks like**:\n```json\n{\n  \"aggs\": {\n    \"all_users\": {\n      \"terms\": {\n        \"field\": \"user_id.keyword\"\n        // No size \u2014 defaults to 10, but 100K users exist\n      }\n    }\n  }\n}\n```\n\n**Why wrong**: Default `size: 10` returns only the top 10 buckets, which is often wrong but doesn't cau...",
+      "block_text": "# Find terms aggregations without explicit size\ngrep -rn '\"terms\"' --include=\"*.json\" queries/ -A5 | grep -v '\"size\"'\nrg '\"terms\"' --type json queries/ -A5 | grep -B3 '\"field\"' | grep -v size\n```\n\n**What it looks like**:\n```json\n{\n  \"aggs\": {\n    \"all_users\": {\n      \"terms\": {\n        \"field\": \"user_id.keyword\"\n        // No size — defaults to 10, but 100K users exist\n      }\n    }\n  }\n}\n```\n\n**Why wrong**: Default `size: 10` returns only the top 10 buckets, which is often wrong but doesn't cau...",
       "domain_hint": "OpenSearch/Elasticsearch Query Optimization"
     },
     {
       "file": "agents/opensearch-elasticsearch-engineer/references/query-optimization.md",
       "line_range": [
-        257,
-        280
+        256,
+        279
       ],
       "block_text": "# Painless scripts in frequently-used queries\ngrep -rn 'script_score\\|script_fields\\|scripted_metric' --include=\"*.json\" queries/\n```\n\n**What it looks like**:\n```json\n{\n  \"query\": {\n    \"script_score\": {\n      \"query\": { \"match_all\": {} },\n      \"script\": {\n        \"source\": \"Math.log(1 + doc['view_count'].value) * params.boost\",\n        \"params\": { \"boost\": 1.5 }\n      }\n    }\n  }\n}\n```\n\n**Why wrong**: Painless scripts run JVM-compiled code per document. On a 1M document index with `match_all`,...",
       "domain_hint": "OpenSearch/Elasticsearch Query Optimization"
@@ -3796,7 +3796,7 @@
         181,
         208
       ],
-      "block_text": "### \u274c Blocking Metric Reporting in the Critical Path\n\n**Detection**:\n```bash\ngrep -rn \"await.*vitals\\|vitals.*await\\|onLCP.*await\" --include=\"*.ts\" --include=\"*.tsx\"\n```\n\n**What it looks like**:\n```typescript\n// In _app.tsx or layout.tsx\nawait setupVitalsMonitoring() // Blocks rendering\n```\n\n**Why wrong**: Metric setup code in the render critical path adds to LCP. Vitals measurement is observational \u2014 it should never affect what it's measuring.\n\n**Fix**:\n```typescript\n// Use useEffect or defer t...",
+      "block_text": "### ❌ Blocking Metric Reporting in the Critical Path\n\n**Detection**:\n```bash\ngrep -rn \"await.*vitals\\|vitals.*await\\|onLCP.*await\" --include=\"*.ts\" --include=\"*.tsx\"\n```\n\n**What it looks like**:\n```typescript\n// In _app.tsx or layout.tsx\nawait setupVitalsMonitoring() // Blocks rendering\n```\n\n**Why wrong**: Metric setup code in the render critical path adds to LCP. Vitals measurement is observational — it should never affect what it's measuring.\n\n**Fix**:\n```typescript\n// Use useEffect or defer t...",
       "domain_hint": "performance-optimization-engineer"
     },
     {
@@ -3814,7 +3814,7 @@
         163,
         196
       ],
-      "block_text": "### \u274c Blocking Layout with Slow Data Fetching\n\n**Detection**:\n```bash\ngrep -rn \"async function.*Layout\\|async.*layout\" --include=\"*.tsx\" --include=\"*.ts\" app/\nrg \"await.*fetch\\|await.*db\\|await.*prisma\" app/layout.tsx app/**/layout.tsx\n```\n\n**What it looks like**:\n```typescript\n// app/layout.tsx\nexport default async function RootLayout({ children }) {\n  const config = await fetchSiteConfig() // Blocks EVERY page render\n  return (\n    <html>\n      <body><Header config={config} />{children}</body>...",
+      "block_text": "### ❌ Blocking Layout with Slow Data Fetching\n\n**Detection**:\n```bash\ngrep -rn \"async function.*Layout\\|async.*layout\" --include=\"*.tsx\" --include=\"*.ts\" app/\nrg \"await.*fetch\\|await.*db\\|await.*prisma\" app/layout.tsx app/**/layout.tsx\n```\n\n**What it looks like**:\n```typescript\n// app/layout.tsx\nexport default async function RootLayout({ children }) {\n  const config = await fetchSiteConfig() // Blocks EVERY page render\n  return (\n    <html>\n      <body><Header config={config} />{children}</body>...",
       "domain_hint": "performance-optimization-engineer"
     },
     {
@@ -3823,7 +3823,7 @@
         198,
         224
       ],
-      "block_text": "### \u274c Using `next/dynamic` When Server Components Are Available\n\n**Detection**:\n```bash\ngrep -rn \"next/dynamic\" --include=\"*.tsx\" --include=\"*.ts\"\nrg \"dynamic\\(\" --type ts --type tsx -A 3 | grep -v \"ssr: false\"\n```\n\n**What it looks like**:\n```typescript\n// Using dynamic() for a component with no browser-only dependencies\nimport dynamic from 'next/dynamic'\nconst ProductCard = dynamic(() => import('./ProductCard'))\n```\n\n**Why wrong**: In App Router, `dynamic()` forces client-side rendering. For co...",
+      "block_text": "### ❌ Using `next/dynamic` When Server Components Are Available\n\n**Detection**:\n```bash\ngrep -rn \"next/dynamic\" --include=\"*.tsx\" --include=\"*.ts\"\nrg \"dynamic\\(\" --type ts --type tsx -A 3 | grep -v \"ssr: false\"\n```\n\n**What it looks like**:\n```typescript\n// Using dynamic() for a component with no browser-only dependencies\nimport dynamic from 'next/dynamic'\nconst ProductCard = dynamic(() => import('./ProductCard'))\n```\n\n**Why wrong**: In App Router, `dynamic()` forces client-side rendering. For co...",
       "domain_hint": "performance-optimization-engineer"
     },
     {
@@ -3832,7 +3832,7 @@
         226,
         253
       ],
-      "block_text": "### \u274c Missing `priority` on Above-Fold Images\n\n**Detection**:\n```bash\ngrep -rn \"next/image\" --include=\"*.tsx\" -A 5 | grep -B 3 -v \"priority\"\nrg '<Image' --type tsx -A 4 | grep -v \"priority\"\n```\n\n**What it looks like**:\n```tsx\n// Hero image \u2014 the LCP element \u2014 without priority\n<Image src=\"/hero.jpg\" width={1200} height={600} alt=\"Hero\" />\n```\n\n**Why wrong**: `next/image` lazy-loads by default using Intersection Observer. The hero image is immediately visible and is the LCP element \u2014 lazy loading ...",
+      "block_text": "### ❌ Missing `priority` on Above-Fold Images\n\n**Detection**:\n```bash\ngrep -rn \"next/image\" --include=\"*.tsx\" -A 5 | grep -B 3 -v \"priority\"\nrg '<Image' --type tsx -A 4 | grep -v \"priority\"\n```\n\n**What it looks like**:\n```tsx\n// Hero image — the LCP element — without priority\n<Image src=\"/hero.jpg\" width={1200} height={600} alt=\"Hero\" />\n```\n\n**Why wrong**: `next/image` lazy-loads by default using Intersection Observer. The hero image is immediately visible and is the LCP element — lazy loading ...",
       "domain_hint": "performance-optimization-engineer"
     },
     {
@@ -3850,7 +3850,7 @@
         147,
         173
       ],
-      "block_text": "# If no output: numberOfRuns is not configured (defaults to 1)\n```\n\n**What it looks like**:\n```javascript\n// .lighthouserc.js\nmodule.exports = {\n  ci: {\n    collect: {\n      url: ['http://localhost:3000'],\n      // numberOfRuns missing \u2014 defaults to 1\n    },\n  },\n}\n```\n\n**Why wrong**: A single Lighthouse run has 10-15 point score variance on CI machines (shared CPU, GC pauses, network jitter). A score of 85 one run, 72 the next \u2014 both from the same code. Single-run CI gates either false-positive...",
+      "block_text": "# If no output: numberOfRuns is not configured (defaults to 1)\n```\n\n**What it looks like**:\n```javascript\n// .lighthouserc.js\nmodule.exports = {\n  ci: {\n    collect: {\n      url: ['http://localhost:3000'],\n      // numberOfRuns missing — defaults to 1\n    },\n  },\n}\n```\n\n**Why wrong**: A single Lighthouse run has 10-15 point score variance on CI machines (shared CPU, GC pauses, network jitter). A score of 85 one run, 72 the next — both from the same code. Single-run CI gates either false-positive...",
       "domain_hint": "performance-optimization-engineer"
     },
     {
@@ -3859,7 +3859,7 @@
         180,
         201
       ],
-      "block_text": "# Check if it uses 'warn' instead of 'error' for core metrics\n```\n\n**What it looks like**:\n```javascript\nassertions: {\n  'largest-contentful-paint': ['warn', { maxNumericValue: 2500 }],\n  // 'warn' doesn't fail CI \u2014 regressions ship silently\n},\n```\n\n**Why wrong**: `warn` level assertions appear in logs but do NOT fail the CI step. LCP regressions will accumulate indefinitely. The only way a performance budget prevents regressions is if it fails the build.\n\n**Fix**:\n```javascript\nassertions: {\n  ...",
+      "block_text": "# Check if it uses 'warn' instead of 'error' for core metrics\n```\n\n**What it looks like**:\n```javascript\nassertions: {\n  'largest-contentful-paint': ['warn', { maxNumericValue: 2500 }],\n  // 'warn' doesn't fail CI — regressions ship silently\n},\n```\n\n**Why wrong**: `warn` level assertions appear in logs but do NOT fail the CI step. LCP regressions will accumulate indefinitely. The only way a performance budget prevents regressions is if it fails the build.\n\n**Fix**:\n```javascript\nassertions: {\n  ...",
       "domain_hint": "performance-optimization-engineer"
     },
     {
@@ -3868,7 +3868,7 @@
         203,
         227
       ],
-      "block_text": "### \u274c Running Lighthouse Against Development Server\n\n**Detection**:\n```bash\ngrep -rn \"next dev\\|npm run dev\\|yarn dev\" .lighthouserc.* .github/workflows/*.yml\n```\n\n**What it looks like**:\n```javascript\ncollect: {\n  startServerCommand: 'npm run dev', // Development server!\n},\n```\n\n**Why wrong**: `next dev` doesn't minify, doesn't split bundles, doesn't optimize images. A dev server Lighthouse score is meaningless for production performance \u2014 typically 20-40 points lower than production. You're te...",
+      "block_text": "### ❌ Running Lighthouse Against Development Server\n\n**Detection**:\n```bash\ngrep -rn \"next dev\\|npm run dev\\|yarn dev\" .lighthouserc.* .github/workflows/*.yml\n```\n\n**What it looks like**:\n```javascript\ncollect: {\n  startServerCommand: 'npm run dev', // Development server!\n},\n```\n\n**Why wrong**: `next dev` doesn't minify, doesn't split bundles, doesn't optimize images. A dev server Lighthouse score is meaningless for production performance — typically 20-40 points lower than production. You're te...",
       "domain_hint": "performance-optimization-engineer"
     },
     {
@@ -3877,7 +3877,7 @@
         236,
         243
       ],
-      "block_text": "# If neither exists: no automated bundle regression detection\n```\n\n**Why wrong**: Without automated bundle size gates, bundle size grows incrementally. Each PR adds \"just a small dependency\" until the main bundle is 500KB and LCP is 4.5s. Manual review doesn't catch this \u2014 bundle analysis is only done when performance is already bad.\n\n**Fix**: Add `size-limit` with `error` thresholds to CI. Start with current bundle size as the baseline and set limits 10% above it to allow headroom, then tighten...",
+      "block_text": "# If neither exists: no automated bundle regression detection\n```\n\n**Why wrong**: Without automated bundle size gates, bundle size grows incrementally. Each PR adds \"just a small dependency\" until the main bundle is 500KB and LCP is 4.5s. Manual review doesn't catch this — bundle analysis is only done when performance is already bad.\n\n**Fix**: Add `size-limit` with `error` thresholds to CI. Start with current bundle size as the baseline and set limits 10% above it to allow headroom, then tighten...",
       "domain_hint": "performance-optimization-engineer"
     },
     {
@@ -3886,7 +3886,7 @@
         1,
         7
       ],
-      "block_text": "# Pipeline Orchestration \u2014 Anti-Patterns\n\n> **Scope**: Common mistakes when creating, scaffolding, and routing toolkit pipelines. Does NOT cover general Go/Python anti-patterns \u2014 see those agents for language-specific issues.\n> **Version range**: claude-code-toolkit all versions\n> **Generated**: 2026-04-09 \u2014 verify detection commands against current repo structure\n\n---\n",
+      "block_text": "# Pipeline Orchestration — Anti-Patterns\n\n> **Scope**: Common mistakes when creating, scaffolding, and routing toolkit pipelines. Does NOT cover general Go/Python anti-patterns — see those agents for language-specific issues.\n> **Version range**: claude-code-toolkit all versions\n> **Generated**: 2026-04-09 — verify detection commands against current repo structure\n\n---\n",
       "domain_hint": "pipeline-orchestrator-engineer"
     },
     {
@@ -3913,7 +3913,7 @@
         57,
         66
       ],
-      "block_text": "# If count is low relative to agent count, discovery was likely skipped\nls agents/*.md | wc -l\n```\n\n**What it looks like**: Creating `monitoring-engineer.md` when `prometheus-grafana-engineer.md` already exists with 80% coverage.\n\n**Why wrong**: Creates a duplicate routing entry. Two agents with overlapping triggers produce non-deterministic routing \u2014 `/do` will route to whichever appears first in the routing table. Users get inconsistent behavior. The duplicate is harder to merge later than to ...",
+      "block_text": "# If count is low relative to agent count, discovery was likely skipped\nls agents/*.md | wc -l\n```\n\n**What it looks like**: Creating `monitoring-engineer.md` when `prometheus-grafana-engineer.md` already exists with 80% coverage.\n\n**Why wrong**: Creates a duplicate routing entry. Two agents with overlapping triggers produce non-deterministic routing — `/do` will route to whichever appears first in the routing table. Users get inconsistent behavior. The duplicate is harder to merge later than to ...",
       "domain_hint": "pipeline-orchestrator-engineer"
     },
     {
@@ -3931,7 +3931,7 @@
         110,
         126
       ],
-      "block_text": "# Zero hits = validation was likely skipped\n```\n\n**What it looks like**: Composing a chain intuitively \u2014 `research \u2192 draft \u2192 review \u2192 publish` \u2014 without checking that each step's output type matches the next step's expected input type.\n\n**Why wrong**: Type incompatibilities surface at runtime, not during scaffolding. A `research` step produces a `ResearchReport` artifact; a `review` step expects `DraftContent`. Connecting them directly produces a type mismatch that silently produces empty or mal...",
+      "block_text": "# Zero hits = validation was likely skipped\n```\n\n**What it looks like**: Composing a chain intuitively — `research → draft → review → publish` — without checking that each step's output type matches the next step's expected input type.\n\n**Why wrong**: Type incompatibilities surface at runtime, not during scaffolding. A `research` step produces a `ResearchReport` artifact; a `review` step expects `DraftContent`. Connecting them directly produces a type mismatch that silently produces empty or mal...",
       "domain_hint": "pipeline-orchestrator-engineer"
     },
     {
@@ -3940,7 +3940,7 @@
         132,
         144
       ],
-      "block_text": "# Agents in agents/ that have no entry in skills/do/references/routing-tables.md\ncomm -23 \\\n  <(ls agents/*.md | xargs -I{} basename {} .md | sort) \\\n  <(grep -o '`[a-z-]*-engineer\\|[a-z-]*-agent`' skills/do/references/routing-tables.md | tr -d '`' | sort)\n```\n\n**What it looks like**: \"I'll add the routing entry in a follow-up PR.\"\n\n**Why wrong**: An unrouted pipeline is invisible. No trigger phrase reaches it. It exists as a file but is dead code \u2014 users get no error, just wrong routing to an u...",
+      "block_text": "# Agents in agents/ that have no entry in skills/do/references/routing-tables.md\ncomm -23 \\\n  <(ls agents/*.md | xargs -I{} basename {} .md | sort) \\\n  <(grep -o '`[a-z-]*-engineer\\|[a-z-]*-agent`' skills/do/references/routing-tables.md | tr -d '`' | sort)\n```\n\n**What it looks like**: \"I'll add the routing entry in a follow-up PR.\"\n\n**Why wrong**: An unrouted pipeline is invisible. No trigger phrase reaches it. It exists as a file but is dead code — users get no error, just wrong routing to an u...",
       "domain_hint": "pipeline-orchestrator-engineer"
     },
     {
@@ -3949,7 +3949,7 @@
         152,
         185
       ],
-      "block_text": "# OR manually:\ngrep -rL 'allowed-tools' agents/*.md\n```\n\n**What it looks like**:\n```yaml\n---\nname: my-new-agent\nmodel: sonnet\ndescription: \"...\"\n---\n```\n\n**Why wrong**: Agents without `allowed-tools` get the full tool set regardless of their role. A read-only reviewer agent that can Edit/Write/Bash can silently modify files during review \u2014 a violation of the reviewer role. ADR-063 mandates tool restriction by role type.\n\n**Fix**: Match tools to role:\n```yaml\nallowed-tools:  # for reviewers / res...",
+      "block_text": "# OR manually:\ngrep -rL 'allowed-tools' agents/*.md\n```\n\n**What it looks like**:\n```yaml\n---\nname: my-new-agent\nmodel: sonnet\ndescription: \"...\"\n---\n```\n\n**Why wrong**: Agents without `allowed-tools` get the full tool set regardless of their role. A read-only reviewer agent that can Edit/Write/Bash can silently modify files during review — a violation of the reviewer role. ADR-063 mandates tool restriction by role type.\n\n**Fix**: Match tools to role:\n```yaml\nallowed-tools:  # for reviewers / res...",
       "domain_hint": "pipeline-orchestrator-engineer"
     },
     {
@@ -3976,7 +3976,7 @@
         171,
         185
       ],
-      "block_text": "# (ADR files are gitignored \u2014 check local disk)\nls adr/pipeline-*.md 2>/dev/null | wc -l\n```\n\n**What it looks like**: Starting Phase 1 research without creating `adr/pipeline-{name}.md` first.\n\n**Why wrong**: Without an ADR, context drifts across phases. Phase 3 sub-agents don't know the Phase 2 decisions. The component manifest from Phase 1 gets lost between phases. In sessions longer than 30 minutes, orchestrators re-derive decisions already made in earlier phases \u2014 wasting context and sometim...",
+      "block_text": "# (ADR files are gitignored — check local disk)\nls adr/pipeline-*.md 2>/dev/null | wc -l\n```\n\n**What it looks like**: Starting Phase 1 research without creating `adr/pipeline-{name}.md` first.\n\n**Why wrong**: Without an ADR, context drifts across phases. Phase 3 sub-agents don't know the Phase 2 decisions. The component manifest from Phase 1 gets lost between phases. In sessions longer than 30 minutes, orchestrators re-derive decisions already made in earlier phases — wasting context and sometim...",
       "domain_hint": "pipeline-orchestrator-engineer"
     },
     {
@@ -3991,8 +3991,8 @@
     {
       "file": "agents/pixijs-combat-renderer/references/combat-visual-effects.md",
       "line_range": [
-        358,
-        358
+        357,
+        357
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "PixiJS Combat Visual Effects"
@@ -4000,10 +4000,10 @@
     {
       "file": "agents/pixijs-combat-renderer/references/combat-visual-effects.md",
       "line_range": [
-        360,
-        385
+        359,
+        384
       ],
-      "block_text": "### \u274c Creating New PIXI.Texture Per Frame\n\n**Detection**:\n```bash\ngrep -rn \"new PIXI\\.Texture\\|Texture\\.from\\|RenderTexture\\.create\" --include=\"*.ts\" --include=\"*.js\"\nrg \"useTick|Ticker\\.shared\" --type ts -A 20 | grep \"Texture\"\n```\n\n**What it looks like**:\n```typescript\napp.ticker.add(() => {\n  const texture = Texture.from('spark_' + Math.floor(Math.random() * 4)); // BAD\n  const sprite = new Sprite(texture);\n  stage.addChild(sprite);\n});\n```\n\n**Why wrong**: Each frame adds a sprite with unclean...",
+      "block_text": "### ❌ Creating New PIXI.Texture Per Frame\n\n**Detection**:\n```bash\ngrep -rn \"new PIXI\\.Texture\\|Texture\\.from\\|RenderTexture\\.create\" --include=\"*.ts\" --include=\"*.js\"\nrg \"useTick|Ticker\\.shared\" --type ts -A 20 | grep \"Texture\"\n```\n\n**What it looks like**:\n```typescript\napp.ticker.add(() => {\n  const texture = Texture.from('spark_' + Math.floor(Math.random() * 4)); // BAD\n  const sprite = new Sprite(texture);\n  stage.addChild(sprite);\n});\n```\n\n**Why wrong**: Each frame adds a sprite with unclean...",
       "domain_hint": "PixiJS Combat Visual Effects"
     },
     {
@@ -4027,8 +4027,8 @@
     {
       "file": "agents/pixijs-combat-renderer/references/pixi-performance.md",
       "line_range": [
-        271,
-        271
+        270,
+        270
       ],
       "block_text": "## Anti-Pattern Catalog\n",
       "domain_hint": "PixiJS Rendering Performance"
@@ -4036,19 +4036,19 @@
     {
       "file": "agents/pixijs-combat-renderer/references/pixi-performance.md",
       "line_range": [
-        273,
-        307
+        272,
+        306
       ],
-      "block_text": "### \u274c Changing Tint Per Frame on Many Sprites\n\n**Detection**:\n```bash\ngrep -rn \"\\.tint\\s*=\" --include=\"*.ts\" --include=\"*.js\"\nrg \"ticker\\.add|useTick\" --type ts -A 20 | grep \"\\.tint\"\n```\n\n**What it looks like**:\n```typescript\napp.ticker.add(() => {\n  // BAD: tint change per frame flushes the batch for each sprite\n  sprites.forEach((sprite, i) => {\n    sprite.tint = hslToHex(i / sprites.length, 1, 0.5 + Math.sin(Date.now() * 0.001 + i) * 0.2);\n  });\n});\n```\n\n**Why wrong**: Setting `.tint` marks t...",
+      "block_text": "### ❌ Changing Tint Per Frame on Many Sprites\n\n**Detection**:\n```bash\ngrep -rn \"\\.tint\\s*=\" --include=\"*.ts\" --include=\"*.js\"\nrg \"ticker\\.add|useTick\" --type ts -A 20 | grep \"\\.tint\"\n```\n\n**What it looks like**:\n```typescript\napp.ticker.add(() => {\n  // BAD: tint change per frame flushes the batch for each sprite\n  sprites.forEach((sprite, i) => {\n    sprite.tint = hslToHex(i / sprites.length, 1, 0.5 + Math.sin(Date.now() * 0.001 + i) * 0.2);\n  });\n});\n```\n\n**Why wrong**: Setting `.tint` marks t...",
       "domain_hint": "PixiJS Rendering Performance"
     },
     {
       "file": "agents/pixijs-combat-renderer/references/pixi-performance.md",
       "line_range": [
-        339,
-        365
+        338,
+        364
       ],
-      "block_text": "### \u274c Loading Individual Textures per Sprite (No Atlas)\n\n**Detection**:\n```bash\ngrep -rn \"Texture\\.from\\|Assets\\.load.*\\.png\" --include=\"*.ts\" --include=\"*.js\"\nrg \"\\.load\\(['\\\"].*\\.png['\\\"]\" --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: each unique PNG = separate GPU texture = separate draw call\nconst playerTexture = await Assets.load('/sprites/player.png');\nconst enemyTexture  = await Assets.load('/sprites/enemy.png');\nconst sparkTexture  = await Assets.load('/sprites/spark.png')...",
+      "block_text": "### ❌ Loading Individual Textures per Sprite (No Atlas)\n\n**Detection**:\n```bash\ngrep -rn \"Texture\\.from\\|Assets\\.load.*\\.png\" --include=\"*.ts\" --include=\"*.js\"\nrg \"\\.load\\(['\\\"].*\\.png['\\\"]\" --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: each unique PNG = separate GPU texture = separate draw call\nconst playerTexture = await Assets.load('/sprites/player.png');\nconst enemyTexture  = await Assets.load('/sprites/enemy.png');\nconst sparkTexture  = await Assets.load('/sprites/spark.png')...",
       "domain_hint": "PixiJS Rendering Performance"
     },
     {
@@ -4075,7 +4075,7 @@
         58,
         68
       ],
-      "block_text": "# Find DOM particle anti-pattern\ngrep -rn \"document.createElement\\|setTimeout.*remove\\|classList.add.*particle\" src/ --include=\"*.ts\" --include=\"*.tsx\"\n```\n\nFlag the DOM particle anti-pattern immediately if found \u2014 `document.createElement` + `setTimeout` removal is the primary replacement target. Each DOM particle adds reflow cost; GPU particles are free by comparison.\n\nIdentify what Zustand stores drive combat state. Read the store file before writing any PixiJS component \u2014 display object updat...",
+      "block_text": "# Find DOM particle anti-pattern\ngrep -rn \"document.createElement\\|setTimeout.*remove\\|classList.add.*particle\" src/ --include=\"*.ts\" --include=\"*.tsx\"\n```\n\nFlag the DOM particle anti-pattern immediately if found — `document.createElement` + `setTimeout` removal is the primary replacement target. Each DOM particle adds reflow cost; GPU particles are free by comparison.\n\nIdentify what Zustand stores drive combat state. Read the store file before writing any PixiJS component — display object updat...",
       "domain_hint": "pixijs"
     },
     {
@@ -4093,7 +4093,7 @@
         118,
         145
       ],
-      "block_text": "### \u274c Single-Window Burn Rate Alert\n\n**Detection**:\n```bash\ngrep -rn 'burn_rate\\|burnrate\\|error_rate.*ratio' --include=\"*.yml\" -A 5 | grep -v 'and'\nrg 'alert.*[Bb]urn' --type yaml -A 8 | grep -v 'and\\s*$'\n```\n\n**What it looks like**:\n```yaml\n- alert: SLOBurnRate\n  expr: job:error_rate:ratio5m > 0.01\n  # Single window \u2014 misses slow burns over hours\n```\n\n**Why wrong**: A single 5-minute window catches fast burns (many errors quickly) but misses slow burns (few errors sustained over hours) that al...",
+      "block_text": "### ❌ Single-Window Burn Rate Alert\n\n**Detection**:\n```bash\ngrep -rn 'burn_rate\\|burnrate\\|error_rate.*ratio' --include=\"*.yml\" -A 5 | grep -v 'and'\nrg 'alert.*[Bb]urn' --type yaml -A 8 | grep -v 'and\\s*$'\n```\n\n**What it looks like**:\n```yaml\n- alert: SLOBurnRate\n  expr: job:error_rate:ratio5m > 0.01\n  # Single window — misses slow burns over hours\n```\n\n**Why wrong**: A single 5-minute window catches fast burns (many errors quickly) but misses slow burns (few errors sustained over hours) that al...",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4111,7 +4111,7 @@
         160,
         166
       ],
-      "block_text": "# A YAML syntax error silences ALL alerts\n```\n\n**Why wrong**: A single YAML syntax error in `alertmanager.yml` causes Alertmanager to reject the config and continue using the previous valid config \u2014 or fail to start. No error surfaces in the UI until alerts fail to route. Silent alert failures are worse than loud ones.\n\n**Fix**:\n```bash",
+      "block_text": "# A YAML syntax error silences ALL alerts\n```\n\n**Why wrong**: A single YAML syntax error in `alertmanager.yml` causes Alertmanager to reject the config and continue using the previous valid config — or fail to start. No error surfaces in the UI until alerts fail to route. Silent alert failures are worse than loud ones.\n\n**Fix**:\n```bash",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4120,7 +4120,7 @@
         180,
         210
       ],
-      "block_text": "### \u274c Missing Runbook Annotations\n\n**Detection**:\n```bash\ngrep -rn '^\\s*- alert:' --include=\"*.yml\" -A 15 | grep -B 10 'severity: critical' | grep -v 'runbook'\nrg 'alert:' --type yaml -A 12 | grep -B8 'severity: critical' | grep -v runbook_url\n```\n\n**What it looks like**:\n```yaml\n- alert: DatabaseConnectionPoolExhausted\n  expr: pg_stat_activity_count > 90\n  labels:\n    severity: critical\n  annotations:\n    summary: \"DB connections exhausted\"\n    # No runbook_url \u2014 on-call must guess remediation ...",
+      "block_text": "### ❌ Missing Runbook Annotations\n\n**Detection**:\n```bash\ngrep -rn '^\\s*- alert:' --include=\"*.yml\" -A 15 | grep -B 10 'severity: critical' | grep -v 'runbook'\nrg 'alert:' --type yaml -A 12 | grep -B8 'severity: critical' | grep -v runbook_url\n```\n\n**What it looks like**:\n```yaml\n- alert: DatabaseConnectionPoolExhausted\n  expr: pg_stat_activity_count > 90\n  labels:\n    severity: critical\n  annotations:\n    summary: \"DB connections exhausted\"\n    # No runbook_url — on-call must guess remediation ...",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4156,7 +4156,7 @@
         75,
         102
       ],
-      "block_text": "# Check actual cardinality of suspect metrics in PromQL\ncount by (user_id) (http_requests_total)  # should return 0 results if correctly designed\n```\n\n**What it looks like**:\n```go\n// Go example \u2014 unbounded label\nhttpRequests.With(prometheus.Labels{\n    \"user_id\": userID,      // WRONG: unbounded\n    \"endpoint\": endpoint,\n    \"status\":  strconv.Itoa(statusCode),\n}).Inc()\n```\n\n**Why wrong**: 100K users \u00d7 50 endpoints \u00d7 5 status codes = 25M series. Prometheus memory usage becomes `25M \u00d7 4KB = 100G...",
+      "block_text": "# Check actual cardinality of suspect metrics in PromQL\ncount by (user_id) (http_requests_total)  # should return 0 results if correctly designed\n```\n\n**What it looks like**:\n```go\n// Go example — unbounded label\nhttpRequests.With(prometheus.Labels{\n    \"user_id\": userID,      // WRONG: unbounded\n    \"endpoint\": endpoint,\n    \"status\":  strconv.Itoa(statusCode),\n}).Inc()\n```\n\n**Why wrong**: 100K users × 50 endpoints × 5 status codes = 25M series. Prometheus memory usage becomes `25M × 4KB = 100G...",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4174,7 +4174,7 @@
         119,
         150
       ],
-      "block_text": "# prometheus.yml \u2014 no relabeling\nscrape_configs:\n  - job_name: 'kubernetes-pods'\n    kubernetes_sd_configs:\n      - role: pod\n    # No relabel_configs \u2014 ingests all labels from pod annotations\n```\n\n**Why wrong**: Kubernetes pods can expose dozens of labels (app, version, helm-release, git-commit, build-time, namespace). Without `relabel_configs`, all of these become Prometheus label dimensions. A git commit hash label creates unique series per deployment, exploding cardinality.\n\n**Fix**:\n```yaml...",
+      "block_text": "# prometheus.yml — no relabeling\nscrape_configs:\n  - job_name: 'kubernetes-pods'\n    kubernetes_sd_configs:\n      - role: pod\n    # No relabel_configs — ingests all labels from pod annotations\n```\n\n**Why wrong**: Kubernetes pods can expose dozens of labels (app, version, helm-release, git-commit, build-time, namespace). Without `relabel_configs`, all of these become Prometheus label dimensions. A git commit hash label creates unique series per deployment, exploding cardinality.\n\n**Fix**:\n```yaml...",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4183,7 +4183,7 @@
         156,
         171
       ],
-      "block_text": "# Find recording rules that preserve high-cardinality labels\ngrep -A 5 'record:' prometheus-rules.yml | grep 'by (' | grep -i 'user\\|request_id\\|pod_name'\nrg 'record:' --type yaml -A 5 | grep 'by\\s*\\(' | grep -v 'service\\|job\\|namespace\\|status'\n```\n\n**What it looks like**:\n```yaml\n- record: job:http_requests:rate5m\n  expr: sum(rate(http_requests_total[5m])) by (job, user_id)\n  # Aggregates but still fans out by user_id \u2014 doesn't help\n```\n\n**Why wrong**: Recording rules are meant to reduce query...",
+      "block_text": "# Find recording rules that preserve high-cardinality labels\ngrep -A 5 'record:' prometheus-rules.yml | grep 'by (' | grep -i 'user\\|request_id\\|pod_name'\nrg 'record:' --type yaml -A 5 | grep 'by\\s*\\(' | grep -v 'service\\|job\\|namespace\\|status'\n```\n\n**What it looks like**:\n```yaml\n- record: job:http_requests:rate5m\n  expr: sum(rate(http_requests_total[5m])) by (job, user_id)\n  # Aggregates but still fans out by user_id — doesn't help\n```\n\n**Why wrong**: Recording rules are meant to reduce query...",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4192,7 +4192,7 @@
         185,
         211
       ],
-      "block_text": "# If no results: no proactive cardinality monitoring\n```\n\n**What it looks like**: No alert for growing series count \u2014 OOM is the first signal.\n\n**Why wrong**: Cardinality growth is gradual. A new deployment adds 50K series per day unnoticed until Prometheus hits memory limits under query load 2 weeks later. By then, the causing deployment is long merged and difficult to identify.\n\n**Fix**:\n```yaml\n- alert: PrometheusHighCardinality\n  expr: prometheus_tsdb_head_series > 1500000\n  for: 10m\n  label...",
+      "block_text": "# If no results: no proactive cardinality monitoring\n```\n\n**What it looks like**: No alert for growing series count — OOM is the first signal.\n\n**Why wrong**: Cardinality growth is gradual. A new deployment adds 50K series per day unnoticed until Prometheus hits memory limits under query load 2 weeks later. By then, the causing deployment is long merged and difficult to identify.\n\n**Fix**:\n```yaml\n- alert: PrometheusHighCardinality\n  expr: prometheus_tsdb_head_series > 1500000\n  for: 10m\n  label...",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4210,7 +4210,7 @@
         95,
         104
       ],
-      "block_text": "### \u274c Using irate() in Alert Rules\n\n**Detection**:\n```bash\ngrep -rn 'irate(' --include=\"*.yml\" --include=\"*.yaml\"\nrg 'irate\\(' --type yaml\n```\n\n**What it looks like**:\n```yaml",
+      "block_text": "### ❌ Using irate() in Alert Rules\n\n**Detection**:\n```bash\ngrep -rn 'irate(' --include=\"*.yml\" --include=\"*.yaml\"\nrg 'irate\\(' --type yaml\n```\n\n**What it looks like**:\n```yaml",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4228,7 +4228,7 @@
         121,
         147
       ],
-      "block_text": "### \u274c Missing `for:` Clause on Latency Alerts\n\n**Detection**:\n```bash\ngrep -B5 'latency\\|duration\\|p99\\|p95\\|quantile' --include=\"*.yml\" --include=\"*.yaml\" -rn | grep -v 'for:'\nrg 'alert:.*[Ll]atency' --type yaml -A 10 | grep -v 'for:'\n```\n\n**What it looks like**:\n```yaml\n- alert: HighLatency\n  expr: histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m])) > 0.5\n  # No for: clause!\n```\n\n**Why wrong**: Without `for:`, a single evaluation above the threshold fires the alert immedia...",
+      "block_text": "### ❌ Missing `for:` Clause on Latency Alerts\n\n**Detection**:\n```bash\ngrep -B5 'latency\\|duration\\|p99\\|p95\\|quantile' --include=\"*.yml\" --include=\"*.yaml\" -rn | grep -v 'for:'\nrg 'alert:.*[Ll]atency' --type yaml -A 10 | grep -v 'for:'\n```\n\n**What it looks like**:\n```yaml\n- alert: HighLatency\n  expr: histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m])) > 0.5\n  # No for: clause!\n```\n\n**Why wrong**: Without `for:`, a single evaluation above the threshold fires the alert immedia...",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4237,7 +4237,7 @@
         149,
         158
       ],
-      "block_text": "### \u274c Querying Summaries with histogram_quantile()\n\n**Detection**:\n```bash\ngrep -rn 'histogram_quantile.*_summary\\|histogram_quantile.*quantile=' --include=\"*.yml\"\nrg 'histogram_quantile' --type yaml -A 3 | grep 'quantile='\n```\n\n**What it looks like**:\n```promql",
+      "block_text": "### ❌ Querying Summaries with histogram_quantile()\n\n**Detection**:\n```bash\ngrep -rn 'histogram_quantile.*_summary\\|histogram_quantile.*quantile=' --include=\"*.yml\"\nrg 'histogram_quantile' --type yaml -A 3 | grep 'quantile='\n```\n\n**What it looks like**:\n```promql",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4246,7 +4246,7 @@
         159,
         166
       ],
-      "block_text": "# Wrong \u2014 using histogram_quantile on a summary type metric\nhistogram_quantile(0.99, rate(rpc_duration_seconds{quantile=\"0.99\"}[5m]))\n```\n\n**Why wrong**: Summary metrics expose pre-computed quantiles (via the `quantile` label) that cannot be re-aggregated. Passing them to `histogram_quantile()` produces nonsense \u2014 the function expects `le` bucket labels, not pre-computed quantile values. The query may not error but will silently return wrong numbers.\n\n**Fix**: Use the pre-computed quantile label...",
+      "block_text": "# Wrong — using histogram_quantile on a summary type metric\nhistogram_quantile(0.99, rate(rpc_duration_seconds{quantile=\"0.99\"}[5m]))\n```\n\n**Why wrong**: Summary metrics expose pre-computed quantiles (via the `quantile` label) that cannot be re-aggregated. Passing them to `histogram_quantile()` produces nonsense — the function expects `le` bucket labels, not pre-computed quantile values. The query may not error but will silently return wrong numbers.\n\n**Fix**: Use the pre-computed quantile label...",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4255,7 +4255,7 @@
         175,
         183
       ],
-      "block_text": "### \u274c Using `increase()` Across Different Windows for Comparison\n\n**Detection**:\n```bash\ngrep -rn 'increase(' --include=\"*.yml\" --include=\"*.yaml\" | grep -v 'record:'\n```\n\n**What it looks like**:\n```promql",
+      "block_text": "### ❌ Using `increase()` Across Different Windows for Comparison\n\n**Detection**:\n```bash\ngrep -rn 'increase(' --include=\"*.yml\" --include=\"*.yaml\" | grep -v 'record:'\n```\n\n**What it looks like**:\n```promql",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4264,7 +4264,7 @@
         184,
         191
       ],
-      "block_text": "# Wrong \u2014 comparing increase over different windows\nincrease(http_requests_total[1h]) > increase(http_requests_total[24h]) * 0.1\n```\n\n**Why wrong**: `increase()` results are not comparable across different window sizes without normalization. This expression always evaluates false since 1h increase is always < 24h \u00d7 0.1 for any reasonable traffic. Use `rate()` for comparisons.\n\n**Fix**:\n```promql",
+      "block_text": "# Wrong — comparing increase over different windows\nincrease(http_requests_total[1h]) > increase(http_requests_total[24h]) * 0.1\n```\n\n**Why wrong**: `increase()` results are not comparable across different window sizes without normalization. This expression always evaluates false since 1h increase is always < 24h × 0.1 for any reasonable traffic. Use `rate()` for comparisons.\n\n**Fix**:\n```promql",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4273,7 +4273,7 @@
         198,
         223
       ],
-      "block_text": "### \u274c Absent Alert Without Sufficient For Clause\n\n**Detection**:\n```bash\ngrep -rn 'absent(' --include=\"*.yml\" --include=\"*.yaml\" -A 5 | grep -v 'for:\\s*[5-9][0-9]\\|for:\\s*[1-9][0-9][0-9]'\n```\n\n**What it looks like**:\n```yaml\n- alert: MetricMissing\n  expr: absent(up{job=\"api\"})\n  for: 1m  # too short \u2014 scrape gaps cause false positives\n```\n\n**Why wrong**: Scrape targets can have momentary gaps during pod restarts, rolling deployments, or network blips. A 1-minute `for:` fires during normal K8s po...",
+      "block_text": "### ❌ Absent Alert Without Sufficient For Clause\n\n**Detection**:\n```bash\ngrep -rn 'absent(' --include=\"*.yml\" --include=\"*.yaml\" -A 5 | grep -v 'for:\\s*[5-9][0-9]\\|for:\\s*[1-9][0-9][0-9]'\n```\n\n**What it looks like**:\n```yaml\n- alert: MetricMissing\n  expr: absent(up{job=\"api\"})\n  for: 1m  # too short — scrape gaps cause false positives\n```\n\n**Why wrong**: Scrape targets can have momentary gaps during pod restarts, rolling deployments, or network blips. A 1-minute `for:` fires during normal K8s po...",
       "domain_hint": "prometheus-grafana-engineer"
     },
     {
@@ -4291,7 +4291,7 @@
         5,
         9
       ],
-      "block_text": "## \u274c Anti-Pattern: Over-Engineering with Abstract Base Classes\n\n**What it looks like**:\n```python\nfrom abc import ABC, abstractmethod\n",
+      "block_text": "## ❌ Anti-Pattern: Over-Engineering with Abstract Base Classes\n\n**What it looks like**:\n```python\nfrom abc import ABC, abstractmethod\n",
       "domain_hint": "python-general-engineer"
     },
     {
@@ -4300,7 +4300,7 @@
         61,
         64
       ],
-      "block_text": "## \u274c Anti-Pattern: Premature Async Conversion\n\n**What it looks like**:\n```python",
+      "block_text": "## ❌ Anti-Pattern: Premature Async Conversion\n\n**What it looks like**:\n```python",
       "domain_hint": "python-general-engineer"
     },
     {
@@ -4309,7 +4309,7 @@
         170,
         176
       ],
-      "block_text": "## \u274c Anti-Pattern: Mutable Default Arguments\n\n**What it looks like**:\n```python\ndef add_item(item: str, items: list[str] = []) -> list[str]:\n    items.append(item)\n    return items\n",
+      "block_text": "## ❌ Anti-Pattern: Mutable Default Arguments\n\n**What it looks like**:\n```python\ndef add_item(item: str, items: list[str] = []) -> list[str]:\n    items.append(item)\n    return items\n",
       "domain_hint": "python-general-engineer"
     },
     {
@@ -4318,7 +4318,7 @@
         376,
         384
       ],
-      "block_text": "## \u274c Anti-Pattern: Not Using Context Managers\n\n**What it looks like**:\n```python\ndef process_file(path: str):\n    f = open(path)\n    data = f.read()\n    # Forgot to close! Resource leak\n    return process(data)\n",
+      "block_text": "## ❌ Anti-Pattern: Not Using Context Managers\n\n**What it looks like**:\n```python\ndef process_file(path: str):\n    f = open(path)\n    data = f.read()\n    # Forgot to close! Resource leak\n    return process(data)\n",
       "domain_hint": "python-general-engineer"
     },
     {
@@ -4327,7 +4327,7 @@
         448,
         452
       ],
-      "block_text": "## \u274c Anti-Pattern: Importing * (Star Imports)\n\n**What it looks like**:\n```python\nfrom module import *\n",
+      "block_text": "## ❌ Anti-Pattern: Importing * (Star Imports)\n\n**What it looks like**:\n```python\nfrom module import *\n",
       "domain_hint": "python-general-engineer"
     },
     {
@@ -4345,7 +4345,7 @@
         108,
         136
       ],
-      "block_text": "### \u274c H201: Bare `except:` Clause\n\n**Detection**:\n```bash\ngrep -rn 'except:' --include=\"*.py\"\nrg 'except:\\s*$' --type py\n```\n\n**What it looks like**:\n```python\ntry:\n    result = db.get_resource(context, resource_id)\nexcept:   # H201 \u2014 catches SystemExit, KeyboardInterrupt, GeneratorExit\n    LOG.warning('Resource not found')\n    return None\n```\n\n**Why wrong**: Catches `SystemExit` and `KeyboardInterrupt`, preventing clean service shutdown. `tox -e pep8` hard blocks this.\n\n**Fix**:\n```python\ntry:\n...",
+      "block_text": "### ❌ H201: Bare `except:` Clause\n\n**Detection**:\n```bash\ngrep -rn 'except:' --include=\"*.py\"\nrg 'except:\\s*$' --type py\n```\n\n**What it looks like**:\n```python\ntry:\n    result = db.get_resource(context, resource_id)\nexcept:   # H201 — catches SystemExit, KeyboardInterrupt, GeneratorExit\n    LOG.warning('Resource not found')\n    return None\n```\n\n**Why wrong**: Catches `SystemExit` and `KeyboardInterrupt`, preventing clean service shutdown. `tox -e pep8` hard blocks this.\n\n**Fix**:\n```python\ntry:\n...",
       "domain_hint": "python-openstack-engineer"
     },
     {
@@ -4354,7 +4354,7 @@
         138,
         160
       ],
-      "block_text": "### \u274c H303: Wildcard Imports\n\n**Detection**:\n```bash\ngrep -rn 'from .* import \\*' --include=\"*.py\"\nrg 'from \\S+ import \\*' --type py\n```\n\n**What it looks like**:\n```python\nfrom oslo_config.cfg import *\nfrom myservice.common import *\n```\n\n**Why wrong**: Pollutes namespace, breaks introspection, makes `tox -e pep8` fail, and hides dependency chain from code review tools like Zuul.\n\n**Fix**: Import only what you use explicitly.\n\n```python\nfrom oslo_config.cfg import CONF, StrOpt, IntOpt\n```\n\n---\n",
+      "block_text": "### ❌ H303: Wildcard Imports\n\n**Detection**:\n```bash\ngrep -rn 'from .* import \\*' --include=\"*.py\"\nrg 'from \\S+ import \\*' --type py\n```\n\n**What it looks like**:\n```python\nfrom oslo_config.cfg import *\nfrom myservice.common import *\n```\n\n**Why wrong**: Pollutes namespace, breaks introspection, makes `tox -e pep8` fail, and hides dependency chain from code review tools like Zuul.\n\n**Fix**: Import only what you use explicitly.\n\n```python\nfrom oslo_config.cfg import CONF, StrOpt, IntOpt\n```\n\n---\n",
       "domain_hint": "python-openstack-engineer"
     },
     {
@@ -4363,7 +4363,7 @@
         162,
         184
       ],
-      "block_text": "### \u274c H304: Relative Imports\n\n**Detection**:\n```bash\ngrep -rn 'from \\.' --include=\"*.py\" | grep -v \"test\\|#\"\nrg 'from \\.' --type py\n```\n\n**What it looks like**:\n```python\nfrom .utils import format_id\nfrom ..exception import ResourceNotFound\n```\n\n**Why wrong**: OpenStack enforces absolute imports throughout. Relative imports break `oslo-config-generator`, tox environments, and Zuul dependency resolution.\n\n**Fix**:\n```python\nfrom myservice.common.utils import format_id\nfrom myservice import except...",
+      "block_text": "### ❌ H304: Relative Imports\n\n**Detection**:\n```bash\ngrep -rn 'from \\.' --include=\"*.py\" | grep -v \"test\\|#\"\nrg 'from \\.' --type py\n```\n\n**What it looks like**:\n```python\nfrom .utils import format_id\nfrom ..exception import ResourceNotFound\n```\n\n**Why wrong**: OpenStack enforces absolute imports throughout. Relative imports break `oslo-config-generator`, tox environments, and Zuul dependency resolution.\n\n**Fix**:\n```python\nfrom myservice.common.utils import format_id\nfrom myservice import except...",
       "domain_hint": "python-openstack-engineer"
     },
     {
@@ -4372,7 +4372,7 @@
         186,
         209
       ],
-      "block_text": "### \u274c H501: % Formatting with locals()/self.__dict__\n\n**Detection**:\n```bash\ngrep -rn 'locals()\\|self\\.__dict__' --include=\"*.py\" | grep '%'\nrg '% (locals|self\\.__dict__)' --type py\n```\n\n**What it looks like**:\n```python\nmsg = 'Creating %(resource_type)s for user %(user_id)s' % locals()\nLOG.debug('State: %(state)s timeout: %(timeout)s' % self.__dict__)\n```\n\n**Why wrong**: `locals()` captures entire local scope including sensitive values (passwords, tokens). Implicit coupling makes refactoring si...",
+      "block_text": "### ❌ H501: % Formatting with locals()/self.__dict__\n\n**Detection**:\n```bash\ngrep -rn 'locals()\\|self\\.__dict__' --include=\"*.py\" | grep '%'\nrg '% (locals|self\\.__dict__)' --type py\n```\n\n**What it looks like**:\n```python\nmsg = 'Creating %(resource_type)s for user %(user_id)s' % locals()\nLOG.debug('State: %(state)s timeout: %(timeout)s' % self.__dict__)\n```\n\n**Why wrong**: `locals()` captures entire local scope including sensitive values (passwords, tokens). Implicit coupling makes refactoring si...",
       "domain_hint": "python-openstack-engineer"
     },
     {
@@ -4390,7 +4390,7 @@
         160,
         184
       ],
-      "block_text": "### \u274c Direct `import logging` in Service Code\n\n**Detection**:\n```bash\ngrep -rn '^import logging$' --include=\"*.py\"\ngrep -rn 'logging\\.getLogger' --include=\"*.py\" | grep -v \"oslo_log\\|# noqa\"\n```\n\n**What it looks like**:\n```python\nimport logging  # Wrong in OpenStack service modules\n\nLOG = logging.getLogger(__name__)\n```\n\n**Why wrong**: Bypasses `oslo.log` integration. Log messages won't carry Oslo context fields (`request_id`, `project_id`), and runtime log level changes via `CONF.debug` won't a...",
+      "block_text": "### ❌ Direct `import logging` in Service Code\n\n**Detection**:\n```bash\ngrep -rn '^import logging$' --include=\"*.py\"\ngrep -rn 'logging\\.getLogger' --include=\"*.py\" | grep -v \"oslo_log\\|# noqa\"\n```\n\n**What it looks like**:\n```python\nimport logging  # Wrong in OpenStack service modules\n\nLOG = logging.getLogger(__name__)\n```\n\n**Why wrong**: Bypasses `oslo.log` integration. Log messages won't carry Oslo context fields (`request_id`, `project_id`), and runtime log level changes via `CONF.debug` won't a...",
       "domain_hint": "python-openstack-engineer"
     },
     {
@@ -4399,7 +4399,7 @@
         186,
         202
       ],
-      "block_text": "### \u274c Hardcoded Transport URL in Code\n\n**Detection**:\n```bash\ngrep -rn 'rabbit://\\|amqp://' --include=\"*.py\" | grep -v \"# example\\|\\.cfg\\|test\"\n```\n\n**What it looks like**:\n```python\ntransport = messaging.get_rpc_transport(\n    CONF, url='rabbit://guest:guest@localhost:5672/')\n```\n\n**Why wrong**: Transport URL must come from oslo.config (`CONF.transport_url`) to be overridable in deployment configs and testable with `oslo_messaging.fake`.\n\n**Fix**:\n```python",
+      "block_text": "### ❌ Hardcoded Transport URL in Code\n\n**Detection**:\n```bash\ngrep -rn 'rabbit://\\|amqp://' --include=\"*.py\" | grep -v \"# example\\|\\.cfg\\|test\"\n```\n\n**What it looks like**:\n```python\ntransport = messaging.get_rpc_transport(\n    CONF, url='rabbit://guest:guest@localhost:5672/')\n```\n\n**Why wrong**: Transport URL must come from oslo.config (`CONF.transport_url`) to be overridable in deployment configs and testable with `oslo_messaging.fake`.\n\n**Fix**:\n```python",
       "domain_hint": "python-openstack-engineer"
     },
     {
@@ -4408,7 +4408,7 @@
         212,
         233
       ],
-      "block_text": "### \u274c Raw SQLAlchemy `create_engine` Without Oslo Session\n\n**Detection**:\n```bash\ngrep -rn 'create_engine\\|sessionmaker' --include=\"*.py\" | grep -v \"enginefacade\\|migration\\|test\"\n```\n\n**What it looks like**:\n```python\nfrom sqlalchemy import create_engine\nfrom sqlalchemy.orm import sessionmaker\n\nengine = create_engine(CONF.database.connection)\nSession = sessionmaker(bind=engine)\nsession = Session()\n```\n\n**Why wrong**: Bypasses oslo.db retry logic (deadlock retries via `@api.wrap_db_retry`), conn...",
+      "block_text": "### ❌ Raw SQLAlchemy `create_engine` Without Oslo Session\n\n**Detection**:\n```bash\ngrep -rn 'create_engine\\|sessionmaker' --include=\"*.py\" | grep -v \"enginefacade\\|migration\\|test\"\n```\n\n**What it looks like**:\n```python\nfrom sqlalchemy import create_engine\nfrom sqlalchemy.orm import sessionmaker\n\nengine = create_engine(CONF.database.connection)\nSession = sessionmaker(bind=engine)\nsession = Session()\n```\n\n**Why wrong**: Bypasses oslo.db retry logic (deadlock retries via `@api.wrap_db_retry`), conn...",
       "domain_hint": "python-openstack-engineer"
     },
     {
@@ -4417,7 +4417,7 @@
         235,
         266
       ],
-      "block_text": "### \u274c Missing `oslo.policy` Enforcement\n\n**Detection**:\n```bash\ngrep -rn 'def (create|update|delete|get|list)_' --include=\"*.py\" -A 10 | grep -v \"policy\\|enforce\"\n```\n\n**What it looks like**:\n```python\ndef delete_resource(self, context, resource_id):\n    # No policy check \u2014 any authenticated user can delete\n    return db.resource_delete(context, resource_id)\n```\n\n**Why wrong**: All API operations must enforce oslo.policy rules. Missing enforcement silently bypasses RBAC \u2014 a security vulnerabilit...",
+      "block_text": "### ❌ Missing `oslo.policy` Enforcement\n\n**Detection**:\n```bash\ngrep -rn 'def (create|update|delete|get|list)_' --include=\"*.py\" -A 10 | grep -v \"policy\\|enforce\"\n```\n\n**What it looks like**:\n```python\ndef delete_resource(self, context, resource_id):\n    # No policy check — any authenticated user can delete\n    return db.resource_delete(context, resource_id)\n```\n\n**Why wrong**: All API operations must enforce oslo.policy rules. Missing enforcement silently bypasses RBAC — a security vulnerabilit...",
       "domain_hint": "python-openstack-engineer"
     },
     {
@@ -4444,7 +4444,7 @@
         170,
         179
       ],
-      "block_text": "# After (version still '1.2' \u2014 NOT bumped!):\ndef create_resource(self, context, name, resource_type):  # Added required arg\n    ...\n```\n\n**Why wrong**: Old nodes calling `create_resource(ctx, name)` will crash with `TypeError` on the new server. Rolling upgrade fails.\n\n**Fix**: Bump `RPC_API_VERSION` to `'1.3'`, make `resource_type` optional with a default, and pin new client calls to `prepare(version='1.3')`.\n\n---\n",
+      "block_text": "# After (version still '1.2' — NOT bumped!):\ndef create_resource(self, context, name, resource_type):  # Added required arg\n    ...\n```\n\n**Why wrong**: Old nodes calling `create_resource(ctx, name)` will crash with `TypeError` on the new server. Rolling upgrade fails.\n\n**Fix**: Bump `RPC_API_VERSION` to `'1.3'`, make `resource_type` optional with a default, and pin new client calls to `prepare(version='1.3')`.\n\n---\n",
       "domain_hint": "python-openstack-engineer"
     },
     {
@@ -4453,7 +4453,7 @@
         181,
         189
       ],
-      "block_text": "### \u274c Calling New Method Without Version Pin\n\n**Detection**:\n```bash\ngrep -rn 'cctxt\\.call\\|cctxt\\.cast' --include=\"*.py\" -B 2 | grep -v \"prepare\"\n```\n\n**What it looks like**:\n```python",
+      "block_text": "### ❌ Calling New Method Without Version Pin\n\n**Detection**:\n```bash\ngrep -rn 'cctxt\\.call\\|cctxt\\.cast' --include=\"*.py\" -B 2 | grep -v \"prepare\"\n```\n\n**What it looks like**:\n```python",
       "domain_hint": "python-openstack-engineer"
     },
     {
@@ -4507,7 +4507,7 @@
         187,
         206
       ],
-      "block_text": "### \u274c Forgetting to Drain Confirm Notifications\n\n**Detection**:\n```bash\nrg 'confirm_delivery|Confirm\\(false\\)' --type py --type go -A 3 | grep -v 'NotifyPublish\\|wait_for_confirms'\n```\n\n**What it looks like**:\n```python\nchannel.confirm_delivery()\nfor msg in messages:\n    channel.basic_publish(...)\n    # never calls channel.wait_for_confirms_or_die()\n```\n\n**Why wrong**: Unread confirms accumulate in pika's internal buffer. After ~1000 unconfirmed messages the channel stalls waiting for the applic...",
+      "block_text": "### ❌ Forgetting to Drain Confirm Notifications\n\n**Detection**:\n```bash\nrg 'confirm_delivery|Confirm\\(false\\)' --type py --type go -A 3 | grep -v 'NotifyPublish\\|wait_for_confirms'\n```\n\n**What it looks like**:\n```python\nchannel.confirm_delivery()\nfor msg in messages:\n    channel.basic_publish(...)\n    # never calls channel.wait_for_confirms_or_die()\n```\n\n**Why wrong**: Unread confirms accumulate in pika's internal buffer. After ~1000 unconfirmed messages the channel stalls waiting for the applic...",
       "domain_hint": "rabbitmq-messaging-engineer"
     },
     {
@@ -4525,7 +4525,7 @@
         189,
         206
       ],
-      "block_text": "# Go\nrg '\\.Consume\\(' --type go -A 3 | grep 'autoAck.*true'\n```\n\n**What it looks like**:\n```python\nchannel.basic_consume(\n    queue='orders',\n    on_message_callback=handle_order,\n    auto_ack=True,  # Broker deletes message on delivery\n)\n```\n\n**Why wrong**: Message is deleted from the queue the instant the broker delivers it to the consumer socket buffer \u2014 before `handle_order` even starts. Consumer crash, OOM kill, or application exception after delivery means the message is permanently lost.\n...",
+      "block_text": "# Go\nrg '\\.Consume\\(' --type go -A 3 | grep 'autoAck.*true'\n```\n\n**What it looks like**:\n```python\nchannel.basic_consume(\n    queue='orders',\n    on_message_callback=handle_order,\n    auto_ack=True,  # Broker deletes message on delivery\n)\n```\n\n**Why wrong**: Message is deleted from the queue the instant the broker delivers it to the consumer socket buffer — before `handle_order` even starts. Consumer crash, OOM kill, or application exception after delivery means the message is permanently lost.\n...",
       "domain_hint": "rabbitmq-messaging-engineer"
     },
     {
@@ -4534,7 +4534,7 @@
         216,
         232
       ],
-      "block_text": "# Go: Nack with requeue=true in error path\nrg '\\.Nack\\(' --type go -A 2 | grep 'true'\n```\n\n**What it looks like**:\n```python\nexcept Exception as e:\n    log.error(\"processing failed: %s\", e)\n    channel.basic_nack(delivery_tag=method.delivery_tag, requeue=True)\n    # Message goes back to queue head \u2014 immediately redelivered \u2014 infinite loop\n```\n\n**Why wrong**: A poison message (malformed JSON, missing field, encoding error) that always raises an exception will loop: deliver \u2192 fail \u2192 requeue \u2192 deli...",
+      "block_text": "# Go: Nack with requeue=true in error path\nrg '\\.Nack\\(' --type go -A 2 | grep 'true'\n```\n\n**What it looks like**:\n```python\nexcept Exception as e:\n    log.error(\"processing failed: %s\", e)\n    channel.basic_nack(delivery_tag=method.delivery_tag, requeue=True)\n    # Message goes back to queue head — immediately redelivered — infinite loop\n```\n\n**Why wrong**: A poison message (malformed JSON, missing field, encoding error) that always raises an exception will loop: deliver → fail → requeue → deli...",
       "domain_hint": "rabbitmq-messaging-engineer"
     },
     {
@@ -4552,7 +4552,7 @@
         248,
         255
       ],
-      "block_text": "# No DLX \u2014 rejected/expired messages vanish\n```\n\n**Why wrong**: Any `basic_nack(requeue=False)` or expired message is silently dropped. There is no audit trail, no replay capability, no alerting on message failures.\n\n**Fix**: Always declare a DLX for any production queue. At minimum, route to a `{queue}.dead` queue with 7-day TTL for investigation.\n\n---\n",
+      "block_text": "# No DLX — rejected/expired messages vanish\n```\n\n**Why wrong**: Any `basic_nack(requeue=False)` or expired message is silently dropped. There is no audit trail, no replay capability, no alerting on message failures.\n\n**Fix**: Always declare a DLX for any production queue. At minimum, route to a `{queue}.dead` queue with 7-day TTL for investigation.\n\n---\n",
       "domain_hint": "rabbitmq-messaging-engineer"
     },
     {
@@ -4579,7 +4579,7 @@
         147,
         154
       ],
-      "block_text": "# No basic_qos call \u2014 broker pushes unlimited messages\n```\n\n**Why wrong**: Broker pushes all queued messages to the first consumer that connects. Memory on the consumer grows without bound. Other consumers get nothing until the first consumer's buffer drains. Under spike load this causes OOM kills on consumer processes.\n\n**Fix**: Always call `channel.basic_qos(prefetch_count=N)` before `basic_consume`. Start with `prefetch_count=10` and tune upward.\n\n---\n",
+      "block_text": "# No basic_qos call — broker pushes unlimited messages\n```\n\n**Why wrong**: Broker pushes all queued messages to the first consumer that connects. Memory on the consumer grows without bound. Other consumers get nothing until the first consumer's buffer drains. Under spike load this causes OOM kills on consumer processes.\n\n**Fix**: Always call `channel.basic_qos(prefetch_count=N)` before `basic_consume`. Start with `prefetch_count=10` and tune upward.\n\n---\n",
       "domain_hint": "rabbitmq-messaging-engineer"
     },
     {
@@ -4588,7 +4588,7 @@
         163,
         192
       ],
-      "block_text": "# Check existing queues without TTL policy\nrabbitmqctl list_queues name policy | grep -v 'ttl\\|expire'\n```\n\n**What it looks like**:\n```python\nchannel.queue_declare(\n    queue='notifications',\n    durable=True,\n    # No TTL, no max-length \u2014 grows forever if consumers are slow\n)\n```\n\n**Why wrong**: Queues without TTL or max-length policies grow unboundedly if consumers fall behind. A queue with 10M messages consumes GB of memory/disk. Memory alarm fires at 40% (default watermark), blocking all pub...",
+      "block_text": "# Check existing queues without TTL policy\nrabbitmqctl list_queues name policy | grep -v 'ttl\\|expire'\n```\n\n**What it looks like**:\n```python\nchannel.queue_declare(\n    queue='notifications',\n    durable=True,\n    # No TTL, no max-length — grows forever if consumers are slow\n)\n```\n\n**Why wrong**: Queues without TTL or max-length policies grow unboundedly if consumers fall behind. A queue with 10M messages consumes GB of memory/disk. Memory alarm fires at 40% (default watermark), blocking all pub...",
       "domain_hint": "rabbitmq-messaging-engineer"
     },
     {
@@ -4597,7 +4597,7 @@
         201,
         213
       ],
-      "block_text": "# Code setting ha-mode in policy\nrg 'ha-mode|ha_mode' --type py --type go --type js\n```\n\n**What it looks like**:\n```bash\nrabbitmqctl set_policy ha-all \".*\" '{\"ha-mode\":\"all\"}' --apply-to queues\n```\n\n**Why wrong**: Classic mirrored queues replicate via synchronous replication to all mirror nodes. This causes write amplification proportional to cluster size. Under high throughput (>10K msg/s), mirrors can't keep up and the queue enters `slave_not_synchronized` state \u2014 at which point failover promo...",
+      "block_text": "# Code setting ha-mode in policy\nrg 'ha-mode|ha_mode' --type py --type go --type js\n```\n\n**What it looks like**:\n```bash\nrabbitmqctl set_policy ha-all \".*\" '{\"ha-mode\":\"all\"}' --apply-to queues\n```\n\n**Why wrong**: Classic mirrored queues replicate via synchronous replication to all mirror nodes. This causes write amplification proportional to cluster size. Under high throughput (>10K msg/s), mirrors can't keep up and the queue enters `slave_not_synchronized` state — at which point failover promo...",
       "domain_hint": "rabbitmq-messaging-engineer"
     },
     {
@@ -4615,7 +4615,7 @@
         152,
         184
       ],
-      "block_text": "### \u274c Using `console.error` as the Only Error Reporting\n\n**Detection**:\n```bash\ngrep -rn 'console\\.error' --include=\"*.tsx\" --include=\"*.ts\" | grep -v \"\\.test\\.\" | grep -v \"\\.spec\\.\"\nrg 'console\\.error' --type ts --type tsx | grep -v test\n```\n\n**What it looks like**:\n```tsx\ntry {\n  await syncData()\n} catch (err) {\n  console.error('Sync failed', err)  // invisible in production\n}\n```\n\n**Why wrong**: `console.error` is stripped or suppressed in production builds. Errors logged this way are invisib...",
+      "block_text": "### ❌ Using `console.error` as the Only Error Reporting\n\n**Detection**:\n```bash\ngrep -rn 'console\\.error' --include=\"*.tsx\" --include=\"*.ts\" | grep -v \"\\.test\\.\" | grep -v \"\\.spec\\.\"\nrg 'console\\.error' --type ts --type tsx | grep -v test\n```\n\n**What it looks like**:\n```tsx\ntry {\n  await syncData()\n} catch (err) {\n  console.error('Sync failed', err)  // invisible in production\n}\n```\n\n**Why wrong**: `console.error` is stripped or suppressed in production builds. Errors logged this way are invisib...",
       "domain_hint": "react-native-engineer"
     },
     {
@@ -4624,7 +4624,7 @@
         186,
         216
       ],
-      "block_text": "### \u274c Empty Catch Blocks\n\n**Detection**:\n```bash\ngrep -rn 'catch\\s*(.*)\\s*{\\s*}' --include=\"*.ts\" --include=\"*.tsx\"\nrg 'catch\\s*\\(.*\\)\\s*\\{\\s*\\}' --type ts\n```\n\n**What it looks like**:\n```ts\ntry {\n  await loadUserPreferences()\n} catch (err) {\n  // TODO: handle this\n}\n```\n\n**Why wrong**: Silent swallow. The error is gone. The app is now in an inconsistent state \u2014 preferences were not loaded, but no error boundary fired, no fallback rendered, no alert triggered. These are the hardest bugs to diagn...",
+      "block_text": "### ❌ Empty Catch Blocks\n\n**Detection**:\n```bash\ngrep -rn 'catch\\s*(.*)\\s*{\\s*}' --include=\"*.ts\" --include=\"*.tsx\"\nrg 'catch\\s*\\(.*\\)\\s*\\{\\s*\\}' --type ts\n```\n\n**What it looks like**:\n```ts\ntry {\n  await loadUserPreferences()\n} catch (err) {\n  // TODO: handle this\n}\n```\n\n**Why wrong**: Silent swallow. The error is gone. The app is now in an inconsistent state — preferences were not loaded, but no error boundary fired, no fallback rendered, no alert triggered. These are the hardest bugs to diagn...",
       "domain_hint": "react-native-engineer"
     },
     {
@@ -4633,7 +4633,7 @@
         218,
         254
       ],
-      "block_text": "### \u274c Missing Error Boundary at Navigation Root\n\n**Detection**:\n```bash\ngrep -rn 'Stack.Screen\\|Tabs.Screen' --include=\"*.tsx\" | grep -v ErrorBoundary\nrg 'NavigationContainer' --type tsx | grep -B5 -A10 'NavigationContainer'\n```\n\n**What it looks like**:\n```tsx\nexport default function RootLayout() {\n  return (\n    <Stack>\n      <Stack.Screen name=\"(tabs)\" component={TabsLayout} />\n      <Stack.Screen name=\"profile\" component={ProfileScreen} />\n    </Stack>\n  )\n}\n```\n\n**Why wrong**: If `ProfileScr...",
+      "block_text": "### ❌ Missing Error Boundary at Navigation Root\n\n**Detection**:\n```bash\ngrep -rn 'Stack.Screen\\|Tabs.Screen' --include=\"*.tsx\" | grep -v ErrorBoundary\nrg 'NavigationContainer' --type tsx | grep -B5 -A10 'NavigationContainer'\n```\n\n**What it looks like**:\n```tsx\nexport default function RootLayout() {\n  return (\n    <Stack>\n      <Stack.Screen name=\"(tabs)\" component={TabsLayout} />\n      <Stack.Screen name=\"profile\" component={ProfileScreen} />\n    </Stack>\n  )\n}\n```\n\n**Why wrong**: If `ProfileScr...",
       "domain_hint": "react-native-engineer"
     },
     {
@@ -4642,7 +4642,7 @@
         256,
         282
       ],
-      "block_text": "### \u274c Accessing `.data` on an Unvalidated API Response\n\n**Detection**:\n```bash\ngrep -rn '\\.data\\.' --include=\"*.ts\" --include=\"*.tsx\" | grep -v \"\\.test\\.\" | grep \"await fetch\\|axios\\|useFetch\"\nrg '(await\\s+\\w+\\(.*\\))\\.data\\.' --type ts\n```\n\n**What it looks like**:\n```ts\nconst response = await fetch('/api/user')\nconst json = await response.json()\nsetUser(json.data.profile.name)  // throws if data or profile is undefined\n```\n\n**Why wrong**: API contracts break. A server returns `{ error: \"not foun...",
+      "block_text": "### ❌ Accessing `.data` on an Unvalidated API Response\n\n**Detection**:\n```bash\ngrep -rn '\\.data\\.' --include=\"*.ts\" --include=\"*.tsx\" | grep -v \"\\.test\\.\" | grep \"await fetch\\|axios\\|useFetch\"\nrg '(await\\s+\\w+\\(.*\\))\\.data\\.' --type ts\n```\n\n**What it looks like**:\n```ts\nconst response = await fetch('/api/user')\nconst json = await response.json()\nsetUser(json.data.profile.name)  // throws if data or profile is undefined\n```\n\n**Why wrong**: API contracts break. A server returns `{ error: \"not foun...",
       "domain_hint": "react-native-engineer"
     },
     {
@@ -4660,7 +4660,7 @@
         167,
         193
       ],
-      "block_text": "### \u274c Mocking `useNavigation` Inside Individual Test Files\n\n**Detection**:\n```bash\ngrep -rn \"jest.mock.*navigation\\|jest.mock.*router\" --include=\"*.test.tsx\"\n```\n\n**What it looks like**:\n```tsx\njest.mock('@react-navigation/native', () => ({\n  useNavigation: () => ({ navigate: jest.fn() }),\n}))\n```\n\n**Why wrong**: Repeated local mocks diverge over time. When the real API adds a new field (`navigation.setOptions`, `navigation.getId`), each test file needs updating separately. Components that call ...",
+      "block_text": "### ❌ Mocking `useNavigation` Inside Individual Test Files\n\n**Detection**:\n```bash\ngrep -rn \"jest.mock.*navigation\\|jest.mock.*router\" --include=\"*.test.tsx\"\n```\n\n**What it looks like**:\n```tsx\njest.mock('@react-navigation/native', () => ({\n  useNavigation: () => ({ navigate: jest.fn() }),\n}))\n```\n\n**Why wrong**: Repeated local mocks diverge over time. When the real API adds a new field (`navigation.setOptions`, `navigation.getId`), each test file needs updating separately. Components that call ...",
       "domain_hint": "react-native-engineer"
     },
     {
@@ -4669,7 +4669,7 @@
         195,
         221
       ],
-      "block_text": "### \u274c Using Snapshots for UI Components\n\n**Detection**:\n```bash\ngrep -rn 'toMatchSnapshot\\|toMatchInlineSnapshot' --include=\"*.test.tsx\"\nrg 'toMatchSnapshot' --type tsx\n```\n\n**What it looks like**:\n```tsx\nit('renders correctly', () => {\n  const tree = render(<Card title=\"Hello\" />).toJSON()\n  expect(tree).toMatchSnapshot()\n})\n```\n\n**Why wrong**: Snapshot tests fail on every styling or structure change, creating update churn. They assert nothing about behavior \u2014 a component that renders the wrong...",
+      "block_text": "### ❌ Using Snapshots for UI Components\n\n**Detection**:\n```bash\ngrep -rn 'toMatchSnapshot\\|toMatchInlineSnapshot' --include=\"*.test.tsx\"\nrg 'toMatchSnapshot' --type tsx\n```\n\n**What it looks like**:\n```tsx\nit('renders correctly', () => {\n  const tree = render(<Card title=\"Hello\" />).toJSON()\n  expect(tree).toMatchSnapshot()\n})\n```\n\n**Why wrong**: Snapshot tests fail on every styling or structure change, creating update churn. They assert nothing about behavior — a component that renders the wrong...",
       "domain_hint": "react-native-engineer"
     },
     {
@@ -4687,7 +4687,7 @@
         134,
         170
       ],
-      "block_text": "### \u274c Marking the Whole Page as Client Component\n\n**Detection**:\n```bash\ngrep -rn \"'use client'\" app/ --include=\"*.tsx\" | grep \"page.tsx\"\nrg \"'use client'\" --type tsx -l | xargs grep -l \"export default function\"\n```\n\n**What it looks like**:\n```tsx\n// app/gallery/page.tsx\n'use client'  // \u2190 entire page becomes a Client Component\nimport { useState } from 'react'\nimport Image from 'next/image'\nimport { artworks } from '@/data/artworks'\n\nexport default function GalleryPage() {\n  const [filter, setFi...",
+      "block_text": "### ❌ Marking the Whole Page as Client Component\n\n**Detection**:\n```bash\ngrep -rn \"'use client'\" app/ --include=\"*.tsx\" | grep \"page.tsx\"\nrg \"'use client'\" --type tsx -l | xargs grep -l \"export default function\"\n```\n\n**What it looks like**:\n```tsx\n// app/gallery/page.tsx\n'use client'  // ← entire page becomes a Client Component\nimport { useState } from 'react'\nimport Image from 'next/image'\nimport { artworks } from '@/data/artworks'\n\nexport default function GalleryPage() {\n  const [filter, setFi...",
       "domain_hint": "react-portfolio-engineer"
     },
     {
@@ -4696,7 +4696,7 @@
         224,
         249
       ],
-      "block_text": "### \u274c Calling getServerSideProps in App Router Pages\n\n**Detection**:\n```bash\ngrep -rn \"getServerSideProps\\|getStaticProps\" app/ --include=\"*.tsx\"\n```\n\n**What it looks like**:\n```tsx\n// app/gallery/page.tsx \u2014 WRONG in App Router\nexport async function getStaticProps() { ... }\nexport async function getServerSideProps() { ... }\n```\n\n**Why wrong**: These are Pages Router APIs. In App Router they are silently ignored \u2014 the functions exist but never run. Data fetching must happen in the `async` compone...",
+      "block_text": "### ❌ Calling getServerSideProps in App Router Pages\n\n**Detection**:\n```bash\ngrep -rn \"getServerSideProps\\|getStaticProps\" app/ --include=\"*.tsx\"\n```\n\n**What it looks like**:\n```tsx\n// app/gallery/page.tsx — WRONG in App Router\nexport async function getStaticProps() { ... }\nexport async function getServerSideProps() { ... }\n```\n\n**Why wrong**: These are Pages Router APIs. In App Router they are silently ignored — the functions exist but never run. Data fetching must happen in the `async` compone...",
       "domain_hint": "react-portfolio-engineer"
     },
     {
@@ -4714,7 +4714,7 @@
         137,
         170
       ],
-      "block_text": "### \u274c Multiple `priority` Images\n\n**Detection**:\n```bash\ngrep -rn \"priority\" --include=\"*.tsx\" | grep -v \"//.*priority\"\nrg \"priority(?:={true})?\" --type tsx\n```\n\n**What it looks like**:\n```tsx\n// Every gallery card has priority \u2014 defeats the purpose\n{artworks.map(art => (\n  <Image src={art.src} alt={art.alt} width={600} height={400} priority />\n))}\n```\n\n**Why wrong**: `priority` injects a `<link rel=\"preload\">` for each image. With 12 gallery items, that's 12 preloads competing for bandwidth at ...",
+      "block_text": "### ❌ Multiple `priority` Images\n\n**Detection**:\n```bash\ngrep -rn \"priority\" --include=\"*.tsx\" | grep -v \"//.*priority\"\nrg \"priority(?:={true})?\" --type tsx\n```\n\n**What it looks like**:\n```tsx\n// Every gallery card has priority — defeats the purpose\n{artworks.map(art => (\n  <Image src={art.src} alt={art.alt} width={600} height={400} priority />\n))}\n```\n\n**Why wrong**: `priority` injects a `<link rel=\"preload\">` for each image. With 12 gallery items, that's 12 preloads competing for bandwidth at ...",
       "domain_hint": "react-portfolio-engineer"
     },
     {
@@ -4723,7 +4723,7 @@
         172,
         207
       ],
-      "block_text": "### \u274c Missing `sizes` on Responsive Gallery Images\n\n**Detection**:\n```bash\ngrep -rn \"next/image\\|from 'next/image'\" --include=\"*.tsx\" -l | xargs grep -L \"sizes=\"\nrg \"width=\\{[0-9]+\\}.*height=\\{[0-9]+\\}\" --type tsx | grep -v \"sizes=\"\n```\n\n**What it looks like**:\n```tsx\n<Image\n  src={artwork.src}\n  alt={artwork.alt}\n  width={1200}\n  height={800}\n  // no sizes prop \u2014 browser defaults to requesting 1200px image on all viewports\n/>\n```\n\n**Why wrong**: The browser requests a 1200px image even on a 375...",
+      "block_text": "### ❌ Missing `sizes` on Responsive Gallery Images\n\n**Detection**:\n```bash\ngrep -rn \"next/image\\|from 'next/image'\" --include=\"*.tsx\" -l | xargs grep -L \"sizes=\"\nrg \"width=\\{[0-9]+\\}.*height=\\{[0-9]+\\}\" --type tsx | grep -v \"sizes=\"\n```\n\n**What it looks like**:\n```tsx\n<Image\n  src={artwork.src}\n  alt={artwork.alt}\n  width={1200}\n  height={800}\n  // no sizes prop — browser defaults to requesting 1200px image on all viewports\n/>\n```\n\n**Why wrong**: The browser requests a 1200px image even on a 375...",
       "domain_hint": "react-portfolio-engineer"
     },
     {
@@ -4732,7 +4732,7 @@
         209,
         240
       ],
-      "block_text": "### \u274c Synchronous Heavy Computation on Filter Interaction\n\n**Detection**:\n```bash\ngrep -rn \"\\.filter\\(.*\\.map\\|\\.sort\\(.*\\.filter\" --include=\"*.tsx\"\nrg \"useMemo|useCallback\" --type tsx -l\n```\n\n**What it looks like**:\n```tsx\n'use client'\nconst filtered = artworks\n  .filter(a => a.category === activeCategory)\n  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())\n  .map(a => ({ ...a, formattedDate: formatDate(a.date) }))\n// Runs on every render, including every keystroke in a s...",
+      "block_text": "### ❌ Synchronous Heavy Computation on Filter Interaction\n\n**Detection**:\n```bash\ngrep -rn \"\\.filter\\(.*\\.map\\|\\.sort\\(.*\\.filter\" --include=\"*.tsx\"\nrg \"useMemo|useCallback\" --type tsx -l\n```\n\n**What it looks like**:\n```tsx\n'use client'\nconst filtered = artworks\n  .filter(a => a.category === activeCategory)\n  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())\n  .map(a => ({ ...a, formattedDate: formatDate(a.date) }))\n// Runs on every render, including every keystroke in a s...",
       "domain_hint": "react-portfolio-engineer"
     },
     {
@@ -4741,7 +4741,7 @@
         242,
         274
       ],
-      "block_text": "### \u274c Importing Full Icon Libraries\n\n**Detection**:\n```bash\ngrep -rn \"from 'react-icons'\" --include=\"*.tsx\"\ngrep -rn \"from '@heroicons/react'\" --include=\"*.tsx\" | grep \"^[^/]\"\n```\n\n**What it looks like**:\n```tsx\nimport { FaArrowLeft, FaArrowRight, FaTimes } from 'react-icons/fa'\n// Imports entire react-icons/fa barrel \u2014 adds ~50KB to bundle\n```\n\n**Why wrong**: Named imports from barrel files like `react-icons/fa` often pull in the entire icon set due to CommonJS export semantics. Even with tree-...",
+      "block_text": "### ❌ Importing Full Icon Libraries\n\n**Detection**:\n```bash\ngrep -rn \"from 'react-icons'\" --include=\"*.tsx\"\ngrep -rn \"from '@heroicons/react'\" --include=\"*.tsx\" | grep \"^[^/]\"\n```\n\n**What it looks like**:\n```tsx\nimport { FaArrowLeft, FaArrowRight, FaTimes } from 'react-icons/fa'\n// Imports entire react-icons/fa barrel — adds ~50KB to bundle\n```\n\n**Why wrong**: Named imports from barrel files like `react-icons/fa` often pull in the entire icon set due to CommonJS export semantics. Even with tree-...",
       "domain_hint": "react-portfolio-engineer"
     },
     {
@@ -4786,7 +4786,7 @@
         162,
         174
       ],
-      "block_text": "# Plan:\n1. Deploy subagent to research GPU supply\n2. WAIT for result\n3. Deploy subagent to research energy requirements\n4. WAIT for result\n5. Deploy subagent to research regulation\n```\n\n**Why wrong**: These three topics are independent \u2014 none requires the GPU supply finding to start the energy research. Sequential deployment triples latency for no reason. On a 60-second subagent, sequential = 180 seconds; parallel = 60 seconds.\n\n**Fix**: Move all three Task calls into a single message. Only use ...",
+      "block_text": "# Plan:\n1. Deploy subagent to research GPU supply\n2. WAIT for result\n3. Deploy subagent to research energy requirements\n4. WAIT for result\n5. Deploy subagent to research regulation\n```\n\n**Why wrong**: These three topics are independent — none requires the GPU supply finding to start the energy research. Sequential deployment triples latency for no reason. On a 60-second subagent, sequential = 180 seconds; parallel = 60 seconds.\n\n**Fix**: Move all three Task calls into a single message. Only use ...",
       "domain_hint": "research-coordinator-engineer"
     },
     {
@@ -4795,7 +4795,7 @@
         180,
         193
       ],
-      "block_text": "# Check if instructions specify word count or format\ngrep -rL \"word\\|paragraph\\|bullet\\|table\\|summary\" research/*/instructions/ 2>/dev/null\n```\n\n**What it looks like**:\n```markdown\n\"Research the regulatory landscape for AI development and provide your findings.\"\n```\n\n**Why wrong**: Subagent may return a 50-word paragraph or a 1500-word essay. Lead agent cannot predict what arrives, making synthesis planning impossible. It also removes the quality bar \u2014 \"provide your findings\" accepts any output...",
+      "block_text": "# Check if instructions specify word count or format\ngrep -rL \"word\\|paragraph\\|bullet\\|table\\|summary\" research/*/instructions/ 2>/dev/null\n```\n\n**What it looks like**:\n```markdown\n\"Research the regulatory landscape for AI development and provide your findings.\"\n```\n\n**Why wrong**: Subagent may return a 50-word paragraph or a 1500-word essay. Lead agent cannot predict what arrives, making synthesis planning impossible. It also removes the quality bar — \"provide your findings\" accepts any output...",
       "domain_hint": "research-coordinator-engineer"
     },
     {
@@ -4804,7 +4804,7 @@
         67,
         75
       ],
-      "block_text": "# Find research plans that delegate synthesis\ngrep -ri \"subagent.*final\\|delegate.*synthesis\\|compile.*report\" research/*/plan.md\ngrep -ri \"write.*final.*report\" research/*/instructions/ | grep -v \"lead agent\"\n```\n\n**Why wrong**: Synthesis delegation violates the hardcoded lead-agent-synthesizes rule. When subagents synthesize, the coordinator loses the cross-stream perspective needed to reconcile conflicts. A subagent sees only its own research stream \u2014 it cannot identify what the other subagen...",
+      "block_text": "# Find research plans that delegate synthesis\ngrep -ri \"subagent.*final\\|delegate.*synthesis\\|compile.*report\" research/*/plan.md\ngrep -ri \"write.*final.*report\" research/*/instructions/ | grep -v \"lead agent\"\n```\n\n**Why wrong**: Synthesis delegation violates the hardcoded lead-agent-synthesizes rule. When subagents synthesize, the coordinator loses the cross-stream perspective needed to reconcile conflicts. A subagent sees only its own research stream — it cannot identify what the other subagen...",
       "domain_hint": "research-coordinator-engineer"
     },
     {
@@ -4813,7 +4813,7 @@
         97,
         105
       ],
-      "block_text": "# Find inline citations\ngrep -rn \"\\[[0-9]\\+\\]\\|([A-Z][a-z]*,\\s*20[0-9][0-9])\" research/*/report.md\n```\n\n**Why wrong**: The citation agent handles citations separately as a downstream step. Including citations in the research report creates duplication, formatting conflicts, and incorrect attribution when the citation agent reformats. Citation-free output is a hardcoded behavior \u2014 the coordinator must strip citations from its synthesis.\n\n**Fix**: Remove all citation markers from the final report....",
+      "block_text": "# Find inline citations\ngrep -rn \"\\[[0-9]\\+\\]\\|([A-Z][a-z]*,\\s*20[0-9][0-9])\" research/*/report.md\n```\n\n**Why wrong**: The citation agent handles citations separately as a downstream step. Including citations in the research report creates duplication, formatting conflicts, and incorrect attribution when the citation agent reformats. Citation-free output is a hardcoded behavior — the coordinator must strip citations from its synthesis.\n\n**Fix**: Remove all citation markers from the final report....",
       "domain_hint": "research-coordinator-engineer"
     },
     {
@@ -4831,7 +4831,7 @@
         99,
         114
       ],
-      "block_text": "# Manual check: are all subagent subjects identical?\ngrep \"Subagent [0-9]\\+:\" research/*/plan.md | sort | uniq -d\n```\n\n**What it looks like**:\n```markdown\nSubagent 1: \"Research AI regulation trends\"\nSubagent 2: \"Research AI regulation trends\"\nSubagent 3: \"Research AI regulation trends\"\n```\n\n**Why wrong**: All three subagents converge on the same sources and produce redundant content. The lead agent has nothing to reconcile \u2014 just three copies of similar findings. Synthesis produces an averaged s...",
+      "block_text": "# Manual check: are all subagent subjects identical?\ngrep \"Subagent [0-9]\\+:\" research/*/plan.md | sort | uniq -d\n```\n\n**What it looks like**:\n```markdown\nSubagent 1: \"Research AI regulation trends\"\nSubagent 2: \"Research AI regulation trends\"\nSubagent 3: \"Research AI regulation trends\"\n```\n\n**Why wrong**: All three subagents converge on the same sources and produce redundant content. The lead agent has nothing to reconcile — just three copies of similar findings. Synthesis produces an averaged s...",
       "domain_hint": "research-coordinator-engineer"
     },
     {
@@ -4858,7 +4858,7 @@
         151,
         161
       ],
-      "block_text": "# Wrong strategy applied:\nSubagent 1: \"Theoretical foundations of frontend frameworks\"\nSubagent 2: \"Historical evolution of JavaScript frameworks\"\nSubagent 3: \"Performance characteristics of SPAs\"\n```\n\n**Why wrong**: Angles don't map to options. The lead agent now has generic framework theory but cannot answer \"which should I choose for enterprise apps?\"\n\n**Fix**: Detect comparison keywords and switch to breadth-first \u2014 one subagent per option.\n\n---\n",
+      "block_text": "# Wrong strategy applied:\nSubagent 1: \"Theoretical foundations of frontend frameworks\"\nSubagent 2: \"Historical evolution of JavaScript frameworks\"\nSubagent 3: \"Performance characteristics of SPAs\"\n```\n\n**Why wrong**: Angles don't map to options. The lead agent now has generic framework theory but cannot answer \"which should I choose for enterprise apps?\"\n\n**Fix**: Detect comparison keywords and switch to breadth-first — one subagent per option.\n\n---\n",
       "domain_hint": "research-coordinator-engineer"
     },
     {
@@ -4885,7 +4885,7 @@
         126,
         141
       ],
-      "block_text": "# Pattern: web_search call followed by direct claim, no web_fetch in between\ngrep -A5 \"web_search\" agent_log.txt | grep -v \"web_fetch\"\n```\n\n**What it looks like**:\n```\nweb_search(\"Python 3.12 release date\")\n\u2192 Snippet: \"Python 3.12 was released...\"\nReport: \"Python 3.12 was released on October 2, 2023\"  # from snippet alone\n```\n\n**Why wrong**: Snippets are truncated, sometimes from outdated cached versions of pages. A claim sourced only from a snippet has no URL citation trail and may omit critica...",
+      "block_text": "# Pattern: web_search call followed by direct claim, no web_fetch in between\ngrep -A5 \"web_search\" agent_log.txt | grep -v \"web_fetch\"\n```\n\n**What it looks like**:\n```\nweb_search(\"Python 3.12 release date\")\n→ Snippet: \"Python 3.12 was released...\"\nReport: \"Python 3.12 was released on October 2, 2023\"  # from snippet alone\n```\n\n**Why wrong**: Snippets are truncated, sometimes from outdated cached versions of pages. A claim sourced only from a snippet has no URL citation trail and may omit critica...",
       "domain_hint": "research-subagent-executor"
     },
     {
@@ -4894,7 +4894,7 @@
         143,
         161
       ],
-      "block_text": "### \u274c Starting Research Without a Budget\n\n**What it looks like**:\n```\nTask received: \"Research the state of WebAssembly tooling in 2025\"\nTurn 1: web_search(\"WebAssembly 2025\")  # No budget stated\n...\nTurn 19: web_search(\"WASI spec status\")  # About to hit hard limit\nTurn 20: [forced termination]\n```\n\n**Why wrong**: Without a budget, the agent has no early-warning system. Hitting turn 20 mid-research produces an incomplete report with no synthesis. The coordinator receives a truncated artifact.\n\n...",
+      "block_text": "### ❌ Starting Research Without a Budget\n\n**What it looks like**:\n```\nTask received: \"Research the state of WebAssembly tooling in 2025\"\nTurn 1: web_search(\"WebAssembly 2025\")  # No budget stated\n...\nTurn 19: web_search(\"WASI spec status\")  # About to hit hard limit\nTurn 20: [forced termination]\n```\n\n**Why wrong**: Without a budget, the agent has no early-warning system. Hitting turn 20 mid-research produces an incomplete report with no synthesis. The coordinator receives a truncated artifact.\n\n...",
       "domain_hint": "research-subagent-executor"
     },
     {
@@ -4903,7 +4903,7 @@
         163,
         177
       ],
-      "block_text": "### \u274c Querying More Than 5 Words\n\n**What it looks like**:\n```\nweb_search(\"what are the best practices for configuring kubernetes resource limits in production\")\n```\n\n**Why wrong**: Search engines perform better with short, keyword-dense queries. Long natural-language queries introduce stop words that dilute ranking signals. They also reduce result diversity (engine interprets as a phrase match).\n\n**Fix**:\n```\nweb_search(\"kubernetes resource limits production 2024\")\n```\n\n---\n",
+      "block_text": "### ❌ Querying More Than 5 Words\n\n**What it looks like**:\n```\nweb_search(\"what are the best practices for configuring kubernetes resource limits in production\")\n```\n\n**Why wrong**: Search engines perform better with short, keyword-dense queries. Long natural-language queries introduce stop words that dilute ranking signals. They also reduce result diversity (engine interprets as a phrase match).\n\n**Fix**:\n```\nweb_search(\"kubernetes resource limits production 2024\")\n```\n\n---\n",
       "domain_hint": "research-subagent-executor"
     },
     {
@@ -4921,7 +4921,7 @@
         90,
         105
       ],
-      "block_text": "# In research logs, flag these URL patterns\ngrep -E \"best-[0-9]|top-[0-9]|vs\\.|comparison|alternative\" urls.txt\nrg \"(best|top|vs|versus|comparison|alternative)\" fetched_urls.txt -i\n```\n\n**What it looks like**:\n```\nweb_fetch(\"https://www.toolscomparison.io/best-kubernetes-monitoring-tools-2024/\")\n\u2192 Report: \"According to industry experts, Prometheus is the leading monitoring tool...\"\n```\n\n**Why wrong**: The aggregator's claim \"according to industry experts\" cites no specific expert. The actual sou...",
+      "block_text": "# In research logs, flag these URL patterns\ngrep -E \"best-[0-9]|top-[0-9]|vs\\.|comparison|alternative\" urls.txt\nrg \"(best|top|vs|versus|comparison|alternative)\" fetched_urls.txt -i\n```\n\n**What it looks like**:\n```\nweb_fetch(\"https://www.toolscomparison.io/best-kubernetes-monitoring-tools-2024/\")\n→ Report: \"According to industry experts, Prometheus is the leading monitoring tool...\"\n```\n\n**Why wrong**: The aggregator's claim \"according to industry experts\" cites no specific expert. The actual sou...",
       "domain_hint": "research-subagent-executor"
     },
     {
@@ -4939,7 +4939,7 @@
         131,
         146
       ],
-      "block_text": "### \u274c Missing Source Citation for Precise Numbers\n\n**What it looks like**:\n```\nReport: \"Kubernetes 1.28 reduced pod startup latency by 23%\"\n[No URL, no source cited]\n```\n\n**Why wrong**: Precise numbers (percentages, benchmarks, release dates, version numbers) are the most likely to be misremembered, misquoted, or context-dependent. Without a URL, the coordinator cannot verify or qualify the claim.\n\n**Fix**: Every numeric claim gets a citation.\n```\nFACT: Kubernetes 1.28 release notes claim ~23% r...",
+      "block_text": "### ❌ Missing Source Citation for Precise Numbers\n\n**What it looks like**:\n```\nReport: \"Kubernetes 1.28 reduced pod startup latency by 23%\"\n[No URL, no source cited]\n```\n\n**Why wrong**: Precise numbers (percentages, benchmarks, release dates, version numbers) are the most likely to be misremembered, misquoted, or context-dependent. Without a URL, the coordinator cannot verify or qualify the claim.\n\n**Fix**: Every numeric claim gets a citation.\n```\nFACT: Kubernetes 1.28 release notes claim ~23% r...",
       "domain_hint": "research-subagent-executor"
     },
     {
@@ -5065,7 +5065,7 @@
         5,
         8
       ],
-      "block_text": "## \u274c Anti-Pattern: No Rollback Plan\n\n**What it looks like**:\n```bash",
+      "block_text": "## ❌ Anti-Pattern: No Rollback Plan\n\n**What it looks like**:\n```bash",
       "domain_hint": "reviewer-domain"
     },
     {
@@ -5074,7 +5074,7 @@
         127,
         132
       ],
-      "block_text": "## \u274c Anti-Pattern: Untested Edge Cases\n\n**What it looks like**:\n```python\ndef calculate_discount(cart_total, discount_percent):\n    return cart_total * (discount_percent / 100)\n",
+      "block_text": "## ❌ Anti-Pattern: Untested Edge Cases\n\n**What it looks like**:\n```python\ndef calculate_discount(cart_total, discount_percent):\n    return cart_total * (discount_percent / 100)\n",
       "domain_hint": "reviewer-domain"
     },
     {
@@ -5146,7 +5146,7 @@
         167,
         180
       ],
-      "block_text": "# JSON unmarshaling field access without existence check (JS/TS)\nrg -n 'data\\.\\w+\\.\\w+' --type ts | rg -v '\\?\\.\\|if.*data\\.\\w+\\|&&'\n```\n\n**What it looks like**:\n```go\nfunc parseFlags(args []string) string {\n    return args[1] // assumes at least 2 args \u2014 no validation\n}\n```\n\n**Why wrong**: The Contrarian asks: \"what if the caller passes zero args?\" The assumption is invisible and produces a panic, not a clear error message.\n\n---\n",
+      "block_text": "# JSON unmarshaling field access without existence check (JS/TS)\nrg -n 'data\\.\\w+\\.\\w+' --type ts | rg -v '\\?\\.\\|if.*data\\.\\w+\\|&&'\n```\n\n**What it looks like**:\n```go\nfunc parseFlags(args []string) string {\n    return args[1] // assumes at least 2 args — no validation\n}\n```\n\n**Why wrong**: The Contrarian asks: \"what if the caller passes zero args?\" The assumption is invisible and produces a panic, not a clear error message.\n\n---\n",
       "domain_hint": "reviewer-perspectives"
     },
     {
@@ -5155,7 +5155,7 @@
         192,
         198
       ],
-      "block_text": "# Node.js: singleton state assumed safe under concurrent requests\nrg -n 'module\\.exports\\.\\w+ = \\[\\|module\\.exports\\.\\w+ = \\{' --type js\n```\n\n**Why wrong**: The Contrarian asks: \"this code runs fine with one request \u2014 what about 100 simultaneous requests?\" Module-level mutable state is shared across all requests in most web frameworks.\n\n---\n",
+      "block_text": "# Node.js: singleton state assumed safe under concurrent requests\nrg -n 'module\\.exports\\.\\w+ = \\[\\|module\\.exports\\.\\w+ = \\{' --type js\n```\n\n**Why wrong**: The Contrarian asks: \"this code runs fine with one request — what about 100 simultaneous requests?\" Module-level mutable state is shared across all requests in most web frameworks.\n\n---\n",
       "domain_hint": "reviewer-perspectives"
     },
     {
@@ -5191,7 +5191,7 @@
         68,
         86
       ],
-      "block_text": "# 404 used for authorization failures (should be 403 or 401)\nrg -n 'NotFound|status.*404' --type go | rg -i 'auth\\|permission\\|forbidden'\n```\n\n**What it looks like**:\n```go\nfunc handler(w http.ResponseWriter, r *http.Request) {\n    user, err := getUser(id)\n    if err != nil {\n        http.Error(w, err.Error(), http.StatusOK) // wrong: 200 on error\n    }\n}\n```\n\n**Why wrong**: RFC 7231 \u00a76 defines status code semantics. Clients (including monitoring tools and API gateways) use status codes to route...",
+      "block_text": "# 404 used for authorization failures (should be 403 or 401)\nrg -n 'NotFound|status.*404' --type go | rg -i 'auth\\|permission\\|forbidden'\n```\n\n**What it looks like**:\n```go\nfunc handler(w http.ResponseWriter, r *http.Request) {\n    user, err := getUser(id)\n    if err != nil {\n        http.Error(w, err.Error(), http.StatusOK) // wrong: 200 on error\n    }\n}\n```\n\n**Why wrong**: RFC 7231 §6 defines status code semantics. Clients (including monitoring tools and API gateways) use status codes to route...",
       "domain_hint": "reviewer-perspectives"
     },
     {
@@ -5200,7 +5200,7 @@
         104,
         112
       ],
-      "block_text": "# Connection strings\ngrep -rn 'postgres://\\|mysql://\\|mongodb://' --include=\"*.go\" --include=\"*.ts\" --include=\"*.py\" | grep -v '_test\\|example\\|sample'\n```\n\n**Why wrong**: Credentials in version history are permanent \u2014 `git filter-branch` does not remove them from forks or cached copies. Leaked credentials require key rotation even after removal.\n\n**Fix**: Load from environment variables (`os.Getenv`, `process.env`, `os.environ`) or a secrets manager. Never commit `.env` files containing real va...",
+      "block_text": "# Connection strings\ngrep -rn 'postgres://\\|mysql://\\|mongodb://' --include=\"*.go\" --include=\"*.ts\" --include=\"*.py\" | grep -v '_test\\|example\\|sample'\n```\n\n**Why wrong**: Credentials in version history are permanent — `git filter-branch` does not remove them from forks or cached copies. Leaked credentials require key rotation even after removal.\n\n**Fix**: Load from environment variables (`os.Getenv`, `process.env`, `os.environ`) or a secrets manager. Never commit `.env` files containing real va...",
       "domain_hint": "reviewer-perspectives"
     },
     {
@@ -5209,7 +5209,7 @@
         127,
         135
       ],
-      "block_text": "# GraphQL resolvers returning all items\ngrep -rn 'findAll\\|getAll\\|fetchAll' --include=\"*.ts\" --include=\"*.go\"\n```\n\n**Why wrong**: A query returning 1,000 rows in development returns 50 million in production, causing OOM crashes or 30-second response times that cascade into timeouts.\n\n**Fix**: Add `LIMIT`/`OFFSET` or cursor-based pagination. Default page size should be \u2264 100.\n\n---\n",
+      "block_text": "# GraphQL resolvers returning all items\ngrep -rn 'findAll\\|getAll\\|fetchAll' --include=\"*.ts\" --include=\"*.go\"\n```\n\n**Why wrong**: A query returning 1,000 rows in development returns 50 million in production, causing OOM crashes or 30-second response times that cascade into timeouts.\n\n**Fix**: Add `LIMIT`/`OFFSET` or cursor-based pagination. Default page size should be ≤ 100.\n\n---\n",
       "domain_hint": "reviewer-perspectives"
     },
     {
@@ -5218,7 +5218,7 @@
         149,
         164
       ],
-      "block_text": "# JavaScript: async race (read then write without transaction)\nrg -n 'await.*get\\|await.*find' --type ts -A2 | rg 'await.*set\\|await.*update\\|await.*save'\n```\n\n**What it looks like**:\n```go\nif _, exists := cache[key]; !exists {\n    cache[key] = computeExpensive(key) // not atomic \u2014 two goroutines can reach this\n}\n```\n\n**Why wrong**: Two goroutines can both pass the `!exists` check before either writes, causing double computation or overwriting a valid value.\n\n**Fix**: Use `sync.Map.LoadOrStore()...",
+      "block_text": "# JavaScript: async race (read then write without transaction)\nrg -n 'await.*get\\|await.*find' --type ts -A2 | rg 'await.*set\\|await.*update\\|await.*save'\n```\n\n**What it looks like**:\n```go\nif _, exists := cache[key]; !exists {\n    cache[key] = computeExpensive(key) // not atomic — two goroutines can reach this\n}\n```\n\n**Why wrong**: Two goroutines can both pass the `!exists` check before either writes, causing double computation or overwriting a valid value.\n\n**Fix**: Use `sync.Map.LoadOrStore()...",
       "domain_hint": "reviewer-perspectives"
     },
     {
@@ -5236,7 +5236,7 @@
         207,
         215
       ],
-      "block_text": "# Express routes without auth middleware\nrg -n 'router\\.(get|post|put|delete)\\(' --type ts -B2 | rg -v 'auth\\|verify\\|require'\n```\n\n**Why wrong**: Authenticated users can access other users' resources. Classic IDOR (Insecure Direct Object Reference) vulnerability \u2014 OWASP A01:2021.\n\n**Fix**: Always filter queries by the authenticated user's ID: `WHERE user_id = $currentUser`.\n\n---\n",
+      "block_text": "# Express routes without auth middleware\nrg -n 'router\\.(get|post|put|delete)\\(' --type ts -B2 | rg -v 'auth\\|verify\\|require'\n```\n\n**Why wrong**: Authenticated users can access other users' resources. Classic IDOR (Insecure Direct Object Reference) vulnerability — OWASP A01:2021.\n\n**Fix**: Always filter queries by the authenticated user's ID: `WHERE user_id = $currentUser`.\n\n---\n",
       "domain_hint": "reviewer-perspectives"
     },
     {
@@ -5254,7 +5254,7 @@
         348,
         358
       ],
-      "block_text": "# Check if the review output cites file:line evidence\ngrep -c 'File:\\|Where:\\|:\\d\\+:' review_output.md 2>/dev/null || echo \"No line references found\"\n```\n\n**What it looks like**: A review with findings like \"the code seems complex\" or \"error handling may be insufficient\" \u2014 no file reference, no line number, no grep evidence.\n\n**Why wrong**: Vague findings are unfalsifiable. The author cannot verify them, cannot rebut them, and cannot be sure what to fix. Evidence-free reviews waste everyone's ti...",
+      "block_text": "# Check if the review output cites file:line evidence\ngrep -c 'File:\\|Where:\\|:\\d\\+:' review_output.md 2>/dev/null || echo \"No line references found\"\n```\n\n**What it looks like**: A review with findings like \"the code seems complex\" or \"error handling may be insufficient\" — no file reference, no line number, no grep evidence.\n\n**Why wrong**: Vague findings are unfalsifiable. The author cannot verify them, cannot rebut them, and cannot be sure what to fix. Evidence-free reviews waste everyone's ti...",
       "domain_hint": "reviewer-perspectives"
     },
     {
@@ -5326,7 +5326,7 @@
         213,
         219
       ],
-      "block_text": "## State Machine Anti-Patterns\n\n**Dead-end states**: Every state must have a transition back to idle. Test this by manually triggering each input in the Rive Editor's preview \u2014 if any state doesn't return to idle, add the transition.\n\n**Race condition on rapid inputs**: If `attack` fires twice in 100ms, the second trigger may interrupt mid-windup. Decide policy in CombatEngine: either debounce triggers (reject new inputs while animation is active) or accept interruption (second attack starts fro...",
+      "block_text": "## State Machine Anti-Patterns\n\n**Dead-end states**: Every state must have a transition back to idle. Test this by manually triggering each input in the Rive Editor's preview — if any state doesn't return to idle, add the transition.\n\n**Race condition on rapid inputs**: If `attack` fires twice in 100ms, the second trigger may interrupt mid-windup. Decide policy in CombatEngine: either debounce triggers (reject new inputs while animation is active) or accept interruption (second attack starts fro...",
       "domain_hint": "rive-skeletal-animator"
     },
     {
@@ -5344,7 +5344,7 @@
         130,
         154
       ],
-      "block_text": "### \u274c Accessing Rive Instance Outside Effect or Callback\n\n**Detection**:\n```bash\ngrep -rn 'rive\\.' --include=\"*.tsx\" | grep -v 'useEffect\\|onLoad\\|onStateChange\\|useCallback\\|//' | grep -v 'RiveComponent\\|useRive\\|import'\nrg '^\\s+rive\\.' --type tsx\n```\n\n**What it looks like**:\n```tsx\nfunction PlayerCharacter() {\n  const { rive, RiveComponent } = useRive({ ... });\n\n  // BUG: rive is null on first render\n  rive.stateMachineInputs('CombatStateMachine')?.find(i => i.name === 'triggerAttack')?.fire()...",
+      "block_text": "### ❌ Accessing Rive Instance Outside Effect or Callback\n\n**Detection**:\n```bash\ngrep -rn 'rive\\.' --include=\"*.tsx\" | grep -v 'useEffect\\|onLoad\\|onStateChange\\|useCallback\\|//' | grep -v 'RiveComponent\\|useRive\\|import'\nrg '^\\s+rive\\.' --type tsx\n```\n\n**What it looks like**:\n```tsx\nfunction PlayerCharacter() {\n  const { rive, RiveComponent } = useRive({ ... });\n\n  // BUG: rive is null on first render\n  rive.stateMachineInputs('CombatStateMachine')?.find(i => i.name === 'triggerAttack')?.fire()...",
       "domain_hint": "rive-skeletal-animator"
     },
     {
@@ -5353,7 +5353,7 @@
         156,
         180
       ],
-      "block_text": "### \u274c Using setTimeout for Animation Sequencing\n\n**Detection**:\n```bash\ngrep -rn 'setTimeout' --include=\"*.tsx\" | grep -i 'anim\\|rive\\|attack\\|hit\\|state'\nrg 'setTimeout.*anim' --type tsx\n```\n\n**What it looks like**:\n```tsx\nconst handleAttack = () => {\n  attackInput?.fire();\n  setTimeout(() => {\n    recoverInput?.fire(); // assume attack finishes in 300ms\n  }, 300);\n};\n```\n\n**Why wrong**: Animation duration in the Rive editor and the `setTimeout` duration in code drift independently. When a desi...",
+      "block_text": "### ❌ Using setTimeout for Animation Sequencing\n\n**Detection**:\n```bash\ngrep -rn 'setTimeout' --include=\"*.tsx\" | grep -i 'anim\\|rive\\|attack\\|hit\\|state'\nrg 'setTimeout.*anim' --type tsx\n```\n\n**What it looks like**:\n```tsx\nconst handleAttack = () => {\n  attackInput?.fire();\n  setTimeout(() => {\n    recoverInput?.fire(); // assume attack finishes in 300ms\n  }, 300);\n};\n```\n\n**Why wrong**: Animation duration in the Rive editor and the `setTimeout` duration in code drift independently. When a desi...",
       "domain_hint": "rive-skeletal-animator"
     },
     {
@@ -5362,7 +5362,7 @@
         182,
         207
       ],
-      "block_text": "### \u274c Polling rive for Non-Null in a Loop or Interval\n\n**Detection**:\n```bash\ngrep -rn 'setInterval\\|while.*rive\\|poll' --include=\"*.tsx\" | grep -i 'rive'\nrg 'setInterval' --type tsx -l | xargs grep -l 'rive'\n```\n\n**What it looks like**:\n```tsx\nuseEffect(() => {\n  const poll = setInterval(() => {\n    if (rive) {\n      clearInterval(poll);\n      rive.play();\n    }\n  }, 50);\n  return () => clearInterval(poll);\n}, []);\n```\n\n**Why wrong**: This re-implements what `useRive` already does with `onLoad`...",
+      "block_text": "### ❌ Polling rive for Non-Null in a Loop or Interval\n\n**Detection**:\n```bash\ngrep -rn 'setInterval\\|while.*rive\\|poll' --include=\"*.tsx\" | grep -i 'rive'\nrg 'setInterval' --type tsx -l | xargs grep -l 'rive'\n```\n\n**What it looks like**:\n```tsx\nuseEffect(() => {\n  const poll = setInterval(() => {\n    if (rive) {\n      clearInterval(poll);\n      rive.play();\n    }\n  }, 50);\n  return () => clearInterval(poll);\n}, []);\n```\n\n**Why wrong**: This re-implements what `useRive` already does with `onLoad`...",
       "domain_hint": "rive-skeletal-animator"
     },
     {
@@ -5389,7 +5389,7 @@
         106,
         131
       ],
-      "block_text": "### \u274c Wrapping RiveComponent in Framer Motion\n\n**Detection**:\n```bash\ngrep -rn 'motion\\.' --include=\"*.tsx\" | grep -i 'rive'\nrg 'motion\\.(div|span)' --type tsx -l | xargs grep -l 'RiveComponent'\n```\n\n**What it looks like**:\n```tsx\n<motion.div animate={{ opacity: 1 }} initial={{ opacity: 0 }}>\n  <RiveComponent />\n</motion.div>\n```\n\n**Why wrong**: Framer Motion and Rive both own animation timing. When Framer Motion drives opacity/transform on the container, it forces composite layer repaints on ev...",
+      "block_text": "### ❌ Wrapping RiveComponent in Framer Motion\n\n**Detection**:\n```bash\ngrep -rn 'motion\\.' --include=\"*.tsx\" | grep -i 'rive'\nrg 'motion\\.(div|span)' --type tsx -l | xargs grep -l 'RiveComponent'\n```\n\n**What it looks like**:\n```tsx\n<motion.div animate={{ opacity: 1 }} initial={{ opacity: 0 }}>\n  <RiveComponent />\n</motion.div>\n```\n\n**Why wrong**: Framer Motion and Rive both own animation timing. When Framer Motion drives opacity/transform on the container, it forces composite layer repaints on ev...",
       "domain_hint": "rive-skeletal-animator"
     },
     {
@@ -5398,7 +5398,7 @@
         133,
         166
       ],
-      "block_text": "### \u274c Creating Rive Instances Outside React Lifecycle\n\n**Detection**:\n```bash\ngrep -rn 'new Rive(' --include=\"*.ts\" --include=\"*.tsx\"\nrg 'new Rive\\(' --type ts\n```\n\n**What it looks like**:\n```ts\n// In a Zustand store or utility function\nconst riveInstance = new Rive({ src: '/characters/player.riv', canvas: canvasEl });\n```\n\n**Why wrong**: Rive instances created outside React components lose their cleanup path. `useRive` manages the instance lifecycle \u2014 loading, resize observation, cleanup \u2014 and ...",
+      "block_text": "### ❌ Creating Rive Instances Outside React Lifecycle\n\n**Detection**:\n```bash\ngrep -rn 'new Rive(' --include=\"*.ts\" --include=\"*.tsx\"\nrg 'new Rive\\(' --type ts\n```\n\n**What it looks like**:\n```ts\n// In a Zustand store or utility function\nconst riveInstance = new Rive({ src: '/characters/player.riv', canvas: canvasEl });\n```\n\n**Why wrong**: Rive instances created outside React components lose their cleanup path. `useRive` manages the instance lifecycle — loading, resize observation, cleanup — and ...",
       "domain_hint": "rive-skeletal-animator"
     },
     {
@@ -5407,7 +5407,7 @@
         168,
         193
       ],
-      "block_text": "### \u274c Rendering Multiple Rive Canvases Simultaneously Without Shared Context\n\n**Detection**:\n```bash\ngrep -rn 'useRive' --include=\"*.tsx\" | grep -v 'test\\|spec\\|story'\n```\n\nCount the number of `useRive` calls active at once. If more than 12, context exhaustion is likely.\n\n**What it looks like**:\n```tsx\n// Character select screen with 8 previews + combat scene with 2 active characters = 10+ contexts\n{characters.map(c => <CharacterPreview key={c.id} rivFile={c.riv} />)}\n```\n\n**Why wrong**: Each `u...",
+      "block_text": "### ❌ Rendering Multiple Rive Canvases Simultaneously Without Shared Context\n\n**Detection**:\n```bash\ngrep -rn 'useRive' --include=\"*.tsx\" | grep -v 'test\\|spec\\|story'\n```\n\nCount the number of `useRive` calls active at once. If more than 12, context exhaustion is likely.\n\n**What it looks like**:\n```tsx\n// Character select screen with 8 previews + combat scene with 2 active characters = 10+ contexts\n{characters.map(c => <CharacterPreview key={c.id} rivFile={c.riv} />)}\n```\n\n**Why wrong**: Each `u...",
       "domain_hint": "rive-skeletal-animator"
     },
     {
@@ -5443,7 +5443,7 @@
         216,
         225
       ],
-      "block_text": "### \u274c Adding NOT NULL Column Without Default on Non-Empty Table\n\n**Detection**:\n```bash\ngrep -rn 'add_column' --include=\"*.py\" -A 2 | grep -v 'null=True\\|default='\nrg 'add_column\\([^)]*\\)' --type py | grep -v 'null=True|default='\n```\n\n**What it looks like**:\n```python",
+      "block_text": "### ❌ Adding NOT NULL Column Without Default on Non-Empty Table\n\n**Detection**:\n```bash\ngrep -rn 'add_column' --include=\"*.py\" -A 2 | grep -v 'null=True\\|default='\nrg 'add_column\\([^)]*\\)' --type py | grep -v 'null=True|default='\n```\n\n**What it looks like**:\n```python",
       "domain_hint": "sqlite-peewee-engineer"
     },
     {
@@ -5452,7 +5452,7 @@
         226,
         235
       ],
-      "block_text": "# FAILS on any non-empty table \u2014 existing rows have no value for 'status'\nmigrate(migrator.add_column('post', 'status', CharField()))\n```\n\n**Why wrong**: SQLite requires all existing rows to have a valid value for the new column.\nA non-null column with no default fails with `OperationalError: Cannot add a NOT NULL column\nwith default value NULL`.\n\n**Fix**:\n```python",
+      "block_text": "# FAILS on any non-empty table — existing rows have no value for 'status'\nmigrate(migrator.add_column('post', 'status', CharField()))\n```\n\n**Why wrong**: SQLite requires all existing rows to have a valid value for the new column.\nA non-null column with no default fails with `OperationalError: Cannot add a NOT NULL column\nwith default value NULL`.\n\n**Fix**:\n```python",
       "domain_hint": "sqlite-peewee-engineer"
     },
     {
@@ -5461,7 +5461,7 @@
         248,
         257
       ],
-      "block_text": "### \u274c Dropping Column on SQLite < 3.35\n\n**Detection**:\n```bash\ngrep -rn 'drop_column' --include=\"*.py\"\nrg 'migrator\\.drop_column\\(' --type py\n```\n\n**What it looks like**:\n```python",
+      "block_text": "### ❌ Dropping Column on SQLite < 3.35\n\n**Detection**:\n```bash\ngrep -rn 'drop_column' --include=\"*.py\"\nrg 'migrator\\.drop_column\\(' --type py\n```\n\n**What it looks like**:\n```python",
       "domain_hint": "sqlite-peewee-engineer"
     },
     {
@@ -5479,7 +5479,7 @@
         291,
         303
       ],
-      "block_text": "### \u274c Running Schema Changes Outside Transaction\n\n**Detection**:\n```bash\ngrep -rn 'migrate(' --include=\"*.py\" -B 3 | grep -v 'atomic\\|with db'\nrg 'migrate\\(' --type py -B 3 | grep -v 'atomic'\n```\n\n**What it looks like**:\n```python\nmigrator = SqliteMigrator(db)\nmigrate(migrator.add_column('user', 'email', TextField(null=True)))  # No atomic()!\nmigrate(migrator.add_index('user', ('email',), False))               # Separate call",
+      "block_text": "### ❌ Running Schema Changes Outside Transaction\n\n**Detection**:\n```bash\ngrep -rn 'migrate(' --include=\"*.py\" -B 3 | grep -v 'atomic\\|with db'\nrg 'migrate\\(' --type py -B 3 | grep -v 'atomic'\n```\n\n**What it looks like**:\n```python\nmigrator = SqliteMigrator(db)\nmigrate(migrator.add_column('user', 'email', TextField(null=True)))  # No atomic()!\nmigrate(migrator.add_index('user', ('email',), False))               # Separate call",
       "domain_hint": "sqlite-peewee-engineer"
     },
     {
@@ -5488,7 +5488,7 @@
         304,
         316
       ],
-      "block_text": "# If second migrate() fails, first is committed \u2014 schema partially updated\n```\n\n**Why wrong**: Each `migrate()` call is its own implicit transaction. If the second call fails,\nthe first is already committed. The schema is now partially updated with no clean rollback path.\n\n**Fix**:\n```python\nwith db.atomic():\n    migrate(\n        migrator.add_column('user', 'email', TextField(null=True)),\n        migrator.add_index('user', ('email',), False),\n    )",
+      "block_text": "# If second migrate() fails, first is committed — schema partially updated\n```\n\n**Why wrong**: Each `migrate()` call is its own implicit transaction. If the second call fails,\nthe first is already committed. The schema is now partially updated with no clean rollback path.\n\n**Fix**:\n```python\nwith db.atomic():\n    migrate(\n        migrator.add_column('user', 'email', TextField(null=True)),\n        migrator.add_index('user', ('email',), False),\n    )",
       "domain_hint": "sqlite-peewee-engineer"
     },
     {
@@ -5497,7 +5497,7 @@
         98,
         102
       ],
-      "block_text": "### Targeted SELECT to Avoid Overfetch\n\nSpecify only needed columns \u2014 prevents loading TEXT/BLOB columns when only IDs or names needed.\n\n```python",
+      "block_text": "### Targeted SELECT to Avoid Overfetch\n\nSpecify only needed columns — prevents loading TEXT/BLOB columns when only IDs or names needed.\n\n```python",
       "domain_hint": "sqlite-peewee-engineer"
     },
     {
@@ -5533,7 +5533,7 @@
         206,
         215
       ],
-      "block_text": "### \u274c Cartesian Product from Prefetch + Join Combination\n\n**Detection**:\n```bash\nrg '\\.prefetch\\(' --type py -A 2 | grep '\\.join\\('\ngrep -rn 'prefetch' --include=\"*.py\" -A 3 | grep 'join'\n```\n\n**What it looks like**:\n```python",
+      "block_text": "### ❌ Cartesian Product from Prefetch + Join Combination\n\n**Detection**:\n```bash\nrg '\\.prefetch\\(' --type py -A 2 | grep '\\.join\\('\ngrep -rn 'prefetch' --include=\"*.py\" -A 3 | grep 'join'\n```\n\n**What it looks like**:\n```python",
       "domain_hint": "sqlite-peewee-engineer"
     },
     {
@@ -5542,7 +5542,7 @@
         216,
         228
       ],
-      "block_text": "# BUG: join + prefetch on same model produces cartesian product rows\nusers = (User\n    .select()\n    .join(Post)  # Creates JOIN\n    .prefetch(Post))  # Also prefetches \u2014 duplicates Post rows\n```\n\n**Why wrong**: `join()` and `prefetch()` for the same model are mutually exclusive operations.\nUsing both causes Post rows to appear multiple times in `user.posts` after prefetch populates\nfrom the JOIN result set.\n\n**Fix**:\n```python",
+      "block_text": "# BUG: join + prefetch on same model produces cartesian product rows\nusers = (User\n    .select()\n    .join(Post)  # Creates JOIN\n    .prefetch(Post))  # Also prefetches — duplicates Post rows\n```\n\n**Why wrong**: `join()` and `prefetch()` for the same model are mutually exclusive operations.\nUsing both causes Post rows to appear multiple times in `user.posts` after prefetch populates\nfrom the JOIN result set.\n\n**Fix**:\n```python",
       "domain_hint": "sqlite-peewee-engineer"
     },
     {
@@ -5551,7 +5551,7 @@
         242,
         248
       ],
-      "block_text": "# Model.select() with no arguments \u2014 loads all columns\nrg '\\.select\\(\\s*\\)' --type py\ngrep -rn '\\.select()' --include=\"*.py\" | grep -v 'select(.*\\.'\n```\n\n**What it looks like**:\n```python",
+      "block_text": "# Model.select() with no arguments — loads all columns\nrg '\\.select\\(\\s*\\)' --type py\ngrep -rn '\\.select()' --include=\"*.py\" | grep -v 'select(.*\\.'\n```\n\n**What it looks like**:\n```python",
       "domain_hint": "sqlite-peewee-engineer"
     },
     {
@@ -5587,7 +5587,7 @@
         201,
         219
       ],
-      "block_text": "# conftest.py \u2014 WRONG: shared database across all tests\ndb = SqliteDatabase(':memory:')\ndb.bind([User, Post])\ndb.create_tables([User, Post])\n\ndef test_create_user():\n    User.create(username='alice')\n\ndef test_user_count():\n    # FAILS if test_create_user ran first \u2014 count is 1, not 0\n    assert User.select().count() == 0\n```\n\n**Why wrong**: Module-level `:memory:` databases persist for the entire test session. Rows\ncreated in one test are visible to all subsequent tests. Test order determines r...",
+      "block_text": "# conftest.py — WRONG: shared database across all tests\ndb = SqliteDatabase(':memory:')\ndb.bind([User, Post])\ndb.create_tables([User, Post])\n\ndef test_create_user():\n    User.create(username='alice')\n\ndef test_user_count():\n    # FAILS if test_create_user ran first — count is 1, not 0\n    assert User.select().count() == 0\n```\n\n**Why wrong**: Module-level `:memory:` databases persist for the entire test session. Rows\ncreated in one test are visible to all subsequent tests. Test order determines r...",
       "domain_hint": "sqlite-peewee-engineer"
     },
     {
@@ -5605,7 +5605,7 @@
         242,
         272
       ],
-      "block_text": "# Uses real app.db in tests \u2014 modifies production data\ndb = SqliteDatabase('app.db')\n\ndef test_delete_user():\n    User.delete().where(User.username == 'test').execute()\n    # Deletes from real database!\n```\n\n**Why wrong**: Test teardown failures, CI environment errors, or parallel test runs corrupt\nthe production database file. SQLite file databases have no transaction isolation between\nprocesses.\n\n**Fix**: Always use `SqliteDatabase(':memory:')` in tests. For integration tests that need\na file,...",
+      "block_text": "# Uses real app.db in tests — modifies production data\ndb = SqliteDatabase('app.db')\n\ndef test_delete_user():\n    User.delete().where(User.username == 'test').execute()\n    # Deletes from real database!\n```\n\n**Why wrong**: Test teardown failures, CI environment errors, or parallel test runs corrupt\nthe production database file. SQLite file databases have no transaction isolation between\nprocesses.\n\n**Fix**: Always use `SqliteDatabase(':memory:')` in tests. For integration tests that need\na file,...",
       "domain_hint": "sqlite-peewee-engineer"
     },
     {
@@ -5614,7 +5614,7 @@
         274,
         283
       ],
-      "block_text": "### \u274c Not Enabling FK Constraints in Test DB\n\n**Detection**:\n```bash\nrg 'SqliteDatabase.*:memory:' --type py | grep -v 'foreign_keys'\ngrep -rn \"SqliteDatabase(':memory:')\" --include=\"*.py\" -A 3 | grep -v 'foreign_keys'\n```\n\n**What it looks like**:\n```python",
+      "block_text": "### ❌ Not Enabling FK Constraints in Test DB\n\n**Detection**:\n```bash\nrg 'SqliteDatabase.*:memory:' --type py | grep -v 'foreign_keys'\ngrep -rn \"SqliteDatabase(':memory:')\" --include=\"*.py\" -A 3 | grep -v 'foreign_keys'\n```\n\n**What it looks like**:\n```python",
       "domain_hint": "sqlite-peewee-engineer"
     },
     {
@@ -5623,7 +5623,7 @@
         284,
         301
       ],
-      "block_text": "# SQLite disables FK checks by default \u2014 tests pass but prod fails\ndb = SqliteDatabase(':memory:')  # No foreign_keys pragma\n\ndef test_post_without_user():\n    # This succeeds in test \u2014 SQLite allows orphaned FK\n    Post.create(user_id=99999, title='Orphan')\n    # In production with foreign_keys=1 this raises IntegrityError\n```\n\n**Why wrong**: SQLite disables foreign key constraints by default for backwards compatibility.\nTests pass with invalid data that production rejects. The divergence is in...",
+      "block_text": "# SQLite disables FK checks by default — tests pass but prod fails\ndb = SqliteDatabase(':memory:')  # No foreign_keys pragma\n\ndef test_post_without_user():\n    # This succeeds in test — SQLite allows orphaned FK\n    Post.create(user_id=99999, title='Orphan')\n    # In production with foreign_keys=1 this raises IntegrityError\n```\n\n**Why wrong**: SQLite disables foreign key constraints by default for backwards compatibility.\nTests pass with invalid data that production rejects. The divergence is in...",
       "domain_hint": "sqlite-peewee-engineer"
     },
     {
@@ -5695,7 +5695,7 @@
         45,
         52
       ],
-      "block_text": "### \u274c Implementing Domain Changes Inline\n\n**What it looks like**: Directly editing `hooks/posttool-rename-sweep.py` instead of\ndispatching `hook-development-engineer`. Writing new agent frontmatter inline instead of\ndispatching `skill-creator`.\n\n**Detection**:\n```bash",
+      "block_text": "### ❌ Implementing Domain Changes Inline\n\n**What it looks like**: Directly editing `hooks/posttool-rename-sweep.py` instead of\ndispatching `hook-development-engineer`. Writing new agent frontmatter inline instead of\ndispatching `skill-creator`.\n\n**Detection**:\n```bash",
       "domain_hint": "system-upgrade-engineer"
     },
     {
@@ -5704,7 +5704,7 @@
         55,
         69
       ],
-      "block_text": "# system-upgrade-engineer should only create task_plan.md and branch setup files\n```\n\n**Why wrong**: Domain specialists (hook-development-engineer, skill-creator) carry template\nconventions, event schema knowledge, and frontmatter validation that inline edits bypass.\nA hook written inline without hook-development-engineer's exit code contract knowledge will\nlikely use wrong exit codes. An agent written inline will miss required frontmatter fields.\n\n**Fix**:\n- Hook changes \u2192 dispatch `hook-develo...",
+      "block_text": "# system-upgrade-engineer should only create task_plan.md and branch setup files\n```\n\n**Why wrong**: Domain specialists (hook-development-engineer, skill-creator) carry template\nconventions, event schema knowledge, and frontmatter validation that inline edits bypass.\nA hook written inline without hook-development-engineer's exit code contract knowledge will\nlikely use wrong exit codes. An agent written inline will miss required frontmatter fields.\n\n**Fix**:\n- Hook changes → dispatch `hook-develo...",
       "domain_hint": "system-upgrade-engineer"
     },
     {
@@ -5713,7 +5713,7 @@
         81,
         92
       ],
-      "block_text": "# Should be present \u2014 if missing, audit had no scope\n```\n\n**Why wrong**: Auditing all 120+ skills for a 2-hook change produces noise proportional to\nscope. When every component appears in the audit, the PLAN phase cannot distinguish affected\nfrom unaffected. Tier assignment degrades to noise.\n\n**Fix**: Build the Change Manifest with a \"Component Types\" column first. Default scope\nis 10 most-recently-modified agents + all hooks + affected routing tables. Comprehensive\naudit only with the explicit...",
+      "block_text": "# Should be present — if missing, audit had no scope\n```\n\n**Why wrong**: Auditing all 120+ skills for a 2-hook change produces noise proportional to\nscope. When every component appears in the audit, the PLAN phase cannot distinguish affected\nfrom unaffected. Tier assignment degrades to noise.\n\n**Fix**: Build the Change Manifest with a \"Component Types\" column first. Default scope\nis 10 most-recently-modified agents + all hooks + affected routing tables. Comprehensive\naudit only with the explicit...",
       "domain_hint": "system-upgrade-engineer"
     },
     {
@@ -5776,7 +5776,7 @@
         120,
         131
       ],
-      "block_text": "### \u274c Treating a Mention as an Upgrade Requirement\n\n**What it looks like**: A release note mentions \"improved JSON output\" and the agent\nimmediately schedules upgrades to every script that uses JSON.\n\n**Why wrong**: Not every mention is a breaking change. Only changes that alter the\ninterface (tool signature, event schema, model name) require upgrades.\n\n**Fix**: For each signal, ask: \"Does this change the interface a component depends on?\"\nIf no: Minor or skip. If yes: Important or Critical.\n\n--...",
+      "block_text": "### ❌ Treating a Mention as an Upgrade Requirement\n\n**What it looks like**: A release note mentions \"improved JSON output\" and the agent\nimmediately schedules upgrades to every script that uses JSON.\n\n**Why wrong**: Not every mention is a breaking change. Only changes that alter the\ninterface (tool signature, event schema, model name) require upgrades.\n\n**Fix**: For each signal, ask: \"Does this change the interface a component depends on?\"\nIf no: Minor or skip. If yes: Important or Critical.\n\n--...",
       "domain_hint": "system-upgrade-engineer"
     },
     {
@@ -5785,7 +5785,7 @@
         133,
         143
       ],
-      "block_text": "### \u274c Mixing Signal Types in One Manifest\n\n**What it looks like**: A single Change Manifest combining release-note signals, user\ngoal-change statements, and retro signals without flagging their source.\n\n**Why wrong**: Each signal type has different urgency heuristics and different component\nscope. Mixing them without source labels causes the PLAN phase to assign wrong tiers.\n\n**Fix**: Separate into sections by signal type. Label each row with its source.\n\n---\n",
+      "block_text": "### ❌ Mixing Signal Types in One Manifest\n\n**What it looks like**: A single Change Manifest combining release-note signals, user\ngoal-change statements, and retro signals without flagging their source.\n\n**Why wrong**: Each signal type has different urgency heuristics and different component\nscope. Mixing them without source labels causes the PLAN phase to assign wrong tiers.\n\n**Fix**: Separate into sections by signal type. Label each row with its source.\n\n---\n",
       "domain_hint": "system-upgrade-engineer"
     },
     {
@@ -5803,7 +5803,7 @@
         1,
         7
       ],
-      "block_text": "# API Documentation Anti-Patterns\n\n> **Scope**: Detectable anti-patterns in API documentation \u2014 hallucinated params, untested examples, missing source verification. Does NOT cover style/structure standards (see `documentation-standards.md`).\n> **Version range**: REST APIs, OpenAPI 3.x, curl 7.x+\n> **Generated**: 2026-04-15\n\n---\n",
+      "block_text": "# API Documentation Anti-Patterns\n\n> **Scope**: Detectable anti-patterns in API documentation — hallucinated params, untested examples, missing source verification. Does NOT cover style/structure standards (see `documentation-standards.md`).\n> **Version range**: REST APIs, OpenAPI 3.x, curl 7.x+\n> **Generated**: 2026-04-15\n\n---\n",
       "domain_hint": "technical-documentation-engineer"
     },
     {
@@ -5893,7 +5893,7 @@
         106,
         128
       ],
-      "block_text": "### \u274c Vague Parameter Descriptions\n\n**Detection**:\n```bash\ngrep -n \"the [a-z]* to\\|value of\\|represents the\\|specifies the\" docs/**/*.md\nrg \"the \\w+ to use|value of the|this is the\" --glob \"*.md\"\n```\n\n**What it looks like**:\n```markdown\n| config | object | No | The config object to use |\n| data   | string | No | The data value |\n```\n\n**Why wrong**: \"The config object to use\" tells the reader nothing they couldn't infer from the parameter name. It's word-count theater. Readers need to know: what ...",
+      "block_text": "### ❌ Vague Parameter Descriptions\n\n**Detection**:\n```bash\ngrep -n \"the [a-z]* to\\|value of\\|represents the\\|specifies the\" docs/**/*.md\nrg \"the \\w+ to use|value of the|this is the\" --glob \"*.md\"\n```\n\n**What it looks like**:\n```markdown\n| config | object | No | The config object to use |\n| data   | string | No | The data value |\n```\n\n**Why wrong**: \"The config object to use\" tells the reader nothing they couldn't infer from the parameter name. It's word-count theater. Readers need to know: what ...",
       "domain_hint": "technical-documentation-engineer"
     },
     {
@@ -5902,7 +5902,7 @@
         130,
         156
       ],
-      "block_text": "### \u274c Missing Required/Optional Distinction\n\n**Detection**:\n```bash\ngrep -n \"| Parameter | Type | Description |\" docs/**/*.md\nrg \"\\| Parameter \\| Type \\| Description \\|\" --glob \"*.md\"\n```\n\n**What it looks like**:\n```markdown\n| Parameter | Type | Description |\n|-----------|------|-------------|\n| name      | string | Resource name |\n| config    | object | Configuration |\n```\n\n**Why wrong**: Reader cannot tell which parameters are mandatory without making a failed request. A missing `name` returns...",
+      "block_text": "### ❌ Missing Required/Optional Distinction\n\n**Detection**:\n```bash\ngrep -n \"| Parameter | Type | Description |\" docs/**/*.md\nrg \"\\| Parameter \\| Type \\| Description \\|\" --glob \"*.md\"\n```\n\n**What it looks like**:\n```markdown\n| Parameter | Type | Description |\n|-----------|------|-------------|\n| name      | string | Resource name |\n| config    | object | Configuration |\n```\n\n**Why wrong**: Reader cannot tell which parameters are mandatory without making a failed request. A missing `name` returns...",
       "domain_hint": "technical-documentation-engineer"
     },
     {
@@ -5911,7 +5911,7 @@
         158,
         176
       ],
-      "block_text": "### \u274c Prose Error Documentation\n\n**Detection**:\n```bash\ngrep -n \"returns.*400\\|returns.*401\\|returns.*500\\|will return an error\" docs/**/*.md\nrg \"returns? (a )?4\\d\\d|returns? (a )?5\\d\\d\" --glob \"*.md\"\n```\n\n**What it looks like**:\n```markdown\nThe endpoint will return a 400 error if the name is invalid, or a 500 error if there\nis an internal server error. Authentication failures result in a 401.\n```\n\n**Why wrong**: Prose error documentation cannot be scanned. The reader must parse English sentence...",
+      "block_text": "### ❌ Prose Error Documentation\n\n**Detection**:\n```bash\ngrep -n \"returns.*400\\|returns.*401\\|returns.*500\\|will return an error\" docs/**/*.md\nrg \"returns? (a )?4\\d\\d|returns? (a )?5\\d\\d\" --glob \"*.md\"\n```\n\n**What it looks like**:\n```markdown\nThe endpoint will return a 400 error if the name is invalid, or a 500 error if there\nis an internal server error. Authentication failures result in a 401.\n```\n\n**Why wrong**: Prose error documentation cannot be scanned. The reader must parse English sentence...",
       "domain_hint": "technical-documentation-engineer"
     },
     {
@@ -5920,7 +5920,7 @@
         178,
         199
       ],
-      "block_text": "### \u274c Undated Version Notes\n\n**Detection**:\n```bash\ngrep -n \"changed\\|deprecated\\|removed\\|added in\" docs/**/*.md | grep -v \"v[0-9]\\|[0-9]\\.[0-9]\"\nrg \"(changed|deprecated|removed|added) in\" --glob \"*.md\" | grep -v \"v\\d|\\d\\.\\d\"\n```\n\n**What it looks like**:\n```markdown\n> **Note:** The `legacy_mode` parameter was deprecated in a recent release.\n```\n\n**Why wrong**: \"Recent release\" becomes meaningless after time passes. Readers cannot determine if the deprecation applies to the version they're runni...",
+      "block_text": "### ❌ Undated Version Notes\n\n**Detection**:\n```bash\ngrep -n \"changed\\|deprecated\\|removed\\|added in\" docs/**/*.md | grep -v \"v[0-9]\\|[0-9]\\.[0-9]\"\nrg \"(changed|deprecated|removed|added) in\" --glob \"*.md\" | grep -v \"v\\d|\\d\\.\\d\"\n```\n\n**What it looks like**:\n```markdown\n> **Note:** The `legacy_mode` parameter was deprecated in a recent release.\n```\n\n**Why wrong**: \"Recent release\" becomes meaningless after time passes. Readers cannot determine if the deprecation applies to the version they're runni...",
       "domain_hint": "technical-documentation-engineer"
     },
     {
@@ -5938,7 +5938,7 @@
         147,
         156
       ],
-      "block_text": "### \u274c Vague Symptoms Section\n\n**Detection**:\n```bash\ngrep -n \"may\\|might\\|could\\|possibly\\|sometimes\" runbooks/**/*.md | grep -i \"symptom\\|alert\\|issue\"\nrg \"(may|might|could) (be|indicate|suggest|mean)\" --glob \"runbooks/**/*.md\"\n```\n\n**What it looks like**:\n```markdown",
+      "block_text": "### ❌ Vague Symptoms Section\n\n**Detection**:\n```bash\ngrep -n \"may\\|might\\|could\\|possibly\\|sometimes\" runbooks/**/*.md | grep -i \"symptom\\|alert\\|issue\"\nrg \"(may|might|could) (be|indicate|suggest|mean)\" --glob \"runbooks/**/*.md\"\n```\n\n**What it looks like**:\n```markdown",
       "domain_hint": "technical-documentation-engineer"
     },
     {
@@ -5947,7 +5947,7 @@
         157,
         165
       ],
-      "block_text": "## Symptoms\nThe service may be experiencing issues. Performance might degrade under load.\nUsers could see errors.\n```\n\n**Why wrong**: \"May be experiencing issues\" is a description of the alert condition, not the symptom. The oncall engineer is reading this because they got paged \u2014 they already know something is wrong. They need to know what specific signal confirms the diagnosis.\n\n**Fix**:\n```markdown",
+      "block_text": "## Symptoms\nThe service may be experiencing issues. Performance might degrade under load.\nUsers could see errors.\n```\n\n**Why wrong**: \"May be experiencing issues\" is a description of the alert condition, not the symptom. The oncall engineer is reading this because they got paged — they already know something is wrong. They need to know what specific signal confirms the diagnosis.\n\n**Fix**:\n```markdown",
       "domain_hint": "technical-documentation-engineer"
     },
     {
@@ -5974,7 +5974,7 @@
         220,
         230
       ],
-      "block_text": "### \u274c Escalation Section Without Contact Details\n\n**Detection**:\n```bash\ngrep -n \"escalate\\|contact\\|reach out\\|ask\" runbooks/**/*.md \\\n  | grep -v \"#[a-z]\\|@[a-z]\\|pagerduty\\|phone\\|email\"\nrg \"escalate to (the )?team|contact support\" --glob \"runbooks/**/*.md\"\n```\n\n**What it looks like**:\n```markdown",
+      "block_text": "### ❌ Escalation Section Without Contact Details\n\n**Detection**:\n```bash\ngrep -n \"escalate\\|contact\\|reach out\\|ask\" runbooks/**/*.md \\\n  | grep -v \"#[a-z]\\|@[a-z]\\|pagerduty\\|phone\\|email\"\nrg \"escalate to (the )?team|contact support\" --glob \"runbooks/**/*.md\"\n```\n\n**What it looks like**:\n```markdown",
       "domain_hint": "technical-documentation-engineer"
     },
     {
@@ -5983,7 +5983,7 @@
         231,
         239
       ],
-      "block_text": "## Escalation\n\nIf the issue persists, escalate to the platform team.\n```\n\n**Why wrong**: \"The platform team\" doesn't exist at 2am \u2014 specific people and channels do. Vague escalation paths cause delay while the oncall engineer asks \"who is the platform team?\"\n\n**Fix**:\n```markdown",
+      "block_text": "## Escalation\n\nIf the issue persists, escalate to the platform team.\n```\n\n**Why wrong**: \"The platform team\" doesn't exist at 2am — specific people and channels do. Vague escalation paths cause delay while the oncall engineer asks \"who is the platform team?\"\n\n**Fix**:\n```markdown",
       "domain_hint": "technical-documentation-engineer"
     },
     {
@@ -5992,7 +5992,7 @@
         257,
         267
       ],
-      "block_text": "# Deploy runbooks without rollback are a gap \u2014 flag manually\ngrep -l \"deploy\\|release\" runbooks/**/*.md \\\n  | xargs grep -L \"rollback\\|undo\\|revert\"\n```\n\n**What it looks like**: A deploy runbook with steps to apply a new version, but no section on what to do if the deploy breaks production.\n\n**Why wrong**: When a deploy causes a P0, the first question is \"how do we roll back?\" A missing rollback section means someone must figure this out under pressure without documentation.\n\n**Fix**: Every depl...",
+      "block_text": "# Deploy runbooks without rollback are a gap — flag manually\ngrep -l \"deploy\\|release\" runbooks/**/*.md \\\n  | xargs grep -L \"rollback\\|undo\\|revert\"\n```\n\n**What it looks like**: A deploy runbook with steps to apply a new version, but no section on what to do if the deploy breaks production.\n\n**Why wrong**: When a deploy causes a P0, the first question is \"how do we roll back?\" A missing rollback section means someone must figure this out under pressure without documentation.\n\n**Fix**: Every depl...",
       "domain_hint": "technical-documentation-engineer"
     },
     {
@@ -6019,7 +6019,7 @@
         131,
         137
       ],
-      "block_text": "### What Happens Next Will Surprise You\n```\n\n**Why wrong**: Clickbait headers delay information by making the reader read the section to find out what it covers. Descriptive headers function as navigation \u2014 the reader scans headers to find relevant sections.\n\n**Fix**:\n```markdown",
+      "block_text": "### What Happens Next Will Surprise You\n```\n\n**Why wrong**: Clickbait headers delay information by making the reader read the section to find out what it covers. Descriptive headers function as navigation — the reader scans headers to find relevant sections.\n\n**Fix**:\n```markdown",
       "domain_hint": "technical-journalist-writer"
     },
     {
@@ -6055,7 +6055,7 @@
         211,
         218
       ],
-      "block_text": "### What To Do\n```\n\n**Why wrong**: A section with one short paragraph is either padding (can be deleted) or incomplete (the idea wasn't developed). The journalist voice covers each point thoroughly or cuts it.\n\n**Fix**: Either develop the section with specific examples, data, or mechanisms \u2014 or remove the section header and fold the content into an adjacent paragraph.\n\n---\n",
+      "block_text": "### What To Do\n```\n\n**Why wrong**: A section with one short paragraph is either padding (can be deleted) or incomplete (the idea wasn't developed). The journalist voice covers each point thoroughly or cuts it.\n\n**Fix**: Either develop the section with specific examples, data, or mechanisms — or remove the section header and fold the content into an adjacent paragraph.\n\n---\n",
       "domain_hint": "technical-journalist-writer"
     },
     {
@@ -6073,7 +6073,7 @@
         103,
         122
       ],
-      "block_text": "# Numeric comparative claims (\"X times faster\", \"X% improvement\")\nrg '\\b[0-9]+ times (faster|slower|larger|smaller)\\b' article.md\n```\n\n**What it looks like**:\n```\nStudies show that 80% of developers prefer this approach. It's 3x faster\nthan the alternative in most workloads.\n```\n\n**Why wrong**: \"Studies show\" without a specific study is not a source \u2014 it's a rhetorical move. \"3x faster\" without a benchmark methodology is marketing language. Both patterns erode credibility when readers verify the...",
+      "block_text": "# Numeric comparative claims (\"X times faster\", \"X% improvement\")\nrg '\\b[0-9]+ times (faster|slower|larger|smaller)\\b' article.md\n```\n\n**What it looks like**:\n```\nStudies show that 80% of developers prefer this approach. It's 3x faster\nthan the alternative in most workloads.\n```\n\n**Why wrong**: \"Studies show\" without a specific study is not a source — it's a rhetorical move. \"3x faster\" without a benchmark methodology is marketing language. Both patterns erode credibility when readers verify the...",
       "domain_hint": "technical-journalist-writer"
     },
     {
@@ -6091,7 +6091,7 @@
         165,
         184
       ],
-      "block_text": "# \"When X was released/launched/introduced\" without year\nrg 'when .* (was released|launched|introduced|shipped)' article.md -i | grep -v '\\b(19|20)[0-9][0-9]\\b'\n```\n\n**What it looks like**:\n```\nWhen Kubernetes was first released, the networking model was much simpler.\nOriginally, services used flat networks without namespace isolation.\n```\n\n**Why wrong**: \"When Kubernetes was first released\" is vague \u2014 Kubernetes 1.0 shipped July 2015. Without the date, the reader can't evaluate how much the eco...",
+      "block_text": "# \"When X was released/launched/introduced\" without year\nrg 'when .* (was released|launched|introduced|shipped)' article.md -i | grep -v '\\b(19|20)[0-9][0-9]\\b'\n```\n\n**What it looks like**:\n```\nWhen Kubernetes was first released, the networking model was much simpler.\nOriginally, services used flat networks without namespace isolation.\n```\n\n**Why wrong**: \"When Kubernetes was first released\" is vague — Kubernetes 1.0 shipped July 2015. Without the date, the reader can't evaluate how much the eco...",
       "domain_hint": "technical-journalist-writer"
     },
     {
@@ -6100,7 +6100,7 @@
         193,
         215
       ],
-      "block_text": "# \"Widely adopted\", \"commonly used\", \"most teams\" \u2014 popularity claims need data\nrg '\\b(widely|commonly|most teams|most developers|industry standard|best practice)\\b' article.md -i\n```\n\n**What it looks like**:\n```\nPostgreSQL is more reliable than MySQL for write-heavy workloads.\nMost teams have moved away from monolithic architectures.\n```\n\n**Why wrong**: \"More reliable\" requires a specific reliability metric and measured workload. \"Most teams\" requires a survey. Without these, the claims are opi...",
+      "block_text": "# \"Widely adopted\", \"commonly used\", \"most teams\" — popularity claims need data\nrg '\\b(widely|commonly|most teams|most developers|industry standard|best practice)\\b' article.md -i\n```\n\n**What it looks like**:\n```\nPostgreSQL is more reliable than MySQL for write-heavy workloads.\nMost teams have moved away from monolithic architectures.\n```\n\n**Why wrong**: \"More reliable\" requires a specific reliability metric and measured workload. \"Most teams\" requires a survey. Without these, the claims are opi...",
       "domain_hint": "technical-journalist-writer"
     },
     {
@@ -6118,7 +6118,7 @@
         44,
         70
       ],
-      "block_text": "### \u274c Enthusiasm Markers\n\n**Detection**:\n```bash\nrg -i '\\b(amazing|incredible|revolutionary|powerful|elegant|game-changing|cutting-edge)\\b' --type md\n```\n\n**What it looks like**:\n```\nThe system is amazing! It elegantly leverages PostgreSQL's powerful MVCC capabilities\nto beautifully solve concurrency without compromising performance.\n```\n\n**Why wrong**: Enthusiasm adjectives make claims that can't be verified. \"Powerful\" compared to what? \"Elegantly\" by whose standard? These words add editoriali...",
+      "block_text": "### ❌ Enthusiasm Markers\n\n**Detection**:\n```bash\nrg -i '\\b(amazing|incredible|revolutionary|powerful|elegant|game-changing|cutting-edge)\\b' --type md\n```\n\n**What it looks like**:\n```\nThe system is amazing! It elegantly leverages PostgreSQL's powerful MVCC capabilities\nto beautifully solve concurrency without compromising performance.\n```\n\n**Why wrong**: Enthusiasm adjectives make claims that can't be verified. \"Powerful\" compared to what? \"Elegantly\" by whose standard? These words add editoriali...",
       "domain_hint": "technical-journalist-writer"
     },
     {
@@ -6127,7 +6127,7 @@
         72,
         95
       ],
-      "block_text": "### \u274c Persuasive Framing\n\n**Detection**:\n```bash\nrg -i '\\b(you should|you must|you need to|you will want to|trust me|make sure to|I recommend)\\b' --type md\n```\n\n**What it looks like**:\n```\nYou absolutely must write documentation! It's the single most important thing\nyou can do. Trust me, you'll thank yourself later.\n```\n\n**Why wrong**: The journalist voice informs, it doesn't prescribe. \"You must\" assumes authority over the reader's situation \u2014 which the author doesn't have. \"Trust me\" substitut...",
+      "block_text": "### ❌ Persuasive Framing\n\n**Detection**:\n```bash\nrg -i '\\b(you should|you must|you need to|you will want to|trust me|make sure to|I recommend)\\b' --type md\n```\n\n**What it looks like**:\n```\nYou absolutely must write documentation! It's the single most important thing\nyou can do. Trust me, you'll thank yourself later.\n```\n\n**Why wrong**: The journalist voice informs, it doesn't prescribe. \"You must\" assumes authority over the reader's situation — which the author doesn't have. \"Trust me\" substitut...",
       "domain_hint": "technical-journalist-writer"
     },
     {
@@ -6136,7 +6136,7 @@
         97,
         120
       ],
-      "block_text": "### \u274c Throat-Clearing Openers\n\n**Detection**:\n```bash\nrg -i '^(Have you ever|Did you know|In today|In this article|Welcome to|As we all know)' --type md\nrg '^[A-Z][^.!?]{10,60}\\?$' --type md -m 3  # Rhetorical question openers\n```\n\n**What it looks like**:\n```\nHave you ever wondered about the best way to handle database migrations?\nIt's a fascinating problem that many developers face! Let me share an\nexciting new approach...\n```\n\n**Why wrong**: The first sentence is the highest-value real estate ...",
+      "block_text": "### ❌ Throat-Clearing Openers\n\n**Detection**:\n```bash\nrg -i '^(Have you ever|Did you know|In today|In this article|Welcome to|As we all know)' --type md\nrg '^[A-Z][^.!?]{10,60}\\?$' --type md -m 3  # Rhetorical question openers\n```\n\n**What it looks like**:\n```\nHave you ever wondered about the best way to handle database migrations?\nIt's a fascinating problem that many developers face! Let me share an\nexciting new approach...\n```\n\n**Why wrong**: The first sentence is the highest-value real estate ...",
       "domain_hint": "technical-journalist-writer"
     },
     {
@@ -6145,7 +6145,7 @@
         122,
         144
       ],
-      "block_text": "### \u274c Condescending Explanations\n\n**Detection**:\n```bash\nrg -i \"\\b(as you (probably )?know|don't worry|let me explain|i'll break|for those who don't|in simple terms|step by step)\\b\" --type md\n```\n\n**What it looks like**:\n```\nAs you probably know, JWT stands for JSON Web Token. Don't worry if this\nsounds complicated \u2014 I'll break it down step by step!\n```\n\n**Why wrong**: The knowledgeable reader assumption means this audience knows JWT basics. Explaining them signals the author misjudged the audie...",
+      "block_text": "### ❌ Condescending Explanations\n\n**Detection**:\n```bash\nrg -i \"\\b(as you (probably )?know|don't worry|let me explain|i'll break|for those who don't|in simple terms|step by step)\\b\" --type md\n```\n\n**What it looks like**:\n```\nAs you probably know, JWT stands for JSON Web Token. Don't worry if this\nsounds complicated — I'll break it down step by step!\n```\n\n**Why wrong**: The knowledgeable reader assumption means this audience knows JWT basics. Explaining them signals the author misjudged the audie...",
       "domain_hint": "technical-journalist-writer"
     },
     {
@@ -6154,7 +6154,7 @@
         146,
         167
       ],
-      "block_text": "### \u274c Vague Abstractions\n\n**Detection**:\n```bash\nrg -i '\\b(appropriate(ly)?|proper(ly)?|correct(ly)?|graceful(ly)?|careful(ly)?|thorough(ly)?)\\b' --type md\n```\n\n**What it looks like**:\n```\nThe API has rate limiting. It returns an error when you make too many requests.\nYou should implement appropriate backoff strategies to handle this gracefully.\n```\n\n**Why wrong**: \"Appropriate\" and \"gracefully\" are placeholders for specific knowledge the author didn't provide. The reader needs the specific beha...",
+      "block_text": "### ❌ Vague Abstractions\n\n**Detection**:\n```bash\nrg -i '\\b(appropriate(ly)?|proper(ly)?|correct(ly)?|graceful(ly)?|careful(ly)?|thorough(ly)?)\\b' --type md\n```\n\n**What it looks like**:\n```\nThe API has rate limiting. It returns an error when you make too many requests.\nYou should implement appropriate backoff strategies to handle this gracefully.\n```\n\n**Why wrong**: \"Appropriate\" and \"gracefully\" are placeholders for specific knowledge the author didn't provide. The reader needs the specific beha...",
       "domain_hint": "technical-journalist-writer"
     },
     {
@@ -6199,7 +6199,7 @@
         145,
         180
       ],
-      "block_text": "### \u274c setTimeout / sleep Delays in Tests\n\n**Detection**:\n```bash\ngrep -rn 'setTimeout\\|waitForTimeout\\|new Promise.*sleep' --include=\"*.test.ts\" --include=\"*.test.tsx\" --include=\"*.spec.ts\"\nrg 'waitForTimeout|page\\.waitFor\\b' --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: arbitrary delay in RTL\nit('shows result after fetch', async () => {\n  render(<DataLoader />)\n  await new Promise(resolve => setTimeout(resolve, 500))  // hope it loaded\n  expect(screen.getByText(/result/i)).toBeIn...",
+      "block_text": "### ❌ setTimeout / sleep Delays in Tests\n\n**Detection**:\n```bash\ngrep -rn 'setTimeout\\|waitForTimeout\\|new Promise.*sleep' --include=\"*.test.ts\" --include=\"*.test.tsx\" --include=\"*.spec.ts\"\nrg 'waitForTimeout|page\\.waitFor\\b' --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: arbitrary delay in RTL\nit('shows result after fetch', async () => {\n  render(<DataLoader />)\n  await new Promise(resolve => setTimeout(resolve, 500))  // hope it loaded\n  expect(screen.getByText(/result/i)).toBeIn...",
       "domain_hint": "testing-automation-engineer"
     },
     {
@@ -6208,7 +6208,7 @@
         182,
         211
       ],
-      "block_text": "### \u274c Un-awaited userEvent Actions (RTL 14+)\n\n**Detection**:\n```bash\ngrep -rn 'user\\.' --include=\"*.test.ts\" --include=\"*.test.tsx\" | grep -v 'await user\\.\\|const user\\|let user'\nrg 'userEvent\\.(click|type|clear|selectOptions)\\(' --type tsx | grep -v 'await '\n```\n\n**What it looks like**:\n```typescript\n// BAD: missing await on user actions (RTL 14+ requires await)\nconst user = userEvent.setup()\nuser.click(button)         // fire-and-forget\nuser.type(input, 'hello')\nexpect(screen.getByText(/hello/...",
+      "block_text": "### ❌ Un-awaited userEvent Actions (RTL 14+)\n\n**Detection**:\n```bash\ngrep -rn 'user\\.' --include=\"*.test.ts\" --include=\"*.test.tsx\" | grep -v 'await user\\.\\|const user\\|let user'\nrg 'userEvent\\.(click|type|clear|selectOptions)\\(' --type tsx | grep -v 'await '\n```\n\n**What it looks like**:\n```typescript\n// BAD: missing await on user actions (RTL 14+ requires await)\nconst user = userEvent.setup()\nuser.click(button)         // fire-and-forget\nuser.type(input, 'hello')\nexpect(screen.getByText(/hello/...",
       "domain_hint": "testing-automation-engineer"
     },
     {
@@ -6217,7 +6217,7 @@
         213,
         234
       ],
-      "block_text": "### \u274c getBy* After Async Operations\n\n**Detection**:\n```bash\nrg 'await user\\.(click|submit|type)' --type ts -A1 | grep 'getBy'\n```\n\n**What it looks like**:\n```typescript\nawait user.click(screen.getByRole('button', { name: /save/i }))\nexpect(screen.getByText(/saved/i)).toBeInTheDocument()  // may not exist yet\n```\n\n**Why wrong**: `user.click` resolves after the event dispatches, not after React re-renders from async work (API calls, state transitions). The `getByText` assertion runs synchronously ...",
+      "block_text": "### ❌ getBy* After Async Operations\n\n**Detection**:\n```bash\nrg 'await user\\.(click|submit|type)' --type ts -A1 | grep 'getBy'\n```\n\n**What it looks like**:\n```typescript\nawait user.click(screen.getByRole('button', { name: /save/i }))\nexpect(screen.getByText(/saved/i)).toBeInTheDocument()  // may not exist yet\n```\n\n**Why wrong**: `user.click` resolves after the event dispatches, not after React re-renders from async work (API calls, state transitions). The `getByText` assertion runs synchronously ...",
       "domain_hint": "testing-automation-engineer"
     },
     {
@@ -6226,7 +6226,7 @@
         236,
         257
       ],
-      "block_text": "### \u274c MSW Without onUnhandledRequest: 'error'\n\n**Detection**:\n```bash\ngrep -rn 'server\\.listen' --include=\"*.ts\" --include=\"*.tsx\" | grep -v 'onUnhandledRequest'\nrg 'setupServer' --type ts -l | xargs rg -L 'onUnhandledRequest'\n```\n\n**What it looks like**:\n```typescript\nserver.listen()  // no onUnhandledRequest \u2014 silent network failures\n```\n\n**Why wrong**: When a component makes an unexpected API call (wrong path, URL typo), MSW passes it through or returns undefined without failing the test. The...",
+      "block_text": "### ❌ MSW Without onUnhandledRequest: 'error'\n\n**Detection**:\n```bash\ngrep -rn 'server\\.listen' --include=\"*.ts\" --include=\"*.tsx\" | grep -v 'onUnhandledRequest'\nrg 'setupServer' --type ts -l | xargs rg -L 'onUnhandledRequest'\n```\n\n**What it looks like**:\n```typescript\nserver.listen()  // no onUnhandledRequest — silent network failures\n```\n\n**Why wrong**: When a component makes an unexpected API call (wrong path, URL typo), MSW passes it through or returns undefined without failing the test. The...",
       "domain_hint": "testing-automation-engineer"
     },
     {
@@ -6271,7 +6271,7 @@
         239,
         268
       ],
-      "block_text": "### \u274c Mocking console.error to Suppress All Warnings\n\n**Detection**:\n```bash\ngrep -rn 'spyOn.*console.*error\\|mock.*console\\.error' --include=\"*.test.ts\" --include=\"*.test.tsx\"\nrg 'console\\.error.*mockImplementation\\(\\s*\\)' --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: blanket suppression hides real problems\nbeforeAll(() => {\n  vi.spyOn(console, 'error').mockImplementation(() => {})\n})\n```\n\n**Why wrong**: This suppresses all React prop-type warnings, act() warnings, and real error...",
+      "block_text": "### ❌ Mocking console.error to Suppress All Warnings\n\n**Detection**:\n```bash\ngrep -rn 'spyOn.*console.*error\\|mock.*console\\.error' --include=\"*.test.ts\" --include=\"*.test.tsx\"\nrg 'console\\.error.*mockImplementation\\(\\s*\\)' --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: blanket suppression hides real problems\nbeforeAll(() => {\n  vi.spyOn(console, 'error').mockImplementation(() => {})\n})\n```\n\n**Why wrong**: This suppresses all React prop-type warnings, act() warnings, and real error...",
       "domain_hint": "testing-automation-engineer"
     },
     {
@@ -6289,7 +6289,7 @@
         137,
         165
       ],
-      "block_text": "### \u274c Using jest.mock() or jest.fn() in Vitest files\n\n**Detection**:\n```bash\ngrep -rn 'jest\\.mock\\|jest\\.fn\\|jest\\.spyOn' --include=\"*.test.ts\" --include=\"*.test.tsx\" --include=\"*.spec.ts\"\nrg 'jest\\.(mock|fn|spyOn|clearAllMocks|resetAllMocks)' --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: jest.fn() is undefined in Vitest\nconst mockFn = jest.fn()\njest.mock('../utils')\njest.spyOn(console, 'error')\n```\n\n**Why wrong**: Vitest does not polyfill the `jest` global by default. These calls...",
+      "block_text": "### ❌ Using jest.mock() or jest.fn() in Vitest files\n\n**Detection**:\n```bash\ngrep -rn 'jest\\.mock\\|jest\\.fn\\|jest\\.spyOn' --include=\"*.test.ts\" --include=\"*.test.tsx\" --include=\"*.spec.ts\"\nrg 'jest\\.(mock|fn|spyOn|clearAllMocks|resetAllMocks)' --type ts\n```\n\n**What it looks like**:\n```typescript\n// BAD: jest.fn() is undefined in Vitest\nconst mockFn = jest.fn()\njest.mock('../utils')\njest.spyOn(console, 'error')\n```\n\n**Why wrong**: Vitest does not polyfill the `jest` global by default. These calls...",
       "domain_hint": "testing-automation-engineer"
     },
     {
@@ -6298,7 +6298,7 @@
         167,
         198
       ],
-      "block_text": "### \u274c Missing vi.restoreAllMocks() \u2014 Spy Leak Between Tests\n\n**Detection**:\n```bash\ngrep -rn 'vi\\.spyOn' --include=\"*.test.ts\" --include=\"*.test.tsx\" -l | xargs grep -L 'restoreAllMocks\\|resetAllMocks'\nrg 'vi\\.spyOn' --type ts -l | xargs rg -l 'restoreAllMocks' --files-without-match\n```\n\n**What it looks like**:\n```typescript\ndescribe('Suite A', () => {\n  it('mocks fetch', () => {\n    vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))\n    // NO afterEach/vi.restoreAllMocks()\n  })\n})\n...",
+      "block_text": "### ❌ Missing vi.restoreAllMocks() — Spy Leak Between Tests\n\n**Detection**:\n```bash\ngrep -rn 'vi\\.spyOn' --include=\"*.test.ts\" --include=\"*.test.tsx\" -l | xargs grep -L 'restoreAllMocks\\|resetAllMocks'\nrg 'vi\\.spyOn' --type ts -l | xargs rg -l 'restoreAllMocks' --files-without-match\n```\n\n**What it looks like**:\n```typescript\ndescribe('Suite A', () => {\n  it('mocks fetch', () => {\n    vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))\n    // NO afterEach/vi.restoreAllMocks()\n  })\n})\n...",
       "domain_hint": "testing-automation-engineer"
     },
     {
@@ -6307,7 +6307,7 @@
         200,
         223
       ],
-      "block_text": "### \u274c No Branch Coverage Threshold\n\n**Detection**:\n```bash\ngrep -rn 'thresholds' vitest.config.ts vitest.config.js\nrg 'thresholds' vitest.config.ts | grep -v branches\n```\n\n**What it looks like**:\n```typescript\ncoverage: {\n  thresholds: {\n    lines: 80,\n    functions: 80,\n    // branches MISSING \u2014 silently passes with 0% branch coverage\n  }\n}\n```\n\n**Why wrong**: A function with `if (user.isAdmin)` tested only with admin users shows 100% line coverage but 0% branch coverage. The non-admin code pat...",
+      "block_text": "### ❌ No Branch Coverage Threshold\n\n**Detection**:\n```bash\ngrep -rn 'thresholds' vitest.config.ts vitest.config.js\nrg 'thresholds' vitest.config.ts | grep -v branches\n```\n\n**What it looks like**:\n```typescript\ncoverage: {\n  thresholds: {\n    lines: 80,\n    functions: 80,\n    // branches MISSING — silently passes with 0% branch coverage\n  }\n}\n```\n\n**Why wrong**: A function with `if (user.isAdmin)` tested only with admin users shows 100% line coverage but 0% branch coverage. The non-admin code pat...",
       "domain_hint": "testing-automation-engineer"
     },
     {
@@ -6334,7 +6334,7 @@
         135,
         142
       ],
-      "block_text": "# (no Accepted state, no Validation Criteria section)\n```\n\n**Why wrong**: Skipping `Accepted` means the decision was never formally reviewed and alternatives were never documented. `Implemented` status becomes meaningless \u2014 it cannot be distinguished from \"I started writing code\" versus \"all criteria verified.\"\n\n**Fix**: Add an `Accepted` block with alternatives and validation criteria, then re-evaluate whether `Implemented` is truly warranted.\n\n---\n",
+      "block_text": "# (no Accepted state, no Validation Criteria section)\n```\n\n**Why wrong**: Skipping `Accepted` means the decision was never formally reviewed and alternatives were never documented. `Implemented` status becomes meaningless — it cannot be distinguished from \"I started writing code\" versus \"all criteria verified.\"\n\n**Fix**: Add an `Accepted` block with alternatives and validation criteria, then re-evaluate whether `Implemented` is truly warranted.\n\n---\n",
       "domain_hint": "toolkit-governance-engineer"
     },
     {
@@ -6352,7 +6352,7 @@
         176,
         181
       ],
-      "block_text": "# Alternative: find Proposed/Accepted/Implemented lines missing date pattern\ngrep -rn \"^Proposed\\|^Accepted\\|^Implemented\\|^Superseded\\|^Rejected\" adr/*.md | grep -v \" \u2014 20[0-9][0-9]-\"\n```\n\n**What it looks like**:\n```markdown",
+      "block_text": "# Alternative: find Proposed/Accepted/Implemented lines missing date pattern\ngrep -rn \"^Proposed\\|^Accepted\\|^Implemented\\|^Superseded\\|^Rejected\" adr/*.md | grep -v \" — 20[0-9][0-9]-\"\n```\n\n**What it looks like**:\n```markdown",
       "domain_hint": "toolkit-governance-engineer"
     },
     {
@@ -6361,7 +6361,7 @@
         182,
         190
       ],
-      "block_text": "## Status\nImplemented\n```\n\n**Why wrong**: `scripts/adr-status.py` parses the date from the status line to compute age and detect stale proposals. Missing dates silently break age-based reporting and make the audit trail unreliable.\n\n**Fix**: Always append ` \u2014 YYYY-MM-DD` to every status line.\n\n---\n",
+      "block_text": "## Status\nImplemented\n```\n\n**Why wrong**: `scripts/adr-status.py` parses the date from the status line to compute age and detect stale proposals. Missing dates silently break age-based reporting and make the audit trail unreliable.\n\n**Fix**: Always append ` — YYYY-MM-DD` to every status line.\n\n---\n",
       "domain_hint": "toolkit-governance-engineer"
     },
     {
@@ -6370,7 +6370,7 @@
         192,
         198
       ],
-      "block_text": "### \u274c Validation Criteria Written After Marking Implemented\n\n**What it looks like**:\nCriteria written in future tense (\"will verify\", \"should check\") or added to the ADR after the `Implemented` date stamp.\n\n**Detection**:\n```bash",
+      "block_text": "### ❌ Validation Criteria Written After Marking Implemented\n\n**What it looks like**:\nCriteria written in future tense (\"will verify\", \"should check\") or added to the ADR after the `Implemented` date stamp.\n\n**Detection**:\n```bash",
       "domain_hint": "toolkit-governance-engineer"
     },
     {
@@ -6397,7 +6397,7 @@
         95,
         112
       ],
-      "block_text": "### \u274c Missing `allowed-tools` in Agent Frontmatter\n\n**Detection**:\n```bash\ngrep -rL \"allowed-tools\" agents/*.md\nrg -L 'allowed-tools' --glob 'agents/*.md'\n```\n\n**What it looks like**:\n```yaml\n---\nname: my-agent\nmodel: sonnet\ndescription: \"Does something\"\nrouting:\n  triggers: [do thing]\n  complexity: Medium\n  category: engineering",
+      "block_text": "### ❌ Missing `allowed-tools` in Agent Frontmatter\n\n**Detection**:\n```bash\ngrep -rL \"allowed-tools\" agents/*.md\nrg -L 'allowed-tools' --glob 'agents/*.md'\n```\n\n**What it looks like**:\n```yaml\n---\nname: my-agent\nmodel: sonnet\ndescription: \"Does something\"\nrouting:\n  triggers: [do thing]\n  complexity: Medium\n  category: engineering",
       "domain_hint": "toolkit-governance-engineer"
     },
     {
@@ -6406,7 +6406,7 @@
         113,
         121
       ],
-      "block_text": "# allowed-tools: missing entirely\n---\n```\n\n**Why wrong**: Without `allowed-tools`, the agent inherits an undefined tool set. Behavior varies by runtime \u2014 some runtimes grant all tools (dangerous), others grant none (agent cannot function).\n\n**Fix**: Add `allowed-tools` matching the agent's role type per the Tool Restrictions table above.\n\n---\n",
+      "block_text": "# allowed-tools: missing entirely\n---\n```\n\n**Why wrong**: Without `allowed-tools`, the agent inherits an undefined tool set. Behavior varies by runtime — some runtimes grant all tools (dangerous), others grant none (agent cannot function).\n\n**Fix**: Add `allowed-tools` matching the agent's role type per the Tool Restrictions table above.\n\n---\n",
       "domain_hint": "toolkit-governance-engineer"
     },
     {
@@ -6415,7 +6415,7 @@
         123,
         143
       ],
-      "block_text": "### \u274c Unquoted Description with Colon\n\n**Detection**:\n```bash\ngrep -n \"^description: [^\\\"'].*:\" agents/*.md\ngrep -n \"^description: [^\\\"'].*:\" skills/*/SKILL.md\n```\n\n**What it looks like**:\n```yaml\ndescription: Toolkit governance: edit skills, update routing  # YAML parse error\n```\n\n**Why wrong**: The YAML parser sees `Toolkit governance` as the value and `edit skills` as an unknown key, producing a parse error. The component becomes invisible to the routing system.\n\n**Fix**:\n```yaml\ndescription:...",
+      "block_text": "### ❌ Unquoted Description with Colon\n\n**Detection**:\n```bash\ngrep -n \"^description: [^\\\"'].*:\" agents/*.md\ngrep -n \"^description: [^\\\"'].*:\" skills/*/SKILL.md\n```\n\n**What it looks like**:\n```yaml\ndescription: Toolkit governance: edit skills, update routing  # YAML parse error\n```\n\n**Why wrong**: The YAML parser sees `Toolkit governance` as the value and `edit skills` as an unknown key, producing a parse error. The component becomes invisible to the routing system.\n\n**Fix**:\n```yaml\ndescription:...",
       "domain_hint": "toolkit-governance-engineer"
     },
     {
@@ -6424,7 +6424,7 @@
         145,
         163
       ],
-      "block_text": "### \u274c Wrong Complexity Casing\n\n**Detection**:\n```bash\ngrep -rn \"complexity:\" agents/*.md skills/*/SKILL.md | grep -vE \"complexity: (Low|Medium|High)\"\n```\n\n**What it looks like**:\n```yaml\nrouting:\n  complexity: moderate  # wrong casing\n  complexity: medium    # wrong casing \u2014 must be capitalized\n```\n\n**Why wrong**: Complexity matching is case-sensitive. `medium` does not match `Medium` \u2014 the router silently assigns a default.\n\n**Fix**: Use exactly `Low`, `Medium`, or `High`.\n\n---\n",
+      "block_text": "### ❌ Wrong Complexity Casing\n\n**Detection**:\n```bash\ngrep -rn \"complexity:\" agents/*.md skills/*/SKILL.md | grep -vE \"complexity: (Low|Medium|High)\"\n```\n\n**What it looks like**:\n```yaml\nrouting:\n  complexity: moderate  # wrong casing\n  complexity: medium    # wrong casing — must be capitalized\n```\n\n**Why wrong**: Complexity matching is case-sensitive. `medium` does not match `Medium` — the router silently assigns a default.\n\n**Fix**: Use exactly `Low`, `Medium`, or `High`.\n\n---\n",
       "domain_hint": "toolkit-governance-engineer"
     },
     {
@@ -6433,7 +6433,7 @@
         165,
         185
       ],
-      "block_text": "### \u274c Reviewer Agent with Write/Edit Tools (ADR-063 Violation)\n\n**Detection**:\n```bash\ngrep -l \"reviewer\" agents/*.md | xargs grep -l \"Edit\\|Write\"\n```\n\n**What it looks like**:\n```yaml\nname: reviewer-code-quality\nallowed-tools:\n  - Read\n  - Edit    # violation: reviewers should not modify files\n  - Grep\n```\n\n**Why wrong**: Reviewer agents with write access can modify files during review passes, creating unintended side-effects. ADR-063 requires reviewers to be read-only.\n\n**Fix**: Remove `Edit` ...",
+      "block_text": "### ❌ Reviewer Agent with Write/Edit Tools (ADR-063 Violation)\n\n**Detection**:\n```bash\ngrep -l \"reviewer\" agents/*.md | xargs grep -l \"Edit\\|Write\"\n```\n\n**What it looks like**:\n```yaml\nname: reviewer-code-quality\nallowed-tools:\n  - Read\n  - Edit    # violation: reviewers should not modify files\n  - Grep\n```\n\n**Why wrong**: Reviewer agents with write access can modify files during review passes, creating unintended side-effects. ADR-063 requires reviewers to be read-only.\n\n**Fix**: Remove `Edit` ...",
       "domain_hint": "toolkit-governance-engineer"
     },
     {
@@ -6442,7 +6442,7 @@
         187,
         202
       ],
-      "block_text": "### \u274c Pre-Production Version on Stable Agent\n\n**Detection**:\n```bash\ngrep -rn \"^version: 0\\.\" agents/*.md\n```\n\n**What it looks like**:\n```yaml\n```\n\n**Why wrong**: Agents in active production use should be at `1.x.x` or higher. `0.x.x` affects coverage reporting confidence scores.\n\n**Fix**: Bump to `version: 1.0.0` once the agent is in stable use.\n\n---\n",
+      "block_text": "### ❌ Pre-Production Version on Stable Agent\n\n**Detection**:\n```bash\ngrep -rn \"^version: 0\\.\" agents/*.md\n```\n\n**What it looks like**:\n```yaml\n```\n\n**Why wrong**: Agents in active production use should be at `1.x.x` or higher. `0.x.x` affects coverage reporting confidence scores.\n\n**Fix**: Bump to `version: 1.0.0` once the agent is in stable use.\n\n---\n",
       "domain_hint": "toolkit-governance-engineer"
     },
     {
@@ -6469,7 +6469,7 @@
         197,
         205
       ],
-      "block_text": "### \u274c Using `sys.stdin.isatty()` to Detect Session Type\n\n**Detection**:\n```bash\ngrep -rn \"stdin.isatty\\|stdout.isatty\" ~/.claude/hooks/*.py\n```\n\n**What it looks like**:\n```python",
+      "block_text": "### ❌ Using `sys.stdin.isatty()` to Detect Session Type\n\n**Detection**:\n```bash\ngrep -rn \"stdin.isatty\\|stdout.isatty\" ~/.claude/hooks/*.py\n```\n\n**What it looks like**:\n```python",
       "domain_hint": "toolkit-governance-engineer"
     },
     {
@@ -6478,7 +6478,7 @@
         206,
         223
       ],
-      "block_text": "# In a hook \u2014 WRONG\nif sys.stdin.isatty():\n    print(\"Interactive session\")\nelse:\n    print(\"Non-interactive \u2014 activating AFK mode\")\n```\n\n**Why wrong**: Claude Code pipes stdin (the event JSON) into hooks and captures stdout (the hook output). Both are always non-TTY in hook context, so `isatty()` always returns False \u2014 every session is classified as non-interactive regardless of actual session type.\n\n**Fix**: Detect session type via environment variables instead.\n```python\nimport os\nis_ssh = bo...",
+      "block_text": "# In a hook — WRONG\nif sys.stdin.isatty():\n    print(\"Interactive session\")\nelse:\n    print(\"Non-interactive — activating AFK mode\")\n```\n\n**Why wrong**: Claude Code pipes stdin (the event JSON) into hooks and captures stdout (the hook output). Both are always non-TTY in hook context, so `isatty()` always returns False — every session is classified as non-interactive regardless of actual session type.\n\n**Fix**: Detect session type via environment variables instead.\n```python\nimport os\nis_ssh = bo...",
       "domain_hint": "toolkit-governance-engineer"
     },
     {
@@ -6586,7 +6586,7 @@
         185,
         225
       ],
-      "block_text": "# If exit prop exists but no AnimatePresence in the same file, that's the bug\ngrep -rn \"exit={{\" --include=\"*.tsx\" | xargs grep -L \"AnimatePresence\"\n```\n\n**What it looks like**:\n```tsx\n// WRONG: exit prop present but AnimatePresence is absent \u2014 exit never runs\n{isOpen && (\n  <motion.div\n    initial={{ opacity: 0 }}\n    animate={{ opacity: 1 }}\n    exit={{ opacity: 0 }}  // silently ignored\n  >\n    Modal content\n  </motion.div>\n)}\n```\n\n**Why wrong**: React unmounts the component synchronously whe...",
+      "block_text": "# If exit prop exists but no AnimatePresence in the same file, that's the bug\ngrep -rn \"exit={{\" --include=\"*.tsx\" | xargs grep -L \"AnimatePresence\"\n```\n\n**What it looks like**:\n```tsx\n// WRONG: exit prop present but AnimatePresence is absent — exit never runs\n{isOpen && (\n  <motion.div\n    initial={{ opacity: 0 }}\n    animate={{ opacity: 1 }}\n    exit={{ opacity: 0 }}  // silently ignored\n  >\n    Modal content\n  </motion.div>\n)}\n```\n\n**Why wrong**: React unmounts the component synchronously whe...",
       "domain_hint": "ui-design-engineer"
     },
     {
@@ -6595,7 +6595,7 @@
         233,
         279
       ],
-      "block_text": "# Or with rg\nrg \"motion\\.\" --type tsx -c | awk -F: '$2 > 6'\n```\n\n**What it looks like**:\n```tsx\n// WRONG: Every element has entrance animation \u2014 hierarchy collapses into noise\n<motion.nav initial={{ y: -20 }} animate={{ y: 0 }}>\n  <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>\n    <motion.ul initial={{ x: -10 }} animate={{ x: 0 }}>\n      {items.map(item => (\n        <motion.li key={item.id} whileHover={{ scale: 1.05 }}>\n          <motion.span initial={{ opacity: 0 }} animate={{ o...",
+      "block_text": "# Or with rg\nrg \"motion\\.\" --type tsx -c | awk -F: '$2 > 6'\n```\n\n**What it looks like**:\n```tsx\n// WRONG: Every element has entrance animation — hierarchy collapses into noise\n<motion.nav initial={{ y: -20 }} animate={{ y: 0 }}>\n  <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>\n    <motion.ul initial={{ x: -10 }} animate={{ x: 0 }}>\n      {items.map(item => (\n        <motion.li key={item.id} whileHover={{ scale: 1.05 }}>\n          <motion.span initial={{ opacity: 0 }} animate={{ o...",
       "domain_hint": "ui-design-engineer"
     },
     {
@@ -6613,7 +6613,7 @@
         1,
         10
       ],
-      "block_text": "# Tailwind CSS Anti-Patterns Reference\n<!-- Loaded by ui-design-engineer when task involves Tailwind configuration, class composition, theme customization, or build-time CSS issues -->\n\n> **Scope**: Tailwind-specific pitfalls that cause style breakage, build bloat, or maintenance debt. Does not cover general CSS anti-patterns.\n> **Version range**: Tailwind CSS v3.0+\n> **Generated**: 2026-04-15 \u2014 verify against current Tailwind v3/v4 release notes\n\nTailwind's utility-first model creates a specifi...",
+      "block_text": "# Tailwind CSS Anti-Patterns Reference\n<!-- Loaded by ui-design-engineer when task involves Tailwind configuration, class composition, theme customization, or build-time CSS issues -->\n\n> **Scope**: Tailwind-specific pitfalls that cause style breakage, build bloat, or maintenance debt. Does not cover general CSS anti-patterns.\n> **Version range**: Tailwind CSS v3.0+\n> **Generated**: 2026-04-15 — verify against current Tailwind v3/v4 release notes\n\nTailwind's utility-first model creates a specifi...",
       "domain_hint": "ui-design-engineer"
     },
     {
@@ -6640,7 +6640,7 @@
         62,
         97
       ],
-      "block_text": "# Count @apply lines per file \u2014 flag files with >8 occurrences\ngrep -c \"@apply\" src/**/*.css 2>/dev/null | awk -F: '$2 > 8 {print $1\": \"$2\" @apply lines\"}'\n```\n\n**What it looks like**:\n```css\n/* WRONG: Recreating component abstractions in CSS using @apply */\n.card {\n  @apply bg-white rounded-lg shadow-md p-6 border border-gray-200\n         hover:shadow-lg transition-shadow duration-200\n         dark:bg-gray-800 dark:border-gray-700;\n}\n```\n\n**Why wrong**: `@apply` re-couples design to CSS files, ...",
+      "block_text": "# Count @apply lines per file — flag files with >8 occurrences\ngrep -c \"@apply\" src/**/*.css 2>/dev/null | awk -F: '$2 > 8 {print $1\": \"$2\" @apply lines\"}'\n```\n\n**What it looks like**:\n```css\n/* WRONG: Recreating component abstractions in CSS using @apply */\n.card {\n  @apply bg-white rounded-lg shadow-md p-6 border border-gray-200\n         hover:shadow-lg transition-shadow duration-200\n         dark:bg-gray-800 dark:border-gray-700;\n}\n```\n\n**Why wrong**: `@apply` re-couples design to CSS files, ...",
       "domain_hint": "ui-design-engineer"
     },
     {
@@ -6649,7 +6649,7 @@
         105,
         137
       ],
-      "block_text": "# Lines with larger breakpoint before smaller on the same property\nrg 'lg:\\S+\\s+sm:\\S+' --type tsx\n```\n\n**What it looks like**:\n```tsx\n// WRONG: Starting with desktop size, patching down to mobile\n<h1 className=\"text-4xl sm:text-2xl md:text-xl\">\n  {/* mobile gets text-4xl (the bare class), sm gets text-2xl \u2014 opposite of intent */}\n</h1>\n\n// Also wrong: bare class after responsive prefix (bare always applies at all widths)\n<div className=\"sm:flex block\">\n  {/* block applies at ALL widths, sm:flex...",
+      "block_text": "# Lines with larger breakpoint before smaller on the same property\nrg 'lg:\\S+\\s+sm:\\S+' --type tsx\n```\n\n**What it looks like**:\n```tsx\n// WRONG: Starting with desktop size, patching down to mobile\n<h1 className=\"text-4xl sm:text-2xl md:text-xl\">\n  {/* mobile gets text-4xl (the bare class), sm gets text-2xl — opposite of intent */}\n</h1>\n\n// Also wrong: bare class after responsive prefix (bare always applies at all widths)\n<div className=\"sm:flex block\">\n  {/* block applies at ALL widths, sm:flex...",
       "domain_hint": "ui-design-engineer"
     },
     {

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -60,6 +60,8 @@ Three mechanisms enforce this:
 
 **Memory corollary:** if it can be re-derived from a source of truth, do not save it to memory. Git log, the file system, and running queries are always available. Memory should capture what cannot be derived: feedback about working style, project context that lives outside the codebase, references to external systems the model cannot introspect. Saving derivable facts to memory turns it into a noisy cache that drifts out of sync with reality. Save human judgment, not machine-readable state.
 
+**Auto-memory is disabled in this repo** (`.claude/settings.json` sets `autoMemoryEnabled: false`). Claude Code's auto-memory feature surfaces an index of session-level fragments (feedback snippets, parallel project names, insight entries) at the top of every conversation. That index is useful as a lookup target but wrong as a constant context injection: it loads granular state at the wrong level of abstraction, on every turn, regardless of task relevance. The toolkit already has better homes for each fragment type. User feedback belongs in hooks and skill instructions where it becomes an enforced rule rather than a reminder. Project state lives in `adr/`, the codebase itself, and git history. Session insights belong in `learning.db`, where retro-knowledge injection can surface only the entries relevant to the current task. Loading all of it every turn violates the progressive context principle this toolkit is built on. Off by default, retrieved on demand.
+
 ## Tokens Are Expensive, Use Progressive Context
 
 Spending tokens on the right context ensures correctness. Spending tokens on unfocused context adds cost without improving quality.

--- a/scripts/strip-phantom-name-frontmatter.py
+++ b/scripts/strip-phantom-name-frontmatter.py
@@ -29,10 +29,37 @@ Safety
   modified file aborts the run with a non-zero exit code.
 - Files with no ``name:`` field are never touched.
 
+Verified-safe mode
+==================
+The default audit is conservative: any substring match in the routing table
+or a pipeline JSON is treated as a dispatch dependency and the file is
+skipped. A prior investigation showed that for the 29 files under
+``skills/workflow/references/*.md`` plus
+``skills/kotlin-coroutines/references/anti-patterns.md``, the substring
+matches are false positives for dispatch purposes:
+
+1. The pipeline dispatcher in ``scripts/index-router.py`` keys on JSON keys
+   from ``skills/workflow/references/pipeline-index.json`` and on file paths,
+   not on the YAML ``name:`` field inside the reference files themselves.
+2. The only script that reads the YAML ``name:`` field is
+   ``scripts/generate-pipeline-catalog.py``. When ``name`` is absent it
+   falls back to ``skill_file.stem`` (line using ``frontmatter.get("name",
+   skill_file.stem)``), which produces the same string for these files
+   because the YAML name already matches the filename stem.
+3. Hits against the routing table are on prose descriptions of routed
+   *skills*, not on the reference-file umbrella entries.
+
+The ``--verified-safe`` flag enables an allowlist of these 29 paths so the
+strip proceeds on them. The proof of no behavioral change is a
+byte-identical ``skills/workflow/references/auto-pipeline/references/pipeline-catalog.json``
+before and after the strip. Always regenerate and diff that file when
+running with ``--verified-safe``.
+
 Usage
 =====
-    python3 scripts/strip-phantom-name-frontmatter.py            # apply edits
-    python3 scripts/strip-phantom-name-frontmatter.py --dry-run  # inventory only
+    python3 scripts/strip-phantom-name-frontmatter.py                    # default audit
+    python3 scripts/strip-phantom-name-frontmatter.py --dry-run          # inventory only
+    python3 scripts/strip-phantom-name-frontmatter.py --verified-safe    # allowlist mode
 
 Rollback
 ========
@@ -64,6 +91,48 @@ AGENT_REF_GLOB = "agents/*/references/*.md"
 SKILL_REF_GLOB = "skills/*/references/*.md"
 
 ROUTING_TABLE = REPO_ROOT / "skills" / "do" / "references" / "routing-tables.md"
+
+
+# Verified-safe allowlist. These files were flagged by the conservative
+# audit as potentially routed, but investigation showed the matches are
+# false positives: dispatch is JSON-keyed (see scripts/index-router.py)
+# and scripts/generate-pipeline-catalog.py has a skill_file.stem fallback
+# that reproduces the same string after name: is removed. The proof of
+# no behavioral change is a byte-identical pipeline-catalog.json before
+# and after running with --verified-safe.
+VERIFIED_SAFE_PATHS: frozenset[str] = frozenset(
+    {
+        "skills/kotlin-coroutines/references/anti-patterns.md",
+        "skills/workflow/references/agent-upgrade.md",
+        "skills/workflow/references/article-evaluation-pipeline.md",
+        "skills/workflow/references/auto-pipeline.md",
+        "skills/workflow/references/chain-composer.md",
+        "skills/workflow/references/comprehensive-review.md",
+        "skills/workflow/references/de-ai-pipeline.md",
+        "skills/workflow/references/do-perspectives.md",
+        "skills/workflow/references/doc-pipeline.md",
+        "skills/workflow/references/domain-research.md",
+        "skills/workflow/references/explore-pipeline.md",
+        "skills/workflow/references/github-profile-rules.md",
+        "skills/workflow/references/hook-development-pipeline.md",
+        "skills/workflow/references/mcp-pipeline-builder.md",
+        "skills/workflow/references/perses-dac-pipeline.md",
+        "skills/workflow/references/perses-plugin-pipeline.md",
+        "skills/workflow/references/pipeline-retro.md",
+        "skills/workflow/references/pipeline-scaffolder.md",
+        "skills/workflow/references/pipeline-test-runner.md",
+        "skills/workflow/references/research-pipeline.md",
+        "skills/workflow/references/research-to-article.md",
+        "skills/workflow/references/skill-creation-pipeline.md",
+        "skills/workflow/references/system-upgrade.md",
+        "skills/workflow/references/systematic-debugging.md",
+        "skills/workflow/references/systematic-refactoring.md",
+        "skills/workflow/references/toolkit-improvement.md",
+        "skills/workflow/references/voice-calibrator.md",
+        "skills/workflow/references/voice-writer.md",
+        "skills/workflow/references/workflow-orchestrator.md",
+    }
+)
 
 
 FRONTMATTER_RE = re.compile(
@@ -270,6 +339,15 @@ def main() -> int:
         action="store_true",
         help="Inventory and audit only; do not modify any file.",
     )
+    parser.add_argument(
+        "--verified-safe",
+        action="store_true",
+        help=(
+            "Strip name: from paths on the VERIFIED_SAFE_PATHS allowlist even "
+            "if the conservative audit would otherwise skip them. See the "
+            "module docstring for the verdict evidence."
+        ),
+    )
     args = parser.parse_args()
 
     print("== Inventory ==")
@@ -297,6 +375,28 @@ def main() -> int:
                     skip_list.add(path)
     else:
         print("No phantom names appear as routed targets.")
+
+    if args.verified_safe:
+        print()
+        print("== Verified-safe overrides ==")
+        overridden: list[Path] = []
+        for path in list(skip_list):
+            rel = str(path.relative_to(REPO_ROOT))
+            if rel in VERIFIED_SAFE_PATHS:
+                skip_list.discard(path)
+                overridden.append(path)
+        print(f"Allowlist hits removed from skip list: {len(overridden)}")
+        for path in overridden:
+            print(f"  OVERRIDE: {path.relative_to(REPO_ROOT)}")
+        # Warn if the allowlist references paths that are not even
+        # candidates (e.g. already stripped on a prior run). This is
+        # informational, not fatal.
+        candidate_paths = {str(p.relative_to(REPO_ROOT)) for p, _ in candidates}
+        stale = sorted(VERIFIED_SAFE_PATHS - candidate_paths)
+        if stale:
+            print(f"Allowlist entries already stripped (no-op): {len(stale)}")
+            for rel in stale:
+                print(f"  NO-OP: {rel}")
 
     safe = [(p, n) for p, n in candidates if p not in skip_list]
     print()

--- a/scripts/strip-phantom-name-frontmatter.py
+++ b/scripts/strip-phantom-name-frontmatter.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""
+Normalize YAML frontmatter on agent and skill reference files.
+
+Purpose
+=======
+Reference files under ``agents/*/references/*.md`` and ``skills/*/references/*.md``
+are progressive-disclosure content loaded on demand by their parent agent or
+skill. They are not independently routable components.
+
+Historically some of these files shipped with a top-level ``name:`` field in
+their YAML frontmatter. Indexers that treat any ``.md`` file with a ``name:``
+as a registerable component pick these up and register them as top-level
+entries. That inflates the base context shown at session start with entries
+that have no routing table presence, no discoverability, and no independent
+purpose.
+
+This script removes the ``name:`` field from reference-file frontmatter so
+they remain scoped under their parent umbrella. Other frontmatter fields
+(description, allowed-tools, etc.) are preserved verbatim.
+
+Safety
+======
+- Every candidate file's frontmatter value for ``name:`` is audited against
+  the routing table (``skills/do/references/routing-tables.md``) and all
+  pipeline JSON files. Any name that appears as a routed target is added
+  to a skip list and left untouched.
+- After each edit the resulting YAML is re-parsed. A parse failure on any
+  modified file aborts the run with a non-zero exit code.
+- Files with no ``name:`` field are never touched.
+
+Usage
+=====
+    python3 scripts/strip-phantom-name-frontmatter.py            # apply edits
+    python3 scripts/strip-phantom-name-frontmatter.py --dry-run  # inventory only
+
+Rollback
+========
+This is a single-commit, reversible change. To roll back:
+
+    git revert <commit-sha>
+
+No other state is touched (no indexes, no caches, no external files).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML is required. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+AGENT_REF_GLOB = "agents/*/references/*.md"
+SKILL_REF_GLOB = "skills/*/references/*.md"
+
+ROUTING_TABLE = REPO_ROOT / "skills" / "do" / "references" / "routing-tables.md"
+
+
+FRONTMATTER_RE = re.compile(
+    r"\A---\r?\n(.*?)\r?\n---\r?\n",
+    re.DOTALL,
+)
+
+
+def read_frontmatter(path: Path) -> tuple[dict | None, str | None, str]:
+    """Return (parsed_frontmatter, raw_frontmatter_block, full_text).
+
+    parsed_frontmatter is None when the file has no YAML frontmatter.
+    """
+    text = path.read_text(encoding="utf-8")
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return None, None, text
+    raw = match.group(1)
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return None, raw, text
+    if not isinstance(data, dict):
+        return None, raw, text
+    return data, raw, text
+
+
+def inventory_candidates() -> list[tuple[Path, str]]:
+    """Return (path, name_value) for every reference file with a top-level name:."""
+    candidates: list[tuple[Path, str]] = []
+    for pattern in (AGENT_REF_GLOB, SKILL_REF_GLOB):
+        for path in sorted(REPO_ROOT.glob(pattern)):
+            # Exclude anything under worktrees (not part of the main tree).
+            if ".claude/worktrees" in str(path):
+                continue
+            data, _raw, _text = read_frontmatter(path)
+            if not data:
+                continue
+            name = data.get("name")
+            if isinstance(name, str) and name.strip():
+                candidates.append((path, name.strip()))
+    return candidates
+
+
+def collect_pipeline_json_paths() -> list[Path]:
+    paths: list[Path] = []
+    for pattern in (
+        "skills/*/references/*pipeline*.json",
+        "skills/workflow/references/*.json",
+        "**/pipeline-index.json",
+    ):
+        for path in REPO_ROOT.glob(pattern):
+            if ".claude/worktrees" in str(path):
+                continue
+            paths.append(path)
+    # Deduplicate while preserving order.
+    seen: set[Path] = set()
+    uniq: list[Path] = []
+    for p in paths:
+        if p not in seen:
+            seen.add(p)
+            uniq.append(p)
+    return uniq
+
+
+def audit_routed_names(candidates: list[tuple[Path, str]]) -> dict[str, list[str]]:
+    """Return {phantom_name: [evidence_strings]} for names used as routed targets.
+
+    An evidence string looks like: 'routing-tables.md: line 42: ...context...'
+
+    A hit in routing-tables.md is flagged conservatively: any literal text match
+    causes the name to land on the skip list. It is cheaper to spare a file from
+    stripping than to break a route.
+
+    A hit in a pipeline JSON is flagged when the name appears as a value
+    (e.g. "file": "..." or a trigger phrase) that the pipeline system dispatches
+    against.
+    """
+    hits: dict[str, list[str]] = {}
+
+    routing_text = ROUTING_TABLE.read_text(encoding="utf-8") if ROUTING_TABLE.exists() else ""
+    routing_lines = routing_text.splitlines()
+
+    pipeline_paths = collect_pipeline_json_paths()
+    pipeline_blobs: list[tuple[Path, str]] = []
+    for p in pipeline_paths:
+        try:
+            pipeline_blobs.append((p, p.read_text(encoding="utf-8")))
+        except OSError:
+            continue
+
+    for _path, name in candidates:
+        # The phantom names we are worried about are ones that have semantic
+        # routing weight. Very short generic tokens (like "mcp" or "patterns")
+        # would false-positive everywhere. We therefore only flag a name if
+        # the literal string is present AND is reasonably specific
+        # (>= 8 characters), which filters out common words.
+        if len(name) < 8:
+            continue
+
+        evidence: list[str] = []
+
+        for i, line in enumerate(routing_lines, start=1):
+            if name in line:
+                snippet = line.strip()
+                if len(snippet) > 140:
+                    snippet = snippet[:140] + "..."
+                evidence.append(f"routing-tables.md:{i}: {snippet}")
+
+        for p, blob in pipeline_blobs:
+            if name in blob:
+                # Find which key/value carries it for readability.
+                try:
+                    data = json.loads(blob)
+                except json.JSONDecodeError:
+                    data = None
+                context = _locate_in_json(data, name) if data else "(raw string match)"
+                evidence.append(f"{p.relative_to(REPO_ROOT)}: {context}")
+
+        if evidence:
+            hits[name] = evidence
+
+    return hits
+
+
+def _locate_in_json(obj, needle: str, path: str = "$") -> str:
+    """Best-effort locator: return the JSON path where needle appears as a string."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(k, str) and needle in k:
+                return f"{path}.{k}"
+            inner = _locate_in_json(v, needle, f"{path}.{k}")
+            if inner:
+                return inner
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            inner = _locate_in_json(v, needle, f"{path}[{i}]")
+            if inner:
+                return inner
+    elif isinstance(obj, str):
+        if needle in obj:
+            return f"{path} == {obj[:80]!r}"
+    return ""
+
+
+def strip_name_field(path: Path) -> tuple[bool, str]:
+    """Remove the top-level ``name:`` line from the frontmatter.
+
+    Returns (changed, message). If the rewrite cannot be done safely (no
+    frontmatter, no name field, parse failure after edit), returns
+    (False, reason) and leaves the file untouched.
+    """
+    text = path.read_text(encoding="utf-8")
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return False, "no frontmatter"
+
+    raw_block = match.group(1)
+    end_of_fm = match.end()  # position after the closing '---\n'
+
+    # Remove only a top-level (non-indented) name: line. Preserve nested
+    # ``name:`` keys inside other structures.
+    lines = raw_block.splitlines()
+    new_lines: list[str] = []
+    removed = False
+    for line in lines:
+        if not removed and re.match(r"^name\s*:", line):
+            removed = True
+            continue
+        new_lines.append(line)
+
+    if not removed:
+        return False, "no top-level name: field"
+
+    new_raw = "\n".join(new_lines)
+
+    # Re-parse to confirm it still loads as a mapping.
+    try:
+        reparsed = yaml.safe_load(new_raw)
+    except yaml.YAMLError as exc:
+        return False, f"YAML parse error after edit: {exc}"
+    if reparsed is not None and not isinstance(reparsed, dict):
+        return False, "frontmatter no longer parses as a mapping"
+
+    # Preserve trailing newline convention used by original block.
+    trailing = "\n" if raw_block.endswith("\n") else ""
+    rebuilt = f"---\n{new_raw}{trailing}\n---\n" + text[end_of_fm:]
+
+    path.write_text(rebuilt, encoding="utf-8")
+
+    # Post-write verification.
+    data, _raw, _full = read_frontmatter(path)
+    if data is None:
+        return False, "post-write frontmatter fails to parse"
+    if "name" in data:
+        return False, "post-write frontmatter still contains name:"
+    return True, "stripped"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__ or "")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Inventory and audit only; do not modify any file.",
+    )
+    args = parser.parse_args()
+
+    print("== Inventory ==")
+    candidates = inventory_candidates()
+    print(f"Reference files with top-level name: field: {len(candidates)}")
+    for path, name in candidates:
+        rel = path.relative_to(REPO_ROOT)
+        print(f"  {rel}  ->  name: {name}")
+
+    print()
+    print("== Audit ==")
+    print(f"Checking {ROUTING_TABLE.relative_to(REPO_ROOT)} and pipeline JSONs...")
+    hits = audit_routed_names(candidates)
+
+    skip_list: set[Path] = set()
+    if hits:
+        print(f"Potential routed targets found: {len(hits)}")
+        for name, evidence in hits.items():
+            print(f"  SKIP candidate name: {name}")
+            for ev in evidence:
+                print(f"    {ev}")
+            # Collect the paths whose name matches.
+            for path, cand_name in candidates:
+                if cand_name == name:
+                    skip_list.add(path)
+    else:
+        print("No phantom names appear as routed targets.")
+
+    safe = [(p, n) for p, n in candidates if p not in skip_list]
+    print()
+    print("== Plan ==")
+    print(f"Safe to strip: {len(safe)}")
+    print(f"Skipped (routed reference found): {len(skip_list)}")
+
+    if args.dry_run:
+        print()
+        print("Dry-run mode: no files modified.")
+        return 0
+
+    print()
+    print("== Execute ==")
+    modified = 0
+    failures: list[tuple[Path, str]] = []
+    for path, _name in safe:
+        ok, msg = strip_name_field(path)
+        rel = path.relative_to(REPO_ROOT)
+        if ok:
+            modified += 1
+            print(f"  modified: {rel}")
+        else:
+            print(f"  unchanged: {rel} ({msg})")
+            if "parse error" in msg or "still contains name" in msg or "no longer parses" in msg:
+                failures.append((path, msg))
+
+    print()
+    print("== Summary ==")
+    print(f"Inventoried: {len(candidates)}")
+    print(f"Skipped:     {len(skip_list)}")
+    print(f"Modified:    {modified}")
+    print(f"Failures:    {len(failures)}")
+    if failures:
+        for path, msg in failures:
+            print(f"  FAIL: {path.relative_to(REPO_ROOT)} - {msg}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/kotlin-coroutines/references/anti-patterns.md
+++ b/skills/kotlin-coroutines/references/anti-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: anti-patterns
 description: "Kotlin coroutine anti-patterns: GlobalScope, unstructured launch, CancellationException swallowing."
 level: 2
 ---

--- a/skills/kotlin-coroutines/references/channel-patterns.md
+++ b/skills/kotlin-coroutines/references/channel-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: channel-patterns
 description: "Kotlin Channel types, fan-in/fan-out, and producer-consumer patterns."
 level: 2
 ---

--- a/skills/kotlin-coroutines/references/concurrency-patterns.md
+++ b/skills/kotlin-coroutines/references/concurrency-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: concurrency-patterns
 description: "Kotlin structured concurrency: coroutineScope, supervisorScope, cancellation, dispatchers, exception handling."
 level: 2
 ---

--- a/skills/kotlin-coroutines/references/flow-patterns.md
+++ b/skills/kotlin-coroutines/references/flow-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: flow-patterns
 description: "Kotlin Flow patterns: cold streams, StateFlow, SharedFlow comparison and usage."
 level: 2
 ---

--- a/skills/phaser-gamedev/references/game-feel-patterns.md
+++ b/skills/phaser-gamedev/references/game-feel-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: Phaser Game Feel Patterns
 description: Screen shake, particle bursts, hit pause, scale punch, tween chaining, sound timing — techniques that make Phaser 3 games feel polished and responsive
 agent: phaser-gamedev
 category: visual-techniques

--- a/skills/phaser-gamedev/references/tilemaps-and-physics.md
+++ b/skills/phaser-gamedev/references/tilemaps-and-physics.md
@@ -1,5 +1,4 @@
 ---
-name: Phaser Tilemaps and Physics
 description: Tiled map integration, Matter.js vs Arcade physics decision table, collision groups, slopes, object layers for enemy spawning, and physics performance patterns
 agent: phaser-gamedev
 category: patterns

--- a/skills/swift-concurrency/references/actor-isolation.md
+++ b/skills/swift-concurrency/references/actor-isolation.md
@@ -1,5 +1,4 @@
 ---
-name: swift-actor-isolation
 description: "Actor isolation, @MainActor, nonisolated patterns with code examples."
 type: reference
 ---

--- a/skills/swift-concurrency/references/anti-patterns.md
+++ b/skills/swift-concurrency/references/anti-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: swift-concurrency-anti-patterns
 description: "Common concurrency mistakes: blocking MainActor, task leaking, actor reentrancy."
 type: reference
 ---

--- a/skills/swift-concurrency/references/fundamentals.md
+++ b/skills/swift-concurrency/references/fundamentals.md
@@ -1,5 +1,4 @@
 ---
-name: swift-concurrency-fundamentals
 description: "async/await basics, Task and Task.detached patterns, Sendable/@Sendable protocol."
 type: reference
 ---

--- a/skills/swift-concurrency/references/task-patterns.md
+++ b/skills/swift-concurrency/references/task-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: swift-task-patterns
 description: "TaskGroup, AsyncSequence, AsyncStream, and cancellation patterns."
 type: reference
 ---

--- a/skills/threejs-builder/references/advanced-animation.md
+++ b/skills/threejs-builder/references/advanced-animation.md
@@ -1,5 +1,4 @@
 ---
-name: Three.js Advanced Animation
 description: AnimationMixer with morph targets, skeletal animation, procedural IK approximation, GSAP integration, particle system animation via BufferGeometry attributes
 agent: threejs-builder
 category: visual-techniques

--- a/skills/threejs-builder/references/performance-patterns.md
+++ b/skills/threejs-builder/references/performance-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: Three.js Performance Patterns
 description: InstancedMesh, BufferGeometry manipulation, draw call batching, LOD, texture compression, and memory disposal for Three.js r150+
 agent: threejs-builder
 category: performance

--- a/skills/threejs-builder/references/shader-patterns.md
+++ b/skills/threejs-builder/references/shader-patterns.md
@@ -1,5 +1,4 @@
 ---
-name: Three.js Shader Patterns
 description: Custom GLSL shaders in Three.js — ShaderMaterial, vertex displacement, fragment effects, and EffectComposer postprocessing pipeline
 agent: threejs-builder
 category: visual-techniques

--- a/skills/workflow/references/agent-upgrade.md
+++ b/skills/workflow/references/agent-upgrade.md
@@ -1,5 +1,4 @@
 ---
-name: agent-upgrade
 description: "5-phase agent/skill improvement: AUDIT, DIFF, PLAN, IMPLEMENT, RE-EVALUATE."
 user-invocable: false
 argument-hint: "<agent-or-skill-name>"

--- a/skills/workflow/references/article-evaluation-pipeline.md
+++ b/skills/workflow/references/article-evaluation-pipeline.md
@@ -1,5 +1,4 @@
 ---
-name: article-evaluation-pipeline
 description: "Wabi-sabi-aware 4-phase article evaluation for voice authenticity."
 user-invocable: false
 allowed-tools:

--- a/skills/workflow/references/auto-pipeline.md
+++ b/skills/workflow/references/auto-pipeline.md
@@ -1,5 +1,4 @@
 ---
-name: auto-pipeline
 description: "Automatic pipeline generation for unrouted tasks via /do."
 user-invocable: false
 allowed-tools:

--- a/skills/workflow/references/chain-composer.md
+++ b/skills/workflow/references/chain-composer.md
@@ -1,5 +1,4 @@
 ---
-name: chain-composer
 description: "Compose valid pipeline chains from the step menu per subdomain."
 user-invocable: false
 agent: pipeline-orchestrator-engineer

--- a/skills/workflow/references/comprehensive-review.md
+++ b/skills/workflow/references/comprehensive-review.md
@@ -1,5 +1,4 @@
 ---
-name: comprehensive-review
 description: "Four-wave code review pipeline for large or high-risk changes."
 effort: high
 user-invocable: false

--- a/skills/workflow/references/de-ai-pipeline.md
+++ b/skills/workflow/references/de-ai-pipeline.md
@@ -1,5 +1,4 @@
 ---
-name: de-ai-pipeline
 description: "Scan-fix-verify loop for removing AI writing patterns from docs."
 user-invocable: false
 argument-hint: "[<path-or-glob>]"

--- a/skills/workflow/references/do-perspectives.md
+++ b/skills/workflow/references/do-perspectives.md
@@ -1,5 +1,4 @@
 ---
-name: do-perspectives
 description: "Inline multi-perspective analysis with 10 analytical lenses."
 user-invocable: false
 argument-hint: "<target-name> <source-path>"

--- a/skills/workflow/references/doc-pipeline.md
+++ b/skills/workflow/references/doc-pipeline.md
@@ -1,5 +1,4 @@
 ---
-name: doc-pipeline
 description: "Structured 5-phase documentation pipeline with research."
 user-invocable: false
 allowed-tools:

--- a/skills/workflow/references/domain-research.md
+++ b/skills/workflow/references/domain-research.md
@@ -1,5 +1,4 @@
 ---
-name: domain-research
 description: "Discover and classify subdomains for pipeline generation."
 user-invocable: false
 agent: pipeline-orchestrator-engineer

--- a/skills/workflow/references/explore-pipeline.md
+++ b/skills/workflow/references/explore-pipeline.md
@@ -1,5 +1,4 @@
 ---
-name: explore-pipeline
 description: "Systematic codebase exploration with parallel subagents."
 user-invocable: false
 allowed-tools:

--- a/skills/workflow/references/github-profile-rules.md
+++ b/skills/workflow/references/github-profile-rules.md
@@ -1,5 +1,4 @@
 ---
-name: github-profile-rules
 description: "Extract coding conventions from a GitHub user's public profile."
 user-invocable: false
 argument-hint: "<github-username>"

--- a/skills/workflow/references/hook-development-pipeline.md
+++ b/skills/workflow/references/hook-development-pipeline.md
@@ -1,5 +1,4 @@
 ---
-name: hook-development-pipeline
 description: "5-phase hook creation pipeline with performance gates."
 user-invocable: false
 agent: hook-development-engineer

--- a/skills/workflow/references/mcp-pipeline-builder.md
+++ b/skills/workflow/references/mcp-pipeline-builder.md
@@ -1,5 +1,4 @@
 ---
-name: mcp-pipeline-builder
 description: "Convert any repository into a registered MCP server."
 user-invocable: false
 argument-hint: "<repo-url-or-path>"

--- a/skills/workflow/references/perses-dac-pipeline.md
+++ b/skills/workflow/references/perses-dac-pipeline.md
@@ -1,5 +1,4 @@
 ---
-name: perses-dac-pipeline
 user-invocable: false
 description: "Dashboard-as-Code pipeline for Perses with CUE and percli."
 allowed-tools:

--- a/skills/workflow/references/perses-plugin-pipeline.md
+++ b/skills/workflow/references/perses-plugin-pipeline.md
@@ -1,5 +1,4 @@
 ---
-name: perses-plugin-pipeline
 user-invocable: false
 description: "End-to-end Perses plugin development pipeline."
 allowed-tools:

--- a/skills/workflow/references/pipeline-retro.md
+++ b/skills/workflow/references/pipeline-retro.md
@@ -1,5 +1,4 @@
 ---
-name: pipeline-retro
 description: "Trace pipeline test failures to generator root causes."
 user-invocable: false
 agent: pipeline-orchestrator-engineer

--- a/skills/workflow/references/pipeline-scaffolder.md
+++ b/skills/workflow/references/pipeline-scaffolder.md
@@ -1,5 +1,4 @@
 ---
-name: pipeline-scaffolder
 description: "Scaffold pipeline components from a Pipeline Spec JSON."
 user-invocable: false
 agent: pipeline-orchestrator-engineer

--- a/skills/workflow/references/pipeline-test-runner.md
+++ b/skills/workflow/references/pipeline-test-runner.md
@@ -1,5 +1,4 @@
 ---
-name: pipeline-test-runner
 description: "Test generated pipeline skills against real targets."
 user-invocable: false
 agent: pipeline-orchestrator-engineer

--- a/skills/workflow/references/research-pipeline.md
+++ b/skills/workflow/references/research-pipeline.md
@@ -1,5 +1,4 @@
 ---
-name: research-pipeline
 description: "Formal 5-phase research pipeline with artifact saving and source quality gates. Min 3 parallel agents."
 user-invocable: true
 argument-hint: "<research topic>"

--- a/skills/workflow/references/research-to-article.md
+++ b/skills/workflow/references/research-to-article.md
@@ -1,5 +1,4 @@
 ---
-name: research-to-article
 description: "Multi-agent research pipeline for voice content generation."
 user-invocable: false
 context: fork

--- a/skills/workflow/references/skill-creation-pipeline.md
+++ b/skills/workflow/references/skill-creation-pipeline.md
@@ -1,5 +1,4 @@
 ---
-name: skill-creation-pipeline
 description: "5-phase skill creation pipeline with quality gates."
 user-invocable: false
 allowed-tools:

--- a/skills/workflow/references/system-upgrade.md
+++ b/skills/workflow/references/system-upgrade.md
@@ -1,5 +1,4 @@
 ---
-name: system-upgrade
 description: "6-phase pipeline for adapting agents, skills, and hooks to changes."
 user-invocable: false
 agent: system-upgrade-engineer

--- a/skills/workflow/references/systematic-debugging.md
+++ b/skills/workflow/references/systematic-debugging.md
@@ -1,5 +1,4 @@
 ---
-name: systematic-debugging
 description: "Evidence-based 5-phase debugging: OBSERVE, HYPOTHESIZE, TEST, FIX, RECORD."
 effort: high
 user-invocable: false

--- a/skills/workflow/references/systematic-refactoring.md
+++ b/skills/workflow/references/systematic-refactoring.md
@@ -1,5 +1,4 @@
 ---
-name: systematic-refactoring
 description: "Safe 5-phase refactoring with test characterization and learning."
 user-invocable: false
 context: fork

--- a/skills/workflow/references/toolkit-improvement.md
+++ b/skills/workflow/references/toolkit-improvement.md
@@ -1,5 +1,4 @@
 ---
-name: toolkit-improvement
 description: "Multi-angle toolkit evaluation, ADR creation, and fix pipeline."
 effort: high
 context: fork

--- a/skills/workflow/references/voice-calibrator.md
+++ b/skills/workflow/references/voice-calibrator.md
@@ -1,5 +1,4 @@
 ---
-name: voice-calibrator
 description: "Analyze writing samples and extract voice patterns for profiles."
 user-invocable: false
 command: /voice

--- a/skills/workflow/references/voice-writer.md
+++ b/skills/workflow/references/voice-writer.md
@@ -1,5 +1,4 @@
 ---
-name: voice-writer
 description: "Unified voice content generation with 9-phase pipeline: validation, joy-check, voice profile support."
 user-invocable: true
 argument-hint: "<topic or title>"

--- a/skills/workflow/references/workflow-orchestrator.md
+++ b/skills/workflow/references/workflow-orchestrator.md
@@ -1,5 +1,4 @@
 ---
-name: workflow-orchestrator
 user-invocable: false
 description: "Three-phase task orchestration: BRAINSTORM, WRITE-PLAN, EXECUTE-PLAN."
 success-criteria:


### PR DESCRIPTION
## Summary

Removes the top-level `name:` field from YAML frontmatter on agent and skill reference files so they stay scoped under their parent umbrella. Reference files are progressive-disclosure content loaded on demand by a parent agent or skill; they are not independently routable components and should not appear as top-level entries in the base context.

This PR contains two commits:

1. `86db011` (already on branch): initial strip of 23 files whose names had no substring match in the routing table or any pipeline JSON.
2. `fb5496c` (this commit): extends the strip to the remaining 29 files under `skills/workflow/references/` and `skills/kotlin-coroutines/references/`, which the conservative audit previously skipped due to substring matches that are false positives for dispatch purposes.

## What changed

- `scripts/strip-phantom-name-frontmatter.py`: adds a `--verified-safe` flag that applies an explicit 29-path allowlist, bypassing the conservative audit for files whose matches have been investigated and ruled safe. The verdict evidence is recorded in the module docstring.
- 29 reference files: `name:` line removed. Every other frontmatter field is preserved verbatim.

## Why this is safe

The dispatch path is not name-driven for these files:

- `scripts/index-router.py` keys on JSON keys from `skills/workflow/references/pipeline-index.json` and on file paths. It never reads the YAML `name:` field on reference files.
- The only script that reads `name:` is `scripts/generate-pipeline-catalog.py`, which falls back to `skill_file.stem` when `name` is absent. Because the YAML name already matched the filename stem for all 29 files, the fallback produces the same string.
- Routing-table substring hits are against prose descriptions of routed skills, not against these reference-file umbrella entries.

## Verification

- `ruff check . --config pyproject.toml`: pass.
- `ruff format --check . --config pyproject.toml`: pass (319 files).
- `scripts/generate-pipeline-catalog.py` output: the `pipelines` array of `skills/workflow/references/auto-pipeline/references/pipeline-catalog.json` is byte-identical before and after the strip (comparison excludes the regeneration timestamp, which always changes). 28 pipelines in, 28 pipelines out, every name, description, phase list, chain, task_type, and trigger list identical.

## Test plan

- [x] Local: `ruff check . --config pyproject.toml` passes.
- [x] Local: `ruff format --check . --config pyproject.toml` passes.
- [x] Local: pipeline-catalog.json regenerates byte-identical (timestamp aside).
- [ ] CI: Tests workflow green on this branch.
- [ ] Post-merge: fresh `claude -p` session shows reduced base context with no reference-file stragglers surfacing as top-level components; pipeline dispatch (`/do research`, `/do review`, `/do explore`) still routes to the correct pipelines.