### PR TITLE
feat(distinctive-frontend-design): add game-ui-polish reference

### DIFF
--- a/skills/distinctive-frontend-design/SKILL.md
+++ b/skills/distinctive-frontend-design/SKILL.md
@@ -37,6 +37,7 @@ Optional capabilities (off unless explicitly enabled by the user): design system
 | implementation patterns | `css-audit-patterns.md` | Loads detailed guidance from `css-audit-patterns.md`. |
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
 | example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
+| game UI, AAA game, polished game, Steam game, roguelike UI, Slay the Spire | `game-ui-polish.md` | Loads game-native polish rules that prevent website-like surfaces, excessive gradients, nested boxes, and fake-premium chrome. |
 | example-driven tasks | `implementation-examples.md` | Loads detailed guidance from `implementation-examples.md`. |
 | performance work | `performance-budgets.md` | Loads detailed guidance from `performance-budgets.md`. |
 | tasks related to this reference | `phase-details.md` | Loads detailed guidance from `phase-details.md`. |
@@ -209,6 +210,7 @@ These reference files contain the curated domain knowledge that drives design de
 - `${CLAUDE_SKILL_DIR}/references/app-vs-landing-rules.md`: Full rule sets for landing vs app surface types
 - `${CLAUDE_SKILL_DIR}/references/examples.md`: Worked examples for new landing page and design audit
 - `${CLAUDE_SKILL_DIR}/references/error-handling.md`: Recovery for banned fonts, cliche palettes, low distinctiveness scores
+- `${CLAUDE_SKILL_DIR}/references/game-ui-polish.md`: Game-native UI polish rules for AAA/Steam/roguelike surfaces, including anti-patterns learned from Road to AEW
 - `${CLAUDE_SKILL_DIR}/references/css-audit-patterns.md`: grep/rg detection commands for banned fonts, hardcoded colors, over-animation, and flat backgrounds in implementation code — load when auditing CSS/SCSS/TSX files or verifying a generated spec was implemented correctly
 - `${CLAUDE_SKILL_DIR}/references/performance-budgets.md`: CSS property render costs, compositor-thread promotion rules, layout thrashing detection commands, frame budget reference — load when animation performance is in scope or "animation performance profiling" optional capability is enabled
 
@@ -225,5 +227,6 @@ See `references/error-handling.md` for recovery procedures covering banned fonts
 - `${CLAUDE_SKILL_DIR}/references/anti-patterns.json`
 - `${CLAUDE_SKILL_DIR}/references/implementation-examples.md`
 - `${CLAUDE_SKILL_DIR}/references/project-history.json`
+- `${CLAUDE_SKILL_DIR}/references/game-ui-polish.md`
 - `${CLAUDE_SKILL_DIR}/references/css-audit-patterns.md`
 - `${CLAUDE_SKILL_DIR}/references/performance-budgets.md`

--- a/skills/distinctive-frontend-design/references/game-ui-polish.md
+++ b/skills/distinctive-frontend-design/references/game-ui-polish.md
@@ -1,0 +1,162 @@
+# Game UI Polish Reference
+
+Use this reference when the work mentions game UI, AAA game polish, Steam game polish, roguelike UI, Slay the Spire, deckbuilder UI, or when a user says an interface feels like a website instead of a game.
+
+## Core Thesis
+
+Polished game UI does not come from more gradients, heavier chrome, or “premium” colors. It comes from a coherent interaction metaphor, disciplined hierarchy, and surfaces that feel authored as part of the game world. When a game UI feels wrong, first remove web-product idioms before adding decoration.
+
+For game surfaces, the goal is not “beautiful panel.” The goal is “a screen the game would have shipped.”
+
+## First Diagnostic Question
+
+Ask: would a shipped game like Slay the Spire build this exact surface?
+
+If the honest answer is no, do not tune the palette. Identify the structural web idiom:
+
+- Nested rounded containers around every group.
+- Gradient panels used to imply polish.
+- Badges and pills explaining state.
+- Instructional text explaining obvious interactions.
+- Form-like labels and helper text everywhere.
+- Dashboard/card mosaics where every item is boxed.
+- Decorative glow, shine, blur, or texture competing with readability.
+- Multiple accent hues used because the screen lacks hierarchy.
+
+Fix those before color, typography, or asset generation.
+
+## AAA / Steam Polish Heuristics
+
+High-polish game UI usually has these properties:
+
+- One composed screen, not a stack of web sections.
+- A small number of strong materials, reused consistently.
+- Flat or lightly painted surfaces with intentional edges.
+- Selection state shown by position, value, highlight strip, silhouette, or icon, not by a full bordered card treatment.
+- Text hierarchy that behaves like game signage: short headers, object names, numbers, terse mechanical labels.
+- Interaction objects carry the visual weight; containers stay quiet.
+- The background supports focus rather than proving visual effort.
+- Fewer simultaneous effects than a website mockup. Restraint reads expensive.
+
+## Layout Rules
+
+Prefer:
+
+- One shell or board per screen.
+- Rows, columns, dividers, tabs, silhouettes, and object placement.
+- Spatial grouping instead of nested cards.
+- One persistent preview/summary region if the interaction needs it.
+- Selection marks: left strip, lift, glow, check, slot fill, or value change.
+
+Avoid:
+
+- A modal containing a header gradient, then panels, then cards, then badges.
+- Rounded boxes around every option.
+- Pill labels for every small attribute.
+- Repeating borders with the same visual weight.
+- Multiple section backgrounds inside one screen.
+- “Step 1 / Step 2” web-form structure unless the game fiction genuinely supports it.
+
+## Color Rules
+
+Game UI can use any palette, but hierarchy must be obvious.
+
+- Choose material first, then color. Example: parchment, steel, canvas, leather, arcade plastic, CRT glass, blueprint paper.
+- Avoid “gold equals premium” unless the game fiction truly needs gold.
+- Avoid brown by default. Brown often reads muddy unless paired with strong material contrast and deliberate art direction.
+- Avoid pink/red fades as a generic drama layer. They often reduce readability and look like a web gradient.
+- Accent color should mark state or action, not decorate every border.
+- If color is doing too much, remove surfaces instead of inventing a better palette.
+
+## Texture And Gradient Rules
+
+Gradients are not banned, but they must have a job.
+
+Acceptable jobs:
+
+- Lighting a scene.
+- Separating foreground from background.
+- Simulating a specific material.
+- Directing attention to the primary action.
+
+Bad jobs:
+
+- Making an empty rectangle feel premium.
+- Decorating every panel.
+- Hiding weak hierarchy.
+- Adding “AAA vibes” without a game-world reason.
+
+Default to flat material plus one restrained lighting layer. If every box has a gradient, the screen will feel like a website.
+
+## Typography And Text Budget
+
+Game UI text should be terse.
+
+- One screen title, usually 1-3 words.
+- Option names and mechanical payoffs are allowed.
+- Helper sentences should be rare and only solve confusion discovered in play.
+- If the screen still works after removing a sentence, remove it.
+- Do not use badges to narrate state. Make the state visible.
+
+Common cuts:
+
+- “Click to...”
+- “Choose X to...”
+- “Step 1”
+- “Your name appears...”
+- “4 sprite looks”
+- Repeated subtitles under every item.
+
+## Slay The Spire-Style Deckbuilder Guidance
+
+Slay the Spire-like polish comes from object clarity and low container count.
+
+Prefer:
+
+- Cards, relics, rewards, map nodes, and characters as the primary objects.
+- Dark scrim or simple board behind the objects.
+- Clear hover/selected states.
+- Minimal labels.
+- Layouts where the player understands the interaction from object placement.
+
+Avoid:
+
+- Website modals with explanatory sections.
+- Reward choices in uniform rounded boxes when the card/relic itself should be the object.
+- Overdesigned chrome competing with card art.
+- Fake “premium” metallic treatments.
+
+## Corrective Workflow
+
+When a user says “this does not feel AAA/polished/game-like,” do this in order:
+
+1. Screenshot the current UI and name the structural failures.
+2. Remove nested boxes and decorative gradients before choosing new colors.
+3. Define the screen metaphor in one sentence: board, hand, poster, locker, map, shop shelf, ring apron, etc.
+4. Rebuild hierarchy with layout and state, not decoration.
+5. Reduce text to object names, mechanical labels, and one screen title.
+6. Reuse existing game assets as objects, not as stickers inside web cards.
+7. Validate with a screenshot and ask the Slay-the-Spire test again.
+
+Do not respond to “make it AAA” by making surfaces shinier. That is the failure mode.
+
+## Road To AEW Lesson
+
+In Road to AEW, the useful improvement came only after removing:
+
+- Metallic gold “premium” treatment.
+- Pink/red gradient wash.
+- Rounded boxes around every option.
+- Nested modal > panel > card > badge structure.
+- Decorative badge labels.
+
+The better direction was:
+
+- One flat game board.
+- Dark material base.
+- Thin dividers.
+- Generated emblems as actual option objects.
+- Selection as a left accent strip and subtle fill.
+- Fewer gradients and fewer words.
+
+The remaining palette issue was brownness, not structure. This distinction matters: once the structure became game-native, color could be iterated separately.


### PR DESCRIPTION
## Summary
- Adds `skills/distinctive-frontend-design/references/game-ui-polish.md` (162 lines): game-native UI polish rulebook for AAA/Steam/roguelike/deckbuilder surfaces.
- Wires it into `SKILL.md`: reference loading table entry (game UI, AAA game, Steam game, roguelike UI, Slay the Spire triggers), reference-file description list, and reference-file manifest at the bottom.
- Codifies anti-patterns observed while polishing Road to AEW (metallic gold chrome, pink/red gradient washes, nested rounded boxes, badge narration, web-form step structure).

## Review notes
Inline self-review (no `claude -p` subprocesses spawned, per quota-aware instructions):

- File follows the same structural pattern as sibling references (`error-handling.md`, `examples.md`, etc.) — no schema drift.
- SKILL.md references the new file in all three expected places: reference loading table (line 40), reference-file description list (line 213), reference-file manifest (line 230). No declared-but-missing drift.
- No typos, broken markdown, or contradictions with the main SKILL.md body — the new material extends, not conflicts with, existing anti-cliche guidance.
- Content is self-contained (no cross-file links that could break).

No changes required from review.

## Test plan
- [x] `ruff check . --config pyproject.toml` — all checks passed
- [x] `ruff format --check . --config pyproject.toml` — 319 files already formatted
- [x] `scripts/validate-references.py --agent distinctive-frontend-design` — N/A (script is agent-oriented; `--all` mode fails with a pre-existing bug on main unrelated to this change)
- [ ] GitHub Actions green