### PR TITLE
fix(hooks): add WAL mode to usage_db.py

### DIFF
--- a/hooks/lib/usage_db.py
+++ b/hooks/lib/usage_db.py
@@ -44,6 +44,7 @@ def get_connection():
     """Get a database connection with automatic cleanup."""
     conn = sqlite3.connect(get_db_path(), timeout=5.0)
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
     try:
         yield conn
     finally:


### PR DESCRIPTION
## Summary
- Add `PRAGMA journal_mode=WAL` to `usage_db.py` connection setup
- Matches existing pattern in `learning_db_v2.py`
- Prevents `SQLITE_BUSY` errors under concurrent Claude Code sessions

## Test plan
- [x] Ruff check passes
- [x] WAL mode confirmed active via runtime test
- [x] One-line change, no behavioral difference except concurrent safety