### PR TITLE
docs(do,philosophy): add Orwell's six rules as output standard

### DIFF
--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -405,6 +405,36 @@ Skill documents place the workflow (Instructions/Phases) immediately after the f
 
 **Progressive disclosure completes the picture:** Workflow-first ordering keeps SKILL.md navigable. For skills exceeding ~500 lines, detailed catalogs, agent rosters, and specification tables move to `references/` files. The SKILL.md workflow tells the model when to load each reference -- "Read `references/wave-1-foundation.md` for the agent list and dispatch prompts." The model gets the orchestration logic upfront and loads deep context only when the current phase needs it.
 
+## Plain Language Over Jargon
+
+Clear writing proves clear thinking. Padding and jargon prove the opposite.
+
+George Orwell codified this in "Politics and the English Language" (1946) with six rules that apply directly to how this toolkit communicates:
+
+1. Never use a metaphor, simile, or figure of speech you are accustomed to seeing in print.
+2. Never use a long word where a short one will do.
+3. If it is possible to cut a word out, always cut it out.
+4. Never use the passive where you can use the active.
+5. Never use a foreign phrase, a scientific word, or a jargon word if you can think of an everyday English equivalent.
+6. Break any of these rules sooner than say anything outright barbarous.
+
+These rules govern all toolkit output: agent summaries, error messages, phase banners, skill instructions, and documentation. A user reading output from this system should feel they're talking to someone who understands the problem, not someone performing understanding.
+
+**What this means in practice:**
+
+| Instead of | Write |
+|------------|-------|
+| "I've identified several potential optimization vectors for consideration" | "Three things are slow. Here's why." |
+| "Leverage the existing infrastructure" | "Use what's already there" |
+| "An unexpected condition was encountered during processing" | "This broke. Here's what happened." |
+| "The implementation has been successfully completed" | "Done." |
+
+The test: if a sentence sounds like it was written by a corporate communications department, rewrite it until it sounds like it was written by someone who knows the subject.
+
+Rule 6 matters as much as rules 1-5. Sometimes the clearest way to say something requires a long word, a passive construction, or a technical term. Use them when they earn their place. The goal is clarity, not a word game.
+
+*Citation: Orwell, George. "Politics and the English Language." Horizon, vol. 13, no. 76, April 1946, pp. 252-265.*
+
 ## One Domain, One Component
 
 The system prompt token budget is finite. Every agent description and every skill description appears in the system prompt at session start. As agent and skill counts grow, description bloat directly degrades routing quality and consumes tokens before any work begins.

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -52,6 +52,33 @@ When the model feels confident handling a task directly, treat that confidence a
 
 ---
 
+## Output Discipline
+
+Say more with fewer words. Every sentence the router prints is a sentence the user reads before seeing results.
+
+**Orwell's Six Rules** apply to all output from this router and every agent it dispatches. From George Orwell, "Politics and the English Language" (1946):
+
+1. Never use a metaphor, simile, or figure of speech you are accustomed to seeing in print.
+2. Never use a long word where a short one will do.
+3. If it is possible to cut a word out, always cut it out.
+4. Never use the passive where you can use the active.
+5. Never use a foreign phrase, a scientific word, or a jargon word if you can think of an everyday English equivalent.
+6. Break any of these rules sooner than say anything outright barbarous.
+
+Clear language proves understanding. Jargon proves the opposite. If output sounds like a committee wrote it, rewrite it until it sounds like a person who knows the subject wrote it.
+
+**What the user sees:**
+- Phase banners — always shown, they orient the reader
+- The routing decision banner — always shown, it explains the dispatch
+- A brief summary after each agent completes — what changed, not how
+
+**What stays internal:**
+- Haiku routing agent responses — consumed by the router, never printed
+- Classification reasoning
+- Enhancement stacking details (unless Verbose Routing is ON)
+
+---
+
 ## Instructions
 
 ### Phase Banners (MANDATORY)
@@ -164,6 +191,8 @@ Rules:
 **Step 1b: Apply the Haiku agent's recommendation**
 
 Use the Haiku agent's `agent` and `skill` fields directly. If `confidence` is "low", fall back to reading INDEX files (`agents/INDEX.json`, `skills/INDEX.json`) and `references/routing-tables.md` to verify or override manually.
+
+**The Haiku agent's response is internal.** Do not print its JSON or reasoning to the user. Extract the fields, apply them, move on. The routing banner is the user-facing summary.
 
 **Critical**: "push", "commit", "create PR", "merge" are NOT trivial git commands. They MUST route through skills that run quality gates. The skills bundle lint, tests, review loops, CI verification, and repo classification into the single command so the push lands cleanly.
 


### PR DESCRIPTION
## Summary
- Add Output Discipline section to /do router with Orwell's six rules
- Make Haiku routing agent output internal-only (never printed to user)
- Add "Plain Language Over Jargon" section to PHILOSOPHY.md with full citation
- Before/after table showing concrete rewrites

## Changes
- `skills/do/SKILL.md`: New Output Discipline section + internal-only Haiku note
- `docs/PHILOSOPHY.md`: New Plain Language Over Jargon section with MLA citation

## Test plan
- [x] Ruff passes
- [x] 2618 tests pass, 0 failures
- [x] YAML frontmatter validates