### PR TITLE
fix(routing): restore pairs_with stacking semantics + fix phantom references

### DIFF
--- a/agents/github-profile-rules-engineer.md
+++ b/agents/github-profile-rules-engineer.md
@@ -10,7 +10,7 @@ routing:
     - github conventions
     - programming rules
   pairs_with:
-    - github-profile-rules
+    - workflow
   complexity: Medium
   category: meta
 allowed-tools:

--- a/agents/perses-engineer.md
+++ b/agents/perses-engineer.md
@@ -33,7 +33,6 @@ routing:
     - perses cue schema
     - plugin schema
   pairs_with:
-    - perses-onboard
     - perses
     - golang-general-engineer
     - typescript-frontend-engineer

--- a/agents/system-upgrade-engineer.md
+++ b/agents/system-upgrade-engineer.md
@@ -16,11 +16,11 @@ routing:
     - new claude version
     - apply retro
   pairs_with:
-    - system-upgrade
+    - toolkit-evolution
     - agent-evaluation
     - codebase-analyzer
     - routing-table-updater
-    - pr-pipeline
+    - pr-workflow
   complexity: Complex
   category: meta
 allowed-tools:

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -275,7 +275,7 @@ If relevant retro knowledge is already present in context, use it. If it is abse
 
 When in doubt, do NOT inject — the manual `/quick --interview` flag and the explicit phrase triggers are alternative paths that cover deliberate cases. False positives on auto-injection cost the user one round of friction (Phase 0 opt-out question); false negatives are fully recoverable via the manual paths.
 
-Before stacking any enhancement, check the target skill's `pairs_with` field in `skills/INDEX.json`. Some skills ship with their own verification gates and work best on their own terms. Specifically: empty `pairs_with: []` means no stacking allowed. Skills with built-in verification gates handle their own verification. The `quick --trivial` mode handles its own testing. Stack only compatible enhancements.
+Before stacking any enhancement, check the target skill's `pairs_with` field in `skills/INDEX.json`. Skills that declare `pairs_with` list their compatible companions — prefer stacking with listed pairs. An empty `pairs_with: []` means pairings have not been declared yet, not that stacking is prohibited. Skills with built-in verification gates (like `quick --trivial`) handle their own testing and may not benefit from additional stacking. Use judgment based on the skill's documentation.
 
 Add anti-rationalization patterns for these task types when the task benefits from explicit rigor:
 
@@ -430,6 +430,6 @@ Solution: Stop execution. Create `task_plan.md`. Resume routing after plan is in
 - `${CLAUDE_SKILL_DIR}/references/routing-tables.md`: Complete category-specific skill routing
 - `${CLAUDE_SKILL_DIR}/references/progressive-depth.md`: Progressive depth escalation protocol
 - `agents/INDEX.json`: Agent triggers and metadata
-- `skills/INDEX.json`: Skill triggers, force-route flags, pairs_with
+- `skills/INDEX.json`: Skill triggers, force-route flags, and pairs_with agent/skill pairings
 - `skills/workflow/SKILL.md`: Workflow phases, triggers, composition chains
 - `skills/workflow/references/pipeline-index.json`: Pipeline metadata, triggers, phases


### PR DESCRIPTION
## Summary
- Restores correct `pairs_with` stacking semantics in `/do` SKILL.md Phase 3: empty `pairs_with: []` means pairings not declared yet, NOT stacking prohibited (regression from PR #509 fix that never merged)
- Fixes 4 phantom `pairs_with` references in agent frontmatter:
  - `github-profile-rules-engineer`: `github-profile-rules` → `workflow`
  - `perses-engineer`: removed `perses-onboard` (not a skill; `perses` already listed)
  - `system-upgrade-engineer`: `system-upgrade` → `toolkit-evolution`
  - `system-upgrade-engineer`: `pr-pipeline` → `pr-workflow`

## Test plan
- [x] `python3 scripts/validate-pairs-with.py` — "All pairs_with references are valid"
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [ ] CI checks pass