### PR TITLE
feat(publish): WordPress category auto-create, frontmatter-leak fix, media library search

### DIFF
--- a/scripts/wordpress-edit-post.py
+++ b/scripts/wordpress-edit-post.py
@@ -127,6 +127,56 @@ def _get_auth_headers(config: dict[str, str], content_type: str | None = "applic
 # ---------------------------------------------------------------------------
 
 
+def strip_yaml_frontmatter(text: str) -> str:
+    """Strip a leading YAML frontmatter block from markdown text.
+
+    A frontmatter block opens with a line containing only ``---`` (after an
+    optional UTF-8 BOM) and closes with the next line that is exactly ``---``.
+    Anything between those fences is discarded; everything after the closing
+    fence is returned, with leading blank lines stripped.
+
+    No-op cases (input returned verbatim):
+        - Text that does not start with a ``---`` fence line.
+        - Text that opens with ``---`` but never closes (malformed) — a
+          warning is logged to stderr so the caller notices, and the original
+          text is returned so the rendered post still ships rather than crashing.
+
+    Handles both LF and CRLF line endings.
+
+    Args:
+        text: Raw markdown content, possibly with frontmatter.
+
+    Returns:
+        Markdown body with frontmatter removed (or the original text if there
+        is no frontmatter or it is malformed).
+    """
+    # Strip optional UTF-8 BOM only for the leading-fence check; preserve in
+    # output if no frontmatter is present.
+    probe = text.lstrip("﻿")
+    # Normalize line endings for fence detection without mutating return value.
+    # We split on \n and strip trailing \r so CRLF input behaves like LF.
+    lines = probe.split("\n")
+    if not lines or lines[0].rstrip("\r").strip() != "---":
+        return text
+
+    # Find the closing fence line (exactly --- after stripping CR/whitespace).
+    end_idx: int | None = None
+    for i in range(1, len(lines)):
+        if lines[i].rstrip("\r").strip() == "---":
+            end_idx = i
+            break
+
+    if end_idx is None:
+        print(
+            "Warning: content file opens with '---' but no closing '---' fence was found; treating as no frontmatter.",
+            file=sys.stderr,
+        )
+        return text
+
+    body = "\n".join(lines[end_idx + 1 :])
+    return body.lstrip("\n").lstrip("\r\n")
+
+
 def markdown_to_html(markdown_content: str) -> str:
     """Convert markdown to HTML for content updates.
 
@@ -472,7 +522,7 @@ def main() -> int:
         if not file_path.exists():
             print(json.dumps({"status": "error", "error": f"Content file not found: {args.content_file}"}, indent=2))
             return 1
-        content = markdown_to_html(file_path.read_text())
+        content = markdown_to_html(strip_yaml_frontmatter(file_path.read_text()))
 
     result = edit_post(
         config=config,

--- a/scripts/wordpress-upload.py
+++ b/scripts/wordpress-upload.py
@@ -5,11 +5,14 @@ Uploads markdown files to WordPress as posts using Application Passwords authent
 Parses YAML frontmatter for metadata (title, categories, tags, slug, excerpt).
 Categories and tags are resolved by name via the WordPress REST API.
 Tags are created automatically if they don't exist.
+Categories are skipped with a warning if they don't exist, unless
+``--create-missing-categories`` is passed (then they are created on demand).
 
 Usage:
     python3 scripts/wordpress-upload.py --file article.md --status draft --human
     python3 scripts/wordpress-upload.py --file article.md --title "My Title" --category "News" --status draft
     python3 scripts/wordpress-upload.py --file article.md --classic --status draft
+    python3 scripts/wordpress-upload.py --file article.md --create-missing-categories --human
 
 Environment Variables (from ~/.env):
     WORDPRESS_SITE         WordPress site URL (e.g., https://your-blog.com)
@@ -268,6 +271,95 @@ def lookup_category_id(config: dict[str, str], name: str) -> int | None:
     return None
 
 
+def create_category(config: dict[str, str], name: str) -> int | None:
+    """Create a WordPress category by name and return its new ID.
+
+    Used when ``--create-missing-categories`` is enabled and a frontmatter
+    or CLI category doesn't exist on the target site.
+
+    Args:
+        config: WordPress config dict.
+        name: Category name to create.
+
+    Returns:
+        New category ID on success, None on failure (permission denied,
+        validation error, network failure, etc.). Failures are logged to
+        stderr and the caller falls back to skip-with-warning behavior.
+    """
+    api_url = f"{config['site'].rstrip('/')}/wp-json/wp/v2/categories"
+    headers = _get_auth_headers(config)
+
+    try:
+        response = requests.post(api_url, headers=headers, json={"name": name}, timeout=15)
+        if response.status_code == 201:
+            new_cat = response.json()
+            return new_cat.get("id")
+
+        # Handle "term_exists" race: a category with this slug already exists
+        # but the prior search didn't surface it (e.g., slug vs name mismatch).
+        if response.status_code == 400:
+            error_data: dict[str, Any] = {}
+            with contextlib.suppress(Exception):
+                error_data = response.json()
+            if error_data.get("code") == "term_exists":
+                existing_id = error_data.get("data", {}).get("term_id")
+                if existing_id:
+                    return existing_id
+
+        # Permission denied or other API error — warn and let the caller skip.
+        print(f"Warning: failed to create category '{name}': HTTP {response.status_code}", file=sys.stderr)
+    except Exception as e:
+        print(f"Warning: category creation failed for '{name}': {e}", file=sys.stderr)
+
+    return None
+
+
+def lookup_or_create_category_id(
+    config: dict[str, str],
+    name: str,
+    *,
+    create_missing: bool = False,
+    human: bool = False,
+) -> int | None:
+    """Look up a category by name; optionally create it if it doesn't exist.
+
+    Wraps ``lookup_category_id`` with an opt-in create-on-miss path. The
+    new ID (if creation succeeds) is written back into ``_category_cache``
+    so subsequent lookups within the same run skip the API.
+
+    Args:
+        config: WordPress config dict.
+        name: Category name to find or create.
+        create_missing: If True, attempt to create the category when the
+            lookup misses. Defaults to False (preserves the legacy
+            skip-with-warning behavior).
+        human: If True, print a human-readable line on successful creation.
+
+    Returns:
+        Category ID if found or created, None on miss-and-no-create or
+        on creation failure.
+    """
+    cat_id = lookup_category_id(config, name)
+    if cat_id is not None:
+        return cat_id
+
+    if not create_missing:
+        return None
+
+    new_id = create_category(config, name)
+    if new_id is not None:
+        # Cache the new ID under the same lower-cased key used by
+        # lookup_category_id so future lookups in this run hit the cache.
+        _category_cache[name.lower()] = new_id
+        if human:
+            print(f"Created category '{name}' (id {new_id})")
+        else:
+            print(f"Info: created category '{name}' (id {new_id})", file=sys.stderr)
+        return new_id
+
+    return None
+
+
 def lookup_or_create_tag_id(config: dict[str, str], name: str) -> int | None:
     """Look up a WordPress tag by name, creating it if it doesn't exist.
 
@@ -317,15 +409,27 @@ def lookup_or_create_tag_id(config: dict[str, str], name: str) -> int | None:
     return None
 
 
-def resolve_taxonomy_ids(config: dict[str, str], frontmatter: dict[str, Any]) -> tuple[list[int], list[int]]:
+def resolve_taxonomy_ids(
+    config: dict[str, str],
+    frontmatter: dict[str, Any],
+    *,
+    create_missing_categories: bool = False,
+    human: bool = False,
+) -> tuple[list[int], list[int]]:
     """Resolve frontmatter category/tag names to WordPress taxonomy IDs.
 
-    Categories that don't exist are skipped with a warning.
+    Categories that don't exist are skipped with a warning by default.
+    When ``create_missing_categories`` is True, missing categories are
+    created via ``POST /wp/v2/categories`` and the new IDs are reused.
     Tags that don't exist are created automatically.
 
     Args:
         config: WordPress config dict.
         frontmatter: Parsed YAML frontmatter dict.
+        create_missing_categories: If True, auto-create categories that
+            don't exist on the target site. Falls back to skip-with-
+            warning on creation failure (e.g., permission denied).
+        human: If True, log creation events on stdout for ``--human`` mode.
 
     Returns:
         Tuple of (category_ids, tag_ids).
@@ -342,7 +446,12 @@ def resolve_taxonomy_ids(config: dict[str, str], frontmatter: dict[str, Any]) ->
         raw_tags = [raw_tags]
 
     for cat_name in raw_categories:
-        cat_id = lookup_category_id(config, cat_name)
+        cat_id = lookup_or_create_category_id(
+            config,
+            cat_name,
+            create_missing=create_missing_categories,
+            human=human,
+        )
         if cat_id is not None:
             category_ids.append(cat_id)
         else:
@@ -975,6 +1084,15 @@ def main() -> int:
     )
     parser.add_argument("--classic", action="store_true", help="Use classic HTML format instead of Gutenberg blocks")
     parser.add_argument(
+        "--create-missing-categories",
+        action="store_true",
+        help=(
+            "Auto-create frontmatter and --category names that don't exist on the target site "
+            "(POST /wp/v2/categories). Default off; missing categories are skipped with a warning. "
+            "On permission denied or other API failure, falls back to skip-with-warning."
+        ),
+    )
+    parser.add_argument(
         "--validate",
         action="store_true",
         help="Convert to Gutenberg HTML, validate blocks, print results, and exit (no upload)",
@@ -1042,7 +1160,12 @@ def main() -> int:
         return 1
 
     # Resolve taxonomy IDs from frontmatter
-    fm_category_ids, fm_tag_ids = resolve_taxonomy_ids(config, frontmatter)
+    fm_category_ids, fm_tag_ids = resolve_taxonomy_ids(
+        config,
+        frontmatter,
+        create_missing_categories=args.create_missing_categories,
+        human=args.human,
+    )
 
     # Resolve taxonomy IDs from CLI args
     cli_category_ids: list[int] = []
@@ -1050,7 +1173,12 @@ def main() -> int:
 
     if args.category:
         for cat_name in args.category:
-            cat_id = lookup_category_id(config, cat_name)
+            cat_id = lookup_or_create_category_id(
+                config,
+                cat_name,
+                create_missing=args.create_missing_categories,
+                human=args.human,
+            )
             if cat_id is not None:
                 cli_category_ids.append(cat_id)
             else:

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -10,7 +10,8 @@ description: |
   frontmatter update", "mass edit", "audit links", "broken links", "audit
   images", "alt text check", "audit taxonomy", "fix tags", "merge
   categories", "upload to wordpress", "create wordpress draft", "post to
-  wordpress", or "edit wordpress post".
+  wordpress", "edit wordpress post", "create wp categories", "auto-create
+  categories", "search wp media", or "find existing wordpress image".
 user-invocable: false
 agent: general-purpose
 allowed-tools:
@@ -68,6 +69,15 @@ routing:
     - "edit wordpress post"
     - "update wordpress post"
     - "wordpress media"
+    - "create wp categories"
+    - "auto-create categories"
+    - "create missing categories"
+    - "search wp media"
+    - "search wordpress media"
+    - "search media library"
+    - "find existing wordpress image"
+    - "find existing image"
+    - "reuse existing media"
   category: content-publishing
   complexity: medium
 ---
@@ -89,7 +99,7 @@ Detect the user's intent and load the appropriate reference file:
 | **Link-audit** | "audit links", "find broken links", "link health", "broken links", "dead links" | `${CLAUDE_SKILL_DIR}/references/link-audit.md` |
 | **Image-audit** | "audit images", "check broken images", "image accessibility", "alt text check", "image optimization" | `${CLAUDE_SKILL_DIR}/references/image-audit.md` |
 | **Taxonomy** | "audit taxonomy", "fix tags", "merge categories", "tag cleanup", "category management" | `${CLAUDE_SKILL_DIR}/references/taxonomy.md` |
-| **WordPress-upload** | "upload to wordpress", "create wordpress draft", "post to wordpress", "wordpress draft", "upload article", "upload image to wordpress", "edit wordpress post", "update wordpress post", "wordpress media" | `${CLAUDE_SKILL_DIR}/references/wordpress-upload.md` |
+| **WordPress-upload** | "upload to wordpress", "create wordpress draft", "post to wordpress", "wordpress draft", "upload article", "upload image to wordpress", "edit wordpress post", "update wordpress post", "wordpress media", "create wp categories", "auto-create categories", "create missing categories", "search wp media", "search wordpress media", "search media library", "find existing wordpress image", "find existing image", "reuse existing media" | `${CLAUDE_SKILL_DIR}/references/wordpress-upload.md` |
 
 ## Reference Loading Table
 
@@ -102,7 +112,7 @@ Detect the user's intent and load the appropriate reference file:
 | "audit links", "find broken links", "link health", "broken links", "dead links" | `link-audit.md` | **Link-audit** |
 | "audit images", "check broken images", "image accessibility", "alt text check", "image optimization" | `image-audit.md` | **Image-audit** |
 | "audit taxonomy", "fix tags", "merge categories", "tag cleanup", "category management" | `taxonomy.md` | **Taxonomy** |
-| "upload to wordpress", "create wordpress draft", "post to wordpress", "wordpress draft", "upload article", "upload image to wordpress", "edit wordpress post", "update wordpress post", "wordpress media" | `wordpress-upload.md` | **WordPress-upload** |
+| "upload to wordpress", "create wordpress draft", "post to wordpress", "wordpress draft", "upload article", "upload image to wordpress", "edit wordpress post", "update wordpress post", "wordpress media", "create wp categories", "auto-create categories", "create missing categories", "search wp media", "search wordpress media", "search media library", "find existing wordpress image", "find existing image", "reuse existing media" | `wordpress-upload.md` | **WordPress-upload** |
 
 ## Instructions
 

--- a/skills/publish/references/wordpress-upload-script-reference.md
+++ b/skills/publish/references/wordpress-upload-script-reference.md
@@ -10,10 +10,11 @@
 | `--category` | | Category by NAME, e.g. `--category "News"` (script looks up ID via REST API). Repeatable. |
 | `--tag` | | Tag by NAME, e.g. `--tag "Example Tag"` (creates if missing). Repeatable. |
 | `--author` | | Author user ID |
+| `--create-missing-categories` | | Auto-create frontmatter / `--category` names that don't exist on the target site. Off by default; missing categories are skipped with a warning. Falls back to skip-with-warning on permission denied or API failure. |
 | `--validate` | | Convert to Gutenberg HTML, validate block structure, print results as JSON, and exit without uploading |
 | `--human` | | Human-readable output |
 
-**WordPress categories**: Look up your site's category IDs via the REST API or wp-admin. Use category names with `--category` and the script resolves IDs automatically.
+**WordPress categories**: Look up your site's category IDs via the REST API or wp-admin. Use category names with `--category` and the script resolves IDs automatically. Pass `--create-missing-categories` to create names that don't already exist on the target site instead of skipping them.
 
 **YAML frontmatter**: The upload script auto-strips frontmatter from the article body. No YAML should appear in the published content. If you see `---` or key-value pairs in the published article, the upload failed to strip it.
 

--- a/skills/publish/references/wordpress-upload.md
+++ b/skills/publish/references/wordpress-upload.md
@@ -58,6 +58,21 @@ python3 ~/.claude/scripts/wordpress-upload.py \
 
 The `--title` flag is optional. If omitted, the script extracts the title from markdown H1. If both `--title` AND H1 exist, this creates a duplicate title rendering in WordPress (anti-pattern). Use one or the other, not both.
 
+**Auto-create missing categories (opt-in):**
+
+By default, frontmatter or `--category` names that don't exist on the target site are skipped with a warning, and the post lands without them. Pass `--create-missing-categories` to create them on the fly via `POST /wp/v2/categories`:
+
+```bash
+python3 ~/.claude/scripts/wordpress-upload.py \
+  --file <path-to-markdown> \
+  --create-missing-categories \
+  --human
+```
+
+When the flag is on, every missing category triggers `Created category '<name>' (id <new-id>)` in `--human` output, the new ID is cached for the rest of the run, and the new ID is attached to the post. On permission denied or any 4xx/5xx from the categories endpoint, the script logs a warning and falls back to the existing skip behavior — the upload never crashes.
+
+Auto-create only applies at upload time. `wordpress-edit-post.py` accepts category IDs (not names) and does not perform name resolution or auto-create; create categories at upload time, or pre-create them via the REST API, before editing.
+
 **For media uploads:**
 
 ```bash
@@ -116,6 +131,78 @@ Use `--get` to retrieve post details for review before making edits.
 **No partial success**. If a multi-step operation fails at step N, report which steps succeeded and which failed. Do not claim completion.
 
 **Gate**: User has received confirmation with URLs and IDs, all steps in workflow completed (or explicit failure report). Operation is complete.
+
+### Phase 3.5: SEARCH MEDIA LIBRARY BEFORE UPLOADING (Optional)
+
+**Goal**: Reuse imagery the site already hosts before uploading new media.
+
+Before calling `wordpress-media-upload.py` for a new image, search the existing library by keyword. If a match exists, embed its URL inline in the markdown body or pass its ID to `wordpress-edit-post.py --featured-image <id>`. This saves CDN bytes, keeps the library tidy, and reuses already-licensed/already-cleared imagery.
+
+**Workflow:**
+
+1. Query `GET /wp/v2/media?search=<KEYWORD>&per_page=N&_fields=id,source_url,title,alt_text,date` with Application-Password basic auth.
+2. Pick existing media items (by `id` or `source_url`) that match the article subject. Prefer recent results when ranking ties.
+3. Embed the chosen `source_url` inline in the markdown body, or pass the `id` to `wordpress-edit-post.py --featured-image <id>` for the hero image.
+4. Skip the new upload entirely when the library already covers the topic.
+
+**Stdlib search snippet** (no third-party deps; uses the same `~/.env` credentials as the upload scripts):
+
+```python
+import base64
+import json
+import os
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+def load_env(path: Path = Path.home() / ".env") -> dict[str, str]:
+    out: dict[str, str] = {}
+    if not path.exists():
+        return out
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        out[k.strip()] = v.strip()
+    return out
+
+
+def search_media(keyword: str, per_page: int = 10) -> list[dict]:
+    env = load_env()
+    site = os.environ.get("WORDPRESS_SITE", env.get("WORDPRESS_SITE", "")).rstrip("/")
+    user = os.environ.get("WORDPRESS_USER", env.get("WORDPRESS_USER", ""))
+    pwd = os.environ.get("WORDPRESS_APP_PASSWORD", env.get("WORDPRESS_APP_PASSWORD", ""))
+    token = base64.b64encode(f"{user}:{pwd}".encode()).decode()
+
+    qs = urllib.parse.urlencode(
+        {
+            "search": keyword,
+            "per_page": per_page,
+            "_fields": "id,source_url,title,alt_text,date",
+        }
+    )
+    req = urllib.request.Request(
+        f"{site}/wp-json/wp/v2/media?{qs}",
+        headers={"Authorization": f"Basic {token}"},
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read().decode())
+
+
+if __name__ == "__main__":
+    import sys
+
+    keyword = sys.argv[1] if len(sys.argv) > 1 else "<KEYWORD>"
+    for item in search_media(keyword):
+        title = item.get("title", {}).get("rendered", "") if isinstance(item.get("title"), dict) else item.get("title", "")
+        print(f"{item['id']}\t{title}\t{item['source_url']}")
+```
+
+Save as `wp_media_search.py` and run `python3 wp_media_search.py "<KEYWORD>"` to print `id<TAB>title<TAB>source_url` for the top matches. Pipe through `head` or `grep` to narrow further.
+
+**When to skip the search**: brand-new subjects with zero prior coverage, or imagery that must be unique to this post (custom hero art, screenshots of a specific UI state). Otherwise, search first.
 
 ### Phase 4: POST-UPLOAD WORKFLOWS (Optional)
 


### PR DESCRIPTION
## Summary

Three generic, opt-in improvements to the WordPress publishing pipeline.

- **`wordpress-upload.py`** gains an opt-in `--create-missing-categories` flag. When set, frontmatter or `--category` names that don't exist on the target site are created via `POST /wp/v2/categories` instead of being silently skipped. New IDs are cached in the existing `_category_cache` for the rest of the run, and any 4xx/5xx (permission denied, validation error, network failure) falls back to the existing skip-with-warning path so the upload never crashes. Default behavior is unchanged.
- **`wordpress-edit-post.py`** now strips YAML frontmatter before converting the markdown body to HTML when `--content-file` is used. Previously the entire file (including the `---` fences and frontmatter lines) was shipped to `markdown_to_html()`, which rendered the leading `---` as `<hr>` and every `key: value` line as a `<p>` paragraph in the published body. The new helper is a no-op when the file has no frontmatter and warns + returns the input unchanged on a missing closing fence so a malformed file never crashes the upload.
- **`skills/publish/references/wordpress-upload.md`** documents the new flag and adds a "Search the media library before uploading" section with a copy-pasteable stdlib (`urllib.request` + `base64`) snippet. Authors can search the existing library by keyword, reuse already-licensed imagery, and skip duplicate uploads — saving CDN bytes and keeping the media library tidy.
- **`skills/publish/SKILL.md`** picks up new semantic triggers ("create wp categories", "auto-create categories", "search wp media", "find existing wordpress image", "reuse existing media", etc.) so routing surfaces these behaviors when authors describe the intent.
- `wordpress-edit-post.py` accepts category IDs (not names) and is otherwise unchanged; the limitation is documented in the reference rather than expanding edit-post's scope.

## Why

All three fixes are universal — every WordPress site has the same category, frontmatter-handling, and media-library shape.

- The current upload script silently skips frontmatter categories that don't exist on the target site, forcing manual `wp-admin` work to fix posts after the fact. An opt-in flag lets authors create taxonomy on demand without changing default semantics for anyone relying on the strict-skip behavior.
- The edit-post script's `--content-file` path was leaking frontmatter into the rendered body, polluting published HTML with `<hr>` plus `<p>title:</p>`, `<p>author:</p>`, etc. Reusing the same fence-search logic as the upload script restores the expected behavior.
- The skill previously gave no guidance on reusing existing WP media. Authors keep re-uploading similar imagery for repeat subjects, bloating the library. Documenting "search first, upload only if needed" closes that gap with a stdlib-only snippet that needs no third-party deps.

## Changes

- `scripts/wordpress-upload.py`: new `create_category()` helper, new `lookup_or_create_category_id()` wrapper, `resolve_taxonomy_ids()` and CLI `--category` resolver thread the flag through; `--create-missing-categories` argparse entry; usage docstring updated.
- `scripts/wordpress-edit-post.py`: new `strip_yaml_frontmatter()` helper called before `markdown_to_html()` in the `--content-file` branch. No-op when no frontmatter is present; warns + falls through on missing closing fence; handles CRLF and an optional UTF-8 BOM.
- `skills/publish/references/wordpress-upload.md`: "Auto-create missing categories" subsection in Phase 2 plus a new Phase 3.5 "Search media library before uploading" section with a `wp_media_search.py` snippet.
- `skills/publish/references/wordpress-upload-script-reference.md`: flag table updated.
- `skills/publish/SKILL.md`: description triggers, routing trigger list, and both routing tables extended with the new semantic phrases.

## Test plan

- [x] `ruff check . --config pyproject.toml` clean.
- [x] `ruff format --check . --config pyproject.toml` clean.
- [x] `python3 scripts/wordpress-upload.py --help` renders `--create-missing-categories` with the expected description.
- [x] In-process behavioral test of `lookup_or_create_category_id`: confirms (a) `create_missing=False` returns `None` on miss (legacy skip), (b) `create_missing=True` posts to the categories endpoint and returns the new ID, (c) the new ID is written back to `_category_cache` so the next call hits the cache without an API round-trip.
- [x] In-process behavioral test of `strip_yaml_frontmatter`: covers (a) no frontmatter (no-op), (b) standard frontmatter at start (body returned), (c) opening fence with no closing fence (warning emitted, input returned unchanged), (d) CRLF line endings, plus an optional UTF-8 BOM bonus case.
- [x] End-to-end repair: re-ran the patched edit-post script against a previously affected draft, then re-fetched the post via `GET /wp/v2/posts/<id>?status=any&_fields=content,status,featured_media` — rendered body no longer contains `focus_keyword`, `featured_image`, `<p>title:`, `<p>author:`, or the `<hr>\n<p>title:` regression signature; status and featured media unchanged; signature quotes and inline images preserved.
- [x] YAML frontmatter on `skills/publish/SKILL.md` parses; trigger count went from 45 to 54.
- [ ] Manual end-to-end: `python3 scripts/wordpress-upload.py --file <draft.md> --create-missing-categories --human` against a sandbox WordPress site with a frontmatter category that doesn't exist on the target.
- [ ] Manual permission-denied path: same command with an Application Password that lacks `manage_categories` — verify the warning prints and the post still uploads with the existing skip-with-warning behavior.
