### PR TITLE
feat(routing): add explicit agent fields and enrich pairs_with across 60 skills

### DIFF
--- a/agents/INDEX.json
+++ b/agents/INDEX.json
@@ -113,7 +113,8 @@
         "programming rules"
       ],
       "pairs_with": [
-        "github-profile-rules"
+        "codebase-analyzer",
+        "generate-claudemd"
       ],
       "complexity": "Medium",
       "category": "meta"
@@ -340,7 +341,6 @@
         "plugin schema"
       ],
       "pairs_with": [
-        "perses-onboard",
         "perses",
         "golang-general-engineer",
         "typescript-frontend-engineer",
@@ -796,11 +796,11 @@
         "apply retro"
       ],
       "pairs_with": [
-        "system-upgrade",
+        "toolkit-evolution",
         "agent-evaluation",
         "codebase-analyzer",
         "routing-table-updater",
-        "pr-pipeline"
+        "pr-workflow"
       ],
       "complexity": "Complex",
       "category": "meta"

--- a/agents/github-profile-rules-engineer.md
+++ b/agents/github-profile-rules-engineer.md
@@ -10,7 +10,8 @@ routing:
     - github conventions
     - programming rules
   pairs_with:
-    - workflow
+    - codebase-analyzer
+    - generate-claudemd
   complexity: Medium
   category: meta
 allowed-tools:

--- a/scripts/validate-pairs-with.py
+++ b/scripts/validate-pairs-with.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate that all pairs_with entries in agent frontmatter resolve to real
+"""Validate that all pairs_with entries in agent and skill frontmatter resolve to real
 skills, pipelines, or other agents.
 
 Exit 0 if every reference resolves; exit 1 if any are broken.
@@ -84,7 +84,7 @@ def parse_frontmatter(text: str) -> dict[str, object] | None:
             # Block list item
             list_match = re.match(r"^\s+-\s+(.*)", stripped)
             if list_match:
-                item = list_match.group(1).strip()
+                item = list_match.group(1).strip().strip("'\"")
                 if current_list is None:
                     current_list = []
                     # Figure out which key this list belongs to
@@ -212,8 +212,53 @@ def validate_agents(agents_dir: Path, skills_dir: Path, pipelines_dir: Path) -> 
     return broken
 
 
+def validate_skills(skills_dir: Path, pipelines_dir: Path, agents_dir: Path) -> list[tuple[str, str, str]]:
+    """Validate all pairs_with references in skill frontmatter.
+
+    Returns list of (skill_dir_name, broken_ref, suggestion).
+    """
+    valid_names = collect_valid_names(skills_dir, pipelines_dir, agents_dir)
+    broken: list[tuple[str, str, str]] = []
+
+    if not skills_dir.is_dir():
+        return broken
+
+    for skill_dir in sorted(skills_dir.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        skill_file = skill_dir / "SKILL.md"
+        if not skill_file.exists():
+            continue
+
+        text = skill_file.read_text(encoding="utf-8")
+        frontmatter = parse_frontmatter(text)
+        if not frontmatter:
+            continue
+
+        routing = frontmatter.get("routing")
+        if not isinstance(routing, dict):
+            continue
+
+        pairs_with = routing.get("pairs_with")
+        if not pairs_with:
+            continue
+
+        if isinstance(pairs_with, str):
+            pairs_with = [pairs_with]
+        if not isinstance(pairs_with, list):
+            continue
+
+        for ref in pairs_with:
+            ref = str(ref).strip()
+            if ref and ref not in valid_names:
+                suggestion = suggest_fix(ref, valid_names)
+                broken.append((skill_dir.name, ref, suggestion))
+
+    return broken
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Validate pairs_with references in agent frontmatter")
+    parser = argparse.ArgumentParser(description="Validate pairs_with references in agent and skill frontmatter")
     parser.add_argument(
         "--agents-dir",
         default="agents",
@@ -237,24 +282,27 @@ def main() -> None:
     pipelines_dir = Path(args.pipelines_dir).resolve()
 
     broken = validate_agents(agents_dir, skills_dir, pipelines_dir)
+    skill_broken = validate_skills(skills_dir, pipelines_dir, agents_dir)
 
-    if not broken:
+    all_broken = [(f"agent:{b[0]}", b[1], b[2]) for b in broken] + [(f"skill:{b[0]}", b[1], b[2]) for b in skill_broken]
+
+    if not all_broken:
         print("All pairs_with references are valid.")
         sys.exit(0)
 
     # Print results table
-    max_agent = max(len(b[0]) for b in broken)
-    max_ref = max(len(b[1]) for b in broken)
-    max_sug = max(len(b[2]) for b in broken)
+    max_source = max(len(b[0]) for b in all_broken)
+    max_ref = max(len(b[1]) for b in all_broken)
+    max_sug = max(len(b[2]) for b in all_broken)
 
-    header = f"{'Agent File':<{max_agent}}  {'Broken Reference':<{max_ref}}  {'Suggested Fix':<{max_sug}}"
+    header = f"{'Source':<{max_source}}  {'Broken Reference':<{max_ref}}  {'Suggested Fix':<{max_sug}}"
     print(header)
     print("-" * len(header))
 
-    for agent_file, ref, suggestion in broken:
-        print(f"{agent_file:<{max_agent}}  {ref:<{max_ref}}  {suggestion:<{max_sug}}")
+    for source, ref, suggestion in all_broken:
+        print(f"{source:<{max_source}}  {ref:<{max_ref}}  {suggestion:<{max_sug}}")
 
-    print(f"\nTotal broken references: {len(broken)}")
+    print(f"\nTotal broken references: {len(all_broken)}")
     sys.exit(1)
 
 

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-04-27T18:53:32Z",
+  "generated": "2026-04-27T23:07:27Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
     "adr-consultation": {
@@ -33,7 +33,11 @@
         "run autoresearch"
       ],
       "category": "meta-tooling",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "agent-evaluation",
+        "skill-eval"
+      ]
     },
     "agent-evaluation": {
       "file": "skills/agent-evaluation/SKILL.md",
@@ -47,7 +51,12 @@
         "agent quality"
       ],
       "category": "meta-tooling",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "agent-comparison",
+        "skill-eval",
+        "skill-creator"
+      ]
     },
     "anti-ai-editor": {
       "file": "skills/anti-ai-editor/SKILL.md",
@@ -60,7 +69,12 @@
         "humanize text"
       ],
       "category": "content-creation",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "voice-writer",
+        "voice-validator",
+        "joy-check"
+      ]
     },
     "auto-dream": {
       "file": "skills/auto-dream/SKILL.md",
@@ -91,6 +105,9 @@
       ],
       "category": "research",
       "user_invocable": false,
+      "pairs_with": [
+        "content-engine"
+      ],
       "agent": "python-general-engineer"
     },
     "cobalt-core": {
@@ -111,7 +128,8 @@
         "go-patterns",
         "prometheus-grafana-engineer",
         "kubernetes-helm-engineer"
-      ]
+      ],
+      "agent": "kubernetes-helm-engineer"
     },
     "code-cleanup": {
       "file": "skills/code-cleanup/SKILL.md",
@@ -126,7 +144,12 @@
         "find unused"
       ],
       "category": "code-quality",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "code-linting",
+        "universal-quality-gate",
+        "comment-quality"
+      ]
     },
     "code-linting": {
       "file": "skills/code-linting/SKILL.md",
@@ -139,7 +162,12 @@
         "lint errors"
       ],
       "category": "code-quality",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "code-cleanup",
+        "universal-quality-gate",
+        "python-quality-gate"
+      ]
     },
     "codebase-analyzer": {
       "file": "skills/codebase-analyzer/SKILL.md",
@@ -153,7 +181,11 @@
         "structural metrics"
       ],
       "category": "analysis",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "codebase-overview",
+        "go-patterns"
+      ]
     },
     "codebase-overview": {
       "file": "skills/codebase-overview/SKILL.md",
@@ -167,7 +199,11 @@
         "understand this codebase"
       ],
       "category": "analysis",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "codebase-analyzer",
+        "generate-claudemd"
+      ]
     },
     "comment-quality": {
       "file": "skills/comment-quality/SKILL.md",
@@ -180,7 +216,11 @@
         "outdated comment"
       ],
       "category": "code-quality",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "code-cleanup",
+        "systematic-code-review"
+      ]
     },
     "condition-based-waiting": {
       "file": "skills/condition-based-waiting/SKILL.md",
@@ -195,7 +235,11 @@
         "retry until success"
       ],
       "category": "process",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "shell-process-patterns",
+        "service-health-check"
+      ]
     },
     "content-calendar": {
       "file": "skills/content-calendar/SKILL.md",
@@ -208,7 +252,12 @@
         "publication plan"
       ],
       "category": "content-creation",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "topic-brainstormer",
+        "series-planner",
+        "publish"
+      ]
     },
     "content-engine": {
       "file": "skills/content-engine/SKILL.md",
@@ -247,7 +296,7 @@
       "force_route": true,
       "user_invocable": false,
       "pairs_with": [
-        "voice-calibrator",
+        "voice-validator",
         "voice-writer"
       ]
     },
@@ -262,7 +311,11 @@
         "scheduled task safety"
       ],
       "category": "infrastructure",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "shell-process-patterns",
+        "headless-cron-creator"
+      ]
     },
     "csuite": {
       "file": "skills/csuite/SKILL.md",
@@ -358,7 +411,12 @@
         "evaluate options"
       ],
       "category": "process",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "multi-persona-critique",
+        "adr-consultation",
+        "planning"
+      ]
     },
     "distinctive-frontend-design": {
       "file": "skills/distinctive-frontend-design/SKILL.md",
@@ -371,7 +429,12 @@
         "design language"
       ],
       "category": "frontend",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "threejs-builder",
+        "webgl-card-effects",
+        "frontend-slides"
+      ]
     },
     "do": {
       "file": "skills/do/SKILL.md",
@@ -397,7 +460,11 @@
         "README outdated"
       ],
       "category": "documentation",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "generate-claudemd",
+        "codebase-overview"
+      ]
     },
     "e2e-testing": {
       "file": "skills/e2e-testing/SKILL.md",
@@ -432,7 +499,11 @@
         "smoke test"
       ],
       "category": "infrastructure",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "service-health-check",
+        "e2e-testing"
+      ]
     },
     "explanation-traces": {
       "file": "skills/explanation-traces/SKILL.md",
@@ -490,7 +561,6 @@
       "pairs_with": [
         "workflow",
         "subagent-driven-development",
-        "pr-pipeline",
         "pr-workflow",
         "verification-before-completion",
         "universal-quality-gate",
@@ -583,7 +653,8 @@
       "category": "analysis",
       "user_invocable": true,
       "pairs_with": [
-        "comprehensive-review"
+        "systematic-code-review",
+        "parallel-code-review"
       ]
     },
     "game-asset-generator": {
@@ -621,7 +692,8 @@
       "pairs_with": [
         "threejs-builder",
         "typescript-frontend-engineer"
-      ]
+      ],
+      "agent": "typescript-frontend-engineer"
     },
     "game-pipeline": {
       "file": "skills/game-pipeline/SKILL.md",
@@ -678,7 +750,8 @@
         "phaser-gamedev",
         "threejs-builder",
         "python-general-engineer"
-      ]
+      ],
+      "agent": "python-general-engineer"
     },
     "gemini-image-generator": {
       "file": "skills/gemini-image-generator/SKILL.md",
@@ -697,7 +770,8 @@
       "pairs_with": [
         "python-general-engineer",
         "workflow"
-      ]
+      ],
+      "agent": "python-general-engineer"
     },
     "generate-claudemd": {
       "file": "skills/generate-claudemd/SKILL.md",
@@ -799,6 +873,10 @@
       ],
       "category": "process",
       "user_invocable": false,
+      "pairs_with": [
+        "cron-job-auditor",
+        "shell-process-patterns"
+      ],
       "agent": "python-general-engineer"
     },
     "image-to-video": {
@@ -854,7 +932,7 @@
       "user_invocable": false,
       "pairs_with": [
         "feature-lifecycle",
-        "comprehensive-review"
+        "systematic-code-review"
       ]
     },
     "joy-check": {
@@ -922,6 +1000,10 @@
       ],
       "category": "research",
       "user_invocable": false,
+      "pairs_with": [
+        "research-pipeline",
+        "topic-brainstormer"
+      ],
       "agent": "general-purpose"
     },
     "kotlin-coroutines": {
@@ -937,6 +1019,9 @@
       ],
       "category": "kotlin",
       "user_invocable": false,
+      "pairs_with": [
+        "kotlin-testing"
+      ],
       "agent": "kotlin-general-engineer"
     },
     "kotlin-testing": {
@@ -951,6 +1036,10 @@
       ],
       "category": "kotlin",
       "user_invocable": false,
+      "pairs_with": [
+        "kotlin-coroutines",
+        "test-driven-development"
+      ],
       "agent": "kotlin-general-engineer"
     },
     "kubernetes-debugging": {
@@ -966,6 +1055,10 @@
       ],
       "category": "kubernetes",
       "user_invocable": false,
+      "pairs_with": [
+        "kubernetes-security",
+        "service-health-check"
+      ],
       "agent": "kubernetes-helm-engineer"
     },
     "kubernetes-security": {
@@ -980,6 +1073,10 @@
       ],
       "category": "kubernetes",
       "user_invocable": false,
+      "pairs_with": [
+        "kubernetes-debugging",
+        "cobalt-core"
+      ],
       "agent": "kubernetes-helm-engineer"
     },
     "learn": {
@@ -993,7 +1090,11 @@
         "save learning"
       ],
       "category": "meta-tooling",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "retro",
+        "auto-dream"
+      ]
     },
     "motion-pipeline": {
       "file": "skills/motion-pipeline/SKILL.md",
@@ -1012,7 +1113,11 @@
         "skeletal animation data"
       ],
       "category": "game-animation",
-      "user_invocable": true
+      "user_invocable": true,
+      "pairs_with": [
+        "game-sprite-pipeline",
+        "phaser-gamedev"
+      ]
     },
     "multi-persona-critique": {
       "file": "skills/multi-persona-critique/SKILL.md",
@@ -1054,7 +1159,8 @@
       "pairs_with": [
         "python-general-engineer",
         "universal-quality-gate"
-      ]
+      ],
+      "agent": "python-general-engineer"
     },
     "pair-programming": {
       "file": "skills/pair-programming/SKILL.md",
@@ -1070,7 +1176,11 @@
         "interactive coding"
       ],
       "category": "process",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "test-driven-development",
+        "subagent-driven-development"
+      ]
     },
     "parallel-code-review": {
       "file": "skills/parallel-code-review/SKILL.md",
@@ -1083,7 +1193,11 @@
         "concurrent review"
       ],
       "category": "code-review",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "systematic-code-review",
+        "verification-before-completion"
+      ]
     },
     "perses": {
       "file": "skills/perses/SKILL.md",
@@ -1129,7 +1243,8 @@
       "pairs_with": [
         "typescript-frontend-engineer",
         "game-asset-generator"
-      ]
+      ],
+      "agent": "typescript-frontend-engineer"
     },
     "php-quality": {
       "file": "skills/php-quality/SKILL.md",
@@ -1143,6 +1258,10 @@
       ],
       "category": "php",
       "user_invocable": false,
+      "pairs_with": [
+        "php-testing",
+        "code-linting"
+      ],
       "agent": "php-general-engineer"
     },
     "php-testing": {
@@ -1156,6 +1275,10 @@
       ],
       "category": "php",
       "user_invocable": false,
+      "pairs_with": [
+        "php-quality",
+        "test-driven-development"
+      ],
       "agent": "php-general-engineer"
     },
     "planning": {
@@ -1231,6 +1354,11 @@
       "category": "process",
       "force_route": true,
       "user_invocable": true,
+      "pairs_with": [
+        "workflow",
+        "feature-lifecycle",
+        "decision-helper"
+      ],
       "agent": "general-purpose"
     },
     "plant-seed": {
@@ -1326,7 +1454,12 @@
       ],
       "category": "git-workflow",
       "force_route": true,
-      "user_invocable": true
+      "user_invocable": true,
+      "pairs_with": [
+        "verification-before-completion",
+        "code-linting",
+        "systematic-code-review"
+      ]
     },
     "professional-communication": {
       "file": "skills/professional-communication/SKILL.md",
@@ -1342,7 +1475,11 @@
         "status update"
       ],
       "category": "content-creation",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "voice-writer",
+        "pptx-generator"
+      ]
     },
     "publish": {
       "file": "skills/publish/SKILL.md",
@@ -1396,6 +1533,10 @@
       ],
       "category": "content-publishing",
       "user_invocable": false,
+      "pairs_with": [
+        "content-calendar",
+        "wordpress-live-validation"
+      ],
       "agent": "general-purpose"
     },
     "python-quality-gate": {
@@ -1414,6 +1555,10 @@
       "category": "code-quality",
       "force_route": true,
       "user_invocable": false,
+      "pairs_with": [
+        "code-linting",
+        "test-driven-development"
+      ],
       "agent": "python-general-engineer"
     },
     "quick": {
@@ -1453,7 +1598,10 @@
         "inspect only"
       ],
       "category": "process",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "codebase-overview"
+      ]
     },
     "reddit-moderate": {
       "file": "skills/reddit-moderate/SKILL.md",
@@ -1467,6 +1615,9 @@
       ],
       "category": "process",
       "user_invocable": false,
+      "pairs_with": [
+        "content-engine"
+      ],
       "agent": "python-general-engineer"
     },
     "reference-enrichment": {
@@ -1522,6 +1673,10 @@
       ],
       "category": "research",
       "user_invocable": true,
+      "pairs_with": [
+        "kb",
+        "topic-brainstormer"
+      ],
       "agent": "research-coordinator-engineer"
     },
     "retro": {
@@ -1535,7 +1690,11 @@
         "search learnings"
       ],
       "category": "meta-tooling",
-      "user_invocable": true
+      "user_invocable": true,
+      "pairs_with": [
+        "learn",
+        "auto-dream"
+      ]
     },
     "roast": {
       "file": "skills/roast/SKILL.md",
@@ -1549,7 +1708,11 @@
         "poke holes in this"
       ],
       "category": "analysis",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "multi-persona-critique",
+        "systematic-code-review"
+      ]
     },
     "routing-table-updater": {
       "file": "skills/routing-table-updater/SKILL.md",
@@ -1562,7 +1725,11 @@
         "routing drift"
       ],
       "category": "meta-tooling",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "toolkit-evolution",
+        "generate-claudemd"
+      ]
     },
     "sapcc-audit": {
       "file": "skills/sapcc-audit/SKILL.md",
@@ -1623,7 +1790,8 @@
       "user_invocable": false,
       "pairs_with": [
         "python-general-engineer"
-      ]
+      ],
+      "agent": "python-general-engineer"
     },
     "series-planner": {
       "file": "skills/series-planner/SKILL.md",
@@ -1636,7 +1804,12 @@
         "content arc"
       ],
       "category": "content-creation",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "content-calendar",
+        "topic-brainstormer",
+        "publish"
+      ]
     },
     "service-health-check": {
       "file": "skills/service-health-check/SKILL.md",
@@ -1649,7 +1822,12 @@
         "check health"
       ],
       "category": "infrastructure",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "kubernetes-debugging",
+        "endpoint-validator",
+        "condition-based-waiting"
+      ]
     },
     "shell-process-patterns": {
       "file": "skills/shell-process-patterns/SKILL.md",
@@ -1684,7 +1862,11 @@
         "combine skills"
       ],
       "category": "meta-tooling",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "workflow",
+        "feature-lifecycle"
+      ]
     },
     "skill-creator": {
       "file": "skills/skill-creator/SKILL.md",
@@ -1748,7 +1930,11 @@
         "teach me to find it"
       ],
       "category": "process",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "forensics",
+        "systematic-code-review"
+      ]
     },
     "subagent-driven-development": {
       "file": "skills/subagent-driven-development/SKILL.md",
@@ -1761,7 +1947,11 @@
         "fresh context per task"
       ],
       "category": "process",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "pair-programming",
+        "testing-agents-with-subagents"
+      ]
     },
     "swift-concurrency": {
       "file": "skills/swift-concurrency/SKILL.md",
@@ -1774,6 +1964,9 @@
       ],
       "category": "swift",
       "user_invocable": false,
+      "pairs_with": [
+        "swift-testing"
+      ],
       "agent": "swift-general-engineer"
     },
     "swift-testing": {
@@ -1787,6 +1980,10 @@
       ],
       "category": "swift",
       "user_invocable": false,
+      "pairs_with": [
+        "swift-concurrency",
+        "test-driven-development"
+      ],
       "agent": "swift-general-engineer"
     },
     "systematic-code-review": {
@@ -1801,7 +1998,12 @@
         "comprehensive review"
       ],
       "category": "code-review",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "forensics",
+        "verification-before-completion",
+        "parallel-code-review"
+      ]
     },
     "test-driven-development": {
       "file": "skills/test-driven-development/SKILL.md",
@@ -1816,7 +2018,12 @@
         "tests before code"
       ],
       "category": "testing",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "verification-before-completion",
+        "testing-anti-patterns",
+        "vitest-runner"
+      ]
     },
     "testing-agents-with-subagents": {
       "file": "skills/testing-agents-with-subagents/SKILL.md",
@@ -1829,7 +2036,11 @@
         "agent test harness"
       ],
       "category": "testing",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "agent-evaluation",
+        "subagent-driven-development"
+      ]
     },
     "testing-anti-patterns": {
       "file": "skills/testing-anti-patterns/SKILL.md",
@@ -1891,7 +2102,8 @@
         "typescript-frontend-engineer",
         "react-native-engineer",
         "distinctive-frontend-design"
-      ]
+      ],
+      "agent": "typescript-frontend-engineer"
     },
     "toolkit-evolution": {
       "file": "skills/toolkit-evolution/SKILL.md",
@@ -1924,7 +2136,12 @@
         "what to write about"
       ],
       "category": "content-creation",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "content-calendar",
+        "series-planner",
+        "research-pipeline"
+      ]
     },
     "typescript-check": {
       "file": "skills/typescript-check/SKILL.md",
@@ -1938,6 +2155,10 @@
       ],
       "category": "code-quality",
       "user_invocable": false,
+      "pairs_with": [
+        "vitest-runner",
+        "code-linting"
+      ],
       "agent": "typescript-frontend-engineer"
     },
     "universal-quality-gate": {
@@ -1951,7 +2172,11 @@
         "language-agnostic lint"
       ],
       "category": "code-quality",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "code-linting",
+        "verification-before-completion"
+      ]
     },
     "verification-before-completion": {
       "file": "skills/verification-before-completion/SKILL.md",
@@ -1964,7 +2189,11 @@
         "final verification"
       ],
       "category": "process",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "systematic-code-review",
+        "with-anti-rationalization"
+      ]
     },
     "video-editing": {
       "file": "skills/video-editing/SKILL.md",
@@ -2000,11 +2229,16 @@
         "vitest output"
       ],
       "category": "testing",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "test-driven-development",
+        "typescript-check",
+        "e2e-testing"
+      ]
     },
     "voice-feynman": {
       "file": "skills/voice-feynman/SKILL.md",
-      "description": "Apply Richard Feynman's voice profile for content generation: mechanism-first thinking, refusal of jargon, plain English when truth is embarrassing...",
+      "description": "Apply Richard Feynman's voice profile for content generation: mechanism-first",
       "triggers": [
         "voice-feynman",
         "voice",
@@ -2024,7 +2258,12 @@
         "writing style check"
       ],
       "category": "voice",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "voice-writer",
+        "anti-ai-editor",
+        "joy-check"
+      ]
     },
     "voice-writer": {
       "file": "skills/voice-writer/SKILL.md",
@@ -2037,7 +2276,13 @@
         "content pipeline"
       ],
       "category": "voice",
-      "user_invocable": true
+      "user_invocable": true,
+      "pairs_with": [
+        "voice-validator",
+        "anti-ai-editor",
+        "joy-check",
+        "voice-feynman"
+      ]
     },
     "webgl-card-effects": {
       "file": "skills/webgl-card-effects/SKILL.md",
@@ -2059,7 +2304,8 @@
       "pairs_with": [
         "typescript-frontend-engineer",
         "ui-design-engineer"
-      ]
+      ],
+      "agent": "typescript-frontend-engineer"
     },
     "with-anti-rationalization": {
       "file": "skills/with-anti-rationalization/SKILL.md",
@@ -2072,7 +2318,10 @@
         "no shortcuts"
       ],
       "category": "process",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "verification-before-completion"
+      ]
     },
     "wordpress-live-validation": {
       "file": "skills/wordpress-live-validation/SKILL.md",
@@ -2090,9 +2339,8 @@
       "category": "content-publishing",
       "user_invocable": false,
       "pairs_with": [
-        "wordpress-uploader",
-        "pre-publish-checker",
-        "seo-optimizer"
+        "publish",
+        "e2e-testing"
       ]
     },
     "workflow": {
@@ -2106,7 +2354,12 @@
         "orchestrated workflow"
       ],
       "category": "meta-tooling",
-      "user_invocable": false
+      "user_invocable": false,
+      "pairs_with": [
+        "planning",
+        "feature-lifecycle",
+        "verification-before-completion"
+      ]
     },
     "workflow-help": {
       "file": "skills/workflow-help/SKILL.md",
@@ -2120,7 +2373,11 @@
         "toolkit help"
       ],
       "category": "meta-tooling",
-      "user_invocable": true
+      "user_invocable": true,
+      "pairs_with": [
+        "workflow",
+        "do"
+      ]
     },
     "worktree-agent": {
       "file": "skills/worktree-agent/SKILL.md",

--- a/skills/agent-comparison/SKILL.md
+++ b/skills/agent-comparison/SKILL.md
@@ -19,6 +19,9 @@ routing:
     - "optimize description"
     - "run autoresearch"
   category: meta-tooling
+  pairs_with:
+    - agent-evaluation
+    - skill-eval
 ---
 
 # Agent Comparison Skill

--- a/skills/agent-evaluation/SKILL.md
+++ b/skills/agent-evaluation/SKILL.md
@@ -17,6 +17,10 @@ routing:
     - "grade agent"
     - "agent quality"
   category: meta-tooling
+  pairs_with:
+    - agent-comparison
+    - skill-eval
+    - skill-creator
 ---
 
 # Agent Evaluation Skill

--- a/skills/anti-ai-editor/SKILL.md
+++ b/skills/anti-ai-editor/SKILL.md
@@ -20,6 +20,10 @@ routing:
     - "remove AI voice"
     - "humanize text"
   category: content-creation
+  pairs_with:
+    - voice-writer
+    - voice-validator
+    - joy-check
 ---
 
 # Anti-AI Editor

--- a/skills/bluesky-reader/SKILL.md
+++ b/skills/bluesky-reader/SKILL.md
@@ -14,6 +14,8 @@ routing:
     - "Bluesky feed"
     - "bsky"
   category: research
+  pairs_with:
+    - content-engine
 ---
 
 # Bluesky Reader Skill

--- a/skills/cobalt-core/SKILL.md
+++ b/skills/cobalt-core/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cobalt-core
 description: "Cobalt Core infrastructure knowledge: KVM exporters, hypervisor tooling, OpenStack compute."
+agent: kubernetes-helm-engineer
 user-invocable: true
 argument-hint: "<cobaltcore topic or repo name>"
 allowed-tools:

--- a/skills/code-cleanup/SKILL.md
+++ b/skills/code-cleanup/SKILL.md
@@ -31,6 +31,10 @@ routing:
     - "remove dead code"
     - "find unused"
   category: code-quality
+  pairs_with:
+    - code-linting
+    - universal-quality-gate
+    - comment-quality
 ---
 
 # Code Cleanup Skill

--- a/skills/code-linting/SKILL.md
+++ b/skills/code-linting/SKILL.md
@@ -17,6 +17,10 @@ routing:
     - "format code"
     - "lint errors"
   category: code-quality
+  pairs_with:
+    - code-cleanup
+    - universal-quality-gate
+    - python-quality-gate
 ---
 
 # Code Linting Skill

--- a/skills/codebase-analyzer/SKILL.md
+++ b/skills/codebase-analyzer/SKILL.md
@@ -20,6 +20,9 @@ routing:
     - "pattern frequency"
     - "structural metrics"
   category: analysis
+  pairs_with:
+    - codebase-overview
+    - go-patterns
 ---
 
 # Codebase Analyzer Skill

--- a/skills/codebase-overview/SKILL.md
+++ b/skills/codebase-overview/SKILL.md
@@ -21,6 +21,9 @@ routing:
     - "summarize this repo"
     - "understand this codebase"
   category: analysis
+  pairs_with:
+    - codebase-analyzer
+    - generate-claudemd
 ---
 
 # Codebase Overview Skill

--- a/skills/comment-quality/SKILL.md
+++ b/skills/comment-quality/SKILL.md
@@ -18,6 +18,9 @@ routing:
     - "stale comments"
     - "outdated comment"
   category: code-quality
+  pairs_with:
+    - code-cleanup
+    - systematic-code-review
 ---
 
 # Comment Quality Skill

--- a/skills/condition-based-waiting/SKILL.md
+++ b/skills/condition-based-waiting/SKILL.md
@@ -19,6 +19,9 @@ routing:
     - "poll until ready"
     - "retry until success"
   category: process
+  pairs_with:
+    - shell-process-patterns
+    - service-health-check
 ---
 
 # Condition-Based Waiting

--- a/skills/content-calendar/SKILL.md
+++ b/skills/content-calendar/SKILL.md
@@ -17,6 +17,10 @@ routing:
     - "content schedule"
     - "publication plan"
   category: content-creation
+  pairs_with:
+    - topic-brainstormer
+    - series-planner
+    - publish
 ---
 
 # Content Calendar Skill

--- a/skills/create-voice/SKILL.md
+++ b/skills/create-voice/SKILL.md
@@ -24,7 +24,7 @@ routing:
     - voice profile from scratch
     - make a voice
   pairs_with:
-    - voice-calibrator
+    - voice-validator
     - voice-writer
   complexity: Medium
   category: content

--- a/skills/cron-job-auditor/SKILL.md
+++ b/skills/cron-job-auditor/SKILL.md
@@ -15,6 +15,9 @@ routing:
     - "cron reliability"
     - "scheduled task safety"
   category: infrastructure
+  pairs_with:
+    - shell-process-patterns
+    - headless-cron-creator
 ---
 
 # Cron Job Auditor Skill

--- a/skills/decision-helper/SKILL.md
+++ b/skills/decision-helper/SKILL.md
@@ -21,6 +21,10 @@ routing:
     - "should I use"
     - "evaluate options"
   category: process
+  pairs_with:
+    - multi-persona-critique
+    - adr-consultation
+    - planning
 ---
 
 # Decision Helper Skill

--- a/skills/distinctive-frontend-design/SKILL.md
+++ b/skills/distinctive-frontend-design/SKILL.md
@@ -19,6 +19,10 @@ routing:
     - "visual identity"
     - "design language"
   category: frontend
+  pairs_with:
+    - threejs-builder
+    - webgl-card-effects
+    - frontend-slides
 ---
 
 # Distinctive Frontend Design Skill

--- a/skills/docs-sync-checker/SKILL.md
+++ b/skills/docs-sync-checker/SKILL.md
@@ -18,6 +18,9 @@ routing:
     - "documentation drift"
     - "README outdated"
   category: documentation
+  pairs_with:
+    - generate-claudemd
+    - codebase-overview
 ---
 
 # Documentation Sync Checker Skill

--- a/skills/endpoint-validator/SKILL.md
+++ b/skills/endpoint-validator/SKILL.md
@@ -17,6 +17,9 @@ routing:
     - "check API"
     - "smoke test"
   category: infrastructure
+  pairs_with:
+    - service-health-check
+    - e2e-testing
 ---
 
 # Endpoint Validator Skill

--- a/skills/feature-lifecycle/SKILL.md
+++ b/skills/feature-lifecycle/SKILL.md
@@ -46,7 +46,6 @@ routing:
   pairs_with:
     - workflow
     - subagent-driven-development
-    - pr-pipeline
     - pr-workflow
     - verification-before-completion
     - universal-quality-gate

--- a/skills/full-repo-review/SKILL.md
+++ b/skills/full-repo-review/SKILL.md
@@ -19,7 +19,8 @@ routing:
     - review all files
     - full codebase review
   pairs_with:
-    - comprehensive-review
+    - systematic-code-review
+    - parallel-code-review
   complexity: Medium
   category: analysis
 ---

--- a/skills/game-asset-generator/SKILL.md
+++ b/skills/game-asset-generator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: game-asset-generator
 description: "Deterministic palette/matrix pixel art (not AI). Use for procedural tile art, color-quantized output, matrix sprites."
+agent: typescript-frontend-engineer
 user-invocable: false
 command: /game-assets
 allowed-tools:

--- a/skills/game-sprite-pipeline/SKILL.md
+++ b/skills/game-sprite-pipeline/SKILL.md
@@ -2,6 +2,7 @@
 name: game-sprite-pipeline
 version: 1.0.0
 description: "AI sprite generation: portraits, idle loops, animated sheets via Codex/Nano Banana. Use for generated character art."
+agent: python-general-engineer
 user-invocable: false
 allowed-tools:
   - Read

--- a/skills/gemini-image-generator/SKILL.md
+++ b/skills/gemini-image-generator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: gemini-image-generator
 description: "Generate images from text prompts via Google Gemini."
+agent: python-general-engineer
 user-invocable: false
 allowed-tools:
   - Read

--- a/skills/headless-cron-creator/SKILL.md
+++ b/skills/headless-cron-creator/SKILL.md
@@ -19,6 +19,9 @@ routing:
     - "background automation"
     - "recurring agent"
   category: process
+  pairs_with:
+    - cron-job-auditor
+    - shell-process-patterns
 ---
 
 # Headless Cron Creator Skill

--- a/skills/integration-checker/SKILL.md
+++ b/skills/integration-checker/SKILL.md
@@ -19,7 +19,7 @@ routing:
     - wiring check
   pairs_with:
     - feature-lifecycle
-    - comprehensive-review
+    - systematic-code-review
   complexity: Medium
   category: process
 ---

--- a/skills/kb/SKILL.md
+++ b/skills/kb/SKILL.md
@@ -34,6 +34,9 @@ routing:
     - "kb consistency"
   category: research
   complexity: medium
+  pairs_with:
+    - research-pipeline
+    - topic-brainstormer
 ---
 
 # KB Skill

--- a/skills/kotlin-coroutines/SKILL.md
+++ b/skills/kotlin-coroutines/SKILL.md
@@ -13,6 +13,8 @@ routing:
     - "suspend function"
     - "structured concurrency kotlin"
   category: kotlin
+  pairs_with:
+    - kotlin-testing
 ---
 
 # Kotlin Coroutines Patterns

--- a/skills/kotlin-testing/SKILL.md
+++ b/skills/kotlin-testing/SKILL.md
@@ -12,6 +12,9 @@ routing:
     - "junit 5 kotlin"
     - "kotlin test dispatcher"
   category: kotlin
+  pairs_with:
+    - kotlin-coroutines
+    - test-driven-development
 ---
 
 # Kotlin Testing Patterns

--- a/skills/kubernetes-debugging/SKILL.md
+++ b/skills/kubernetes-debugging/SKILL.md
@@ -13,6 +13,9 @@ routing:
     - "OOMKilled"
     - "pod pending"
   category: kubernetes
+  pairs_with:
+    - kubernetes-security
+    - service-health-check
 ---
 
 # Kubernetes Debugging Skill

--- a/skills/kubernetes-security/SKILL.md
+++ b/skills/kubernetes-security/SKILL.md
@@ -12,6 +12,9 @@ routing:
     - "pod security policy"
     - "network policy"
   category: kubernetes
+  pairs_with:
+    - kubernetes-debugging
+    - cobalt-core
 ---
 
 # Kubernetes Security Skill

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -14,6 +14,9 @@ routing:
     - "teach error pattern"
     - "save learning"
   category: meta-tooling
+  pairs_with:
+    - retro
+    - auto-dream
 ---
 
 # Learn Error Pattern Skill

--- a/skills/motion-pipeline/SKILL.md
+++ b/skills/motion-pipeline/SKILL.md
@@ -23,6 +23,9 @@ routing:
     - "FABRIK"
     - "skeletal animation data"
   category: game-animation
+  pairs_with:
+    - game-sprite-pipeline
+    - phaser-gamedev
   agents:
     - rive-skeletal-animator
     - pixijs-combat-renderer

--- a/skills/nano-banana-builder/SKILL.md
+++ b/skills/nano-banana-builder/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nano-banana-builder
 description: "Image generation and post-processing via Gemini Nano Banana APIs."
+agent: python-general-engineer
 user-invocable: false
 allowed-tools:
   - Read

--- a/skills/pair-programming/SKILL.md
+++ b/skills/pair-programming/SKILL.md
@@ -20,6 +20,9 @@ routing:
     - "walk me through"
     - "interactive coding"
   category: process
+  pairs_with:
+    - test-driven-development
+    - subagent-driven-development
 ---
 
 # Pair Programming Skill

--- a/skills/parallel-code-review/SKILL.md
+++ b/skills/parallel-code-review/SKILL.md
@@ -16,6 +16,9 @@ routing:
     - "multi-reviewer"
     - "concurrent review"
   category: code-review
+  pairs_with:
+    - systematic-code-review
+    - verification-before-completion
 ---
 
 # Parallel Code Review Skill

--- a/skills/phaser-gamedev/SKILL.md
+++ b/skills/phaser-gamedev/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: phaser-gamedev
 description: "Phaser 3 2D game dev: scenes, physics, tilemaps, sprites, polish."
+agent: typescript-frontend-engineer
 user-invocable: false
 allowed-tools:
   - Read

--- a/skills/php-quality/SKILL.md
+++ b/skills/php-quality/SKILL.md
@@ -12,6 +12,9 @@ routing:
     - "phpstan"
     - "php-cs-fixer"
   category: php
+  pairs_with:
+    - php-testing
+    - code-linting
 ---
 
 # PHP Quality Skill

--- a/skills/php-testing/SKILL.md
+++ b/skills/php-testing/SKILL.md
@@ -11,6 +11,9 @@ routing:
     - "pest php"
     - "php mock"
   category: php
+  pairs_with:
+    - php-quality
+    - test-driven-development
 ---
 
 # PHP Testing Skill

--- a/skills/planning/SKILL.md
+++ b/skills/planning/SKILL.md
@@ -88,6 +88,10 @@ routing:
     - "what's next"
   category: process
   complexity: medium
+  pairs_with:
+    - workflow
+    - feature-lifecycle
+    - decision-helper
 ---
 
 # Planning Skill

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -70,6 +70,10 @@ routing:
     - "gpt review"
     - "cross-model review"
   category: git-workflow
+  pairs_with:
+    - verification-before-completion
+    - code-linting
+    - systematic-code-review
 ---
 
 # PR Workflow Skill

--- a/skills/professional-communication/SKILL.md
+++ b/skills/professional-communication/SKILL.md
@@ -16,6 +16,9 @@ routing:
     - "summarize for management"
     - "status update"
   category: content-creation
+  pairs_with:
+    - voice-writer
+    - pptx-generator
 ---
 
 # Professional Communication Skill

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -80,6 +80,9 @@ routing:
     - "reuse existing media"
   category: content-publishing
   complexity: medium
+  pairs_with:
+    - content-calendar
+    - wordpress-live-validation
 ---
 
 # Publish Skill

--- a/skills/python-quality-gate/SKILL.md
+++ b/skills/python-quality-gate/SKILL.md
@@ -24,6 +24,9 @@ routing:
     - "check python"
     - "pre-commit check"
   category: code-quality
+  pairs_with:
+    - code-linting
+    - test-driven-development
 ---
 
 # Python Quality Gate Skill

--- a/skills/read-only-ops/SKILL.md
+++ b/skills/read-only-ops/SKILL.md
@@ -15,6 +15,8 @@ routing:
     - "browse code"
     - "inspect only"
   category: process
+  pairs_with:
+    - codebase-overview
 ---
 
 # Read-Only Operations Skill

--- a/skills/reddit-moderate/SKILL.md
+++ b/skills/reddit-moderate/SKILL.md
@@ -15,6 +15,8 @@ routing:
     - "Reddit moderation"
     - "check reports"
   category: process
+  pairs_with:
+    - content-engine
 ---
 
 # Reddit Moderate

--- a/skills/research-pipeline/SKILL.md
+++ b/skills/research-pipeline/SKILL.md
@@ -26,6 +26,9 @@ routing:
     - "research report"
     - "gather evidence"
   category: research
+  pairs_with:
+    - kb
+    - topic-brainstormer
 ---
 
 # Research Pipeline

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -17,6 +17,9 @@ routing:
     - "learning stats"
     - "search learnings"
   category: meta-tooling
+  pairs_with:
+    - learn
+    - auto-dream
 ---
 
 # Retro Knowledge Skill

--- a/skills/roast/SKILL.md
+++ b/skills/roast/SKILL.md
@@ -20,6 +20,9 @@ routing:
     - "stress test this idea"
     - "poke holes in this"
   category: analysis
+  pairs_with:
+    - multi-persona-critique
+    - systematic-code-review
 ---
 
 # Roast: Devil's Advocate Analysis

--- a/skills/routing-table-updater/SKILL.md
+++ b/skills/routing-table-updater/SKILL.md
@@ -19,6 +19,9 @@ routing:
     - "rebuild routing index"
     - "routing drift"
   category: meta-tooling
+  pairs_with:
+    - toolkit-evolution
+    - generate-claudemd
 ---
 
 # Routing Table Updater Skill

--- a/skills/security-threat-model/SKILL.md
+++ b/skills/security-threat-model/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: security-threat-model
 description: "Security threat model: scan toolkit for attack surface, supply-chain risks."
+agent: python-general-engineer
 effort: high
 user-invocable: false
 allowed-tools:

--- a/skills/series-planner/SKILL.md
+++ b/skills/series-planner/SKILL.md
@@ -19,6 +19,10 @@ routing:
     - "article series"
     - "content arc"
   category: content-creation
+  pairs_with:
+    - content-calendar
+    - topic-brainstormer
+    - publish
 ---
 
 # Series Planner Skill

--- a/skills/service-health-check/SKILL.md
+++ b/skills/service-health-check/SKILL.md
@@ -15,6 +15,10 @@ routing:
     - "is service running"
     - "check health"
   category: infrastructure
+  pairs_with:
+    - kubernetes-debugging
+    - endpoint-validator
+    - condition-based-waiting
 ---
 
 # Service Health Check Skill

--- a/skills/skill-composer/SKILL.md
+++ b/skills/skill-composer/SKILL.md
@@ -19,6 +19,9 @@ routing:
     - "skill pipeline"
     - "combine skills"
   category: meta-tooling
+  pairs_with:
+    - workflow
+    - feature-lifecycle
 ---
 
 # Skill Composer

--- a/skills/socratic-debugging/SKILL.md
+++ b/skills/socratic-debugging/SKILL.md
@@ -18,6 +18,9 @@ routing:
     - "coaching mode"
     - "teach me to find it"
   category: process
+  pairs_with:
+    - forensics
+    - systematic-code-review
 ---
 # Socratic Debugging Skill
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -18,6 +18,9 @@ routing:
     - "execute plan with agents"
     - "fresh context per task"
   category: process
+  pairs_with:
+    - pair-programming
+    - testing-agents-with-subagents
 ---
 
 # Subagent-Driven Development Skill

--- a/skills/swift-concurrency/SKILL.md
+++ b/skills/swift-concurrency/SKILL.md
@@ -11,6 +11,8 @@ routing:
     - "Swift Actor"
     - "Swift Task group"
   category: swift
+  pairs_with:
+    - swift-testing
 ---
 
 # Swift Structured Concurrency

--- a/skills/swift-testing/SKILL.md
+++ b/skills/swift-testing/SKILL.md
@@ -11,6 +11,9 @@ routing:
     - "Swift Testing framework"
     - "async test swift"
   category: swift
+  pairs_with:
+    - swift-concurrency
+    - test-driven-development
 ---
 
 # Swift Testing Patterns

--- a/skills/systematic-code-review/SKILL.md
+++ b/skills/systematic-code-review/SKILL.md
@@ -16,6 +16,10 @@ routing:
     - "review methodology"
     - "comprehensive review"
   category: code-review
+  pairs_with:
+    - forensics
+    - verification-before-completion
+    - parallel-code-review
 ---
 
 # Systematic Code Review Skill

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -22,6 +22,10 @@ routing:
     - "start with failing test"
     - "tests before code"
   category: testing
+  pairs_with:
+    - verification-before-completion
+    - testing-anti-patterns
+    - vitest-runner
 ---
 
 # Test-Driven Development (TDD) Skill

--- a/skills/testing-agents-with-subagents/SKILL.md
+++ b/skills/testing-agents-with-subagents/SKILL.md
@@ -18,6 +18,9 @@ routing:
     - "validate agent"
     - "agent test harness"
   category: testing
+  pairs_with:
+    - agent-evaluation
+    - subagent-driven-development
 ---
 
 # Testing Agents With Subagents

--- a/skills/threejs-builder/SKILL.md
+++ b/skills/threejs-builder/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: threejs-builder
 description: "Three.js app builder: imperative, React Three Fiber, and WebGPU in 4 phases."
+agent: typescript-frontend-engineer
 user-invocable: false
 command: /threejs
 allowed-tools:

--- a/skills/topic-brainstormer/SKILL.md
+++ b/skills/topic-brainstormer/SKILL.md
@@ -18,6 +18,10 @@ routing:
     - "blog topic ideas"
     - "what to write about"
   category: content-creation
+  pairs_with:
+    - content-calendar
+    - series-planner
+    - research-pipeline
 ---
 
 # Topic Brainstormer

--- a/skills/typescript-check/SKILL.md
+++ b/skills/typescript-check/SKILL.md
@@ -16,6 +16,9 @@ routing:
     - "tsc errors"
     - "TypeScript type validation"
   category: code-quality
+  pairs_with:
+    - vitest-runner
+    - code-linting
 ---
 
 # TypeScript Type Check Skill

--- a/skills/universal-quality-gate/SKILL.md
+++ b/skills/universal-quality-gate/SKILL.md
@@ -15,6 +15,9 @@ routing:
     - "code quality check"
     - "language-agnostic lint"
   category: code-quality
+  pairs_with:
+    - code-linting
+    - verification-before-completion
 ---
 
 # Universal Quality Gate Skill

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -21,6 +21,9 @@ routing:
     - "defense in depth"
     - "final verification"
   category: process
+  pairs_with:
+    - systematic-code-review
+    - with-anti-rationalization
 ---
 
 # Verification Before Completion Skill

--- a/skills/vitest-runner/SKILL.md
+++ b/skills/vitest-runner/SKILL.md
@@ -15,6 +15,10 @@ routing:
     - "vite tests"
     - "vitest output"
   category: testing
+  pairs_with:
+    - test-driven-development
+    - typescript-check
+    - e2e-testing
 ---
 
 # Vitest Test Runner Skill

--- a/skills/voice-feynman/SKILL.md
+++ b/skills/voice-feynman/SKILL.md
@@ -1,4 +1,8 @@
 ---
+  pairs_with:
+    - voice-writer
+    - voice-validator
+    - anti-ai-editor
 name: voice-feynman
 user-invocable: false
 allowed-tools:

--- a/skills/voice-validator/SKILL.md
+++ b/skills/voice-validator/SKILL.md
@@ -19,6 +19,10 @@ routing:
     - "voice fidelity"
     - "writing style check"
   category: voice
+  pairs_with:
+    - voice-writer
+    - anti-ai-editor
+    - joy-check
 ---
 
 # Voice Validator Skill

--- a/skills/voice-writer/SKILL.md
+++ b/skills/voice-writer/SKILL.md
@@ -28,6 +28,11 @@ routing:
     - "blog post voice"
     - "content pipeline"
   category: voice
+  pairs_with:
+    - voice-validator
+    - anti-ai-editor
+    - joy-check
+    - voice-feynman
 ---
 
 # Voice Writer

--- a/skills/webgl-card-effects/SKILL.md
+++ b/skills/webgl-card-effects/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: webgl-card-effects
 description: "Standalone WebGL fragment shaders for card visual effects: holographic foil, shimmer, rarity glow."
+agent: typescript-frontend-engineer
 user-invocable: false
 command: /card-effects
 allowed-tools:

--- a/skills/with-anti-rationalization/SKILL.md
+++ b/skills/with-anti-rationalization/SKILL.md
@@ -19,6 +19,8 @@ routing:
     - "strict mode"
     - "no shortcuts"
   category: process
+  pairs_with:
+    - verification-before-completion
 ---
 
 # Anti-Rationalization Enforcement Skill

--- a/skills/wordpress-live-validation/SKILL.md
+++ b/skills/wordpress-live-validation/SKILL.md
@@ -32,9 +32,8 @@ routing:
     - post rendering check
     - live site validation
   pairs_with:
-    - wordpress-uploader
-    - pre-publish-checker
-    - seo-optimizer
+    - publish
+    - e2e-testing
   complexity: Medium
   category: content-publishing
 ---

--- a/skills/workflow-help/SKILL.md
+++ b/skills/workflow-help/SKILL.md
@@ -17,6 +17,9 @@ routing:
     - "I am stuck"
     - "toolkit help"
   category: meta-tooling
+  pairs_with:
+    - workflow
+    - do
 ---
 
 # Workflow Help Skill

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -5,6 +5,10 @@ user-invocable: false
 context: fork
 routing:
   category: meta-tooling
+  pairs_with:
+    - planning
+    - feature-lifecycle
+    - verification-before-completion
   triggers:
     - "workflow"
     - "multi-phase task"


### PR DESCRIPTION
## Summary
- Adds explicit `agent:` field to 9 skills that previously depended on `pairs_with` for agent resolution (making resolution robust via Step 1 instead of Step 2)
- Enriches 60 skills with domain-appropriate `pairs_with` pairings
- Fixes 11 additional broken `pairs_with` references (7 in skills, 4 in agents)
- Extends `validate-pairs-with.py` to check skill references too (previously only agents)
- Regenerates both INDEX files

### Skills that gained explicit `agent:` fields

| Skill | Agent |
|-------|-------|
| cobalt-core | kubernetes-helm-engineer |
| game-asset-generator | typescript-frontend-engineer |
| game-sprite-pipeline | python-general-engineer |
| gemini-image-generator | python-general-engineer |
| nano-banana-builder | python-general-engineer |
| phaser-gamedev | typescript-frontend-engineer |
| security-threat-model | python-general-engineer |
| threejs-builder | typescript-frontend-engineer |
| webgl-card-effects | typescript-frontend-engineer |

### Enrichment clusters (60 skills)
Code-quality (7), testing (11), voice/content (9), infrastructure (5), frontend (2), workflow/planning (10), meta/toolkit (9), learning (4), game-dev (1), social (2)

## Test plan
- [x] `python3 scripts/validate-pairs-with.py` — "All pairs_with references are valid"
- [x] `pytest scripts/tests/test_index_router.py` — 71 passed
- [x] `pytest scripts/tests/test_routing_accuracy.py` — 49 passed
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [ ] CI checks pass on GitHub