### PR TITLE
fix: resolve validate-references crash and positive-instruction violations

### DIFF
--- a/agents/swift-general-engineer/references/swift-security.md
+++ b/agents/swift-general-engineer/references/swift-security.md
@@ -306,9 +306,9 @@ rg -n 'pinnedCertificates\|pinnedPublicKeys\|certificatePinner' . --type swift
 
 ---
 
-## Avoid UserDefaults for Sensitive Data
+## Store Sensitive Data in Keychain Services
 
-Use UserDefaults only for non-sensitive preferences (theme, language, onboarding state). Sensitive data belongs in Keychain.
+Store tokens, keys, and credentials in Keychain Services, which encrypts data with the device passcode. Reserve UserDefaults for non-sensitive preferences (theme, language, onboarding state).
 
 ```swift
 // Correct: UserDefaults for preferences only

--- a/agents/typescript-frontend-engineer/references/nextjs-security.md
+++ b/agents/typescript-frontend-engineer/references/nextjs-security.md
@@ -200,9 +200,9 @@ rg -n 'X-Frame-Options|frame-ancestors' .
 
 ---
 
-## Avoid dangerouslySetInnerHTML
+## Render Content Through React's Built-in Escaping
 
-Use React's default JSX escaping. If raw HTML rendering is unavoidable, sanitize with DOMPurify or a server-side sanitizer first.
+Use React's default JSX escaping for all user-facing content. When raw HTML rendering is genuinely needed (CMS content, markdown output), sanitize with DOMPurify or a server-side sanitizer first.
 
 ```tsx
 // Correct: React JSX auto-escapes by default

--- a/scripts/validate-references.py
+++ b/scripts/validate-references.py
@@ -273,7 +273,10 @@ def validate_reference_file(ref_path: Path) -> list[ReferenceIssue]:
     """Check structural requirements of a single reference .md file."""
     issues: list[ReferenceIssue] = []
     content = ref_path.read_text(encoding="utf-8")
-    rel = str(ref_path.relative_to(AGENTS_DIR))
+    try:
+        rel = str(ref_path.relative_to(AGENTS_DIR))
+    except ValueError:
+        rel = str(ref_path.relative_to(REPO_ROOT))
 
     headings = [line for line in content.splitlines() if line.startswith("## ")]
     if not headings:


### PR DESCRIPTION
## Summary
- Fix `validate-references.py` crash when agent references files outside `agents/` directory (falls back to repo-relative path)
- Reframe 2 negative headings in new security references to positive instruction format:
  - "Avoid UserDefaults for Sensitive Data" → "Store Sensitive Data in Keychain Services"
  - "Avoid dangerouslySetInnerHTML" → "Render Content Through React's Built-in Escaping"

## Test plan
- [x] `validate-references.py --all` — no crash
- [x] `validate_positive_instruction_docs.py` — count dropped from 7 to 5
- [x] `ruff check` — passes