### PR TITLE
[codex] Fix voice-feynman skill frontmatter

### DIFF
--- a/skills/voice-feynman/SKILL.md
+++ b/skills/voice-feynman/SKILL.md
@@ -1,8 +1,4 @@
 ---
-  pairs_with:
-    - voice-writer
-    - voice-validator
-    - anti-ai-editor
 name: voice-feynman
 user-invocable: false
 allowed-tools:
@@ -26,7 +22,18 @@ description: |
 version: 1.0.0
 command: /voice-feynman
 routing:
-  force_routing: true
+  triggers:
+    - voice-feynman
+    - feynman voice
+    - richard feynman voice
+    - feynman writing style
+    - feynman explanation
+  pairs_with:
+    - voice-writer
+    - voice-validator
+    - anti-ai-editor
+  category: voice
+  force_route: true
 ---
 
 ## Operator Context


### PR DESCRIPTION
Fixes malformed YAML frontmatter in skills/voice-feynman/SKILL.md.

The skill had a top-level indented pairs_with block before name and used force_routing instead of the router/index field force_route. This caused the skill index generator to fall back to regex parsing.

Validation on the cleaned upstream-based branch:
- git diff --name-only upstream/main..HEAD showed only skills/voice-feynman/SKILL.md
- python3 scripts/generate-skill-index.py --output /tmp/voice-feynman-clean-index-check.json
- python3 -m pytest scripts/tests/test_generate_skill_index.py -q