### PR TITLE
feat: add 5-layer skill frontmatter validation system

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -239,6 +239,12 @@
             "command": "python3 \"$HOME/.claude/hooks/posttool-security-scan.py\"",
             "description": "Advisory scan for credentials and SQL injection in Write/Edit output",
             "timeout": 3000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/posttool-skill-frontmatter-check.py\"",
+            "description": "Validate skill YAML frontmatter after Write/Edit on SKILL.md files",
+            "timeout": 5000
           }
         ]
       },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ruff
+      - run: pip install ruff pyyaml
       - run: ruff check . --config pyproject.toml
       - run: ruff format --check . --config pyproject.toml
       - run: python scripts/validate-references.py --check-do-framing
-      - run: pip install pyyaml
       - run: python scripts/validate-skill-frontmatter.py
 
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
       - run: ruff check . --config pyproject.toml
       - run: ruff format --check . --config pyproject.toml
       - run: python scripts/validate-references.py --check-do-framing
+      - run: pip install pyyaml
+      - run: python scripts/validate-skill-frontmatter.py
 
   test:
     runs-on: ubuntu-latest

--- a/hooks/posttool-skill-frontmatter-check.py
+++ b/hooks/posttool-skill-frontmatter-check.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+PostToolUse Hook: Skill Frontmatter Validation
+
+After Write or Edit operations on skills/*/SKILL.md files, runs the
+frontmatter validator and injects errors as context if validation fails.
+
+Advisory hook — always exits 0.
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
+# Pattern matching skill SKILL.md files
+SKILL_FILE_RE = re.compile(r"skills/[^/]+/SKILL\.md$")
+
+
+def main():
+    """Process PostToolUse hook event."""
+    try:
+        event_data = read_stdin(timeout=2)
+        if not event_data.strip():
+            return
+        event = json.loads(event_data)
+
+        # Get the file path from tool input
+        tool_input = event.get("tool_input", {})
+        file_path = tool_input.get("file_path", "")
+
+        if not file_path:
+            return
+
+        # Only act on skills/*/SKILL.md files
+        if not SKILL_FILE_RE.search(file_path):
+            return
+
+        # Check the file exists
+        if not Path(file_path).exists():
+            return
+
+        # Find the validator script relative to this hook
+        hook_dir = Path(__file__).resolve().parent
+        # The validator is at scripts/validate-skill-frontmatter.py relative to repo root.
+        # hooks/ is at the repo root level, so go up one level.
+        repo_root = hook_dir.parent
+        validator = repo_root / "scripts" / "validate-skill-frontmatter.py"
+
+        if not validator.exists():
+            return
+
+        # Run the validator
+        result = subprocess.run(
+            [sys.executable, str(validator), file_path],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+        if result.returncode != 0 and result.stdout.strip():
+            # Inject validation errors as context
+            print(f"[skill-frontmatter] Validation failed for {Path(file_path).name}:")
+            for line in result.stdout.strip().splitlines():
+                if line.strip():
+                    print(f"  {line.strip()}")
+            print("[skill-frontmatter] Fix frontmatter before proceeding.")
+
+    except Exception:
+        pass
+    finally:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/posttool-skill-frontmatter-check.py
+++ b/hooks/posttool-skill-frontmatter-check.py
@@ -71,8 +71,8 @@ def main():
                     print(f"  {line.strip()}")
             print("[skill-frontmatter] Fix frontmatter before proceeding.")
 
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"[skill-frontmatter] hook error: {e}", file=sys.stderr)
     finally:
         sys.exit(0)
 

--- a/scripts/generate-skill-index.py
+++ b/scripts/generate-skill-index.py
@@ -23,6 +23,7 @@ Exit codes:
     0 - Success
     1 - Fatal error (directory not found, write failed)
     2 - Trigger collisions detected among force-routed entries
+    3 - Regex fallback was used (non-strict mode warning)
 """
 
 import argparse
@@ -273,6 +274,7 @@ def generate_index(
     collection_key: str,
     is_pipeline: bool = False,
     include_private: bool = False,
+    strict: bool = False,
 ) -> tuple[dict, list[str]]:
     """Generate a dict-keyed routing index from all SKILL.md files in a directory.
 
@@ -283,6 +285,7 @@ def generate_index(
         is_pipeline: Whether entries are pipelines (enables phase extraction).
         include_private: When True, include symlinked directories. When False (default),
             only directly-tracked directories are indexed.
+        strict: When True, YAML parse failure skips the skill (no regex fallback).
 
     Returns:
         tuple: (index dict with version/generated/generated_by/collection,
@@ -318,6 +321,11 @@ def generate_index(
         try:
             frontmatter, used_fallback = extract_frontmatter(content)
             if used_fallback:
+                if strict:
+                    warnings.append(
+                        f"  - {skill_dir.name}: YAML parsing failed (strict mode: skipping, no regex fallback)"
+                    )
+                    continue
                 warnings.append(f"  - {skill_dir.name}: Used regex fallback (YAML parsing failed)")
         except re.error as e:
             warnings.append(f"  - {skill_dir.name}: Regex error in frontmatter: {e}")
@@ -417,6 +425,12 @@ def main() -> int:
         default=None,
         help="Output file path (default: skills/INDEX.json relative to repo root).",
     )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help="Disable regex fallback. YAML parse failure = skip the skill and log an error.",
+    )
     args = parser.parse_args()
 
     script_dir = Path(__file__).parent
@@ -437,6 +451,7 @@ def main() -> int:
         collection_key="skills",
         is_pipeline=False,
         include_private=args.include_private,
+        strict=args.strict,
     )
 
     # Report warnings if any
@@ -510,7 +525,16 @@ def main() -> int:
         print(f"\nCompleted with {len(collisions)} trigger collision(s)", file=sys.stderr)
         return 2
 
-    # Return warning exit code if there were parse issues
+    # Return exit code 3 if regex fallback was used (non-strict mode)
+    fallback_warnings = [w for w in skills_warnings if "regex fallback" in w.lower()]
+    if fallback_warnings:
+        print(
+            f"\nCompleted with {len(fallback_warnings)} regex fallback(s) — fix YAML in these skills",
+            file=sys.stderr,
+        )
+        return 3
+
+    # Report non-fallback warnings
     if skills_warnings:
         print(f"\nCompleted with {len(skills_warnings)} warning(s)", file=sys.stderr)
 

--- a/scripts/tests/test_validate_skill_frontmatter.py
+++ b/scripts/tests/test_validate_skill_frontmatter.py
@@ -1,0 +1,514 @@
+"""Tests for scripts/validate-skill-frontmatter.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "validate-skill-frontmatter.py"
+
+
+def _load_module():
+    """Load validate-skill-frontmatter.py as a module."""
+    spec = importlib.util.spec_from_file_location("validate_skill_frontmatter", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+vsf = _load_module()
+
+
+# --- Helpers ---
+
+
+def _make_skill(tmp_path: Path, name: str, frontmatter: str) -> Path:
+    """Create a skill directory with SKILL.md containing the given frontmatter."""
+    skill_dir = tmp_path / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text(frontmatter)
+    return skill_file
+
+
+_VALID_FM = """\
+---
+name: test-skill
+description: "A test skill for validation."
+routing:
+  triggers:
+    - test
+    - validate
+  category: testing
+---
+
+# Test Skill
+"""
+
+
+# --- Valid frontmatter ---
+
+
+class TestValidFrontmatter:
+    """Tests that valid frontmatter passes validation."""
+
+    def test_minimal_valid(self, tmp_path: Path) -> None:
+        skill_file = _make_skill(tmp_path, "test-skill", _VALID_FM)
+        errors = vsf.validate_skill(skill_file)
+        assert errors == []
+
+    def test_valid_with_optional_fields(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: my-skill
+description: "Full featured skill."
+version: "1.0.0"
+user-invocable: true
+allowed-tools:
+  - Read
+  - Write
+routing:
+  triggers:
+    - my skill
+  pairs_with:
+    - other-skill
+  complexity: Medium
+  category: engineering
+  force_route: true
+---
+"""
+        skill_file = _make_skill(tmp_path, "my-skill", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert errors == []
+
+    def test_valid_with_multiline_description(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: desc-skill
+description: |
+  A multiline description that spans
+  multiple lines for clarity.
+routing:
+  triggers:
+    - desc test
+  category: testing
+---
+"""
+        skill_file = _make_skill(tmp_path, "desc-skill", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert errors == []
+
+
+# --- YAML parse errors ---
+
+
+class TestYAMLParseErrors:
+    """Tests that broken YAML is caught."""
+
+    def test_broken_yaml(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: broken
+description: [unclosed bracket
+routing:
+  triggers:
+    - test
+---
+"""
+        skill_file = _make_skill(tmp_path, "broken", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert len(errors) == 1
+        assert "YAML parse error" in errors[0]
+
+    def test_no_frontmatter_delimiters(self, tmp_path: Path) -> None:
+        skill_file = _make_skill(tmp_path, "no-fm", "# Just a heading\n\nNo frontmatter here.\n")
+        errors = vsf.validate_skill(skill_file)
+        assert len(errors) == 1
+        assert "No YAML frontmatter" in errors[0]
+
+    def test_frontmatter_not_a_mapping(self, tmp_path: Path) -> None:
+        fm = """\
+---
+- item1
+- item2
+---
+"""
+        skill_file = _make_skill(tmp_path, "list-fm", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert len(errors) == 1
+        assert "not a mapping" in errors[0]
+
+
+# --- Name checks ---
+
+
+class TestNameValidation:
+    """Tests for name field and name-directory matching."""
+
+    def test_missing_name(self, tmp_path: Path) -> None:
+        fm = """\
+---
+description: "No name field."
+routing:
+  triggers:
+    - test
+  category: testing
+---
+"""
+        skill_file = _make_skill(tmp_path, "unnamed", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert any("Missing 'name'" in e for e in errors)
+
+    def test_name_directory_mismatch(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: wrong-name
+description: "Name does not match directory."
+routing:
+  triggers:
+    - test
+  category: testing
+---
+"""
+        skill_file = _make_skill(tmp_path, "actual-dir-name", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert any("Name mismatch" in e for e in errors)
+        assert any("wrong-name" in e for e in errors)
+        assert any("actual-dir-name" in e for e in errors)
+
+
+# --- Description checks ---
+
+
+class TestDescriptionValidation:
+    """Tests for description field."""
+
+    def test_missing_description(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: no-desc
+routing:
+  triggers:
+    - test
+  category: testing
+---
+"""
+        skill_file = _make_skill(tmp_path, "no-desc", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert any("Missing or empty description" in e for e in errors)
+
+    def test_empty_description(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: empty-desc
+description: ""
+routing:
+  triggers:
+    - test
+  category: testing
+---
+"""
+        skill_file = _make_skill(tmp_path, "empty-desc", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert any("Missing or empty description" in e for e in errors)
+
+
+# --- Routing section checks ---
+
+
+class TestRoutingValidation:
+    """Tests for routing section structure."""
+
+    def test_missing_routing(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: no-routing
+description: "Has no routing section."
+---
+"""
+        skill_file = _make_skill(tmp_path, "no-routing", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert any("Missing routing section" in e for e in errors)
+
+    def test_routing_not_a_dict(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: bad-routing
+description: "Routing is a string."
+routing: "not a dict"
+---
+"""
+        skill_file = _make_skill(tmp_path, "bad-routing", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert any("routing must be a mapping" in e for e in errors)
+
+    def test_missing_triggers(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: no-triggers
+description: "No triggers."
+routing:
+  category: testing
+---
+"""
+        skill_file = _make_skill(tmp_path, "no-triggers", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert any("Missing routing.triggers" in e for e in errors)
+
+    def test_empty_triggers(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: empty-triggers
+description: "Empty triggers list."
+routing:
+  triggers: []
+  category: testing
+---
+"""
+        skill_file = _make_skill(tmp_path, "empty-triggers", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert any("routing.triggers is empty" in e for e in errors)
+
+    def test_triggers_not_a_list(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: str-triggers
+description: "Triggers is a string."
+routing:
+  triggers: "just a string"
+  category: testing
+---
+"""
+        skill_file = _make_skill(tmp_path, "str-triggers", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert any("routing.triggers must be a list" in e for e in errors)
+
+    def test_missing_category(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: no-category
+description: "No category."
+routing:
+  triggers:
+    - test
+---
+"""
+        skill_file = _make_skill(tmp_path, "no-category", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert any("Missing routing.category" in e for e in errors)
+
+
+# --- Top-level pairs_with ---
+
+
+class TestTopLevelPairsWith:
+    """Tests that pairs_with at top level is caught."""
+
+    def test_top_level_pairs_with(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: top-pairs
+description: "pairs_with wrongly at top level."
+pairs_with:
+  - other-skill
+routing:
+  triggers:
+    - test
+  category: testing
+---
+"""
+        skill_file = _make_skill(tmp_path, "top-pairs", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert any("pairs_with at top level" in e for e in errors)
+
+    def test_pairs_with_under_routing_is_ok(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: ok-pairs
+description: "pairs_with correctly under routing."
+routing:
+  triggers:
+    - test
+  pairs_with:
+    - other-skill
+  category: testing
+---
+"""
+        skill_file = _make_skill(tmp_path, "ok-pairs", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert errors == []
+
+
+# --- force_routing typo ---
+
+
+class TestForceRoutingTypo:
+    """Tests that force_routing (wrong) vs force_route (correct) is caught."""
+
+    def test_force_routing_at_top_level(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: typo-force
+description: "Has force_routing typo."
+force_routing: true
+routing:
+  triggers:
+    - test
+  category: testing
+---
+"""
+        skill_file = _make_skill(tmp_path, "typo-force", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert any("force_routing" in e and "force_route" in e for e in errors)
+
+    def test_force_routing_under_routing(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: typo-nested
+description: "Has force_routing typo under routing."
+routing:
+  triggers:
+    - test
+  category: testing
+  force_routing: true
+---
+"""
+        skill_file = _make_skill(tmp_path, "typo-nested", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert any("force_routing" in e and "force_route" in e for e in errors)
+
+    def test_force_route_is_ok(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: correct-force
+description: "Uses correct force_route."
+routing:
+  triggers:
+    - test
+  category: testing
+  force_route: true
+---
+"""
+        skill_file = _make_skill(tmp_path, "correct-force", fm)
+        errors = vsf.validate_skill(skill_file)
+        assert errors == []
+
+
+# --- Strict mode ---
+
+
+class TestStrictMode:
+    """Tests for --strict flag checking optional fields."""
+
+    def test_strict_missing_version(self, tmp_path: Path) -> None:
+        skill_file = _make_skill(tmp_path, "test-skill", _VALID_FM)
+        errors = vsf.validate_skill(skill_file, strict=True)
+        assert any("[strict] Missing 'version'" in e for e in errors)
+
+    def test_strict_missing_allowed_tools(self, tmp_path: Path) -> None:
+        skill_file = _make_skill(tmp_path, "test-skill", _VALID_FM)
+        errors = vsf.validate_skill(skill_file, strict=True)
+        assert any("[strict] Missing 'allowed-tools'" in e for e in errors)
+
+    def test_strict_passes_with_all_fields(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: full-skill
+description: "All fields present."
+version: "1.0.0"
+allowed-tools:
+  - Read
+routing:
+  triggers:
+    - test
+  category: testing
+---
+"""
+        skill_file = _make_skill(tmp_path, "full-skill", fm)
+        errors = vsf.validate_skill(skill_file, strict=True)
+        assert errors == []
+
+
+# --- CLI integration ---
+
+
+class TestCLI:
+    """Tests for command-line interface."""
+
+    def test_cli_all_skills_exit_0(self) -> None:
+        """The script exits 0 when run against all real skills."""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+    def test_cli_single_file(self, tmp_path: Path) -> None:
+        # Use "test-skill" as dir name to match _VALID_FM's name field
+        skill_file = _make_skill(tmp_path, "test-skill", _VALID_FM)
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), str(skill_file)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+
+    def test_cli_bad_file_exit_1(self, tmp_path: Path) -> None:
+        fm = """\
+---
+name: bad
+description: "Missing routing."
+---
+"""
+        skill_file = _make_skill(tmp_path, "bad", fm)
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), str(skill_file)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+
+    def test_cli_missing_file_exit_2(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "/nonexistent/SKILL.md"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+
+    def test_cli_strict_flag(self, tmp_path: Path) -> None:
+        skill_file = _make_skill(tmp_path, "test-skill", _VALID_FM)
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--strict", str(skill_file)],
+            capture_output=True,
+            text=True,
+        )
+        # _VALID_FM lacks version and allowed-tools, so strict should fail
+        assert result.returncode == 1
+
+
+# --- Multiple errors ---
+
+
+class TestMultipleErrors:
+    """Tests that multiple errors are reported for a single file."""
+
+    def test_multiple_errors_reported(self, tmp_path: Path) -> None:
+        fm = """\
+---
+description: ""
+pairs_with:
+  - some-skill
+force_routing: true
+---
+"""
+        skill_file = _make_skill(tmp_path, "multi-bad", fm)
+        errors = vsf.validate_skill(skill_file)
+        # Should catch: missing name, empty description, missing routing,
+        # top-level pairs_with, force_routing typo
+        assert len(errors) >= 4

--- a/scripts/validate-skill-frontmatter.py
+++ b/scripts/validate-skill-frontmatter.py
@@ -48,17 +48,17 @@ def validate_skill(filepath: Path, strict: bool = False) -> list[str]:
         List of error strings. Empty list means valid.
     """
     errors: list[str] = []
-    rel = str(filepath)
+    display_path = str(filepath)
 
     try:
         content = filepath.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as e:
-        return [f"{rel}: Cannot read file: {e}"]
+        return [f"{display_path}: Cannot read file: {e}"]
 
     # Extract frontmatter block
     match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
     if not match:
-        return [f"{rel}: No YAML frontmatter found (missing --- delimiters)"]
+        return [f"{display_path}: No YAML frontmatter found (missing --- delimiters)"]
 
     yaml_content = match.group(1)
 
@@ -66,59 +66,63 @@ def validate_skill(filepath: Path, strict: bool = False) -> list[str]:
     try:
         fm = yaml.safe_load(yaml_content)
     except yaml.YAMLError as e:
-        return [f"{rel}: YAML parse error: {e}"]
+        return [f"{display_path}: YAML parse error: {e}"]
 
     if not isinstance(fm, dict):
-        return [f"{rel}: Frontmatter is not a mapping (got {type(fm).__name__})"]
+        return [f"{display_path}: Frontmatter is not a mapping (got {type(fm).__name__})"]
 
     # Derive expected name from directory
     dir_name = filepath.parent.name
 
     # Check: name exists and matches directory
     if "name" not in fm:
-        errors.append(f"{rel}: Missing 'name' field")
+        errors.append(f"{display_path}: Missing 'name' field")
     elif fm["name"] != dir_name:
-        errors.append(f"{rel}: Name mismatch: '{fm['name']}' vs directory '{dir_name}'")
+        errors.append(f"{display_path}: Name mismatch: '{fm['name']}' vs directory '{dir_name}'")
 
     # Check: description exists and is non-empty
     desc = fm.get("description")
     if not desc or (isinstance(desc, str) and not desc.strip()):
-        errors.append(f"{rel}: Missing or empty description")
+        errors.append(f"{display_path}: Missing or empty description")
 
     # Check: routing section exists and is a dict
     routing = fm.get("routing")
     if routing is None:
-        errors.append(f"{rel}: Missing routing section")
+        errors.append(f"{display_path}: Missing routing section")
     elif not isinstance(routing, dict):
-        errors.append(f"{rel}: routing must be a mapping, got {type(routing).__name__}")
+        errors.append(f"{display_path}: routing must be a mapping, got {type(routing).__name__}")
     else:
         # Check: routing.triggers is non-empty list
         triggers = routing.get("triggers")
         if triggers is None:
-            errors.append(f"{rel}: Missing routing.triggers")
+            errors.append(f"{display_path}: Missing routing.triggers")
         elif not isinstance(triggers, list):
-            errors.append(f"{rel}: routing.triggers must be a list, got {type(triggers).__name__}")
+            errors.append(f"{display_path}: routing.triggers must be a list, got {type(triggers).__name__}")
         elif len(triggers) == 0:
-            errors.append(f"{rel}: routing.triggers is empty (need at least one trigger)")
+            errors.append(f"{display_path}: routing.triggers is empty (need at least one trigger)")
+
+        # Check: non-string trigger items
+        if isinstance(triggers, list) and any(not isinstance(t, str) for t in triggers):
+            errors.append(f"{display_path}: routing.triggers contains non-string items")
 
         # Check: routing.category exists
         if "category" not in routing:
-            errors.append(f"{rel}: Missing routing.category")
+            errors.append(f"{display_path}: Missing routing.category")
 
     # Check: pairs_with NOT at top level (must be under routing:)
     if "pairs_with" in fm:
-        errors.append(f"{rel}: pairs_with at top level; must be under routing:")
+        errors.append(f"{display_path}: pairs_with at top level; must be under routing:")
 
     # Check: no force_routing key anywhere (should be force_route)
     if _find_key_recursive(fm, "force_routing"):
-        errors.append(f"{rel}: Found 'force_routing'; use 'force_route'")
+        errors.append(f"{display_path}: Found 'force_routing'; use 'force_route'")
 
     # Strict mode: check optional fields
     if strict:
         if "version" not in fm:
-            errors.append(f"{rel}: [strict] Missing 'version' field")
+            errors.append(f"{display_path}: [strict] Missing 'version' field")
         if "allowed-tools" not in fm:
-            errors.append(f"{rel}: [strict] Missing 'allowed-tools' field")
+            errors.append(f"{display_path}: [strict] Missing 'allowed-tools' field")
 
     return errors
 

--- a/scripts/validate-skill-frontmatter.py
+++ b/scripts/validate-skill-frontmatter.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Validate YAML frontmatter in skill SKILL.md files.
+
+Checks structural correctness, required fields, naming consistency,
+and common mistakes (top-level pairs_with, force_routing typo).
+
+Usage:
+    python3 scripts/validate-skill-frontmatter.py                       # all skills
+    python3 scripts/validate-skill-frontmatter.py skills/foo/SKILL.md   # one file
+    python3 scripts/validate-skill-frontmatter.py --strict              # also check optional fields
+
+Exit codes:
+    0 - All validations passed
+    1 - One or more validation errors found
+    2 - Script error (bad arguments, missing directory)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def _find_key_recursive(data: object, key: str) -> bool:
+    """Recursively check if a key exists anywhere in a nested dict."""
+    if isinstance(data, dict):
+        if key in data:
+            return True
+        return any(_find_key_recursive(v, key) for v in data.values())
+    if isinstance(data, list):
+        return any(_find_key_recursive(item, key) for item in data)
+    return False
+
+
+def validate_skill(filepath: Path, strict: bool = False) -> list[str]:
+    """Validate a single SKILL.md file's frontmatter.
+
+    Args:
+        filepath: Path to a SKILL.md file.
+        strict: When True, also check optional fields (version, allowed-tools).
+
+    Returns:
+        List of error strings. Empty list means valid.
+    """
+    errors: list[str] = []
+    rel = str(filepath)
+
+    try:
+        content = filepath.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        return [f"{rel}: Cannot read file: {e}"]
+
+    # Extract frontmatter block
+    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        return [f"{rel}: No YAML frontmatter found (missing --- delimiters)"]
+
+    yaml_content = match.group(1)
+
+    # Parse YAML
+    try:
+        fm = yaml.safe_load(yaml_content)
+    except yaml.YAMLError as e:
+        return [f"{rel}: YAML parse error: {e}"]
+
+    if not isinstance(fm, dict):
+        return [f"{rel}: Frontmatter is not a mapping (got {type(fm).__name__})"]
+
+    # Derive expected name from directory
+    dir_name = filepath.parent.name
+
+    # Check: name exists and matches directory
+    if "name" not in fm:
+        errors.append(f"{rel}: Missing 'name' field")
+    elif fm["name"] != dir_name:
+        errors.append(f"{rel}: Name mismatch: '{fm['name']}' vs directory '{dir_name}'")
+
+    # Check: description exists and is non-empty
+    desc = fm.get("description")
+    if not desc or (isinstance(desc, str) and not desc.strip()):
+        errors.append(f"{rel}: Missing or empty description")
+
+    # Check: routing section exists and is a dict
+    routing = fm.get("routing")
+    if routing is None:
+        errors.append(f"{rel}: Missing routing section")
+    elif not isinstance(routing, dict):
+        errors.append(f"{rel}: routing must be a mapping, got {type(routing).__name__}")
+    else:
+        # Check: routing.triggers is non-empty list
+        triggers = routing.get("triggers")
+        if triggers is None:
+            errors.append(f"{rel}: Missing routing.triggers")
+        elif not isinstance(triggers, list):
+            errors.append(f"{rel}: routing.triggers must be a list, got {type(triggers).__name__}")
+        elif len(triggers) == 0:
+            errors.append(f"{rel}: routing.triggers is empty (need at least one trigger)")
+
+        # Check: routing.category exists
+        if "category" not in routing:
+            errors.append(f"{rel}: Missing routing.category")
+
+    # Check: pairs_with NOT at top level (must be under routing:)
+    if "pairs_with" in fm:
+        errors.append(f"{rel}: pairs_with at top level; must be under routing:")
+
+    # Check: no force_routing key anywhere (should be force_route)
+    if _find_key_recursive(fm, "force_routing"):
+        errors.append(f"{rel}: Found 'force_routing'; use 'force_route'")
+
+    # Strict mode: check optional fields
+    if strict:
+        if "version" not in fm:
+            errors.append(f"{rel}: [strict] Missing 'version' field")
+        if "allowed-tools" not in fm:
+            errors.append(f"{rel}: [strict] Missing 'allowed-tools' field")
+
+    return errors
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Validate YAML frontmatter in skill SKILL.md files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Specific SKILL.md files to validate. If omitted, validates all skills.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help="Also check optional fields (version, allowed-tools).",
+    )
+    args = parser.parse_args()
+
+    # Determine which files to validate
+    if args.files:
+        targets = [Path(f) for f in args.files]
+        for t in targets:
+            if not t.exists():
+                print(f"Error: File not found: {t}", file=sys.stderr)
+                return 2
+    else:
+        # Auto-discover: find all skills/*/SKILL.md
+        script_dir = Path(__file__).resolve().parent
+        repo_root = script_dir.parent
+        skills_dir = repo_root / "skills"
+        if not skills_dir.exists():
+            print(f"Error: skills directory not found at {skills_dir}", file=sys.stderr)
+            return 2
+        targets = sorted(skills_dir.glob("*/SKILL.md"))
+        if not targets:
+            print("Error: No SKILL.md files found", file=sys.stderr)
+            return 2
+
+    # Validate each file
+    all_errors: list[str] = []
+    valid_count = 0
+    for filepath in targets:
+        errors = validate_skill(filepath, strict=args.strict)
+        if errors:
+            all_errors.extend(errors)
+        else:
+            valid_count += 1
+
+    # Report results
+    total = len(targets)
+    if all_errors:
+        print(f"Skill frontmatter validation: {len(all_errors)} error(s) in {total - valid_count} file(s)")
+        for err in all_errors:
+            print(f"  ERROR: {err}")
+        return 1
+
+    print(f"Skill frontmatter validation: {total} file(s) OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -175,6 +175,17 @@ surface and the slash-command namespace; both are scarce.
 
 > See `references/skill-template.md` for the complete frontmatter template with all fields and valid values.
 
+**Frontmatter validation (mandatory post-write gate):** After writing SKILL.md,
+validate YAML frontmatter:
+
+```bash
+python3 scripts/validate-skill-frontmatter.py skills/<skill-name>/SKILL.md
+```
+
+Scaffold is not complete until this exits 0. The validator catches: broken YAML,
+name/directory mismatch, missing routing section, missing triggers, missing
+category, top-level `pairs_with`, and `force_routing` typo.
+
 The description is the primary triggering mechanism. Claude tends to undertrigger skills -- be explicit about trigger contexts. Include "Use for" with concrete phrases users would say.
 
 **Body** -- workflow first, then context:

--- a/skills/skill-creator/references/skill-template.md
+++ b/skills/skill-creator/references/skill-template.md
@@ -25,7 +25,7 @@ routing:                                 # REQUIRED — must be a mapping
   pairs_with:                            # Optional — MUST be under routing:, never top-level
     - related-skill
   complexity: Simple | Medium | Medium-Complex | Complex
-  category: engineering                  # REQUIRED — string
+  category: language | infrastructure | review | meta | content | voice | code-quality | analysis | testing | process | meta-tooling | git-workflow | frontend | research | security | decision-support | documentation | kubernetes | video-creation | image-generation | kotlin | php | swift | github  # REQUIRED
   # force_route: true                    # Optional — only for skills that must bypass scoring
 ---
 ```

--- a/skills/skill-creator/references/skill-template.md
+++ b/skills/skill-creator/references/skill-template.md
@@ -6,32 +6,71 @@ Complete SKILL.md template with all required sections.
 
 ```yaml
 ---
-name: skill-slug-name
-description: |
+name: skill-slug-name                   # REQUIRED — must match directory name exactly
+description: |                           # REQUIRED — 1024 char max
   [WHAT it does — 1-2 sentences]. [WHEN to use it — trigger phrases users
   would actually say]. Use when user says "[phrase 1]", "[phrase 2]", or
   "[phrase 3]". Keep the scope specific enough that adjacent skills do not
   accidentally match.
-# Optional fields:
+# Optional top-level fields:
 # allowed-tools: [Read, Write, Bash, Grep, Glob]
 # compatibility: "Requires Python 3.10+, network access for API calls"
 # user-invocable: false
 # agent: golang-general-engineer
 # model: sonnet
-routing:
-  triggers:
+routing:                                 # REQUIRED — must be a mapping
+  triggers:                              # REQUIRED — non-empty list
     - keyword1
     - keyword2
-  pairs_with:
+  pairs_with:                            # Optional — MUST be under routing:, never top-level
     - related-skill
   complexity: Simple | Medium | Medium-Complex | Complex
-  category: language | infrastructure | review | meta | content
+  category: engineering                  # REQUIRED — string
+  # force_route: true                    # Optional — only for skills that must bypass scoring
 ---
 ```
 
 **Description Formula**: `[WHAT] + [WHEN] + [capabilities] + [clear scope boundary when needed]`
 
 **Max length**: 1024 characters (Anthropic enforced limit)
+
+### Common Mistakes (Invalid Frontmatter)
+
+These patterns cause validation failures and silent routing breakage:
+
+```yaml
+# WRONG: pairs_with at top level (must be under routing:)
+---
+name: my-skill
+description: "Does something."
+pairs_with:                    # ERROR — this belongs under routing:
+  - other-skill
+routing:
+  triggers: [my skill]
+  category: engineering
+---
+
+# WRONG: force_routing instead of force_route
+---
+name: my-skill
+description: "Does something."
+routing:
+  triggers: [my skill]
+  category: engineering
+  force_routing: true          # ERROR — use force_route, not force_routing
+---
+
+# WRONG: missing routing: wrapper
+---
+name: my-skill
+description: "Does something."
+triggers:                      # ERROR — triggers must be under routing:
+  - my skill
+category: engineering          # ERROR — category must be under routing:
+---
+```
+
+Validate after writing: `python3 scripts/validate-skill-frontmatter.py skills/<name>/SKILL.md`
 
 **Triggering note**: Claude tends to "undertrigger" skills — not invoking them when they'd be helpful. To combat this, make descriptions slightly assertive. Instead of just stating what the skill does, explicitly list trigger contexts. Example: "Make sure to use this skill whenever the user mentions X, Y, or Z, even if they don't explicitly ask for it."
 


### PR DESCRIPTION
## Summary

- **New validator script** (`scripts/validate-skill-frontmatter.py`) — parses all 110 skills' YAML frontmatter, catches broken YAML, wrong nesting (`pairs_with` at top level), typo keys (`force_routing` vs `force_route`), missing required fields
- **CI gate** — validator runs in the lint job; broken frontmatter blocks merge
- **PostToolUse hook** — runs validator after Write/Edit on `skills/*/SKILL.md`, injects errors as context so agents fix immediately
- **Template improvements** — nesting annotations, `force_route` field, "Common Mistakes" section with invalid examples in `skill-template.md`
- **Index script hardening** — `generate-skill-index.py` exits nonzero when regex fallback fires; `--strict` flag disables fallback entirely

## Motivation

Skill frontmatter defects have recurred twice (commits `552923b` and `f6227f7`/PR #553). Both were caused by LLM agents generating YAML with wrong nesting or typo keys. The existing pipeline silently accepted broken YAML via a regex fallback in `generate-skill-index.py`, and no CI step caught the defect before merge.

This PR breaks the failure chain at every level: agents get immediate feedback (hook), the index generator refuses to mask errors (strict mode), and CI rejects broken frontmatter (lint gate).

## Test plan

- [x] `python3 scripts/validate-skill-frontmatter.py` exits 0 on all 110 existing skills
- [x] 30 unit tests pass (`pytest scripts/tests/test_validate_skill_frontmatter.py -v`)
- [x] `ruff check` and `ruff format` pass on all new/modified files
- [ ] CI GitHub Actions pass (lint, test, routing-benchmark, routing-drift)