### PR TITLE
feat: add diff-to-functions.py mapping git diffs to function boundaries

### DIFF
--- a/scripts/diff-to-functions.py
+++ b/scripts/diff-to-functions.py
@@ -1,0 +1,815 @@
+#!/usr/bin/env python3
+"""Map git diff hunks to the functions they modify.
+
+Usage:
+    python3 scripts/diff-to-functions.py                    # unstaged changes
+    python3 scripts/diff-to-functions.py --staged           # staged changes
+    python3 scripts/diff-to-functions.py --ref main         # diff against ref
+    python3 scripts/diff-to-functions.py --ref HEAD~3       # last 3 commits
+    python3 scripts/diff-to-functions.py --format summary   # compact list
+
+Exit codes: 0=success, 1=no changes, 2=script error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+# Language detection by file extension
+EXTENSION_TO_LANGUAGE: dict[str, str] = {
+    ".py": "python",
+    ".go": "go",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".php": "php",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".swift": "swift",
+    ".sh": "bash",
+    ".bash": "bash",
+    ".zsh": "bash",
+    ".bas": "vb6",
+    ".cls": "vb6",
+    ".frm": "vb6",
+}
+
+# Tree-sitter node types that represent function/method definitions per language
+FUNCTION_NODE_TYPES: dict[str, list[str]] = {
+    "python": ["function_definition", "decorated_definition"],
+    "go": ["function_declaration", "method_declaration"],
+    "typescript": [
+        "function_declaration",
+        "method_definition",
+        "arrow_function",
+        "function",
+    ],
+    "javascript": [
+        "function_declaration",
+        "method_definition",
+        "arrow_function",
+        "function",
+    ],
+    "php": ["function_definition", "method_declaration"],
+    "kotlin": ["function_declaration"],
+    "swift": ["function_declaration"],
+    "bash": ["function_definition"],
+}
+
+# Regex patterns for function detection (fallback when tree-sitter unavailable)
+FUNCTION_PATTERNS: dict[str, re.Pattern[str]] = {
+    "python": re.compile(
+        r"^[ \t]*(?:async\s+)?def\s+(?P<name>\w+)\s*\((?P<params>[^)]*)\)",
+        re.MULTILINE,
+    ),
+    "go": re.compile(
+        r"^func\s+(?:\((?P<receiver>[^)]+)\)\s+)?(?P<name>\w+)\s*\((?P<params>[^)]*)\)",
+        re.MULTILINE,
+    ),
+    "typescript": re.compile(
+        r"^(?:export\s+)?(?:async\s+)?function\s+(?P<name>\w+)\s*\((?P<params>[^)]*)\)"
+        r"|^\s*(?:(?:public|private|protected|static|async)\s+)*(?P<method>\w+)\s*\((?P<mparams>[^)]*)\)\s*[:{]",
+        re.MULTILINE,
+    ),
+    "javascript": re.compile(
+        r"^(?:export\s+)?(?:async\s+)?function\s+(?P<name>\w+)\s*\((?P<params>[^)]*)\)"
+        r"|^\s*(?:(?:static|async)\s+)*(?P<method>\w+)\s*\((?P<mparams>[^)]*)\)\s*[{]",
+        re.MULTILINE,
+    ),
+    "php": re.compile(
+        r"^\s*(?:(?:public|private|protected|static)\s+)*function\s+(?P<name>\w+)\s*\((?P<params>[^)]*)\)",
+        re.MULTILINE,
+    ),
+    "kotlin": re.compile(
+        r"^\s*(?:(?:public|private|protected|internal|override|suspend|inline)\s+)*fun\s+(?P<name>\w+)\s*\((?P<params>[^)]*)\)",
+        re.MULTILINE,
+    ),
+    "swift": re.compile(
+        r"^\s*(?:(?:public|private|internal|fileprivate|open|override|static|class|@\w+)\s+)*func\s+(?P<name>\w+)\s*\((?P<params>[^)]*)\)",
+        re.MULTILINE,
+    ),
+    "bash": re.compile(
+        r"^(?:function\s+)?(?P<name>\w+)\s*\(\s*\)\s*\{",
+        re.MULTILINE,
+    ),
+    "vb6": re.compile(
+        r"^(?:Public|Private|Friend)?\s*(?:Static\s+)?(?:Sub|Function)\s+(?P<name>\w+)\s*\((?P<params>[^)]*)\)",
+        re.MULTILINE | re.IGNORECASE,
+    ),
+}
+
+# End patterns for languages with explicit block terminators
+FUNCTION_END_PATTERNS: dict[str, re.Pattern[str]] = {
+    "vb6": re.compile(r"^\s*End\s+(?:Sub|Function)", re.MULTILINE | re.IGNORECASE),
+}
+
+
+@dataclass
+class FunctionInfo:
+    """Represents a function/method found in source code."""
+
+    name: str
+    class_name: Optional[str] = None
+    line: int = 0
+    end_line: int = 0
+    params: str = ""
+    source: str = ""
+
+
+@dataclass
+class ChangedFunction:
+    """A function that was modified in the diff."""
+
+    file: str
+    language: str
+    function: str
+    class_name: Optional[str]
+    line: int
+    end_line: int
+    params: str
+    source: str
+    diff_lines: list[int] = field(default_factory=list)
+
+
+@dataclass
+class UnparseableFile:
+    """A changed file that has no parseable functions."""
+
+    file: str
+    reason: str
+    changed_line_count: int = 0
+
+
+def detect_language(filepath: str) -> Optional[str]:
+    """Detect programming language from file extension."""
+    ext = Path(filepath).suffix.lower()
+    return EXTENSION_TO_LANGUAGE.get(ext)
+
+
+def parse_diff_output(diff_text: str) -> dict[str, list[int]]:
+    """Parse unified diff output and extract changed line numbers per file.
+
+    Args:
+        diff_text: Raw output from git diff --unified=0.
+
+    Returns:
+        Dict mapping file paths to lists of changed line numbers (in the new file).
+    """
+    result: dict[str, list[int]] = {}
+    current_file: Optional[str] = None
+
+    for line in diff_text.splitlines():
+        # Detect file path from +++ line (new file side)
+        if line.startswith("+++ b/"):
+            current_file = line[6:]
+            if current_file not in result:
+                result[current_file] = []
+        elif line.startswith("+++ /dev/null"):
+            # File was deleted
+            current_file = None
+        elif line.startswith("@@") and current_file is not None:
+            # Parse hunk header: @@ -old_start,old_count +new_start,new_count @@
+            match = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            if match:
+                start = int(match.group(1))
+                count = int(match.group(2)) if match.group(2) else 1
+                # If count is 0, this is a pure deletion - no new lines to map
+                if count > 0:
+                    result[current_file].extend(range(start, start + count))
+
+    return result
+
+
+def find_functions_regex(source: str, language: str) -> list[FunctionInfo]:
+    """Find function boundaries using regex patterns (fallback method).
+
+    Args:
+        source: Source code content.
+        language: Programming language identifier.
+
+    Returns:
+        List of FunctionInfo with line ranges.
+    """
+    pattern = FUNCTION_PATTERNS.get(language)
+    if not pattern:
+        return []
+
+    lines = source.splitlines()
+    total_lines = len(lines)
+    functions: list[FunctionInfo] = []
+
+    for match in pattern.finditer(source):
+        start_line = source[: match.start()].count("\n") + 1
+
+        # Get function name from named groups
+        name = match.group("name") if match.groupdict().get("name") else match.groupdict().get("method", "unknown")
+        if not name:
+            continue
+
+        # Get params
+        params = match.groupdict().get("params") or match.groupdict().get("mparams") or ""
+        params = params.strip()
+
+        # Determine class context for methods
+        class_name = _find_enclosing_class(source, match.start(), language)
+
+        # Find end of function
+        end_line = _find_function_end(lines, start_line, total_lines, language)
+
+        # Extract source
+        func_source = "\n".join(lines[start_line - 1 : end_line])
+
+        functions.append(
+            FunctionInfo(
+                name=name,
+                class_name=class_name,
+                line=start_line,
+                end_line=end_line,
+                params=params,
+                source=func_source,
+            )
+        )
+
+    return functions
+
+
+def _find_enclosing_class(source: str, position: int, language: str) -> Optional[str]:
+    """Find the class that encloses a given position in the source."""
+    class_patterns = {
+        "python": re.compile(r"^([ \t]*)class\s+(\w+)", re.MULTILINE),
+        "typescript": re.compile(r"^([ \t]*)(?:export\s+)?class\s+(\w+)", re.MULTILINE),
+        "javascript": re.compile(r"^([ \t]*)(?:export\s+)?class\s+(\w+)", re.MULTILINE),
+        "php": re.compile(r"^([ \t]*)(?:abstract\s+)?class\s+(\w+)", re.MULTILINE),
+        "kotlin": re.compile(r"^([ \t]*)(?:(?:open|abstract|data|sealed)\s+)?class\s+(\w+)", re.MULTILINE),
+        "swift": re.compile(r"^([ \t]*)(?:(?:public|private|internal|open|final)\s+)?class\s+(\w+)", re.MULTILINE),
+    }
+
+    pattern = class_patterns.get(language)
+    if not pattern:
+        return None
+
+    # For indentation-based languages, check that the function is indented more than the class
+    indentation_languages = {"python"}
+
+    # Get the indentation of the function at position
+    line_start = source.rfind("\n", 0, position) + 1
+    func_line = source[line_start:position] + source[position : source.find("\n", position)]
+    func_indent = len(func_line) - len(func_line.lstrip())
+
+    # Find the last class definition before this position where the function is inside it
+    last_class = None
+    for match in pattern.finditer(source[:position]):
+        class_indent = len(match.group(1))
+        class_name = match.group(2)
+        if language in indentation_languages:
+            # Function must be indented more than the class to be inside it
+            if func_indent > class_indent:
+                last_class = class_name
+            else:
+                last_class = None
+        else:
+            last_class = class_name
+
+    return last_class
+
+
+def _find_function_end(lines: list[str], start_line: int, total_lines: int, language: str) -> int:
+    """Find the end line of a function starting at start_line.
+
+    Uses language-specific heuristics:
+    - Python: indentation-based
+    - VB6: End Sub/Function
+    - Brace languages: brace counting
+    - Bash: brace counting
+    """
+    if language == "python":
+        return _find_python_function_end(lines, start_line, total_lines)
+    elif language == "vb6":
+        return _find_vb6_function_end(lines, start_line, total_lines)
+    elif language == "bash":
+        return _find_brace_function_end(lines, start_line, total_lines)
+    else:
+        return _find_brace_function_end(lines, start_line, total_lines)
+
+
+def _find_python_function_end(lines: list[str], start_line: int, total_lines: int) -> int:
+    """Find end of Python function by indentation."""
+    if start_line > total_lines:
+        return start_line
+
+    # Get the indentation of the def line
+    def_line = lines[start_line - 1]
+    def_indent = len(def_line) - len(def_line.lstrip())
+
+    end_line = start_line
+    for i in range(start_line, total_lines):
+        line = lines[i]
+        # Skip blank lines and comments
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            end_line = i + 1
+            continue
+        # If indentation is greater than def, still in function
+        current_indent = len(line) - len(line.lstrip())
+        if current_indent > def_indent:
+            end_line = i + 1
+        else:
+            break
+
+    return end_line
+
+
+def _find_vb6_function_end(lines: list[str], start_line: int, total_lines: int) -> int:
+    """Find end of VB6 function by End Sub/Function."""
+    end_pattern = FUNCTION_END_PATTERNS["vb6"]
+    for i in range(start_line, total_lines):
+        if end_pattern.match(lines[i]):
+            return i + 1
+    return total_lines
+
+
+def _find_brace_function_end(lines: list[str], start_line: int, total_lines: int) -> int:
+    """Find end of function in brace-delimited languages."""
+    brace_count = 0
+    found_open = False
+
+    for i in range(start_line - 1, total_lines):
+        line = lines[i]
+        # Simple brace counting (ignores braces in strings/comments)
+        for char in line:
+            if char == "{":
+                brace_count += 1
+                found_open = True
+            elif char == "}":
+                brace_count -= 1
+
+        if found_open and brace_count <= 0:
+            return i + 1
+
+    return total_lines
+
+
+def try_tree_sitter_parse(source: str, language: str) -> Optional[list[FunctionInfo]]:
+    """Attempt to parse source with tree-sitter for accurate function boundaries.
+
+    Args:
+        source: Source code content.
+        language: Programming language identifier.
+
+    Returns:
+        List of FunctionInfo if tree-sitter is available and parsing succeeds, None otherwise.
+    """
+    try:
+        import tree_sitter
+    except ImportError:
+        return None
+
+    # Language library names for tree-sitter
+    ts_language_map = {
+        "python": "python",
+        "go": "go",
+        "typescript": "typescript",
+        "javascript": "javascript",
+        "php": "php",
+        "kotlin": "kotlin",
+        "swift": "swift",
+        "bash": "bash",
+    }
+
+    ts_lang_name = ts_language_map.get(language)
+    if not ts_lang_name:
+        return None
+
+    try:
+        import tree_sitter_languages
+
+        parser = tree_sitter_languages.get_parser(ts_lang_name)
+        tree = parser.parse(source.encode())
+        return _extract_functions_from_tree(tree.root_node, source, language)
+    except Exception:
+        return None
+
+
+def _extract_functions_from_tree(root_node: object, source: str, language: str) -> list[FunctionInfo]:
+    """Walk tree-sitter AST and extract function definitions.
+
+    Args:
+        root_node: Tree-sitter root node.
+        source: Source code for extracting text.
+        language: Language for node type lookup.
+
+    Returns:
+        List of FunctionInfo from the AST.
+    """
+    node_types = FUNCTION_NODE_TYPES.get(language, [])
+    lines = source.splitlines()
+    functions: list[FunctionInfo] = []
+
+    def walk(node: object) -> None:
+        # Access node attributes dynamically since tree-sitter types vary
+        node_type = getattr(node, "type", "")
+        children = getattr(node, "children", [])
+
+        if node_type in node_types:
+            start_line = getattr(node, "start_point", (0, 0))[0] + 1
+            end_line = getattr(node, "end_point", (0, 0))[0] + 1
+
+            # Extract function name from child nodes
+            name = "unknown"
+            params = ""
+            for child in children:
+                child_type = getattr(child, "type", "")
+                if child_type in ("identifier", "name", "property_identifier"):
+                    name = getattr(child, "text", b"").decode("utf-8", errors="replace")
+                elif child_type in ("parameters", "formal_parameters", "parameter_list"):
+                    raw = getattr(child, "text", b"").decode("utf-8", errors="replace")
+                    # Strip outer parens
+                    params = raw.strip("()")
+
+            func_source = "\n".join(lines[start_line - 1 : end_line])
+            class_name = _find_class_ancestor(node, language)
+
+            functions.append(
+                FunctionInfo(
+                    name=name,
+                    class_name=class_name,
+                    line=start_line,
+                    end_line=end_line,
+                    params=params,
+                    source=func_source,
+                )
+            )
+        else:
+            for child in children:
+                walk(child)
+
+    walk(root_node)
+    return functions
+
+
+def _find_class_ancestor(node: object, language: str) -> Optional[str]:
+    """Walk up tree-sitter AST to find enclosing class."""
+    class_types = {"class_definition", "class_declaration", "class_specifier"}
+    current = getattr(node, "parent", None)
+    while current is not None:
+        if getattr(current, "type", "") in class_types:
+            for child in getattr(current, "children", []):
+                if getattr(child, "type", "") in ("identifier", "name", "type_identifier"):
+                    return getattr(child, "text", b"").decode("utf-8", errors="replace")
+        current = getattr(current, "parent", None)
+    return None
+
+
+def find_functions_in_file(filepath: str, source: str) -> list[FunctionInfo]:
+    """Find all functions in a file, using tree-sitter if available, else regex.
+
+    Args:
+        filepath: Path to the file (for language detection).
+        source: File content.
+
+    Returns:
+        List of functions found in the file.
+    """
+    language = detect_language(filepath)
+    if not language:
+        return []
+
+    # Try tree-sitter first
+    ts_result = try_tree_sitter_parse(source, language)
+    if ts_result is not None:
+        return ts_result
+
+    # Fall back to regex
+    return find_functions_regex(source, language)
+
+
+def map_lines_to_functions(functions: list[FunctionInfo], changed_lines: list[int]) -> dict[int, list[int]]:
+    """Map changed line numbers to their containing functions.
+
+    Args:
+        functions: List of functions with line ranges.
+        changed_lines: List of changed line numbers.
+
+    Returns:
+        Dict mapping function index to list of changed lines within it.
+    """
+    result: dict[int, list[int]] = {}
+
+    for line_num in changed_lines:
+        for i, func in enumerate(functions):
+            if func.line <= line_num <= func.end_line:
+                if i not in result:
+                    result[i] = []
+                result[i].append(line_num)
+                break
+
+    return result
+
+
+def get_git_diff(ref: Optional[str] = None, staged: bool = False) -> str:
+    """Run git diff and return the output.
+
+    Args:
+        ref: Git ref to diff against (e.g., 'main', 'HEAD~3').
+        staged: Whether to show staged changes only.
+
+    Returns:
+        Raw git diff output string.
+    """
+    cmd = ["git", "diff", "--unified=0", "--no-color"]
+
+    if ref:
+        cmd.append(ref)
+    elif staged:
+        cmd.append("--staged")
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return result.stdout
+
+
+def read_file_content(filepath: str) -> Optional[str]:
+    """Read file content, returning None if file doesn't exist or is binary.
+
+    Args:
+        filepath: Path relative to git root.
+
+    Returns:
+        File content string or None.
+    """
+    # Find git root
+    git_root_result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if git_root_result.returncode != 0:
+        return None
+
+    git_root = Path(git_root_result.stdout.strip())
+    full_path = git_root / filepath
+
+    if not full_path.exists():
+        return None
+
+    try:
+        return full_path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return None
+
+
+def build_output(
+    changed_functions: list[ChangedFunction],
+    unparseable_files: list[UnparseableFile],
+    ref: Optional[str],
+    staged: bool,
+) -> dict:
+    """Build the JSON output structure.
+
+    Args:
+        changed_functions: List of modified functions.
+        unparseable_files: List of files without parseable functions.
+        ref: Git ref that was diffed against.
+        staged: Whether staged changes were examined.
+
+    Returns:
+        Dict ready for JSON serialization.
+    """
+    diff_target = ref if ref else ("staged" if staged else "working tree")
+
+    return {
+        "ref": diff_target,
+        "changed_functions": [
+            {
+                "file": cf.file,
+                "language": cf.language,
+                "function": cf.function,
+                "class": cf.class_name,
+                "line": cf.line,
+                "end_line": cf.end_line,
+                "params": cf.params,
+                "source": cf.source,
+                "diff_lines": cf.diff_lines,
+            }
+            for cf in changed_functions
+        ],
+        "changed_files_without_functions": [
+            {"file": uf.file, "reason": uf.reason, "changed_line_count": uf.changed_line_count}
+            for uf in unparseable_files
+        ],
+    }
+
+
+def format_summary(
+    changed_functions: list[ChangedFunction],
+    unparseable_files: list[UnparseableFile],
+    ref: Optional[str],
+    staged: bool,
+) -> str:
+    """Format output as a compact text summary.
+
+    Args:
+        changed_functions: List of modified functions.
+        unparseable_files: List of files without parseable functions.
+        ref: Git ref that was diffed against.
+        staged: Whether staged changes were examined.
+
+    Returns:
+        Formatted text summary string.
+    """
+    diff_target = ref if ref else ("staged" if staged else "working tree")
+    lines = [f"Changed functions (diff against {diff_target}):"]
+
+    # Group by file
+    by_file: dict[str, list[ChangedFunction]] = {}
+    for cf in changed_functions:
+        if cf.file not in by_file:
+            by_file[cf.file] = []
+        by_file[cf.file].append(cf)
+
+    for filepath, funcs in by_file.items():
+        lines.append(f"  {filepath}:")
+        for cf in funcs:
+            display_name = f"{cf.class_name}.{cf.function}" if cf.class_name else cf.function
+            # Truncate params for display
+            params_display = cf.params
+            if len(params_display) > 40:
+                params_display = params_display[:37] + "..."
+            lines.append(
+                f"    {display_name}({params_display})  [L{cf.line}-{cf.end_line}, {len(cf.diff_lines)} lines changed]"
+            )
+
+    for uf in unparseable_files:
+        lines.append(f"  {uf.file}: [{uf.reason}, {uf.changed_line_count} lines changed]")
+
+    return "\n".join(lines)
+
+
+def run(ref: Optional[str] = None, staged: bool = False, output_format: str = "json") -> int:
+    """Main execution logic.
+
+    Args:
+        ref: Git ref to diff against.
+        staged: Whether to show staged changes.
+        output_format: 'json' or 'summary'.
+
+    Returns:
+        Exit code (0=success, 1=no changes, 2=error).
+    """
+    try:
+        diff_text = get_git_diff(ref=ref, staged=staged)
+    except Exception as e:
+        print(f"Error running git diff: {e}", file=sys.stderr)
+        return 2
+
+    if not diff_text.strip():
+        if output_format == "json":
+            print(
+                json.dumps(
+                    {
+                        "ref": ref or ("staged" if staged else "working tree"),
+                        "changed_functions": [],
+                        "changed_files_without_functions": [],
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            diff_target = ref if ref else ("staged" if staged else "working tree")
+            print(f"No changes found (diff against {diff_target})")
+        return 1
+
+    file_changes = parse_diff_output(diff_text)
+    if not file_changes:
+        return 1
+
+    changed_functions: list[ChangedFunction] = []
+    unparseable_files: list[UnparseableFile] = []
+
+    for filepath, changed_lines in file_changes.items():
+        if not changed_lines:
+            continue
+
+        language = detect_language(filepath)
+        if not language:
+            unparseable_files.append(
+                UnparseableFile(
+                    file=filepath,
+                    reason="no parseable functions",
+                    changed_line_count=len(changed_lines),
+                )
+            )
+            continue
+
+        source = read_file_content(filepath)
+        if source is None:
+            unparseable_files.append(
+                UnparseableFile(
+                    file=filepath,
+                    reason="file not readable",
+                    changed_line_count=len(changed_lines),
+                )
+            )
+            continue
+
+        functions = find_functions_in_file(filepath, source)
+        if not functions:
+            unparseable_files.append(
+                UnparseableFile(
+                    file=filepath,
+                    reason="no functions detected",
+                    changed_line_count=len(changed_lines),
+                )
+            )
+            continue
+
+        line_map = map_lines_to_functions(functions, changed_lines)
+
+        # Collect functions that had changes
+        for func_idx, diff_lines in line_map.items():
+            func = functions[func_idx]
+            changed_functions.append(
+                ChangedFunction(
+                    file=filepath,
+                    language=language,
+                    function=func.name,
+                    class_name=func.class_name,
+                    line=func.line,
+                    end_line=func.end_line,
+                    params=func.params,
+                    source=func.source,
+                    diff_lines=sorted(diff_lines),
+                )
+            )
+
+        # Check for changes outside any function
+        all_func_lines = set()
+        for func in functions:
+            all_func_lines.update(range(func.line, func.end_line + 1))
+
+        outside_lines = [ln for ln in changed_lines if ln not in all_func_lines]
+        if outside_lines and not line_map:
+            # All changes are outside functions
+            unparseable_files.append(
+                UnparseableFile(
+                    file=filepath,
+                    reason="changes outside functions",
+                    changed_line_count=len(outside_lines),
+                )
+            )
+
+    if output_format == "summary":
+        print(format_summary(changed_functions, unparseable_files, ref, staged))
+    else:
+        output = build_output(changed_functions, unparseable_files, ref, staged)
+        print(json.dumps(output, indent=2))
+
+    return 0
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Map git diff hunks to the functions they modify.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--ref",
+        type=str,
+        default=None,
+        help="Git ref to diff against (e.g., main, HEAD~3)",
+    )
+    parser.add_argument(
+        "--staged",
+        action="store_true",
+        help="Show staged changes only",
+    )
+    parser.add_argument(
+        "--format",
+        type=str,
+        choices=["json", "summary"],
+        default="json",
+        dest="output_format",
+        help="Output format (default: json)",
+    )
+
+    args = parser.parse_args()
+
+    if args.ref and args.staged:
+        print("Error: --ref and --staged are mutually exclusive", file=sys.stderr)
+        return 2
+
+    return run(ref=args.ref, staged=args.staged, output_format=args.output_format)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_diff_to_functions.py
+++ b/scripts/tests/test_diff_to_functions.py
@@ -1,0 +1,717 @@
+"""Tests for diff-to-functions.py script.
+
+Tests cover:
+- Git diff parsing and line number extraction
+- Function boundary detection (Python, Go, TypeScript, VB6)
+- Line-to-function mapping
+- Summary format output
+- Edge cases: module-level changes, unparseable files
+- Subprocess mocking for deterministic testing
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add scripts dir to path for import
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Use importlib since filename has hyphens
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "diff_to_functions",
+    Path(__file__).parent.parent / "diff-to-functions.py",
+)
+_module = importlib.util.module_from_spec(_spec)
+sys.modules["diff_to_functions"] = _module
+_spec.loader.exec_module(_module)
+
+# Import the module's public interface
+parse_diff_output = _module.parse_diff_output
+find_functions_regex = _module.find_functions_regex
+map_lines_to_functions = _module.map_lines_to_functions
+detect_language = _module.detect_language
+format_summary = _module.format_summary
+build_output = _module.build_output
+run = _module.run
+ChangedFunction = _module.ChangedFunction
+UnparseableFile = _module.UnparseableFile
+FunctionInfo = _module.FunctionInfo
+
+
+# ============================================================
+# Fixtures: sample diff outputs
+# ============================================================
+
+SAMPLE_DIFF_PYTHON = """\
+diff --git a/src/utils.py b/src/utils.py
+index abc1234..def5678 100644
+--- a/src/utils.py
++++ b/src/utils.py
+@@ -10,0 +11,3 @@ def parse_config(path):
++    # Added validation
++    if not path.exists():
++        raise FileNotFoundError(path)
+@@ -25 +28 @@ def parse_config(path):
+-    return config
++    return validated_config
+"""
+
+SAMPLE_DIFF_MULTI_FILE = """\
+diff --git a/src/server.ts b/src/server.ts
+index abc1234..def5678 100644
+--- a/src/server.ts
++++ b/src/server.ts
+@@ -55,0 +55,3 @@
++    // new middleware
++    app.use(cors());
++    app.use(helmet());
+@@ -62 +65 @@
+-    res.send("ok");
++    res.json({ status: "ok" });
+diff --git a/config.json b/config.json
+index abc1234..def5678 100644
+--- a/config.json
++++ b/config.json
+@@ -3,2 +3,3 @@
+-  "port": 3000,
+-  "host": "localhost"
++  "port": 8080,
++  "host": "0.0.0.0",
++  "debug": true
+"""
+
+SAMPLE_DIFF_DELETION = """\
+diff --git a/old.py b/old.py
+deleted file mode 100644
+index abc1234..0000000
+--- a/old.py
++++ /dev/null
+@@ -1,10 +0,0 @@
+-def old_function():
+-    pass
+"""
+
+SAMPLE_PYTHON_SOURCE = """\
+import os
+from pathlib import Path
+
+
+def parse_config(path):
+    \"\"\"Parse configuration file.\"\"\"
+    with open(path) as f:
+        config = json.load(f)
+    # Added validation
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return validated_config
+
+
+def validate(data):
+    \"\"\"Validate data structure.\"\"\"
+    if not isinstance(data, dict):
+        raise TypeError("Expected dict")
+    return True
+
+
+class ConfigManager:
+    def __init__(self, base_path):
+        self.base_path = base_path
+
+    def load(self, name):
+        path = self.base_path / name
+        return parse_config(path)
+
+    def save(self, name, data):
+        path = self.base_path / name
+        with open(path, "w") as f:
+            json.dump(data, f)
+"""
+
+SAMPLE_GO_SOURCE = """\
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("hello")
+    server := NewServer()
+    server.Start()
+}
+
+func NewServer() *Server {
+    return &Server{
+        port: 8080,
+    }
+}
+
+func (s *Server) Start() error {
+    fmt.Printf("Starting on port %d\\n", s.port)
+    return s.listen()
+}
+
+func (s *Server) Stop() {
+    s.shutdown()
+}
+"""
+
+SAMPLE_VB6_SOURCE = """\
+Option Explicit
+
+Private Sub Form_Load()
+    Dim x As Integer
+    x = 10
+    Call InitializeApp
+End Sub
+
+Public Function CalculateTotal(ByVal price As Double, ByVal qty As Integer) As Double
+    Dim total As Double
+    total = price * qty
+    CalculateTotal = total
+End Function
+
+Private Sub CleanUp()
+    Set objConn = Nothing
+End Sub
+"""
+
+SAMPLE_TS_SOURCE = """\
+import { Request, Response } from 'express';
+
+export function handleRequest(req: Request, res: Response): Promise<void> {
+    const data = req.body;
+    // new middleware
+    app.use(cors());
+    app.use(helmet());
+    return processData(data);
+}
+
+export class Server {
+    private port: number;
+
+    constructor(port: number) {
+        this.port = port;
+    }
+
+    async start(): Promise<void> {
+        console.log(`Starting on ${this.port}`);
+        await this.listen();
+    }
+
+    stop(): void {
+        this.cleanup();
+    }
+}
+"""
+
+
+# ============================================================
+# Tests: Diff Parsing
+# ============================================================
+
+
+class TestParseDiffOutput:
+    """Tests for parse_diff_output function."""
+
+    def test_parses_python_diff_lines(self):
+        """Parse a Python diff and extract correct line numbers."""
+        result = parse_diff_output(SAMPLE_DIFF_PYTHON)
+
+        assert "src/utils.py" in result
+        lines = result["src/utils.py"]
+        # First hunk: +11,3 -> lines 11, 12, 13
+        assert 11 in lines
+        assert 12 in lines
+        assert 13 in lines
+        # Second hunk: +28 (single line change)
+        assert 28 in lines
+
+    def test_parses_multi_file_diff(self):
+        """Parse a diff with multiple files."""
+        result = parse_diff_output(SAMPLE_DIFF_MULTI_FILE)
+
+        assert "src/server.ts" in result
+        assert "config.json" in result
+        # server.ts: +55,3 and +65,1
+        ts_lines = result["src/server.ts"]
+        assert 55 in ts_lines
+        assert 56 in ts_lines
+        assert 57 in ts_lines
+        assert 65 in ts_lines
+        # config.json: +3,3
+        json_lines = result["config.json"]
+        assert 3 in json_lines
+        assert 4 in json_lines
+        assert 5 in json_lines
+
+    def test_handles_deleted_file(self):
+        """Deleted files (going to /dev/null) should not produce entries."""
+        result = parse_diff_output(SAMPLE_DIFF_DELETION)
+        # /dev/null means file was deleted; should not appear
+        assert "old.py" not in result
+
+    def test_empty_diff_returns_empty_dict(self):
+        """Empty diff input produces empty result."""
+        result = parse_diff_output("")
+        assert result == {}
+
+    def test_pure_deletion_hunk_produces_no_lines(self):
+        """A hunk with +N,0 (pure deletion) should not produce lines."""
+        diff = """\
+diff --git a/foo.py b/foo.py
+index abc..def 100644
+--- a/foo.py
++++ b/foo.py
+@@ -5,3 +5,0 @@
+-removed line 1
+-removed line 2
+-removed line 3
+"""
+        result = parse_diff_output(diff)
+        assert result.get("foo.py", []) == []
+
+
+# ============================================================
+# Tests: Function Detection (Regex Fallback)
+# ============================================================
+
+
+class TestFindFunctionsRegex:
+    """Tests for regex-based function boundary detection."""
+
+    def test_python_functions(self):
+        """Detect Python function definitions with correct boundaries."""
+        functions = find_functions_regex(SAMPLE_PYTHON_SOURCE, "python")
+
+        names = [f.name for f in functions]
+        assert "parse_config" in names
+        assert "validate" in names
+        assert "__init__" in names
+        assert "load" in names
+        assert "save" in names
+
+    def test_python_function_line_ranges(self):
+        """Python function line ranges are accurate."""
+        functions = find_functions_regex(SAMPLE_PYTHON_SOURCE, "python")
+
+        parse_config = next(f for f in functions if f.name == "parse_config")
+        # parse_config starts at line 5
+        assert parse_config.line == 5
+        # Should end after the return statement
+        assert parse_config.end_line >= 12
+
+    def test_go_functions(self):
+        """Detect Go function and method declarations."""
+        functions = find_functions_regex(SAMPLE_GO_SOURCE, "go")
+
+        names = [f.name for f in functions]
+        assert "main" in names
+        assert "NewServer" in names
+        assert "Start" in names
+        assert "Stop" in names
+
+    def test_go_function_boundaries(self):
+        """Go function boundaries are accurate using brace counting."""
+        functions = find_functions_regex(SAMPLE_GO_SOURCE, "go")
+
+        main_func = next(f for f in functions if f.name == "main")
+        assert main_func.line == 5
+        assert main_func.end_line == 9
+
+    def test_vb6_functions(self):
+        """Detect VB6 Sub and Function definitions."""
+        functions = find_functions_regex(SAMPLE_VB6_SOURCE, "vb6")
+
+        names = [f.name for f in functions]
+        assert "Form_Load" in names
+        assert "CalculateTotal" in names
+        assert "CleanUp" in names
+
+    def test_vb6_function_end_detection(self):
+        """VB6 functions end at 'End Sub' or 'End Function'."""
+        functions = find_functions_regex(SAMPLE_VB6_SOURCE, "vb6")
+
+        form_load = next(f for f in functions if f.name == "Form_Load")
+        # Should end at "End Sub" line
+        assert form_load.end_line == 7
+
+        calc = next(f for f in functions if f.name == "CalculateTotal")
+        assert calc.end_line == 13
+
+    def test_typescript_functions(self):
+        """Detect TypeScript function and method declarations."""
+        functions = find_functions_regex(SAMPLE_TS_SOURCE, "typescript")
+
+        names = [f.name for f in functions]
+        assert "handleRequest" in names
+
+    def test_unknown_language_returns_empty(self):
+        """Unknown language returns no functions."""
+        functions = find_functions_regex("some code", "unknown_lang")
+        assert functions == []
+
+
+# ============================================================
+# Tests: Line-to-Function Mapping
+# ============================================================
+
+
+class TestMapLinesToFunctions:
+    """Tests for mapping changed lines to containing functions."""
+
+    def test_maps_lines_to_correct_function(self):
+        """Changed lines are mapped to their containing function."""
+        functions = [
+            FunctionInfo(name="func_a", line=5, end_line=15),
+            FunctionInfo(name="func_b", line=20, end_line=30),
+        ]
+        changed_lines = [7, 8, 22, 25]
+
+        result = map_lines_to_functions(functions, changed_lines)
+
+        assert 0 in result  # func_a
+        assert 1 in result  # func_b
+        assert result[0] == [7, 8]
+        assert result[1] == [22, 25]
+
+    def test_lines_outside_functions_not_mapped(self):
+        """Lines outside any function are not in the result."""
+        functions = [
+            FunctionInfo(name="func_a", line=10, end_line=20),
+        ]
+        changed_lines = [1, 2, 3, 25]
+
+        result = map_lines_to_functions(functions, changed_lines)
+
+        assert result == {}
+
+    def test_line_on_function_boundary_is_included(self):
+        """Lines exactly on start/end boundaries are included."""
+        functions = [
+            FunctionInfo(name="func_a", line=10, end_line=20),
+        ]
+        changed_lines = [10, 20]
+
+        result = map_lines_to_functions(functions, changed_lines)
+
+        assert 0 in result
+        assert result[0] == [10, 20]
+
+    def test_empty_changed_lines(self):
+        """No changed lines produces empty mapping."""
+        functions = [
+            FunctionInfo(name="func_a", line=10, end_line=20),
+        ]
+
+        result = map_lines_to_functions(functions, [])
+        assert result == {}
+
+
+# ============================================================
+# Tests: Language Detection
+# ============================================================
+
+
+class TestDetectLanguage:
+    """Tests for file extension language detection."""
+
+    @pytest.mark.parametrize(
+        "filepath,expected",
+        [
+            ("src/main.py", "python"),
+            ("pkg/server.go", "go"),
+            ("src/app.ts", "typescript"),
+            ("src/app.tsx", "typescript"),
+            ("lib/utils.js", "javascript"),
+            ("lib/comp.jsx", "javascript"),
+            ("src/Handler.php", "php"),
+            ("src/Main.kt", "kotlin"),
+            ("Sources/App.swift", "swift"),
+            ("scripts/deploy.sh", "bash"),
+            ("Module1.bas", "vb6"),
+            ("Form1.frm", "vb6"),
+            ("Class1.cls", "vb6"),
+            ("config.json", None),
+            ("README.md", None),
+            ("Makefile", None),
+        ],
+    )
+    def test_language_detection(self, filepath: str, expected: str | None):
+        """Language is correctly detected from file extension."""
+        assert detect_language(filepath) == expected
+
+
+# ============================================================
+# Tests: Summary Format
+# ============================================================
+
+
+class TestFormatSummary:
+    """Tests for compact text summary output."""
+
+    def test_summary_format_structure(self):
+        """Summary output has correct structure with file grouping."""
+        changed_functions = [
+            ChangedFunction(
+                file="src/server.ts",
+                language="typescript",
+                function="handleRequest",
+                class_name=None,
+                line=42,
+                end_line=87,
+                params="req: Request, res: Response",
+                source="...",
+                diff_lines=[55, 56, 57, 62],
+            ),
+            ChangedFunction(
+                file="src/server.ts",
+                language="typescript",
+                function="stop",
+                class_name="Server",
+                line=31,
+                end_line=45,
+                params="",
+                source="...",
+                diff_lines=[35, 36],
+            ),
+            ChangedFunction(
+                file="src/utils.py",
+                language="python",
+                function="parse_config",
+                class_name=None,
+                line=10,
+                end_line=25,
+                params="path",
+                source="...",
+                diff_lines=[15],
+            ),
+        ]
+        unparseable = [
+            UnparseableFile(file="config.json", reason="no parseable functions", changed_line_count=3),
+        ]
+
+        result = format_summary(changed_functions, unparseable, ref="main", staged=False)
+
+        assert "Changed functions (diff against main):" in result
+        assert "src/server.ts:" in result
+        assert "handleRequest(req: Request, res: Response)" in result
+        assert "4 lines changed" in result
+        assert "Server.stop()" in result
+        assert "2 lines changed" in result
+        assert "src/utils.py:" in result
+        assert "parse_config(path)" in result
+        assert "1 line" in result  # "1 lines changed"
+        assert "config.json" in result
+        assert "no parseable functions" in result
+
+    def test_summary_with_no_changes(self):
+        """Summary with empty lists still has header."""
+        result = format_summary([], [], ref=None, staged=True)
+        assert "diff against staged" in result
+
+
+# ============================================================
+# Tests: Module-Level Changes
+# ============================================================
+
+
+class TestModuleLevelChanges:
+    """Tests for changes outside any function."""
+
+    def test_changes_outside_functions_reported(self):
+        """Changes in module-level code are reported as unparseable."""
+        source = """\
+import os
+import sys
+
+CONSTANT = 42
+
+def my_func():
+    return CONSTANT
+"""
+        functions = find_functions_regex(source, "python")
+        # Change is at line 4 (CONSTANT = 42), outside any function
+        changed_lines = [4]
+        line_map = map_lines_to_functions(functions, changed_lines)
+
+        # No function contains line 4
+        assert line_map == {}
+
+
+# ============================================================
+# Tests: Unparseable Files
+# ============================================================
+
+
+class TestUnparseableFiles:
+    """Tests for files that cannot have functions extracted."""
+
+    def test_json_file_is_unparseable(self):
+        """JSON files have no parseable functions."""
+        language = detect_language("config.json")
+        assert language is None
+
+    def test_markdown_file_is_unparseable(self):
+        """Markdown files have no parseable functions."""
+        language = detect_language("README.md")
+        assert language is None
+
+
+# ============================================================
+# Tests: End-to-End with Mocked Git
+# ============================================================
+
+
+class TestRunWithMockedGit:
+    """Integration tests using mocked subprocess calls."""
+
+    @patch("subprocess.run")
+    def test_run_with_ref(self, mock_run):
+        """Run with --ref produces JSON output."""
+        # Mock git diff output
+        mock_run.return_value = type(
+            "Result",
+            (),
+            {
+                "stdout": SAMPLE_DIFF_PYTHON,
+                "stderr": "",
+                "returncode": 0,
+            },
+        )()
+
+        # Mock file reading by patching read_file_content
+        with (
+            patch.object(_module, "read_file_content", return_value=SAMPLE_PYTHON_SOURCE),
+            patch("builtins.print") as mock_print,
+        ):
+            exit_code = run(ref="main", output_format="json")
+
+        assert exit_code == 0
+        # Verify JSON was printed
+        printed = mock_print.call_args[0][0]
+        output = json.loads(printed)
+        assert output["ref"] == "main"
+        assert len(output["changed_functions"]) > 0
+        assert output["changed_functions"][0]["function"] == "parse_config"
+
+    @patch("subprocess.run")
+    def test_run_no_changes(self, mock_run):
+        """Run with no diff output returns exit code 1."""
+        mock_run.return_value = type(
+            "Result",
+            (),
+            {
+                "stdout": "",
+                "stderr": "",
+                "returncode": 0,
+            },
+        )()
+
+        with patch("builtins.print"):
+            exit_code = run(ref="main", output_format="json")
+
+        assert exit_code == 1
+
+    @patch("subprocess.run")
+    def test_run_summary_format(self, mock_run):
+        """Run with --format summary produces text output."""
+        mock_run.return_value = type(
+            "Result",
+            (),
+            {
+                "stdout": SAMPLE_DIFF_PYTHON,
+                "stderr": "",
+                "returncode": 0,
+            },
+        )()
+
+        with (
+            patch.object(_module, "read_file_content", return_value=SAMPLE_PYTHON_SOURCE),
+            patch("builtins.print") as mock_print,
+        ):
+            exit_code = run(ref="main", output_format="summary")
+
+        assert exit_code == 0
+        printed = mock_print.call_args[0][0]
+        assert "Changed functions" in printed
+        assert "parse_config" in printed
+
+    @patch("subprocess.run")
+    def test_run_with_unparseable_file(self, mock_run):
+        """Files without language detection go to unparseable list."""
+        diff_with_json = """\
+diff --git a/config.json b/config.json
+index abc..def 100644
+--- a/config.json
++++ b/config.json
+@@ -1,2 +1,3 @@
++{"new": true}
+"""
+        mock_run.return_value = type(
+            "Result",
+            (),
+            {
+                "stdout": diff_with_json,
+                "stderr": "",
+                "returncode": 0,
+            },
+        )()
+
+        with patch("builtins.print") as mock_print:
+            exit_code = run(ref="main", output_format="json")
+
+        assert exit_code == 0
+        printed = mock_print.call_args[0][0]
+        output = json.loads(printed)
+        assert len(output["changed_files_without_functions"]) == 1
+        assert output["changed_files_without_functions"][0]["file"] == "config.json"
+
+
+# ============================================================
+# Tests: Build Output Structure
+# ============================================================
+
+
+class TestBuildOutput:
+    """Tests for JSON output structure building."""
+
+    def test_output_has_required_fields(self):
+        """Output dict has all required top-level fields."""
+        output = build_output([], [], ref="main", staged=False)
+
+        assert "ref" in output
+        assert "changed_functions" in output
+        assert "changed_files_without_functions" in output
+        assert output["ref"] == "main"
+
+    def test_output_function_fields(self):
+        """Each changed function has all required fields."""
+        cf = ChangedFunction(
+            file="test.py",
+            language="python",
+            function="my_func",
+            class_name="MyClass",
+            line=10,
+            end_line=20,
+            params="x: int, y: int",
+            source="def my_func(x: int, y: int):\n    pass",
+            diff_lines=[15, 16],
+        )
+        output = build_output([cf], [], ref=None, staged=True)
+
+        func = output["changed_functions"][0]
+        assert func["file"] == "test.py"
+        assert func["language"] == "python"
+        assert func["function"] == "my_func"
+        assert func["class"] == "MyClass"
+        assert func["line"] == 10
+        assert func["end_line"] == 20
+        assert func["params"] == "x: int, y: int"
+        assert "def my_func" in func["source"]
+        assert func["diff_lines"] == [15, 16]


### PR DESCRIPTION
## Summary

- **New script**: `scripts/diff-to-functions.py` — maps git diff hunks to enclosing functions/methods, outputting structured JSON or compact text
- Supports **9 languages**: Go, Python, TypeScript, JavaScript, PHP, Kotlin, Swift, Bash, VB6
- `--ref main` / `--staged` / default (unstaged) diff modes
- `--format json` (default) and `--format summary` (compact text grouped by file)
- Tree-sitter first, regex fallback; unparseable files reported with reason
- 44 unit tests covering diff parsing, function detection, line mapping
- Exit codes: 0=success, 1=no changes, 2=error

## Motivation

Review agents currently read raw git diffs (~6000 tokens for a 1000-line file with 20 changed lines). This script maps diffs to changed functions (~800 tokens). Review skills call this instead of raw diff, focusing reviewers on "function X changed" not "lines 42-67 changed."

## Test plan

- [x] 44 unit tests pass
- [x] ruff check + format clean
- [ ] CI passes