### PR TITLE
feat: add deadcode tool to Go agent, cut tree-sitter scripts

### DIFF
--- a/agents/golang-general-engineer.md
+++ b/agents/golang-general-engineer.md
@@ -106,6 +106,7 @@ Load these reference files when the task type matches:
 | Concurrency patterns (worker pools, fan-out/fan-in, pipelines) | [golang-general-engineer/references/go-concurrency.md](golang-general-engineer/references/go-concurrency.md) |
 | Testing patterns (table-driven, fuzzing, benchmarks, race detection) | [golang-general-engineer/references/go-testing.md](golang-general-engineer/references/go-testing.md) |
 | Security, auth, injection, XSS, CSRF, SSRF, or any vulnerability-related code | [golang-general-engineer/references/go-security.md](golang-general-engineer/references/go-security.md) |
+| Dead code analysis, cleanup, unused functions, refactoring prep, call-graph navigation | [golang-general-engineer/references/go-dead-code-analysis.md](golang-general-engineer/references/go-dead-code-analysis.md) |
 
 **Shared Patterns**:
 - [shared-patterns/anti-rationalization-core.md](../skills/shared-patterns/anti-rationalization-core.md) — Universal rationalization patterns
@@ -131,7 +132,7 @@ Apply minimum-viable edits because over-engineering beyond the request is the mo
 **Gate**: `go_diagnostics` returns zero errors for edited files.
 
 ### Phase 4: VERIFY
-Run `gofmt -w` on every edited file because unformatted Go code fails CI before any logic review runs. Run `go test ./...` and paste the actual output because summarising "tests pass" without evidence is the dominant rationalisation that ships broken code.
+Run `gofmt -w` on every edited file because unformatted Go code fails CI before any logic review runs. Run `go test ./...` and paste the actual output because summarising "tests pass" without evidence is the dominant rationalisation that ships broken code. For cleanup, review, or refactoring tasks, run `deadcode ./...` after `go vet` to find unreachable functions — see [go-dead-code-analysis.md](golang-general-engineer/references/go-dead-code-analysis.md) for usage and false-positive guidance.
 
 **Gate**: `go test ./...` output shown in full, `go vet ./...` clean.
 

--- a/agents/golang-general-engineer.md
+++ b/agents/golang-general-engineer.md
@@ -106,7 +106,7 @@ Load these reference files when the task type matches:
 | Concurrency patterns (worker pools, fan-out/fan-in, pipelines) | [golang-general-engineer/references/go-concurrency.md](golang-general-engineer/references/go-concurrency.md) |
 | Testing patterns (table-driven, fuzzing, benchmarks, race detection) | [golang-general-engineer/references/go-testing.md](golang-general-engineer/references/go-testing.md) |
 | Security, auth, injection, XSS, CSRF, SSRF, or any vulnerability-related code | [golang-general-engineer/references/go-security.md](golang-general-engineer/references/go-security.md) |
-| Dead code analysis, cleanup, unused functions, refactoring prep, call-graph navigation | [golang-general-engineer/references/go-dead-code-analysis.md](golang-general-engineer/references/go-dead-code-analysis.md) |
+| Dead code analysis, cleanup, unused functions, refactoring prep | [golang-general-engineer/references/go-dead-code-analysis.md](golang-general-engineer/references/go-dead-code-analysis.md) |
 
 **Shared Patterns**:
 - [shared-patterns/anti-rationalization-core.md](../skills/shared-patterns/anti-rationalization-core.md) — Universal rationalization patterns

--- a/agents/golang-general-engineer/references/go-dead-code-analysis.md
+++ b/agents/golang-general-engineer/references/go-dead-code-analysis.md
@@ -1,6 +1,6 @@
 # Go Dead Code Analysis
 
-Tools and decision guidance for dead code detection and call-graph navigation in Go codebases. Load when the task involves finding unused functions, cleanup, refactoring prep, or understanding call chains.
+Tool and decision guidance for dead code detection in Go codebases. Load when the task involves finding unused functions, cleanup, or refactoring prep.
 
 ## deadcode — Primary Tool for Dead Code Detection
 
@@ -43,6 +43,9 @@ deadcode's SSA analysis builds the complete call graph including these edges. A 
 ```bash
 # Confirm the function is used in tests before dismissing the finding
 grep -rn "setupTestDB" --include="*_test.go"
+
+# To include test binary entry points in the analysis
+deadcode -test ./...
 ```
 
 **Exported API surface**: Libraries expose exported functions for external consumers. deadcode cannot see callers outside the module. For library code, focus deadcode findings on unexported functions.
@@ -62,7 +65,7 @@ deadcode is not mandatory for every task. It adds value when the question is "wh
 # VERIFY phase sequence for cleanup tasks
 go vet ./...
 deadcode ./...
-go test -v -race ./...
+go test ./...
 ```
 
 ## Why Not Tree-Sitter for Go?

--- a/agents/golang-general-engineer/references/go-dead-code-analysis.md
+++ b/agents/golang-general-engineer/references/go-dead-code-analysis.md
@@ -65,39 +65,10 @@ deadcode ./...
 go test -v -race ./...
 ```
 
-## Tree-Sitter Call Graph — Complementary Tool for Navigation
+## Why Not Tree-Sitter for Go?
 
-`scripts/call-graph.py` (when available in the toolkit) builds a cross-file call graph from tree-sitter syntax analysis with a SQLite cache. It answers "who calls this function?" and "what does this function call?" across all files in a codebase.
+Tree-sitter parses syntax, not semantics. It cannot resolve interface dispatch, method values, or reflection. In Go codebases that use interfaces (which is most of them), syntax-level call graph tools produce false positives: functions called through interfaces appear to have zero callers because the call site references the interface method, not the concrete implementation.
 
-### Commands
+A/B tested across 5 tests on 2 repos (hermes, log-router): tree-sitter call graph added no measurable value over grep + file reading for dead code detection, code audits, PR reviews, or impact analysis. `deadcode` + `gopls` + grep cover all Go use cases with equal or better results.
 
-```bash
-# Build the call graph index (SQLite-cached)
-python3 scripts/call-graph.py index ./
-
-# Find all callers of a function
-python3 scripts/call-graph.py callers MyFunction
-
-# Find all callees of a function
-python3 scripts/call-graph.py callees MyFunction
-```
-
-### When to Use
-
-- **Impact analysis**: "What breaks if I change this function's signature?"
-- **Navigation in unfamiliar codebases**: "Where is this function called from? What does it depend on?"
-- **Understanding call chains**: tracing the path from entry point to a specific function.
-
-### When NOT to Use for Go Dead Code
-
-Tree-sitter parses syntax, not semantics. It cannot resolve interface dispatch, method values, or reflection. In Go codebases that use interfaces (which is most of them), tree-sitter produces false positives: functions called through interfaces appear to have zero callers because the call site references the interface method, not the concrete implementation. Use deadcode instead — it resolves these edges correctly.
-
-## Decision Table
-
-| Task | deadcode | call-graph.py |
-|------|----------|---------------|
-| Find dead code | Primary tool — SSA resolves interfaces | Too many false positives in Go |
-| Impact analysis ("what calls X?") | Wrong tool | Primary tool |
-| Code review (dead code check) | Run as part of review | Supplement only |
-| Navigate unfamiliar codebase | Wrong tool | Primary tool |
-| Refactoring prep | Find what is safe to remove | Find what calls what |
+For **impact analysis** ("what calls this function?"), use `gopls` MCP's `go_symbol_references` tool or grep. Both outperformed tree-sitter call graphs in blind testing.

--- a/agents/golang-general-engineer/references/go-dead-code-analysis.md
+++ b/agents/golang-general-engineer/references/go-dead-code-analysis.md
@@ -1,0 +1,103 @@
+# Go Dead Code Analysis
+
+Tools and decision guidance for dead code detection and call-graph navigation in Go codebases. Load when the task involves finding unused functions, cleanup, refactoring prep, or understanding call chains.
+
+## deadcode — Primary Tool for Dead Code Detection
+
+`golang.org/x/tools/cmd/deadcode` is the official Go team tool for finding unreachable functions. It uses SSA (Static Single Assignment) whole-program analysis with Rapid Type Analysis to resolve interface dispatch, method values, and reflection — none of which syntax-level tools can handle.
+
+### Install and Run
+
+```bash
+go install golang.org/x/tools/cmd/deadcode@latest
+
+# Text output — one line per unreachable function
+deadcode ./...
+
+# Structured output — machine-parseable JSON
+deadcode -json ./...
+
+# Filter to a specific package
+deadcode ./internal/processor/...
+```
+
+### What It Catches
+
+- **Unexported unreachable functions**: functions not reachable from any `main` package entry point through the whole-program call graph.
+- **Exported functions with no callers**: exported functions that no `main` package entry point reaches. These are candidates for removal or unexport.
+
+### Why SSA Beats Syntax Analysis
+
+Syntax-level tools (grep, tree-sitter, gopls references) find textual call sites. They cannot resolve:
+
+- **Interface dispatch**: `handler.Process(x)` calls whichever concrete type implements `Handler` — the actual target depends on runtime types, not source text.
+- **Method values**: `f := obj.Method; f()` — the call to `Method` happens through the variable `f`, invisible to syntax search.
+- **Reflection**: `reflect.ValueOf(x).MethodByName("Foo").Call(...)` — no syntax tool can resolve this.
+
+deadcode's SSA analysis builds the complete call graph including these edges. A function that appears unused by grep may be reachable through an interface. A function that appears used by grep may actually be dead — the call site itself is unreachable.
+
+### Known False Positives
+
+**Test helpers**: deadcode analyzes reachability from `main` package entry points. Functions called only from `_test.go` files are not reachable from `main` — they are reachable from test binaries, which deadcode does not analyze. This is expected behavior, not a bug. When deadcode flags a function that is clearly a test helper (e.g., `setupTestDB`, `assertResponse`), verify by checking test file usage before removing:
+
+```bash
+# Confirm the function is used in tests before dismissing the finding
+grep -rn "setupTestDB" --include="*_test.go"
+```
+
+**Exported API surface**: Libraries expose exported functions for external consumers. deadcode cannot see callers outside the module. For library code, focus deadcode findings on unexported functions.
+
+### Integration with VERIFY Phase
+
+Run deadcode after `go vet` during Phase 4 (VERIFY) when the task involves:
+
+- Dead code audits or cleanup tasks
+- Code review where unused functions are a concern
+- Refactoring prep — identifying what is safe to remove
+- Post-migration cleanup after removing a feature or dependency
+
+deadcode is not mandatory for every task. It adds value when the question is "what can I safely delete?" — not when the question is "does this build and pass tests?"
+
+```bash
+# VERIFY phase sequence for cleanup tasks
+go vet ./...
+deadcode ./...
+go test -v -race ./...
+```
+
+## Tree-Sitter Call Graph — Complementary Tool for Navigation
+
+`scripts/call-graph.py` (when available in the toolkit) builds a cross-file call graph from tree-sitter syntax analysis with a SQLite cache. It answers "who calls this function?" and "what does this function call?" across all files in a codebase.
+
+### Commands
+
+```bash
+# Build the call graph index (SQLite-cached)
+python3 scripts/call-graph.py index ./
+
+# Find all callers of a function
+python3 scripts/call-graph.py callers MyFunction
+
+# Find all callees of a function
+python3 scripts/call-graph.py callees MyFunction
+```
+
+### When to Use
+
+- **Impact analysis**: "What breaks if I change this function's signature?"
+- **Navigation in unfamiliar codebases**: "Where is this function called from? What does it depend on?"
+- **Understanding call chains**: tracing the path from entry point to a specific function.
+
+### When NOT to Use for Go Dead Code
+
+Tree-sitter parses syntax, not semantics. It cannot resolve interface dispatch, method values, or reflection. In Go codebases that use interfaces (which is most of them), tree-sitter produces false positives: functions called through interfaces appear to have zero callers because the call site references the interface method, not the concrete implementation. Use deadcode instead — it resolves these edges correctly.
+
+## Decision Table
+
+| Task | deadcode | call-graph.py |
+|------|----------|---------------|
+| Find dead code | Primary tool — SSA resolves interfaces | Too many false positives in Go |
+| Impact analysis ("what calls X?") | Wrong tool | Primary tool |
+| Code review (dead code check) | Run as part of review | Supplement only |
+| Navigate unfamiliar codebase | Wrong tool | Primary tool |
+| Refactoring prep | Find what is safe to remove | Find what calls what |


### PR DESCRIPTION
## Summary

- Add `go-dead-code-analysis.md` reference file to the Go agent with `deadcode` (`golang.org/x/tools/cmd/deadcode`) integration: install, usage, SSA vs syntax analysis explanation, false-positive guidance, VERIFY phase integration
- Update Go agent's Reference Loading Table and Phase 4 (VERIFY) to include deadcode for cleanup/review/refactoring tasks
- Document why tree-sitter was cut: 5 blind A/B tests across 2 repos showed zero measurable value over grep + gopls + deadcode

## What changed

**New file:** `agents/golang-general-engineer/references/go-dead-code-analysis.md` (74 lines)
- deadcode install, usage, what it catches, known false positives (test helpers, exported API)
- "Why Not Tree-Sitter" section with A/B test evidence
- Impact analysis guidance: use gopls `go_symbol_references` or grep

**Modified:** `agents/golang-general-engineer.md` (+2 lines)
- Reference Loading Table: new row for dead code tasks
- VERIFY phase: optional `deadcode ./...` step for cleanup/review tasks

## What was cut (not in this PR, already closed)

- PR #556 (code-outline.py) — closed
- PR #557 (diff-to-functions.py) — closed  
- call-graph.py worktree — deleted, never PR'd
- 3 worktrees, 2 remote branches, 2 SQLite cache DBs removed

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] `validate-skill-frontmatter.py` passes (110 skills OK)
- [x] `validate-references.py` confirms reference file is registered
- [x] A/B tested deadcode value across 5 blind tests on 2 Go repos