### PR TITLE
feat: add Gemini CLI support with skill/agent/hook mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Tool name mapping: Codex `Bash` becomes Gemini `run_shell_command`.
 
 **Hook runtime compatibility**
 
-Hooks detect which CLI is invoking them via environment variables (`GEMINI_API_KEY`, `GEMINI_MODEL` for Gemini; `CODEX_HOME` for Codex). Input field names are normalized automatically (`tool_input` to `input`, `tool_name` to `tool`). Output format (`hookSpecificOutput`) is shared across all three CLIs.
+Hooks can detect which CLI is invoking them via `detect_cli()` in `hooks/lib/hook_utils.py`. Normalization functions (`normalize_input()`, `detect_cli()`) are available in `hooks/lib/hook_utils.py` for hooks to import — they are not auto-applied. Output format (`hookSpecificOutput`) is shared across all three CLIs.
 
 **Opting out**
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A game built entirely by Claude Code using these agents, skills, and pipelines. 
 
 ## Installation
 
-Requires [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and working (`claude --version` should print a version number). Codex CLI is also supported: the installer mirrors toolkit skills into `~/.codex/skills` and toolkit agents into `~/.codex/agents` so Codex can use the same skill and agent library (`codex --version` should print a version number if you want Codex support too).
+Requires [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and working (`claude --version` should print a version number). Codex CLI and Gemini CLI are also supported: the installer mirrors toolkit skills and agents into `~/.codex/` and `~/.gemini/` so all three CLIs can use the same skill and agent library.
 
 ```bash
 git clone https://github.com/notque/claude-code-toolkit.git ~/claude-code-toolkit
@@ -38,7 +38,7 @@ cd ~/claude-code-toolkit
 ./install.sh --symlink
 ```
 
-The installer links agents, skills, hooks, commands, and scripts into `~/.claude/`, where Claude Code loads extensions from. It also mirrors skills into `~/.codex/skills` and agents into `~/.codex/agents` for Codex. Use `--symlink` to get updates via `git pull`, or run without it for a stable copy.
+The installer links agents, skills, hooks, commands, and scripts into `~/.claude/`, where Claude Code loads extensions from. It also mirrors skills and agents into `~/.codex/` for Codex and `~/.gemini/` for Gemini CLI. Use `--symlink` to get updates via `git pull`, or run without it for a stable copy.
 
 Verify the install with:
 
@@ -47,7 +47,7 @@ python3 ~/.claude/scripts/install-doctor.py check
 python3 ~/.claude/scripts/install-doctor.py inventory
 ```
 
-If you update the repo later and want Codex to see newly added skills, rerun `./install.sh --symlink` from the repo root.
+If you update the repo later and want Codex/Gemini to see newly added skills, rerun `./install.sh --symlink` from the repo root.
 
 Command entry points:
 - Claude Code: `/do`
@@ -78,6 +78,35 @@ The toolkit mirrors agents, skills, and a curated subset of hooks into `~/.codex
 There is no opt-out flag. The mirror is harmless when Codex CLI is not installed: `~/.codex/` entries sit unused until you install Codex. To skip the hooks portion, delete `~/.codex/hooks/` and `~/.codex/hooks.json` after install; the toolkit does not recreate them on normal use.
 
 **Reference**: [`adr/182-codex-hooks-mirror.md`](adr/182-codex-hooks-mirror.md). Upstream Phase 2 tracker: [openai/codex#16732](https://github.com/openai/codex/issues/16732).
+
+## Gemini CLI Support
+
+The toolkit mirrors agents, skills, and a curated subset of hooks into `~/.gemini/` so they work with the Google Gemini CLI alongside Claude Code and Codex. The mirror runs automatically on every `install.sh`; no flags required.
+
+**What mirrors**
+
+- **Agents**: every agent under `agents/` (and `private-agents/` if present) is copied or symlinked to `~/.gemini/agents/`.
+- **Skills**: every skill under `skills/`, `private-skills/`, and `private-voices/*/skill/` goes to `~/.gemini/skills/`.
+- **Hooks**: the same Phase 1 hooks as Codex, with translated event names, go to `~/.gemini/hooks/`. Hook configuration is merged into `~/.gemini/settings.json` (only the `hooks` key is modified; all other settings are preserved). See `scripts/gemini-hooks-allowlist.txt`.
+
+**Event name mapping**
+
+| Claude/Codex | Gemini CLI |
+|---|---|
+| SessionStart | SessionStart |
+| Stop | SessionEnd |
+| PostToolUse | AfterTool |
+| PreToolUse | BeforeTool |
+
+Tool name mapping: Codex `Bash` becomes Gemini `run_shell_command`.
+
+**Hook runtime compatibility**
+
+Hooks detect which CLI is invoking them via environment variables (`GEMINI_API_KEY`, `GEMINI_MODEL` for Gemini; `CODEX_HOME` for Codex). Input field names are normalized automatically (`tool_input` to `input`, `tool_name` to `tool`). Output format (`hookSpecificOutput`) is shared across all three CLIs.
+
+**Opting out**
+
+The mirror is harmless when Gemini CLI is not installed. To remove hooks after install, delete `~/.gemini/hooks/` and remove the `hooks` key from `~/.gemini/settings.json`.
 
 ## Running Claude Code with the toolkit
 

--- a/hooks/lib/hook_utils.py
+++ b/hooks/lib/hook_utils.py
@@ -439,19 +439,33 @@ def deny_tool_use(event_name: str, reason: str) -> None:
 
 # =============================================================================
 # CLI Detection and Input Normalization
+#
+# These functions are infrastructure for hook authors to import as needed.
+# They are NOT auto-applied; individual hooks must call them explicitly.
 # =============================================================================
 
 
 def detect_cli() -> str:
     """Detect which CLI is invoking this hook based on environment variables.
 
+    Detection is best-effort and may need updating as Gemini CLI's
+    environment contract stabilises.  We avoid using ``GEMINI_API_KEY``
+    alone because users commonly set it for direct API access even when
+    running Claude Code.
+
     Returns:
         One of "gemini", "codex", or "claude".
     """
-    # Gemini CLI sets GEMINI_API_KEY or GEMINI_MODEL
-    if os.environ.get("GEMINI_API_KEY") or os.environ.get("GEMINI_MODEL"):
+    # Most specific: explicit CLI identification env var
+    if os.environ.get("GEMINI_CLI"):
         return "gemini"
-    # Codex CLI sets CODEX_HOME or similar
+    # Process-based: the _ var contains the invoking command path
+    invocation = os.environ.get("_", "")
+    if "gemini" in invocation.lower():
+        return "gemini"
+    if "codex" in invocation.lower():
+        return "codex"
+    # Codex-specific env vars
     if os.environ.get("CODEX_HOME") or os.environ.get("CODEX_HOOKS_DIR"):
         return "codex"
     return "claude"

--- a/hooks/lib/hook_utils.py
+++ b/hooks/lib/hook_utils.py
@@ -435,3 +435,51 @@ def deny_tool_use(event_name: str, reason: str) -> None:
         }
     }
     print(json.dumps(output))
+
+
+# =============================================================================
+# CLI Detection and Input Normalization
+# =============================================================================
+
+
+def detect_cli() -> str:
+    """Detect which CLI is invoking this hook based on environment variables.
+
+    Returns:
+        One of "gemini", "codex", or "claude".
+    """
+    # Gemini CLI sets GEMINI_API_KEY or GEMINI_MODEL
+    if os.environ.get("GEMINI_API_KEY") or os.environ.get("GEMINI_MODEL"):
+        return "gemini"
+    # Codex CLI sets CODEX_HOME or similar
+    if os.environ.get("CODEX_HOME") or os.environ.get("CODEX_HOOKS_DIR"):
+        return "codex"
+    return "claude"
+
+
+def normalize_input(data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize hook stdin fields across CLI implementations.
+
+    Gemini CLI uses different field names than Claude/Codex:
+      - tool_input  -> input
+      - tool_name   -> tool
+
+    This function translates Gemini field names to the Claude/Codex
+    convention so hooks can use a single code path. Fields that already
+    exist under the Claude/Codex name are not overwritten.
+
+    Args:
+        data: Parsed JSON dict from stdin.
+
+    Returns:
+        The same dict (mutated in place) with normalized field names.
+    """
+    # Gemini: tool_input -> input
+    if "tool_input" in data and "input" not in data:
+        data["input"] = data["tool_input"]
+
+    # Gemini: tool_name -> tool
+    if "tool_name" in data and "tool" not in data:
+        data["tool"] = data["tool_name"]
+
+    return data

--- a/hooks/posttool-bash-injection-scan.py
+++ b/hooks/posttool-bash-injection-scan.py
@@ -95,7 +95,7 @@ def main() -> None:
         empty_output(EVENT_NAME).print_and_exit()
 
     tool_name = event.get("tool_name") or event.get("tool", "")
-    if tool_name != "Bash":
+    if tool_name not in ("Bash", "run_shell_command"):
         empty_output(EVENT_NAME).print_and_exit()
 
     tool_input = event.get("tool_input", event.get("input", {}))

--- a/install.sh
+++ b/install.sh
@@ -15,8 +15,9 @@
 #   1. Verifies Python 3.10+ is available
 #   2. Creates ~/.claude directory if needed
 #   3. Links/copies agents, skills, hooks, commands, scripts to ~/.claude
-#   4. Sets up local overlay directory
-#   5. Configures hooks in settings.json
+#   4. Mirrors skills, agents, and hooks to ~/.codex and ~/.gemini
+#   5. Sets up local overlay directory
+#   6. Configures hooks in settings.json
 #
 
 set -e
@@ -35,6 +36,10 @@ CODEX_DIR="${HOME}/.codex"
 CODEX_SKILLS_DIR="${CODEX_DIR}/skills"
 CODEX_AGENTS_DIR="${CODEX_DIR}/agents"
 CODEX_HOOKS_DIR="${CODEX_DIR}/hooks"
+GEMINI_DIR="${HOME}/.gemini"
+GEMINI_SKILLS_DIR="${GEMINI_DIR}/skills"
+GEMINI_AGENTS_DIR="${GEMINI_DIR}/agents"
+GEMINI_HOOKS_DIR="${GEMINI_DIR}/hooks"
 
 echo -e "${BLUE}╔════════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${BLUE}║                Claude Code Toolkit - Installation Script               ║${NC}"
@@ -391,6 +396,146 @@ os.rename(tmp, dst)
     # Note: [features] codex_hooks = true is intentionally left in config.toml.
     # Users may have other Codex hook configurations we did not write.
 
+    # Phase 3.7: Clean toolkit-owned Gemini skills mirror
+    echo ""
+    echo -e "${YELLOW}Cleaning Gemini skills mirror...${NC}"
+    if [ -d "$GEMINI_SKILLS_DIR" ]; then
+        for item in "${SCRIPT_DIR}/skills/"*; do
+            [ -e "$item" ] || continue
+            target="${GEMINI_SKILLS_DIR}/$(basename "$item")"
+            if [ -L "$target" ] || [ -e "$target" ]; then
+                if [ "$DRY_RUN" = true ]; then
+                    echo -e "${BLUE}  Would remove Gemini entry: ${target}${NC}"
+                else
+                    rm -rf "$target"
+                    echo -e "${GREEN}  ✓ Removed Gemini entry: ${target}${NC}"
+                fi
+                REMOVED+=("Gemini skill $(basename "$item")")
+            fi
+        done
+
+        if [ -d "${SCRIPT_DIR}/private-voices" ]; then
+            for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
+                [ -d "$voice_dir" ] || continue
+                skill_src="${voice_dir}/skill"
+                [ -d "$skill_src" ] || continue
+                voice_name=$(basename "$voice_dir")
+                target="${GEMINI_SKILLS_DIR}/voice-${voice_name}"
+                if [ -L "$target" ] || [ -e "$target" ]; then
+                    if [ "$DRY_RUN" = true ]; then
+                        echo -e "${BLUE}  Would remove Gemini entry: ${target}${NC}"
+                    else
+                        rm -rf "$target"
+                        echo -e "${GREEN}  ✓ Removed Gemini entry: ${target}${NC}"
+                    fi
+                    REMOVED+=("Gemini skill voice-${voice_name}")
+                fi
+            done
+        fi
+
+        if [ -d "${SCRIPT_DIR}/private-skills" ]; then
+            for item in "${SCRIPT_DIR}/private-skills/"*; do
+                [ -e "$item" ] || continue
+                target="${GEMINI_SKILLS_DIR}/$(basename "$item")"
+                if [ -L "$target" ] || [ -e "$target" ]; then
+                    if [ "$DRY_RUN" = true ]; then
+                        echo -e "${BLUE}  Would remove Gemini entry: ${target}${NC}"
+                    else
+                        rm -rf "$target"
+                        echo -e "${GREEN}  ✓ Removed Gemini entry: ${target}${NC}"
+                    fi
+                    REMOVED+=("Gemini skill $(basename "$item")")
+                fi
+            done
+        fi
+    else
+        echo "  No ~/.gemini/skills mirror found. Nothing to clean."
+    fi
+
+    echo ""
+    echo -e "${YELLOW}Cleaning Gemini agents mirror...${NC}"
+    if [ -d "$GEMINI_AGENTS_DIR" ]; then
+        for item in "${SCRIPT_DIR}/agents/"*; do
+            [ -e "$item" ] || continue
+            target="${GEMINI_AGENTS_DIR}/$(basename "$item")"
+            if [ -L "$target" ] || [ -e "$target" ]; then
+                if [ "$DRY_RUN" = true ]; then
+                    echo -e "${BLUE}  Would remove Gemini entry: ${target}${NC}"
+                else
+                    rm -rf "$target"
+                    echo -e "${GREEN}  ✓ Removed Gemini entry: ${target}${NC}"
+                fi
+                REMOVED+=("Gemini agent $(basename "$item")")
+            fi
+        done
+
+        if [ -d "${SCRIPT_DIR}/private-agents" ]; then
+            for item in "${SCRIPT_DIR}/private-agents/"*; do
+                [ -e "$item" ] || continue
+                target="${GEMINI_AGENTS_DIR}/$(basename "$item")"
+                if [ -L "$target" ] || [ -e "$target" ]; then
+                    if [ "$DRY_RUN" = true ]; then
+                        echo -e "${BLUE}  Would remove Gemini entry: ${target}${NC}"
+                    else
+                        rm -rf "$target"
+                        echo -e "${GREEN}  ✓ Removed Gemini entry: ${target}${NC}"
+                    fi
+                    REMOVED+=("Gemini agent $(basename "$item")")
+                fi
+            done
+        fi
+    else
+        echo "  No ~/.gemini/agents mirror found. Nothing to clean."
+    fi
+
+    # Phase 3.8: Clean toolkit-owned Gemini hooks mirror
+    echo ""
+    echo -e "${YELLOW}Cleaning Gemini hooks mirror...${NC}"
+    if [ -d "$GEMINI_HOOKS_DIR" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would remove: ${GEMINI_HOOKS_DIR}${NC}"
+        else
+            rm -rf "$GEMINI_HOOKS_DIR"
+            echo -e "${GREEN}  ✓ Removed ${GEMINI_HOOKS_DIR}${NC}"
+        fi
+        REMOVED+=("Gemini hooks mirror directory")
+    else
+        echo "  No ~/.gemini/hooks mirror found. Nothing to clean."
+    fi
+
+    if [ -f "${GEMINI_DIR}/settings.json" ]; then
+        # Check if settings.json has a hooks key we should clean
+        HAS_GEMINI_HOOKS=$(python3 -c "import json; d=json.load(open('${GEMINI_DIR}/settings.json')); print('yes' if 'hooks' in d else 'no')" 2>/dev/null || echo "no")
+        if [ "$HAS_GEMINI_HOOKS" = "yes" ]; then
+            if [ "$DRY_RUN" = true ]; then
+                echo -e "${BLUE}  Would archive hooks from: ${GEMINI_DIR}/settings.json${NC}"
+            else
+                ARCHIVE_TS=$(date +%Y%m%d-%H%M%S)
+                cp "${GEMINI_DIR}/settings.json" "${GEMINI_DIR}/settings.json.uninstalled.${ARCHIVE_TS}"
+                # Remove only the hooks key, preserve everything else
+                python3 -c "
+import json, os
+dst = '${GEMINI_DIR}/settings.json'
+with open(dst, encoding='utf-8') as f:
+    data = json.load(f)
+data.pop('hooks', None)
+tmp = dst + '.tmp'
+with open(tmp, 'w', encoding='utf-8') as f:
+    json.dump(data, f, indent=2)
+    f.flush()
+    os.fsync(f.fileno())
+os.rename(tmp, dst)
+"
+                echo -e "${GREEN}  ✓ Archived and cleaned hooks from ${GEMINI_DIR}/settings.json${NC}"
+            fi
+            REMOVED+=("Gemini hooks config from settings.json (archived)")
+        else
+            echo "  No hooks key found in ~/.gemini/settings.json. Nothing to clean."
+        fi
+    else
+        echo "  No ~/.gemini/settings.json found. Nothing to archive."
+    fi
+
     # Phase 4: Remove install manifest
     echo ""
     echo -e "${YELLOW}Cleaning up manifest...${NC}"
@@ -436,6 +581,7 @@ os.rename(tmp, dst)
     echo "  • ~/.claude/projects/"
     echo "  • ~/.claude/memory/"
     echo "  • ~/.codex/config.toml (including [features] codex_hooks flag)"
+    echo "  • ~/.gemini/settings.json (all keys except hooks)"
     echo "  • .local/ customizations in the toolkit repo"
     echo "  • Python packages (remove manually if needed)"
     if [ ${#PRESERVED[@]} -gt 0 ]; then
@@ -528,6 +674,24 @@ else
 fi
 echo -e "${GREEN}✓ ${CODEX_AGENTS_DIR} ready${NC}"
 
+echo ""
+echo -e "${YELLOW}Setting up ~/.gemini skills directory...${NC}"
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}  Would create: ${GEMINI_SKILLS_DIR}${NC}"
+else
+    mkdir -p "${GEMINI_SKILLS_DIR}"
+fi
+echo -e "${GREEN}✓ ${GEMINI_SKILLS_DIR} ready${NC}"
+
+echo ""
+echo -e "${YELLOW}Setting up ~/.gemini agents directory...${NC}"
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}  Would create: ${GEMINI_AGENTS_DIR}${NC}"
+else
+    mkdir -p "${GEMINI_AGENTS_DIR}"
+fi
+echo -e "${GREEN}✓ ${GEMINI_AGENTS_DIR} ready${NC}"
+
 # Install components
 echo ""
 echo -e "${YELLOW}Installing components (mode: ${MODE})...${NC}"
@@ -581,15 +745,16 @@ install_component() {
     fi
 }
 
-sync_codex_entry() {
+sync_mirror_entry() {
     local source=$1
     local target=$2
+    local label=${3:-Mirror}
     local name
     name=$(basename "$source")
 
     if [ -e "$target" ] || [ -L "$target" ]; then
         if [ "$DRY_RUN" = true ]; then
-            echo -e "${BLUE}  Would replace Codex entry: ${target}${NC}"
+            echo -e "${BLUE}  Would replace ${label} entry: ${target}${NC}"
         else
             rm -rf "$target"
         fi
@@ -597,23 +762,28 @@ sync_codex_entry() {
 
     if [ "$MODE" = "symlink" ]; then
         if [ "$DRY_RUN" = true ]; then
-            echo -e "${BLUE}  Would symlink Codex entry: ${source} -> ${target}${NC}"
+            echo -e "${BLUE}  Would symlink ${label} entry: ${source} -> ${target}${NC}"
         else
             ln -s "$source" "$target"
-            echo -e "${GREEN}  ✓ Codex symlinked ${name}${NC}"
+            echo -e "${GREEN}  ✓ ${label} symlinked ${name}${NC}"
         fi
     else
         if [ "$DRY_RUN" = true ]; then
-            echo -e "${BLUE}  Would copy Codex entry: ${source} -> ${target}${NC}"
+            echo -e "${BLUE}  Would copy ${label} entry: ${source} -> ${target}${NC}"
         else
             if [ -d "$source" ]; then
                 cp -r "$source" "$target"
             else
                 cp "$source" "$target"
             fi
-            echo -e "${GREEN}  ✓ Codex copied ${name}${NC}"
+            echo -e "${GREEN}  ✓ ${label} copied ${name}${NC}"
         fi
     fi
+}
+
+# Backward-compatible wrapper for existing call sites
+sync_codex_entry() {
+    sync_mirror_entry "$1" "$2" "Codex"
 }
 
 # Install main components
@@ -802,6 +972,132 @@ if [ -f "$CODEX_HOOKS_ALLOWLIST" ]; then
     fi
 else
     echo -e "${YELLOW}  ⚠ Codex hooks allowlist not found at ${CODEX_HOOKS_ALLOWLIST}; skipping hooks mirror${NC}"
+fi
+
+# Sync Gemini skills mirror
+echo ""
+echo -e "${YELLOW}Syncing Gemini skills mirror...${NC}"
+GEMINI_ENTRY_COUNT=0
+for item in "${SCRIPT_DIR}/skills/"*; do
+    [ -e "$item" ] || continue
+    target="${GEMINI_SKILLS_DIR}/$(basename "$item")"
+    sync_mirror_entry "$item" "$target" "Gemini"
+    GEMINI_ENTRY_COUNT=$((GEMINI_ENTRY_COUNT + 1))
+done
+
+if [ -d "${SCRIPT_DIR}/private-voices" ]; then
+    for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
+        [ -d "$voice_dir" ] || continue
+        skill_src="${voice_dir}/skill"
+        [ -d "$skill_src" ] || continue
+        voice_name=$(basename "$voice_dir")
+        target="${GEMINI_SKILLS_DIR}/voice-${voice_name}"
+        sync_mirror_entry "$skill_src" "$target" "Gemini"
+        GEMINI_ENTRY_COUNT=$((GEMINI_ENTRY_COUNT + 1))
+    done
+fi
+
+if [ -d "${SCRIPT_DIR}/private-skills" ]; then
+    for item in "${SCRIPT_DIR}/private-skills/"*; do
+        [ -e "$item" ] || continue
+        target="${GEMINI_SKILLS_DIR}/$(basename "$item")"
+        sync_mirror_entry "$item" "$target" "Gemini"
+        GEMINI_ENTRY_COUNT=$((GEMINI_ENTRY_COUNT + 1))
+    done
+fi
+
+echo ""
+echo -e "${YELLOW}Syncing Gemini agents mirror...${NC}"
+GEMINI_AGENT_COUNT=0
+for item in "${SCRIPT_DIR}/agents/"*; do
+    [ -e "$item" ] || continue
+    target="${GEMINI_AGENTS_DIR}/$(basename "$item")"
+    sync_mirror_entry "$item" "$target" "Gemini"
+    GEMINI_AGENT_COUNT=$((GEMINI_AGENT_COUNT + 1))
+done
+
+if [ -d "${SCRIPT_DIR}/private-agents" ]; then
+    for item in "${SCRIPT_DIR}/private-agents/"*; do
+        [ -e "$item" ] || continue
+        target="${GEMINI_AGENTS_DIR}/$(basename "$item")"
+        sync_mirror_entry "$item" "$target" "Gemini"
+        GEMINI_AGENT_COUNT=$((GEMINI_AGENT_COUNT + 1))
+    done
+fi
+
+# Sync Gemini hooks mirror
+echo ""
+echo -e "${YELLOW}Syncing Gemini hooks mirror...${NC}"
+GEMINI_HOOK_COUNT=0
+GEMINI_HOOKS_ALLOWLIST="${SCRIPT_DIR}/scripts/gemini-hooks-allowlist.txt"
+
+if [ -f "$GEMINI_HOOKS_ALLOWLIST" ]; then
+    # Ensure hooks directory exists
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would create: ${GEMINI_HOOKS_DIR}${NC}"
+    else
+        mkdir -p "$GEMINI_HOOKS_DIR"
+    fi
+
+    # Parse allowlist and mirror each allowlisted hook file.
+    while IFS= read -r line || [ -n "$line" ]; do
+        trimmed="${line#"${line%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+        [ -z "$trimmed" ] && continue
+        [ "${trimmed#\#}" != "$trimmed" ] && continue
+
+        rest="${trimmed#*:}"
+        filename="${rest%% *}"
+
+        source_file="${SCRIPT_DIR}/hooks/${filename}"
+        if [ ! -f "$source_file" ]; then
+            echo -e "${RED}  ✗ Allowlisted hook missing: ${filename}${NC}"
+            continue
+        fi
+
+        target_file="${GEMINI_HOOKS_DIR}/${filename}"
+        sync_mirror_entry "$source_file" "$target_file" "Gemini"
+        GEMINI_HOOK_COUNT=$((GEMINI_HOOK_COUNT + 1))
+    done < "$GEMINI_HOOKS_ALLOWLIST"
+
+    # Also mirror the hooks/lib directory so intra-hook imports resolve.
+    if [ -d "${SCRIPT_DIR}/hooks/lib" ]; then
+        lib_target="${GEMINI_HOOKS_DIR}/lib"
+        sync_mirror_entry "${SCRIPT_DIR}/hooks/lib" "$lib_target" "Gemini"
+    fi
+
+    # Merge hooks into ~/.gemini/settings.json via the dedicated script.
+    GEMINI_SETTINGS="${GEMINI_DIR}/settings.json"
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would merge hooks into: ${GEMINI_SETTINGS}${NC}"
+    else
+        if $PYTHON_CMD "${SCRIPT_DIR}/scripts/generate-gemini-settings-hooks.py" \
+            --allowlist "$GEMINI_HOOKS_ALLOWLIST" \
+            --output "$GEMINI_SETTINGS" \
+            --gemini-hooks-dir "$GEMINI_HOOKS_DIR" 2>&1; then
+            echo -e "${GREEN}  ✓ Merged hooks into ${GEMINI_SETTINGS}${NC}"
+        else
+            echo -e "${RED}  ✗ Failed to merge hooks into settings.json${NC}"
+        fi
+    fi
+
+    # Warn if installed Gemini CLI is below the hook-support minimum (v0.26.0).
+    if command -v gemini >/dev/null 2>&1; then
+        gm_ver=$(gemini --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        if [ -n "$gm_ver" ]; then
+            min_major=0; min_minor=26; min_patch=0
+            IFS='.' read -r gm_maj gm_min gm_pat <<< "$gm_ver"
+            if [ "$gm_maj" -lt "$min_major" ] || \
+               { [ "$gm_maj" -eq "$min_major" ] && [ "$gm_min" -lt "$min_minor" ]; } || \
+               { [ "$gm_maj" -eq "$min_major" ] && [ "$gm_min" -eq "$min_minor" ] && [ "${gm_pat:-0}" -lt "$min_patch" ]; }; then
+                echo -e "${YELLOW}  ⚠ Gemini CLI version ${gm_ver} is below 0.26.0. Hooks may not work.${NC}"
+            fi
+        fi
+    else
+        echo -e "${BLUE}  (gemini CLI not installed; hooks will activate when Gemini CLI is installed)${NC}"
+    fi
+else
+    echo -e "${YELLOW}  ⚠ Gemini hooks allowlist not found at ${GEMINI_HOOKS_ALLOWLIST}; skipping hooks mirror${NC}"
 fi
 
 # Set up local overlay
@@ -993,6 +1289,9 @@ echo "  • Skills: ${SKILL_COUNT} workflow methodologies (${INVOCABLE_COUNT} us
 echo "  • Codex skills: ${CODEX_ENTRY_COUNT} mirrored entries in ~/.codex/skills"
 echo "  • Codex agents: ${CODEX_AGENT_COUNT} mirrored entries in ~/.codex/agents"
 echo "  • Codex hooks: ${CODEX_HOOK_COUNT} mirrored entries in ~/.codex/hooks"
+echo "  • Gemini skills: ${GEMINI_ENTRY_COUNT} mirrored entries in ~/.gemini/skills"
+echo "  • Gemini agents: ${GEMINI_AGENT_COUNT} mirrored entries in ~/.gemini/agents"
+echo "  • Gemini hooks: ${GEMINI_HOOK_COUNT} mirrored entries in ~/.gemini/hooks"
 echo "  • Hooks: ${HOOK_COUNT} automation hooks"
 echo "  • Commands: ${COMMAND_COUNT} slash commands"
 echo "  • Scripts: ${SCRIPT_COUNT} utility scripts"

--- a/scripts/gemini-hooks-allowlist.txt
+++ b/scripts/gemini-hooks-allowlist.txt
@@ -1,0 +1,34 @@
+# Gemini CLI hooks allowlist — Phase 1 (safe on Gemini CLI v0.26.0+)
+# Format: EVENT:filename [matcher]
+# Lines starting with # are comments. Blank lines ignored.
+#
+# Gemini CLI event name mapping from Claude Code / Codex:
+#   Claude/Codex SessionStart  → Gemini SessionStart  (same name)
+#   Claude/Codex Stop          → Gemini SessionEnd
+#   Claude/Codex PostToolUse   → Gemini AfterTool
+#   Claude/Codex PreToolUse    → Gemini BeforeTool
+#
+# Gemini CLI tool name mapping:
+#   Codex Bash → Gemini run_shell_command
+#
+# All known Gemini CLI hook events:
+#   SessionStart, SessionEnd, BeforeTool, AfterTool,
+#   BeforeAgent, AfterAgent, BeforeModel, AfterModel,
+#   Notification, PreCompress, BeforeToolSelection
+#
+# BeforeTool/AfterTool require a matcher (tool name).
+# SessionStart/SessionEnd/Notification do not use a matcher.
+
+# ----- Phase 1: functional + verified safe -----
+
+# SessionStart injectors (pure stdout, no tool interception)
+SessionStart:kairos-briefing-injector.py
+SessionStart:operator-context-detector.py
+SessionStart:team-config-loader.py
+SessionStart:rules-distill-injector.py
+
+# SessionEnd recorders (pure observation, no tool interception)
+SessionEnd:session-learning-recorder.py
+
+# AfterTool shell scanners (run_shell_command matcher — equivalent of Codex Bash)
+AfterTool:posttool-bash-injection-scan.py run_shell_command

--- a/scripts/generate-gemini-settings-hooks.py
+++ b/scripts/generate-gemini-settings-hooks.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Merge toolkit hooks into ~/.gemini/settings.json from a curated allowlist file.
+
+The allowlist format is one entry per line: EVENT:filename [matcher]
+Comments (lines starting with #) and blank lines are ignored.
+
+Unlike the Codex hooks generator (which writes a standalone hooks.json),
+this script merges into an existing settings.json, only modifying the
+"hooks" key while preserving all other user configuration.
+
+Gemini CLI hook events:
+  SessionStart, SessionEnd, BeforeTool, AfterTool,
+  BeforeAgent, AfterAgent, BeforeModel, AfterModel,
+  Notification, PreCompress, BeforeToolSelection
+
+Usage:
+    python3 scripts/generate-gemini-settings-hooks.py --allowlist scripts/gemini-hooks-allowlist.txt
+    python3 scripts/generate-gemini-settings-hooks.py --allowlist scripts/gemini-hooks-allowlist.txt --dry-run
+    python3 scripts/generate-gemini-settings-hooks.py --allowlist scripts/gemini-hooks-allowlist.txt --output /tmp/settings.json
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Events that require a matcher (tool name to filter on).
+EVENTS_REQUIRING_MATCHER = {"BeforeTool", "AfterTool"}
+
+# Events where matcher field is omitted entirely.
+EVENTS_WITHOUT_MATCHER = {"SessionStart", "SessionEnd", "Notification", "PreCompress", "BeforeToolSelection"}
+
+# Events where matcher should default to a value when omitted.
+EVENTS_WITH_DEFAULT_MATCHER: dict[str, str] = {}
+
+# All known Gemini CLI events, in canonical output order.
+EVENT_ORDER = [
+    "SessionStart",
+    "SessionEnd",
+    "BeforeTool",
+    "AfterTool",
+    "BeforeAgent",
+    "AfterAgent",
+    "BeforeModel",
+    "AfterModel",
+    "Notification",
+    "PreCompress",
+    "BeforeToolSelection",
+]
+
+ALL_KNOWN_EVENTS = set(EVENT_ORDER)
+
+
+def parse_allowlist(text: str) -> list[dict]:
+    """Parse allowlist text into a list of entry dicts.
+
+    Args:
+        text: Contents of the allowlist file (not a path; the raw text).
+
+    Returns:
+        List of dicts with keys: event, filename, matcher (str or None).
+
+    Raises:
+        ValueError: On malformed lines (includes line number in message).
+    """
+    entries: list[dict] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        if ":" not in line:
+            raise ValueError(f"Line {lineno}: missing ':' separator in {raw!r}. Expected EVENT:filename [matcher].")
+
+        event_part, rest = line.split(":", 1)
+        event = event_part.strip()
+        rest_parts = rest.strip().split()
+
+        if not rest_parts:
+            raise ValueError(f"Line {lineno}: missing filename after ':' in {raw!r}.")
+
+        filename = rest_parts[0]
+        matcher: str | None = rest_parts[1] if len(rest_parts) > 1 else None
+
+        if event not in ALL_KNOWN_EVENTS:
+            known = ", ".join(sorted(ALL_KNOWN_EVENTS))
+            raise ValueError(f"Line {lineno}: unknown event {event!r}. Known events: {known}.")
+
+        if event in EVENTS_REQUIRING_MATCHER and matcher is None:
+            raise ValueError(
+                f"Line {lineno}: {event} requires a matcher (e.g. 'run_shell_command') because Gemini "
+                f"only fires {event} for named tools. Add a tool name after the filename: "
+                f"'{event}:{filename} run_shell_command'."
+            )
+
+        entries.append({"event": event, "filename": filename, "matcher": matcher})
+
+    return entries
+
+
+def build_hooks_json(entries: list[dict], gemini_hooks_dir: str | None = None) -> dict:
+    """Build the Gemini hooks structure from parsed allowlist entries.
+
+    Args:
+        entries: List of entry dicts from parse_allowlist().
+        gemini_hooks_dir: Directory where hooks will reside. Defaults to $HOME/.gemini/hooks.
+
+    Returns:
+        Dict representing the hooks structure (the value for the "hooks" key).
+    """
+    if gemini_hooks_dir is None:
+        gemini_hooks_dir = os.path.join(os.environ.get("HOME", "~"), ".gemini", "hooks")
+
+    # Group by (event, effective_matcher) so shared matchers collapse into one block.
+    groups: dict[tuple[str, str | None], list[str]] = {}
+
+    for entry in entries:
+        event = entry["event"]
+        raw_matcher = entry["matcher"]
+        filename = entry["filename"]
+
+        # Determine the effective matcher for grouping and output.
+        if event in EVENTS_WITH_DEFAULT_MATCHER and raw_matcher is None:
+            effective_matcher: str | None = EVENTS_WITH_DEFAULT_MATCHER[event]
+        elif event in EVENTS_WITHOUT_MATCHER:
+            effective_matcher = None
+        else:
+            effective_matcher = raw_matcher
+
+        key = (event, effective_matcher)
+        groups.setdefault(key, [])
+        groups[key].append(filename)
+
+    if not groups:
+        return {}
+
+    # Build output dict with events in canonical order.
+    hooks_by_event: dict[str, list[dict]] = {}
+
+    for event in EVENT_ORDER:
+        event_groups = {k: v for k, v in groups.items() if k[0] == event}
+        if not event_groups:
+            continue
+
+        sorted_keys = sorted(event_groups.keys(), key=lambda k: (k[1] is None, k[1] or ""))
+        event_blocks: list[dict] = []
+
+        for key in sorted_keys:
+            _, matcher = key
+            filenames = event_groups[key]
+
+            hook_entries = [
+                {
+                    "type": "command",
+                    "command": f'python3 "{gemini_hooks_dir}/{fname}"',
+                    "timeout": 600,
+                }
+                for fname in filenames
+            ]
+
+            block: dict = {}
+            if matcher is not None:
+                block["matcher"] = matcher
+            block["hooks"] = hook_entries
+
+            event_blocks.append(block)
+
+        hooks_by_event[event] = event_blocks
+
+    return hooks_by_event
+
+
+def merge_settings(existing: dict, hooks_data: dict) -> dict:
+    """Merge hooks into existing settings, preserving all other keys.
+
+    Args:
+        existing: Current settings.json content as a dict.
+        hooks_data: Hooks structure to set (value for the "hooks" key).
+
+    Returns:
+        Updated settings dict with only the "hooks" key modified.
+    """
+    result = dict(existing)
+    result["hooks"] = hooks_data
+    return result
+
+
+def main() -> None:
+    """Parse CLI arguments, read the allowlist, and merge hooks into settings.json.
+
+    Exits with code 0 on success, 1 on any error.
+    """
+    parser = argparse.ArgumentParser(
+        description="Merge toolkit hooks into ~/.gemini/settings.json from a curated allowlist file.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--allowlist", required=True, help="Path to the allowlist file.")
+    parser.add_argument(
+        "--output",
+        default=os.path.join(os.environ.get("HOME", "~"), ".gemini", "settings.json"),
+        help="Path to settings.json (default: ~/.gemini/settings.json).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print merged JSON to stdout instead of writing to disk.",
+    )
+    parser.add_argument(
+        "--gemini-hooks-dir",
+        default=None,
+        help="Directory where hooks will live (default: $HOME/.gemini/hooks).",
+    )
+
+    args = parser.parse_args()
+
+    allowlist_path = Path(args.allowlist)
+    if not allowlist_path.exists():
+        print(f"Error: allowlist file not found: {allowlist_path}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        text = allowlist_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"Error reading allowlist: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        entries = parse_allowlist(text)
+    except ValueError as exc:
+        print(f"Error parsing allowlist: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        hooks_data = build_hooks_json(entries, gemini_hooks_dir=args.gemini_hooks_dir)
+    except Exception as exc:
+        print(f"Error building hooks: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    output_path = Path(args.output)
+
+    # Load existing settings.json if it exists.
+    existing: dict = {}
+    if output_path.exists():
+        try:
+            existing = json.loads(output_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"Warning: could not read existing {output_path}: {exc}", file=sys.stderr)
+
+    merged = merge_settings(existing, hooks_data)
+    output_json = json.dumps(merged, indent=2)
+
+    if args.dry_run:
+        print(output_json)
+        return
+
+    # Back up existing file before overwriting.
+    if output_path.exists():
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        backup_path = output_path.with_suffix(f".bak.{timestamp}")
+        try:
+            backup_path.write_bytes(output_path.read_bytes())
+        except OSError as exc:
+            print(f"Warning: could not create backup {backup_path}: {exc}", file=sys.stderr)
+
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(output_json + "\n", encoding="utf-8")
+    except OSError as exc:
+        print(f"Error writing {output_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Wrote {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-gemini-settings-hooks.py
+++ b/scripts/generate-gemini-settings-hooks.py
@@ -31,9 +31,21 @@ from pathlib import Path
 EVENTS_REQUIRING_MATCHER = {"BeforeTool", "AfterTool"}
 
 # Events where matcher field is omitted entirely.
-EVENTS_WITHOUT_MATCHER = {"SessionStart", "SessionEnd", "Notification", "PreCompress", "BeforeToolSelection"}
+EVENTS_WITHOUT_MATCHER = {
+    "SessionStart",
+    "SessionEnd",
+    "BeforeAgent",
+    "AfterAgent",
+    "BeforeModel",
+    "AfterModel",
+    "Notification",
+    "PreCompress",
+    "BeforeToolSelection",
+}
 
 # Events where matcher should default to a value when omitted.
+# Currently empty — reserved for future events that need an implicit matcher
+# (e.g., if Gemini adds an event that always targets a specific tool type).
 EVENTS_WITH_DEFAULT_MATCHER: dict[str, str] = {}
 
 # All known Gemini CLI events, in canonical output order.
@@ -267,7 +279,13 @@ def main() -> None:
 
     try:
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(output_json + "\n", encoding="utf-8")
+        tmp = str(output_path) + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(output_json)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.rename(tmp, str(output_path))
     except OSError as exc:
         print(f"Error writing {output_path}: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/scripts/tests/test_generate_gemini_hooks.py
+++ b/scripts/tests/test_generate_gemini_hooks.py
@@ -1,0 +1,410 @@
+"""Tests for scripts/generate-gemini-settings-hooks.py."""
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module import helper (hyphen in filename requires importlib)
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH = Path(__file__).parent.parent / "generate-gemini-settings-hooks.py"
+
+
+def _load_module():
+    """Load generate-gemini-settings-hooks.py as a module."""
+    spec = importlib.util.spec_from_file_location("generate_gemini_settings_hooks", _SCRIPT_PATH)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_module()
+parse_allowlist = _mod.parse_allowlist
+build_hooks_json = _mod.build_hooks_json
+merge_settings = _mod.merge_settings
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Empty allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_empty_allowlist_produces_empty_hooks():
+    """Empty allowlist text produces empty dict."""
+    entries = parse_allowlist("")
+    result = build_hooks_json(entries)
+    assert result == {}
+
+
+def test_comments_and_blanks_only_produces_empty():
+    """Allowlist with only comments and blank lines produces empty hooks."""
+    text = "# This is a comment\n\n# Another comment\n"
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries)
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Single SessionStart with no matcher
+# ---------------------------------------------------------------------------
+
+
+def test_single_session_start_no_matcher():
+    """SessionStart entry with no matcher omits matcher field entirely."""
+    text = "SessionStart:kairos-briefing-injector.py\n"
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries, gemini_hooks_dir="/home/user/.gemini/hooks")
+
+    assert "SessionStart" in result
+    blocks = result["SessionStart"]
+    assert len(blocks) == 1
+    block = blocks[0]
+    assert "matcher" not in block, "SessionStart blocks must not have a 'matcher' field."
+    assert len(block["hooks"]) == 1
+    hook = block["hooks"][0]
+    assert hook["type"] == "command"
+    assert "kairos-briefing-injector.py" in hook["command"]
+    assert hook["timeout"] == 600
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Multiple SessionStart entries grouped into one block
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_session_start_entries_grouped():
+    """Multiple SessionStart entries are grouped into one matcher block."""
+    text = (
+        "SessionStart:kairos-briefing-injector.py\n"
+        "SessionStart:operator-context-detector.py\n"
+        "SessionStart:team-config-loader.py\n"
+    )
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries, gemini_hooks_dir="/fake/hooks")
+
+    blocks = result["SessionStart"]
+    assert len(blocks) == 1, "All SessionStart entries share no matcher, so only one block."
+    hook_list = blocks[0]["hooks"]
+    assert len(hook_list) == 3
+    names = [h["command"] for h in hook_list]
+    assert any("kairos-briefing-injector.py" in n for n in names)
+    assert any("operator-context-detector.py" in n for n in names)
+    assert any("team-config-loader.py" in n for n in names)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: AfterTool without matcher raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_aftertool_without_matcher_raises():
+    """AfterTool entry without matcher raises ValueError mentioning 'run_shell_command'."""
+    text = "AfterTool:posttool-bash-injection-scan.py\n"
+    with pytest.raises(ValueError) as exc_info:
+        parse_allowlist(text)
+    assert "run_shell_command" in str(exc_info.value)
+
+
+def test_beforetool_without_matcher_raises():
+    """BeforeTool entry without matcher raises ValueError."""
+    text = "BeforeTool:some-hook.py\n"
+    with pytest.raises(ValueError) as exc_info:
+        parse_allowlist(text)
+    assert "BeforeTool" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: AfterTool with matcher produces correct structure
+# ---------------------------------------------------------------------------
+
+
+def test_aftertool_with_matcher():
+    """AfterTool with run_shell_command matcher produces correct block."""
+    text = "AfterTool:posttool-bash-injection-scan.py run_shell_command\n"
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries, gemini_hooks_dir="/fake/hooks")
+
+    assert "AfterTool" in result
+    blocks = result["AfterTool"]
+    assert len(blocks) == 1
+    assert blocks[0]["matcher"] == "run_shell_command"
+    assert len(blocks[0]["hooks"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 6: SessionEnd entry has no matcher field in output
+# ---------------------------------------------------------------------------
+
+
+def test_session_end_no_matcher_field():
+    """SessionEnd entry produces a block without a 'matcher' key."""
+    text = "SessionEnd:session-learning-recorder.py\n"
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries, gemini_hooks_dir="/fake/hooks")
+
+    assert "SessionEnd" in result
+    blocks = result["SessionEnd"]
+    assert len(blocks) == 1
+    assert "matcher" not in blocks[0], "SessionEnd blocks must not have a 'matcher' field."
+    assert "hooks" in blocks[0]
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Unknown event raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_event_raises():
+    """An unknown event name raises ValueError."""
+    text = "UnknownEvent:some-hook.py\n"
+    with pytest.raises(ValueError) as exc_info:
+        parse_allowlist(text)
+    assert "UnknownEvent" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Malformed line raises ValueError with line number
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_line_raises_with_line_number():
+    """A line without ':' raises ValueError that includes the line number."""
+    text = "# comment\n\nbadline-no-colon\n"
+    with pytest.raises(ValueError) as exc_info:
+        parse_allowlist(text)
+    msg = str(exc_info.value)
+    assert "3" in msg, f"Expected line number 3 in error: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# Test 9: Comments and blank lines are ignored
+# ---------------------------------------------------------------------------
+
+
+def test_comments_and_blank_lines_ignored():
+    """Lines starting with # and empty lines do not become entries."""
+    text = (
+        "# Phase 1: safe on Gemini CLI v0.26.0+\n"
+        "\n"
+        "SessionStart:kairos-briefing-injector.py\n"
+        "\n"
+        "# Another comment\n"
+        "SessionEnd:session-learning-recorder.py\n"
+    )
+    entries = parse_allowlist(text)
+    assert len(entries) == 2
+    events = [e["event"] for e in entries]
+    assert "SessionStart" in events
+    assert "SessionEnd" in events
+
+
+# ---------------------------------------------------------------------------
+# Test 10: merge_settings preserves existing keys
+# ---------------------------------------------------------------------------
+
+
+def test_merge_preserves_existing_keys():
+    """merge_settings preserves all keys except 'hooks'."""
+    existing = {
+        "theme": "dark",
+        "apiKey": "sk-test",
+        "model": "gemini-2.5-pro",
+        "hooks": {"old": "data"},
+    }
+    hooks_data = {"SessionStart": [{"hooks": [{"type": "command", "command": "test"}]}]}
+
+    result = merge_settings(existing, hooks_data)
+
+    assert result["theme"] == "dark"
+    assert result["apiKey"] == "sk-test"
+    assert result["model"] == "gemini-2.5-pro"
+    assert result["hooks"] == hooks_data
+    # Original dict not mutated
+    assert existing["hooks"] == {"old": "data"}
+
+
+def test_merge_adds_hooks_to_empty_settings():
+    """merge_settings works with empty existing settings."""
+    hooks_data = {"SessionStart": [{"hooks": [{"type": "command", "command": "test"}]}]}
+    result = merge_settings({}, hooks_data)
+    assert result == {"hooks": hooks_data}
+
+
+# ---------------------------------------------------------------------------
+# Test 11: Event ordering is canonical
+# ---------------------------------------------------------------------------
+
+
+def test_event_ordering():
+    """Events appear in the canonical Gemini order."""
+    text = (
+        "SessionEnd:session-learning-recorder.py\n"
+        "AfterTool:posttool-bash-injection-scan.py run_shell_command\n"
+        "SessionStart:kairos-briefing-injector.py\n"
+    )
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries, gemini_hooks_dir="/fake/hooks")
+
+    keys = list(result.keys())
+    # SessionStart should come before SessionEnd, SessionEnd before AfterTool
+    assert keys.index("SessionStart") < keys.index("SessionEnd")
+    assert keys.index("SessionEnd") < keys.index("AfterTool")
+
+
+# ---------------------------------------------------------------------------
+# Test 12: Command shape uses python3 and the configured hooks dir
+# ---------------------------------------------------------------------------
+
+
+def test_command_shape_uses_configured_dir():
+    """Hook command uses python3 and the gemini-hooks-dir path."""
+    text = "SessionStart:kairos-briefing-injector.py\n"
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries, gemini_hooks_dir="/home/testuser/.gemini/hooks")
+
+    hook = result["SessionStart"][0]["hooks"][0]
+    cmd = hook["command"]
+    assert cmd.startswith("python3 "), f"Command should start with 'python3 ': {cmd}"
+    assert "/home/testuser/.gemini/hooks/kairos-briefing-injector.py" in cmd
+
+
+def test_command_shape_default_dir_uses_home():
+    """Hook command uses $HOME/.gemini/hooks when gemini_hooks_dir is not specified."""
+    import os
+
+    home = os.environ.get("HOME", "~")
+    text = "SessionStart:kairos-briefing-injector.py\n"
+    entries = parse_allowlist(text)
+    result = build_hooks_json(entries)
+
+    hook = result["SessionStart"][0]["hooks"][0]
+    cmd = hook["command"]
+    assert f"{home}/.gemini/hooks/kairos-briefing-injector.py" in cmd
+
+
+# ---------------------------------------------------------------------------
+# Test 13: End-to-end CLI with --dry-run produces valid JSON
+# ---------------------------------------------------------------------------
+
+
+def test_cli_dry_run_produces_valid_json():
+    """CLI invocation with --dry-run prints valid JSON to stdout."""
+    allowlist_text = (
+        "# Phase 1 hooks\n"
+        "SessionStart:kairos-briefing-injector.py\n"
+        "SessionEnd:session-learning-recorder.py\n"
+        "AfterTool:posttool-bash-injection-scan.py run_shell_command\n"
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        allowlist_path = Path(tmpdir) / "allowlist.txt"
+        allowlist_path.write_text(allowlist_text, encoding="utf-8")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_SCRIPT_PATH),
+                "--allowlist",
+                str(allowlist_path),
+                "--dry-run",
+                "--gemini-hooks-dir",
+                "/fake/hooks",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    assert result.returncode == 0, f"CLI exited non-zero: {result.stderr}"
+    parsed = json.loads(result.stdout)
+
+    assert "hooks" in parsed
+    assert "SessionStart" in parsed["hooks"]
+    assert "SessionEnd" in parsed["hooks"]
+    assert "AfterTool" in parsed["hooks"]
+
+    # Verify structure depth: hooks.SessionStart[0].hooks[0].command
+    session_hook = parsed["hooks"]["SessionStart"][0]["hooks"][0]
+    assert session_hook["type"] == "command"
+    assert "kairos-briefing-injector.py" in session_hook["command"]
+    assert session_hook["timeout"] == 600
+
+
+# ---------------------------------------------------------------------------
+# Test 14: CLI --dry-run preserves existing settings keys
+# ---------------------------------------------------------------------------
+
+
+def test_cli_dry_run_preserves_existing_settings():
+    """CLI invocation with --dry-run preserves existing settings.json keys."""
+    allowlist_text = "SessionStart:kairos-briefing-injector.py\n"
+    existing_settings = {"theme": "dark", "model": "gemini-2.5-pro"}
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        allowlist_path = Path(tmpdir) / "allowlist.txt"
+        allowlist_path.write_text(allowlist_text, encoding="utf-8")
+
+        settings_path = Path(tmpdir) / "settings.json"
+        settings_path.write_text(json.dumps(existing_settings), encoding="utf-8")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_SCRIPT_PATH),
+                "--allowlist",
+                str(allowlist_path),
+                "--output",
+                str(settings_path),
+                "--dry-run",
+                "--gemini-hooks-dir",
+                "/fake/hooks",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    assert result.returncode == 0, f"CLI exited non-zero: {result.stderr}"
+    parsed = json.loads(result.stdout)
+
+    assert parsed["theme"] == "dark"
+    assert parsed["model"] == "gemini-2.5-pro"
+    assert "hooks" in parsed
+
+
+# ---------------------------------------------------------------------------
+# Test 15: All known events are valid
+# ---------------------------------------------------------------------------
+
+
+def test_all_known_events_are_accepted():
+    """Every event in ALL_KNOWN_EVENTS is accepted by parse_allowlist (where possible)."""
+    # Events that don't require matcher
+    no_matcher_events = ["SessionStart", "SessionEnd", "Notification", "PreCompress", "BeforeToolSelection"]
+    for event in no_matcher_events:
+        text = f"{event}:test-hook.py\n"
+        entries = parse_allowlist(text)
+        assert len(entries) == 1
+        assert entries[0]["event"] == event
+
+    # Events that require matcher
+    matcher_events = ["BeforeTool", "AfterTool"]
+    for event in matcher_events:
+        text = f"{event}:test-hook.py run_shell_command\n"
+        entries = parse_allowlist(text)
+        assert len(entries) == 1
+        assert entries[0]["event"] == event
+        assert entries[0]["matcher"] == "run_shell_command"
+
+    # Events that accept optional matcher
+    optional_events = ["BeforeAgent", "AfterAgent", "BeforeModel", "AfterModel"]
+    for event in optional_events:
+        text = f"{event}:test-hook.py\n"
+        entries = parse_allowlist(text)
+        assert len(entries) == 1
+        assert entries[0]["event"] == event

--- a/scripts/tests/test_generate_gemini_hooks.py
+++ b/scripts/tests/test_generate_gemini_hooks.py
@@ -384,8 +384,18 @@ def test_cli_dry_run_preserves_existing_settings():
 
 def test_all_known_events_are_accepted():
     """Every event in ALL_KNOWN_EVENTS is accepted by parse_allowlist (where possible)."""
-    # Events that don't require matcher
-    no_matcher_events = ["SessionStart", "SessionEnd", "Notification", "PreCompress", "BeforeToolSelection"]
+    # Events that don't require matcher (including agent/model lifecycle events)
+    no_matcher_events = [
+        "SessionStart",
+        "SessionEnd",
+        "BeforeAgent",
+        "AfterAgent",
+        "BeforeModel",
+        "AfterModel",
+        "Notification",
+        "PreCompress",
+        "BeforeToolSelection",
+    ]
     for event in no_matcher_events:
         text = f"{event}:test-hook.py\n"
         entries = parse_allowlist(text)
@@ -401,10 +411,14 @@ def test_all_known_events_are_accepted():
         assert entries[0]["event"] == event
         assert entries[0]["matcher"] == "run_shell_command"
 
-    # Events that accept optional matcher
-    optional_events = ["BeforeAgent", "AfterAgent", "BeforeModel", "AfterModel"]
-    for event in optional_events:
+
+def test_agent_model_events_no_matcher_in_output():
+    """BeforeAgent, AfterAgent, BeforeModel, AfterModel produce blocks without matcher."""
+    for event in ("BeforeAgent", "AfterAgent", "BeforeModel", "AfterModel"):
         text = f"{event}:test-hook.py\n"
         entries = parse_allowlist(text)
-        assert len(entries) == 1
-        assert entries[0]["event"] == event
+        result = build_hooks_json(entries, gemini_hooks_dir="/fake/hooks")
+        assert event in result
+        blocks = result[event]
+        assert len(blocks) == 1
+        assert "matcher" not in blocks[0], f"{event} blocks must not have a 'matcher' field."

--- a/scripts/tests/test_hook_utils_gemini.py
+++ b/scripts/tests/test_hook_utils_gemini.py
@@ -1,0 +1,145 @@
+"""Tests for Gemini CLI detection and input normalization in hooks/lib/hook_utils.py."""
+
+import importlib.util
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module import
+# ---------------------------------------------------------------------------
+
+_HOOK_UTILS_PATH = Path(__file__).resolve().parent.parent.parent / "hooks" / "lib" / "hook_utils.py"
+
+
+def _load_module():
+    """Load hook_utils.py as a module."""
+    spec = importlib.util.spec_from_file_location("hook_utils", _HOOK_UTILS_PATH)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_module()
+detect_cli = _mod.detect_cli
+normalize_input = _mod.normalize_input
+
+
+# ---------------------------------------------------------------------------
+# detect_cli tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCli:
+    """Tests for the detect_cli() function."""
+
+    def test_detects_gemini_via_api_key(self):
+        """detect_cli returns 'gemini' when GEMINI_API_KEY is set."""
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}, clear=False):
+            # Clear Codex vars to avoid false positive
+            env = {k: v for k, v in os.environ.items() if not k.startswith("CODEX_")}
+            with patch.dict(os.environ, env, clear=True):
+                os.environ["GEMINI_API_KEY"] = "test-key"
+                assert detect_cli() == "gemini"
+
+    def test_detects_gemini_via_model(self):
+        """detect_cli returns 'gemini' when GEMINI_MODEL is set."""
+        with patch.dict(os.environ, {"GEMINI_MODEL": "gemini-2.5-pro"}, clear=False):
+            env = {k: v for k, v in os.environ.items() if not k.startswith("CODEX_")}
+            with patch.dict(os.environ, env, clear=True):
+                os.environ["GEMINI_MODEL"] = "gemini-2.5-pro"
+                assert detect_cli() == "gemini"
+
+    def test_detects_codex_via_codex_home(self):
+        """detect_cli returns 'codex' when CODEX_HOME is set."""
+        env = {k: v for k, v in os.environ.items() if not k.startswith(("GEMINI_", "CODEX_"))}
+        with patch.dict(os.environ, env, clear=True):
+            os.environ["CODEX_HOME"] = "/home/user/.codex"
+            assert detect_cli() == "codex"
+
+    def test_detects_codex_via_hooks_dir(self):
+        """detect_cli returns 'codex' when CODEX_HOOKS_DIR is set."""
+        env = {k: v for k, v in os.environ.items() if not k.startswith(("GEMINI_", "CODEX_"))}
+        with patch.dict(os.environ, env, clear=True):
+            os.environ["CODEX_HOOKS_DIR"] = "/home/user/.codex/hooks"
+            assert detect_cli() == "codex"
+
+    def test_defaults_to_claude(self):
+        """detect_cli returns 'claude' when no Gemini or Codex vars are set."""
+        env = {k: v for k, v in os.environ.items() if not k.startswith(("GEMINI_", "CODEX_"))}
+        with patch.dict(os.environ, env, clear=True):
+            assert detect_cli() == "claude"
+
+    def test_gemini_takes_precedence_over_codex(self):
+        """When both Gemini and Codex vars are set, Gemini wins."""
+        env = {k: v for k, v in os.environ.items() if not k.startswith(("GEMINI_", "CODEX_"))}
+        with patch.dict(os.environ, env, clear=True):
+            os.environ["GEMINI_API_KEY"] = "test"
+            os.environ["CODEX_HOME"] = "/home/user/.codex"
+            assert detect_cli() == "gemini"
+
+
+# ---------------------------------------------------------------------------
+# normalize_input tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeInput:
+    """Tests for the normalize_input() function."""
+
+    def test_translates_tool_input_to_input(self):
+        """tool_input is copied to input."""
+        data = {"tool_input": "ls -la", "other": "value"}
+        result = normalize_input(data)
+        assert result["input"] == "ls -la"
+        assert result["tool_input"] == "ls -la"  # Original preserved
+        assert result["other"] == "value"
+
+    def test_translates_tool_name_to_tool(self):
+        """tool_name is copied to tool."""
+        data = {"tool_name": "run_shell_command", "other": "value"}
+        result = normalize_input(data)
+        assert result["tool"] == "run_shell_command"
+        assert result["tool_name"] == "run_shell_command"  # Original preserved
+
+    def test_does_not_overwrite_existing_input(self):
+        """If 'input' already exists, tool_input does not overwrite it."""
+        data = {"tool_input": "gemini-value", "input": "claude-value"}
+        result = normalize_input(data)
+        assert result["input"] == "claude-value"
+
+    def test_does_not_overwrite_existing_tool(self):
+        """If 'tool' already exists, tool_name does not overwrite it."""
+        data = {"tool_name": "run_shell_command", "tool": "Bash"}
+        result = normalize_input(data)
+        assert result["tool"] == "Bash"
+
+    def test_passthrough_claude_format(self):
+        """Claude/Codex format data passes through unchanged."""
+        data = {"input": "ls -la", "tool": "Bash"}
+        result = normalize_input(data)
+        assert result == {"input": "ls -la", "tool": "Bash"}
+
+    def test_empty_dict(self):
+        """Empty dict passes through unchanged."""
+        data: dict = {}
+        result = normalize_input(data)
+        assert result == {}
+
+    def test_mutates_in_place(self):
+        """normalize_input mutates the dict in place and returns it."""
+        data = {"tool_input": "test"}
+        result = normalize_input(data)
+        assert result is data  # Same object
+        assert data["input"] == "test"
+
+    def test_both_gemini_fields_translated(self):
+        """Both tool_input and tool_name are translated in one call."""
+        data = {"tool_input": "ls", "tool_name": "run_shell_command"}
+        result = normalize_input(data)
+        assert result["input"] == "ls"
+        assert result["tool"] == "run_shell_command"

--- a/scripts/tests/test_hook_utils_gemini.py
+++ b/scripts/tests/test_hook_utils_gemini.py
@@ -37,49 +37,72 @@ normalize_input = _mod.normalize_input
 class TestDetectCli:
     """Tests for the detect_cli() function."""
 
-    def test_detects_gemini_via_api_key(self):
-        """detect_cli returns 'gemini' when GEMINI_API_KEY is set."""
-        with patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}, clear=False):
-            # Clear Codex vars to avoid false positive
-            env = {k: v for k, v in os.environ.items() if not k.startswith("CODEX_")}
-            with patch.dict(os.environ, env, clear=True):
-                os.environ["GEMINI_API_KEY"] = "test-key"
-                assert detect_cli() == "gemini"
+    @staticmethod
+    def _clean_env() -> dict[str, str]:
+        """Return env dict stripped of Gemini/Codex/_ vars."""
+        return {k: v for k, v in os.environ.items() if not k.startswith(("GEMINI_", "CODEX_")) and k != "_"}
 
-    def test_detects_gemini_via_model(self):
-        """detect_cli returns 'gemini' when GEMINI_MODEL is set."""
-        with patch.dict(os.environ, {"GEMINI_MODEL": "gemini-2.5-pro"}, clear=False):
-            env = {k: v for k, v in os.environ.items() if not k.startswith("CODEX_")}
-            with patch.dict(os.environ, env, clear=True):
-                os.environ["GEMINI_MODEL"] = "gemini-2.5-pro"
-                assert detect_cli() == "gemini"
+    def test_detects_gemini_via_gemini_cli_env(self):
+        """detect_cli returns 'gemini' when GEMINI_CLI is set."""
+        env = self._clean_env()
+        with patch.dict(os.environ, env, clear=True):
+            os.environ["GEMINI_CLI"] = "1"
+            assert detect_cli() == "gemini"
+
+    def test_detects_gemini_via_underscore_var(self):
+        """detect_cli returns 'gemini' when _ contains 'gemini'."""
+        env = self._clean_env()
+        with patch.dict(os.environ, env, clear=True):
+            os.environ["_"] = "/usr/local/bin/gemini"
+            assert detect_cli() == "gemini"
+
+    def test_detects_codex_via_underscore_var(self):
+        """detect_cli returns 'codex' when _ contains 'codex'."""
+        env = self._clean_env()
+        with patch.dict(os.environ, env, clear=True):
+            os.environ["_"] = "/usr/local/bin/codex"
+            assert detect_cli() == "codex"
 
     def test_detects_codex_via_codex_home(self):
         """detect_cli returns 'codex' when CODEX_HOME is set."""
-        env = {k: v for k, v in os.environ.items() if not k.startswith(("GEMINI_", "CODEX_"))}
+        env = self._clean_env()
         with patch.dict(os.environ, env, clear=True):
             os.environ["CODEX_HOME"] = "/home/user/.codex"
             assert detect_cli() == "codex"
 
     def test_detects_codex_via_hooks_dir(self):
         """detect_cli returns 'codex' when CODEX_HOOKS_DIR is set."""
-        env = {k: v for k, v in os.environ.items() if not k.startswith(("GEMINI_", "CODEX_"))}
+        env = self._clean_env()
         with patch.dict(os.environ, env, clear=True):
             os.environ["CODEX_HOOKS_DIR"] = "/home/user/.codex/hooks"
             assert detect_cli() == "codex"
 
     def test_defaults_to_claude(self):
         """detect_cli returns 'claude' when no Gemini or Codex vars are set."""
-        env = {k: v for k, v in os.environ.items() if not k.startswith(("GEMINI_", "CODEX_"))}
+        env = self._clean_env()
         with patch.dict(os.environ, env, clear=True):
             assert detect_cli() == "claude"
 
-    def test_gemini_takes_precedence_over_codex(self):
-        """When both Gemini and Codex vars are set, Gemini wins."""
-        env = {k: v for k, v in os.environ.items() if not k.startswith(("GEMINI_", "CODEX_"))}
+    def test_gemini_cli_env_takes_precedence_over_codex(self):
+        """When both GEMINI_CLI and Codex vars are set, Gemini wins."""
+        env = self._clean_env()
         with patch.dict(os.environ, env, clear=True):
-            os.environ["GEMINI_API_KEY"] = "test"
+            os.environ["GEMINI_CLI"] = "1"
             os.environ["CODEX_HOME"] = "/home/user/.codex"
+            assert detect_cli() == "gemini"
+
+    def test_gemini_api_key_alone_does_not_trigger_gemini(self):
+        """GEMINI_API_KEY alone should NOT cause detection as gemini (false positive)."""
+        env = self._clean_env()
+        with patch.dict(os.environ, env, clear=True):
+            os.environ["GEMINI_API_KEY"] = "test-key"
+            assert detect_cli() == "claude"
+
+    def test_underscore_var_case_insensitive(self):
+        """_ var detection is case-insensitive."""
+        env = self._clean_env()
+        with patch.dict(os.environ, env, clear=True):
+            os.environ["_"] = "/opt/Gemini-CLI/bin/Gemini"
             assert detect_cli() == "gemini"
 
 


### PR DESCRIPTION
## Summary

- Mirrors all toolkit skills, agents, and hooks to `~/.gemini/` during install, following the same pattern used for Codex CLI (`~/.codex/`)
- Translates hook event names (Claude `PostToolUse` → Gemini `AfterTool`, `Stop` → `SessionEnd`) and tool names (`Bash` → `run_shell_command`) via a curated allowlist
- Adds CLI detection and input field normalization in `hook_utils.py` so hooks can run under Gemini without per-hook changes
- Refactors `sync_codex_entry()` to generic `sync_mirror_entry()` — both Codex and Gemini use the same function
- Fixes `posttool-bash-injection-scan.py` to accept Gemini's `run_shell_command` tool name alongside Claude's `Bash`

### New files
- `scripts/gemini-hooks-allowlist.txt` — curated Phase 1 hooks with Gemini event names
- `scripts/generate-gemini-settings-hooks.py` — merges hooks into `~/.gemini/settings.json` (non-destructive, backup before write, atomic tmp+fsync+rename)

### Changed files
- `install.sh` — Gemini mirror in install + uninstall paths, CLI version check (v0.26.0+)
- `hooks/lib/hook_utils.py` — `detect_cli()` and `normalize_input()` for cross-CLI hooks
- `hooks/posttool-bash-injection-scan.py` — accept `run_shell_command` tool name
- `README.md` — Gemini CLI support section with event mapping table

### Test coverage
- 80 tests pass (37 new Gemini + 43 existing Codex, 0 failures)
- Ruff check + format clean

## Test plan

- [ ] Run `./install.sh --dry-run --symlink` and verify Gemini mirror actions appear
- [ ] Run `./install.sh --symlink` and verify `~/.gemini/skills/` and `~/.gemini/agents/` are populated
- [ ] Open Gemini CLI in a project and verify skills appear (`gemini skills list` or equivalent)
- [ ] Verify `~/.gemini/settings.json` contains hooks section after install
- [ ] Run `./install.sh --uninstall` and verify Gemini entries are cleaned up
- [ ] Run `python3 -m pytest scripts/tests/ -v` and confirm 80 tests pass