### PR TITLE
fix: preserve symlinks in SessionStart sync hook

### DIFF
--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -285,7 +285,7 @@ def _ensure_symlink(src: Path, dst: Path) -> bool:
     """
     if dst.is_symlink():
         try:
-            current_target = Path(os.readlink(dst)).resolve()
+            current_target = dst.resolve()
             if current_target == src.resolve():
                 return True  # Already correct
         except OSError:

--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -242,6 +242,69 @@ def _backup_settings_json(settings_path: Path, keep: int = 3) -> None:
                 pass
 
 
+def _read_install_mode(user_claude: Path) -> str:
+    """Read the install mode from the install manifest.
+
+    Returns "symlink" or "copy" (default).
+    """
+    manifest_path = user_claude / ".install-manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        return manifest.get("mode", "copy")
+    except (json.JSONDecodeError, OSError):
+        return "copy"
+
+
+def _update_manifest_toolkit_path(user_claude: Path, repo_root: Path) -> None:
+    """Update the toolkit_path in the install manifest when the repo has moved.
+
+    This happens when the repo is re-cloned to a different directory (e.g.,
+    renamed from claude-code-toolkit to vexjoy-agent). The manifest records
+    the old path, which breaks symlink validation. Update it to the current
+    repo root so future runs and install-doctor can find the source.
+    """
+    manifest_path = user_claude / ".install-manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return
+
+    recorded_path = manifest.get("toolkit_path", "")
+    current_path = str(repo_root)
+    if recorded_path != current_path:
+        manifest["toolkit_path"] = current_path
+        _atomic_json_write(manifest_path, manifest)
+
+
+def _ensure_symlink(src: Path, dst: Path) -> bool:
+    """Ensure dst is a symlink pointing to src.
+
+    If dst is already the correct symlink, returns True (no change needed).
+    If dst is a broken symlink, stale symlink, or regular directory, removes
+    it and creates the correct symlink. Returns True on success.
+    """
+    if dst.is_symlink():
+        try:
+            current_target = Path(os.readlink(dst)).resolve()
+            if current_target == src.resolve():
+                return True  # Already correct
+        except OSError:
+            pass
+        # Wrong target or unreadable — remove and recreate
+        dst.unlink()
+
+    elif dst.is_dir():
+        # Regular directory from a previous copy-mode install or broken sync.
+        # Remove it so we can replace with a symlink.
+        shutil.rmtree(dst)
+
+    elif dst.exists():
+        dst.unlink()
+
+    dst.symlink_to(src)
+    return True
+
+
 def main():
     # Only run when in the agents repo
     cwd = Path.cwd()
@@ -254,6 +317,14 @@ def main():
     # Paths - use CWD as repo root (not script location, since script may be in ~/.claude/hooks/)
     repo_root = cwd
     user_claude = Path.home() / ".claude"
+
+    # Detect install mode from manifest. In symlink mode, components that
+    # support it get directory-level symlinks instead of file-by-file copies.
+    install_mode = _read_install_mode(user_claude)
+
+    # Update the manifest's toolkit_path if the repo has moved (e.g., renamed
+    # from claude-code-toolkit to vexjoy-agent and re-cloned).
+    _update_manifest_toolkit_path(user_claude, repo_root)
 
     # Components to sync (directories)
     components = [
@@ -275,6 +346,11 @@ def main():
     # knowledge accumulated from other repos in ~/.claude/retro/.
     merge_components = {"retro"}
 
+    # Components eligible for symlink mode. Merge components (retro) and
+    # additive components (commands) must always use file-by-file sync because
+    # they aggregate content from multiple sources.
+    symlinkable_components = {"agents", "skills", "hooks", "scripts"}
+
     synced = []
     errors = []
 
@@ -293,7 +369,16 @@ def main():
             continue
 
         try:
-            # Resolve symlinks to a real directory before syncing
+            # Symlink mode: create a directory-level symlink for eligible components.
+            # This preserves the symlinks created by install.sh --symlink instead of
+            # destroying them and replacing with file copies.
+            if install_mode == "symlink" and src_name in symlinkable_components:
+                _ensure_symlink(src, dst)
+                synced.append(f"{dst_name}(symlink)")
+                continue
+
+            # Copy mode: resolve any existing symlinks to a real directory before
+            # file-by-file sync. This handles the transition from symlink to copy mode.
             if dst.is_symlink():
                 dst.unlink()
 
@@ -477,25 +562,32 @@ def main():
     private_voices_dir = repo_root / "private-voices"
     if private_voices_dir.is_dir():
         voice_count = 0
+        # Resolve the skills target directory. In symlink mode, ~/.claude/skills
+        # is a symlink to repo/skills/, so we create voice symlinks inside it.
+        skills_base = user_claude / "skills"
         for voice_dir in sorted(private_voices_dir.iterdir()):
             if not voice_dir.is_dir():
                 continue
             skill_src = voice_dir / "skill"
             if not skill_src.is_dir():
                 continue
-            # Map private-voices/{name}/skill/ -> ~/.claude/skills/voice-{name}/
             voice_name = voice_dir.name
-            skill_dst = user_claude / "skills" / f"voice-{voice_name}"
+            skill_dst = skills_base / f"voice-{voice_name}"
             try:
-                skill_dst.mkdir(parents=True, exist_ok=True)
-                for item in skill_src.rglob("*"):
-                    if item.is_file():
-                        rel = item.relative_to(skill_src)
-                        target = skill_dst / rel
-                        target.parent.mkdir(parents=True, exist_ok=True)
-                        if target.exists() and filecmp.cmp(item, target, shallow=False):
-                            continue
-                        shutil.copy2(item, target)
+                if install_mode == "symlink":
+                    # In symlink mode, create individual symlinks for private
+                    # voice skills, matching install.sh --symlink behavior.
+                    _ensure_symlink(skill_src, skill_dst)
+                else:
+                    skill_dst.mkdir(parents=True, exist_ok=True)
+                    for item in skill_src.rglob("*"):
+                        if item.is_file():
+                            rel = item.relative_to(skill_src)
+                            target = skill_dst / rel
+                            target.parent.mkdir(parents=True, exist_ok=True)
+                            if target.exists() and filecmp.cmp(item, target, shallow=False):
+                                continue
+                            shutil.copy2(item, target)
                 voice_count += 1
             except Exception as e:
                 errors.append(f"voice-{voice_name}: {e}")

--- a/hooks/tests/test_sync_to_user_claude.py
+++ b/hooks/tests/test_sync_to_user_claude.py
@@ -1,0 +1,275 @@
+"""Tests for sync-to-user-claude.py symlink preservation logic."""
+
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add hooks/ to sys.path so we can import the module
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HOOKS_DIR))
+
+# Import the module under test (filename has hyphens, use importlib)
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "sync_to_user_claude",
+    HOOKS_DIR / "sync-to-user-claude.py",
+)
+sync_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sync_mod)
+
+
+class TestReadInstallMode:
+    """Tests for _read_install_mode."""
+
+    def test_symlink_mode(self, tmp_path: Path) -> None:
+        manifest = {"mode": "symlink", "toolkit_path": "/some/path"}
+        (tmp_path / ".install-manifest.json").write_text(json.dumps(manifest))
+        assert sync_mod._read_install_mode(tmp_path) == "symlink"
+
+    def test_copy_mode(self, tmp_path: Path) -> None:
+        manifest = {"mode": "copy", "toolkit_path": "/some/path"}
+        (tmp_path / ".install-manifest.json").write_text(json.dumps(manifest))
+        assert sync_mod._read_install_mode(tmp_path) == "copy"
+
+    def test_missing_manifest(self, tmp_path: Path) -> None:
+        assert sync_mod._read_install_mode(tmp_path) == "copy"
+
+    def test_invalid_json(self, tmp_path: Path) -> None:
+        (tmp_path / ".install-manifest.json").write_text("{invalid json")
+        assert sync_mod._read_install_mode(tmp_path) == "copy"
+
+    def test_missing_mode_key(self, tmp_path: Path) -> None:
+        manifest = {"toolkit_path": "/some/path"}
+        (tmp_path / ".install-manifest.json").write_text(json.dumps(manifest))
+        assert sync_mod._read_install_mode(tmp_path) == "copy"
+
+
+class TestUpdateManifestToolkitPath:
+    """Tests for _update_manifest_toolkit_path."""
+
+    def test_updates_stale_path(self, tmp_path: Path) -> None:
+        manifest = {"mode": "symlink", "toolkit_path": "/old/repo/path"}
+        manifest_path = tmp_path / ".install-manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+
+        new_repo = tmp_path / "new-repo"
+        new_repo.mkdir()
+        sync_mod._update_manifest_toolkit_path(tmp_path, new_repo)
+
+        updated = json.loads(manifest_path.read_text())
+        assert updated["toolkit_path"] == str(new_repo)
+        assert updated["mode"] == "symlink"
+
+    def test_no_update_when_path_matches(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        manifest = {"mode": "symlink", "toolkit_path": str(repo)}
+        manifest_path = tmp_path / ".install-manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+
+        mtime_before = manifest_path.stat().st_mtime
+        sync_mod._update_manifest_toolkit_path(tmp_path, repo)
+
+        # File should not have been rewritten
+        mtime_after = manifest_path.stat().st_mtime
+        assert mtime_before == mtime_after
+
+    def test_no_crash_on_missing_manifest(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        # Should not raise
+        sync_mod._update_manifest_toolkit_path(tmp_path, repo)
+
+
+class TestEnsureSymlink:
+    """Tests for _ensure_symlink."""
+
+    def test_creates_new_symlink(self, tmp_path: Path) -> None:
+        src = tmp_path / "source"
+        src.mkdir()
+        (src / "test.txt").write_text("hello")
+
+        dst = tmp_path / "target"
+        result = sync_mod._ensure_symlink(src, dst)
+
+        assert result is True
+        assert dst.is_symlink()
+        assert dst.resolve() == src.resolve()
+        assert (dst / "test.txt").read_text() == "hello"
+
+    def test_preserves_correct_symlink(self, tmp_path: Path) -> None:
+        src = tmp_path / "source"
+        src.mkdir()
+        dst = tmp_path / "target"
+        dst.symlink_to(src)
+
+        result = sync_mod._ensure_symlink(src, dst)
+
+        assert result is True
+        assert dst.is_symlink()
+
+    def test_replaces_wrong_symlink(self, tmp_path: Path) -> None:
+        src = tmp_path / "source"
+        src.mkdir()
+        wrong_src = tmp_path / "wrong"
+        wrong_src.mkdir()
+        dst = tmp_path / "target"
+        dst.symlink_to(wrong_src)
+
+        result = sync_mod._ensure_symlink(src, dst)
+
+        assert result is True
+        assert dst.is_symlink()
+        assert dst.resolve() == src.resolve()
+
+    def test_replaces_regular_directory(self, tmp_path: Path) -> None:
+        src = tmp_path / "source"
+        src.mkdir()
+        (src / "real.txt").write_text("real")
+
+        dst = tmp_path / "target"
+        dst.mkdir()
+        (dst / "copied.txt").write_text("copy")
+
+        result = sync_mod._ensure_symlink(src, dst)
+
+        assert result is True
+        assert dst.is_symlink()
+        assert dst.resolve() == src.resolve()
+        # The copied file should be gone, replaced by symlink to source
+        assert (dst / "real.txt").read_text() == "real"
+        assert not (dst / "copied.txt").exists()
+
+    def test_replaces_broken_symlink(self, tmp_path: Path) -> None:
+        src = tmp_path / "source"
+        src.mkdir()
+        dst = tmp_path / "target"
+        dst.symlink_to(tmp_path / "nonexistent")
+
+        result = sync_mod._ensure_symlink(src, dst)
+
+        assert result is True
+        assert dst.is_symlink()
+        assert dst.resolve() == src.resolve()
+
+
+class TestMainSymlinkMode:
+    """Integration tests for main() in symlink mode."""
+
+    def _setup_repo(self, tmp_path: Path) -> Path:
+        """Create a minimal repo structure for testing."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        # Create component directories with sample files
+        for comp in ["agents", "skills", "hooks", "commands", "scripts"]:
+            comp_dir = repo / comp
+            comp_dir.mkdir()
+            (comp_dir / "sample.md").write_text(f"# {comp} sample")
+
+        # Create .claude/settings.json in repo
+        repo_claude = repo / ".claude"
+        repo_claude.mkdir()
+        settings = {"hooks": {"SessionStart": []}}
+        (repo_claude / "settings.json").write_text(json.dumps(settings))
+
+        return repo
+
+    def _setup_user_claude(self, tmp_path: Path, mode: str, repo: Path) -> Path:
+        """Create ~/.claude with install manifest."""
+        user_claude = tmp_path / "home" / ".claude"
+        user_claude.mkdir(parents=True)
+        manifest = {
+            "mode": mode,
+            "toolkit_path": str(repo),
+            "components": ["agents", "skills", "hooks", "commands", "scripts"],
+        }
+        (user_claude / ".install-manifest.json").write_text(json.dumps(manifest))
+        return user_claude
+
+    def test_symlink_mode_creates_symlinks(self, tmp_path: Path) -> None:
+        repo = self._setup_repo(tmp_path)
+        user_claude = self._setup_user_claude(tmp_path, "symlink", repo)
+
+        with (
+            patch.object(Path, "home", return_value=tmp_path / "home"),
+            patch.object(Path, "cwd", return_value=repo),
+        ):
+            sync_mod.main()
+
+        # Check that symlinkable components are symlinks
+        for comp in ["agents", "skills", "hooks", "scripts"]:
+            target = user_claude / comp
+            assert target.is_symlink(), f"{comp} should be a symlink"
+            assert target.resolve() == (repo / comp).resolve()
+
+        # Commands is additive-only, should be a directory (not symlink)
+        commands_target = user_claude / "commands"
+        assert commands_target.is_dir()
+        assert not commands_target.is_symlink()
+
+    def test_copy_mode_creates_directories(self, tmp_path: Path) -> None:
+        repo = self._setup_repo(tmp_path)
+        user_claude = self._setup_user_claude(tmp_path, "copy", repo)
+
+        with (
+            patch.object(Path, "home", return_value=tmp_path / "home"),
+            patch.object(Path, "cwd", return_value=repo),
+        ):
+            sync_mod.main()
+
+        # All components should be regular directories
+        for comp in ["agents", "skills", "hooks", "commands", "scripts"]:
+            target = user_claude / comp
+            assert target.is_dir()
+            assert not target.is_symlink(), f"{comp} should NOT be a symlink in copy mode"
+
+    def test_symlink_mode_preserves_existing_symlinks(self, tmp_path: Path) -> None:
+        repo = self._setup_repo(tmp_path)
+        user_claude = self._setup_user_claude(tmp_path, "symlink", repo)
+
+        # Pre-create correct symlinks (as install.sh would)
+        for comp in ["agents", "skills", "hooks", "scripts"]:
+            (user_claude / comp).symlink_to(repo / comp)
+
+        with (
+            patch.object(Path, "home", return_value=tmp_path / "home"),
+            patch.object(Path, "cwd", return_value=repo),
+        ):
+            sync_mod.main()
+
+        # Symlinks should still be there
+        for comp in ["agents", "skills", "hooks", "scripts"]:
+            target = user_claude / comp
+            assert target.is_symlink()
+            assert target.resolve() == (repo / comp).resolve()
+
+    def test_symlink_mode_replaces_copy_directories(self, tmp_path: Path) -> None:
+        repo = self._setup_repo(tmp_path)
+        user_claude = self._setup_user_claude(tmp_path, "symlink", repo)
+
+        # Pre-create regular directories (as broken copy-mode sync would)
+        for comp in ["agents", "skills", "hooks", "scripts"]:
+            comp_dir = user_claude / comp
+            comp_dir.mkdir()
+            (comp_dir / "stale.txt").write_text("stale copy")
+
+        with (
+            patch.object(Path, "home", return_value=tmp_path / "home"),
+            patch.object(Path, "cwd", return_value=repo),
+        ):
+            sync_mod.main()
+
+        # Should now be symlinks, not directories
+        for comp in ["agents", "skills", "hooks", "scripts"]:
+            target = user_claude / comp
+            assert target.is_symlink()
+            assert target.resolve() == (repo / comp).resolve()
+            # Stale files should be gone
+            assert not (target / "stale.txt").exists()


### PR DESCRIPTION
## Summary
- The `sync-to-user-claude.py` SessionStart hook unconditionally destroyed symlinks on every session start, replacing them with file copies — even when the install manifest declared `"mode": "symlink"`
- Added `_read_install_mode()` to check the manifest's mode before syncing
- Added `_ensure_symlink()` for idempotent symlink management (creates, replaces wrong targets, no-ops if correct)
- Added `_update_manifest_toolkit_path()` to fix stale paths after repo renames (e.g. claude-code-toolkit → vexjoy-agent)
- In symlink mode, eligible components (`agents`, `skills`, `hooks`, `scripts`) get directory-level symlinks; additive components (`commands`, `retro`) continue with file-by-file merge

## Test plan
- [x] 17 unit tests covering all new functions and both modes (symlink + copy)
- [x] `ruff check` and `ruff format` pass
- [x] Live validation: `install.sh --symlink` → sync hook → symlinks survive
- [x] Verified content accessible through symlinks