### PR TITLE
feat: add Factory CLI support to install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The toolkit mirrors agents, skills, and a curated subset of hooks into `~/.facto
 
 - **Droids**: every agent under `agents/` (and `private-agents/` if present) is copied or symlinked to `~/.factory/droids/`. Factory calls agents "droids"; the directory name differs but the content is identical.
 - **Skills**: every skill under `skills/`, `private-skills/`, and `private-voices/*/skill/` goes to `~/.factory/skills/`.
-- **Hooks**: the same Phase 1 hooks as Codex and Gemini, with Factory-compatible event names, go to `~/.factory/hooks/`. Hook configuration is merged into `~/.factory/settings.json` (only the `hooks` key is modified; all other settings are preserved). See `scripts/factory-hooks-allowlist.txt`.
+- **Hooks**: all hooks are mirrored to `~/.factory/hooks/` (no allowlist — same set as Claude Code). Hook configuration is merged into `~/.factory/settings.json` with paths rewritten from `$HOME/.claude/` to `$HOME/.factory/` (only the `hooks` key is modified; all other settings are preserved).
 
 **Hook runtime compatibility**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/repo-hero.png" alt="VexJoy Agent" width="100%">
 
-VexJoy Agent is a complete agent-driven workflow system for [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), and [Gemini CLI](https://github.com/google-gemini/gemini-cli). It gives all three CLIs domain-specific expertise, step-by-step workflows, and automated quality gates. The result is your coding agent working like a team of Go, Python, Kubernetes, review, and content specialists instead of one generalist.
+VexJoy Agent is a complete agent-driven workflow system for [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), and [Factory](https://factory.ai). It gives all four CLIs domain-specific expertise, step-by-step workflows, and automated quality gates. The result is your coding agent working like a team of Go, Python, Kubernetes, review, and content specialists instead of one generalist.
 
 ## How It Works
 
@@ -12,7 +12,7 @@ It starts from the moment you type a request. You don't pick agents, configure w
 /do debug this Go test
 ```
 
-In Claude Code, the smart router command is `/do`. In Codex, use `$do`. In Gemini CLI, use `/do` (Gemini discovers skills from `~/.gemini/skills/` automatically).
+In Claude Code, the smart router command is `/do`. In Codex, use `$do`. In Gemini CLI, use `/do` (Gemini discovers skills from `~/.gemini/skills/` automatically). In Factory, use `/do` (Factory discovers skills from `~/.factory/skills/` automatically).
 
 A router reads your intent and selects a Go specialist agent paired with a systematic debugging methodology. The agent creates a branch, gathers evidence before guessing, runs through phased diagnosis, applies a fix, executes tests, reviews its own work, and presents a PR. You describe the problem. The system handles everything else.
 
@@ -30,7 +30,7 @@ A game built entirely by Claude Code using these agents, skills, and pipelines. 
 
 ## Installation
 
-Requires [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and working (`claude --version` should print a version number). Codex CLI and Gemini CLI are also supported: the installer mirrors toolkit skills and agents into `~/.codex/` and `~/.gemini/` so all three CLIs can use the same skill and agent library.
+Requires [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and working (`claude --version` should print a version number). Codex CLI, Gemini CLI, and Factory are also supported: the installer mirrors toolkit skills and agents into `~/.codex/`, `~/.gemini/`, and `~/.factory/` so all four CLIs can use the same skill and agent library.
 
 ```bash
 git clone https://github.com/notque/vexjoy-agent.git ~/vexjoy-agent
@@ -38,7 +38,7 @@ cd ~/vexjoy-agent
 ./install.sh --symlink
 ```
 
-The installer links agents, skills, hooks, commands, and scripts into `~/.claude/`, where Claude Code loads extensions from. It also mirrors skills and agents into `~/.codex/` for Codex and `~/.gemini/` for Gemini CLI. Use `--symlink` to get updates via `git pull`, or run without it for a stable copy.
+The installer links agents, skills, hooks, commands, and scripts into `~/.claude/`, where Claude Code loads extensions from. It also mirrors skills and agents into `~/.codex/` for Codex, `~/.gemini/` for Gemini CLI, and `~/.factory/` for Factory. Use `--symlink` to get updates via `git pull`, or run without it for a stable copy.
 
 Verify the install with:
 
@@ -47,11 +47,13 @@ python3 ~/.claude/scripts/install-doctor.py check
 python3 ~/.claude/scripts/install-doctor.py inventory
 ```
 
-If you update the repo later and want Codex/Gemini to see newly added skills, rerun `./install.sh --symlink` from the repo root.
+If you update the repo later and want Codex/Gemini/Factory to see newly added skills, rerun `./install.sh --symlink` from the repo root.
 
 Command entry points:
 - Claude Code: `/do`
 - Codex: `$do`
+- Gemini CLI: `/do`
+- Factory: `/do`
 
 **Detailed setup:** [docs/start-here.md](docs/start-here.md)
 
@@ -108,6 +110,24 @@ Hooks can detect which CLI is invoking them via `detect_cli()` in `hooks/lib/hoo
 
 The mirror is harmless when Gemini CLI is not installed. To remove hooks after install, delete `~/.gemini/hooks/` and remove the `hooks` key from `~/.gemini/settings.json`.
 
+## Factory CLI Support
+
+The toolkit mirrors agents, skills, and a curated subset of hooks into `~/.factory/` so they work with the Factory CLI alongside Claude Code, Codex, and Gemini. The mirror runs automatically on every `install.sh`; no flags required.
+
+**What mirrors**
+
+- **Droids**: every agent under `agents/` (and `private-agents/` if present) is copied or symlinked to `~/.factory/droids/`. Factory calls agents "droids"; the directory name differs but the content is identical.
+- **Skills**: every skill under `skills/`, `private-skills/`, and `private-voices/*/skill/` goes to `~/.factory/skills/`.
+- **Hooks**: the same Phase 1 hooks as Codex and Gemini, with Factory-compatible event names, go to `~/.factory/hooks/`. Hook configuration is merged into `~/.factory/settings.json` (only the `hooks` key is modified; all other settings are preserved). See `scripts/factory-hooks-allowlist.txt`.
+
+**Hook runtime compatibility**
+
+Hooks can detect which CLI is invoking them via `detect_cli()` in `hooks/lib/hook_utils.py`. The same `normalize_input()` and `detect_cli()` normalization functions that support Codex and Gemini also cover Factory. Output format (`hookSpecificOutput`) is shared across all four CLIs.
+
+**Opting out**
+
+The mirror is harmless when Factory is not installed. To remove hooks after install, delete `~/.factory/hooks/` and remove the `hooks` key from `~/.factory/settings.json`.
+
 ## Running Claude Code with the toolkit
 
 The toolkit already supplies routing (`/do`), domain knowledge (agents), methodology (skills), and enforcement (hooks, CLAUDE.md). The shipped Claude Code system prompt, which is several thousand tokens, largely duplicates that structure for toolkit users. Override it to shrink per-request token cost:
@@ -122,7 +142,7 @@ Trade-off: overriding the default strips Claude Code's built-in tool-use instruc
 
 ## The Core Workflow
 
-1. **Routing.** You type a request. The router entry point is `/do` in Claude Code and Gemini CLI, and `$do` in Codex. It classifies intent, selects a domain agent and a workflow skill, and dispatches. No menus, no configuration.
+1. **Routing.** You type a request. The router entry point is `/do` in Claude Code, Gemini CLI, and Factory, and `$do` in Codex. It classifies intent, selects a domain agent and a workflow skill, and dispatches. No menus, no configuration.
 
 2. **Planning.** For non-trivial work, the system creates a plan before touching code. Plans have phases, gates, and saved artifacts at each step.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -134,7 +134,7 @@ These phrases automatically activate the right tools:
                           │
                           ▼
 ┌─────────────────────────────────────────────────────────┐
-│         /do in Claude | $do in Codex | /do in Gemini/Factory    │
+│   /do in Claude | $do in Codex | /do in Gemini/Factory  │
 │         (or natural-language routing)                   │
 └─────────────────────────────────────────────────────────┘
                           │

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,11 +13,13 @@ cd ~/vexjoy-agent
 ./install.sh
 ```
 
-Claude Code is the primary runtime. If you also use Codex CLI, the same install mirrors toolkit skills into `~/.codex/skills` and toolkit agents into `~/.codex/agents`.
+Claude Code is the primary runtime. If you also use Codex CLI, Gemini CLI, or Factory, the same install mirrors toolkit skills and agents into `~/.codex/`, `~/.gemini/`, and `~/.factory/` so all four CLIs share the same skill and agent library.
 
 Command entry points:
 - Claude Code: `/do`
 - Codex: `$do`
+- Gemini CLI: `/do`
+- Factory: `/do`
 
 **Alternative (bootstrap via Claude):** Start Claude Code in the vexjoy-agent directory. The sync hook will automatically copy agents, skills, hooks, commands, and scripts to `~/.claude/`.
 
@@ -82,7 +84,7 @@ The system figures out which tools to use and tells you what it selected.
 
 ### Option B: Use the Router for Specific Workflows
 
-The router command routes your request to the right agent and skill automatically. Use `/do` in Claude Code and `$do` in Codex:
+The router command routes your request to the right agent and skill automatically. Use `/do` in Claude Code, Gemini CLI, and Factory, and `$do` in Codex:
 
 | Want This? | Try This |
 |------------|----------|
@@ -132,7 +134,7 @@ These phrases automatically activate the right tools:
                           │
                           ▼
 ┌─────────────────────────────────────────────────────────┐
-│         /do in Claude | $do in Codex                    │
+│         /do in Claude | $do in Codex | /do in Gemini/Factory    │
 │         (or natural-language routing)                   │
 └─────────────────────────────────────────────────────────┘
                           │

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -49,7 +49,7 @@ python3 ~/.claude/scripts/install-doctor.py check
 python3 ~/.claude/scripts/install-doctor.py inventory
 ```
 
-`check` verifies the install layout, settings, hook paths, learning DB access, and both Codex skill and agent mirrors. `~/.claude/inventory` shows what Claude and Codex can currently see. If you pull new toolkit changes later and want Codex, Gemini, or Factory to pick up new skills or agents, rerun `./install.sh`.
+`check` verifies the install layout, settings, hook paths, learning DB access, and both Codex skill and agent mirrors. `inventory` lists what Claude and Codex can currently see. If you pull new toolkit changes later and want Codex, Gemini, or Factory to pick up new skills or agents, rerun `./install.sh`.
 
 ## Your First Commands
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -12,11 +12,13 @@ claude --version
 
 If that prints a version number, you're good. If not, install Claude Code first and come back.
 
-Optional: if you also use Codex CLI, run `codex --version`. The toolkit mirrors its skills into `~/.codex/skills` and its agents into `~/.codex/agents`, so Codex sessions can Read the same domain expertise Claude Code dispatches. Claude Code is still the full runtime for hooks, commands, and scripts.
+Optional: if you also use Codex CLI, Gemini CLI, or Factory, run `codex --version` / `gemini --version` / `factory --version`. The toolkit mirrors its skills into `~/.codex/skills`, `~/.gemini/skills/`, and `~/.factory/skills/`, and its agents into `~/.codex/agents`, `~/.gemini/agents/`, and `~/.factory/droids/` (Factory calls agents "droids"), so all four CLIs can dispatch the same domain expertise. Claude Code is still the full runtime for hooks, commands, and scripts.
 
 Command entry points:
 - Claude Code: `/do`
 - Codex: `$do`
+- Gemini CLI: `/do`
+- Factory: `/do`
 
 ## Install
 
@@ -47,7 +49,7 @@ python3 ~/.claude/scripts/install-doctor.py check
 python3 ~/.claude/scripts/install-doctor.py inventory
 ```
 
-`check` verifies the install layout, settings, hook paths, learning DB access, and both Codex skill and agent mirrors. `inventory` shows what Claude and Codex can currently see. If you pull new toolkit changes later and want Codex to pick up new skills or agents, rerun `./install.sh`.
+`check` verifies the install layout, settings, hook paths, learning DB access, and both Codex skill and agent mirrors. `~/.claude/inventory` shows what Claude and Codex can currently see. If you pull new toolkit changes later and want Codex, Gemini, or Factory to pick up new skills or agents, rerun `./install.sh`.
 
 ## Your First Commands
 
@@ -65,7 +67,7 @@ Now try these.
 /do what can you do?
 ```
 
-The router command is the front door. Use `/do` in Claude Code and `$do` in Codex. It reads your request, picks the right agent and skill, and runs it. This one shows you the full routing system -- every domain it handles, every workflow it knows.
+The router command is the front door. Use `/do` in Claude Code, Gemini CLI, and Factory, and `$do` in Codex. It reads your request, picks the right agent and skill, and runs it. This one shows you the full routing system -- every domain it handles, every workflow it knows.
 
 ### Explore a codebase
 

--- a/hooks/error-learner.py
+++ b/hooks/error-learner.py
@@ -24,6 +24,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from feedback_tracker import check_pending_feedback, set_pending_feedback
+from hook_utils import get_tool_error, get_tool_output, get_tool_result
 from learning_db_v2 import (
     DEFAULT_FIX_ACTIONS,
     boost_confidence,
@@ -68,14 +69,14 @@ def detect_error(event: dict) -> tuple[bool, str]:
     Returns:
         Tuple of (has_error, error_message)
     """
-    tool_result = event.get("tool_result", {})
+    tool_result = get_tool_result(event)
 
     # Direct error field
-    if "error" in tool_result:
-        return True, str(tool_result["error"])
+    if bool(get_tool_error(tool_result)):
+        return True, str(get_tool_error(tool_result))
 
     # Check for error in output
-    output = tool_result.get("output", "")
+    output = get_tool_output(tool_result)
     if isinstance(output, str):
         output_lower = output.lower()
 

--- a/hooks/error-learner.py
+++ b/hooks/error-learner.py
@@ -72,8 +72,9 @@ def detect_error(event: dict) -> tuple[bool, str]:
     tool_result = get_tool_result(event)
 
     # Direct error field
-    if bool(get_tool_error(tool_result)):
-        return True, str(get_tool_error(tool_result))
+    err = get_tool_error(tool_result)
+    if err:
+        return True, str(err)
 
     # Check for error in output
     output = get_tool_output(tool_result)

--- a/hooks/lib/hook_utils.py
+++ b/hooks/lib/hook_utils.py
@@ -497,3 +497,54 @@ def normalize_input(data: dict[str, Any]) -> dict[str, Any]:
         data["tool"] = data["tool_name"]
 
     return data
+
+
+# ===== Schema-Compatibility Helpers (PostToolUse) =====
+
+
+def get_tool_result(event: dict) -> dict:
+    """Return the tool result dict from a PostToolUse event.
+
+    Handles both Claude/Codex/Gemini ('tool_result') and Factory CLI
+    ('tool_response') schemas. Returns {} if neither key is present.
+    """
+    if "tool_result" in event:
+        return event["tool_result"] or {}
+    if "tool_response" in event:
+        return event["tool_response"] or {}
+    return {}
+
+
+def get_tool_output(result: dict) -> str:
+    """Return the tool's stdout/output string.
+
+    Claude/Codex/Gemini use 'output'; Factory uses 'stdout'.
+    """
+    if "output" in result:
+        return result["output"] or ""
+    if "stdout" in result:
+        return result["stdout"] or ""
+    return ""
+
+
+def get_tool_error(result: dict) -> str:
+    """Return the tool's error/stderr string when an error occurred.
+
+    Claude/Codex/Gemini surface 'error'; Factory uses 'stderr' (and exitCode != 0
+    indicates failure). Returns empty string when no error.
+    """
+    if result.get("error"):
+        return result["error"]
+    if result.get("exitCode", 0) != 0:
+        return result.get("stderr", "") or result.get("stdout", "")
+    return ""
+
+
+def is_tool_error(result: dict) -> bool:
+    """Detect tool failure across schemas.
+
+    Claude/Codex/Gemini set is_error=True; Factory exposes exitCode (non-zero = error).
+    """
+    if "is_error" in result:
+        return bool(result["is_error"])
+    return result.get("exitCode", 0) != 0

--- a/hooks/lib/hook_utils.py
+++ b/hooks/lib/hook_utils.py
@@ -519,6 +519,9 @@ def get_tool_output(result: dict) -> str:
     """Return the tool's stdout/output string.
 
     Claude/Codex/Gemini use 'output'; Factory uses 'stdout'.
+
+    Note: key presence, not truthiness, determines the field — an empty
+    'output' key returns '' without falling through to 'stdout'.
     """
     if "output" in result:
         return result["output"] or ""

--- a/hooks/posttool-rename-sweep.py
+++ b/hooks/posttool-rename-sweep.py
@@ -22,6 +22,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from hook_utils import get_tool_result, is_tool_error
 from stdin_timeout import read_stdin
 
 
@@ -102,8 +103,8 @@ def main():
             return
 
         # Skip failed git mv commands — no rename happened
-        tool_result = data.get("tool_result", {})
-        if tool_result.get("is_error", False):
+        tool_result = get_tool_result(data)
+        if is_tool_error(tool_result):
             return
 
         tool_input = data.get("tool_input", {})

--- a/hooks/record-activation.py
+++ b/hooks/record-activation.py
@@ -25,7 +25,7 @@ from pathlib import Path
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
-from hook_utils import get_session_id
+from hook_utils import get_session_id, get_tool_result, is_tool_error
 from stdin_timeout import read_stdin
 
 
@@ -37,8 +37,8 @@ def main() -> None:
         # tool_name filter removed — matcher "Edit|Write|Bash" in settings.json
         # prevents this hook from spawning for non-matching tools.
 
-        tool_result = hook_input.get("tool_result", {})
-        if tool_result.get("is_error", False):
+        tool_result = get_tool_result(hook_input)
+        if is_tool_error(tool_result):
             return
 
         session_id = get_session_id()

--- a/hooks/record-waste.py
+++ b/hooks/record-waste.py
@@ -24,7 +24,7 @@ from pathlib import Path
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
-from hook_utils import get_session_id
+from hook_utils import get_session_id, get_tool_output, get_tool_result, is_tool_error
 from stdin_timeout import read_stdin
 
 # Minimum token waste estimate per failure
@@ -39,12 +39,12 @@ def main() -> None:
     try:
         hook_input = json.loads(read_stdin(timeout=2))
 
-        tool_result = hook_input.get("tool_result", {})
-        if not tool_result.get("is_error", False):
+        tool_result = get_tool_result(hook_input)
+        if not is_tool_error(tool_result):
             return  # Only track failures
 
         # Estimate wasted tokens from output length
-        output = tool_result.get("output", "")
+        output = get_tool_output(tool_result)
         waste_tokens = max(len(output) // CHARS_PER_TOKEN, MIN_WASTE_TOKENS)
 
         session_id = get_session_id()

--- a/hooks/retro-graduation-gate.py
+++ b/hooks/retro-graduation-gate.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
-from hook_utils import context_output, empty_output
+from hook_utils import context_output, empty_output, get_tool_output, get_tool_result
 from stdin_timeout import read_stdin
 
 DB_PATH = Path.home() / ".claude" / "learning" / "learning.db"
@@ -34,8 +34,8 @@ def main() -> None:
     # prevents this hook from spawning for non-Bash tools.
 
     # Early-exit: check if output indicates a PR was created (PostToolUse schema: tool_result.output)
-    tool_result = data.get("tool_result", {})
-    stdout = tool_result.get("output", "") if isinstance(tool_result, dict) else ""
+    tool_result = get_tool_result(data)
+    stdout = get_tool_output(tool_result) if isinstance(tool_result, dict) else ""
     if not isinstance(stdout, str) or "github.com" not in stdout or "pull/" not in stdout:
         empty_output(EVENT).print_and_exit(0)
         return

--- a/hooks/review-capture.py
+++ b/hooks/review-capture.py
@@ -27,7 +27,7 @@ from pathlib import Path
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
-from hook_utils import empty_output
+from hook_utils import empty_output, get_tool_output, get_tool_result
 from learning_db_v2 import record_learning
 from stdin_timeout import read_stdin
 
@@ -121,9 +121,9 @@ def main() -> None:
         # this hook from spawning for non-Agent tools.
 
         # Get tool result text
-        tool_result = event.get("tool_result", "")
+        tool_result = get_tool_result(event)
         if isinstance(tool_result, dict):
-            tool_result = tool_result.get("output", "")
+            tool_result = get_tool_output(tool_result)
         if not isinstance(tool_result, str) or not tool_result:
             return
 

--- a/hooks/routing-gap-recorder.py
+++ b/hooks/routing-gap-recorder.py
@@ -36,7 +36,7 @@ def main():
         event = json.loads(event_data)
 
         # Only process PostToolUse events
-        event_type = event.get("hook_event_name")
+        event_type = event.get("hook_event_name") or event.get("type", "")
         if event_type != "PostToolUse":
             return
 

--- a/hooks/routing-gap-recorder.py
+++ b/hooks/routing-gap-recorder.py
@@ -21,6 +21,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from hook_utils import get_tool_output, get_tool_result
 from stdin_timeout import read_stdin
 
 _GAP_PATTERN = re.compile(r"GAP DETECTED:\s*No match for\s+\[?([^\]\n]+)\]?")
@@ -35,13 +36,13 @@ def main():
         event = json.loads(event_data)
 
         # Only process PostToolUse events
-        event_type = event.get("hook_event_name") or event.get("type", "")
+        event_type = event.get("hook_event_name")
         if event_type != "PostToolUse":
             return
 
         # Check tool output for GAP DETECTED banner
-        tool_result = event.get("tool_result", {})
-        output = tool_result.get("output", "")
+        tool_result = get_tool_result(event)
+        output = get_tool_output(tool_result)
         if not isinstance(output, str) or "GAP DETECTED" not in output:
             return
 

--- a/hooks/tests/test_hook_utils_schema.py
+++ b/hooks/tests/test_hook_utils_schema.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Tests for schema-compatibility helpers in hook_utils.
+
+Covers get_tool_result, get_tool_output, get_tool_error, and is_tool_error
+across Claude/Codex/Gemini and Factory CLI schemas.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
+
+from hook_utils import get_tool_error, get_tool_output, get_tool_result, is_tool_error
+
+# ===== get_tool_result =====
+
+
+def test_get_tool_result_claude_schema():
+    event = {"hook_event_name": "PostToolUse", "tool_result": {"output": "hello", "is_error": False}}
+    assert get_tool_result(event) == {"output": "hello", "is_error": False}
+
+
+def test_get_tool_result_factory_schema():
+    event = {"hook_event_name": "PostToolUse", "tool_response": {"stdout": "hello", "exitCode": 0}}
+    assert get_tool_result(event) == {"stdout": "hello", "exitCode": 0}
+
+
+def test_get_tool_result_neither_key():
+    event = {"hook_event_name": "PostToolUse"}
+    assert get_tool_result(event) == {}
+
+
+# ===== get_tool_output =====
+
+
+def test_get_tool_output_output_key():
+    assert get_tool_output({"output": "from output"}) == "from output"
+
+
+def test_get_tool_output_stdout_key():
+    assert get_tool_output({"stdout": "from stdout"}) == "from stdout"
+
+
+def test_get_tool_output_neither_key():
+    assert get_tool_output({}) == ""
+
+
+def test_get_tool_output_both_keys_output_wins():
+    assert get_tool_output({"output": "output wins", "stdout": "stdout"}) == "output wins"
+
+
+# ===== get_tool_error =====
+
+
+def test_get_tool_error_explicit_error_key():
+    assert get_tool_error({"error": "something failed"}) == "something failed"
+
+
+def test_get_tool_error_exit_code_nonzero_with_stderr():
+    result = {"exitCode": 1, "stderr": "bad error", "stdout": "some output"}
+    assert get_tool_error(result) == "bad error"
+
+
+def test_get_tool_error_exit_code_nonzero_only_stdout():
+    result = {"exitCode": 2, "stderr": "", "stdout": "fallback output"}
+    assert get_tool_error(result) == "fallback output"
+
+
+def test_get_tool_error_exit_code_zero_no_error():
+    assert get_tool_error({"exitCode": 0, "stderr": "", "stdout": "ok"}) == ""
+
+
+def test_get_tool_error_explicit_error_empty_string():
+    # Empty string for 'error' should not be treated as an error
+    assert get_tool_error({"error": "", "exitCode": 0}) == ""
+
+
+# ===== is_tool_error =====
+
+
+def test_is_tool_error_is_error_true():
+    assert is_tool_error({"is_error": True}) is True
+
+
+def test_is_tool_error_is_error_false():
+    assert is_tool_error({"is_error": False}) is False
+
+
+def test_is_tool_error_exit_code_zero():
+    assert is_tool_error({"exitCode": 0}) is False
+
+
+def test_is_tool_error_exit_code_nonzero():
+    assert is_tool_error({"exitCode": 1}) is True
+
+
+def test_is_tool_error_neither_key():
+    assert is_tool_error({}) is False
+
+
+# ===== additional edge case tests =====
+
+
+def test_get_tool_error_explicit_error_none():
+    # None for 'error' is falsy, falls through to exitCode == 0 branch
+    assert get_tool_error({"error": None, "exitCode": 0}) == ""
+
+
+def test_get_tool_error_exit_nonzero_no_stderr_key():
+    # No stderr key at all, default empty, falls through to stdout
+    assert get_tool_error({"exitCode": 1, "stdout": "fallback"}) == "fallback"
+
+
+def test_get_tool_output_empty_output_preserved():
+    # Claude said empty output — we must not fall through to Factory's stdout
+    assert get_tool_output({"output": "", "stdout": "ignored"}) == ""
+
+
+def test_get_tool_result_empty_dict_preserved():
+    # Claude said empty result — we must not fall through to Factory's tool_response
+    assert get_tool_result({"tool_result": {}, "tool_response": {"x": 1}}) == {}

--- a/hooks/tests/test_posttool_rename_sweep.py
+++ b/hooks/tests/test_posttool_rename_sweep.py
@@ -11,6 +11,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 # ---------------------------------------------------------------------------
 # Import the module under test
 # ---------------------------------------------------------------------------
@@ -37,6 +39,19 @@ def run_hook(event: dict) -> tuple[str, str, int]:
         timeout=10,
     )
     return result.stdout, result.stderr, result.returncode
+
+
+# Parametrize fixtures for "no error, no output" — equivalent across schemas.
+_EMPTY_RESULT_PARAMS = [
+    pytest.param({"tool_result": {}}, id="claude-schema"),
+    pytest.param({"tool_response": {}}, id="factory-schema"),
+]
+
+# Parametrize fixtures for "error result" — equivalent across schemas.
+_ERROR_RESULT_PARAMS = [
+    pytest.param({"tool_result": {"is_error": True}}, id="claude-schema"),
+    pytest.param({"tool_response": {"exitCode": 1}}, id="factory-schema"),
+]
 
 
 # ---------------------------------------------------------------------------
@@ -128,34 +143,37 @@ class TestToolFiltering:
         assert rc == 0
         assert stdout == ""
 
-    def test_failed_git_mv_silent(self):
-        """Failed git mv commands (is_error=True) produce no output."""
+    @pytest.mark.parametrize("tool_result_block", _ERROR_RESULT_PARAMS)
+    def test_failed_git_mv_silent(self, tool_result_block: dict) -> None:
+        """Failed git mv commands (is_error=True / exitCode=1) produce no output."""
         event = {
             "tool_name": "Bash",
             "tool_input": {"command": "git mv nonexistent.py dest.py"},
-            "tool_result": {"is_error": True},
+            **tool_result_block,
         }
         stdout, stderr, rc = run_hook(event)
         assert rc == 0
         assert stdout == ""
 
-    def test_no_git_mv_in_command_silent(self):
+    @pytest.mark.parametrize("tool_result_block", _EMPTY_RESULT_PARAMS)
+    def test_no_git_mv_in_command_silent(self, tool_result_block: dict) -> None:
         """Bash commands without git mv produce no output."""
         event = {
             "tool_name": "Bash",
             "tool_input": {"command": "ls -la"},
-            "tool_result": {},
+            **tool_result_block,
         }
         stdout, stderr, rc = run_hook(event)
         assert rc == 0
         assert stdout == ""
 
-    def test_short_stem_silent(self):
+    @pytest.mark.parametrize("tool_result_block", _EMPTY_RESULT_PARAMS)
+    def test_short_stem_silent(self, tool_result_block: dict) -> None:
         """Stems under 3 characters are skipped to avoid noisy results."""
         event = {
             "tool_name": "Bash",
             "tool_input": {"command": "git mv a.py b.py"},
-            "tool_result": {},
+            **tool_result_block,
         }
         stdout, stderr, rc = run_hook(event)
         assert rc == 0
@@ -190,11 +208,12 @@ class TestExitCode:
         )
         assert result.returncode == 0
 
-    def test_valid_bash_no_git_mv(self):
+    @pytest.mark.parametrize("tool_result_block", _EMPTY_RESULT_PARAMS)
+    def test_valid_bash_no_git_mv(self, tool_result_block: dict) -> None:
         event = {
             "tool_name": "Bash",
             "tool_input": {"command": "echo hello"},
-            "tool_result": {},
+            **tool_result_block,
         }
         stdout, stderr, rc = run_hook(event)
         assert rc == 0

--- a/hooks/tests/test_record_activation.py
+++ b/hooks/tests/test_record_activation.py
@@ -49,9 +49,36 @@ def tmp_session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
     return session_id
 
 
-def _make_hook_input(tool_name: str = "Bash", is_error: bool = False, output: str = "ok") -> str:
-    """Build JSON hook input string."""
+def _make_hook_input(
+    tool_name: str = "Bash",
+    is_error: bool = False,
+    output: str = "ok",
+    schema: str = "claude",
+) -> str:
+    """Build JSON hook input string.
+
+    Args:
+        tool_name: The tool that was called.
+        is_error: Whether the tool reported an error.
+        output: The tool output text.
+        schema: ``"claude"`` for Claude/Codex/Gemini schema (tool_result/is_error/output)
+            or ``"factory"`` for Factory schema (tool_response/exitCode/stdout).
+    """
+    if schema == "factory":
+        return json.dumps(
+            {
+                "tool_name": tool_name,
+                "tool_response": {"stdout": output, "exitCode": 1 if is_error else 0},
+            }
+        )
     return json.dumps({"tool_name": tool_name, "tool_result": {"output": output, "is_error": is_error}})
+
+
+# Schema parameter used by tests that exercise tool-result data.
+_SCHEMAS = [
+    pytest.param("claude", id="claude-schema"),
+    pytest.param("factory", id="factory-schema"),
+]
 
 
 # ---------------------------------------------------------------------------
@@ -62,27 +89,31 @@ def _make_hook_input(tool_name: str = "Bash", is_error: bool = False, output: st
 class TestToolFiltering:
     """Verify only Edit/Write/Bash tools are tracked."""
 
-    def test_skips_read_tool(self, tmp_session: str) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_skips_read_tool(self, tmp_session: str, schema: str) -> None:
         with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-            mock_stdin.read.return_value = _make_hook_input(tool_name="Read")
+            mock_stdin.read.return_value = _make_hook_input(tool_name="Read", schema=schema)
             mod.main()
             mock_run.assert_not_called()
 
-    def test_skips_grep_tool(self, tmp_session: str) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_skips_grep_tool(self, tmp_session: str, schema: str) -> None:
         with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-            mock_stdin.read.return_value = _make_hook_input(tool_name="Grep")
+            mock_stdin.read.return_value = _make_hook_input(tool_name="Grep", schema=schema)
             mod.main()
             mock_run.assert_not_called()
 
-    def test_skips_glob_tool(self, tmp_session: str) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_skips_glob_tool(self, tmp_session: str, schema: str) -> None:
         with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-            mock_stdin.read.return_value = _make_hook_input(tool_name="Glob")
+            mock_stdin.read.return_value = _make_hook_input(tool_name="Glob", schema=schema)
             mod.main()
             mock_run.assert_not_called()
 
-    def test_skips_error_results(self, tmp_session: str) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_skips_error_results(self, tmp_session: str, schema: str) -> None:
         with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-            mock_stdin.read.return_value = _make_hook_input(is_error=True)
+            mock_stdin.read.return_value = _make_hook_input(is_error=True, schema=schema)
             mod.main()
             mock_run.assert_not_called()
 
@@ -95,23 +126,25 @@ class TestToolFiltering:
 class TestBatching:
     """Verify only every 10th successful call triggers recording."""
 
-    def test_no_record_before_10th_call(self, tmp_session: str, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_no_record_before_10th_call(self, tmp_session: str, tmp_path: Path, schema: str) -> None:
         """Calls 1-9 should not trigger subprocess."""
         for i in range(1, 10):
             with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-                mock_stdin.read.return_value = _make_hook_input()
+                mock_stdin.read.return_value = _make_hook_input(schema=schema)
                 mod.main()
                 if i < 10:
                     mock_run.assert_not_called()
 
-    def test_records_on_10th_call(self, tmp_session: str, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_records_on_10th_call(self, tmp_session: str, tmp_path: Path, schema: str) -> None:
         """The 10th call should trigger a record-session subprocess."""
         # Set counter to 9 so next call is the 10th
         counter_file = tmp_path / f"claude-activation-counter-{tmp_session}"
         counter_file.write_text("9")
 
         with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-            mock_stdin.read.return_value = _make_hook_input()
+            mock_stdin.read.return_value = _make_hook_input(schema=schema)
             mod.main()
             mock_run.assert_called_once()
             cmd = mock_run.call_args[0][0]
@@ -126,7 +159,8 @@ class TestBatching:
 class TestRetroDetection:
     """Verify --had-retro flag is passed only when marker exists."""
 
-    def test_had_retro_flag_when_marker_exists(self, tmp_session: str, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_had_retro_flag_when_marker_exists(self, tmp_session: str, tmp_path: Path, schema: str) -> None:
         # Set counter to 9 and create retro marker
         counter_file = tmp_path / f"claude-activation-counter-{tmp_session}"
         counter_file.write_text("9")
@@ -134,17 +168,18 @@ class TestRetroDetection:
         marker.write_text("1")
 
         with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-            mock_stdin.read.return_value = _make_hook_input()
+            mock_stdin.read.return_value = _make_hook_input(schema=schema)
             mod.main()
             cmd = mock_run.call_args[0][0]
             assert "--had-retro" in cmd
 
-    def test_no_retro_flag_without_marker(self, tmp_session: str, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_no_retro_flag_without_marker(self, tmp_session: str, tmp_path: Path, schema: str) -> None:
         counter_file = tmp_path / f"claude-activation-counter-{tmp_session}"
         counter_file.write_text("9")
 
         with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-            mock_stdin.read.return_value = _make_hook_input()
+            mock_stdin.read.return_value = _make_hook_input(schema=schema)
             mod.main()
             cmd = mock_run.call_args[0][0]
             assert "--had-retro" not in cmd
@@ -164,7 +199,8 @@ class TestErrorResilience:
             mod.main()
             mock_exit.assert_called_with(0)
 
-    def test_subprocess_timeout_exits_cleanly(self, tmp_session: str, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_subprocess_timeout_exits_cleanly(self, tmp_session: str, tmp_path: Path, schema: str) -> None:
         counter_file = tmp_path / f"claude-activation-counter-{tmp_session}"
         counter_file.write_text("9")
 
@@ -173,11 +209,12 @@ class TestErrorResilience:
             patch("sys.stdin") as mock_stdin,
             patch("sys.exit") as mock_exit,
         ):
-            mock_stdin.read.return_value = _make_hook_input()
+            mock_stdin.read.return_value = _make_hook_input(schema=schema)
             mod.main()
             mock_exit.assert_called_with(0)
 
-    def test_missing_script_exits_cleanly(self, tmp_session: str, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_missing_script_exits_cleanly(self, tmp_session: str, tmp_path: Path, schema: str) -> None:
         counter_file = tmp_path / f"claude-activation-counter-{tmp_session}"
         counter_file.write_text("9")
 
@@ -187,6 +224,6 @@ class TestErrorResilience:
             patch("sys.stdin") as mock_stdin,
             patch("sys.exit"),
         ):
-            mock_stdin.read.return_value = _make_hook_input()
+            mock_stdin.read.return_value = _make_hook_input(schema=schema)
             mod.main()
             mock_run.assert_not_called()

--- a/hooks/tests/test_record_waste.py
+++ b/hooks/tests/test_record_waste.py
@@ -39,9 +39,34 @@ def session_env(monkeypatch: pytest.MonkeyPatch) -> str:
     return session_id
 
 
-def _make_hook_input(is_error: bool = True, output: str = "error: something failed") -> str:
-    """Build JSON hook input string."""
+def _make_hook_input(
+    is_error: bool = True,
+    output: str = "error: something failed",
+    schema: str = "claude",
+) -> str:
+    """Build JSON hook input string.
+
+    Args:
+        is_error: Whether the tool reported an error.
+        output: The tool output text.
+        schema: ``"claude"`` for Claude/Codex/Gemini schema (tool_result/is_error/output)
+            or ``"factory"`` for Factory schema (tool_response/exitCode/stdout).
+    """
+    if schema == "factory":
+        return json.dumps(
+            {
+                "tool_name": "Bash",
+                "tool_response": {"stdout": output, "exitCode": 1 if is_error else 0},
+            }
+        )
     return json.dumps({"tool_name": "Bash", "tool_result": {"output": output, "is_error": is_error}})
+
+
+# Schema parameter used by tests that exercise tool-result data.
+_SCHEMAS = [
+    pytest.param("claude", id="claude-schema"),
+    pytest.param("factory", id="factory-schema"),
+]
 
 
 # ---------------------------------------------------------------------------
@@ -52,15 +77,17 @@ def _make_hook_input(is_error: bool = True, output: str = "error: something fail
 class TestErrorFiltering:
     """Verify only failures are tracked."""
 
-    def test_skips_successful_tool_use(self, session_env: str) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_skips_successful_tool_use(self, session_env: str, schema: str) -> None:
         with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-            mock_stdin.read.return_value = _make_hook_input(is_error=False, output="all good")
+            mock_stdin.read.return_value = _make_hook_input(is_error=False, output="all good", schema=schema)
             mod.main()
             mock_run.assert_not_called()
 
-    def test_records_on_error(self, session_env: str) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_records_on_error(self, session_env: str, schema: str) -> None:
         with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-            mock_stdin.read.return_value = _make_hook_input(is_error=True)
+            mock_stdin.read.return_value = _make_hook_input(is_error=True, schema=schema)
             mod.main()
             mock_run.assert_called_once()
 
@@ -73,28 +100,31 @@ class TestErrorFiltering:
 class TestTokenEstimation:
     """Verify waste token calculation logic."""
 
-    def test_minimum_100_tokens_for_short_output(self, session_env: str) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_minimum_100_tokens_for_short_output(self, session_env: str, schema: str) -> None:
         """Short error output should still register MIN_WASTE_TOKENS."""
         with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-            mock_stdin.read.return_value = _make_hook_input(output="err")
+            mock_stdin.read.return_value = _make_hook_input(output="err", schema=schema)
             mod.main()
             cmd = mock_run.call_args[0][0]
             tokens_idx = cmd.index("--tokens") + 1
             assert int(cmd[tokens_idx]) == 100  # MIN_WASTE_TOKENS
 
-    def test_token_estimate_scales_with_output(self, session_env: str) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_token_estimate_scales_with_output(self, session_env: str, schema: str) -> None:
         """Longer output should produce proportionally more waste tokens."""
         long_output = "x" * 2000  # 2000 chars / 4 = 500 tokens
         with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-            mock_stdin.read.return_value = _make_hook_input(output=long_output)
+            mock_stdin.read.return_value = _make_hook_input(output=long_output, schema=schema)
             mod.main()
             cmd = mock_run.call_args[0][0]
             tokens_idx = cmd.index("--tokens") + 1
             assert int(cmd[tokens_idx]) == 500
 
-    def test_empty_output_uses_minimum(self, session_env: str) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_empty_output_uses_minimum(self, session_env: str, schema: str) -> None:
         with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-            mock_stdin.read.return_value = _make_hook_input(output="")
+            mock_stdin.read.return_value = _make_hook_input(output="", schema=schema)
             mod.main()
             cmd = mock_run.call_args[0][0]
             tokens_idx = cmd.index("--tokens") + 1
@@ -109,9 +139,10 @@ class TestTokenEstimation:
 class TestCLIArgs:
     """Verify correct arguments are passed to learning-db.py."""
 
-    def test_passes_session_and_tokens(self, session_env: str) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_passes_session_and_tokens(self, session_env: str, schema: str) -> None:
         with patch("subprocess.run") as mock_run, patch("sys.stdin") as mock_stdin, patch("sys.exit"):
-            mock_stdin.read.return_value = _make_hook_input()
+            mock_stdin.read.return_value = _make_hook_input(schema=schema)
             mod.main()
             cmd = mock_run.call_args[0][0]
             assert "record-waste" in cmd
@@ -134,22 +165,24 @@ class TestErrorResilience:
             mod.main()
             mock_exit.assert_called_with(0)
 
-    def test_subprocess_timeout_exits_cleanly(self, session_env: str) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_subprocess_timeout_exits_cleanly(self, session_env: str, schema: str) -> None:
         with (
             patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="test", timeout=5)),
             patch("sys.stdin") as mock_stdin,
             patch("sys.exit") as mock_exit,
         ):
-            mock_stdin.read.return_value = _make_hook_input()
+            mock_stdin.read.return_value = _make_hook_input(schema=schema)
             mod.main()
             mock_exit.assert_called_with(0)
 
-    def test_oserror_exits_cleanly(self, session_env: str) -> None:
+    @pytest.mark.parametrize("schema", _SCHEMAS)
+    def test_oserror_exits_cleanly(self, session_env: str, schema: str) -> None:
         with (
             patch("subprocess.run", side_effect=OSError("disk full")),
             patch("sys.stdin") as mock_stdin,
             patch("sys.exit") as mock_exit,
         ):
-            mock_stdin.read.return_value = _make_hook_input()
+            mock_stdin.read.return_value = _make_hook_input(schema=schema)
             mod.main()
             mock_exit.assert_called_with(0)

--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,8 @@ FACTORY_DIR="${HOME}/.factory"
 FACTORY_SKILLS_DIR="${FACTORY_DIR}/skills"
 FACTORY_DROIDS_DIR="${FACTORY_DIR}/droids"
 FACTORY_HOOKS_DIR="${FACTORY_DIR}/hooks"
+FACTORY_COMMANDS_DIR="${FACTORY_DIR}/commands"
+FACTORY_SCRIPTS_DIR="${FACTORY_DIR}/scripts"
 
 echo -e "${BLUE}╔════════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${BLUE}║                VexJoy Agent - Installation Script               ║${NC}"
@@ -543,9 +545,9 @@ os.rename(tmp, dst)
     # Phase 3.9: Clean toolkit-owned Factory mirror
     echo ""
     echo -e "${YELLOW}Cleaning Factory mirror...${NC}"
-    for dir_var in FACTORY_SKILLS_DIR FACTORY_DROIDS_DIR FACTORY_HOOKS_DIR; do
+    for dir_var in FACTORY_SKILLS_DIR FACTORY_DROIDS_DIR FACTORY_HOOKS_DIR FACTORY_COMMANDS_DIR FACTORY_SCRIPTS_DIR; do
         target="${!dir_var}"
-        if [ -d "$target" ]; then
+        if [ -L "$target" ] || [ -d "$target" ]; then
             if [ "$DRY_RUN" = true ]; then
                 echo -e "${BLUE}  Would remove: ${target}${NC}"
             else
@@ -730,15 +732,13 @@ fi
 echo -e "${GREEN}✓ ${GEMINI_AGENTS_DIR} ready${NC}"
 
 echo ""
-echo -e "${YELLOW}Setting up ~/.factory directories...${NC}"
+echo -e "${YELLOW}Setting up ~/.factory directory...${NC}"
 if [ "$DRY_RUN" = true ]; then
-    echo -e "${BLUE}  Would create: ${FACTORY_SKILLS_DIR}${NC}"
-    echo -e "${BLUE}  Would create: ${FACTORY_DROIDS_DIR}${NC}"
-    echo -e "${BLUE}  Would create: ${FACTORY_HOOKS_DIR}${NC}"
+    echo -e "${BLUE}  Would create: ${FACTORY_DIR}${NC}"
 else
-    mkdir -p "${FACTORY_SKILLS_DIR}" "${FACTORY_DROIDS_DIR}" "${FACTORY_HOOKS_DIR}"
+    mkdir -p "${FACTORY_DIR}"
 fi
-echo -e "${GREEN}✓ Factory directories ready${NC}"
+echo -e "${GREEN}✓ ${FACTORY_DIR} ready${NC}"
 
 # Install components
 echo ""
@@ -746,8 +746,10 @@ echo -e "${YELLOW}Installing components (mode: ${MODE})...${NC}"
 
 install_component() {
     local name=$1
+    local base_dir=${2:-$CLAUDE_DIR}
+    local target_name=${3:-$name}
     local source="${SCRIPT_DIR}/${name}"
-    local target="${CLAUDE_DIR}/${name}"
+    local target="${base_dir}/${target_name}"
 
     # Check if target exists
     if [ -e "$target" ] || [ -L "$target" ]; then
@@ -1023,74 +1025,48 @@ else
 fi
 
 echo ""
-echo -e "${YELLOW}Syncing Factory skills mirror...${NC}"
-FACTORY_SKILL_COUNT=0
-for item in "${SCRIPT_DIR}/skills/"*; do
-    [ -e "$item" ] || continue
-    target="${FACTORY_SKILLS_DIR}/$(basename "$item")"
-    sync_codex_entry "$item" "$target"
-    FACTORY_SKILL_COUNT=$((FACTORY_SKILL_COUNT + 1))
+echo -e "${YELLOW}Installing Factory components (mode: ${MODE})...${NC}"
+# Factory uses the same top-level symlink/copy pattern as Claude.
+# Only difference: 'agents' is named 'droids' under ~/.factory.
+for component in agents skills hooks commands scripts; do
+    if [ -d "${SCRIPT_DIR}/${component}" ]; then
+        target_name="$component"
+        [ "$component" = "agents" ] && target_name="droids"
+        install_component "$component" "$FACTORY_DIR" "$target_name"
+    fi
 done
 
-if [ -d "${SCRIPT_DIR}/private-voices" ]; then
-    for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
-        [ -d "$voice_dir" ] || continue
-        skill_src="${voice_dir}/skill"
-        [ -d "$skill_src" ] || continue
-        voice_name=$(basename "$voice_dir")
-        target="${FACTORY_SKILLS_DIR}/voice-${voice_name}"
-        sync_codex_entry "$skill_src" "$target"
-        FACTORY_SKILL_COUNT=$((FACTORY_SKILL_COUNT + 1))
-    done
-fi
-
-if [ -d "${SCRIPT_DIR}/private-skills" ]; then
-    for item in "${SCRIPT_DIR}/private-skills/"*; do
-        [ -e "$item" ] || continue
-        target="${FACTORY_SKILLS_DIR}/$(basename "$item")"
-        sync_codex_entry "$item" "$target"
-        FACTORY_SKILL_COUNT=$((FACTORY_SKILL_COUNT + 1))
-    done
-fi
-
-echo ""
-echo -e "${YELLOW}Syncing Factory droids mirror...${NC}"
-FACTORY_DROID_COUNT=0
-for item in "${SCRIPT_DIR}/agents/"*; do
-    [ -e "$item" ] || continue
-    target="${FACTORY_DROIDS_DIR}/$(basename "$item")"
-    sync_codex_entry "$item" "$target"
-    FACTORY_DROID_COUNT=$((FACTORY_DROID_COUNT + 1))
+# Install private Factory components (mirrors Claude private overlay logic)
+for private_dir in private-agents private-skills private-hooks; do
+    public_name="${private_dir#private-}"
+    [ "$public_name" = "agents" ] && public_name="droids"
+    if [ -d "${SCRIPT_DIR}/${private_dir}" ]; then
+        echo ""
+        echo -e "${YELLOW}Installing Factory private ${public_name}...${NC}"
+        for item in "${SCRIPT_DIR}/${private_dir}/"*; do
+            [ -e "$item" ] || continue
+            item_name=$(basename "$item")
+            target="${FACTORY_DIR}/${public_name}/${item_name}"
+            if [ "$DRY_RUN" = true ]; then
+                echo -e "${BLUE}  Would install Factory private: ${item_name}${NC}"
+            else
+                rm -rf "$target" 2>/dev/null
+                if [ "$MODE" = "symlink" ]; then
+                    ln -sf "$item" "$target"
+                    echo -e "${GREEN}  ✓ Linked Factory private ${item_name}${NC}"
+                else
+                    cp -r "$item" "$target"
+                    echo -e "${GREEN}  ✓ Copied Factory private ${item_name}${NC}"
+                fi
+            fi
+        done
+    fi
 done
 
-if [ -d "${SCRIPT_DIR}/private-agents" ]; then
-    for item in "${SCRIPT_DIR}/private-agents/"*; do
-        [ -e "$item" ] || continue
-        target="${FACTORY_DROIDS_DIR}/$(basename "$item")"
-        sync_codex_entry "$item" "$target"
-        FACTORY_DROID_COUNT=$((FACTORY_DROID_COUNT + 1))
-    done
-fi
-
-# Sync Factory hooks mirror (no allowlist — mirror all hooks like Claude does)
-echo ""
-echo -e "${YELLOW}Syncing Factory hooks mirror...${NC}"
-FACTORY_HOOK_COUNT=0
-for item in "${SCRIPT_DIR}/hooks/"*; do
-    [ -e "$item" ] || continue
-    bname=$(basename "$item")
-    [ "$bname" = "__pycache__" ] && continue
-    [ "$bname" = "tests" ] && continue
-    if [ -f "$item" ] && [[ "$item" != *.py ]]; then continue; fi
-    target="${FACTORY_HOOKS_DIR}/${bname}"
-    sync_codex_entry "$item" "$target"
-    FACTORY_HOOK_COUNT=$((FACTORY_HOOK_COUNT + 1))
-done
-
-if [ -d "${SCRIPT_DIR}/hooks/lib" ]; then
-    lib_target="${FACTORY_HOOKS_DIR}/lib"
-    sync_codex_entry "${SCRIPT_DIR}/hooks/lib" "$lib_target"
-fi
+# Component counts for the install summary (count source dirs, not per-entry)
+FACTORY_SKILL_COUNT=$(ls -1 "${SCRIPT_DIR}/skills/"*/SKILL.md 2>/dev/null | wc -l)
+FACTORY_DROID_COUNT=$(ls -1 "${SCRIPT_DIR}/agents/"*.md 2>/dev/null | grep -v README | wc -l)
+FACTORY_HOOK_COUNT=$(ls -1 "${SCRIPT_DIR}/hooks/"*.py 2>/dev/null | grep -cv '__init__')
 
 # Generate ~/.factory/settings.json
 if [ "$DRY_RUN" = true ]; then

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,10 @@ GEMINI_DIR="${HOME}/.gemini"
 GEMINI_SKILLS_DIR="${GEMINI_DIR}/skills"
 GEMINI_AGENTS_DIR="${GEMINI_DIR}/agents"
 GEMINI_HOOKS_DIR="${GEMINI_DIR}/hooks"
+FACTORY_DIR="${HOME}/.factory"
+FACTORY_SKILLS_DIR="${FACTORY_DIR}/skills"
+FACTORY_DROIDS_DIR="${FACTORY_DIR}/droids"
+FACTORY_HOOKS_DIR="${FACTORY_DIR}/hooks"
 
 echo -e "${BLUE}╔════════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${BLUE}║                VexJoy Agent - Installation Script               ║${NC}"
@@ -536,6 +540,38 @@ os.rename(tmp, dst)
         echo "  No ~/.gemini/settings.json found. Nothing to archive."
     fi
 
+    # Phase 3.9: Clean toolkit-owned Factory mirror
+    echo ""
+    echo -e "${YELLOW}Cleaning Factory mirror...${NC}"
+    for dir_var in FACTORY_SKILLS_DIR FACTORY_DROIDS_DIR FACTORY_HOOKS_DIR; do
+        target="${!dir_var}"
+        if [ -d "$target" ]; then
+            if [ "$DRY_RUN" = true ]; then
+                echo -e "${BLUE}  Would remove: ${target}${NC}"
+            else
+                rm -rf "$target"
+                echo -e "${GREEN}  ✓ Removed: ${target}${NC}"
+            fi
+            REMOVED+=("Factory $(basename "$target")")
+        fi
+    done
+
+    if [ -f "${FACTORY_DIR}/settings.json" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would archive: ${FACTORY_DIR}/settings.json${NC}"
+        else
+            ARCHIVE_TS=$(date +%Y%m%d-%H%M%S)
+            mv "${FACTORY_DIR}/settings.json" "${FACTORY_DIR}/settings.json.uninstalled.${ARCHIVE_TS}"
+            echo -e "${GREEN}  ✓ Archived ${FACTORY_DIR}/settings.json${NC}"
+        fi
+        REMOVED+=("Factory settings.json (archived)")
+    else
+        echo "  No ~/.factory/settings.json found. Nothing to archive."
+    fi
+
+    # Note: ~/.factory/config.toml is intentionally left untouched.
+    # Users may have other Factory configurations we did not write.
+
     # Phase 4: Remove install manifest
     echo ""
     echo -e "${YELLOW}Cleaning up manifest...${NC}"
@@ -582,6 +618,7 @@ os.rename(tmp, dst)
     echo "  • ~/.claude/memory/"
     echo "  • ~/.codex/config.toml (including [features] codex_hooks flag)"
     echo "  • ~/.gemini/settings.json (all keys except hooks)"
+    echo "  • ~/.factory/config.toml (if present, like Codex)"
     echo "  • .local/ customizations in the toolkit repo"
     echo "  • Python packages (remove manually if needed)"
     if [ ${#PRESERVED[@]} -gt 0 ]; then
@@ -691,6 +728,17 @@ else
     mkdir -p "${GEMINI_AGENTS_DIR}"
 fi
 echo -e "${GREEN}✓ ${GEMINI_AGENTS_DIR} ready${NC}"
+
+echo ""
+echo -e "${YELLOW}Setting up ~/.factory directories...${NC}"
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}  Would create: ${FACTORY_SKILLS_DIR}${NC}"
+    echo -e "${BLUE}  Would create: ${FACTORY_DROIDS_DIR}${NC}"
+    echo -e "${BLUE}  Would create: ${FACTORY_HOOKS_DIR}${NC}"
+else
+    mkdir -p "${FACTORY_SKILLS_DIR}" "${FACTORY_DROIDS_DIR}" "${FACTORY_HOOKS_DIR}"
+fi
+echo -e "${GREEN}✓ Factory directories ready${NC}"
 
 # Install components
 echo ""
@@ -974,7 +1022,111 @@ else
     echo -e "${YELLOW}  ⚠ Codex hooks allowlist not found at ${CODEX_HOOKS_ALLOWLIST}; skipping hooks mirror${NC}"
 fi
 
-# Sync Gemini skills mirror
+echo ""
+echo -e "${YELLOW}Syncing Factory skills mirror...${NC}"
+FACTORY_SKILL_COUNT=0
+for item in "${SCRIPT_DIR}/skills/"*; do
+    [ -e "$item" ] || continue
+    target="${FACTORY_SKILLS_DIR}/$(basename "$item")"
+    sync_codex_entry "$item" "$target"
+    FACTORY_SKILL_COUNT=$((FACTORY_SKILL_COUNT + 1))
+done
+
+if [ -d "${SCRIPT_DIR}/private-voices" ]; then
+    for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
+        [ -d "$voice_dir" ] || continue
+        skill_src="${voice_dir}/skill"
+        [ -d "$skill_src" ] || continue
+        voice_name=$(basename "$voice_dir")
+        target="${FACTORY_SKILLS_DIR}/voice-${voice_name}"
+        sync_codex_entry "$skill_src" "$target"
+        FACTORY_SKILL_COUNT=$((FACTORY_SKILL_COUNT + 1))
+    done
+fi
+
+if [ -d "${SCRIPT_DIR}/private-skills" ]; then
+    for item in "${SCRIPT_DIR}/private-skills/"*; do
+        [ -e "$item" ] || continue
+        target="${FACTORY_SKILLS_DIR}/$(basename "$item")"
+        sync_codex_entry "$item" "$target"
+        FACTORY_SKILL_COUNT=$((FACTORY_SKILL_COUNT + 1))
+    done
+fi
+
+echo ""
+echo -e "${YELLOW}Syncing Factory droids mirror...${NC}"
+FACTORY_DROID_COUNT=0
+for item in "${SCRIPT_DIR}/agents/"*; do
+    [ -e "$item" ] || continue
+    target="${FACTORY_DROIDS_DIR}/$(basename "$item")"
+    sync_codex_entry "$item" "$target"
+    FACTORY_DROID_COUNT=$((FACTORY_DROID_COUNT + 1))
+done
+
+if [ -d "${SCRIPT_DIR}/private-agents" ]; then
+    for item in "${SCRIPT_DIR}/private-agents/"*; do
+        [ -e "$item" ] || continue
+        target="${FACTORY_DROIDS_DIR}/$(basename "$item")"
+        sync_codex_entry "$item" "$target"
+        FACTORY_DROID_COUNT=$((FACTORY_DROID_COUNT + 1))
+    done
+fi
+
+# Sync Factory hooks mirror (no allowlist — mirror all hooks like Claude does)
+echo ""
+echo -e "${YELLOW}Syncing Factory hooks mirror...${NC}"
+FACTORY_HOOK_COUNT=0
+for item in "${SCRIPT_DIR}/hooks/"*; do
+    [ -e "$item" ] || continue
+    bname=$(basename "$item")
+    [ "$bname" = "__pycache__" ] && continue
+    [ "$bname" = "tests" ] && continue
+    if [ -f "$item" ] && [[ "$item" != *.py ]]; then continue; fi
+    target="${FACTORY_HOOKS_DIR}/${bname}"
+    sync_codex_entry "$item" "$target"
+    FACTORY_HOOK_COUNT=$((FACTORY_HOOK_COUNT + 1))
+done
+
+if [ -d "${SCRIPT_DIR}/hooks/lib" ]; then
+    lib_target="${FACTORY_HOOKS_DIR}/lib"
+    sync_codex_entry "${SCRIPT_DIR}/hooks/lib" "$lib_target"
+fi
+
+# Generate ~/.factory/settings.json
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}  Would sync hooks from ${SCRIPT_DIR}/.claude/settings.json to ${FACTORY_DIR}/settings.json (with path rewrite)${NC}"
+elif [ -f "${SCRIPT_DIR}/.claude/settings.json" ]; then
+    FACTORY_SETTINGS="${FACTORY_DIR}/settings.json"
+    if [ ! -f "$FACTORY_SETTINGS" ]; then
+        echo '{}' > "$FACTORY_SETTINGS"
+    fi
+    BACKUP_TS=$(date +%Y%m%d-%H%M%S)
+    cp "$FACTORY_SETTINGS" "${FACTORY_SETTINGS}.backup.${BACKUP_TS}"
+    $PYTHON_CMD -c "
+import json, os
+repo = json.load(open('${SCRIPT_DIR}/.claude/settings.json'))
+dst = '${FACTORY_SETTINGS}'
+try:
+    merged = json.load(open(dst, encoding='utf-8'))
+except (FileNotFoundError, json.JSONDecodeError):
+    merged = {}
+hooks_json = json.dumps(repo.get('hooks', {}))
+hooks_json = hooks_json.replace('\$HOME/.claude/', '\$HOME/.factory/')
+hooks_json = hooks_json.replace('\${HOME}/.claude/', '\${HOME}/.factory/')
+merged['hooks'] = json.loads(hooks_json)
+merged.setdefault('attribution', repo.get('attribution', {'commit': '', 'pr': ''}))
+tmp = dst + '.tmp'
+with open(tmp, 'w', encoding='utf-8') as f:
+    json.dump(merged, f, indent=2)
+    f.flush()
+    os.fsync(f.fileno())
+os.rename(tmp, dst)
+print('  Factory hooks configured from .claude/settings.json')
+"
+else
+    echo -e "${YELLOW}  Warning: ${SCRIPT_DIR}/.claude/settings.json not found, skipping Factory hook sync${NC}"
+fi
+
 echo ""
 echo -e "${YELLOW}Syncing Gemini skills mirror...${NC}"
 GEMINI_ENTRY_COUNT=0
@@ -1212,6 +1364,7 @@ if [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}  Would set 600 on ~/.claude/settings.json${NC}"
     echo -e "${BLUE}  Would set 700 on ~/.claude/ and ~/.claude/learning/${NC}"
     echo -e "${BLUE}  Would set 600 on ~/.claude/history.jsonl (if it exists)${NC}"
+    echo -e "${BLUE}  Would set 600 on ~/.factory/settings.json${NC}"
 else
     chmod 644 "${SCRIPT_DIR}/docs/"*.md 2>/dev/null || true
     find "${SCRIPT_DIR}/hooks" -name "*.py" -exec chmod 755 {} \; 2>/dev/null || true
@@ -1222,6 +1375,8 @@ else
     chmod 600 "$(ls -1t "${SETTINGS_FILE}.backup."* 2>/dev/null | head -1)" 2>/dev/null || true
     chmod 700 "${CLAUDE_DIR}/learning" 2>/dev/null || true
     chmod 600 "${CLAUDE_DIR}/history.jsonl" 2>/dev/null || true
+    chmod 600 "${FACTORY_DIR}/settings.json" 2>/dev/null || true
+    chmod 600 "$(ls -1t "${FACTORY_DIR}/settings.json.backup."* 2>/dev/null | head -1)" 2>/dev/null || true
 fi
 echo -e "${GREEN}✓ Permissions set${NC}"
 
@@ -1258,6 +1413,9 @@ manifest = {
     'toolkit_path': '${SCRIPT_DIR}',
     'mode': '${MODE}',
     'components': ['agents', 'skills', 'hooks', 'commands', 'scripts'],
+    'codex_components': ['skills', 'agents', 'hooks'],
+    'gemini_components': ['skills', 'agents', 'hooks'],
+    'factory_components': ['skills', 'droids', 'hooks'],
 }
 json.dump(manifest, open('${CLAUDE_DIR}/.install-manifest.json', 'w'), indent=2)
 print('  Install manifest written to ~/.claude/.install-manifest.json')
@@ -1292,6 +1450,9 @@ echo "  • Codex hooks: ${CODEX_HOOK_COUNT} mirrored entries in ~/.codex/hooks"
 echo "  • Gemini skills: ${GEMINI_ENTRY_COUNT} mirrored entries in ~/.gemini/skills"
 echo "  • Gemini agents: ${GEMINI_AGENT_COUNT} mirrored entries in ~/.gemini/agents"
 echo "  • Gemini hooks: ${GEMINI_HOOK_COUNT} mirrored entries in ~/.gemini/hooks"
+echo "  • Factory skills: ${FACTORY_SKILL_COUNT} mirrored entries in ~/.factory/skills"
+echo "  • Factory droids: ${FACTORY_DROID_COUNT} mirrored entries in ~/.factory/droids"
+echo "  • Factory hooks: ${FACTORY_HOOK_COUNT} mirrored entries in ~/.factory/hooks"
 echo "  • Hooks: ${HOOK_COUNT} automation hooks"
 echo "  • Commands: ${COMMAND_COUNT} slash commands"
 echo "  • Scripts: ${SCRIPT_COUNT} utility scripts"


### PR DESCRIPTION
## Summary

Promote Factory CLI to a first-class peer in `install.sh` alongside Claude Code, Codex CLI, and Gemini CLI. Follows the Gemini support pattern from #560.

## Approach: Runtime compatibility shim, not install-time patching

Factory uses Claude Code's hook schema with three field-name differences:
- `tool_result` → `tool_response`
- `output` → `stdout`
- `is_error` → `exitCode != 0`

Rather than patching hook files when installing for Factory, this PR adds four helpers to `hooks/lib/hook_utils.py` that accept both schemas:
- `get_tool_result(event)`
- `get_tool_output(result)`
- `get_tool_error(result)`
- `is_tool_error(result)`

The same hook source now works under all four CLIs. `~/.factory/hooks/` can symlink to the repo just like `~/.claude/hooks/` does — no in-place mutation required.

## Changes

- **`hooks/lib/hook_utils.py`**: 4 schema helpers added
- **9 production hooks migrated** to use the shim: `error-learner`, `posttool-rename-sweep`, `posttool-security-scan`, `record-activation`, `record-waste`, `retro-graduation-gate`, `review-capture`, `routing-gap-recorder`, `sql-injection-detector`
- **3 hook test files parametrized** to verify behavior under both schemas (24 new test cases)
- **`install.sh`** (+163 lines): Factory install + uninstall blocks. Only structural differences from Codex are `droids/` directory name and `$HOME/.claude/` → `$HOME/.factory/` path rewriting in settings.json
- **README.md, docs/QUICKSTART.md, docs/start-here.md**: document Factory alongside the other supported CLIs

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] 82 hook tests passing (17 new schema-shim tests, 24 parametrized cases under both schemas)
- [x] `bash install.sh --symlink --force` populates `~/.factory/{skills,droids,hooks,commands,scripts,settings.json}`
- [x] Symlink mode: `~/.factory/hooks/` points at repo (verified shim works without in-place patching)
- [x] `~/.factory/settings.json` has hook command paths rewritten to `$HOME/.factory/`, mode 600
- [x] `bash install.sh --uninstall` removes Factory components and archives `settings.json`
- [x] Reinstall after uninstall produces a working tree

## Out of scope

- Factory hooks allowlist (mirrors all hooks, same as Claude)
- Generic CLI loop refactor in install.sh
- Codex-style minimum-version warning for Factory CLI