### PR TITLE
feat: route pipeline content checks through content-check.py

### DIFF
--- a/skills/workflow/references/voice-writer.md
+++ b/skills/workflow/references/voice-writer.md
@@ -245,6 +245,13 @@ See `references/joy-check-rubric.md` for the full rubric table, scoring system, 
 
 Voice validation checks stylistic fidelity. Joy-check checks tonal framing. Neither catches AI tells: emotional flatline ("This is the part I find most interesting"), false concessions, synonym cycling, puffery, dangling -ing clauses, or reasoning chain artifacts. The anti-AI editor has 14 detection categories with regex patterns and LLM analysis that catch patterns invisible to the other gates. This phase is not optional.
 
+**Step 0: Deterministic pattern scan** (MANDATORY — run before LLM scan)
+
+Run `python3 ~/vexjoy/scripts/content-check.py <draft-file> --strict`
+
+Score must be ≤ 5. If non-zero findings, fix each one before proceeding.
+This catches every regex-matchable pattern from detection-patterns.md, voice-guide.md, and pre-publish rules.
+
 **Step 1: Invoke the anti-AI editor skill**
 
 The anti-AI editor is a **skill**, not a script. Do not attempt to run `scripts/anti-ai-editor.py` (it does not exist). Invoke the skill by dispatching an agent with the `anti-ai-editor` skill, or by reading `skills/anti-ai-editor/SKILL.md` and following its ASSESS phase against the draft content.

--- a/skills/workflow/references/voice-writer/references/generation-checklist.md
+++ b/skills/workflow/references/voice-writer/references/generation-checklist.md
@@ -38,6 +38,12 @@ If the voice skill has no `## Architectural Patterns` section, skip this step en
 
 NEVER generate em-dashes in any voice output. Em-dashes are the most reliable AI marker. Use commas, periods, or restructure sentences instead.
 
+**Verification command** (run after generation, before validation):
+```bash
+python3 ~/vexjoy/scripts/content-check.py /tmp/voice-content-draft.md --strict
+```
+Result must show score ≤ 5. This covers em-dashes plus all other deterministic checks.
+
 This applies to all voices, all modes, all content types. No exceptions.
 
 ---


### PR DESCRIPTION
## Summary

- **voice-writer.md** — Phase 7 now begins with a mandatory Step 0 that runs `content-check.py --strict` before the LLM-based anti-AI editor scan. This catches every regex-matchable AI tell deterministically.
- **generation-checklist.md** — Em-dash verification command updated from inline grep to the full `content-check.py --strict` invocation, covering em-dashes plus all other deterministic checks.

Implements the toolkit philosophy "Everything That Can Be Deterministic, Should Be" by replacing fragile inline bash grep commands with a single maintained script.

## Test plan

- [ ] Verify `content-check.py --strict` runs correctly against a sample draft
- [ ] Confirm voice-writer Phase 7 Step 0 references the correct script path
- [ ] Confirm generation-checklist verification command matches the script invocation