### PR TITLE
refactor: condense /do router from 4,649 to 2,788 words

### DIFF
--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -22,60 +22,48 @@ routing:
 
 # /do - Smart Router
 
-/do is a **ROUTER**, not a worker. Its ONLY job is to classify requests, select the right agent + skill, and dispatch. It delegates all execution, implementation, debugging, review, and fixes to specialized agents.
+/do is a **ROUTER**, not a worker. Classify requests, select the right agent + skill, dispatch. All execution goes to specialized agents.
 
-**What the main thread does:** (1) Classify, (2) Select agent+skill, (3) Dispatch via Agent tool, (4) Evaluate if more work needed, (5) Route to ANOTHER agent if yes, (6) Report results.
+**Main thread:** (1) Classify, (2) Select agent+skill, (3) Dispatch, (4) Evaluate, (5) Route again if needed, (6) Report.
 
-**The main thread delegates to agents:** code reading (Explore agent), file edits (domain agents), test runs (agent with skill), documentation (technical-documentation-engineer), all Simple+ tasks.
-
-The main thread is an **orchestrator**. If you find yourself reading source code, writing code, or doing analysis — pause and route to an agent instead.
+If you find yourself reading source code, writing code, or doing analysis — pause and route to an agent.
 
 ---
 
 ## The Completeness Standard
 
-The marginal cost of completeness is near zero. Do the whole thing. Do it right. Do it with tests. Do it with documentation. Do it so well that the user is genuinely impressed.
+Do the whole thing. Do it right. Do it with tests. Do it with documentation.
 
-This is not aspirational. It is the execution standard for every agent dispatched through /do. It derives from the toolkit's core principle (docs/PHILOSOPHY.md: "Tokens Are Expensive, Use Progressive Context") and extends it: spending tokens on thoroughness is not just acceptable, it is required.
+- The answer is the finished product, not a plan. Plans organize execution, not replace it.
+- Never table work when the permanent solve is within reach. Never present a workaround when the real fix exists.
+- If an agent returns partial work, route a follow-up to finish it.
+- Search before building. Test before shipping.
+- The router decomposes complexity into agent-sized work. Use it.
 
-**What this means for routing and dispatch:**
+**The standard:** the result should make the user think "that's done" not "that's a start." Inject this into agent prompts for all Simple+ work.
 
-- When asked for something, the answer is the finished product, not a plan to build it. Plans exist to organize execution, not to replace it.
-- Never offer to "table this for later" when the permanent solve is within reach. Never present a workaround when the real fix exists. Never leave a dangling thread when tying it off takes five more minutes of agent time.
-- Do not truncate output or stop mid-task. Dispatch agents that deliver complete, executable solutions. If an agent returns partial work, route a follow-up agent to finish it.
-- Search before building. Test before shipping. Ship the complete thing.
-- Time is not an excuse. Complexity is not an excuse. The router exists to decompose complexity into agent-sized work. Use it.
-
-**The standard for every dispatched agent:** the result should make the user think "that's done" not "that's a start." Inject this expectation into agent prompts for all Simple+ work.
-
-When the model feels confident handling a task directly, treat that confidence as a signal to route, not a signal to proceed. Direct handling skips the agent's domain knowledge, the skill's methodology, and the agent's reference files — each of which exists because prior work put expertise on disk that the main thread does not have.
+Model confidence in handling a task directly is a signal to route, not to proceed. Direct handling skips domain knowledge, methodology, and reference files that exist on disk.
 
 ---
 
 ## Output Discipline
 
-Say more with fewer words. Every sentence the router prints is a sentence the user reads before seeing results.
+Every sentence the router prints is a sentence the user reads before seeing results.
 
-**Orwell's Six Rules** apply to all output from this router and every agent it dispatches. From George Orwell, "Politics and the English Language" (1946):
+**Orwell's Six Rules** (1946) apply to all output and all agent prompts:
 
-1. Never use a metaphor, simile, or figure of speech you are accustomed to seeing in print.
-2. Never use a long word where a short one will do.
-3. If it is possible to cut a word out, always cut it out.
-4. Never use the passive where you can use the active.
-5. Never use a foreign phrase, a scientific word, or a jargon word if you can think of an everyday English equivalent.
-6. Break any of these rules sooner than say anything outright barbarous.
+1. No stale metaphors or figures of speech.
+2. Short words over long.
+3. Cut every word you can.
+4. Active voice over passive.
+5. Everyday English over jargon.
+6. Break any rule sooner than say anything barbarous.
 
-Clear language proves understanding. Jargon proves the opposite. If output sounds like a committee wrote it, rewrite it until it sounds like a person who knows the subject wrote it.
+These rules apply equally to agent prompts. Every word in a dispatched prompt costs tokens on that agent's context window.
 
-**What the user sees:**
-- Phase banners — always shown, they orient the reader
-- The routing decision banner — always shown, it explains the dispatch
-- A brief summary after each agent completes — what changed, not how
+**User sees:** phase banners, routing decision banner, brief post-agent summary (what changed, not how).
 
-**What stays internal:**
-- Haiku routing agent responses — consumed by the router, never printed
-- Classification reasoning
-- Enhancement stacking details (unless Verbose Routing is ON)
+**Internal only:** Haiku routing responses, classification reasoning, enhancement stacking details (unless Verbose Routing ON).
 
 ---
 
@@ -102,50 +90,44 @@ Read and follow the repository CLAUDE.md before making any routing decision, bec
 | Medium | **Required** | **Required** | Route to agent |
 | Complex | Required (2+) | Required (2+) | Route to agent |
 
-**Trivial = reading a file the user named by exact path.** Everything else is Simple+ and MUST use an agent, skill, or pipeline. When uncertain, classify UP not down. Routing up finds the agent who ships it complete; tokens are cheap, and an agent that actually ships is what the user came for.
+**Trivial = reading a file the user named by exact path.** Everything else is Simple+ and MUST route. When uncertain, classify UP.
 
-**Opus 4.7 override:** Opus 4.7 defaults to fewer subagents and more direct handling. That default is correct for ad-hoc prompting; it is wrong here. The /do router is a delegation machine by design. Do not apply the model's default judiciousness. Classify Simple+ tasks to agents without reasoning about whether you could handle them directly. If a task is reading a file the user named by exact path, it is Trivial; if it is anything else — including tasks the model feels capable of handling in one response — it is Simple+ and MUST route.
+**Opus 4.7 override:** The model defaults to fewer subagents and more direct handling. That default is wrong here. /do is a delegation machine. Classify Simple+ tasks to agents without reasoning about whether you could handle them directly. Anything beyond reading a user-named file MUST route.
 
-**Progressive Depth**: For requests where complexity is ambiguous, consider starting at a shallower depth and allowing the agent to escalate. See `references/progressive-depth.md` for the escalation protocol and signal format.
+**Progressive Depth**: For ambiguous complexity, start shallow and let the agent escalate. See `references/progressive-depth.md`.
 
-**Common misclassifications** (these are NOT Trivial — route them): evaluating repos/URLs, any opinion/recommendation, git operations, codebase questions (`explore-pipeline`), retro lookups (`retro` skill), comparing approaches.
+**Common misclassifications** (NOT Trivial — route them): evaluating repos/URLs, opinions/recommendations, git operations, codebase questions (`explore-pipeline`), retro lookups (`retro`), comparing approaches.
 
-**Maximize skill/agent/pipeline usage.** If a skill or pipeline exists for the task, USE IT. Skills encode domain patterns earned through prior work; using them gives you that expertise for free.
+**Maximize skill/agent/pipeline usage.** If a skill exists for the task, USE IT.
 
-**Check for parallel patterns FIRST** because independent work items finish fastest when dispatched concurrently, and the routing table below matches the shape of the work: 2+ independent failures or 3+ subtasks → `dispatching-parallel-agents`; broad research → `research-coordinator-engineer`; multi-agent coordination → `project-coordinator-engineer`; plan exists + "execute" → `subagent-driven-development`; new feature → `feature-lifecycle` (check `.feature/` directory; if present, use `feature-state.py status` for current phase).
+**Check for parallel patterns FIRST**: 2+ independent failures or 3+ subtasks → `dispatching-parallel-agents`; broad research → `research-coordinator-engineer`; multi-agent coordination → `project-coordinator-engineer`; plan + "execute" → `subagent-driven-development`; new feature → `feature-lifecycle` (check `.feature/` directory; if present, run `feature-state.py status`).
 
-**Opus 4.7 override:** Opus 4.7 is more judicious about spawning subagents by default. When the router detects 2+ independent items, dispatch all agents in parallel in a single message. Do not consolidate independent items into a single agent dispatch to "save subagent spawns" — that consolidation is the model's default under Opus 4.7 and it is wrong for this router.
+**Opus 4.7 parallel override:** When the router detects 2+ independent items, dispatch all in parallel in a single message. Do not consolidate into one agent — that is the model's default and it is wrong here.
 
-**Optional: Force Direct** — OFF by default. When explicitly enabled, overrides routing for trivial operations. Only applies when the user explicitly requests it.
+**Optional: Force Direct** — OFF by default. Only applies when user explicitly requests it.
 
 **Creation Request Detection** (MANDATORY scan before Gate):
 
-Scan the request for creation signals before completing Phase 1:
-- Explicit creation verbs: "create", "scaffold", "build", "add new", "new [component]", "implement new"
-- Domain object targets: agent, skill, pipeline, hook, feature, plugin, workflow, voice profile
-- Implicit creation: "I need a [component]", "we need a [component]", "build me a [component]"
+Scan for creation signals:
+- Verbs: "create", "scaffold", "build", "add new", "new [component]", "implement new"
+- Targets: agent, skill, pipeline, hook, feature, plugin, workflow, voice profile
+- Implicit: "I need a [component]", "build me a [component]"
 
-If ANY creation signal is found AND complexity is Simple+:
-1. Set an internal flag: `is_creation = true`
-2. **Phase 4 Step 0 is MANDATORY** — write ADR before dispatching any agent
+If ANY creation signal found AND complexity Simple+: set `is_creation = true`, Phase 4 Step 0 is MANDATORY (write ADR before dispatching).
 
-This early detection ensures Phase 4 Step 0 fires reliably by catching the signal before Phase 2's routing work begins. The Gate below locks in the acknowledgment before moving on.
+**Not creation**: debugging, reviewing, fixing, refactoring, explaining, auditing existing components. When ambiguous, check whether output is a NEW file.
 
-**Not a creation request**: debugging, reviewing, fixing, refactoring, explaining, running, checking, auditing existing components. When ambiguous, check whether the output would be a NEW file that doesn't yet exist.
-
-**Gate**: Complexity classified. If a creation signal was detected, output `[CREATION REQUEST DETECTED]` before displaying the routing banner. This tag is a routing signal emitted by `/do` itself (not by a hook); it announces that Phase 4 Step 0 will fire before any agent dispatch. Downstream steps read the tag as confirmation, not as an instruction to re-route. Display routing banner (ALL classifications). If not Trivial, proceed to Phase 2. If Trivial, handle directly after showing banner.
+**Gate**: Complexity classified. If creation detected, output `[CREATION REQUEST DETECTED]` before routing banner. Display banner (ALL classifications). Trivial: handle directly. Simple+: proceed to Phase 2.
 
 ---
 
 ### Phase 2: ROUTE
 
-**Goal**: Select the correct agent + skill combination via the Haiku routing agent.
-
-All routing goes through a single Haiku agent dispatch. The manifest includes `FORCE`-labeled entries that the Haiku agent must prefer when intent matches — but matching is semantic, not keyword-based. This replaced the prior two-tier system (deterministic keyword check + LLM fallback) after A/B testing showed Haiku-only scored 10/10 vs 9/10 for the two-tier approach, with the keyword matcher producing false positives on ambiguous words (e.g. "fish for bugs" → `fish-shell-config`).
+**Goal**: Select the correct agent + skill via a single Haiku routing agent. FORCE-labeled entries are preferred when intent matches semantically (not keyword-based).
 
 **Step 1: Dispatch Haiku routing agent**
 
-Generate the routing manifest, then dispatch the Haiku agent:
+Generate the manifest, then dispatch:
 
 ```bash
 python3 scripts/routing-manifest.py
@@ -190,25 +172,17 @@ Rules:
 
 **Step 1b: Apply the Haiku agent's recommendation**
 
-Use the Haiku agent's `agent` and `skill` fields directly. If `confidence` is "low", fall back to reading INDEX files (`agents/INDEX.json`, `skills/INDEX.json`) and `references/routing-tables.md` to verify or override manually.
+Use `agent` and `skill` fields directly. If `confidence` is "low", verify against INDEX files and `references/routing-tables.md`. Haiku response is internal — never print to user.
 
-**The Haiku agent's response is internal.** Do not print its JSON or reasoning to the user. Extract the fields, apply them, move on. The routing banner is the user-facing summary.
+**Critical**: "push", "commit", "create PR", "merge" MUST route through skills with quality gates (lint, tests, CI verification).
 
-**Critical**: "push", "commit", "create PR", "merge" are NOT trivial git commands. They MUST route through skills that run quality gates. The skills bundle lint, tests, review loops, CI verification, and repo classification into the single command so the push lands cleanly.
-
-Route to the simplest agent+skill that satisfies the request. A lean routing decision keeps attention on the work itself, not on managing the routing layer.
-
-When `[cross-repo]` output is present, route to `.claude/agents/` local agents. They carry project-specific knowledge the generic agents cannot know.
-
-Route all code modifications to domain agents. Domain agents carry language-specific expertise, testing methodology, and quality gates built for that language.
+Route to the simplest agent+skill that satisfies the request. When `[cross-repo]` output is present, route to `.claude/agents/` local agents. Route all code modifications to domain agents.
 
 **Step 2: Apply skill override** (task verb overrides default skill)
 
 When the request verb implies a specific methodology, override the agent's default skill. Common overrides: "review" → systematic-code-review, "debug" → systematic-debugging, "refactor" → systematic-refactoring, "TDD" → test-driven-development. Full override table in `references/routing-tables.md`.
 
-**Step 3: Display routing decision** (MANDATORY — do this NOW, before anything else)
-
-This banner MUST be the FIRST visible output for EVERY /do invocation. Display BEFORE creating plans, BEFORE invoking agents, BEFORE any work begins. No exceptions.
+**Step 3: Display routing decision** (MANDATORY — FIRST visible output, before any work)
 
 ```
 ===================================================================
@@ -239,18 +213,15 @@ python3 ~/.claude/scripts/learning-db.py record \
     --tags "{applicable_flags}"
 ```
 
-Tags: `auto-pipeline` (as applicable), `thinking:slow` (if "think carefully" directive injected in Phase 4 Step 2), `thinking:fast` (if "respond quickly" directive injected in Phase 4 Step 2). This call is advisory — if it fails, continue.
-Valid categories: `error, pivot, review, design, debug, gotcha, effectiveness, misroute`. Use `effectiveness` for successful routing, `misroute` for reroutes.
+Tags: `thinking:slow` or `thinking:fast` (from Step 2 directive). Advisory — continue if it fails. Categories: `effectiveness` (success), `misroute` (reroutes).
 
-**Gate**: Agent and skill selected. Banner displayed. Routing decision recorded. Proceed to Phase 3.
+**Gate**: Agent+skill selected. Banner displayed. Decision recorded. Proceed to Phase 3.
 
 ---
 
 ### Phase 3: ENHANCE
 
-**Goal**: Stack additional skills based on signals in the request.
-
-If relevant retro knowledge is already present in context, use it. If it is absent, continue without spending prompt space restating hook mechanics.
+**Goal**: Stack additional skills based on request signals. Use retro knowledge if present in context.
 
 | Signal in Request | Enhancement to Add |
 |-------------------|-------------------|
@@ -262,20 +233,20 @@ If relevant retro knowledge is already present in context, use it. If it is abse
 | Complex implementation | Offer subagent-driven-development |
 | Vague verb + ambiguous object + no concrete file/symbol named + multiple plausible interpretations | `planning` (interview mode) — load `depth-first-interview.md` |
 
-**Interview-mode signal heuristic.** The interview-mode row fires when the request shape suggests the user is uncertain about decisions, not just unclear about scope. Concrete shape: short request (typically <15 words), verb in `{build, design, make, fix, figure out, set up}`, object is a noun without a file/symbol/path qualifier, no acceptance criteria stated. Document the heuristic with example match/non-match pairs to bound false-positive rate:
+**Interview-mode heuristic.** Fires when: short request (<15 words), verb in `{build, design, make, fix, figure out, set up}`, object has no file/symbol/path qualifier, no acceptance criteria.
 
 | Example | Match? | Why |
 |---|---|---|
-| "i'm not sure how to approach this complex build" | MATCH | Uncertainty signal + vague verb (`approach`) + ambiguous object (`this complex build`) + no concrete target. |
-| "fix the typo on line 42 of foo.py" | NON-MATCH | Concrete file (`foo.py`), concrete location (`line 42`), unambiguous verb (`fix the typo`). |
-| "build a thing that does X" | MATCH | Vague verb (`build`), ambiguous object (`a thing`), no file or symbol named, no acceptance criteria. |
-| "add a test for `parseConfig` in src/config.go" | NON-MATCH | Concrete symbol (`parseConfig`), concrete file (`src/config.go`), unambiguous verb (`add a test`). |
-| "where do i even start with this rewrite" | MATCH | Explicit uncertainty trigger (`where do i even start`), no concrete subject of the rewrite named. |
-| "rename `cfg` to `config` in `internal/`" | NON-MATCH | Concrete symbol, concrete directory, unambiguous mechanical operation. |
+| "i'm not sure how to approach this complex build" | MATCH | Uncertainty + vague verb + no concrete target |
+| "fix the typo on line 42 of foo.py" | NO | Concrete file, location, verb |
+| "build a thing that does X" | MATCH | Vague verb + ambiguous object + no file named |
+| "add a test for `parseConfig` in src/config.go" | NO | Concrete symbol + file + verb |
+| "where do i even start with this rewrite" | MATCH | Explicit uncertainty, no concrete subject |
+| "rename `cfg` to `config` in `internal/`" | NO | Concrete symbol + directory + mechanical op |
 
-When in doubt, defer injection. The manual `/quick --interview` flag and the explicit phrase triggers cover deliberate cases. False positives on auto-injection cost the user one round of friction (Phase 0 opt-out question), while false negatives are fully recoverable through the manual paths.
+When in doubt, defer injection. False positives cost one round of friction; false negatives are recoverable via `/quick --interview`.
 
-Before stacking any enhancement, check the target skill's `pairs_with` field in `skills/INDEX.json`. Skills that declare `pairs_with` list their compatible companions — prefer stacking with listed pairs. An empty `pairs_with: []` means pairings have not been declared yet, not that stacking is prohibited. Skills with built-in verification gates (like `quick --trivial`) handle their own testing and may not benefit from additional stacking. Use judgment based on the skill's documentation.
+Before stacking, check `pairs_with` in `skills/INDEX.json`. Prefer listed pairs. Empty `pairs_with: []` means undeclared, not prohibited. Skills with built-in verification gates may not benefit from stacking.
 
 Add anti-rationalization patterns for these task types when the task benefits from explicit rigor:
 
@@ -298,93 +269,84 @@ For explicit maximum rigor, use `/with-anti-rationalization [task]`.
 
 **Goal**: Invoke the selected agent + skill and deliver results.
 
-**Step 0: Execute Creation Protocol** (for creation requests ONLY)
+**Step 0: Execute Creation Protocol** (creation requests ONLY)
 
-If request contains "create", "new", "scaffold", "build pipeline/agent/skill/hook" AND complexity is Simple+, automatically sequence: (1) Write ADR at `adr/{kebab-case-name}.md`, (2) Register via `adr-query.py register`, (3) Proceed to plan creation. The `adr-context-injector` and `adr-enforcement` hooks handle cross-agent ADR compliance automatically. This protocol fires automatically because creation requests at Simple+ complexity need architectural grounding before implementation begins.
+If creation signal + Simple+: (1) Write ADR at `adr/{kebab-case-name}.md`, (2) Register via `adr-query.py register`, (3) Proceed to plan. ADR hooks (`adr-context-injector`, `adr-enforcement`) handle cross-agent compliance automatically.
 
-**Step 1: Create plan** (for Simple+ complexity)
+**Step 1: Create plan** (Simple+)
 
-Create `task_plan.md` before execution, because a plan turns the next N turns into progress instead of rework. Skip only for Trivial tasks.
+Create `task_plan.md` before execution. Skip for Trivial only.
 
-**Step 1b: Apply quality-loop pipeline** (for Medium+ code modifications)
+**Step 1b: Apply quality-loop pipeline** (Medium+ code modifications)
 
-When the request is a code modification (implementation, bug fix, feature addition, refactoring) at Medium or Complex complexity, load `references/quality-loop.md` and use it as the **outer orchestration wrapper** around Step 2. The quality-loop and the agent+skill are complementary layers, not alternatives:
+For code modifications at Medium/Complex, load `references/quality-loop.md` as the **outer orchestration wrapper**:
 
-- **Quality-loop** (outer) = the full 14-phase lifecycle: ADR → PLAN → IMPLEMENT → TEST → REVIEW → INTENT VERIFY → LIVE VALIDATE → FIX → RETEST → PR → CODEX REVIEW → ADR RECONCILE → RECORD → CLEANUP
-- **Agent + skill** (inner) = the domain expertise used inside PHASE 2 (IMPLEMENT)
+- **Quality-loop** (outer) = 14-phase lifecycle: ADR → PLAN → IMPLEMENT → TEST → REVIEW → INTENT VERIFY → LIVE VALIDATE → FIX → RETEST → PR → CODEX REVIEW → ADR RECONCILE → RECORD → CLEANUP
+- **Agent + skill** (inner) = domain expertise inside IMPLEMENT phase
 
-When quality-loop applies, it absorbs Step 0 (ADR creation) and Step 1 (plan creation) into its own PHASES 0-1. Do not run Steps 0-1 separately — the quality-loop handles them.
+Quality-loop absorbs Steps 0-1. The Phase 2 agent+skill selection becomes the implementation agent. Force-route skills are used INSIDE the loop.
 
-The router still selects the best agent+skill in Phase 2 (e.g., `golang-general-engineer` + `go-patterns`). That selection becomes the implementation agent for quality-loop PHASE 1. Force-route skills like `go-patterns` are used INSIDE the loop, not excluded from it — a Go implementation gets Go-specific patterns AND testing, review, and PR gates.
-
-The quality-loop does NOT apply when:
-- Complexity is Trivial or Simple (use quick or quick --trivial instead)
-- The task is review-only, research, debugging, or content creation
-- The user explicitly requests a simpler flow
+Does NOT apply when: Trivial/Simple (use `quick`), review-only/research/debugging/content creation, or user requests simpler flow.
 
 **Step 2: Invoke agent with skill**
 
-Dispatch the agent. MCP tool discovery is the agent's responsibility — each agent's markdown declares which MCP tools it needs. Do not inject MCP instructions from /do.
+Dispatch the agent. MCP tool discovery is the agent's responsibility — do not inject MCP instructions from /do.
 
-**Opus 4.7 override: Prepend first-turn Task Specification block for Medium+ tasks.** Opus 4.7 benefits most from well-specified first-turn task descriptions. The router has upstream context the dispatched agent does not (memory feedback, operator profile, CLAUDE.md files) — enrich the first turn rather than passing the user request verbatim. For Medium+ tasks, compose and prepend this block to the dispatched agent's prompt. For Simple tasks, include Intent and Acceptance criteria if extractable; otherwise skip the block. Do not invent acceptance criteria the user did not imply. Do not expand task scope beyond the user request.
+**Opus 4.7: Prepend Task Specification for Medium+ tasks.** The router has upstream context the agent lacks. Compose and prepend this block. For Simple tasks, include Intent and Acceptance if extractable. Do not invent criteria or expand scope.
 
 ```
 ## Task Specification (auto-extracted)
 
 **Intent:** <one sentence: what does success look like?>
-**Constraints:** <inferred: branch rules, operator-context profile, file paths user named, memory feedback that applies>
-**Acceptance criteria:** <observable: tests pass, file exists, PR merges, specific output produced>
-**Relevant file locations:** <paths extracted from the request, paths the domain agent is expected to touch>
-**Operator context:** <profile from [operator-context] tag>
+**Constraints:** <branch rules, operator-context, file paths, memory feedback>
+**Acceptance criteria:** <observable: tests pass, file exists, PR merges, specific output>
+**Relevant file locations:** <paths from request + expected paths>
+**Operator context:** <from [operator-context] tag>
 ```
 
-Extraction rules: Intent from the request's verb and object (one sentence, not a paraphrase). Constraints include branch-safety rules (never merge to main), memory feedback matching the domain, and operator-context profile implications. Acceptance criteria are observable: what files change, what command proves it works, what output the user specified. For creation requests, add to Constraints: "Implementation must match ADR `<kebab-case-name>`." This preamble is input to agent planning, not a replacement for task_plan.md.
+Extraction: Intent from verb+object. Constraints include branch safety (never merge to main), memory feedback, operator context. Acceptance = observable outcomes. For creation requests, add "Implementation must match ADR `<kebab-case-name>`."
 
-**MANDATORY: Inject reference loading instruction for ALL dispatched agents.** Every agent prompt MUST include: "Before starting work, read your agent .md file or skill SKILL.md to find the Reference Loading Table. Load EVERY reference file whose signal matches this task. Load greedily, not conservatively. If multiple signals match, load all matching references. Reference files contain domain-specific patterns, anti-patterns, code examples, and detection commands that make your output expert-quality. Loading these files gives you domain expertise that prior work already put on disk, earned and waiting for you to use." This applies to ALL agents and skills, not just umbrella components. The nightly enrichment pipeline generates and updates reference files autonomously, so loading the table is how a dispatched agent inherits the domain knowledge created specifically for its work.
+**MANDATORY: Inject reference loading instruction for ALL dispatched agents.** Every agent prompt MUST include: "Before starting work, read your agent .md file to find the Reference Loading Table. Load EVERY reference file whose signal matches this task. Load greedily — if multiple signals match, load all matching references."
 
-**MANDATORY: Inject the completeness standard for ALL Simple+ dispatches.** Every agent prompt MUST include: "Deliver the finished product, not a plan. Do not offer to table work for later when the solve is within reach. Do not present workarounds when the real fix exists. Do not stop mid-task or truncate output. Search before building. Test before shipping. Ship the complete thing."
+**MANDATORY: Inject the completeness standard for ALL Simple+ dispatches.** Every agent prompt MUST include: "Deliver the finished product. Ship the complete thing."
 
-**Opus 4.7 override: Inject complexity-calibrated thinking directive.** Opus 4.7 exposes thinking rate to prompt-level control. Prepend the appropriate directive to the dispatched agent's prompt as a single sentence (verbatim, no framing), because calibrating thinking rate per task class reduces both over-reasoning on simple work and under-reasoning on complex work:
+**Opus 4.7: Inject thinking directive.** Prepend verbatim, no framing:
 
 | Complexity | Thinking Directive |
 |---|---|
-| Trivial | None (handled directly, no agent dispatched) |
+| Trivial | None (no agent) |
 | Simple | "Prioritize responding quickly rather than thinking deeply. When in doubt, respond directly." |
-| Medium | None (let adaptive thinking decide) |
+| Medium | None (adaptive) |
 | Complex | "Think carefully and step-by-step before responding; this problem is harder than it looks." |
 
-Category overrides (regardless of complexity class). Always inject "Think carefully and step-by-step before responding; this problem is harder than it looks." for: security work (threat modeling, vulnerability analysis, auth changes), API or schema design, migrations (data, code, legacy systems), code review spanning 5+ files, architectural decisions (ADR writing, design proposals). Always inject "Prioritize responding quickly rather than thinking deeply. When in doubt, respond directly." for: lookups with clear answers (what file contains X, what commit did Y), status checks (is CI green, is the PR mergeable), simple renames or straightforward refactors inside a single function.
+**Category overrides** (regardless of complexity): `thinking:slow` for security work, API/schema design, migrations, 5+ file reviews, architectural decisions. `thinking:fast` for lookups, status checks, single-function renames/refactors.
 
-Record the injected directive in the Phase 2 Step 4 `--tags` field as `thinking:slow` (for "think carefully") or `thinking:fast` (for "respond quickly"), so the learning-db can correlate dispatch outcome with thinking-rate choice.
+Record as `thinking:slow` or `thinking:fast` in Phase 2 Step 4 `--tags`.
 
-**Verb-based model dispatch for Complex tasks.** When the task verb indicates data extraction rather than analysis, the coordinator dispatches parallel Haiku readers instead of a single Opus agent. This is 38% cheaper and 23% faster with equivalent quality for extraction tasks (A/B tested, blind-reviewed).
+**Verb-based model dispatch for Complex tasks (3+ data sources).** Extraction verbs use parallel Haiku readers; analysis verbs use single Opus agent (38% cheaper, 23% faster for extraction — A/B tested).
 
-| Task verb class | Dispatch mode | Rationale |
-|---|---|---|
-| list, count, extract, inventory, search, check, find, grep | Parallel Haiku readers → Opus synthesizer | Structured extraction. Haiku matches quality. 5x cheaper per token. |
-| review, audit, assess, analyze, debug, investigate, evaluate | Single Opus agent (direct) | Requires semantic reasoning. Haiku misses silent failures. |
+| Task verb class | Dispatch mode |
+|---|---|
+| list, count, extract, inventory, search, check, find, grep | Parallel Haiku readers → Opus synthesizer |
+| review, audit, assess, analyze, debug, investigate, evaluate | Single Opus agent (direct) |
 
-To dispatch Haiku readers: for each file or data source, spawn an Agent with `model: "haiku"` and a directed prompt ("read file X, return: [specific fields]"). Collect all results, then dispatch the synthesis agent with only the extracts. The synthesis agent never sees raw file contents.
+Haiku dispatch: spawn Agent with `model: "haiku"` per data source, collect extracts, synthesize with Opus. Simple/Medium: dispatch directly.
 
-This applies to Complex tasks with 3+ data sources. For Simple/Medium tasks, dispatch directly — the overhead of parallel readers outweighs the savings.
+Route to agents that create feature branches. Include "commit your changes on the branch" in agent prompts for file modifications.
 
-Route to agents that create feature branches for all commits. Feature branches isolate the change so it ships cleanly after review, and the branch itself becomes the unit of review and revert.
+For `isolation: "worktree"` agents, inject `worktree-agent` skill rules: "Verify CWD contains .claude/worktrees/. Create feature branch before edits. Skip task_plan.md. Stage specific files only."
 
-When dispatching agents for file modifications, explicitly include "commit your changes on the branch" in the agent prompt. That instruction closes the loop so the orchestrator sees the committed work and moves forward with it as the authoritative state.
-
-When dispatching agents with `isolation: "worktree"`, inject the `worktree-agent` skill rules into the agent prompt. The skill at `skills/worktree-agent/SKILL.md` contains mandatory rules that prevent worktree isolation failures (leaked changes, branch confusion, auto-plan hook interference). At minimum include: "Verify your CWD contains .claude/worktrees/. Create feature branch before edits. Skip task_plan.md creation (handled by orchestrator). Stage specific files only."
-
-For repos without organization-gated workflows, run up to 3 iterations of `/pr-review` → fix before creating a PR, because pre-merge review lets you land once and move on. For repos under protected organizations (via `scripts/classify-repo.py`), require user confirmation before EACH git action. Confirm before executing or merging so the organization's compliance requirements get the explicit approval they exist to capture.
+Non-org repos: up to 3 iterations of `/pr-review` → fix before PR creation. Org-gated repos (via `scripts/classify-repo.py`): require user confirmation before EACH git action.
 
 **Step 3: Handle multi-part requests**
 
 Detect: "first...then", "and also", numbered lists, semicolons. Sequential dependencies execute in order. Independent items launch multiple Task tools in single message. Max parallelism: 10 agents.
 
-**Step 4: Auto-Pipeline Fallback** (when no agent/skill matches AND complexity >= Simple)
+**Step 4: Auto-Pipeline Fallback** (no match AND complexity >= Simple)
 
-Always invoke `auto-pipeline` for unmatched requests. Every unmatched request is a new routing pattern to capture, and the pipeline picks up the work while the gap gets recorded. If no pipeline matches either, fall back to closest agent + verification-before-completion.
+Invoke `auto-pipeline` for unmatched requests. If no pipeline matches, fall back to closest agent + verification-before-completion.
 
-When uncertain which route: **ROUTE ANYWAY.** Add verification-before-completion as safety net. Routing up finds the right agent and gives the work a home; routing down leaves the main thread improvising in isolation.
+When uncertain: **ROUTE ANYWAY** with verification-before-completion as safety net.
 
 **Gate**: Agent invoked, results delivered. Proceed to Phase 5.
 
@@ -392,9 +354,9 @@ When uncertain which route: **ROUTE ANYWAY.** Add verification-before-completion
 
 ### Phase 5: LEARN
 
-**Goal**: Ensure session insights are captured to `learning.db`.
+**Goal**: Capture session insights to `learning.db`.
 
-**Routing outcome recording** (Simple+ tasks, observable facts only — no self-grading):
+**Routing outcome** (Simple+, observable facts only):
 ```bash
 python3 ~/.claude/scripts/learning-db.py record \
     routing "{selected_agent}:{selected_skill}" \
@@ -402,20 +364,17 @@ python3 ~/.claude/scripts/learning-db.py record \
     --category effectiveness
 ```
 
-Record only observable facts (tool_errors, user_rerouted). Routing outcome quality is measured by user reroutes, not self-assessment.
+**Auto-capture** (hooks, zero LLM cost): `error-learner.py`, `review-capture.py` (PostToolUse), `session-learning-recorder.py` (Stop).
 
-**Auto-capture** (hooks, zero LLM cost): `error-learner.py` (PostToolUse), `review-capture.py` (PostToolUse), `session-learning-recorder.py` (Stop).
-
-**Skill-scoped recording** (preferred — one-liner):
+**Skill-scoped recording**:
 ```bash
-python3 ~/.claude/scripts/learning-db.py learn --skill go-patterns "insight about testing"
-python3 ~/.claude/scripts/learning-db.py learn --agent golang-general-engineer "insight about agent"
-python3 ~/.claude/scripts/learning-db.py learn "general insight without scope"
+python3 ~/.claude/scripts/learning-db.py learn --skill go-patterns "insight"
+python3 ~/.claude/scripts/learning-db.py learn --agent golang-general-engineer "insight"
 ```
 
-**Immediate graduation for review findings** (MANDATORY): When a review finds an issue and it gets fixed in the same PR: (1) Record scoped to responsible agent/skill, (2) Boost to 1.0, (3) Embed into agent anti-patterns, (4) Graduate, (5) Stage changes in same PR. One cycle — no waiting for "multiple observations."
+**Immediate graduation for review findings** (MANDATORY): Issue found + fixed in same PR → (1) Record scoped, (2) Boost to 1.0, (3) Embed into anti-patterns, (4) Graduate, (5) Stage in same PR.
 
-**Gate**: After Simple+ tasks, record at least one learning via `learn`. Review findings get immediate graduation.
+**Gate**: Record at least one learning for Simple+ tasks. Review findings get immediate graduation.
 
 ---
 


### PR DESCRIPTION
## Summary
- Condensed two MANDATORY injection texts that every dispatched agent receives: reference loading injection (~80 → ~30 words), completeness standard (~40 → ~10 words)
- Added density principle to Output Discipline: "These rules apply equally to agent prompts. Every word in a dispatched prompt costs tokens on that agent's context window."
- Full condense pass on entire SKILL.md applying condense skill rules: cut redundant restatements, motivational framing, filler phrases, and multi-angle paragraphs

Result: 4,649 → 2,788 words (40% reduction). Every instruction, gate, phase, command, table, code block, and reference preserved. YAML frontmatter unchanged.

## Why this matters
The /do SKILL.md loads on every routed request. The two MANDATORY injection texts copy into every dispatched agent's prompt. Every word cut saves tokens on every dispatch — this is the highest-leverage condensation target in the toolkit.

## Validation
- `python3 scripts/check-routing-drift.py` — pass
- YAML frontmatter parses — verified
- All key terms present (phases, gates, commands, references) — verified via grep
- `ruff check` — pass

## Test plan
- [ ] Verify /do routing still classifies and dispatches correctly
- [ ] Verify dispatched agents still receive reference loading and completeness instructions
- [ ] Spot-check that no instructions were lost by comparing before/after