### PR TITLE
feat: add information density principle to all enforcement layers

### DIFF
--- a/AGENT_TEMPLATE_V2.md
+++ b/AGENT_TEMPLATE_V2.md
@@ -152,11 +152,9 @@ This agent operates as an operator for [domain/function], configuring Claude's b
 
 ### Default Behaviors (ON unless disabled)
 - **Communication Style**:
-  - Fact-based progress: Report what was done without self-congratulation ("Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues")
-  - Concise summaries: Skip verbose explanations unless complexity warrants detail
-  - Natural language: Conversational but professional, avoid machine-like phrasing
-  - Show work: Display commands and outputs rather than describing them
-  - Direct and grounded: Provide fact-based reports rather than self-celebratory updates
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**:
   - Clean up temporary files created during iteration at task completion
   - Remove helper scripts, test scaffolds, or development files not requested by user

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ The toolkit uses **agents, skills, hooks, and scripts** to absorb complexity tha
 
 **LLMs orchestrate, programs execute.** If a process is deterministic and measurable (file searching, test execution, build validation, frontmatter checking), use a script. Reserve LLM judgment for contextual diagnosis, design decisions, and code review.
 
+**Write dense.** High fidelity, minimum words. Cut every word that carries no instruction, rule, or decision. Prefer tables and lists over paragraphs. If cutting a sentence loses no instruction, cut it.
+
 ---
 
 ## Trust Boundary: Untrusted Content

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -310,6 +310,8 @@ Extraction: Intent from verb+object. Constraints include branch safety (never me
 
 **MANDATORY: Inject the completeness standard for ALL Simple+ dispatches.** Every agent prompt MUST include: "Deliver the finished product. Ship the complete thing."
 
+**MANDATORY: Inject density standard for ALL Simple+ dispatches.** Every agent prompt MUST include: "Write dense: high fidelity, minimum words. Cut filler, prefer tables over paragraphs, report what changed — not how."
+
 **Opus 4.7: Inject thinking directive.** Prepend verbatim, no framing:
 
 | Complexity | Thinking Directive |


### PR DESCRIPTION
## Summary
- Add "Write dense" directive to project `CLAUDE.md` (every session reads it)
- Add 3rd MANDATORY injection to `/do SKILL.md` (every dispatched agent receives it)
- Replace 5 vague Communication Style lines with 3 specific density-focused lines in `AGENT_TEMPLATE_V2.md` (every future agent inherits it)
- Also added to `~/.claude/CLAUDE.md` (global policy, outside repo)

Completes the density enforcement chain: global policy → project policy → dispatch injection → template inheritance. ~90 tokens total. No propagation gap remains.

## Test plan
- [ ] CI passes (lint, routing-benchmark, routing-drift, tests)
- [ ] Verify `CLAUDE.md` density line appears in project conventions
- [ ] Verify `/do SKILL.md` has 3 MANDATORY injection blocks
- [ ] Verify `AGENT_TEMPLATE_V2.md` Communication Style has 3 dense lines (not 5 vague ones)