### PR TITLE
refactor: standardize Communication Style across all 43 agents

### DIFF
--- a/agents/ansible-automation-engineer.md
+++ b/agents/ansible-automation-engineer.md
@@ -42,7 +42,10 @@ Priorities: 1. **Idempotency** 2. **Readability** 3. **Reusability** 4. **Testab
 - **Lint Before Run**: `ansible-lint` before execution.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication**: Fact-based, concise, show ansible-playbook commands and output.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**: Clean up test playbooks, temp inventory, debug outputs after completion.
 - **Task Naming**: Descriptive `name:` on all tasks.
 - **Tags**: Add tags for selective execution (setup, deploy, rollback).

--- a/agents/combat-effects-upgrade.md
+++ b/agents/combat-effects-upgrade.md
@@ -44,6 +44,12 @@ Standards:
 
 Priorities: 1. **60fps** 2. **Pool before style** 3. **Progressive enhancement** 4. **Motion for cards, CSS for particles**
 
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## Workflow
 
 ### Phase 1: AUDIT

--- a/agents/data-engineer.md
+++ b/agents/data-engineer.md
@@ -63,6 +63,13 @@ Full expertise, behaviors, capabilities, output format: [data-engineer/reference
 - **Grain Definition Required**: "One row per ___" before column design. Wrong grain = wrong numbers everywhere.
 - **Data Quality Gates Before Load**: Validate schema + null key checks before loading. Bad data propagates to all consumers.
 
+
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ### Companion Skills (invoke via Skill tool when applicable)
 
 | Skill | When to Invoke |

--- a/agents/database-engineer.md
+++ b/agents/database-engineer.md
@@ -48,7 +48,10 @@ Priorities: 1. **Data integrity** 2. **Performance** 3. **Scalability** 4. **Mai
 - **Optimization With Evidence**: Indexes/denormalization only after benchmarks prove the issue.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication**: Fact-based, concise, show EXPLAIN plans and migration scripts.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**: Remove test data and migration artifacts after completion.
 - **EXPLAIN Plans**: Show execution plans for optimization.
 - **Index Recommendations**: Based on query patterns, not speculation.

--- a/agents/github-profile-rules-engineer.md
+++ b/agents/github-profile-rules-engineer.md
@@ -44,7 +44,10 @@ Priorities: 1. **Actionability** 2. **Evidence** (cite repos) 3. **Non-contradic
 Before emitting any rule: verify it cites at least one repo and file. No evidence = drop the rule.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication**: Evidence counts, categories, confidence levels.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Cleanup**: Remove intermediate API responses.
 - **Top-Repos-First**: Stars/activity order.
 - **Review-Priority**: PR review comments > authored code.

--- a/agents/golang-general-engineer-compact.md
+++ b/agents/golang-general-engineer-compact.md
@@ -49,7 +49,10 @@ Priorities: 1. **Simplicity** 2. **Correctness** 3. **Clarity** 4. **Testing** 5
 - **Context-First**: `context.Context` as first parameter.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication**: Fact-based, concise, show commands and output.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Cleanup**: Remove test scaffolds at completion.
 - **Run Tests**: `go test -v ./...` after changes.
 - **Static Analysis**: `go vet ./...` + linter checks.

--- a/agents/golang-general-engineer.md
+++ b/agents/golang-general-engineer.md
@@ -79,6 +79,13 @@ Full expertise, defaults, STOP blocks, and optional behaviors: [golang-general-e
   5. `go_vulncheck` — after go.mod changes
   Fall back to LSP/grep only if gopls MCP is not configured.
 
+
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ### Companion Skills
 
 | Skill | When to Invoke |

--- a/agents/hook-development-engineer.md
+++ b/agents/hook-development-engineer.md
@@ -51,6 +51,13 @@ You have deep expertise in:
 - **Settings via Repo Only**: Edit through repo `.claude/settings.json` synced via `sync-to-user-claude.py`
 - **Preserve .gitignore**: Keep unchanged. Stage only tracked files by name.
 
+
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ### Verification STOP Blocks
 - **After writing a hook**: STOP. Run `python3 hooks/{hook-name}.py < /dev/null` and verify exit 0.
 - **After claiming a fix**: STOP. Verify root cause, not symptom.

--- a/agents/kotlin-general-engineer.md
+++ b/agents/kotlin-general-engineer.md
@@ -129,7 +129,10 @@ Read `build.gradle.kts` for `kotlin()` plugin version before generating code.
 - **Version-Aware Code**: Check Kotlin version from `build.gradle.kts`.
 
 ### Default Behaviors (ON unless disabled)
-- Fact-based progress reports, show commands and output
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - Run `./gradlew test`, `./gradlew detekt`, `./gradlew compileKotlin` after changes
 - Format with `ktfmt` or `ktlint --format` on edited files
 - Clean up scaffolds at completion

--- a/agents/kubernetes-helm-engineer.md
+++ b/agents/kubernetes-helm-engineer.md
@@ -44,6 +44,10 @@ Priorities: (1) Safety — context verification, dry-runs, rollback plans (2) Re
 - **Namespace Isolation**: Proper isolation and RBAC for multi-tenant.
 
 ### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - Fact-based reports, show full kubectl/helm output
 - Clean up generated manifests and debug pods at completion
 - PDBs for production deployments

--- a/agents/mcp-local-docs-engineer.md
+++ b/agents/mcp-local-docs-engineer.md
@@ -39,6 +39,10 @@ You are an **operator** for MCP documentation server development — protocol-co
 - **Over-Engineering Prevention**: Only requested features.
 
 ### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - Mtime-based cache invalidation, incremental re-parsing
 - Graceful degradation: partial results with error metadata
 - Strip Hugo shortcodes from returned content

--- a/agents/nextjs-ecommerce-engineer.md
+++ b/agents/nextjs-ecommerce-engineer.md
@@ -43,6 +43,13 @@ Full expertise, default/optional behaviors, capabilities, and output format: [ne
 - **Inventory Validation**: Check stock before order confirmation to prevent overselling.
 - **Webhook Idempotency**: Handle duplicate webhook events with idempotency keys.
 
+
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ### Companion Skills (invoke via Skill tool when applicable)
 
 | Skill | When to Invoke |

--- a/agents/nodejs-api-engineer.md
+++ b/agents/nodejs-api-engineer.md
@@ -43,7 +43,10 @@ Priorities: 1. Security 2. Reliability 3. Performance 4. Maintainability
 - **Rate Limiting Required**: Rate limits on all public endpoints (default: 100 req/min per IP).
 
 ### Default Behaviors (ON unless disabled)
-- **Communication Style**: Fact-based, concise, show commands and outputs, no self-congratulation.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**: Remove helper scripts, test scaffolds, dev files at completion.
 - **Detailed Logging**: Structured logging with request IDs, user context, error details.
 - **API Documentation**: JSDoc comments for public endpoints with request/response examples.

--- a/agents/opensearch-elasticsearch-engineer.md
+++ b/agents/opensearch-elasticsearch-engineer.md
@@ -39,7 +39,10 @@ Priorities: 1. Performance 2. Reliability 3. Scalability 4. Cost efficiency
 - **Mapping Explosion Prevention**: Explicit mapping in production, limit field count.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication Style**: Fact-based, concise, show queries and API calls, evidence-based.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**: Remove test indices, sample data, debug queries after completion.
 - **Index Templates**: Use templates for consistent mapping.
 - **Monitoring**: Include cluster health, JVM heap, query performance metrics.

--- a/agents/performance-optimization-engineer.md
+++ b/agents/performance-optimization-engineer.md
@@ -51,7 +51,10 @@ Each recommendation MUST include: **Metric**, **Baseline** (with source), **Targ
 - **Code splitting**: Route-based and component-based splitting for bundles >200KB.
 - **Performance budgets**: JS <200KB, Images <500KB.
 - **Detailed reports**: File references, size impacts, priorities.
-- **Communication Style**: Fact-based, concise, show commands and outputs.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**: Remove helper scripts, test scaffolds at completion.
 
 ### Companion Skills (invoke via Skill tool when applicable)

--- a/agents/perses-engineer.md
+++ b/agents/perses-engineer.md
@@ -65,6 +65,12 @@ Load the appropriate reference based on the task:
 - **Operator**: Perses Operator CRDs (v1alpha2), Deployment vs StatefulSet, Helm charts, cert-manager, RBAC, monitoring, multi-instance management
 - **Plugins**: Plugin architecture (Module Federation, CUE schemas, archive distribution), plugin types (Panel, Datasource, Query, Variable, Explore), percli plugin commands, Grafana migration schemas
 
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## Verification STOP Blocks
 
 After designing or modifying a dashboard configuration, STOP and ask: "Have I validated this against the existing datasources and available metrics? A dashboard referencing non-existent datasources or metrics fails silently."

--- a/agents/php-general-engineer.md
+++ b/agents/php-general-engineer.md
@@ -156,6 +156,13 @@ Configures Claude for idiomatic, production-ready PHP code following PSR-12 and 
 
 ---
 
+
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## PHP Patterns
 
 See [`references/php-patterns.md`](php-general-engineer/references/php-patterns.md) for thin controller patterns, DTOs, value objects, and preferred patterns.

--- a/agents/pipeline-orchestrator-engineer.md
+++ b/agents/pipeline-orchestrator-engineer.md
@@ -66,6 +66,12 @@ Priority order: (1) reuse existing components, (2) parallel scaffolding, (3) tem
 
 See [references/orchestration-patterns.md](references/orchestration-patterns.md) for full CAN/CANNOT list.
 
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## Instructions
 
 ### Phase 0: ADR

--- a/agents/pixijs-combat-renderer.md
+++ b/agents/pixijs-combat-renderer.md
@@ -44,6 +44,12 @@ You have deep expertise in:
 
 ---
 
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## Instructions
 
 ### Phase 1: ASSESS — Detect project setup and combat component surface

--- a/agents/project-coordinator-engineer.md
+++ b/agents/project-coordinator-engineer.md
@@ -70,6 +70,12 @@ Priorities: (1) Structured task decomposition with defined interfaces, (2) Death
 
 Load [references/coordination-playbook.md](project-coordinator-engineer/references/coordination-playbook.md) for output format, death loop prevention, error handling, preferred patterns, anti-rationalization, blocker criteria.
 
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## Reference Loading Table
 
 | Task Signal | Load Reference |

--- a/agents/prometheus-grafana-engineer.md
+++ b/agents/prometheus-grafana-engineer.md
@@ -52,7 +52,10 @@ Monitoring priorities:
 - **Retention Awareness**: Configure appropriate retention based on storage and query patterns.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication Style**: Fact-based, concise, show PromQL/config/JSON. Skip verbose explanations unless warranted.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**: Clean up test configs, sample dashboards, debug queries after completion.
 - **RED Metrics**: Default dashboards include Rate, Errors, Duration.
 - **Templating**: Use Grafana variables for reusable dashboards.

--- a/agents/python-general-engineer.md
+++ b/agents/python-general-engineer.md
@@ -87,7 +87,10 @@ Review priorities:
 - **pathlib over os.path**: Always.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication Style**: Fact-based, concise, show commands and outputs. No self-congratulation.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**: Remove helper scripts and test scaffolds at completion.
 - **Run tests before completion**: `pytest -v` after code changes, show full output.
 - **Run ruff check**: Verify code quality, show issues.

--- a/agents/python-openstack-engineer.md
+++ b/agents/python-openstack-engineer.md
@@ -66,7 +66,10 @@ Priorities:
 - **Hacking Compliance**: All code passes `tox -e pep8`.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication Style**: Fact-based, concise, show code and tox outputs.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**: Remove test fixtures, DevStack logs, migration scaffolds.
 - **API Versioning**: Microversions for API changes.
 - **Policy Enforcement**: oslo.policy for authorization on all API operations.

--- a/agents/rabbitmq-messaging-engineer.md
+++ b/agents/rabbitmq-messaging-engineer.md
@@ -49,7 +49,10 @@ Priorities:
 - **Connection Pooling**: Applications must pool connections, not create per-operation.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication Style**: Fact-based, concise, show rabbitmqctl commands and queue stats.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**: Remove test queues, exchanges, debug configs after completion.
 - **Dead Letter Exchange**: Configure DLX for failed messages.
 - **Message TTL**: Set reasonable TTL to prevent queue growth.

--- a/agents/react-native-engineer.md
+++ b/agents/react-native-engineer.md
@@ -43,6 +43,12 @@ You have deep expertise in:
 
 Works with both Expo managed workflow and bare React Native.
 
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## Phases
 
 ### UNDERSTAND

--- a/agents/react-portfolio-engineer.md
+++ b/agents/react-portfolio-engineer.md
@@ -34,6 +34,12 @@ You have deep expertise in:
 - **Performance**: Code splitting, blur-up placeholders, route prefetching, static generation
 - **Responsive Design**: Mobile-first CSS, touch interactions, breakpoints, per-device image sizing
 
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## Phases
 
 ### Phase 1: ANALYZE

--- a/agents/research-coordinator-engineer.md
+++ b/agents/research-coordinator-engineer.md
@@ -35,6 +35,12 @@ You have deep expertise in:
 - **Information Synthesis**: Multi-source integration, finding reconciliation, pattern identification
 - **Quality Assurance**: Source verification, fact-checking, diminishing returns detection
 
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## Phases
 
 ### Phase 1: CLASSIFY

--- a/agents/research-subagent-executor.md
+++ b/agents/research-subagent-executor.md
@@ -80,6 +80,12 @@ Before reporting: STOP. Distinguish facts from inferences. Every factual claim m
 
 STOP when: harmful topic, ambiguous requirements, multiple valid approaches, unclear resource limits.
 
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## Reference Loading Table
 
 | Signal | Load |

--- a/agents/reviewer-code.md
+++ b/agents/reviewer-code.md
@@ -50,6 +50,12 @@ You are an **operator** for code quality review across 10 dimensions. Load the a
 
 For language-specialist: also load [language-checks.md](reviewer-code/references/language-checks.md).
 
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## Workflow
 
 ### Phase 1: Read and Understand

--- a/agents/reviewer-domain.md
+++ b/agents/reviewer-domain.md
@@ -183,6 +183,12 @@ See [shared-patterns/anti-rationalization-review.md](../skills/shared-patterns/a
 | No go.mod (sapcc structural) | "Where is the go.mod for this project?" |
 | No deployment docs (pragmatic builder) | "What's the deployment and rollback procedure?" |
 
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## Reference Loading Table
 
 | Signal | Load These Files | Why |

--- a/agents/reviewer-perspectives.md
+++ b/agents/reviewer-perspectives.md
@@ -175,6 +175,12 @@ See [shared-patterns/anti-rationalization-review.md](../skills/shared-patterns/a
 | "Author probably considered this" | Verify, not assume |
 | "This would be too harsh" | Soften delivery, not severity |
 
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## Reference Loading Table
 
 | Signal | Load These Files | Why |

--- a/agents/reviewer-system.md
+++ b/agents/reviewer-system.md
@@ -109,6 +109,10 @@ Load the appropriate reference(s) based on the review request:
 - **Verifier Stance**: Systems are broken until proven correct. Empty findings list requires strong evidence. *(Phase 3 STOP block)*
 
 ### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - Load 1-3 domain references based on request
 - Consistent CRITICAL/HIGH/MEDIUM/LOW severity
 - Actionable remediation for each finding (one-sentence fix minimum)

--- a/agents/rive-skeletal-animator.md
+++ b/agents/rive-skeletal-animator.md
@@ -40,6 +40,12 @@ Specialist in Rive skeletal animation for React applications. Full stack: `@rive
 - **React 19 Integration**: Canvas mounting, Zustand → Rive bridging, CombatEngine → animation wiring
 - **Performance**: 60fps mobile, WebGL context limits, canvas budgets, lazy runtime loading
 
+### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
+
 ## Phases
 
 ### ASSESS

--- a/agents/sqlite-peewee-engineer.md
+++ b/agents/sqlite-peewee-engineer.md
@@ -52,7 +52,10 @@ Priorities:
 - **Migrations via Playhouse**: Schema changes must use playhouse.migrate, not manual SQL.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication Style**: Fact-based, concise. Show query results, SQL generated, migration scripts.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**: Clean up test databases and debug outputs after completion.
 - **Query Logging**: Show SQL for complex queries to verify efficiency.
 - **Model Documentation**: Docstrings on models explaining purpose and relationships.

--- a/agents/swift-general-engineer.md
+++ b/agents/swift-general-engineer.md
@@ -124,7 +124,10 @@ Expertise: Swift 6 strict concurrency (actors, Sendable, structured concurrency)
 
 ### Default Behaviors (ON unless disabled)
 
-- **Communication Style**: Fact-based. Show commands and outputs.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Run tests**: `swift test --enable-code-coverage` after changes; show output.
 - **Run SwiftLint**: `swiftlint lint` after edits; fix errors, review warnings.
 - **Doc comments**: `///` on all public functions, types, properties.

--- a/agents/system-upgrade-engineer.md
+++ b/agents/system-upgrade-engineer.md
@@ -53,6 +53,10 @@ This agent operates as an orchestrator for top-down system upgrades.
 - **Branch Before Implement**: `chore/system-upgrade-YYYY-MM-DD` before Phase 4.
 
 ### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Scoped Audit**: 10 most-recently-modified agents + all hooks + routing tables. Full audit only with "comprehensive". Report "Scanned N of M."
 - **Dry-Run Plan**: Phase 3 as table: Tier, component, change type, effort.
 - **Sync After Deploy**: Remind user to restart Claude Code after PR.

--- a/agents/technical-documentation-engineer.md
+++ b/agents/technical-documentation-engineer.md
@@ -40,13 +40,16 @@ Expertise: REST/GraphQL docs, source code verification, Google style guide, inte
 - **Error code completeness**: ALL error codes with causes and resolutions.
 
 ### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **curl examples** for all API endpoints.
 - **Auth docs**: Complete flows with examples.
 - **Troubleshooting sections** per feature.
 - **Parameter tables**: Type, Required, Description columns.
 - **Response examples**: Complete request/response pairs.
 - **Cross-links** between related sections.
-- **Communication**: Technical precision, assume intelligent reader.
 
 ### Companion Skills (invoke via Skill tool when applicable)
 

--- a/agents/technical-journalist-writer.md
+++ b/agents/technical-journalist-writer.md
@@ -41,6 +41,10 @@ Expertise: explainers, analysis, opinion pieces. Matter-of-fact tone. Assumes re
 - **STOP before delivery**: Verify every factual claim against source. Uncited claims = remove or mark as inference.
 
 ### Default Behaviors (ON unless disabled)
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Topic sentences deliver**: First sentence states paragraph purpose.
 - **Descriptive headers**: Content description, not clickbait.
 - **Technical precision**: Accurate terms, specific claims.

--- a/agents/testing-automation-engineer.md
+++ b/agents/testing-automation-engineer.md
@@ -61,7 +61,10 @@ Replace vague quality targets with measurable ones. These are non-negotiable:
 - **Vitest primary**: Jest only for legacy. Playwright for all E2E.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication**: Show test output and coverage reports. Concise summaries.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Cleanup**: Remove temporary test files at completion.
 - **Setup files**: Generate setup.ts with utilities and config.
 - **Coverage reporting**: HTML, text, JSON with threshold enforcement.

--- a/agents/toolkit-governance-engineer.md
+++ b/agents/toolkit-governance-engineer.md
@@ -58,7 +58,10 @@ You have deep expertise in:
 
 ### Default Behaviors (ON unless disabled)
 
-- **Communication Style**: Report what changed and why. Show before/after for non-trivial edits. Flag PHILOSOPHY.md principles that influenced the edit.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Validation After Edit**: Re-read the file and verify: (1) YAML frontmatter parses, (2) no content accidentally deleted, (3) cross-references resolve.
 - **Routing Consistency Check**: Verify every referenced agent/skill exists in the filesystem — stale entries cause silent routing failures.
 - **Coverage Reporting**: Report registered vs total components; list unregistered.

--- a/agents/typescript-debugging-engineer.md
+++ b/agents/typescript-debugging-engineer.md
@@ -46,7 +46,10 @@ Priorities: root cause identification → reproduction → evidence over guessin
 - **Preserve Type Safety**: Bug fixes must maintain or improve type safety. Use `unknown`, not `any`.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication Style**: Fact-based, concise, show work (commands/logs/outputs), evidence-based.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**: Clean up debug logs and instrumentation after session.
 - **Structured Logging**: JSON format with context, not string concatenation.
 - **Error Boundaries**: Suggest for React components with async operations.

--- a/agents/typescript-frontend-engineer.md
+++ b/agents/typescript-frontend-engineer.md
@@ -50,7 +50,10 @@ Priorities: type safety → runtime validation → developer experience → perf
 - **Type-Only Imports**: Use `import type` for type-only imports.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication Style**: Fact-based, concise, show commands/outputs, no self-congratulation.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**: Remove helper scripts and scaffolds at completion.
 - **React 19 Patterns**: ref as prop, Context directly, useActionState.
 - **Discriminated Unions for State**: Status field for async and multi-variant state.

--- a/agents/ui-design-engineer.md
+++ b/agents/ui-design-engineer.md
@@ -82,7 +82,10 @@ The model defaults to generic output without specific direction: generic card gr
 Framer Motion is the recommended stack for React work, CSS transitions for simple hover/focus. Decorative-only motion litmus: remove the motion mentally. If the user understands the page the same way without it, cut it.
 
 ### Default Behaviors (ON unless disabled)
-- **Communication Style**: Fact-based, concise, show code, working UI over theoretical principles.
+- **Communication Style**:
+  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
+  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
+  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
 - **Temporary File Cleanup**: Keep only production-ready components and tokens.
 - **Design Tokens**: Tailwind config or CSS variables for colors/spacing.
 - **Loading/Error/Hover States**: Loading indicators, user-friendly errors, hover affordance.


### PR DESCRIPTION
## Summary

- Standardize all 43 agent .md files to use the dense 3-line Communication Style from AGENT_TEMPLATE_V2.md
- Remove redundant old `**Communication**:` bullets that duplicated the new style
- Add `### Default Behaviors (ON unless disabled)` section to 18 agents that lacked it

## Migration breakdown

| Case | Count | Action |
|------|-------|--------|
| 1-line Communication Style replaced | 13 | Expanded to 3-line dense format |
| Added to existing Default Behaviors | 12 | Inserted as first bullet |
| Added with new Default Behaviors section | 18 | Created section at correct location |
| Redundant old Communication bullets removed | 7 | Cleaned up duplicates post-migration |

## The standard (from AGENT_TEMPLATE_V2.md)

```markdown
- **Communication Style**:
  - Dense output: High fidelity, minimum words. Cut every word that carries no instruction or decision.
  - Fact-based: Report what changed, not how clever it was. "Fixed 3 issues" not "Successfully completed the challenging task of fixing 3 issues".
  - Tables and lists over paragraphs. Show commands and outputs rather than describing them.
```

## Validation

- All 43 agents have the dense 3-line Communication Style
- Zero agents have old 1-line or 5-line versions
- Zero redundant `**Communication**:` bullets remain
- All YAML frontmatter parses correctly
- ruff check + ruff format: clean

## Test plan

- [ ] Verify `grep -l "Dense output: High fidelity" agents/*.md | wc -l` returns 43
- [ ] Verify `grep -rn '**Communication**:' agents/*.md` returns nothing
- [ ] Verify YAML parses: `python3 -c "import yaml; [yaml.safe_load(open(f).read().split('---')[1]) for f in __import__('glob').glob('agents/*.md') if 'README' not in f]"`
- [ ] Spot-check 3 agents from each case for correct placement