### PR TITLE
feat: close learning.db feedback loop with effectiveness validation

### DIFF
--- a/hooks/lib/hook_utils.py
+++ b/hooks/lib/hook_utils.py
@@ -551,3 +551,35 @@ def is_tool_error(result: dict) -> bool:
     if "is_error" in result:
         return bool(result["is_error"])
     return result.get("exitCode", 0) != 0
+
+
+# =============================================================================
+# Activation Recording
+# =============================================================================
+
+
+def record_activations_safe(
+    results: list[dict],
+    session_id: str | None = None,
+    *,
+    debug: bool = False,
+) -> None:
+    """Record activations for injected learnings. Never blocks.
+
+    Extracts (topic, key) pairs from result dicts and batch-records them.
+    Swallows all exceptions so hook execution is never interrupted.
+
+    Args:
+        results: List of learning dicts with "topic" and "key" keys.
+        session_id: Session identifier for activation tracking.
+        debug: If True, log failures to stderr.
+    """
+    try:
+        from learning_db_v2 import record_activations
+
+        entries = [(r["topic"], r["key"]) for r in results]
+        if entries:
+            record_activations(entries, session_id)
+    except Exception as e:
+        if debug:
+            print(f"[activation] Recording failed: {e}", file=sys.stderr)

--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -714,6 +714,28 @@ def lookup_error_solution(
         return None
 
 
+def record_activation(
+    topic: str,
+    key: str,
+    session_id: str | None = None,
+    outcome: str = "success",
+) -> None:
+    """Record that a learning was surfaced during a session.
+
+    Lightweight INSERT into the activations table — no upsert, no conflict
+    handling.  Called from injection hooks to track which learnings are
+    actually used.  Designed for <5ms execution.
+    """
+    init_db()
+    now = datetime.now().isoformat()
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT INTO activations (topic, key, session_id, timestamp, outcome) VALUES (?, ?, ?, ?, ?)",
+            (topic, key, session_id, now, outcome),
+        )
+        conn.commit()
+
+
 def boost_confidence(topic: str, key: str, delta: float = 0.10) -> float:
     """Boost confidence for an entry. Returns new confidence."""
     init_db()

--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -714,6 +714,34 @@ def lookup_error_solution(
         return None
 
 
+def record_activations(
+    entries: list[tuple[str, str]],
+    session_id: str | None = None,
+    outcome: str = "success",
+) -> None:
+    """Record that multiple learnings were surfaced during a session.
+
+    Uses a single connection + executemany for efficiency.
+    Called from injection hooks to track which learnings are actually used.
+
+    Args:
+        entries: List of (topic, key) pairs to record.
+        session_id: Session identifier.
+        outcome: Outcome string (default "success").
+    """
+    if not entries:
+        return
+    init_db()
+    now = datetime.now().isoformat()
+    rows = [(topic, key, session_id, now, outcome) for topic, key in entries]
+    with get_connection() as conn:
+        conn.executemany(
+            "INSERT INTO activations (topic, key, session_id, timestamp, outcome) VALUES (?, ?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+
+
 def record_activation(
     topic: str,
     key: str,
@@ -722,18 +750,9 @@ def record_activation(
 ) -> None:
     """Record that a learning was surfaced during a session.
 
-    Lightweight INSERT into the activations table — no upsert, no conflict
-    handling.  Called from injection hooks to track which learnings are
-    actually used.  Designed for <5ms execution.
+    Thin wrapper around record_activations() for single-entry convenience.
     """
-    init_db()
-    now = datetime.now().isoformat()
-    with get_connection() as conn:
-        conn.execute(
-            "INSERT INTO activations (topic, key, session_id, timestamp, outcome) VALUES (?, ?, ?, ?, ?)",
-            (topic, key, session_id, now, outcome),
-        )
-        conn.commit()
+    record_activations([(topic, key)], session_id, outcome)
 
 
 def boost_confidence(topic: str, key: str, delta: float = 0.10) -> float:

--- a/hooks/pretool-learning-injector.py
+++ b/hooks/pretool-learning-injector.py
@@ -178,7 +178,11 @@ def main():
 
         # Query learning.db for matching patterns via FTS5 full-text search
         # Lazy import to avoid paying cost when early-exiting
-        from learning_db_v2 import sanitize_for_context, search_learnings
+        from learning_db_v2 import (
+            record_activation,
+            sanitize_for_context,
+            search_learnings,
+        )
 
         query_str = " OR ".join(tags)
         results = search_learnings(
@@ -197,6 +201,14 @@ def main():
         hint_text = format_hints(results)
         if not hint_text:
             empty_output(EVENT_NAME).print_and_exit()
+
+        # Record activations for injected learnings (ROI tracking)
+        session_id = get_session_id()
+        for r in results:
+            try:
+                record_activation(r["topic"], r["key"], session_id)
+            except Exception:
+                pass  # Never block on activation recording
 
         if debug:
             print(

--- a/hooks/pretool-learning-injector.py
+++ b/hooks/pretool-learning-injector.py
@@ -26,7 +26,7 @@ from pathlib import Path
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
-from hook_utils import context_output, empty_output
+from hook_utils import context_output, empty_output, get_session_id, record_activations_safe
 from stdin_timeout import read_stdin
 
 EVENT_NAME = "PreToolUse"
@@ -179,7 +179,6 @@ def main():
         # Query learning.db for matching patterns via FTS5 full-text search
         # Lazy import to avoid paying cost when early-exiting
         from learning_db_v2 import (
-            record_activation,
             sanitize_for_context,
             search_learnings,
         )
@@ -204,11 +203,7 @@ def main():
 
         # Record activations for injected learnings (ROI tracking)
         session_id = get_session_id()
-        for r in results:
-            try:
-                record_activation(r["topic"], r["key"], session_id)
-            except Exception:
-                pass  # Never block on activation recording
+        record_activations_safe(results, session_id, debug=bool(debug))
 
         if debug:
             print(

--- a/hooks/session-context.py
+++ b/hooks/session-context.py
@@ -26,11 +26,10 @@ from pathlib import Path
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
-from hook_utils import context_output, empty_output, get_session_id
+from hook_utils import context_output, empty_output, get_session_id, record_activations_safe
 from learning_db_v2 import (
     get_stats,
     query_learnings,
-    record_activation,
     sanitize_for_context,
 )
 
@@ -166,20 +165,17 @@ def main():
 
         if learnings:
             # Record activations for ROI tracking
+            debug = bool(os.environ.get("CLAUDE_HOOKS_DEBUG"))
             session_id = get_session_id()
-            for p in learnings:
-                try:
-                    record_activation(p["topic"], p["key"], session_id)
-                except Exception:
-                    pass  # Never block on activation recording
+            record_activations_safe(learnings, session_id, debug=debug)
 
             lines = []
             lines.append(f"[learned-context] Loaded {len(learnings)} high-confidence patterns")
 
             # Group by error type
             by_type = {}
-            for p in learnings:
-                et = p.get("error_type") or p.get("topic", "unknown")
+            for learning in learnings:
+                et = learning.get("error_type") or learning.get("topic", "unknown")
                 by_type[et] = by_type.get(et, 0) + 1
 
             type_summary = ", ".join(f"{et}({count})" for et, count in sorted(by_type.items()))

--- a/hooks/session-context.py
+++ b/hooks/session-context.py
@@ -26,8 +26,13 @@ from pathlib import Path
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
-from hook_utils import context_output, empty_output
-from learning_db_v2 import get_stats, query_learnings, sanitize_for_context
+from hook_utils import context_output, empty_output, get_session_id
+from learning_db_v2 import (
+    get_stats,
+    query_learnings,
+    record_activation,
+    sanitize_for_context,
+)
 
 EVENT_NAME = "SessionStart"
 
@@ -160,6 +165,14 @@ def main():
         )
 
         if learnings:
+            # Record activations for ROI tracking
+            session_id = get_session_id()
+            for p in learnings:
+                try:
+                    record_activation(p["topic"], p["key"], session_id)
+                except Exception:
+                    pass  # Never block on activation recording
+
             lines = []
             lines.append(f"[learned-context] Loaded {len(learnings)} high-confidence patterns")
 

--- a/hooks/tests/test_fts5_search.py
+++ b/hooks/tests/test_fts5_search.py
@@ -444,3 +444,42 @@ class TestQueryGraduationCandidates:
         assert results[2]["topic"] == "skill:medium"
         # Fourth: confidence=0.91, observation_count=5
         assert results[3]["topic"] == "agent:low"
+
+
+class TestRecordActivation:
+    """Test record_activation() library function."""
+
+    def test_inserts_activation(self):
+        db.record_activation("routing", "go-agent:go-patterns", "sess-001")
+        with db.get_connection() as conn:
+            row = conn.execute("SELECT * FROM activations WHERE session_id = 'sess-001'").fetchone()
+        assert row is not None
+        assert row["topic"] == "routing"
+        assert row["key"] == "go-agent:go-patterns"
+        assert row["outcome"] == "success"
+
+    def test_multiple_activations_same_session(self):
+        for key in ["key-a", "key-b", "key-c"]:
+            db.record_activation("error", key, "sess-002")
+        with db.get_connection() as conn:
+            count = conn.execute("SELECT COUNT(*) FROM activations WHERE session_id = 'sess-002'").fetchone()[0]
+        assert count == 3
+
+    def test_default_outcome_is_success(self):
+        db.record_activation("test-topic", "test-key", "sess-003")
+        with db.get_connection() as conn:
+            row = conn.execute("SELECT outcome FROM activations WHERE session_id = 'sess-003'").fetchone()
+        assert row["outcome"] == "success"
+
+    def test_custom_outcome(self):
+        db.record_activation("test-topic", "test-key", "sess-004", outcome="failure")
+        with db.get_connection() as conn:
+            row = conn.execute("SELECT outcome FROM activations WHERE session_id = 'sess-004'").fetchone()
+        assert row["outcome"] == "failure"
+
+    def test_none_session_id(self):
+        db.record_activation("test-topic", "test-key")
+        with db.get_connection() as conn:
+            row = conn.execute("SELECT * FROM activations WHERE topic = 'test-topic'").fetchone()
+        assert row is not None
+        assert row["session_id"] is None

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -622,8 +622,8 @@ def cmd_record_routing_outcome(args: argparse.Namespace) -> None:
     )
     entry = next((r for r in results if r["key"] == key), None)
     if entry is None:
-        print(f"WARNING: No routing entry found for key '{key}' — route was never recorded.")
-        return
+        print(f"WARNING: No routing entry found for key '{key}' — route was never recorded.", file=sys.stderr)
+        sys.exit(1)
 
     if args.success:
         new_conf = boost_confidence("routing", key, delta=0.05)
@@ -661,24 +661,31 @@ def cmd_backfill_routing_outcomes(args: argparse.Namespace) -> None:
     )
 
     boosted = 0
-    decayed = 0
+    decayed_count = 0
+    skipped = 0
     unchanged = 0
 
     for r in results:
+        # Idempotency: skip entries already scored
+        if (r["success_count"] or 0) + (r["failure_count"] or 0) > 0:
+            skipped += 1
+            continue
+
         value = r["value"]
         if "tool_errors=1" in value or "user_rerouted=1" in value:
             decay_confidence("routing", r["key"], delta=0.08)
-            decayed += 1
+            decayed_count += 1
         elif "outcome=committed_and_pushed" in value or "outcome=success" in value:
             boost_confidence("routing", r["key"], delta=0.05)
             boosted += 1
         else:
             unchanged += 1
 
-    total = boosted + decayed + unchanged
+    total = boosted + decayed_count + unchanged + skipped
     print(f"Backfill complete: {total} entries processed")
     print(f"  Boosted:   {boosted}")
-    print(f"  Decayed:   {decayed}")
+    print(f"  Decayed:   {decayed_count}")
+    print(f"  Skipped:   {skipped}")
     print(f"  Unchanged: {unchanged}")
 
 

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -25,6 +25,10 @@ Usage:
     python3 scripts/learning-db.py record-session --session SESSION_ID --had-retro --failures 2 --waste-tokens 3000
     python3 scripts/learning-db.py roi [--json]
     python3 scripts/learning-db.py route-stats --by agent|skill|force-route|errors|override [--json]
+    python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --success
+    python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --failure --reason "user re-routed"
+    python3 scripts/learning-db.py backfill-routing-outcomes
+    python3 scripts/learning-db.py route-health
 """
 
 import argparse
@@ -603,6 +607,111 @@ def cmd_route_stats(args: argparse.Namespace) -> None:
         print(json_mod.dumps(records, indent=2, default=str))
 
 
+def cmd_record_routing_outcome(args: argparse.Namespace) -> None:
+    """Record whether a routing decision succeeded or failed."""
+    init_db()
+    key = args.agent_skill
+
+    # Verify the routing entry exists
+    results = query_learnings(
+        topic="routing",
+        category="effectiveness",
+        limit=10000,
+        exclude_graduated=False,
+        exclude_test_sources=False,
+    )
+    entry = next((r for r in results if r["key"] == key), None)
+    if entry is None:
+        print(f"WARNING: No routing entry found for key '{key}' — route was never recorded.")
+        return
+
+    if args.success:
+        new_conf = boost_confidence("routing", key, delta=0.05)
+    else:
+        new_conf = decay_confidence("routing", key, delta=0.08)
+
+    # Append reason to value if provided
+    if args.reason:
+        with get_connection() as conn:
+            row = conn.execute(
+                "SELECT value FROM learnings WHERE topic = ? AND key = ?",
+                ("routing", key),
+            ).fetchone()
+            if row:
+                new_value = f"{row['value']} | outcome_reason: {args.reason}"
+                conn.execute(
+                    "UPDATE learnings SET value = ? WHERE topic = ? AND key = ?",
+                    (new_value, "routing", key),
+                )
+                conn.commit()
+
+    outcome = "success" if args.success else "failure"
+    print(f"Recorded {outcome} for routing/{key} — confidence: {new_conf:.4f}")
+
+
+def cmd_backfill_routing_outcomes(args: argparse.Namespace) -> None:
+    """Backfill routing outcomes from existing entry data."""
+    init_db()
+    results = query_learnings(
+        topic="routing",
+        category="effectiveness",
+        limit=10000,
+        exclude_graduated=False,
+        exclude_test_sources=False,
+    )
+
+    boosted = 0
+    decayed = 0
+    unchanged = 0
+
+    for r in results:
+        value = r["value"]
+        if "tool_errors=1" in value or "user_rerouted=1" in value:
+            decay_confidence("routing", r["key"], delta=0.08)
+            decayed += 1
+        elif "outcome=committed_and_pushed" in value or "outcome=success" in value:
+            boost_confidence("routing", r["key"], delta=0.05)
+            boosted += 1
+        else:
+            unchanged += 1
+
+    total = boosted + decayed + unchanged
+    print(f"Backfill complete: {total} entries processed")
+    print(f"  Boosted:   {boosted}")
+    print(f"  Decayed:   {decayed}")
+    print(f"  Unchanged: {unchanged}")
+
+
+def cmd_route_health(args: argparse.Namespace) -> None:
+    """Display a quick health summary of routing entries."""
+    init_db()
+    results = query_learnings(
+        topic="routing",
+        category="effectiveness",
+        min_confidence=0.0,
+        limit=10000,
+        exclude_graduated=False,
+        exclude_test_sources=False,
+    )
+
+    total = len(results)
+    if total == 0:
+        print("No routing entries found.")
+        return
+
+    baseline = sum(1 for r in results if r["success_count"] == 0 and r["failure_count"] == 0)
+    boosted = sum(1 for r in results if r["success_count"] > 0)
+    decayed_count = sum(1 for r in results if r["failure_count"] > 0)
+    has_outcome = total - baseline
+    pct = has_outcome / total * 100
+
+    print(f"Route Health: {has_outcome}/{total} entries have outcomes ({pct:.0f}%)")
+    print(f"Confidence: {baseline} at baseline | {boosted} boosted | {decayed_count} decayed")
+    status = "CLOSED" if pct >= 50 else "OPEN"
+    no_outcome_pct = baseline / total * 100
+    print(f"Feedback loop: {status} ({no_outcome_pct:.0f}% entries have no outcome data)")
+
+
 def _print_freq_table(records: list[dict[str, str | int]], label: str, key_fn: object) -> None:
     """Print a frequency table sorted by count descending."""
     from collections import Counter
@@ -875,6 +984,25 @@ def main():
     )
     p_route_stats.add_argument("--json", action="store_true", help="Also output raw JSON")
     p_route_stats.set_defaults(func=cmd_route_stats)
+
+    # record-routing-outcome
+    p_rro = subparsers.add_parser("record-routing-outcome", help="Record routing decision outcome")
+    p_rro.add_argument("agent_skill", help="Routing key (e.g., golang-general-engineer:go-patterns)")
+    p_rro_group = p_rro.add_mutually_exclusive_group(required=True)
+    p_rro_group.add_argument("--success", action="store_true", help="Route succeeded")
+    p_rro_group.add_argument("--failure", action="store_true", help="Route failed")
+    p_rro.add_argument("--reason", help="Reason for outcome (appended to value)")
+    p_rro.set_defaults(func=cmd_record_routing_outcome)
+
+    # backfill-routing-outcomes
+    p_backfill = subparsers.add_parser(
+        "backfill-routing-outcomes", help="Retroactively score routing entries from existing data"
+    )
+    p_backfill.set_defaults(func=cmd_backfill_routing_outcomes)
+
+    # route-health
+    p_route_health = subparsers.add_parser("route-health", help="Quick routing feedback loop health check")
+    p_route_health.set_defaults(func=cmd_route_health)
 
     args = parser.parse_args()
     args.func(args)

--- a/scripts/tests/test_routing_outcome.py
+++ b/scripts/tests/test_routing_outcome.py
@@ -130,7 +130,7 @@ class TestRecordRoutingOutcome:
             ).fetchone()
         assert "outcome_reason: user re-routed" in row["value"]
 
-    def test_nonexistent_key_warns(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_nonexistent_key_exits_with_error(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
         from learning_db_v2 import init_db
 
         init_db()
@@ -140,8 +140,9 @@ class TestRecordRoutingOutcome:
             failure=False,
             reason=None,
         )
-        learning_db.cmd_record_routing_outcome(args)
-        output = capsys.readouterr().out
+        with pytest.raises(SystemExit, match="1"):
+            learning_db.cmd_record_routing_outcome(args)
+        output = capsys.readouterr().err
 
         assert "WARNING" in output
         assert "never recorded" in output
@@ -209,7 +210,26 @@ class TestBackfillRoutingOutcomes:
 
         assert "Boosted:   1" in output
         assert "Decayed:   2" in output
+        assert "Skipped:   0" in output
         assert "Unchanged: 1" in output
+
+    def test_idempotent_skips_already_scored(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """Running backfill twice should skip already-scored entries."""
+        _seed_routing_entry("e1", value="tool_errors=1")
+        _seed_routing_entry("e2", value="outcome=committed_and_pushed")
+
+        args = _ns()
+        # First run
+        learning_db.cmd_backfill_routing_outcomes(args)
+        capsys.readouterr()  # discard first output
+
+        # Second run — should skip both
+        learning_db.cmd_backfill_routing_outcomes(args)
+        output = capsys.readouterr().out
+
+        assert "Skipped:   2" in output
+        assert "Boosted:   0" in output
+        assert "Decayed:   0" in output
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_routing_outcome.py
+++ b/scripts/tests/test_routing_outcome.py
@@ -1,0 +1,275 @@
+"""Tests for routing outcome recording subcommands.
+
+Covers record-routing-outcome, backfill-routing-outcomes, and route-health.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repo hooks/lib takes priority over ~/.claude/hooks/lib
+_repo_root = Path(__file__).resolve().parent.parent.parent
+_repo_hooks_lib = str(_repo_root / "hooks" / "lib")
+
+# Import the CLI module under test
+sys_path_entry = str(Path(__file__).resolve().parent.parent)
+sys.path.insert(0, sys_path_entry)
+learning_db = importlib.import_module("learning-db")
+sys.path.pop(0)
+
+# Force-reload learning_db_v2 from the repo (not from ~/.claude/hooks/lib)
+sys.path.insert(0, _repo_hooks_lib)
+if "learning_db_v2" in sys.modules:
+    del sys.modules["learning_db_v2"]
+import learning_db_v2 as _ld2_repo
+
+# Patch the CLI module's references to point to the repo version
+for attr_name in dir(_ld2_repo):
+    if hasattr(learning_db, attr_name) and not attr_name.startswith("__"):
+        try:
+            setattr(learning_db, attr_name, getattr(_ld2_repo, attr_name))
+        except (AttributeError, TypeError):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point learning DB to a temp directory so tests never touch real data."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+
+    import learning_db_v2
+
+    monkeypatch.setattr(learning_db_v2, "_initialized", False)
+
+    return db_dir
+
+
+def _ns(**kwargs: object) -> argparse.Namespace:
+    """Build a minimal namespace for command functions."""
+    return argparse.Namespace(**kwargs)
+
+
+def _seed_routing_entry(key: str, value: str = "agent: test | skill: test") -> None:
+    """Seed a routing entry in the learnings table."""
+    from learning_db_v2 import record_learning
+
+    record_learning(
+        topic="routing",
+        key=key,
+        value=value,
+        category="effectiveness",
+        source="test:routing",
+    )
+
+
+# ---------------------------------------------------------------------------
+# record-routing-outcome
+# ---------------------------------------------------------------------------
+
+
+class TestRecordRoutingOutcome:
+    """Test the record-routing-outcome subcommand."""
+
+    def test_success_boosts_confidence(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _seed_routing_entry("golang-general-engineer:go-patterns")
+        args = _ns(
+            agent_skill="golang-general-engineer:go-patterns",
+            success=True,
+            failure=False,
+            reason=None,
+        )
+        learning_db.cmd_record_routing_outcome(args)
+        output = capsys.readouterr().out
+
+        assert "success" in output
+        assert "0.5500" in output  # 0.50 + 0.05
+
+    def test_failure_decays_confidence(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _seed_routing_entry("python-general-engineer:python-quality-gate")
+        args = _ns(
+            agent_skill="python-general-engineer:python-quality-gate",
+            success=False,
+            failure=True,
+            reason=None,
+        )
+        learning_db.cmd_record_routing_outcome(args)
+        output = capsys.readouterr().out
+
+        assert "failure" in output
+        assert "0.4200" in output  # 0.50 - 0.08
+
+    def test_reason_appended_to_value(self, isolated_db: Path) -> None:
+        _seed_routing_entry("test-agent:test-skill", value="agent: test-agent")
+        args = _ns(
+            agent_skill="test-agent:test-skill",
+            success=False,
+            failure=True,
+            reason="user re-routed",
+        )
+        learning_db.cmd_record_routing_outcome(args)
+
+        from learning_db_v2 import get_connection, init_db
+
+        init_db()
+        with get_connection() as conn:
+            row = conn.execute(
+                "SELECT value FROM learnings WHERE topic = 'routing' AND key = ?",
+                ("test-agent:test-skill",),
+            ).fetchone()
+        assert "outcome_reason: user re-routed" in row["value"]
+
+    def test_nonexistent_key_warns(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        from learning_db_v2 import init_db
+
+        init_db()
+        args = _ns(
+            agent_skill="nonexistent-agent:nonexistent-skill",
+            success=True,
+            failure=False,
+            reason=None,
+        )
+        learning_db.cmd_record_routing_outcome(args)
+        output = capsys.readouterr().out
+
+        assert "WARNING" in output
+        assert "never recorded" in output
+
+
+# ---------------------------------------------------------------------------
+# backfill-routing-outcomes
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillRoutingOutcomes:
+    """Test the backfill-routing-outcomes subcommand."""
+
+    def test_decays_tool_errors(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _seed_routing_entry("agent-a:skill-a", value="agent: a | tool_errors=1")
+        args = _ns()
+        learning_db.cmd_backfill_routing_outcomes(args)
+        output = capsys.readouterr().out
+
+        assert "Decayed:   1" in output
+
+        from learning_db_v2 import get_connection
+
+        with get_connection() as conn:
+            row = conn.execute(
+                "SELECT confidence FROM learnings WHERE topic = 'routing' AND key = ?",
+                ("agent-a:skill-a",),
+            ).fetchone()
+        assert row["confidence"] == pytest.approx(0.42, abs=0.01)
+
+    def test_decays_user_rerouted(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _seed_routing_entry("agent-b:skill-b", value="agent: b | user_rerouted=1")
+        args = _ns()
+        learning_db.cmd_backfill_routing_outcomes(args)
+        output = capsys.readouterr().out
+
+        assert "Decayed:   1" in output
+
+    def test_boosts_committed_and_pushed(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _seed_routing_entry("agent-c:skill-c", value="agent: c | outcome=committed_and_pushed")
+        args = _ns()
+        learning_db.cmd_backfill_routing_outcomes(args)
+        output = capsys.readouterr().out
+
+        assert "Boosted:   1" in output
+
+        from learning_db_v2 import get_connection
+
+        with get_connection() as conn:
+            row = conn.execute(
+                "SELECT confidence FROM learnings WHERE topic = 'routing' AND key = ?",
+                ("agent-c:skill-c",),
+            ).fetchone()
+        assert row["confidence"] == pytest.approx(0.55, abs=0.01)
+
+    def test_mixed_entries(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _seed_routing_entry("e1", value="tool_errors=1")
+        _seed_routing_entry("e2", value="outcome=committed_and_pushed")
+        _seed_routing_entry("e3", value="agent: x | skill: y")
+        _seed_routing_entry("e4", value="user_rerouted=1")
+
+        args = _ns()
+        learning_db.cmd_backfill_routing_outcomes(args)
+        output = capsys.readouterr().out
+
+        assert "Boosted:   1" in output
+        assert "Decayed:   2" in output
+        assert "Unchanged: 1" in output
+
+
+# ---------------------------------------------------------------------------
+# route-health
+# ---------------------------------------------------------------------------
+
+
+class TestRouteHealth:
+    """Test the route-health subcommand."""
+
+    def test_no_entries(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        from learning_db_v2 import init_db
+
+        init_db()
+        args = _ns()
+        learning_db.cmd_route_health(args)
+        output = capsys.readouterr().out
+
+        assert "No routing entries found" in output
+
+    def test_all_baseline(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        for i in range(5):
+            _seed_routing_entry(f"route-{i}")
+
+        args = _ns()
+        learning_db.cmd_route_health(args)
+        output = capsys.readouterr().out
+
+        assert "0/5 entries have outcomes (0%)" in output
+        assert "5 at baseline" in output
+        assert "0 boosted" in output
+        assert "0 decayed" in output
+        assert "OPEN" in output
+
+    def test_with_outcomes(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        for i in range(4):
+            _seed_routing_entry(f"route-{i}")
+
+        # Boost one, decay one
+        from learning_db_v2 import boost_confidence, decay_confidence
+
+        boost_confidence("routing", "route-0", delta=0.05)
+        decay_confidence("routing", "route-1", delta=0.08)
+
+        args = _ns()
+        learning_db.cmd_route_health(args)
+        output = capsys.readouterr().out
+
+        assert "2/4 entries have outcomes (50%)" in output
+        assert "2 at baseline" in output
+        assert "1 boosted" in output
+        assert "1 decayed" in output
+
+    def test_format_contains_feedback_loop(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _seed_routing_entry("single-route")
+
+        args = _ns()
+        learning_db.cmd_route_health(args)
+        output = capsys.readouterr().out
+
+        assert "Feedback loop:" in output
+        assert "Route Health:" in output
+        assert "Confidence:" in output

--- a/scripts/tests/test_validate_learning_effectiveness.py
+++ b/scripts/tests/test_validate_learning_effectiveness.py
@@ -1,0 +1,583 @@
+"""Tests for validate-learning-effectiveness.py.
+
+Covers each metric section with seeded data, composite score calculation,
+--json output format, and edge cases (empty DB, single entry, all at baseline).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+# Ensure repo hooks/lib takes priority over ~/.claude/hooks/lib
+_repo_root = Path(__file__).resolve().parent.parent.parent
+_repo_hooks_lib = str(_repo_root / "hooks" / "lib")
+
+sys.path.insert(0, _repo_hooks_lib)
+sys.path.insert(0, str(_repo_root / "scripts"))
+
+# Force-reload learning_db_v2 from the repo (not from ~/.claude/hooks/lib)
+if "learning_db_v2" in sys.modules:
+    del sys.modules["learning_db_v2"]
+
+import learning_db_v2
+
+# Import the CLI module so we can re-patch its references
+sys_path_entry = str(Path(__file__).resolve().parent.parent)
+sys.path.insert(0, sys_path_entry)
+_learning_db_cli = importlib.import_module("learning-db")
+sys.path.pop(0)
+
+# Patch the CLI module's references to point to the repo version
+for _attr_name in dir(learning_db_v2):
+    if hasattr(_learning_db_cli, _attr_name) and not _attr_name.startswith("__"):
+        try:
+            setattr(_learning_db_cli, _attr_name, getattr(learning_db_v2, _attr_name))
+        except (AttributeError, TypeError):
+            pass
+
+# Import the script as a module (hyphenated name)
+sys.path.insert(0, sys_path_entry)
+vle = importlib.import_module("validate-learning-effectiveness")
+sys.path.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point learning DB to a temp directory."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    monkeypatch.setattr(learning_db_v2, "_initialized", False)
+    return db_dir
+
+
+def _get_conn(isolated_db: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(isolated_db / "learning.db")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _seed_learnings(
+    isolated_db: Path,
+    entries: list[dict],
+) -> None:
+    """Seed learnings table with full control over fields.
+
+    Each entry dict can have: topic, key, value, category, confidence,
+    success_count, failure_count, observation_count, graduated_to,
+    first_seen, last_seen, source.
+    """
+    learning_db_v2.init_db()
+    conn = _get_conn(isolated_db)
+    now = datetime.now().isoformat()
+    for e in entries:
+        conn.execute(
+            """
+            INSERT INTO learnings
+                (topic, key, value, category, confidence, source,
+                 success_count, failure_count, observation_count,
+                 graduated_to, first_seen, last_seen)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                e.get("topic", "test"),
+                e.get("key", "k1"),
+                e.get("value", "test value"),
+                e.get("category", "design"),
+                e.get("confidence", 0.5),
+                e.get("source", "test"),
+                e.get("success_count", 0),
+                e.get("failure_count", 0),
+                e.get("observation_count", 1),
+                e.get("graduated_to"),
+                e.get("first_seen", now),
+                e.get("last_seen", now),
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _seed_activations(isolated_db: Path, entries: list[tuple[str, str, int]]) -> None:
+    """Seed activations. entries = [(topic, key, count), ...]."""
+    learning_db_v2.init_db()
+    conn = _get_conn(isolated_db)
+    for topic, key, count in entries:
+        for j in range(count):
+            conn.execute(
+                "INSERT INTO activations (topic, key, session_id, timestamp, outcome) VALUES (?, ?, ?, datetime('now'), 'success')",
+                (topic, key, f"sess-{topic}-{key}-{j}"),
+            )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Routing Health
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingHealth:
+    def test_empty_routing(self, isolated_db: Path) -> None:
+        learning_db_v2.init_db()
+        result = vle.measure_routing_health()
+        assert result["total_routing"] == 0
+        assert result["pct_with_outcomes"] == 0.0
+
+    def test_all_at_baseline(self, isolated_db: Path) -> None:
+        _seed_learnings(
+            isolated_db,
+            [
+                {"topic": "routing", "key": f"r{i}", "confidence": 0.5, "success_count": 0, "failure_count": 0}
+                for i in range(5)
+            ],
+        )
+        result = vle.measure_routing_health()
+        assert result["total_routing"] == 5
+        assert result["pct_with_outcomes"] == 0.0
+        assert result["pct_confidence_moved"] == 0.0
+
+    def test_mixed_outcomes(self, isolated_db: Path) -> None:
+        _seed_learnings(
+            isolated_db,
+            [
+                {"topic": "routing", "key": "r1", "confidence": 0.7, "success_count": 3, "failure_count": 0},
+                {"topic": "routing", "key": "r2", "confidence": 0.5, "success_count": 0, "failure_count": 0},
+                {"topic": "routing", "key": "r3", "confidence": 0.3, "success_count": 0, "failure_count": 2},
+                {"topic": "routing", "key": "r4", "confidence": 0.5, "success_count": 0, "failure_count": 0},
+            ],
+        )
+        result = vle.measure_routing_health()
+        assert result["total_routing"] == 4
+        assert result["pct_with_outcomes"] == 50.0  # 2 of 4
+        assert result["pct_confidence_moved"] == 50.0  # 2 of 4 (r1=0.7, r3=0.3)
+        assert result["unique_combos"] == 4
+        assert result["diversity_ratio"] == 1.0
+
+    def test_non_routing_ignored(self, isolated_db: Path) -> None:
+        _seed_learnings(
+            isolated_db,
+            [
+                {"topic": "routing", "key": "r1", "confidence": 0.5},
+                {"topic": "design", "key": "d1", "confidence": 0.9, "success_count": 5},
+            ],
+        )
+        result = vle.measure_routing_health()
+        assert result["total_routing"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Confidence Distribution
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceDistribution:
+    def test_empty_db(self, isolated_db: Path) -> None:
+        learning_db_v2.init_db()
+        result = vle.measure_confidence_distribution()
+        assert all(v == 0 for v in result["histogram"].values())
+        assert result["pct_at_baseline"] == 0.0
+
+    def test_all_at_baseline(self, isolated_db: Path) -> None:
+        _seed_learnings(
+            isolated_db,
+            [{"topic": "t", "key": f"k{i}", "confidence": 0.5} for i in range(10)],
+        )
+        result = vle.measure_confidence_distribution()
+        assert result["pct_at_baseline"] == 100.0
+        assert result["histogram"]["0.5-0.7"] == 10
+
+    def test_histogram_buckets(self, isolated_db: Path) -> None:
+        _seed_learnings(
+            isolated_db,
+            [
+                {"topic": "t", "key": "k1", "confidence": 0.1},
+                {"topic": "t", "key": "k2", "confidence": 0.4},
+                {"topic": "t", "key": "k3", "confidence": 0.6},
+                {"topic": "t", "key": "k4", "confidence": 0.8},
+                {"topic": "t", "key": "k5", "confidence": 0.95},
+                {"topic": "t", "key": "k6", "confidence": 1.0},
+            ],
+        )
+        result = vle.measure_confidence_distribution()
+        assert result["histogram"]["0.0-0.3"] == 1
+        assert result["histogram"]["0.3-0.5"] == 1
+        assert result["histogram"]["0.5-0.7"] == 1
+        assert result["histogram"]["0.7-0.9"] == 1
+        assert result["histogram"]["0.9-1.0"] == 2
+
+    def test_category_movement(self, isolated_db: Path) -> None:
+        _seed_learnings(
+            isolated_db,
+            [
+                {"topic": "t", "key": "k1", "confidence": 0.5, "category": "error"},
+                {"topic": "t", "key": "k2", "confidence": 0.8, "category": "error"},
+                {"topic": "t", "key": "k3", "confidence": 0.5, "category": "design"},
+            ],
+        )
+        result = vle.measure_confidence_distribution()
+        assert result["category_movement"]["error"]["pct_moved"] == 50.0
+        assert result["category_movement"]["design"]["pct_moved"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Utilization
+# ---------------------------------------------------------------------------
+
+
+class TestUtilization:
+    def test_empty_db(self, isolated_db: Path) -> None:
+        learning_db_v2.init_db()
+        result = vle.measure_utilization()
+        assert result["total_learnings"] == 0
+        assert result["coverage_rate"] == 0.0
+        assert result["dead_weight_count"] == 0
+
+    def test_full_coverage(self, isolated_db: Path) -> None:
+        old = (datetime.now() - timedelta(days=10)).isoformat()
+        _seed_learnings(
+            isolated_db,
+            [
+                {"topic": "a", "key": "k1", "first_seen": old},
+                {"topic": "b", "key": "k2", "first_seen": old},
+            ],
+        )
+        _seed_activations(isolated_db, [("a", "k1", 3), ("b", "k2", 1)])
+        result = vle.measure_utilization()
+        assert result["total_with_activations"] == 2
+        assert result["coverage_rate"] == 100.0
+        assert result["dead_weight_count"] == 0
+
+    def test_partial_coverage(self, isolated_db: Path) -> None:
+        old = (datetime.now() - timedelta(days=10)).isoformat()
+        _seed_learnings(
+            isolated_db,
+            [
+                {"topic": "a", "key": "k1", "first_seen": old},
+                {"topic": "b", "key": "k2", "first_seen": old},
+                {"topic": "c", "key": "k3", "first_seen": old},
+                {"topic": "d", "key": "k4", "first_seen": old},
+            ],
+        )
+        _seed_activations(isolated_db, [("a", "k1", 5)])
+        result = vle.measure_utilization()
+        assert result["total_with_activations"] == 1
+        assert result["coverage_rate"] == 25.0
+        assert result["dead_weight_count"] == 3
+
+    def test_dead_weight_ignores_recent(self, isolated_db: Path) -> None:
+        """Entries < 7 days old should not count as dead weight."""
+        recent = datetime.now().isoformat()
+        old = (datetime.now() - timedelta(days=10)).isoformat()
+        _seed_learnings(
+            isolated_db,
+            [
+                {"topic": "new", "key": "k1", "first_seen": recent},
+                {"topic": "old", "key": "k2", "first_seen": old},
+            ],
+        )
+        result = vle.measure_utilization()
+        assert result["dead_weight_count"] == 1  # only old entry
+
+    def test_top_10_sorted(self, isolated_db: Path) -> None:
+        _seed_learnings(isolated_db, [{"topic": "x", "key": "k1"}])
+        _seed_activations(
+            isolated_db,
+            [("x", "k1", 2), ("y", "k2", 10), ("z", "k3", 5)],
+        )
+        result = vle.measure_utilization()
+        counts = [item["count"] for item in result["top_10_activated"]]
+        assert counts == sorted(counts, reverse=True)
+        assert result["top_10_activated"][0]["count"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Staleness
+# ---------------------------------------------------------------------------
+
+
+class TestStaleness:
+    def test_empty_db(self, isolated_db: Path) -> None:
+        learning_db_v2.init_db()
+        result = vle.measure_staleness()
+        assert result["stale_30d"] == 0
+        assert result["stale_90d"] == 0
+
+    def test_fresh_entries(self, isolated_db: Path) -> None:
+        now = datetime.now().isoformat()
+        _seed_learnings(
+            isolated_db,
+            [{"topic": "t", "key": f"k{i}", "last_seen": now} for i in range(5)],
+        )
+        result = vle.measure_staleness()
+        assert result["stale_30d"] == 0
+        assert result["pct_stale_30d"] == 0.0
+
+    def test_stale_entries(self, isolated_db: Path) -> None:
+        old_60 = (datetime.now() - timedelta(days=60)).isoformat()
+        old_120 = (datetime.now() - timedelta(days=120)).isoformat()
+        now = datetime.now().isoformat()
+        _seed_learnings(
+            isolated_db,
+            [
+                {"topic": "t", "key": "k1", "last_seen": now},
+                {"topic": "t", "key": "k2", "last_seen": old_60},
+                {"topic": "t", "key": "k3", "last_seen": old_120},
+            ],
+        )
+        result = vle.measure_staleness()
+        assert result["stale_30d"] == 2
+        assert result["stale_90d"] == 1
+        assert result["pct_stale_30d"] == pytest.approx(66.7, abs=0.1)
+
+    def test_category_breakdown(self, isolated_db: Path) -> None:
+        old = (datetime.now() - timedelta(days=60)).isoformat()
+        _seed_learnings(
+            isolated_db,
+            [
+                {"topic": "t", "key": "k1", "last_seen": old, "category": "error"},
+                {"topic": "t", "key": "k2", "last_seen": old, "category": "error"},
+                {"topic": "t", "key": "k3", "last_seen": old, "category": "design"},
+            ],
+        )
+        result = vle.measure_staleness()
+        assert result["stale_by_category"]["error"] == 2
+        assert result["stale_by_category"]["design"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Category Health
+# ---------------------------------------------------------------------------
+
+
+class TestCategoryHealth:
+    def test_empty_db(self, isolated_db: Path) -> None:
+        learning_db_v2.init_db()
+        result = vle.measure_category_health()
+        assert result["categories"] == {}
+        assert result["zero_graduated"] == []
+
+    def test_single_category(self, isolated_db: Path) -> None:
+        _seed_learnings(
+            isolated_db,
+            [
+                {"topic": "t", "key": "k1", "category": "error", "confidence": 0.8, "observation_count": 3},
+                {"topic": "t", "key": "k2", "category": "error", "confidence": 0.6, "observation_count": 1},
+            ],
+        )
+        result = vle.measure_category_health()
+        assert "error" in result["categories"]
+        assert result["categories"]["error"]["count"] == 2
+        assert result["categories"]["error"]["avg_confidence"] == pytest.approx(0.7, abs=0.01)
+        assert "error" in result["zero_graduated"]
+
+    def test_graduated_entries(self, isolated_db: Path) -> None:
+        _seed_learnings(
+            isolated_db,
+            [
+                {
+                    "topic": "t",
+                    "key": "k1",
+                    "category": "design",
+                    "graduated_to": "agent:test",
+                },
+                {"topic": "t", "key": "k2", "category": "design"},
+            ],
+        )
+        result = vle.measure_category_health()
+        assert result["categories"]["design"]["graduated_count"] == 1
+        assert "design" not in result["zero_graduated"]
+
+
+# ---------------------------------------------------------------------------
+# Effectiveness Score
+# ---------------------------------------------------------------------------
+
+
+class TestEffectivenessScore:
+    def test_all_zeros(self, isolated_db: Path) -> None:
+        """Empty DB should score 0."""
+        learning_db_v2.init_db()
+        routing = vle.measure_routing_health()
+        confidence = vle.measure_confidence_distribution()
+        utilization = vle.measure_utilization()
+        staleness = vle.measure_staleness()
+        category = vle.measure_category_health()
+        score = vle.compute_effectiveness_score(routing, confidence, utilization, staleness, category)
+        assert score["total"] == 0.0
+
+    def test_perfect_score(self, isolated_db: Path) -> None:
+        """Fully healthy DB should score 100."""
+        now = datetime.now().isoformat()
+        _seed_learnings(
+            isolated_db,
+            [
+                {
+                    "topic": "routing",
+                    "key": f"r{i}",
+                    "confidence": 0.9,
+                    "success_count": 5,
+                    "failure_count": 0,
+                    "category": "effectiveness",
+                    "graduated_to": "agent:test",
+                    "last_seen": now,
+                }
+                for i in range(10)
+            ],
+        )
+        _seed_activations(isolated_db, [("routing", f"r{i}", 3) for i in range(10)])
+
+        routing = vle.measure_routing_health()
+        confidence = vle.measure_confidence_distribution()
+        utilization = vle.measure_utilization()
+        staleness = vle.measure_staleness()
+        category = vle.measure_category_health()
+        score = vle.compute_effectiveness_score(routing, confidence, utilization, staleness, category)
+
+        assert score["total"] == 100.0
+
+    def test_weights_sum_to_100(self, isolated_db: Path) -> None:
+        learning_db_v2.init_db()
+        routing = vle.measure_routing_health()
+        confidence = vle.measure_confidence_distribution()
+        utilization = vle.measure_utilization()
+        staleness = vle.measure_staleness()
+        category = vle.measure_category_health()
+        score = vle.compute_effectiveness_score(routing, confidence, utilization, staleness, category)
+        assert sum(score["weights"].values()) == 100
+
+    def test_partial_score(self, isolated_db: Path) -> None:
+        """Some healthy, some broken should be in between."""
+        now = datetime.now().isoformat()
+        _seed_learnings(
+            isolated_db,
+            [
+                # Routing: half with outcomes
+                {"topic": "routing", "key": "r1", "confidence": 0.7, "success_count": 3},
+                {"topic": "routing", "key": "r2", "confidence": 0.5, "success_count": 0},
+                # Non-routing: mixed confidence, some graduated
+                {"topic": "other", "key": "o1", "confidence": 0.9, "category": "error", "graduated_to": "x"},
+                {"topic": "other", "key": "o2", "confidence": 0.5, "category": "design", "last_seen": now},
+            ],
+        )
+        routing = vle.measure_routing_health()
+        confidence = vle.measure_confidence_distribution()
+        utilization = vle.measure_utilization()
+        staleness = vle.measure_staleness()
+        category = vle.measure_category_health()
+        score = vle.compute_effectiveness_score(routing, confidence, utilization, staleness, category)
+
+        assert 0 < score["total"] < 100
+
+
+# ---------------------------------------------------------------------------
+# run_all_sections
+# ---------------------------------------------------------------------------
+
+
+class TestRunAllSections:
+    def test_returns_all_sections(self, isolated_db: Path) -> None:
+        learning_db_v2.init_db()
+        results = vle.run_all_sections()
+        assert "routing" in results
+        assert "confidence" in results
+        assert "utilization" in results
+        assert "staleness" in results
+        assert "category" in results
+        assert "score" in results
+
+    def test_section_filter(self, isolated_db: Path) -> None:
+        learning_db_v2.init_db()
+        results = vle.run_all_sections(section_filter="routing")
+        assert "routing" in results
+        assert "confidence" not in results
+
+    def test_score_section_alone(self, isolated_db: Path) -> None:
+        """--section score should still compute the score."""
+        learning_db_v2.init_db()
+        results = vle.run_all_sections(section_filter="score")
+        assert "score" in results
+        assert "total" in results["score"]
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+
+class TestJsonOutput:
+    def test_json_parseable(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        learning_db_v2.init_db()
+        results = vle.run_all_sections()
+        print(json.dumps(results, indent=2))
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert isinstance(data, dict)
+        assert "score" in data
+
+    def test_json_contains_all_sections(self, isolated_db: Path) -> None:
+        learning_db_v2.init_db()
+        results = vle.run_all_sections()
+        assert set(results.keys()) == {"routing", "confidence", "utilization", "staleness", "category", "score"}
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_single_entry(self, isolated_db: Path) -> None:
+        _seed_learnings(isolated_db, [{"topic": "t", "key": "k1", "confidence": 0.5}])
+        results = vle.run_all_sections()
+        assert results["confidence"]["pct_at_baseline"] == 100.0
+        assert results["utilization"]["total_learnings"] == 1
+        assert results["score"]["total"] >= 0
+
+    def test_empty_database(self, isolated_db: Path) -> None:
+        learning_db_v2.init_db()
+        results = vle.run_all_sections()
+        assert results["routing"]["total_routing"] == 0
+        assert results["utilization"]["total_learnings"] == 0
+        assert results["score"]["total"] == 0.0
+
+    def test_all_graduated(self, isolated_db: Path) -> None:
+        now = datetime.now().isoformat()
+        _seed_learnings(
+            isolated_db,
+            [
+                {"topic": "t", "key": f"k{i}", "category": "design", "graduated_to": "x", "last_seen": now}
+                for i in range(3)
+            ],
+        )
+        result = vle.measure_category_health()
+        assert result["categories"]["design"]["graduated_count"] == 3
+        assert "design" not in result["zero_graduated"]
+
+    def test_confidence_at_exact_boundaries(self, isolated_db: Path) -> None:
+        """Test confidence values at exact bucket boundaries."""
+        _seed_learnings(
+            isolated_db,
+            [
+                {"topic": "t", "key": "k0", "confidence": 0.0},
+                {"topic": "t", "key": "k3", "confidence": 0.3},
+                {"topic": "t", "key": "k5", "confidence": 0.5},
+                {"topic": "t", "key": "k7", "confidence": 0.7},
+                {"topic": "t", "key": "k9", "confidence": 0.9},
+            ],
+        )
+        result = vle.measure_confidence_distribution()
+        total = sum(result["histogram"].values())
+        assert total == 5  # All entries should be bucketed

--- a/scripts/validate-learning-effectiveness.py
+++ b/scripts/validate-learning-effectiveness.py
@@ -34,6 +34,8 @@ from learning_db_v2 import get_connection, init_db
 # Section: Routing Feedback Loop Health
 # ---------------------------------------------------------------------------
 
+DEAD_WEIGHT_AGE_DAYS = 7
+
 VALID_SECTIONS = {"routing", "confidence", "utilization", "staleness", "category", "score"}
 
 
@@ -60,7 +62,7 @@ def measure_routing_health() -> dict:
         }
 
     with_outcomes = sum(1 for r in rows if (r["success_count"] or 0) + (r["failure_count"] or 0) > 0)
-    confidence_moved = sum(1 for r in rows if r["confidence"] != 0.5)
+    confidence_moved = sum(1 for r in rows if abs(r["confidence"] - 0.5) > 1e-9)
     unique_keys = {r["key"] for r in rows}
 
     return {
@@ -117,11 +119,11 @@ def measure_confidence_distribution() -> dict:
                 histogram[label] += 1
                 break
 
-        if conf == 0.5:
+        if abs(conf - 0.5) <= 1e-9:
             at_baseline += 1
 
         category_total[cat] = category_total.get(cat, 0) + 1
-        if conf != 0.5:
+        if abs(conf - 0.5) > 1e-9:
             category_moved[cat] = category_moved.get(cat, 0) + 1
 
     # Build category movement as pct
@@ -171,8 +173,8 @@ def measure_utilization() -> dict:
             """
         ).fetchall()
 
-        # Dead weight: learnings with 0 activations and age > 7 days
-        cutoff_7d = (datetime.now() - timedelta(days=7)).isoformat()
+        # Dead weight: learnings with 0 activations and age > DEAD_WEIGHT_AGE_DAYS
+        cutoff_7d = (datetime.now() - timedelta(days=DEAD_WEIGHT_AGE_DAYS)).isoformat()
         dead_weight = conn.execute(
             """
             SELECT COUNT(*) FROM learnings l
@@ -361,7 +363,8 @@ def print_routing(data: dict, verbose: bool = False) -> None:
     print(f"  With outcomes (s+f > 0):     {data['pct_with_outcomes']}%")
     print(f"  Confidence moved from 0.5:   {data['pct_confidence_moved']}%")
     print(f"  Unique agent:skill combos:   {data['unique_combos']}")
-    print(f"  Diversity ratio:             {data['diversity_ratio']}")
+    if verbose:
+        print(f"  Diversity ratio:             {data['diversity_ratio']}")
     print()
 
 
@@ -428,7 +431,10 @@ def print_score(data: dict, verbose: bool = False) -> None:
         weight = data["weights"][component]
         weighted = round(score * weight / 100, 1)
         label = component.replace("_", " ").title()
-        print(f"  {label:25s}: {score:>5.1f}/100 (weight {weight:>2}, contributes {weighted:.1f})")
+        if verbose:
+            print(f"  {label:25s}: {score:>5.1f}/100 (weight {weight:>2}, contributes {weighted:.1f})")
+        else:
+            print(f"  {label:25s}: {score:>5.1f}/100 (weight {weight:>2})")
     print(f"  {'':25s}  {'─' * 20}")
     print(f"  {'TOTAL':25s}: {data['total']:>5.1f}/100")
     status = "PASS" if data["total"] >= 50 else "FAIL"
@@ -444,11 +450,15 @@ def print_score(data: dict, verbose: bool = False) -> None:
 def run_all_sections(*, section_filter: str | None = None) -> dict:
     """Run all measurement sections and return collected data.
 
+    When section_filter is set to a non-score section, the score is still
+    computed (for exit-code purposes) but stored under the "_score" key so
+    callers can access it without it appearing in printed output.
+
     Args:
-        section_filter: If set, only run this specific section.
+        section_filter: If set, only run/display this specific section.
 
     Returns:
-        Dict with all section results and the composite score.
+        Dict with section results and the composite score.
     """
     init_db()
 
@@ -467,24 +477,23 @@ def run_all_sections(*, section_filter: str | None = None) -> dict:
     if run_all or section_filter == "category":
         results["category"] = measure_category_health()
 
-    # Score requires all sections
+    # Always compute score for exit code purposes
     if run_all or section_filter == "score":
-        if run_all:
-            results["score"] = compute_effectiveness_score(
-                results["routing"],
-                results["confidence"],
-                results["utilization"],
-                results["staleness"],
-                results["category"],
-            )
-        elif section_filter == "score":
-            # Must compute all sections for the score
-            routing = measure_routing_health()
-            confidence = measure_confidence_distribution()
-            utilization = measure_utilization()
-            staleness = measure_staleness()
-            category = measure_category_health()
-            results["score"] = compute_effectiveness_score(routing, confidence, utilization, staleness, category)
+        # Need all section data for score
+        routing = results.get("routing") or measure_routing_health()
+        confidence = results.get("confidence") or measure_confidence_distribution()
+        utilization = results.get("utilization") or measure_utilization()
+        staleness = results.get("staleness") or measure_staleness()
+        category = results.get("category") or measure_category_health()
+        results["score"] = compute_effectiveness_score(routing, confidence, utilization, staleness, category)
+    elif section_filter is not None:
+        # Non-score section filter: compute score for exit code but don't display
+        routing = results.get("routing") or measure_routing_health()
+        confidence = results.get("confidence") or measure_confidence_distribution()
+        utilization = results.get("utilization") or measure_utilization()
+        staleness = results.get("staleness") or measure_staleness()
+        category = results.get("category") or measure_category_health()
+        results["_score"] = compute_effectiveness_score(routing, confidence, utilization, staleness, category)
 
     return results
 
@@ -522,8 +531,9 @@ def main() -> None:
             if section in printers:
                 printers[section](data, verbose=args.verbose)
 
-    # Exit code based on score
-    score = results.get("score", {}).get("total")
+    # Exit code based on score (use _score if score wasn't displayed)
+    score_data = results.get("score") or results.get("_score", {})
+    score = score_data.get("total")
     if score is not None and score < 50:
         sys.exit(1)
 

--- a/scripts/validate-learning-effectiveness.py
+++ b/scripts/validate-learning-effectiveness.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""Validate learning database effectiveness with concrete health metrics.
+
+Measures feedback loop closure, confidence distribution, activation coverage,
+staleness, category health, and produces a composite effectiveness score (0-100).
+
+Usage:
+    python3 scripts/validate-learning-effectiveness.py
+    python3 scripts/validate-learning-effectiveness.py --json
+    python3 scripts/validate-learning-effectiveness.py --verbose
+    python3 scripts/validate-learning-effectiveness.py --section routing
+    python3 scripts/validate-learning-effectiveness.py --section confidence --json
+
+Exit codes:
+    0 - Effectiveness score >= 50
+    1 - Effectiveness score < 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+# Add repo hooks/lib for learning_db_v2 import
+_repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_repo_root / "hooks" / "lib"))
+
+from learning_db_v2 import get_connection, init_db
+
+# ---------------------------------------------------------------------------
+# Section: Routing Feedback Loop Health
+# ---------------------------------------------------------------------------
+
+VALID_SECTIONS = {"routing", "confidence", "utilization", "staleness", "category", "score"}
+
+
+def measure_routing_health() -> dict:
+    """Measure routing feedback loop health.
+
+    Returns:
+        Dict with total_routing, pct_with_outcomes, pct_confidence_moved,
+        diversity_ratio, unique_combos, and detail lists.
+    """
+    with get_connection() as conn:
+        rows = conn.execute(
+            "SELECT key, confidence, success_count, failure_count FROM learnings WHERE topic = 'routing'"
+        ).fetchall()
+
+    total = len(rows)
+    if total == 0:
+        return {
+            "total_routing": 0,
+            "pct_with_outcomes": 0.0,
+            "pct_confidence_moved": 0.0,
+            "unique_combos": 0,
+            "diversity_ratio": 0.0,
+        }
+
+    with_outcomes = sum(1 for r in rows if (r["success_count"] or 0) + (r["failure_count"] or 0) > 0)
+    confidence_moved = sum(1 for r in rows if r["confidence"] != 0.5)
+    unique_keys = {r["key"] for r in rows}
+
+    return {
+        "total_routing": total,
+        "pct_with_outcomes": round(with_outcomes / total * 100, 1),
+        "pct_confidence_moved": round(confidence_moved / total * 100, 1),
+        "unique_combos": len(unique_keys),
+        "diversity_ratio": round(len(unique_keys) / total, 3),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section: Confidence Distribution
+# ---------------------------------------------------------------------------
+
+CONFIDENCE_BUCKETS = [
+    ("0.0-0.3", 0.0, 0.3),
+    ("0.3-0.5", 0.3, 0.5),
+    ("0.5-0.7", 0.5, 0.7),
+    ("0.7-0.9", 0.7, 0.9),
+    ("0.9-1.0", 0.9, 1.01),  # inclusive upper bound for 1.0
+]
+
+
+def measure_confidence_distribution() -> dict:
+    """Measure confidence distribution across all learnings.
+
+    Returns:
+        Dict with histogram (bucket counts), pct_at_baseline,
+        and category_movement breakdown.
+    """
+    with get_connection() as conn:
+        rows = conn.execute("SELECT confidence, category FROM learnings").fetchall()
+
+    total = len(rows)
+    if total == 0:
+        return {
+            "histogram": {label: 0 for label, _, _ in CONFIDENCE_BUCKETS},
+            "pct_at_baseline": 0.0,
+            "category_movement": {},
+        }
+
+    histogram: dict[str, int] = {label: 0 for label, _, _ in CONFIDENCE_BUCKETS}
+    at_baseline = 0
+    category_moved: dict[str, int] = {}
+    category_total: dict[str, int] = {}
+
+    for row in rows:
+        conf = row["confidence"]
+        cat = row["category"]
+
+        for label, low, high in CONFIDENCE_BUCKETS:
+            if low <= conf < high:
+                histogram[label] += 1
+                break
+
+        if conf == 0.5:
+            at_baseline += 1
+
+        category_total[cat] = category_total.get(cat, 0) + 1
+        if conf != 0.5:
+            category_moved[cat] = category_moved.get(cat, 0) + 1
+
+    # Build category movement as pct
+    cat_movement = {}
+    for cat, tot in sorted(category_total.items()):
+        moved = category_moved.get(cat, 0)
+        cat_movement[cat] = {"total": tot, "moved": moved, "pct_moved": round(moved / tot * 100, 1) if tot else 0.0}
+
+    return {
+        "histogram": histogram,
+        "pct_at_baseline": round(at_baseline / total * 100, 1),
+        "category_movement": cat_movement,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section: Learning Utilization
+# ---------------------------------------------------------------------------
+
+
+def measure_utilization() -> dict:
+    """Measure how well learnings are being utilized via activations.
+
+    Returns:
+        Dict with total_learnings, total_with_activations, coverage_rate,
+        top_10_activated, and dead_weight_count.
+    """
+    with get_connection() as conn:
+        total_learnings = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()[0]
+
+        # Learnings that have at least one activation (join on topic+key)
+        activated = conn.execute(
+            """
+            SELECT COUNT(DISTINCT l.id) FROM learnings l
+            INNER JOIN activations a ON l.topic = a.topic AND l.key = a.key
+            """
+        ).fetchone()[0]
+
+        # Top 10 most activated
+        top_10 = conn.execute(
+            """
+            SELECT a.topic, a.key, COUNT(*) as activation_count
+            FROM activations a
+            GROUP BY a.topic, a.key
+            ORDER BY activation_count DESC
+            LIMIT 10
+            """
+        ).fetchall()
+
+        # Dead weight: learnings with 0 activations and age > 7 days
+        cutoff_7d = (datetime.now() - timedelta(days=7)).isoformat()
+        dead_weight = conn.execute(
+            """
+            SELECT COUNT(*) FROM learnings l
+            LEFT JOIN activations a ON l.topic = a.topic AND l.key = a.key
+            WHERE a.id IS NULL AND l.first_seen < ?
+            """,
+            (cutoff_7d,),
+        ).fetchone()[0]
+
+    coverage = round(activated / total_learnings * 100, 1) if total_learnings else 0.0
+
+    return {
+        "total_learnings": total_learnings,
+        "total_with_activations": activated,
+        "coverage_rate": coverage,
+        "top_10_activated": [{"topic": r["topic"], "key": r["key"], "count": r["activation_count"]} for r in top_10],
+        "dead_weight_count": dead_weight,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section: Staleness
+# ---------------------------------------------------------------------------
+
+
+def measure_staleness() -> dict:
+    """Measure staleness of learning entries.
+
+    Returns:
+        Dict with stale_30d, stale_90d, and category breakdown.
+    """
+    now = datetime.now()
+    cutoff_30 = (now - timedelta(days=30)).isoformat()
+    cutoff_90 = (now - timedelta(days=90)).isoformat()
+
+    with get_connection() as conn:
+        total = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()[0]
+
+        stale_30 = conn.execute("SELECT COUNT(*) FROM learnings WHERE last_seen < ?", (cutoff_30,)).fetchone()[0]
+        stale_90 = conn.execute("SELECT COUNT(*) FROM learnings WHERE last_seen < ?", (cutoff_90,)).fetchone()[0]
+
+        # Category breakdown of 30d stale
+        cat_rows = conn.execute(
+            "SELECT category, COUNT(*) as cnt FROM learnings WHERE last_seen < ? GROUP BY category ORDER BY cnt DESC",
+            (cutoff_30,),
+        ).fetchall()
+
+    return {
+        "total": total,
+        "stale_30d": stale_30,
+        "stale_90d": stale_90,
+        "pct_stale_30d": round(stale_30 / total * 100, 1) if total else 0.0,
+        "pct_stale_90d": round(stale_90 / total * 100, 1) if total else 0.0,
+        "stale_by_category": {r["category"]: r["cnt"] for r in cat_rows},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section: Category Health
+# ---------------------------------------------------------------------------
+
+
+def measure_category_health() -> dict:
+    """Measure per-category health metrics.
+
+    Returns:
+        Dict with per-category stats and list of categories with zero graduations.
+    """
+    with get_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT category,
+                   COUNT(*) as count,
+                   AVG(confidence) as avg_confidence,
+                   AVG(observation_count) as avg_observations,
+                   SUM(CASE WHEN graduated_to IS NOT NULL THEN 1 ELSE 0 END) as graduated_count
+            FROM learnings
+            GROUP BY category
+            ORDER BY count DESC
+            """
+        ).fetchall()
+
+    categories = {}
+    zero_graduated = []
+
+    for r in rows:
+        cat = r["category"]
+        categories[cat] = {
+            "count": r["count"],
+            "avg_confidence": round(r["avg_confidence"], 3),
+            "avg_observations": round(r["avg_observations"], 1),
+            "graduated_count": r["graduated_count"],
+        }
+        if r["graduated_count"] == 0:
+            zero_graduated.append(cat)
+
+    return {
+        "categories": categories,
+        "zero_graduated": zero_graduated,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section: Effectiveness Score
+# ---------------------------------------------------------------------------
+
+
+def compute_effectiveness_score(
+    routing: dict,
+    confidence: dict,
+    utilization: dict,
+    staleness: dict,
+    category: dict,
+) -> dict:
+    """Compute composite effectiveness score (0-100).
+
+    Weights:
+        - Feedback loop closure: 30 (% routing entries with outcomes)
+        - Confidence movement: 20 (% entries that moved from baseline)
+        - Activation coverage: 20 (% learnings activated)
+        - Freshness: 15 (% entries seen in last 30 days)
+        - Graduation rate: 15 (% high-confidence entries that graduated)
+
+    Args:
+        routing: Output from measure_routing_health().
+        confidence: Output from measure_confidence_distribution().
+        utilization: Output from measure_utilization().
+        staleness: Output from measure_staleness().
+        category: Output from measure_category_health().
+
+    Returns:
+        Dict with total score, component scores, and weights.
+    """
+    # Component 1: Feedback loop closure (0-100)
+    feedback_score = min(routing["pct_with_outcomes"], 100.0)
+
+    # Component 2: Confidence movement (0-100) — 0 if no learnings exist
+    has_learnings = utilization["total_learnings"] > 0
+    confidence_score = min(100.0 - confidence["pct_at_baseline"], 100.0) if has_learnings else 0.0
+
+    # Component 3: Activation coverage (0-100)
+    activation_score = min(utilization["coverage_rate"], 100.0)
+
+    # Component 4: Freshness (0-100) — % NOT stale in 30d; 0 if no learnings
+    freshness_score = max(100.0 - staleness["pct_stale_30d"], 0.0) if has_learnings else 0.0
+
+    # Component 5: Graduation rate — % of categories with at least one graduation
+    total_cats = len(category["categories"])
+    cats_with_grad = total_cats - len(category["zero_graduated"])
+    graduation_score = round(cats_with_grad / total_cats * 100, 1) if total_cats else 0.0
+
+    weights = {
+        "feedback_loop": 30,
+        "confidence_movement": 20,
+        "activation_coverage": 20,
+        "freshness": 15,
+        "graduation_rate": 15,
+    }
+
+    components = {
+        "feedback_loop": round(feedback_score, 1),
+        "confidence_movement": round(confidence_score, 1),
+        "activation_coverage": round(activation_score, 1),
+        "freshness": round(freshness_score, 1),
+        "graduation_rate": round(graduation_score, 1),
+    }
+
+    total = sum(components[k] * weights[k] / 100 for k in weights)
+
+    return {
+        "total": round(total, 1),
+        "components": components,
+        "weights": weights,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def print_routing(data: dict, verbose: bool = False) -> None:
+    """Print routing feedback loop health."""
+    print("=== Routing Feedback Loop Health ===")
+    print(f"  Total routing entries:       {data['total_routing']}")
+    print(f"  With outcomes (s+f > 0):     {data['pct_with_outcomes']}%")
+    print(f"  Confidence moved from 0.5:   {data['pct_confidence_moved']}%")
+    print(f"  Unique agent:skill combos:   {data['unique_combos']}")
+    print(f"  Diversity ratio:             {data['diversity_ratio']}")
+    print()
+
+
+def print_confidence(data: dict, verbose: bool = False) -> None:
+    """Print confidence distribution."""
+    print("=== Confidence Distribution ===")
+    for bucket, count in data["histogram"].items():
+        bar = "#" * min(count // 5, 40) if count else ""
+        print(f"  {bucket:8s}: {count:>5} {bar}")
+    print(f"  At baseline (0.5):           {data['pct_at_baseline']}%")
+    if verbose and data["category_movement"]:
+        print("  Category movement:")
+        for cat, info in sorted(data["category_movement"].items()):
+            print(f"    {cat:20s}: {info['moved']}/{info['total']} ({info['pct_moved']}%)")
+    print()
+
+
+def print_utilization(data: dict, verbose: bool = False) -> None:
+    """Print learning utilization."""
+    print("=== Learning Utilization ===")
+    print(f"  Total learnings:             {data['total_learnings']}")
+    print(f"  With activations:            {data['total_with_activations']}")
+    print(f"  Coverage rate:               {data['coverage_rate']}%")
+    print(f"  Dead weight (0 act, >7d):    {data['dead_weight_count']}")
+    if verbose and data["top_10_activated"]:
+        print("  Top 10 activated:")
+        for item in data["top_10_activated"]:
+            print(f"    {item['topic']}/{item['key']}: {item['count']} activations")
+    print()
+
+
+def print_staleness(data: dict, verbose: bool = False) -> None:
+    """Print staleness metrics."""
+    print("=== Staleness ===")
+    print(f"  Not seen in 30+ days:        {data['stale_30d']} ({data['pct_stale_30d']}%)")
+    print(f"  Not seen in 90+ days:        {data['stale_90d']} ({data['pct_stale_90d']}%)")
+    if verbose and data["stale_by_category"]:
+        print("  Stale (30d) by category:")
+        for cat, cnt in data["stale_by_category"].items():
+            print(f"    {cat:20s}: {cnt}")
+    print()
+
+
+def print_category(data: dict, verbose: bool = False) -> None:
+    """Print category health."""
+    print("=== Category Health ===")
+    for cat, info in data["categories"].items():
+        grad_marker = " *" if info["graduated_count"] == 0 else ""
+        print(
+            f"  {cat:20s}: n={info['count']:>4}, "
+            f"avg_conf={info['avg_confidence']:.2f}, "
+            f"avg_obs={info['avg_observations']:.1f}, "
+            f"grad={info['graduated_count']}{grad_marker}"
+        )
+    if data["zero_graduated"]:
+        print(f"  (* = zero graduations: {', '.join(data['zero_graduated'])})")
+    print()
+
+
+def print_score(data: dict, verbose: bool = False) -> None:
+    """Print effectiveness score."""
+    print("=== Effectiveness Score ===")
+    for component, score in data["components"].items():
+        weight = data["weights"][component]
+        weighted = round(score * weight / 100, 1)
+        label = component.replace("_", " ").title()
+        print(f"  {label:25s}: {score:>5.1f}/100 (weight {weight:>2}, contributes {weighted:.1f})")
+    print(f"  {'':25s}  {'─' * 20}")
+    print(f"  {'TOTAL':25s}: {data['total']:>5.1f}/100")
+    status = "PASS" if data["total"] >= 50 else "FAIL"
+    print(f"  Status: {status}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def run_all_sections(*, section_filter: str | None = None) -> dict:
+    """Run all measurement sections and return collected data.
+
+    Args:
+        section_filter: If set, only run this specific section.
+
+    Returns:
+        Dict with all section results and the composite score.
+    """
+    init_db()
+
+    results: dict = {}
+
+    run_all = section_filter is None
+
+    if run_all or section_filter == "routing":
+        results["routing"] = measure_routing_health()
+    if run_all or section_filter == "confidence":
+        results["confidence"] = measure_confidence_distribution()
+    if run_all or section_filter == "utilization":
+        results["utilization"] = measure_utilization()
+    if run_all or section_filter == "staleness":
+        results["staleness"] = measure_staleness()
+    if run_all or section_filter == "category":
+        results["category"] = measure_category_health()
+
+    # Score requires all sections
+    if run_all or section_filter == "score":
+        if run_all:
+            results["score"] = compute_effectiveness_score(
+                results["routing"],
+                results["confidence"],
+                results["utilization"],
+                results["staleness"],
+                results["category"],
+            )
+        elif section_filter == "score":
+            # Must compute all sections for the score
+            routing = measure_routing_health()
+            confidence = measure_confidence_distribution()
+            utilization = measure_utilization()
+            staleness = measure_staleness()
+            category = measure_category_health()
+            results["score"] = compute_effectiveness_score(routing, confidence, utilization, staleness, category)
+
+    return results
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Validate learning database effectiveness",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+    parser.add_argument("--verbose", action="store_true", help="Detailed breakdown")
+    parser.add_argument(
+        "--section",
+        choices=sorted(VALID_SECTIONS),
+        default=None,
+        help="Run a single section only",
+    )
+
+    args = parser.parse_args()
+    results = run_all_sections(section_filter=args.section)
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        printers = {
+            "routing": print_routing,
+            "confidence": print_confidence,
+            "utilization": print_utilization,
+            "staleness": print_staleness,
+            "category": print_category,
+            "score": print_score,
+        }
+        for section, data in results.items():
+            if section in printers:
+                printers[section](data, verbose=args.verbose)
+
+    # Exit code based on score
+    score = results.get("score", {}).get("total")
+    if score is not None and score < 50:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -381,7 +381,7 @@ python3 ~/.claude/scripts/learning-db.py record-routing-outcome \
     "{selected_agent}:{selected_skill}" --failure --reason "{brief reason}"
 ```
 
-This closes the routing feedback loop — confidence scores adjust over time, improving future routing accuracy. Do not skip this step.
+Do not skip this step.
 
 **Auto-capture** (hooks, zero LLM cost): `error-learner.py`, `review-capture.py` (PostToolUse), `session-learning-recorder.py` (Stop).
 

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -358,13 +358,30 @@ When uncertain: **ROUTE ANYWAY** with verification-before-completion as safety n
 
 **Goal**: Capture session insights to `learning.db`.
 
-**Routing outcome** (Simple+, observable facts only):
+**Routing decision** (Simple+, observable facts only):
 ```bash
 python3 ~/.claude/scripts/learning-db.py record \
     routing "{selected_agent}:{selected_skill}" \
     "routing-decision: agent={selected_agent} skill={selected_skill} tool_errors: {0|1} user_rerouted: {0|1}" \
     --category effectiveness
 ```
+
+**Routing outcome** (MANDATORY for Simple+ — records whether the route succeeded):
+After the agent completes, evaluate the outcome based on observable facts:
+- **Success signals**: agent produced commits, tests passed, no tool errors, user accepted result
+- **Failure signals**: agent errored, user re-routed, rework required, `tool_errors=1`
+
+```bash
+# On success:
+python3 ~/.claude/scripts/learning-db.py record-routing-outcome \
+    "{selected_agent}:{selected_skill}" --success
+
+# On failure (include reason):
+python3 ~/.claude/scripts/learning-db.py record-routing-outcome \
+    "{selected_agent}:{selected_skill}" --failure --reason "{brief reason}"
+```
+
+This closes the routing feedback loop — confidence scores adjust over time, improving future routing accuracy. Do not skip this step.
 
 **Auto-capture** (hooks, zero LLM cost): `error-learner.py`, `review-capture.py` (PostToolUse), `session-learning-recorder.py` (Stop).
 
@@ -376,7 +393,7 @@ python3 ~/.claude/scripts/learning-db.py learn --agent golang-general-engineer "
 
 **Immediate graduation for review findings** (MANDATORY): Issue found + fixed in same PR → (1) Record scoped, (2) Boost to 1.0, (3) Embed into anti-patterns, (4) Graduate, (5) Stage in same PR.
 
-**Gate**: Record at least one learning for Simple+ tasks. Review findings get immediate graduation.
+**Gate**: Record at least one learning AND one routing outcome for Simple+ tasks. Review findings get immediate graduation.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Validation script** (`validate-learning-effectiveness.py`): 6-section health metrics + composite 0-100 effectiveness score. Measures feedback loop closure, confidence movement, activation coverage, staleness, category health, graduation rate
- **Routing outcome recording**: 3 new CLI subcommands (`record-routing-outcome`, `backfill-routing-outcomes`, `route-health`) to close the routing feedback loop
- **Activation tracking**: `record_activations()` library function + wiring into `pretool-learning-injector.py` and `session-context.py` hooks
- **10-angle PR review fixes**: Backfill idempotency, batched DB writes, shared helper extraction, float tolerance, debug logging, exit code consistency

## Context

The learning database had 1,564 entries across 3,614 sessions but **no feedback loop**:
- Routing decisions: 0% had success/failure outcomes
- Activation coverage: 0% (nobody tracked which learnings were surfaced)
- Baseline effectiveness score: 39.5/100

## Test plan

- [x] 111 tests pass across 4 test files (50 new tests)
- [x] Full suite: 3,323 passed, 0 failed
- [x] `ruff check` + `ruff format --check` clean
- [x] `validate-learning-effectiveness.py --verbose` runs against real DB
- [x] `route-health` shows baseline metrics
- [x] `backfill-routing-outcomes` is idempotent (safe to re-run)
- [x] 10-angle PR review findings all addressed