### PR TITLE
chore: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install ruff pyyaml
@@ -26,8 +26,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install pytest pyyaml pillow numpy
@@ -36,8 +36,8 @@ jobs:
   routing-benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: python scripts/routing-benchmark.py --verbose
@@ -45,8 +45,8 @@ jobs:
   routing-drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: python scripts/check-routing-drift.py --verbose

--- a/scripts/scan-negative-framing.py
+++ b/scripts/scan-negative-framing.py
@@ -92,16 +92,44 @@ NEGATIVE_PATTERNS = [
     (r"\bdisappoint", "negative_emotion", "Names a negative emotion. Reframe around what happened next."),
     (r"\bresent", "negative_emotion", "Names a negative emotion. Reframe entirely."),
     # Self-flagellation / mea culpa
-    (r"\bi was wrong\b", "self_flagellation", "Self-flagellation. State the revised position directly without performing recantation."),
-    (r"\bi wince\b", "self_flagellation", "Self-flagellation. Present the argument without dramatizing the correction."),
+    (
+        r"\bi was wrong\b",
+        "self_flagellation",
+        "Self-flagellation. State the revised position directly without performing recantation.",
+    ),
+    (
+        r"\bi wince\b",
+        "self_flagellation",
+        "Self-flagellation. Present the argument without dramatizing the correction.",
+    ),
     (r"\bi shudder\b", "self_flagellation", "Self-flagellation. Lay out the facts without theatrical regret."),
-    (r"\bembarrassing\b", "self_flagellation", "Self-flagellation. If the new position is stronger, state it. The old position doesn't need to be humiliated."),
-    (r"\bmy error\b", "self_flagellation", "Self-flagellation. State what's true now rather than performing contrition for what was true before."),
-    (r"\bshould have (known|saved|seen|realized)\b", "self_flagellation", "Hindsight self-blame. The interesting thing is what you see now, not that you didn't see it then."),
-    (r"\bi forgot\b", "self_flagellation", "Self-blame framing. Reframe around the insight, not the failure to have it sooner."),
+    (
+        r"\bembarrassing\b",
+        "self_flagellation",
+        "Self-flagellation. If the new position is stronger, state it. The old position doesn't need to be humiliated.",
+    ),
+    (
+        r"\bmy error\b",
+        "self_flagellation",
+        "Self-flagellation. State what's true now rather than performing contrition for what was true before.",
+    ),
+    (
+        r"\bshould have (known|saved|seen|realized)\b",
+        "self_flagellation",
+        "Hindsight self-blame. The interesting thing is what you see now, not that you didn't see it then.",
+    ),
+    (
+        r"\bi forgot\b",
+        "self_flagellation",
+        "Self-blame framing. Reframe around the insight, not the failure to have it sooner.",
+    ),
     (r"\bhow could i\b", "self_flagellation", "Performative self-reproach. State the current understanding directly."),
     (r"\bmea culpa\b", "self_flagellation", "Literal self-flagellation. Reframe as forward-looking insight."),
-    (r"\bi should not have\b", "self_flagellation", "Self-blame. State what's true now without flagellating about what was true before."),
+    (
+        r"\bi should not have\b",
+        "self_flagellation",
+        "Self-blame. State what's true now without flagellating about what was true before.",
+    ),
     # Defensive framing
     (
         r"\bi'm not (accusing|attacking|blaming)\b",


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `actions/setup-python` v5 → v6
- Eliminates Node.js 20 deprecation warnings in CI

## Files changed
- `.github/workflows/test.yml` — 4x checkout, 4x setup-python
- `.github/workflows/claude.yml` — 1x checkout

## Test plan
- [ ] CI passes with no Node.js deprecation warnings