### PR TITLE
fix: flatten INDEX.local.json paths and scan ~/private-skills

### DIFF
--- a/scripts/data/banned-patterns.json
+++ b/scripts/data/banned-patterns.json
@@ -622,6 +622,33 @@
       "notes": "AI connects every section like a museum audio guide. Real technical docs let sections stand alone — readers jump between sections.",
       "message": "Tour guide transition. Technical docs should let sections stand independently.",
       "suggestion_template": "Delete the transition. Start the section with its own content."
+    },
+    "announcing_honesty": {
+      "severity": "error",
+      "patterns": [
+        "that's the honest assessment",
+        "that's the real assessment",
+        "that's the actual assessment",
+        "that's the honest truth",
+        "that's the real truth",
+        "that's the actual truth",
+        "that's the honest take",
+        "that's the real take",
+        "that's the actual take"
+      ],
+      "notes": "If the content were honestly delivered, you wouldn't need to label it as honest. The label signals manufactured authenticity.",
+      "message": "Announcing honesty. If it were honest, you wouldn't need to say so.",
+      "suggestion_template": "Delete the announcement. The facts should speak for themselves."
+    },
+    "thesis_statement_cadence": {
+      "severity": "warning",
+      "patterns": [
+        "entirely dependent on",
+        "fundamentally different"
+      ],
+      "notes": "Overweighted qualifiers that AI uses to sound authoritative. Usually the sentence works without the qualifier.",
+      "message": "Thesis-statement cadence. The qualifier is doing the work instead of the evidence.",
+      "suggestion_template": "Remove the qualifier and let the claim stand on specifics."
     }
   },
   "voice_specific": {

--- a/scripts/generate-skill-index.py
+++ b/scripts/generate-skill-index.py
@@ -201,6 +201,7 @@ def build_entry(
     source_dir: Path | None = None,
     content: str | None = None,
     is_pipeline: bool = False,
+    flatten: bool = False,
 ) -> dict:
     """Build a single index entry from frontmatter and optional content.
 
@@ -211,6 +212,8 @@ def build_entry(
         source_dir: Root scan directory; used to compute relative paths for nested skills.
         content: Full SKILL.md content (needed for pipeline phase extraction).
         is_pipeline: Whether this entry is a pipeline (enables phase extraction).
+        flatten: When True, use leaf directory name only (matches deployed layout).
+            Used for INDEX.local.json where sync hook flattens nested paths.
 
     Returns:
         Dict representing the index entry for this skill/pipeline.
@@ -220,7 +223,10 @@ def build_entry(
     # Compute file path relative to source_dir for nested category folders.
     # Flat: skills/foo/SKILL.md → "skills/foo/SKILL.md"
     # Nested: skills/meta/foo/SKILL.md → "skills/meta/foo/SKILL.md"
-    if source_dir:
+    # Flatten: skills/meta/foo/SKILL.md → "skills/foo/SKILL.md" (matches deployed layout)
+    if flatten:
+        file_path = f"{dir_prefix}/{skill_dir.name}/SKILL.md"
+    elif source_dir:
         rel = skill_dir.relative_to(source_dir)
         file_path = f"{dir_prefix}/{rel}/SKILL.md"
     else:
@@ -286,6 +292,7 @@ def generate_index(
     is_pipeline: bool = False,
     include_private: bool = False,
     strict: bool = False,
+    flatten: bool = False,
 ) -> tuple[dict, list[str]]:
     """Generate a dict-keyed routing index from all SKILL.md files in a directory.
 
@@ -297,6 +304,7 @@ def generate_index(
         include_private: When True, include symlinked directories. When False (default),
             only directly-tracked directories are indexed.
         strict: When True, YAML parse failure skips the skill (no regex fallback).
+        flatten: When True, use leaf directory name for paths (matches deployed layout).
 
     Returns:
         tuple: (index dict with version/generated/generated_by/collection,
@@ -353,6 +361,7 @@ def generate_index(
             source_dir=source_dir,
             content=content_ if is_pipeline else None,
             is_pipeline=is_pipeline,
+            flatten=flatten,
         )
         index[collection_key][name] = entry
 
@@ -471,6 +480,8 @@ def main() -> int:
     output_path: Path = args.output if args.output is not None else skills_dir / "INDEX.json"
 
     # Generate skills index
+    # When --include-private is used (for INDEX.local.json), flatten nested paths
+    # to match the deployed layout where sync hook flattens skills to ~/.claude/skills/{name}/
     skills_index, skills_warnings = generate_index(
         source_dir=skills_dir,
         dir_prefix="skills",
@@ -478,7 +489,61 @@ def main() -> int:
         is_pipeline=False,
         include_private=args.include_private,
         strict=args.strict,
+        flatten=args.include_private,
     )
+
+    # When --include-private, also scan ~/private-skills/ for skills deployed
+    # by the sync hook. These live outside the repo but get symlinked into
+    # ~/.claude/skills/ at session start. Mirror the sync hook's naming:
+    # voice category → voice-{name}, others → {name}.
+    if args.include_private:
+        private_skills_dir = Path.home() / "private-skills"
+        if private_skills_dir.is_dir():
+            for category_dir in sorted(private_skills_dir.iterdir()):
+                if not category_dir.is_dir() or category_dir.name.startswith("."):
+                    continue
+                category = category_dir.name
+                for skill_dir in sorted(category_dir.iterdir()):
+                    if not skill_dir.is_dir():
+                        continue
+                    if not (skill_dir / "SKILL.md").exists():
+                        continue
+                    # Mirror sync hook naming convention
+                    if category == "voice":
+                        deploy_name = f"voice-{skill_dir.name}"
+                    else:
+                        deploy_name = skill_dir.name
+
+                    # Skip if already indexed from repo skills/
+                    if deploy_name in skills_index["skills"]:
+                        continue
+
+                    try:
+                        content_ = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+                    except (OSError, UnicodeDecodeError):
+                        continue
+
+                    fm, used_fallback = extract_frontmatter(content_)
+                    if not fm:
+                        continue
+                    if used_fallback and args.strict:
+                        continue
+
+                    # Override name to match deployed name
+                    fm["name"] = deploy_name
+                    entry = build_entry(
+                        frontmatter=fm,
+                        skill_dir=skill_dir,
+                        dir_prefix="skills",
+                        source_dir=None,
+                        content=None,
+                        is_pipeline=False,
+                        flatten=True,  # Always flat for private skills
+                    )
+                    # Fix: build_entry with source_dir=None uses skill_dir.name,
+                    # but we need deploy_name for the path
+                    entry["file"] = f"skills/{deploy_name}/SKILL.md"
+                    skills_index["skills"][deploy_name] = entry
 
     # Report warnings if any
     if skills_warnings:

--- a/skills/content/content-engine/SKILL.md
+++ b/skills/content/content-engine/SKILL.md
@@ -108,7 +108,7 @@ Mechanically verify drafts before delivery. Both script checks must exit 0. The 
 #### Check 1: Hype Phrase Scan
 
 ```bash
-python3 scripts/scan-negative-framing.py --mode hype --drafts content_drafts.md
+python3 ~/private-skills/scripts/scan-negative-framing.py content_drafts.md
 ```
 
 See `${CLAUDE_SKILL_DIR}/references/phase-playbook.md` for the full list of banned hype phrases and replacement guidance.
@@ -118,7 +118,7 @@ See `${CLAUDE_SKILL_DIR}/references/phase-playbook.md` for the full list of bann
 #### Check 2: Cross-Platform Verbatim Check
 
 ```bash
-python3 scripts/scan-negative-framing.py --mode cross-platform --drafts content_drafts.md
+python3 ~/private-skills/scripts/scan-negative-framing.py content_drafts.md
 ```
 
 This check identifies any sentence appearing verbatim in two or more platform sections of `content_drafts.md`.
@@ -162,4 +162,4 @@ See `${CLAUDE_SKILL_DIR}/references/phase-playbook.md` for error cases: source t
 - `${CLAUDE_SKILL_DIR}/references/platform-specs.md` — Character limits, format rules, and posting norms per platform
 - `${CLAUDE_SKILL_DIR}/references/phase-playbook.md` — Full platform rules for Phase 3, banned hype phrases for Phase 4, error handling
 - `${CLAUDE_SKILL_DIR}/references/error-handling.md` — Gate failure recovery, script fallbacks, error-fix mappings, detection commands
-- `scripts/scan-negative-framing.py` — Negative framing and hype phrase detection
+- `~/private-skills/scripts/scan-negative-framing.py` — Negative framing and hype phrase detection

--- a/skills/content/content-engine/references/error-handling.md
+++ b/skills/content/content-engine/references/error-handling.md
@@ -82,9 +82,9 @@ grep -v "^#\|^---\|^$\|^Status:\|^Generated:\|^Primary" content_drafts.md | sort
 
 ## Manual Fallback Patterns (When Scripts Are Unavailable)
 
-### Fallback for `--mode hype` Gate
+### Fallback for Hype Phrase Gate
 
-When `scan-negative-framing.py --mode hype` fails or is unavailable:
+When `~/private-skills/scripts/scan-negative-framing.py` is unavailable:
 
 ```bash
 # Run exact-match scan manually against content_drafts.md (case-insensitive)
@@ -103,9 +103,9 @@ grep -in "game-changing\|revolutionary\|transformative\|disruptive\|synergy\|lev
 
 Note in the Phase 5 delivery output that the automated gate was unavailable and manual fallback was used.
 
-### Fallback for `--mode cross-platform` Gate
+### Fallback for Cross-Platform Verbatim Gate
 
-When `scan-negative-framing.py --mode cross-platform` is unavailable:
+When `~/private-skills/scripts/scan-negative-framing.py` is unavailable for cross-platform checks:
 
 ```bash
 # Find lines appearing in two or more platform sections
@@ -121,8 +121,7 @@ Non-empty output means a sentence appears verbatim in multiple platform sections
 
 | Error | Root Cause | Fix |
 |-------|------------|-----|
-| `unrecognized arguments: --mode hype` | Script does not yet support `--mode` flag | Use manual `grep -in` fallback; note in delivery |
-| `unrecognized arguments: --mode cross-platform` | Script does not yet support `--mode` flag | Use `uniq -d` fallback; note in delivery |
+| `scan-negative-framing.py: No such file` | Script lives in `~/private-skills/scripts/` | Run `python3 ~/private-skills/scripts/scan-negative-framing.py content_drafts.md`; if missing use manual `grep -in` fallback |
 | Gate never exits 0 after 3 rewrites | Hype phrase is inside a quoted source block or attribution | Remove or rephrase the quoted material itself |
 | `content_drafts.md: No such file or directory` | Phase 3 artifact was not saved before Phase 4 | Return to Phase 3, save the file, then re-run Phase 4 |
 | Script exits 0 but delivery has hype phrase | Phrase was added in post-gate LLM edits | Re-run script after any edits made after the gate passed |

--- a/skills/content/content-engine/references/phase-playbook.md
+++ b/skills/content/content-engine/references/phase-playbook.md
@@ -182,13 +182,9 @@ Opening with hype ("Excited to share our game-changing approach to...") reads as
 Cause: Article or transcript exceeds practical working length.
 Solution: Ask user to identify the section to adapt, or extract section headers first and confirm which section(s) to use.
 
-### Error: scan-negative-framing.py --mode hype not recognized
-Cause: Script does not yet support `--mode hype` flag.
-Solution: Manually scan `content_drafts.md` for banned phrases using Grep. Flag each occurrence, rewrite the affected sentence(s), confirm clean before proceeding. Note in delivery that automated gate was not available.
-
-### Error: scan-negative-framing.py --mode cross-platform not recognized
-Cause: Script does not yet support `--mode cross-platform` flag.
-Solution: Manually compare platform drafts sentence by sentence using Grep for repeated sentences across sections. Rewrite any matches. Note in delivery that automated gate was not available.
+### Error: scan-negative-framing.py not found
+Cause: Script lives in private-skills, not in this repo.
+Solution: Run `python3 ~/private-skills/scripts/scan-negative-framing.py content_drafts.md`. If private-skills is not installed, use the manual grep fallback in `error-handling.md`.
 
 ### Error: Platform target not specified and cannot be inferred
 Cause: User said "make social posts" with no platform context.

--- a/skills/workflow/references/de-ai-pipeline.md
+++ b/skills/workflow/references/de-ai-pipeline.md
@@ -28,7 +28,7 @@ routing:
 
 # De-AI Pipeline
 
-Automated scan-fix-verify loop that removes AI writing patterns from documentation files. Uses `scripts/scan-ai-patterns.py` for deterministic detection against `scripts/data/banned-patterns.json` (323 patterns, 24 categories), then dispatches fix agents per file, then re-scans to verify fixes. Repeats until zero errors or max 3 iterations.
+Automated scan-fix-verify loop that removes AI writing patterns from documentation files. Uses `~/private-skills/scripts/scan-ai-patterns.py` for deterministic detection against `~/private-skills/scripts/data/banned-patterns.json` (323 patterns, 24 categories), then dispatches fix agents per file, then re-scans to verify fixes. Repeats until zero errors or max 3 iterations.
 
 ## Instructions
 
@@ -41,7 +41,7 @@ Automated scan-fix-verify loop that removes AI writing patterns from documentati
 Always use the scanner script for detection — never self-assess a file as "clean" without running the tool. The scanner catches patterns humans miss.
 
 ```bash
-python3 ~/.claude/scripts/scan-ai-patterns.py --errors-only --json
+python3 ~/private-skills/scripts/scan-ai-patterns.py --errors-only --json
 ```
 
 Parse the JSON output. Group hits by file.
@@ -112,7 +112,7 @@ When 2 or more files have errors, dispatch one Agent per file to fix them simult
 **Step 1: Re-run the scanner**
 
 ```bash
-python3 ~/.claude/scripts/scan-ai-patterns.py --errors-only
+python3 ~/private-skills/scripts/scan-ai-patterns.py --errors-only
 ```
 
 **Step 2: Check results**
@@ -156,7 +156,7 @@ Report staged files. Do not run `git commit` — the user owns the final commit 
 
 ### Error: "scan-ai-patterns.py not found"
 **Cause**: Script not in expected location
-**Solution**: Check `scripts/scan-ai-patterns.py` exists. If not, the toolkit may need re-installation.
+**Solution**: Check `~/private-skills/scripts/scan-ai-patterns.py` exists. If not, the private-skills repo may need re-installation.
 
 ### Error: "Pattern match is a false positive"
 **Cause**: Technical term, skill name, or schema value matches a banned pattern
@@ -170,5 +170,5 @@ Report staged files. Do not run `git commit` — the user owns the final commit 
 
 ## References
 
-- `scripts/scan-ai-patterns.py` — Deterministic pattern scanner with 323 banned patterns across 24 categories
-- `scripts/data/banned-patterns.json` — Pattern database with regex rules and categories
+- `~/private-skills/scripts/scan-ai-patterns.py` — Deterministic pattern scanner with 323 banned patterns across 24 categories
+- `~/private-skills/scripts/data/banned-patterns.json` — Pattern database with regex rules and categories


### PR DESCRIPTION
## Summary
- Fixed `generate-skill-index.py` to emit flat paths (`skills/voice-writer/SKILL.md`) matching the deployed layout at `~/.claude/skills/`, instead of nested paths (`skills/content/voice-writer/SKILL.md`)
- Added `~/private-skills/` scanning when `--include-private` is used — voice skills that moved out of the repo are now indexed again (124 skills, up from 113)
- Updated stale scanner references in `content-engine` and `de-ai-pipeline` to point to `~/private-skills/scripts/`
- Synced `banned-patterns.json` with 2 new detection categories (`announcing_honesty`, `thesis_statement_cadence`)

## Root Cause
After voice skills moved from `vexjoy-agent/skills/content/` to `~/private-skills/`, two things broke:
1. INDEX.local.json paths didn't match the flat deployment layout used by the sync hook
2. The index generator didn't scan `~/private-skills/`, so voice skills disappeared from the INDEX entirely

## Test plan
- [x] `python3 -m pytest scripts/tests/test_generate_skill_index.py -v` — 6/6 pass
- [x] Regenerated INDEX.local.json has all 9 voice skills with flat paths
- [x] All voice skill paths resolve at `~/.claude/skills/{name}/SKILL.md`
- [x] `python3 ~/private-skills/scripts/content-check.py` catches patterns (score 19, FAIL)
- [x] `python3 ~/private-skills/scripts/scan-ai-patterns.py` catches 7 hits (6 errors)
- [x] `ruff check` and `ruff format --check` pass