### PR TITLE
feat: centralize ADR lookup path in pretool hook

### DIFF
--- a/hooks/pretool-adr-creation-gate.py
+++ b/hooks/pretool-adr-creation-gate.py
@@ -1,31 +1,39 @@
 #!/usr/bin/env python3
-# hook-version: 1.0.0
+# hook-version: 1.1.0
 """
 PreToolUse:Write Hook: ADR Creation Gate
 
 Blocks creation of new agent/skill/pipeline component files when no ADR
-exists for that component in the adr/ directory.
+exists for that component.
 
 This is a HARD GATE — exits 0 with JSON permissionDecision:deny to block the Write tool.
+
+ADR lookup order (first match wins):
+1. ~/.vexjoy-agent/{repo_name}/adrs/{component_name}.md  (centralized, preferred)
+2. {project_root}/adr/{component_name}.md                (legacy, backwards-compat)
+
+repo_name is derived from: git remote origin URL → repo basename, or failing
+that, the directory basename of the project root.
 
 Detection logic:
 - Tool is Write (edits to existing files pass through)
 - Target path matches /agents/<name>.md, /skills/<name>/SKILL.md,
 - The target file does not already exist on disk (new creation only)
-- adr/{name}.md does not exist in the project root
+- ADR not found in either lookup path
 
 Allow-through conditions:
 - Tool is not Write
 - Target file does not match a component path pattern
 - Target file already exists on disk (update, not creation)
 - Target path matches _ADR_PATH_ALLOWLIST (producer-allowlisted skills like create-voice)
-- adr/{name}.md exists in the project root
+- ADR exists in centralized or project-root location
 - ADR_CREATION_GATE_BYPASS=1 env var
 """
 
 import json
 import os
 import re
+import subprocess
 import sys
 import traceback
 from pathlib import Path
@@ -57,6 +65,85 @@ _ADR_PATH_ALLOWLIST: list[tuple[re.Pattern[str], str]] = [
     # voice-creation methodology; a per-voice ADR would be redundant.
     (re.compile(r"/skills/(?:[^/]+/)?voice-[^/]+/SKILL\.md$"), "create-voice"),
 ]
+
+
+def _derive_repo_name(base_dir: Path) -> str:
+    """Derive the repository name from git remote or directory basename.
+
+    Tries `git remote get-url origin` first; falls back to the directory
+    basename if git is unavailable or no remote is configured.
+
+    NOTE: This logic is duplicated in scripts/vexjoy-adr.py (_derive_repo_name).
+    Keep both in sync when modifying.
+
+    Args:
+        base_dir: The resolved project root directory.
+
+    Returns:
+        Repository name string (e.g., "vexjoy-agent", "openstack-mcp-server").
+    """
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            cwd=str(base_dir),
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            url = result.stdout.strip()
+            # Handle both HTTPS and SSH URLs:
+            # https://github.com/user/repo.git → repo
+            # git@github.com:user/repo.git → repo
+            name = url.rstrip("/").rsplit("/", 1)[-1]
+            if name.endswith(".git"):
+                name = name[:-4]
+            return name
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return base_dir.name
+
+
+_VEXJOY_STATE_DIR = Path.home() / ".vexjoy-agent"
+
+
+def _find_adr(component_name: str, base_dir: Path, debug: bool = False) -> Path | None:
+    """Look up an ADR in centralized then project-root locations.
+
+    Lookup order:
+    1. ~/.vexjoy-agent/{repo_name}/adrs/{component_name}.md
+    2. {base_dir}/adr/{component_name}.md
+
+    Args:
+        component_name: The component to look up.
+        base_dir: Resolved project root directory.
+        debug: Whether to emit debug output.
+
+    Returns:
+        Path to the ADR if found, None otherwise.
+    """
+    repo_name = _derive_repo_name(base_dir)
+
+    # Preferred: centralized location
+    centralized = _VEXJOY_STATE_DIR / repo_name / "adrs" / f"{component_name}.md"
+    if centralized.is_file():
+        if debug:
+            print(f"[adr-creation-gate] ADR found (centralized): {centralized}", file=sys.stderr)
+        return centralized
+
+    # Fallback: project-root adr/ directory
+    project_local = base_dir / "adr" / f"{component_name}.md"
+    if project_local.is_file():
+        if debug:
+            print(f"[adr-creation-gate] ADR found (project-root): {project_local}", file=sys.stderr)
+        return project_local
+
+    if debug:
+        print(
+            f"[adr-creation-gate] ADR not found in:\n  - {centralized}\n  - {project_local}",
+            file=sys.stderr,
+        )
+    return None
 
 
 def _extract_component_name(file_path: str) -> str | None:
@@ -129,15 +216,17 @@ def main() -> None:
     cwd_str = event.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR", ".")
     base_dir = Path(cwd_str).resolve()
 
-    adr_path = base_dir / "adr" / f"{component_name}.md"
-    if adr_path.is_file():
-        if debug:
-            print(f"[adr-creation-gate] ADR found at {adr_path} — allowing through", file=sys.stderr)
+    adr_path = _find_adr(component_name, base_dir, debug=bool(debug))
+    if adr_path:
         sys.exit(0)
 
     # ADR is missing — block.
+    repo_name = _derive_repo_name(base_dir)
+    centralized_hint = f"~/.vexjoy-agent/{repo_name}/adrs/{component_name}.md"
     print(
-        f"[adr-creation-gate] BLOCKED: Create adr/{component_name}.md before creating new component.",
+        f"[adr-creation-gate] BLOCKED: Create ADR before creating new component.\n"
+        f"  Preferred: {centralized_hint}\n"
+        f"  Alternative: adr/{component_name}.md (project root)",
         file=sys.stderr,
     )
     print("[fix-with-skill] plans", file=sys.stderr)
@@ -148,8 +237,8 @@ def main() -> None:
                     "hookEventName": "PreToolUse",
                     "permissionDecision": "deny",
                     "permissionDecisionReason": (
-                        f"Create adr/{component_name}.md before creating this new component. "
-                        "Use the plans skill to draft the ADR first."
+                        f"Create ADR at {centralized_hint} (or adr/{component_name}.md in project root) "
+                        "before creating this new component. Use the plans skill to draft the ADR first."
                     ),
                 }
             }

--- a/hooks/pretool-adr-creation-gate.py
+++ b/hooks/pretool-adr-creation-gate.py
@@ -98,7 +98,8 @@ def _derive_repo_name(base_dir: Path) -> str:
             name = url.rstrip("/").rsplit("/", 1)[-1]
             if name.endswith(".git"):
                 name = name[:-4]
-            return name
+            if name:  # Guard against malformed URLs yielding empty name
+                return name
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         pass
     return base_dir.name

--- a/scripts/vexjoy-adr.py
+++ b/scripts/vexjoy-adr.py
@@ -107,7 +107,8 @@ def _derive_repo_name(cwd: Path) -> str:
             name = url.rstrip("/").rsplit("/", 1)[-1]
             if name.endswith(".git"):
                 name = name[:-4]
-            return name
+            if name:  # Guard against malformed URLs yielding empty name
+                return name
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         pass
     return cwd.name

--- a/scripts/vexjoy-adr.py
+++ b/scripts/vexjoy-adr.py
@@ -5,8 +5,11 @@ vexjoy-adr — Create and manage ADRs in the centralized ~/.vexjoy-agent/ direct
 Keeps governance artifacts out of individual repositories by writing ADRs to
 ~/.vexjoy-agent/{repo_name}/adrs/{component_name}.md
 
+The pretool-adr-creation-gate hook blocks new component creation without an ADR.
+Run this script to create one, then retry your Write.
+
 Usage:
-    python3 scripts/vexjoy-adr.py create <component-name> [--repo <name>]
+    python3 scripts/vexjoy-adr.py create <component-name> [--repo <name>] [--type <type>]
     python3 scripts/vexjoy-adr.py list [--repo <name>]
     python3 scripts/vexjoy-adr.py show <component-name> [--repo <name>]
 
@@ -15,18 +18,24 @@ of the current directory, or the directory basename as fallback.
 
 Exit codes:
     0 = success
-    1 = error (file exists, missing args, etc.)
+    1 = error (file exists, missing args, invalid name, etc.)
 """
 
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 import sys
 from datetime import date
 from pathlib import Path
 
 _VEXJOY_STATE_DIR = Path.home() / ".vexjoy-agent"
+
+# Valid component/repo names: alphanumeric, hyphens, dots, underscores only.
+_SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+
+_COMPONENT_TYPES = ("agent", "skill", "pipeline", "hook", "script")
 
 _ADR_TEMPLATE = """\
 # ADR: {component_name}
@@ -55,8 +64,36 @@ Proposed
 """
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_name(name: str, label: str) -> bool:
+    """Validate that a name is safe for filesystem use (no path traversal).
+
+    Args:
+        name: The name to validate.
+        label: Human label for error messages (e.g., "component name", "repo name").
+
+    Returns:
+        True if valid, False otherwise (prints error to stderr).
+    """
+    if not _SAFE_NAME_RE.match(name):
+        print(
+            f"Invalid {label}: '{name}'. Must be alphanumeric with hyphens/dots/underscores only (no slashes or '..').",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
 def _derive_repo_name(cwd: Path) -> str:
-    """Derive repo name from git remote or directory basename."""
+    """Derive repo name from git remote or directory basename.
+
+    NOTE: This logic is duplicated in ~/.claude/hooks/pretool-adr-creation-gate.py
+    (_derive_repo_name). Keep both in sync when modifying.
+    """
     try:
         result = subprocess.run(
             ["git", "remote", "get-url", "origin"],
@@ -80,18 +117,43 @@ def _guess_component_type(name: str) -> str:
     """Guess component type from naming conventions."""
     if name.endswith("-engineer") or name.endswith("-agent"):
         return "agent"
+    if name.endswith("-pipeline"):
+        return "pipeline"
     if name.startswith("voice-"):
         return "skill (voice)"
-    return "skill/agent"
+    return "skill"
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
 
 
 def cmd_create(args: argparse.Namespace) -> int:
-    """Create a new ADR file at the centralized location."""
+    """Create a new ADR file at the centralized location.
+
+    Args:
+        args: Parsed arguments with component_name, repo, and type fields.
+
+    Returns:
+        0 on success, 1 on error.
+    """
     repo_name = args.repo or _derive_repo_name(Path.cwd())
     component_name = args.component_name
 
+    # Validate inputs to prevent path traversal.
+    if not _validate_name(component_name, "component name"):
+        return 1
+    if args.repo and not _validate_name(args.repo, "repo name"):
+        return 1
+
     adr_dir = _VEXJOY_STATE_DIR / repo_name / "adrs"
     adr_path = adr_dir / f"{component_name}.md"
+
+    # Belt-and-suspenders: verify resolved path stays within state dir.
+    if not adr_path.resolve().is_relative_to(_VEXJOY_STATE_DIR):
+        print(f"Path escapes state directory: {adr_path.resolve()}", file=sys.stderr)
+        return 1
 
     if adr_path.exists():
         print(f"ADR already exists: {adr_path}", file=sys.stderr)
@@ -99,19 +161,31 @@ def cmd_create(args: argparse.Namespace) -> int:
 
     adr_dir.mkdir(parents=True, exist_ok=True)
 
+    component_type = args.type or _guess_component_type(component_name)
     content = _ADR_TEMPLATE.format(
         component_name=component_name,
         date=date.today().isoformat(),
-        component_type=_guess_component_type(component_name),
+        component_type=component_type,
     )
-    adr_path.write_text(content)
+    adr_path.write_text(content, encoding="utf-8")
     print(f"Created: {adr_path}")
+    print("Next: edit the file above to fill in Context/Decision/Consequences, then retry creating your component.")
     return 0
 
 
 def cmd_list(args: argparse.Namespace) -> int:
-    """List ADRs for a repo."""
+    """List ADRs for a repo.
+
+    Args:
+        args: Parsed arguments with optional repo field.
+
+    Returns:
+        0 on success.
+    """
     repo_name = args.repo or _derive_repo_name(Path.cwd())
+    if args.repo and not _validate_name(args.repo, "repo name"):
+        return 1
+
     adr_dir = _VEXJOY_STATE_DIR / repo_name / "adrs"
 
     if not adr_dir.is_dir():
@@ -130,15 +204,29 @@ def cmd_list(args: argparse.Namespace) -> int:
 
 
 def cmd_show(args: argparse.Namespace) -> int:
-    """Show contents of a specific ADR."""
+    """Show contents of a specific ADR.
+
+    Args:
+        args: Parsed arguments with component_name and optional repo.
+
+    Returns:
+        0 on success, 1 if ADR not found.
+    """
     repo_name = args.repo or _derive_repo_name(Path.cwd())
-    adr_path = _VEXJOY_STATE_DIR / repo_name / "adrs" / f"{args.component_name}.md"
+    component_name = args.component_name
+
+    if not _validate_name(component_name, "component name"):
+        return 1
+    if args.repo and not _validate_name(args.repo, "repo name"):
+        return 1
+
+    adr_path = _VEXJOY_STATE_DIR / repo_name / "adrs" / f"{component_name}.md"
 
     if not adr_path.is_file():
         print(f"ADR not found: {adr_path}", file=sys.stderr)
         return 1
 
-    print(adr_path.read_text())
+    print(adr_path.read_text(encoding="utf-8"))
     return 0
 
 
@@ -153,6 +241,11 @@ def main() -> int:
     p_create = sub.add_parser("create", help="Create a new ADR")
     p_create.add_argument("component_name", help="Component name (e.g., sapcc-dns)")
     p_create.add_argument("--repo", help="Override repo name (default: auto-detect)")
+    p_create.add_argument(
+        "--type",
+        choices=_COMPONENT_TYPES,
+        help="Component type (default: auto-detect from name)",
+    )
 
     # list
     p_list = sub.add_parser("list", help="List ADRs for a repo")
@@ -165,15 +258,12 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    if args.command == "create":
-        return cmd_create(args)
-    elif args.command == "list":
-        return cmd_list(args)
-    elif args.command == "show":
-        return cmd_show(args)
-    else:
-        parser.print_help()
-        return 1
+    dispatch = {"create": cmd_create, "list": cmd_list, "show": cmd_show}
+    handler = dispatch.get(args.command)
+    if handler:
+        return handler(args)
+    parser.print_help()
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/vexjoy-adr.py
+++ b/scripts/vexjoy-adr.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+vexjoy-adr — Create and manage ADRs in the centralized ~/.vexjoy-agent/ directory.
+
+Keeps governance artifacts out of individual repositories by writing ADRs to
+~/.vexjoy-agent/{repo_name}/adrs/{component_name}.md
+
+Usage:
+    python3 scripts/vexjoy-adr.py create <component-name> [--repo <name>]
+    python3 scripts/vexjoy-adr.py list [--repo <name>]
+    python3 scripts/vexjoy-adr.py show <component-name> [--repo <name>]
+
+If --repo is omitted, the repo name is derived from the git remote origin URL
+of the current directory, or the directory basename as fallback.
+
+Exit codes:
+    0 = success
+    1 = error (file exists, missing args, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+_VEXJOY_STATE_DIR = Path.home() / ".vexjoy-agent"
+
+_ADR_TEMPLATE = """\
+# ADR: {component_name}
+
+## Status
+Proposed
+
+## Date
+{date}
+
+## Context
+<!-- Why is this component needed? What problem does it solve? -->
+
+## Decision
+<!-- What is the approach? Key design choices. -->
+
+## Consequences
+<!-- What trade-offs does this introduce? What becomes easier/harder? -->
+
+## Components
+- Type: {component_type}
+- Name: `{component_name}`
+
+## References
+<!-- Links to related ADRs, skills, or documentation -->
+"""
+
+
+def _derive_repo_name(cwd: Path) -> str:
+    """Derive repo name from git remote or directory basename."""
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            cwd=str(cwd),
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            url = result.stdout.strip()
+            name = url.rstrip("/").rsplit("/", 1)[-1]
+            if name.endswith(".git"):
+                name = name[:-4]
+            return name
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return cwd.name
+
+
+def _guess_component_type(name: str) -> str:
+    """Guess component type from naming conventions."""
+    if name.endswith("-engineer") or name.endswith("-agent"):
+        return "agent"
+    if name.startswith("voice-"):
+        return "skill (voice)"
+    return "skill/agent"
+
+
+def cmd_create(args: argparse.Namespace) -> int:
+    """Create a new ADR file at the centralized location."""
+    repo_name = args.repo or _derive_repo_name(Path.cwd())
+    component_name = args.component_name
+
+    adr_dir = _VEXJOY_STATE_DIR / repo_name / "adrs"
+    adr_path = adr_dir / f"{component_name}.md"
+
+    if adr_path.exists():
+        print(f"ADR already exists: {adr_path}", file=sys.stderr)
+        return 1
+
+    adr_dir.mkdir(parents=True, exist_ok=True)
+
+    content = _ADR_TEMPLATE.format(
+        component_name=component_name,
+        date=date.today().isoformat(),
+        component_type=_guess_component_type(component_name),
+    )
+    adr_path.write_text(content)
+    print(f"Created: {adr_path}")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    """List ADRs for a repo."""
+    repo_name = args.repo or _derive_repo_name(Path.cwd())
+    adr_dir = _VEXJOY_STATE_DIR / repo_name / "adrs"
+
+    if not adr_dir.is_dir():
+        print(f"No ADRs found for repo '{repo_name}' (dir: {adr_dir})")
+        return 0
+
+    adrs = sorted(adr_dir.glob("*.md"))
+    if not adrs:
+        print(f"No ADRs found for repo '{repo_name}'")
+        return 0
+
+    print(f"ADRs for {repo_name} ({len(adrs)}):")
+    for adr in adrs:
+        print(f"  - {adr.stem}")
+    return 0
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    """Show contents of a specific ADR."""
+    repo_name = args.repo or _derive_repo_name(Path.cwd())
+    adr_path = _VEXJOY_STATE_DIR / repo_name / "adrs" / f"{args.component_name}.md"
+
+    if not adr_path.is_file():
+        print(f"ADR not found: {adr_path}", file=sys.stderr)
+        return 1
+
+    print(adr_path.read_text())
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Manage centralized ADRs in ~/.vexjoy-agent/",
+        prog="vexjoy-adr",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    # create
+    p_create = sub.add_parser("create", help="Create a new ADR")
+    p_create.add_argument("component_name", help="Component name (e.g., sapcc-dns)")
+    p_create.add_argument("--repo", help="Override repo name (default: auto-detect)")
+
+    # list
+    p_list = sub.add_parser("list", help="List ADRs for a repo")
+    p_list.add_argument("--repo", help="Override repo name (default: auto-detect)")
+
+    # show
+    p_show = sub.add_parser("show", help="Show an ADR's contents")
+    p_show.add_argument("component_name", help="Component name to show")
+    p_show.add_argument("--repo", help="Override repo name (default: auto-detect)")
+
+    args = parser.parse_args()
+
+    if args.command == "create":
+        return cmd_create(args)
+    elif args.command == "list":
+        return cmd_list(args)
+    elif args.command == "show":
+        return cmd_show(args)
+    else:
+        parser.print_help()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds `scripts/vexjoy-adr.py` CLI helper that creates/lists/shows ADRs at `~/.vexjoy-agent/{repo_name}/adrs/` instead of polluting each repo with governance artifacts
- Updates `hooks/pretool-adr-creation-gate.py` to v1.1.0 with dual-path ADR lookup: centralized first, project-root `adr/` as fallback
- Derives repo name from git remote origin URL (falls back to directory basename)

## Changes
| File | Change |
|------|--------|
| `scripts/vexjoy-adr.py` | New CLI: `create`, `list`, `show` subcommands with path traversal protection |
| `hooks/pretool-adr-creation-gate.py` | v1.0.0 → v1.1.0: adds `_derive_repo_name`, `_find_adr` with centralized lookup |

## Review iterations
1. **Path traversal fix** — input validation via `_SAFE_NAME_RE` + `is_relative_to()` containment
2. **Empty repo name guard** — malformed git URLs (e.g., `/.git`) no longer yield empty string
3. **Hook sync** — in-repo and deployed `~/.claude/hooks/` copies are identical with cross-references

## Test plan
- [x] `vexjoy-adr.py create` writes to centralized path
- [x] Hook allows writes when centralized ADR exists
- [x] Hook blocks when no ADR in either location
- [x] Path traversal inputs rejected (slashes, `..`)
- [x] `--type` flag overrides auto-detection
- [x] `ruff check` and `ruff format` pass
- [x] Backwards-compatible: project-root `adr/` still works as fallback