### PR TITLE
fix: remove private hook registration from shared settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -101,12 +101,6 @@
             "command": "python3 \"$HOME/.claude/hooks/codex-auto-review.py\"",
             "description": "Auto-inject Codex cross-model review for PR review operations",
             "timeout": 3000
-          },
-          {
-            "type": "command",
-            "command": "python3 \"$HOME/.claude/hooks/voice-output-gate.py\"",
-            "description": "Inject voice output gate for external text actions",
-            "timeout": 2000
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Remove voice-output-gate hook registration from shared `.claude/settings.json`
- The hook file lives in private-skills (gitignored), so fresh clones break: Python can't find the `.py` file, blocking every session at UserPromptSubmit
- The hook still works for users who have it locally via their own settings overlay

## Test plan

- [ ] Fresh clone of vexjoy-agent runs `sync-to-user-claude.py` without errors
- [ ] Existing users with the hook in their personal `~/.claude/settings.json` are unaffected
- [ ] No other hooks in UserPromptSubmit are changed