### PR TITLE
docs: deepen agent reference explanations across 6 agents

### DIFF
--- a/agents/opensearch-elasticsearch-engineer/references/cluster-operations.md
+++ b/agents/opensearch-elasticsearch-engineer/references/cluster-operations.md
@@ -83,7 +83,7 @@ GET /_nodes/stats?filter_path=nodes.*.jvm.gc.collectors.*.collection_time_in_mil
 # GC time > 25% of wall clock = heap pressure
 ```
 
-**Why**: JVM uses compressed ordinary object pointers (compressed OOPs) below 32GB heap. Above 32GB (specifically above ~31GB to leave OS headroom), JVM switches to 64-bit pointers — pointer size doubles, effective heap capacity drops by 30%. Set to exactly 31g maximum; verify with `GET /_nodes` that it took effect.
+**Why**: JVM uses compressed ordinary object pointers (compressed OOPs) when heap is at or below ~31GB. Above this threshold, the JVM switches to 64-bit pointers — pointer size doubles, effective heap capacity drops by ~30%. Set heap to exactly 31g maximum; verify with `GET /_nodes` that compressed OOPs is active.
 
 ---
 
@@ -197,7 +197,7 @@ for nid, n in data['nodes'].items():
 
 **Why this matters**: Above ~31GB, JVM object pointers are 64-bit instead of 32-bit compressed. Memory per object increases significantly. The JVM now needs a larger heap to hold the same amount of data. A 64GB heap may hold less effective data than a properly configured 31GB heap. GC pauses also increase with heap size.
 
-**Preferred action**: Split heap across two nodes rather than increase past 31GB. Two nodes with 15GB heap each outperform one node with 31GB.
+**Preferred action**: Split heap across two nodes rather than increase past 31GB. For search-heavy workloads, two nodes with 15GB heap each generally outperform one node with 31GB because queries parallelize across shards on different nodes.
 
 ---
 

--- a/agents/opensearch-elasticsearch-engineer/references/cluster-operations.md
+++ b/agents/opensearch-elasticsearch-engineer/references/cluster-operations.md
@@ -12,7 +12,7 @@ description: Cluster health, shard allocation, capacity planning, rolling upgrad
 
 ## Overview
 
-Misconfigured heap or shard counts are silent until load spikes. Yellow is tolerable; red is data loss risk. DELETE index, live mapping updates, and shrink are irreversible without snapshots.
+Cluster operations have asymmetric consequences: misconfigured heap or shard counts are silent until load spikes. Yellow cluster status is tolerable; red is data loss risk. The most dangerous operations — DELETE index, update live mapping, shrink shards — are irreversible without snapshots. Every cluster configuration change requires a before/after snapshot.
 
 ---
 
@@ -63,7 +63,7 @@ PUT /_cluster/settings
 }
 ```
 
-**Why**: `allocation/explain` tells exactly why a shard won't assign. Guessing without this leads to misdiagnosis.
+**Why**: `GET /_cluster/allocation/explain` tells you exactly why a shard won't assign (disk full, no eligible node, node excluded, etc.). Guessing without this leads to misdiagnosis.
 
 ---
 
@@ -83,7 +83,7 @@ GET /_nodes/stats?filter_path=nodes.*.jvm.gc.collectors.*.collection_time_in_mil
 # GC time > 25% of wall clock = heap pressure
 ```
 
-**Why**: JVM uses compressed OOPs below ~31GB. Above that, pointer size doubles, effective capacity drops 30%. Set max 31g; verify with `GET /_nodes`.
+**Why**: JVM uses compressed ordinary object pointers (compressed OOPs) below 32GB heap. Above 32GB (specifically above ~31GB to leave OS headroom), JVM switches to 64-bit pointers — pointer size doubles, effective heap capacity drops by 30%. Set to exactly 31g maximum; verify with `GET /_nodes` that it took effect.
 
 ---
 
@@ -123,7 +123,7 @@ GET /_cluster/health?wait_for_status=green&timeout=300s
 # 7. Repeat for each node
 ```
 
-**Why**: Prevents shard recovery storms. Without this, cluster recovers replicas to other nodes then cancels when the node returns.
+**Why**: Disabling allocation before stopping a node prevents shard recovery storms. Without this, the cluster starts recovering replicas to other nodes as soon as the node goes down — only to cancel and re-recover when it comes back up. This wastes network and CPU.
 
 ---
 
@@ -166,7 +166,7 @@ PUT /_slm/policy/nightly-snapshots
 GET /_snapshot/backups/_all?pretty&s=start_time:desc
 ```
 
-**Why**: `include_global_state: true` captures templates, ILM policies, cluster settings. Without it, full restore requires manual config recreation.
+**Why**: `include_global_state: true` captures index templates, ILM policies, and cluster settings — not just data. Without global state, a full cluster restore requires manual recreation of all configuration.
 
 ---
 
@@ -195,9 +195,9 @@ for nid, n in data['nodes'].items():
 -Xmx64g  # 64GB — loses compressed OOPs
 ```
 
-**Why this matters**: Above ~31GB, 64-bit pointers increase memory per object. A 64GB heap may hold less effective data than 31GB. GC pauses increase with heap size.
+**Why this matters**: Above ~31GB, JVM object pointers are 64-bit instead of 32-bit compressed. Memory per object increases significantly. The JVM now needs a larger heap to hold the same amount of data. A 64GB heap may hold less effective data than a properly configured 31GB heap. GC pauses also increase with heap size.
 
-**Preferred action**: Split across two nodes rather than exceed 31GB.
+**Preferred action**: Split heap across two nodes rather than increase past 31GB. Two nodes with 15GB heap each outperform one node with 31GB.
 
 ---
 
@@ -221,7 +221,7 @@ PUT /_cluster/settings
 # Maintenance completes, engineer leaves — setting persists
 ```
 
-**Why this matters**: With `allocation.enable: none`, no shard assignments occur. New nodes receive nothing. Node failures cause unrecovered replicas. Cluster silently degrades to red.
+**Why this matters**: With `allocation.enable: none`, no new shard assignments occur. Adding a new node does nothing — no shards migrate to it. A data node failure causes replicas to become unassigned but not recovered. The cluster silently degrades toward red status.
 
 **Preferred action**: After every maintenance operation, verify allocation is re-enabled:
 ```bash
@@ -252,9 +252,9 @@ PUT /logs-2024-01
 }
 ```
 
-**Why this matters**: Node failure + 0 replicas = data loss for all primaries on that node. Cluster goes RED.
+**Why this matters**: A node failure with 0 replicas causes data loss for all primary shards on that node. Cluster status goes RED. Documents indexed after the last snapshot are permanently lost.
 
-**Preferred action**: `number_of_replicas: 1` minimum in production. Dev clusters: set 0 explicitly with comment.
+**Preferred action**: `number_of_replicas: 1` minimum in production. Even for a single-node dev cluster, set to 0 explicitly with a comment explaining it's dev-only — don't let it be the default.
 
 ---
 
@@ -280,7 +280,7 @@ PUT /tiny-index
 # 5 shards of 100MB each — massive overhead for tiny data
 ```
 
-**Why this matters**: Each shard has fixed overhead (file descriptors, JVM memory, cluster state). 1000 shards of 1MB = same overhead as 1000 of 50GB, but 100x slower from cross-shard coordination.
+**Why this matters**: Each shard has overhead: file descriptors, JVM memory in the shard metadata, cluster state size. 1000 shards of 1MB each consume as much overhead as 1000 shards of 50GB each — but the 1MB shards return results 100x slower due to cross-shard coordination cost on empty shards.
 
 **Preferred action**: `number_of_shards: 1` for indices < 5GB. Use rollover for growing indices rather than pre-allocating many shards.
 

--- a/agents/opensearch-elasticsearch-engineer/references/index-management.md
+++ b/agents/opensearch-elasticsearch-engineer/references/index-management.md
@@ -12,7 +12,7 @@ description: Mapping design, ILM policies, index templates, and reindexing strat
 
 ## Overview
 
-Slow-moving disasters: dynamic mapping causes explosion in 3 months. No ILM means manual deletion during storage emergencies. Mapping is largely irreversible on live indices. Get it right at creation time.
+Index management failures are slow-moving disasters: dynamic mapping enables today, then causes mapping explosion in 3 months. ILM not configured today means manual deletion during a storage emergency. Mapping design is largely irreversible on live indices — reindexing 100GB of data takes hours. Get it right at creation time.
 
 ---
 
@@ -68,7 +68,7 @@ PUT /articles
 }
 ```
 
-**Why**: `"dynamic": "strict"` rejects unknown fields (400 error), preventing gradual mapping accumulation that silently hits `total_fields.limit`.
+**Why**: `"dynamic": "strict"` rejects documents with unknown fields (returns a 400 error). This prevents the gradual accumulation of unknown field mappings that causes `index.mapping.total_fields.limit` to be reached silently.
 
 ---
 
@@ -116,7 +116,7 @@ PUT _ilm/policy/logs-policy
 }
 ```
 
-**Why**: Hot = active writes. Warm = force-merge (read optimization) + shrink to 1 shard. Cold = frozen/object storage. Delete = automatic cleanup.
+**Why**: Hot phase: active writes, high-priority. Warm phase: force-merge reduces segment count (read optimization), shrink consolidates shards from hot to 1 (saves file descriptors). Cold phase: frozen indices move to object storage. Delete: automatic cleanup.
 
 ---
 
@@ -150,7 +150,7 @@ POST _aliases
 GET articles/_alias
 ```
 
-**Why**: Application queries alias, never versioned name. Alias swap is atomic. Zero downtime.
+**Why**: Application code always queries `articles` alias — never the versioned index name. Alias swap is atomic: no gap between removing old and adding new. Clients see no downtime.
 
 ---
 
@@ -183,7 +183,7 @@ PUT _index_template/logs-template
 }
 ```
 
-**Why**: Without template, each rollover creates an index with defaults — no ILM, no explicit mapping.
+**Why**: Template applies automatically to new indices matching the pattern. Without a template, each rollover creates an index with default settings — no ILM policy, no explicit mapping.
 
 ---
 
@@ -225,7 +225,7 @@ GET /your-index/_mapping | jq '.[] | .mappings.properties | keys | length'
 }
 ```
 
-**Why this matters**: Each unique JSON key creates a field mapping. At `total_fields.limit` (default 1000), indexing fails. Reindexing required to fix.
+**Why this matters**: Each unique key in a JSON blob creates a new field mapping. Experiment names, user preference keys, and event properties grow unbounded. At `index.mapping.total_fields.limit` (default 1000), indexing fails with `limit of total fields [1000] has been exceeded`. Existing data is already corrupted by this point — reindexing required.
 
 **Preferred action**: Use `"dynamic": false` on nested objects with variable keys, or use the `flattened` field type:
 ```json
@@ -266,7 +266,7 @@ GET /your-index/_mapping
 }
 ```
 
-**Why this matters**: `text` fields are analyzed/tokenized. `term` queries on `text` fail silently for casing differences. Aggregations on `text` throw `Fielddata is disabled`.
+**Why this matters**: `text` fields are analyzed — `"active"` is tokenized and lowercased. A `term` query for `"active"` works, but `"Active"` misses. `"IS_ACTIVE"` gets tokenized to `["is", "active"]` — `term` query on `"IS_ACTIVE"` returns nothing. Aggregations on `text` fields throw `Fielddata is disabled on text fields`.
 
 **Preferred action**: Use `keyword` for exact-match fields (status, IDs, category); use `text` with `.keyword` sub-field when both full-text search and aggregation are needed.
 
@@ -292,7 +292,7 @@ POST _reindex
 # Then discover v2 has "date" field mapped as "text" in v1
 ```
 
-**Why this matters**: Type mismatches (e.g., `text` in v1, `date` in v2) fail silently. `_reindex` skips failed docs by default, producing an incomplete index.
+**Why this matters**: If `published_at` is `text` in v1 and `date` in v2, reindex fails on any document where `published_at` doesn't parse as a date. `_reindex` continues by default, silently skipping failed documents. The result is an incomplete index with no clear indication of what was dropped.
 
 **Preferred action**: Use `"conflicts": "proceed"` only intentionally, and check task results for failures:
 ```bash

--- a/agents/opensearch-elasticsearch-engineer/references/query-optimization.md
+++ b/agents/opensearch-elasticsearch-engineer/references/query-optimization.md
@@ -12,7 +12,7 @@ description: Query DSL patterns, aggregation optimization, caching strategies, a
 
 ## Overview
 
-Three failure modes: query context where filter context suffices (scores + no cache), returning all fields (network overhead), large aggregations without sampling (cardinality explosions). Profile API pinpoints slow parts; without it, optimization is guesswork.
+Query performance in OpenSearch/Elasticsearch fails in three predictable ways: using query context where filter context is appropriate (query context scores and doesn't cache), returning all fields when only a subset is needed (network and memory overhead), and running large aggregations without sampling (cardinality explosions block query threads). The profile API pinpoints which part of a query is slow; without it, optimization is guesswork.
 
 ---
 
@@ -56,7 +56,7 @@ Use `filter` for non-scoring conditions — filter results are cached and reused
 }
 ```
 
-**Why**: `filter` context is cached. `must` recalculates scores every request. Non-scoring conditions belong in `filter`.
+**Why**: `filter` context is cached in the filter cache. `must` (query context) recalculates relevance scores on every request. Status checks, date ranges, and term filters have no relevance to scoring — they belong in `filter`.
 
 ---
 
@@ -73,7 +73,7 @@ Use `filter` for non-scoring conditions — filter results are cached and reused
 }
 ```
 
-**Why**: 50KB+ content fields mean 20 hits = 1MB+ response. Excluding large fields reduces transfer 90%+.
+**Why**: `content` fields of 50KB+ per document mean a 20-hit response could return 1MB+ over the wire. Excluding large fields reduces network transfer by 90%+ for content-heavy indices.
 
 ---
 
@@ -100,7 +100,7 @@ Use `filter` for non-scoring conditions — filter results are cached and reused
 }
 ```
 
-**Why**: Missing `size` defaults to 10. Set `shard_size` to 5x `size` for accuracy. High `precision_threshold` uses more memory.
+**Why**: `size: 0` or missing `size` defaults to 10. Missing `shard_size` means each shard returns `size` results — set `shard_size` to 5x `size` for accuracy. `cardinality` with high `precision_threshold` uses more memory — tune to accuracy needs.
 
 ---
 
@@ -169,7 +169,7 @@ grep -rn 'wildcard.*\*.*value\|value.*\*.*wild' --include="*.py" --include="*.ts
 }
 ```
 
-**Why this matters**: Leading wildcards force full index scan. On 10M docs with 500K unique terms: ~5ms jumps to 5+ seconds. Trailing wildcards use the index efficiently.
+**Why this matters**: Leading wildcards (`*smith`) force a full index scan — every term in the inverted index must be checked. On a 10M document index with 500K unique usernames, this scans 500K terms per shard. Query latency jumps from ~5ms to 5+ seconds. Trailing wildcards (`smith*`) can use the index efficiently.
 
 **Preferred action**: Use `match_phrase_prefix` for prefix searches or `n-gram` tokenization for infix searches. For substring search, configure `edge_ngram` analyzer at index time.
 
@@ -202,7 +202,7 @@ rg '"from":\s*[0-9]{4,}' --type json
 }
 ```
 
-**Why this matters**: `from: 10000` fetches 10,020 per shard, discards 10,000. On 5 shards: 50,100 fetched, 50,080 discarded. CPU/memory scale linearly. Default limit `max_result_window: 10000`.
+**Why this matters**: `from: 10000` fetches 10,020 documents per shard, discards 10,000, returns 20. On a 5-shard index: 50,100 documents fetched, 50,080 discarded. Memory and CPU scale linearly with `from` value. Default limit is `index.max_result_window: 10000` — exceeding it throws an exception.
 
 **Preferred action**: Use search_after for deep pagination:
 ```json
@@ -239,7 +239,7 @@ rg '"terms"' --type json queries/ -A5 | grep -B3 '"field"' | grep -v size
 }
 ```
 
-**Why this matters**: Default `size: 10` returns top 10 only. Very large sizes materialize all buckets in memory, causing heap pressure on the coordinating node.
+**Why this matters**: Default `size: 10` returns only the top 10 buckets, which is often wrong but doesn't cause performance issues. The real danger is `size: 0` (some clients send this meaning "all") — OpenSearch interprets 0 as default (10). Some versions also accept very large sizes that materialize all buckets in memory, causing heap pressure on the coordinating node.
 
 **Preferred action**: Always set explicit `size`. For cardinality estimates, use `cardinality` aggregation instead of `terms`.
 
@@ -268,7 +268,7 @@ grep -rn 'script_score\|script_fields\|scripted_metric' --include="*.json" queri
 }
 ```
 
-**Why this matters**: Scripts run per document. On 1M docs with `match_all`: 1M invocations per shard. Script cache misses add compilation overhead.
+**Why this matters**: Painless scripts run JVM-compiled code per document. On a 1M document index with `match_all`, this executes 1M script invocations per query, per shard. Compiled script cache is limited — frequent cache misses add compilation overhead.
 
 **Preferred action**: Precompute scores at index time using `rank_features` field type or store the computed value as a regular numeric field.
 

--- a/agents/performance-optimization-engineer/references/metrics-and-monitoring.md
+++ b/agents/performance-optimization-engineer/references/metrics-and-monitoring.md
@@ -9,7 +9,7 @@
 
 ## Overview
 
-Two layers: synthetic (Lighthouse, lab) and RUM (real users). RUM wins when they conflict. Most common failure: measuring only in lab, shipping regressions that appear at P75 in production.
+Performance monitoring requires two layers: **synthetic** (Lighthouse, lab conditions) and **RUM** (real users in production). RUM data always wins when they conflict — lab conditions don't reflect CDN variance, device diversity, or real network conditions. The most common failure mode is measuring only in lab and shipping regressions that only appear at P75 percentile in production.
 
 ---
 
@@ -57,7 +57,7 @@ onTTFB(sendToAnalytics)
 onINP(sendToAnalytics, { reportAllChanges: true }) // INP updates on each interaction
 ```
 
-**Why**: Without `reportAllChanges`, `onINP` only fires on page unload. Mid-session INP degradation is invisible.
+**Why**: `onINP` without `reportAllChanges` only fires on page unload. Interactions throughout the session that degrade INP are invisible without this flag.
 
 ---
 
@@ -82,7 +82,7 @@ function sendToAnalytics(metric: MetricPayload) {
 }
 ```
 
-**Why**: 1M pageviews/day = 5M+ events at 100%. 10% sampling gives P75 accuracy. Below 1% loses significance at page-segment level.
+**Why**: At 1M pageviews/day, 100% reporting generates 5M+ events. 10% sampling gives P75 accuracy with 500K events. Below 1% loses statistical significance at the page-segment level.
 
 ---
 
@@ -108,7 +108,7 @@ onLCP((metric) => {
 })
 ```
 
-**Why**: LCP alone doesn't identify root cause (TTFB vs resource load vs render blocking). Attribution cuts debugging from hours to minutes.
+**Why**: LCP value alone doesn't tell you if the delay is TTFB, resource load time, or render blocking. Attribution data cuts debugging time from hours to minutes.
 
 ---
 
@@ -127,7 +127,7 @@ import { getFID } from 'web-vitals' // deprecated in 3.0, removed in 3.5+
 getFID(sendToAnalytics)
 ```
 
-**Why this matters**: FID removed in web-vitals 3.0 (only captured first interaction). Google replaced with INP (March 2024). `getFID` silently does nothing on 3.0+.
+**Why this matters**: FID was removed from web-vitals 3.0. It only captures the *first* interaction delay, missing the broader picture of all interactions. Google replaced it with INP for Core Web Vitals in March 2024. Code using `getFID` silently does nothing on web-vitals 3.0+.
 
 **Preferred action**:
 ```typescript
@@ -156,7 +156,7 @@ function sendToAnalytics(metric) {
 }
 ```
 
-**Why this matters**: `fetch()` during page unload is cancelled by the browser. CLS and INP report on unload — fetch loses 20-40% of events in production.
+**Why this matters**: `fetch()` calls initiated during page unload are cancelled by the browser. Metrics like CLS and INP report on page unload — fetch-based reporting loses 20-40% of metric events in production. The browser kills in-flight fetch requests when the user navigates away.
 
 **Preferred action**:
 ```typescript
@@ -188,7 +188,7 @@ grep -rn "await.*vitals\|vitals.*await\|onLCP.*await" --include="*.ts" --include
 await setupVitalsMonitoring() // Blocks rendering
 ```
 
-**Why this matters**: Metric setup in render critical path adds to LCP. Vitals measurement should never affect what it measures.
+**Why this matters**: Metric setup code in the render critical path adds to LCP. Vitals measurement is observational — it should never affect what it's measuring.
 
 **Preferred action**:
 ```typescript

--- a/agents/performance-optimization-engineer/references/nextjs-optimization.md
+++ b/agents/performance-optimization-engineer/references/nextjs-optimization.md
@@ -9,7 +9,7 @@
 
 ## Overview
 
-App Router changes the performance playbook (RSC, streaming, partial prerendering). Most common failure: applying Pages Router patterns — `getServerSideProps` mental models or blocking streaming in layout files.
+Next.js App Router introduces React Server Components, streaming, and partial prerendering — all of which change the performance optimization playbook. The most common failure mode is applying Pages Router patterns to App Router: using `getServerSideProps` mental models with Server Components, or blocking streaming with synchronous data fetching in layout files.
 
 ---
 
@@ -52,7 +52,7 @@ async function DashboardPage() {
 }
 ```
 
-**Why**: Sequential: 3 x 200ms = 600ms. Parallel: max(200ms) = 200ms. Directly impacts TTFB and LCP.
+**Why**: Sequential fetches in a single Server Component are serialized on the server — a 3-request chain of 200ms each = 600ms total. Parallel fetches = 200ms total. This directly impacts TTFB and LCP.
 
 ---
 
@@ -80,7 +80,7 @@ export default function DashboardPage() {
 }
 ```
 
-**Why**: Without Suspense, entire page waits for slowest source. With it, HTML streams progressively — above-fold content doesn't block on slow queries.
+**Why**: Without Suspense, the entire page waits for the slowest data source. With Suspense, React streams HTML progressively — users see content faster and LCP improves because the above-fold content doesn't block on slow queries.
 
 ---
 
@@ -105,7 +105,7 @@ import Image from 'next/image'
 />
 ```
 
-**Why**: Without `sizes`, browser downloads full-width image regardless of viewport (4-5x size regression on mobile). `priority` skips lazy loading for LCP candidates.
+**Why**: Without `sizes`, the browser downloads the image at full display width regardless of viewport. A 1600px image downloaded on a 375px mobile viewport is a 4-5x image size regression. The `priority` prop skips lazy loading for LCP candidates — critical for images above the fold.
 
 ---
 
@@ -133,7 +133,7 @@ export default function RootLayout({ children }) {
 }
 ```
 
-**Why**: `@import` blocks rendering. `next/font` downloads at build time, serves from same domain, inlines font-face — eliminating CLS from font swapping.
+**Why**: `@import url('...')` in CSS blocks rendering. `next/font` downloads fonts at build time, serves them from the same domain (no DNS lookup), and automatically inlines the font-face declaration — eliminating the layout shift from font swapping that contributes to CLS.
 
 ---
 
@@ -154,7 +154,7 @@ export const dynamic = 'force-dynamic'
 export const revalidate = false // or: export const dynamic = 'force-static'
 ```
 
-**Why**: Overusing `force-dynamic` bypasses the data cache. Misconfigured `dynamic` is a top cause of slow Next.js apps. Profile which routes need fresh data vs. can be cached.
+**Why**: Overusing `force-dynamic` bypasses the Next.js data cache and kills performance. Profile which routes actually need fresh data (user-specific, real-time) vs. can be cached (product pages, blog posts). Misconfigured `dynamic` is one of the most common causes of unexpectedly slow Next.js apps.
 
 ---
 
@@ -181,7 +181,7 @@ export default async function RootLayout({ children }) {
 }
 ```
 
-**Why wrong**: `layout.tsx` wraps every route. Slow await in root layout adds latency to every page load. Layouts don't stream — they must fully resolve first.
+**Why wrong**: `layout.tsx` wraps every route. A slow await in root layout adds its latency to every page load site-wide. Layouts don't participate in streaming — they must fully resolve before any child page can start rendering.
 
 **Fix**:
 ```typescript
@@ -210,7 +210,7 @@ import dynamic from 'next/dynamic'
 const ProductCard = dynamic(() => import('./ProductCard'))
 ```
 
-**Why wrong**: In App Router, `dynamic()` forces client-side rendering. For components without browser-only APIs, Server Components render faster with less JS. Only use `dynamic()` for browser-only APIs, `ssr: false`, or heavy client components.
+**Why wrong**: In App Router, `dynamic()` forces client-side rendering. For components with no browser-only APIs (no `window`, `localStorage`, event handlers), Server Components render faster and send less JS to the client. `dynamic()` is only appropriate when: (a) the component uses browser-only APIs, (b) you need `ssr: false`, or (c) it's a heavy client component.
 
 **Fix**:
 ```typescript
@@ -237,7 +237,7 @@ rg '<Image' --type tsx -A 4 | grep -v "priority"
 <Image src="/hero.jpg" width={1200} height={600} alt="Hero" />
 ```
 
-**Why wrong**: `next/image` lazy-loads by default. Hero image is the LCP element — lazy loading causes 300-800ms LCP regression.
+**Why wrong**: `next/image` lazy-loads by default using Intersection Observer. The hero image is immediately visible and is the LCP element — lazy loading it means the browser discovers it late, causing LCP regressions of 300-800ms. Lighthouse flags this as "Image elements do not have explicit width and height" or "Preload largest contentful paint image."
 
 **Fix**:
 ```tsx

--- a/agents/performance-optimization-engineer/references/performance-testing.md
+++ b/agents/performance-optimization-engineer/references/performance-testing.md
@@ -9,7 +9,7 @@
 
 ## Overview
 
-Catches regressions before production. Without CI gates, bundle size grows 20% over 6 months with no alerts. Automated budgets prevent this.
+Synthetic performance testing in CI/CD catches regressions before they reach production. The most common failure mode is running Lighthouse manually during development and never catching performance regressions in CI — so bundle size grows 20% over 6 months with no alerts. Performance budgets with automated gates prevent this category of problem entirely.
 
 ---
 
@@ -64,7 +64,7 @@ module.exports = {
 }
 ```
 
-**Why**: Single-run scores have 10-15 point variance on CI. `numberOfRuns: 3` averages it out. `'error'` assertions fail CI. Upload stores historical trends.
+**Why**: `numberOfRuns: 3` is essential — single-run Lighthouse scores have 10-15 point variance on CI machines. Assertions use `'error'` to fail CI (not just warn). The upload step stores historical data so you can see score trends over time.
 
 ---
 
@@ -94,7 +94,7 @@ jobs:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
 ```
 
-**Why**: `lhci autorun` reads config automatically. `LHCI_GITHUB_APP_TOKEN` enables PR status checks and inline comments.
+**Why**: Running `lhci autorun` reads `.lighthouserc.js` automatically. The `LHCI_GITHUB_APP_TOKEN` enables PR status checks and comments. Without it, Lighthouse results don't appear inline in PRs.
 
 ---
 
@@ -133,7 +133,7 @@ jobs:
     github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-**Why**: Measures gzipped output (what browser downloads). Prevents incremental growth where no single PR is "bad" but 6 months add 150KB.
+**Why**: `size-limit` measures gzipped output, which is what the browser actually downloads. Failing CI on bundle size regressions prevents the incremental growth pattern where no single PR is "bad" but 6 months of PRs add 150KB.
 
 ---
 
@@ -159,7 +159,7 @@ module.exports = {
 }
 ```
 
-**Why this matters**: Single run has 10-15 point variance on CI. Score 85 one run, 72 the next from same code. Single-run gates false-positive or miss real regressions.
+**Why this matters**: A single Lighthouse run has 10-15 point score variance on CI machines (shared CPU, GC pauses, network jitter). A score of 85 one run, 72 the next — both from the same code. Single-run CI gates either false-positive (blocking good PRs) or miss real regressions.
 
 **Preferred action**:
 ```javascript
@@ -186,7 +186,7 @@ assertions: {
 },
 ```
 
-**Why it matters**: `warn` appears in logs but allows regressions to ship. Only `error` fails the build.
+**Why it matters**: `warn` level assertions appear in logs but allow regressions to ship. LCP regressions only stop at the gate when the check fails the build.
 
 **Preferred action**:
 ```javascript
@@ -211,7 +211,7 @@ collect: {
 },
 ```
 
-**Why this matters**: `next dev` doesn't minify, split bundles, or optimize images. Dev scores are 20-40 points lower than production. Wrong artifact.
+**Why this matters**: `next dev` doesn't minify, doesn't split bundles, doesn't optimize images. A dev server Lighthouse score is meaningless for production performance — typically 20-40 points lower than production. You're testing the wrong artifact.
 
 **Preferred action**:
 ```javascript
@@ -232,7 +232,7 @@ grep -rn "size-limit\|bundlesize" .github/workflows/*.yml
 # If neither exists: no automated bundle regression detection
 ```
 
-**Why this matters**: Without automated gates, each PR adds "just a small dependency" until main bundle hits 500KB. Manual review only catches it when performance is already bad.
+**Why this matters**: Without automated bundle size gates, bundle size grows incrementally. Each PR adds "just a small dependency" until the main bundle is 500KB and LCP is 4.5s. Manual review doesn't catch this — bundle analysis is only done when performance is already bad.
 
 **Preferred action**: Add `size-limit` with `error` thresholds to CI. Start with current bundle size as the baseline and set limits 10% above it to allow headroom, then tighten over time.
 

--- a/agents/performance-optimization-engineer/references/preferred-patterns.md
+++ b/agents/performance-optimization-engineer/references/preferred-patterns.md
@@ -1,11 +1,33 @@
 # Performance Optimization Patterns to Detect and Fix
 
+Common performance optimization mistakes, preferred fixes, and why they matter.
+
 ## Pattern 1: Premature Optimization Without Profiling
 
-**Signal:** Adding useMemo everywhere, complex code splitting, aggressive caching, rewriting fine code — before measuring.
+**Signal:**
+```typescript
+// User: "Make my app faster"
+// Agent immediately starts optimizing:
+- Adding useMemo everywhere
+- Implementing complex code splitting
+- Setting up aggressive caching
+- Rewriting perfectly fine code
+```
 
-**Fix:** Profile first, identify bottlenecks with data, prioritize by impact, measure again.
+**Why it matters:**
+- No baseline measurements to know what's actually slow
+- Optimizing the wrong things wastes time and adds complexity
+- May introduce bugs or make maintenance harder
+- Can't prove the optimizations actually helped
+
+**Preferred action:**
+1. Profile first: Run Lighthouse, measure Core Web Vitals, check bundle sizes
+2. Identify bottlenecks: Find the actual performance problems with data
+3. Prioritize: Fix the biggest impact items first
+4. Measure again: Verify optimizations actually improved metrics
+
 ```bash
+# Start with measurements
 npm run build -- --profile
 npx webpack-bundle-analyzer build/bundle-stats.json
 lighthouse https://example.com --view
@@ -13,40 +35,91 @@ lighthouse https://example.com --view
 
 ---
 
-## Pattern 2: Micro-Optimizations Over Real Bottlenecks
+## Pattern 2: Over-Engineering with Micro-Optimizations
 
-**Signal:** `useMemo` on trivial ops, caching tiny data, code-splitting small components.
-
-**Fix:** Profile for actual bottlenecks (>16ms ops). Optimize: large list rendering (virtualization), heavy calculations, big bundles. Split routes/features, not tiny components.
-
+**Signal:**
 ```typescript
-// Real targets: expensive list rendering, heavy computation
-const VirtualizedList = memo(({ items }) => (
-  <VirtualList items={items} height={600} itemSize={50} />
-))
+// Optimizing trivial operations that don't matter
+const memoizedAdd = useMemo(() => (a, b) => a + b, [])
+
+// Creating complex caching for tiny data
+const [cachedValue] = useState(() => {
+  const cached = localStorage.getItem('trivialValue')
+  return cached ? JSON.parse(cached) : computeTrivialValue()
+})
+
+// Premature code splitting of small components
+const TinyButton = lazy(() => import('./TinyButton'))
+```
+
+**Why it matters:**
+- Simple operations are already fast (microseconds)
+- Optimization overhead costs more than the operation itself
+- Adds complexity that makes code harder to maintain
+- Distracts from real performance issues
+
+**Preferred action:**
+- Profile to find actual bottlenecks (operations taking >16ms)
+- Optimize expensive operations: large list rendering, heavy calculations, large data fetching
+- Focus on bundle size: Split large routes/features, not tiny components
+- Use performance budgets: Only optimize when metrics exceed thresholds
+
+**Real optimization targets:**
+```typescript
+// Optimize expensive list rendering
+const VirtualizedList = memo(({ items }) => {
+  // Virtual scrolling for 10,000+ items
+  return <VirtualList items={items} height={600} itemSize={50} />
+})
+
+// Optimize heavy computation
 const ExpensiveChart = memo(({ data }) => {
-  const processedData = useMemo(() => processLargeDataset(data), [data])
+  const processedData = useMemo(() => {
+    // Complex statistical analysis on large dataset
+    return processLargeDataset(data) // Actual expensive operation
+  }, [data])
   return <Chart data={processedData} />
 })
 ```
 
 ---
 
-## Pattern 3: Ignoring RUM Data
+## Pattern 3: Ignoring Real User Monitoring (RUM) Data
 
-**Signal:** "Lighthouse 95, no optimization needed" while users complain.
+**Signal:**
+```
+User: "Lighthouse shows 95 score but users complain it's slow"
+Agent: "Lighthouse score is good, no optimization needed"
+```
 
-**Fix:** Implement RUM with web-vitals. Track p75/p95. Segment by device, network, geography. RUM wins over synthetic.
+**Why it matters:**
+- Lab tests use fast networks and powerful devices
+- Real users have slow connections, old devices, poor conditions
+- 95 Lighthouse score doesn't mean good user experience
+- Missing the actual performance problems users face
+
+**Preferred action:**
+- Implement Real User Monitoring with web-vitals library
+- Track p75 and p95 metrics, not just averages
+- Segment by device, network, geography
+- Prioritize RUM data over synthetic tests when they conflict
 
 ```typescript
+// Implement proper RUM tracking
 import { getCLS, getFID, getLCP } from 'web-vitals'
+
 function sendToAnalytics(metric) {
-  navigator.sendBeacon('/api/web-vitals', JSON.stringify({
-    name: metric.name, value: metric.value, rating: metric.rating,
+  const body = JSON.stringify({
+    name: metric.name,
+    value: metric.value,
+    rating: metric.rating,
+    // Include user context
     connection: navigator.connection?.effectiveType,
     deviceMemory: navigator.deviceMemory
-  }))
+  })
+  navigator.sendBeacon('/api/web-vitals', body)
 }
+
 getCLS(sendToAnalytics)
 getFID(sendToAnalytics)
 getLCP(sendToAnalytics)
@@ -56,26 +129,77 @@ getLCP(sendToAnalytics)
 
 ## Pattern 4: Bundle Optimization Without Analysis
 
-**Signal:** Blindly lazy-loading everything, splitting every component, removing all libraries.
+**Signal:**
+```typescript
+// Blindly applying "best practices"
+- Lazy load everything
+- Split every component into separate chunks
+- Remove all libraries "to reduce bundle size"
+- Implement aggressive tree shaking configs
+```
 
-**Fix:** Analyze first. Identify deps >100KB. Split by routes, not components. Initial bundle <200KB. Lazy load below-fold only.
+**Why it matters:**
+- Too many chunks hurt performance (HTTP overhead)
+- Critical components shouldn't be lazy loaded
+- Some libraries provide essential functionality efficiently
+- Can break builds or introduce runtime errors
+
+**Preferred action:**
+1. Analyze current bundle with webpack-bundle-analyzer
+2. Identify large dependencies (>100KB)
+3. Split by routes, not components
+4. Keep initial bundle under 200KB
+5. Lazy load below-fold content only
 
 ```bash
+# Proper bundle analysis workflow
 npm run build
 npx webpack-bundle-analyzer build/stats.json
-# Look for: deps >100KB, duplicates, unused code, misconfigured chunks
+
+# Look for:
+# - Dependencies >100KB (moment.js, lodash, etc)
+# - Duplicate packages
+# - Unused code
+# - Misconfigured chunks
 ```
 
 ---
 
-## Pattern 5: Gaming Metrics Instead of Improving UX
+## Pattern 5: Optimizing Metrics Instead of User Experience
 
-**Signal:** Hiding content for LCP, delaying JS for FID, removing images for CLS, loading everything after metrics recorded.
-
-**Fix:** Optimize the actual resource. Make content load faster, not appear faster. Reserve space for CLS, don't remove features.
-
+**Signal:**
 ```typescript
-<Image src="/hero.webp" priority width={1200} height={600} alt="Hero" />
+// Gaming the metrics without improving UX
+- Hiding content to improve LCP, showing it later
+- Delaying JavaScript to improve FID
+- Removing images to improve CLS
+- Serving minimal page, loading everything after metrics recorded
+```
+
+**Why it matters:**
+- Metrics are proxies for UX, not the goal itself
+- Gaming metrics makes real experience worse
+- Users notice the tricks (delayed content, missing features)
+- Violates the purpose of performance optimization
+
+**Preferred action:**
+- Optimize metrics by improving actual UX
+- Make content load faster, not appear faster
+- Fix layout shifts by reserving space, not removing features
+- Reduce JavaScript execution time, don't just defer it
+
+**Real improvements:**
+```typescript
+// Improve LCP by optimizing the actual resource
+<Image
+  src="/hero.webp"
+  priority // Preload critical image
+  width={1200}
+  height={600}
+  alt="Hero"
+/>
+
+// Fix CLS by reserving space
 <div style={{ aspectRatio: '16/9', position: 'relative' }}>
   <Image src="/banner.jpg" fill alt="Banner" />
 </div>
@@ -85,25 +209,56 @@ npx webpack-bundle-analyzer build/stats.json
 
 ## Pattern 6: Performance Budgets Without Context
 
-**Signal:** "Total bundle must be <200KB" for a data visualization dashboard.
+**Signal:**
+```
+Agent: "Total bundle must be <200KB"
+User: "But my app is a data visualization dashboard with charts"
+Agent: "No exceptions, remove libraries until under 200KB"
+```
 
-**Fix:** Context-appropriate budgets by app type:
+**Why it matters:**
+- Different app types have different requirements
+- Some features require certain library sizes
+- Arbitrary limits don't consider business value
+- May force poor technical decisions
 
+**Preferred action:**
+- Set context-appropriate budgets
+- Justify exceptions with business value
+- Monitor budgets as trends, not hard limits
+- Balance performance with functionality
+
+**Context-appropriate budgets:**
 ```yaml
-Marketing site:   JS 150KB, CSS 50KB, Images 500KB
-E-commerce:       JS 250KB, CSS 75KB, Images 800KB
-Data dashboard:   JS 400KB, CSS 100KB, lazy-chunks 200KB/route
+# Marketing site
+initial-js: 150KB
+initial-css: 50KB
+images: 500KB
+
+# E-commerce platform
+initial-js: 250KB  # Cart, checkout, analytics
+initial-css: 75KB
+images: 800KB
+
+# Data dashboard
+initial-js: 400KB  # Charting libraries necessary
+initial-css: 100KB
+lazy-chunks: 200KB per route
 ```
 
 ---
 
-## Checklist
+## Summary: Performance Optimization Checklist
 
-1. Have baseline metrics (Lighthouse, RUM, bundle analysis)
-2. Know what's actually slow (profiling data, not assumptions)
-3. Understand user context (devices, networks, geography)
-4. Set context-appropriate budgets
-5. Optimize real bottlenecks (data-driven)
-6. Measure impact (before/after)
-7. Monitor in production (RUM)
-8. Avoid over-engineering
+Before optimizing, verify:
+
+1. ✅ Have current baseline metrics (Lighthouse, RUM, bundle analysis)
+2. ✅ Know what's actually slow (profiling data, not assumptions)
+3. ✅ Understand user context (devices, networks, geography)
+4. ✅ Set appropriate budgets (based on app type and business needs)
+5. ✅ Optimize real bottlenecks (data-driven priorities)
+6. ✅ Measure impact (before/after comparisons)
+7. ✅ Monitor in production (RUM tracking implemented)
+8. ✅ Maintain simplicity (avoid over-engineering)
+
+**Remember:** Performance optimization is about improving user experience with measurable results, not blindly applying "best practices" or gaming metrics.

--- a/agents/performance-optimization-engineer/references/preferred-patterns.md
+++ b/agents/performance-optimization-engineer/references/preferred-patterns.md
@@ -252,13 +252,13 @@ lazy-chunks: 200KB per route
 
 Before optimizing, verify:
 
-1. ✅ Have current baseline metrics (Lighthouse, RUM, bundle analysis)
-2. ✅ Know what's actually slow (profiling data, not assumptions)
-3. ✅ Understand user context (devices, networks, geography)
-4. ✅ Set appropriate budgets (based on app type and business needs)
-5. ✅ Optimize real bottlenecks (data-driven priorities)
-6. ✅ Measure impact (before/after comparisons)
-7. ✅ Monitor in production (RUM tracking implemented)
-8. ✅ Maintain simplicity (avoid over-engineering)
+1. Have current baseline metrics (Lighthouse, RUM, bundle analysis)
+2. Know what's actually slow (profiling data, not assumptions)
+3. Understand user context (devices, networks, geography)
+4. Set appropriate budgets (based on app type and business needs)
+5. Optimize real bottlenecks (data-driven priorities)
+6. Measure impact (before/after comparisons)
+7. Monitor in production (RUM tracking implemented)
+8. Maintain simplicity (avoid over-engineering)
 
 **Remember:** Performance optimization is about improving user experience with measurable results, not blindly applying "best practices" or gaming metrics.

--- a/agents/performance-optimization-engineer/references/react-rendering-performance.md
+++ b/agents/performance-optimization-engineer/references/react-rendering-performance.md
@@ -2,10 +2,11 @@
 <!-- Loaded by performance-optimization-engineer when task involves rendering, layout, CLS, hydration, or visual performance -->
 
 ## CSS content-visibility for Long Lists
-**Impact:** HIGH — 10x improvement for 1000+ item lists
+**Impact:** HIGH — faster initial render; 10x improvement for lists of 1000+ items
 
-`content-visibility: auto` skips layout/paint for off-screen items. `contain-intrinsic-size` provides a placeholder size for accurate scrollbar.
+`content-visibility: auto` lets the browser skip layout and paint for off-screen items. For a list of 1000 messages, the browser skips those calculations for ~990 off-screen items. `contain-intrinsic-size` provides a placeholder size so the scrollbar remains accurate without forcing layout of every item.
 
+**Use:**
 ```css
 .message-item {
   content-visibility: auto;
@@ -31,13 +32,14 @@ function MessageList({ messages }: { messages: Message[] }) {
 ---
 
 ## Hoist Static JSX Outside Render
-**Impact:** LOW — avoids object re-creation per render
+**Impact:** LOW — avoids object re-creation on every render
 
-Static elements that never change can be declared at module scope. Especially valuable for large static SVG nodes.
+JSX evaluates to object creation. Static elements that never change can be declared once at module scope rather than recreated on every render call. This is especially valuable for large static SVG nodes.
 
 **Instead of:**
 ```tsx
 function Container() {
+  // New object created every render
   return (
     <div>
       {loading && <div className="animate-pulse h-20 bg-gray-200" />}
@@ -61,15 +63,26 @@ function Container() {
 }
 ```
 
-Note: React Compiler auto-hoists static JSX — manual hoisting unnecessary if enabled.
+Note: If React Compiler is enabled in your project, it automatically hoists static JSX — manual hoisting is unnecessary in that case.
 
 ---
 
 ## SVG Precision Optimization
 **Impact:** LOW — reduces file size
 
-Precision beyond 1 decimal place is rarely visible. Automate with SVGO:
+SVG coordinate precision beyond 1 decimal place is rarely visible at typical display sizes. Reducing precision shrinks file size with no perceptible quality loss. The optimal precision depends on the viewBox size.
 
+**Instead of:**
+```svg
+<path d="M 10.293847 20.847362 L 30.938472 40.192837" />
+```
+
+**Use:**
+```svg
+<path d="M 10.3 20.8 L 30.9 40.2" />
+```
+
+Automate with SVGO:
 ```bash
 npx svgo --precision=1 --multipass icon.svg
 ```
@@ -79,8 +92,29 @@ npx svgo --precision=1 --multipass icon.svg
 ## Hydration Mismatch Prevention
 **Impact:** MEDIUM — avoids visual flicker and hydration errors
 
-Client-side storage (localStorage, cookies) causes flash when read in `useEffect`. Inject a synchronous inline script that runs before React hydrates:
+When rendering content that depends on client-side storage (localStorage, cookies), a naive `useEffect` approach causes a visible flash: the server renders a default value, hydration completes, then the effect runs and updates to the real value. Injecting a synchronous inline script that runs before React hydrates avoids both the SSR error and the flash.
 
+**Instead of (SSR error):**
+```tsx
+function ThemeWrapper({ children }: { children: ReactNode }) {
+  const theme = localStorage.getItem('theme') || 'light' // throws on server
+  return <div className={theme}>{children}</div>
+}
+```
+
+**Instead of (visible flash):**
+```tsx
+function ThemeWrapper({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState('light')
+  useEffect(() => {
+    const stored = localStorage.getItem('theme')
+    if (stored) setTheme(stored) // runs after hydration — user sees flash
+  }, [])
+  return <div className={theme}>{children}</div>
+}
+```
+
+**Use (no flash, no hydration error):**
 ```tsx
 function ThemeWrapper({ children }: { children: ReactNode }) {
   return (
@@ -106,6 +140,8 @@ function ThemeWrapper({ children }: { children: ReactNode }) {
 }
 ```
 
+The inline script executes synchronously before the first paint, so the DOM already has the correct value when React hydrates — no mismatch, no flash.
+
 Useful for: theme toggles, user preferences, authentication states, locale settings.
 
 ---
@@ -113,15 +149,39 @@ Useful for: theme toggles, user preferences, authentication states, locale setti
 ## Script defer and async Placement
 **Impact:** HIGH — eliminates render-blocking
 
-- `defer`: downloads in parallel, executes after HTML parsing, maintains order — DOM-dependent scripts
-- `async`: downloads in parallel, executes immediately when ready, no order guarantee — analytics
+Script tags without `defer` or `async` block HTML parsing while downloading and executing, delaying First Contentful Paint and Time to Interactive. Adding the correct attribute costs nothing and gains significant render-blocking elimination.
 
+- `defer`: downloads in parallel, executes after HTML parsing, maintains order — use for DOM-dependent scripts
+- `async`: downloads in parallel, executes immediately when ready, no order guarantee — use for independent scripts like analytics
+
+**Instead of:**
+```html
+<script src="https://example.com/analytics.js"></script>
+<script src="/scripts/utils.js"></script>
+```
+
+**Use:**
 ```html
 <script src="https://example.com/analytics.js" async></script>
 <script src="/scripts/utils.js" defer></script>
 ```
 
-Next.js variant:
+In React:
+```tsx
+export default function Document() {
+  return (
+    <html>
+      <head>
+        <script src="https://example.com/analytics.js" async />
+        <script src="/scripts/utils.js" defer />
+      </head>
+      <body>{/* content */}</body>
+    </html>
+  )
+}
+```
+
+Next.js variant using the `Script` component with `strategy` prop:
 ```tsx
 import Script from 'next/script'
 
@@ -134,10 +194,29 @@ import Script from 'next/script'
 ## Explicit Conditional Rendering
 **Impact:** LOW — prevents rendering `0` or `NaN` as visible text
 
-`&&` renders falsy values `0` and `NaN` as visible text. Use explicit ternary:
+The `&&` operator renders any falsy value that is not `false`, `null`, or `undefined` — notably `0` and `NaN` both render as visible text. Explicit ternary operators avoid this class of bug entirely.
 
+**Instead of:**
 ```tsx
-{count > 0 ? <span className="badge">{count}</span> : null}
+function Badge({ count }: { count: number }) {
+  return (
+    <div>
+      {count && <span className="badge">{count}</span>}
+      {/* When count = 0, renders: <div>0</div> */}
+    </div>
+  )
+}
+```
+
+**Use:**
+```tsx
+function Badge({ count }: { count: number }) {
+  return (
+    <div>
+      {count > 0 ? <span className="badge">{count}</span> : null}
+    </div>
+  )
+}
 ```
 
 ---
@@ -145,23 +224,41 @@ import Script from 'next/script'
 ## React DOM Resource Hints
 **Impact:** HIGH — reduces load time for critical resources
 
+React DOM provides APIs to hint the browser about resources it will need. These are especially useful in server components: the hints travel with the HTML response, so the browser can start loading resources before scripts execute.
+
 ```tsx
 import { prefetchDNS, preconnect, preload, preinit } from 'react-dom'
 
 export default function App() {
-  prefetchDNS('https://analytics.example.com')
-  preconnect('https://api.example.com')
-  preload('/fonts/inter.woff2', { as: 'font', type: 'font/woff2', crossOrigin: 'anonymous' })
-  preinit('/styles/critical.css', { as: 'style' })
+  prefetchDNS('https://analytics.example.com')      // resolve DNS early
+  preconnect('https://api.example.com')              // DNS + TCP + TLS
+  preload('/fonts/inter.woff2', {
+    as: 'font',
+    type: 'font/woff2',
+    crossOrigin: 'anonymous'
+  })
+  preinit('/styles/critical.css', { as: 'style' })  // fetch and apply
+
   return <main>{/* content */}</main>
 }
 ```
 
-Preload modules on hover:
+Preload modules for likely next navigation on hover:
 ```tsx
-<a href="/dashboard" onMouseEnter={() => preloadModule('/dashboard.js', { as: 'script' })}>
-  Dashboard
-</a>
+import { preloadModule } from 'react-dom'
+
+function Navigation() {
+  return (
+    <nav>
+      <a
+        href="/dashboard"
+        onMouseEnter={() => preloadModule('/dashboard.js', { as: 'script' })}
+      >
+        Dashboard
+      </a>
+    </nav>
+  )
+}
 ```
 
 | API | Use case |
@@ -178,10 +275,32 @@ Reference: [React DOM Resource Preloading APIs](https://react.dev/reference/reac
 ---
 
 ## useTransition for Loading States
-**Impact:** LOW — reduces re-renders, auto-resets on error
+**Impact:** LOW — reduces re-renders and improves code clarity
 
-`useTransition` provides `isPending` that auto-resets even on throw. Eliminates forgotten `setIsLoading(false)` in error paths. New transitions cancel pending ones.
+`useTransition` provides built-in `isPending` state that automatically resets even when a transition throws. It also lets React keep the UI responsive by marking the update as non-urgent. Compared to manual `useState` + `setIsLoading(true/false)` pairs, it eliminates the risk of forgetting to reset loading state in error paths.
 
+**Instead of:**
+```tsx
+function SearchResults() {
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSearch = async (value: string) => {
+    setIsLoading(true)
+    const data = await fetchResults(value)
+    setResults(data)
+    setIsLoading(false) // forgotten in error paths = stuck spinner
+  }
+
+  return (
+    <>
+      <input onChange={e => handleSearch(e.target.value)} />
+      {isLoading && <Spinner />}
+    </>
+  )
+}
+```
+
+**Use:**
 ```tsx
 import { useTransition, useState } from 'react'
 
@@ -206,6 +325,8 @@ function SearchResults() {
 }
 ```
 
+New transitions automatically cancel pending ones, so rapid input changes cancel earlier in-flight fetches.
+
 Reference: [useTransition](https://react.dev/reference/react/useTransition)
 
 ---
@@ -213,8 +334,9 @@ Reference: [useTransition](https://react.dev/reference/react/useTransition)
 ## Activity Component for Show/Hide
 **Impact:** MEDIUM — preserves state and DOM for frequently-toggled components
 
-`<Activity>` keeps tree mounted and state intact when hidden. Avoids unmount/remount cost.
+React's `<Activity>` keeps the component tree mounted and state intact when switching to `hidden` mode, then makes it visible again without re-initialization. This avoids the cost of unmounting and remounting expensive components on every toggle.
 
+**Use:**
 ```tsx
 import { Activity } from 'react'
 
@@ -227,15 +349,27 @@ function Dropdown({ isOpen }: Props) {
 }
 ```
 
-Use when: expensive initialization, stateful forms, animations needing DOM continuity.
+Use when: components have expensive initialization, stateful forms that should not reset on hide, or animations that need DOM continuity.
 
 ---
 
 ## SVG Animation Wrapping
 **Impact:** LOW — enables hardware acceleration for SVG animations
 
-Browsers lack GPU acceleration for CSS animations on SVG elements directly. Wrap SVG in a `<div>` and animate the wrapper:
+Many browsers do not have hardware acceleration for CSS animations applied directly to SVG elements. Wrapping the SVG in a `<div>` and animating the wrapper allows the browser to use GPU compositing for smooth animations.
 
+**Instead of:**
+```tsx
+function LoadingSpinner() {
+  return (
+    <svg className="animate-spin" width="24" height="24" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="10" stroke="currentColor" />
+    </svg>
+  )
+}
+```
+
+**Use:**
 ```tsx
 function LoadingSpinner() {
   return (
@@ -248,21 +382,34 @@ function LoadingSpinner() {
 }
 ```
 
-Applies to `transform`, `opacity`, `translate`, `scale`, `rotate` on SVG elements.
+Applies to all CSS transforms and transitions (`transform`, `opacity`, `translate`, `scale`, `rotate`) on SVG elements.
 
 ---
 
 ## Suppress Expected Hydration Warnings
 **Impact:** LOW-MEDIUM — eliminates noisy console warnings for known server/client differences
 
-For intentionally different values (timestamps, random IDs, timezone-formatted dates):
+Some values are intentionally different between server render and client hydration: timestamps, random IDs, timezone-formatted dates. `suppressHydrationWarning` tells React to skip the mismatch warning for that specific element. Use it only for genuinely expected differences — do not use it to hide real bugs.
 
+**Instead of:**
 ```tsx
-<span suppressHydrationWarning>
-  {new Date().toLocaleString()}
-</span>
+function Timestamp() {
+  return <span>{new Date().toLocaleString()}</span>
+  // Warning: Prop `children` did not match...
+}
 ```
 
-Apply at the specific element with the known mismatch, not at container level. Do not use to hide real bugs.
+**Use:**
+```tsx
+function Timestamp() {
+  return (
+    <span suppressHydrationWarning>
+      {new Date().toLocaleString()}
+    </span>
+  )
+}
+```
+
+Apply at the specific element with the known mismatch, not at a container level.
 
 ---

--- a/agents/performance-optimization-engineer/references/react-rendering-performance.md
+++ b/agents/performance-optimization-engineer/references/react-rendering-performance.md
@@ -327,6 +327,8 @@ function SearchResults() {
 
 New transitions automatically cancel pending ones, so rapid input changes cancel earlier in-flight fetches.
 
+**Version note**: Async functions inside `startTransition` require React 19+. In React 18, `startTransition` only tracks synchronous state updates — use `startTransition(() => { setResults(data) })` after awaiting outside the callback.
+
 Reference: [useTransition](https://react.dev/reference/react/useTransition)
 
 ---

--- a/agents/php-general-engineer/references/hooks-and-behaviors.md
+++ b/agents/php-general-engineer/references/hooks-and-behaviors.md
@@ -142,7 +142,7 @@ Always check `composer.json` `require.php` before using features. Use only featu
 | `verification-before-completion` | Final verification gate before marking any implementation complete |
 | `systematic-code-review` | Structured multi-pass code review for PRs |
 
-> **Roadmap**: Planned companion skills `php-testing` (force-routed on PHPUnit/Pest) and `php-error-handling` (exception hierarchy patterns) will mirror the Go `go-patterns`/`go-patterns` pair. These will be force-routed once created.
+> **Roadmap**: Planned companion skills `php-testing` (force-routed on PHPUnit/Pest) and `php-error-handling` (exception hierarchy patterns) will mirror the Go `go-patterns`/`go-testing` pair. These will be force-routed once created.
 
 **Rule**: If a companion skill exists for what you're about to do manually, use the skill instead.
 

--- a/agents/php-general-engineer/references/hooks-and-behaviors.md
+++ b/agents/php-general-engineer/references/hooks-and-behaviors.md
@@ -2,7 +2,7 @@
 
 ## PostToolUse Hook (full command block)
 
-Fires on Edit/Write of `.php` files. Emits format/analyse reminders and scans for debug output, raw SQL interpolation, and CSRF/session bypass.
+This is the full PostToolUse hook that fires on Edit/Write of `.php` files. It emits format/analyse reminders and scans for debug output, raw SQL interpolation, and CSRF/session bypass patterns.
 
 ```yaml
 hooks:
@@ -71,7 +71,7 @@ hooks:
 
 ## PHP Version Assumptions
 
-Default target: **PHP 8.2+** unless `composer.json` specifies otherwise.
+Default target: **PHP 8.2+** unless the project's `composer.json` specifies otherwise.
 
 | Feature | Minimum Version |
 |---------|----------------|
@@ -87,63 +87,71 @@ Default target: **PHP 8.2+** unless `composer.json` specifies otherwise.
 | `never` return type | 8.1 |
 | First-class callable syntax | 8.1 |
 
-Always check `composer.json` `require.php` before using features.
+Always check `composer.json` `require.php` before using features. Use only features available in the project's target version.
 
 ## Framework Variants
 
 | Framework | Key Idioms |
 |-----------|-----------|
-| Laravel | Eloquent, form requests, policies, Queues, Artisan, Blade, Pint |
-| Symfony | DI container, EventDispatcher, Security, Messenger, Twig |
-| Plain PHP | PSR-11 containers, PSR-7/15 middleware stacks |
-| SAP Commerce Cloud | Hybris service layer, Spring-like DI, impex, backoffice extension |
+| Laravel | Eloquent, form requests for validation, policies for authorization, Queues for deferred work, Artisan commands for CLI |
+| Symfony | Dependency injection container, EventDispatcher, Security component, Messenger for async, Twig templates |
+| Plain PHP | PSR-11 containers (PHP-DI, Pimple), PSR-7/15 middleware stacks |
+| SAP Commerce Cloud (Hybris) | Hybris service layer conventions, Spring-like DI, impex imports, backoffice customization via extension |
 
 ## Static Analysis Tier
 
 | Tool | Preferred Configuration |
 |------|------------------------|
-| PHPStan | Level 8+ (`phpstan.neon`), Larastan for Laravel |
+| PHPStan | Level 8+ (`phpstan.neon`), Larastan for Laravel projects |
 | Psalm | Strict mode (`psalm.xml`), errorLevel 1 |
-| PHP-CS-Fixer | PSR-12 rule set, or Laravel Pint |
+| PHP-CS-Fixer | PSR-12 rule set, or Laravel Pint for Laravel projects |
 
 ## Hardcoded Behaviors (Always Apply)
 
-- **Read before editing.** Never edit a file you have not read in this session.
-- **Run tests/analysis before reporting completion.** Execute phpunit/pest and phpstan, show actual output.
-- **Feature branch only.** Never commit to main.
-- **Verify dependencies.** Check `composer.json` before adding `use` statements.
-- **CLAUDE.md Compliance**: Project instructions override defaults.
-- **Over-Engineering Prevention**: Only make requested changes.
-- **`declare(strict_types=1)` on new files**: Non-negotiable.
-- **Format after every edit**: `./vendor/bin/pint` or `php-cs-fixer fix`.
-- **Prepared statements only**: PDO, Doctrine QueryBuilder, or Eloquent. No raw interpolation.
-- **Constructor injection**: No service-locator in business logic.
-- **Version-Aware Code**: Check `composer.json` for PHP version target.
+- **STOP. Read the file before editing.** Never edit a file you have not read in this session. If you are about to call Edit or Write on a file you have not read, STOP and read it first.
+- **STOP. Run tests/analysis before reporting completion.** Execute `./vendor/bin/phpunit` (or `./vendor/bin/pest`) and `./vendor/bin/phpstan analyse` and show their actual output. Do not summarize as "tests pass."
+- **Create feature branch, never commit to main.** All code changes go on a feature branch. If on main, create a branch before committing.
+- **Verify dependencies exist before importing them.** Check `composer.json` for the package before adding a `use` statement. Do not assume a package is installed.
+- **CLAUDE.md Compliance**: Read and follow repository CLAUDE.md files before any implementation. Project instructions override default agent behaviors.
+- **Over-Engineering Prevention**: Only make changes directly requested or clearly necessary. Keep solutions simple and focused. Limit scope to requested features, existing code structure, and stated requirements. Reuse existing abstractions over creating new ones.
+- **`declare(strict_types=1)` on new files**: Every new PHP application file must open with `<?php\ndeclare(strict_types=1);`. Non-negotiable.
+- **Format after every edit**: After editing any `.php` file, run `./vendor/bin/pint` (Laravel) or `php-cs-fixer fix` before committing.
+- **Complete command output**: Show actual `phpunit` or `pest` output instead of summarizing as "tests pass".
+- **Prepared statements only**: Use PDO prepared statements, Doctrine QueryBuilder, or Eloquent query builder for all SQL. Raw string interpolation is a SQL injection vector.
+- **Constructor injection**: Inject dependencies through constructors. Use constructor injection instead of service-locator lookups (`app()->make()`, `container->get()`) inside business services.
+- **Version-Aware Code**: Check `composer.json` for PHP version target. Use only features available in the project's target PHP version.
 
 ## Default Behaviors (ON unless disabled)
 
-- Report facts without self-congratulation. Show commands and outputs.
-- Clean up temporary files at completion.
-- Run `phpunit`/`pest` and `phpstan analyse` after changes, show full output.
-- PHPDoc on all public methods: `@param`, `@return`, `@throws`.
-- Check N+1 queries: review `with()`, `load()` for Eloquent relationships.
+- **Communication Style**:
+  - Fact-based progress: Report what was done without self-congratulation ("Fixed 3 issues" not "Successfully resolved the complex task of fixing 3 issues")
+  - Concise summaries: Skip verbose explanations unless complexity warrants detail
+  - Show work: Display commands and outputs rather than describing them
+  - Direct and grounded: Provide fact-based reports rather than self-celebratory updates
+- **Temporary File Cleanup**: Clean up temporary files and test scaffolds created during iteration at task completion.
+- **Run tests before completion**: Execute `./vendor/bin/phpunit --colors=always` or `./vendor/bin/pest` after code changes, show full output.
+- **Run static analysis**: Execute `./vendor/bin/phpstan analyse` after edits, show any issues.
+- **Add docblocks**: Include PHPDoc on all public methods — `@param`, `@return`, `@throws` where applicable.
+- **Check for N+1 queries**: Review eager loading (`with()`, `load()`) when implementing Eloquent relationships.
 
-## Companion Skills
+## Companion Skills (invoke via Skill tool when applicable)
 
 | Skill | When to Invoke |
 |-------|---------------|
-| `systematic-debugging` | Multi-hypothesis debugging, unknown root cause |
-| `verification-before-completion` | Final verification gate |
-| `systematic-code-review` | Structured multi-pass code review |
+| `systematic-debugging` | Systematic multi-hypothesis debugging when root cause is unknown |
+| `verification-before-completion` | Final verification gate before marking any implementation complete |
+| `systematic-code-review` | Structured multi-pass code review for PRs |
+
+> **Roadmap**: Planned companion skills `php-testing` (force-routed on PHPUnit/Pest) and `php-error-handling` (exception hierarchy patterns) will mirror the Go `go-patterns`/`go-patterns` pair. These will be force-routed once created.
 
 **Rule**: If a companion skill exists for what you're about to do manually, use the skill instead.
 
 ## Optional Behaviors (OFF unless enabled)
 
-- Aggressive refactoring beyond immediate task.
-- Adding Composer dependencies without request.
-- Performance optimization before profiling.
-- Async/fiber patterns unless requested.
+- **Aggressive refactoring**: Major structural changes beyond the immediate task.
+- **Add Composer dependencies**: Introducing new packages without explicit request.
+- **Performance optimization**: Query tuning, caching layers, or micro-optimizations before profiling confirms the bottleneck.
+- **Async/fiber patterns**: Fibers and async libraries only when explicitly requested.
 
 ---
 
@@ -152,22 +160,37 @@ Always check `composer.json` `require.php` before using features.
 | Domain | Key Capabilities |
 |--------|----------------|
 | PHP 8.2+ | Readonly classes, enums, fibers, first-class callables, constructor promotion, match, named arguments |
-| PSR Standards | PSR-12, PSR-4, PSR-7, PSR-11, PSR-15, PSR-3 |
-| Laravel | Eloquent, form requests, policies, queues, events, Artisan, Blade, Pint |
+| PSR Standards | PSR-12 style, PSR-4 autoloading, PSR-7 HTTP, PSR-11 container, PSR-15 middleware, PSR-3 logging |
+| Laravel | Eloquent, form requests, policies, queues, events, Artisan, Blade, Laravel Pint |
 | Symfony | DI container, Security, Messenger, Console, EventDispatcher, Twig |
 | Doctrine | ORM entities, repositories, QueryBuilder, migrations, embeddables |
-| Static Analysis | PHPStan 8+, Psalm strict, Larastan, PHP-CS-Fixer |
+| Static Analysis | PHPStan level 8+, Psalm strict, Larastan, PHP-CS-Fixer |
 | Testing | PHPUnit 10+, Pest 2, Mockery, factories, database transactions |
 | Security | Prepared statements, CSRF, session management, `password_hash`, `composer audit` |
-| SAP Commerce Cloud | Hybris service layer, impex, backoffice extension |
+| SAP Commerce Cloud | Hybris service layer, impex, backoffice extension, Spring-like DI in PHP layer |
 
 ---
 
 ## Capabilities & Limitations
 
-**CAN Do**: Design type-safe PHP 8.2+ apps, implement thin controller/service architecture, configure static analysis, write PHPUnit/Pest suites, audit security (SQL injection, mass-assignment, CSRF, sessions), review Laravel/Symfony/Doctrine, implement DTOs/value objects, debug PHP apps.
+### What This Agent CAN Do
 
-**CANNOT Do**: Execute PHP code, access external APIs/databases, manage infrastructure, guarantee PHP 7.x compatibility, profile your specific code.
+- Design type-safe PHP applications with PHP 8.2+ features and PSR-12 style
+- Implement thin controller / application service architecture
+- Configure static analysis (PHPStan/Psalm) and formatters (Pint/PHP-CS-Fixer)
+- Write PHPUnit and Pest test suites with factories, mocks, and integration tests
+- Audit codebases for SQL injection, mass-assignment, CSRF, and session vulnerabilities
+- Review Laravel/Symfony/Doctrine code for idiomatic patterns and anti-patterns
+- Implement DTOs, value objects, and immutable data structures
+- Debug PHP applications with systematic error analysis
+
+### What This Agent CANNOT Do
+
+- **Cannot execute PHP code**: Provides patterns and commands; you must run them.
+- **Cannot access external APIs or databases**: No live connectivity.
+- **Cannot manage infrastructure**: Focus is PHP code, not Docker, web servers, or cloud resources.
+- **Cannot guarantee PHP 7.x compatibility**: Focus is modern PHP 8.2+.
+- **Cannot profile your specific code**: Provides profiling patterns, not actual profiling results.
 
 ---
 
@@ -175,7 +198,10 @@ Always check `composer.json` `require.php` before using features.
 
 ```markdown
 ## Summary
-[1-2 sentence overview]
+[1-2 sentence overview of what was implemented]
+
+## Implementation
+[Description of approach and key decisions]
 
 ## Files Changed
 | File | Change | Lines |
@@ -186,4 +212,7 @@ Always check `composer.json` `require.php` before using features.
 - [x] Tests pass: `./vendor/bin/phpunit` output
 - [x] Static analysis: `./vendor/bin/phpstan analyse` output
 - [x] Format: `./vendor/bin/pint` output
+
+## Next Steps
+- [ ] [Follow-up if any]
 ```

--- a/agents/php-general-engineer/references/php-security.md
+++ b/agents/php-general-engineer/references/php-security.md
@@ -1,30 +1,42 @@
 # PHP Secure Implementation Patterns
 
-Secure-by-default patterns for PHP 8.2+. Load when the task involves security, auth, injection, XSS, CSRF, deserialization, session management, or any vulnerability-related code.
+Secure-by-default patterns for PHP 8.2+ applications. Each section shows what correct code looks like and why it matters. Load this reference when the task involves security, auth, injection, XSS, CSRF, deserialization, session management, or any vulnerability-related code.
 
 ---
 
 ## Use Strict Comparisons and strict_types
 
-Declare `strict_types=1` in every file. Use `===` for all comparisons, especially security-critical ones.
+Declare `strict_types=1` in every PHP file and use `===` for all comparisons, especially security-critical ones.
 
 ```php
 <?php
+
 declare(strict_types=1);
 
+// Correct: strict comparison for auth checks
 function verifyApiKey(string $provided, string $expected): bool {
-    return hash_equals($expected, $provided);  // Timing-safe
+    return hash_equals($expected, $provided);  // Timing-safe comparison
 }
 
+// Correct: strict type checking prevents type juggling
 function isAdmin(mixed $role): bool {
-    return $role === 'admin';  // "0" !== 0, null !== false
+    return $role === 'admin';  // "0" !== 0, null !== false, "" !== 0
+}
+
+// Correct: validate types before comparison
+function findUser(mixed $id): ?User {
+    if (!is_int($id) && !is_string($id)) {
+        throw new \InvalidArgumentException('Invalid ID type');
+    }
+    return User::find($id);
 }
 ```
 
-PHP's `==` performs type juggling: `"0e1234" == "0e5678"` is `true` (both coerce to float 0). In auth contexts, this can bypass password verification via magic hash collisions.
+**Why this matters**: PHP's `==` performs type juggling: `"0" == false` is `true`, `"0e1234" == "0e5678"` is `true` (both coerce to float 0), and `null == ""` is `true`. In auth contexts, `$hash == $input` with type juggling can bypass password verification when both values start with `0e` (a magic hash collision). `declare(strict_types=1)` prevents implicit type coercion in function calls.
 
 **Detection**:
 ```bash
+rg -n 'declare\(strict_types' . --type php | head -5
 rg -n '\$.*==\s' . --type php | rg -v '===' | rg -i 'password\|token\|hash\|key\|secret\|admin\|role'
 ```
 
@@ -32,41 +44,83 @@ rg -n '\$.*==\s' . --type php | rg -v '===' | rg -i 'password\|token\|hash\|key\
 
 ## Use json_decode Instead of unserialize for Untrusted Input
 
+Deserialize untrusted data with `json_decode`. Never use `unserialize` on data from outside the trust boundary.
+
 ```php
+<?php
+
+declare(strict_types=1);
+
+// Correct: JSON for API payloads and client data
 $data = json_decode($requestBody, associative: true, flags: JSON_THROW_ON_ERROR);
 
-// When unserialize is needed for internal data:
+// Correct: structured validation after decoding
+function parseUserConfig(string $json): array {
+    $config = json_decode($json, associative: true, flags: JSON_THROW_ON_ERROR);
+
+    // Validate expected structure
+    if (!isset($config['theme']) || !in_array($config['theme'], ['light', 'dark'], strict: true)) {
+        throw new \InvalidArgumentException('Invalid theme');
+    }
+
+    return $config;
+}
+
+// When unserialize is needed for internal data (cache, session):
+// Use allowed_classes to restrict what can be instantiated
 $data = unserialize($cacheValue, ['allowed_classes' => [DateTime::class, Money::class]]);
 ```
 
-`unserialize($user_data)` executes magic methods (`__wakeup`, `__destruct`) producing RCE through gadget chains. `json_decode` cannot instantiate objects.
+**Why this matters**: `unserialize($user_data)` executes PHP magic methods (`__wakeup`, `__destruct`, `__toString`) on deserialized objects. Combined with available classes in the autoloader, this produces RCE through well-catalogued gadget chains (Laravel, Symfony, WordPress). `json_decode` cannot instantiate objects or execute code.
 
 **Detection**:
 ```bash
 rg -n 'unserialize\(' . --type php | rg -v 'allowed_classes'
+rg -n 'json_decode\(' . --type php
 ```
 
 ---
 
 ## Use PDO Prepared Statements for All Database Access
 
+Use PDO with prepared statements and bound parameters. Never concatenate user input into SQL strings.
+
 ```php
-// PDO
+<?php
+
+declare(strict_types=1);
+
+// Correct: PDO prepared statement with named parameters
 $stmt = $pdo->prepare('SELECT * FROM users WHERE email = :email AND org_id = :org_id');
 $stmt->execute(['email' => $email, 'org_id' => $orgId]);
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
 
-// Eloquent
-$invoices = Invoice::where('customer_id', $customerId)->where('org_id', $orgId)->get();
+// Correct: PDO prepared statement with positional parameters
+$stmt = $pdo->prepare('INSERT INTO invoices (customer_id, amount) VALUES (?, ?)');
+$stmt->execute([$customerId, $amount]);
 
-// Doctrine QueryBuilder
-$qb->select('u')->from(User::class, 'u')->where('u.email = :email')->setParameter('email', $email);
+// Correct: Laravel Eloquent (parameterized by default)
+$invoices = Invoice::where('customer_id', $customerId)
+    ->where('org_id', $orgId)
+    ->get();
+
+// Correct: Laravel query builder with bindings
+$results = DB::select('SELECT * FROM users WHERE name = ?', [$name]);
+
+// Correct: Doctrine QueryBuilder
+$qb = $entityManager->createQueryBuilder();
+$qb->select('u')
+    ->from(User::class, 'u')
+    ->where('u.email = :email')
+    ->setParameter('email', $email);
 ```
 
-Prepared statements separate SQL structure from data at the driver level.
+**Why this matters**: `$pdo->query("SELECT * FROM users WHERE name = '$name'")` allows SQL injection through string interpolation. Prepared statements separate SQL structure from data at the database driver level, preventing injection regardless of input content. Sequelize CVE-2023-25813 demonstrated that even ORM escape hatches can be vulnerable when used incorrectly.
 
 **Detection**:
 ```bash
 rg -n 'query\(.*\$|exec\(.*\$' . --type php | rg -i 'select\|insert\|update\|delete'
+rg -n '->prepare\(' . --type php
 rg -n 'DB::raw\(.*\$' . --type php
 ```
 
@@ -74,80 +128,134 @@ rg -n 'DB::raw\(.*\$' . --type php
 
 ## Prevent File Inclusion With User Input
 
-Never pass user input to `include`/`require`. Use allowlists:
+Never pass user input to `include`, `require`, `include_once`, or `require_once`. Use allowlists for dynamic page loading.
 
 ```php
+<?php
+
+declare(strict_types=1);
+
+// Correct: allowlist-based page routing
 $allowedPages = ['home', 'about', 'contact', 'pricing'];
+
 $page = $_GET['page'] ?? 'home';
-if (!in_array($page, $allowedPages, strict: true)) { $page = 'home'; }
+if (!in_array($page, $allowedPages, strict: true)) {
+    $page = 'home';
+}
 require __DIR__ . '/templates/' . $page . '.php';
+
+// Correct: use a router or switch statement
+match ($page) {
+    'home' => require __DIR__ . '/templates/home.php',
+    'about' => require __DIR__ . '/templates/about.php',
+    'contact' => require __DIR__ . '/templates/contact.php',
+    default => require __DIR__ . '/templates/404.php',
+};
 ```
 
-`include($_GET['page'])` allows LFI (`?page=../../etc/passwd`) and with `allow_url_include=On`, RFI.
+**Why this matters**: `include($_GET['page'])` allows Local File Inclusion (LFI) where `?page=../../etc/passwd` reads arbitrary files. With `allow_url_include=On`, it becomes Remote File Inclusion (RFI) where `?page=http://attacker.com/shell.php` executes remote code. The `match` expression or allowlist eliminates this entirely.
 
 **Detection**:
 ```bash
-rg -n 'include.*\$_|require.*\$_' . --type php
+rg -n 'include.*\$_|require.*\$_|include_once.*\$_|require_once.*\$_' . --type php
+rg -n 'include\s*\(\s*\$|require\s*\(\s*\$' . --type php
 ```
 
 ---
 
 ## Use password_hash With Strong Algorithms
 
+Hash passwords with `password_hash` using `PASSWORD_BCRYPT` or `PASSWORD_ARGON2ID`. Verify with `password_verify`. Never use MD5, SHA1, or SHA256 for password storage.
+
 ```php
+<?php
+
+declare(strict_types=1);
+
+// Correct: hash on registration
 function hashPassword(string $password): string {
     return password_hash($password, PASSWORD_ARGON2ID, [
-        'memory_cost' => 65536, 'time_cost' => 4, 'threads' => 3,
+        'memory_cost' => 65536,  // 64MB
+        'time_cost' => 4,
+        'threads' => 3,
     ]);
 }
 
+// Correct: verify on login
 function verifyPassword(string $password, string $hash): bool {
     return password_verify($password, $hash);
 }
 
+// Correct: rehash when algorithm or cost changes
 function rehashIfNeeded(string $password, string $hash): ?string {
-    if (password_needs_rehash($hash, PASSWORD_ARGON2ID)) { return hashPassword($password); }
+    if (password_needs_rehash($hash, PASSWORD_ARGON2ID)) {
+        return hashPassword($password);
+    }
     return null;
 }
 ```
 
-`md5`/`sha256` are fast hashes for integrity, not passwords. GPUs compute billions/sec. `PASSWORD_ARGON2ID` is memory-hard and time-hard. `PASSWORD_BCRYPT` has 72-byte limit but is a supported fallback.
+**Why this matters**: `md5($password)` and `sha256($password)` are fast hashes designed for integrity checking, not password storage. A GPU can compute billions of SHA256 hashes per second. `PASSWORD_ARGON2ID` is memory-hard and time-hard, designed to resist GPU and ASIC attacks. `PASSWORD_BCRYPT` has a 72-byte input limit but is widely supported as a fallback.
 
 **Detection**:
 ```bash
-rg -n 'md5\(.*password\|sha1\(.*password' . --type php
+rg -n 'md5\(.*password\|sha1\(.*password\|sha256\(.*password\|hash\(.*password' . --type php
+rg -n 'password_hash\|password_verify\|PASSWORD_ARGON2ID\|PASSWORD_BCRYPT' . --type php
 ```
 
 ---
 
 ## Regenerate Session ID on Auth State Changes
 
+Regenerate the session ID on login, logout, and privilege elevation. Set secure session cookie attributes.
+
 ```php
+<?php
+
+declare(strict_types=1);
+
+// Correct: secure session configuration
 ini_set('session.cookie_httponly', '1');
 ini_set('session.cookie_secure', '1');
 ini_set('session.cookie_samesite', 'Lax');
 ini_set('session.use_strict_mode', '1');
 ini_set('session.use_only_cookies', '1');
 
+// Correct: regenerate on login
 function loginUser(User $user): void {
-    session_regenerate_id(true);  // true = delete old session
+    session_regenerate_id(true);  // true = delete old session file
     $_SESSION['user_id'] = $user->id;
+    $_SESSION['role'] = $user->role;
+    $_SESSION['ip'] = $_SERVER['REMOTE_ADDR'];
+    $_SESSION['user_agent'] = $_SERVER['HTTP_USER_AGENT'];
 }
 
+// Correct: regenerate on privilege change
+function elevateToAdmin(): void {
+    session_regenerate_id(true);
+    $_SESSION['role'] = 'admin';
+}
+
+// Correct: regenerate on logout
 function logout(): void {
     $_SESSION = [];
     session_regenerate_id(true);
     session_destroy();
 }
 
-// Laravel: $request->session()->regenerate();
+// Correct: Laravel session regeneration
+public function login(Request $request): RedirectResponse {
+    $request->session()->regenerate();
+    // ...
+}
 ```
 
-Without regeneration, pre-login session ID capture (XSS, sniffing, fixation) retains access after authentication.
+**Why this matters**: Without session regeneration, an attacker who captures a pre-login session ID (via XSS, network sniffing, or session fixation) retains access after the victim authenticates. `session_regenerate_id(true)` creates a new ID and deletes the old session data, breaking the fixation chain.
 
 **Detection**:
 ```bash
 rg -n 'session_regenerate_id' . --type php
+rg -n 'session_start\(\)' . --type php
 rg -n 'session\.cookie_httponly\|session\.cookie_secure' . --type php
 ```
 
@@ -155,28 +263,52 @@ rg -n 'session\.cookie_httponly\|session\.cookie_secure' . --type php
 
 ## Escape Output With htmlspecialchars
 
+Escape all dynamic output in HTML context using `htmlspecialchars` with `ENT_QUOTES` and explicit encoding. Use framework template engines that auto-escape by default.
+
 ```php
+<?php
+
+declare(strict_types=1);
+
+// Correct: htmlspecialchars with ENT_QUOTES for HTML output
 function e(string $value): string {
     return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 }
 
-// Plain PHP: <?= e($username) ?>
-// Blade: {{ $username }} (auto-escaped), {!! $trustedHtml !!} (raw)
-// Twig: {{ username }} (auto-escaped), {{ trusted_html|raw }}
+// In plain PHP templates:
+<p>Hello, <?= e($username) ?></p>
+<input type="text" value="<?= e($searchQuery) ?>">
+<a href="/profile?id=<?= e((string)$userId) ?>">Profile</a>
+
+// Correct: Laravel Blade (auto-escapes {{ }})
+// {{ $username }} — escaped
+// {!! $trustedHtml !!} — raw (only for trusted content)
+
+// Correct: Symfony Twig (auto-escapes {{ }})
+// {{ username }} — escaped
+// {{ trusted_html|raw }} — raw (only for trusted content)
 ```
 
-`ENT_QUOTES` escapes both quote types, preventing attribute breakout. `ENT_SUBSTITUTE` replaces invalid encoding.
+**Why this matters**: `echo $username` without escaping allows XSS when `$username` contains `<script>alert(1)</script>`. `ENT_QUOTES` escapes both single and double quotes, preventing attribute-value breakout. The `ENT_SUBSTITUTE` flag replaces invalid encoding sequences instead of returning empty strings.
 
 **Detection**:
 ```bash
 rg -n 'echo\s+\$|print\s+\$' . --type php | rg -v 'htmlspecialchars\|htmlentities\|e\('
+rg -n '<\?=\s*\$' . --type php | rg -v 'htmlspecialchars\|e\('
 ```
 
 ---
 
 ## Implement CSRF Token Validation
 
+Include and verify CSRF tokens on all state-changing forms. Use framework-provided CSRF protection when available.
+
 ```php
+<?php
+
+declare(strict_types=1);
+
+// Correct: generate CSRF token
 function generateCsrfToken(): string {
     if (empty($_SESSION['csrf_token'])) {
         $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
@@ -184,18 +316,38 @@ function generateCsrfToken(): string {
     return $_SESSION['csrf_token'];
 }
 
+// Correct: verify CSRF token
 function verifyCsrfToken(string $token): bool {
     return hash_equals($_SESSION['csrf_token'] ?? '', $token);
 }
 
-// Laravel: @csrf (automatic)
-// Symfony: {{ form_start(form) }} (automatic)
+// In forms:
+// <input type="hidden" name="_token" value="<?= e(generateCsrfToken()) ?>">
+
+// In request handling:
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!verifyCsrfToken($_POST['_token'] ?? '')) {
+        http_response_code(403);
+        exit('CSRF validation failed');
+    }
+    // ...process form
+}
+
+// Correct: Laravel (automatic with @csrf)
+// <form method="POST">
+//     @csrf
+//     ...
+// </form>
+
+// Correct: Symfony (automatic with form component)
+// {{ form_start(form) }}  — includes _token automatically
 ```
 
-Use `hash_equals` for timing-safe comparison.
+**Why this matters**: Without CSRF tokens, any website can submit forms to your application using the visitor's authenticated session. The visitor's browser automatically includes session cookies with the cross-origin request. CSRF tokens prove the form submission originated from your application. Use `hash_equals` for timing-safe token comparison.
 
 **Detection**:
 ```bash
+rg -n 'csrf_token\|_token\|@csrf' . --type php
 rg -n '<form.*method.*POST' . --type php
 rg -n 'VerifyCsrfToken\|csrf.*except' . --type php
 ```
@@ -204,50 +356,98 @@ rg -n 'VerifyCsrfToken\|csrf.*except' . --type php
 
 ## Use Mass Assignment Protection
 
+Always specify allowed fields for mass assignment. Never pass raw request data to model create/update methods.
+
 ```php
-// Eloquent: always $fillable, never $guarded = []
+<?php
+
+declare(strict_types=1);
+
+// Correct: Laravel Eloquent with $fillable allowlist
 class User extends Model {
     protected $fillable = ['name', 'email', 'avatar_url'];
+    // $guarded is the inverse; prefer $fillable for explicitness
+    // Never: protected $guarded = [];  // Allows all fields
 }
 
-// Validate and extract specific fields
-$validated = $request->validate(['name' => 'required|string|max:100', 'email' => 'required|email']);
+// Correct: validate and extract specific fields
+$validated = $request->validate([
+    'name' => 'required|string|max:100',
+    'email' => 'required|email',
+    'avatar_url' => 'nullable|url',
+]);
 $user->update($validated);
+
+// Correct: Symfony with explicit DTO
+class UpdateProfileCommand {
+    public function __construct(
+        public readonly string $name,
+        public readonly string $email,
+        public readonly ?string $avatarUrl = null,
+    ) {}
+}
+
+// Map request to DTO, then to entity
+$command = new UpdateProfileCommand(
+    name: $request->get('name'),
+    email: $request->get('email'),
+    avatarUrl: $request->get('avatar_url'),
+);
 ```
 
-`User::create($request->all())` lets attackers POST `{"is_admin": true}`.
+**Why this matters**: `User::create($request->all())` allows an attacker to POST `{"is_admin": true, "role": "superadmin"}` and set arbitrary model attributes. The `$fillable` allowlist restricts which attributes can be set via mass assignment. This is the PHP equivalent of DRF's `fields = '__all__'` problem.
 
 **Detection**:
 ```bash
 rg -n '\$guarded\s*=\s*\[\s*\]' . --type php
-rg -n '::create\(\$request->all\(\)\)' . --type php
+rg -n '::create\(\$request->all\(\)\)|->update\(\$request->all\(\)\)' . --type php
+rg -n '\$fillable' . --type php
 ```
 
 ---
 
 ## Validate Outbound URLs to Prevent SSRF
 
+Resolve hostnames to IPs and validate against private ranges before making outbound HTTP requests.
+
 ```php
+<?php
+
+declare(strict_types=1);
+
 function validateUrl(string $url): string {
     $parsed = parse_url($url);
     if (!$parsed || !in_array($parsed['scheme'] ?? '', ['http', 'https'], strict: true)) {
         throw new \InvalidArgumentException('Invalid URL scheme');
     }
-    $ip = gethostbyname($parsed['host'] ?? '');
-    if ($ip === ($parsed['host'] ?? '')) { throw new \InvalidArgumentException('DNS failed'); }
-    if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+
+    $host = $parsed['host'] ?? '';
+    $ip = gethostbyname($host);
+    if ($ip === $host) {
+        throw new \InvalidArgumentException('DNS resolution failed');
+    }
+
+    // Block private/internal ranges
+    $flags = FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
+    if (filter_var($ip, FILTER_VALIDATE_IP, $flags) === false) {
         throw new \InvalidArgumentException('Disallowed IP range');
     }
+
     return $url;
 }
 
-// Usage: $validatedUrl = validateUrl($userUrl);
-// Guzzle: ['allow_redirects' => false, 'timeout' => 10]
+// Usage with Guzzle
+$validatedUrl = validateUrl($userUrl);
+$response = $client->get($validatedUrl, [
+    'allow_redirects' => false,
+    'timeout' => 10,
+]);
 ```
 
-Blocks cloud metadata endpoints (`169.254.169.254`) and RFC1918 addresses. Disable redirects to prevent bypass.
+**Why this matters**: User-controlled URLs reach internal services including cloud metadata endpoints (`169.254.169.254`). `FILTER_FLAG_NO_PRIV_RANGE` and `FILTER_FLAG_NO_RES_RANGE` reject RFC1918 and reserved addresses. Disable redirect following to prevent redirect-based bypasses.
 
 **Detection**:
 ```bash
 rg -n 'file_get_contents\(.*\$|curl_exec\|Guzzle.*\$' . --type php
+rg -n 'FILTER_FLAG_NO_PRIV_RANGE\|FILTER_FLAG_NO_RES_RANGE' . --type php
 ```

--- a/agents/prometheus-grafana-engineer/references/alerting-patterns.md
+++ b/agents/prometheus-grafana-engineer/references/alerting-patterns.md
@@ -268,7 +268,7 @@ route:
 |---------|--------|--------|
 | Alertmanager 0.20 | `inhibit_rules.source_matchers` / `target_matchers` syntax | Old `source_match` / `target_match` deprecated in 0.22 |
 | Alertmanager 0.22 | `matchers` field for routes (replaces `match` + `match_re`) | `match:` still works but `matchers:` is preferred |
-| Alertmanager 0.25 | `time_intervals` replaces `time_intervals` in mute_time_intervals | Check config if upgrading — key rename causes silent ignore |
+| Alertmanager 0.25 | `time_intervals` replaces `mute_time_intervals` | Check config if upgrading — key rename causes silent ignore |
 | Prometheus 2.28 | `for` clause resets on alert state change | Alerts that briefly resolve then re-fire restart the `for:` timer |
 
 ---

--- a/agents/prometheus-grafana-engineer/references/alerting-patterns.md
+++ b/agents/prometheus-grafana-engineer/references/alerting-patterns.md
@@ -1,14 +1,20 @@
 # Alerting Patterns Reference
 
-> **Scope**: SLO-based alerting, multi-window burn rate, Alertmanager configuration
+> **Scope**: SLO-based alerting, multi-window burn rate, and Alertmanager configuration patterns
 > **Version range**: Prometheus 2.0+ / Alertmanager 0.20+
 > **Generated**: 2026-04-09 — verify burn rate math against your SLO targets
 
 ---
 
+## Overview
+
+SLO-based alerting is the production standard for actionable alerts. The primary failure mode is alerting on symptoms (CPU, disk, memory) that have no direct user impact, or using single-window burn rate that misses both slow and fast burns. Google's SRE book multi-window burn rate pattern detects 99% of SLO violations with low false-positive rate.
+
+---
+
 ## SLO Burn Rate — Core Math
 
-A burn rate of N means you're consuming error budget N× faster than allowed.
+A burn rate of N means you're consuming your error budget N× faster than allowed.
 
 | Burn Rate | Time to Exhaust Budget | Severity | Window |
 |-----------|----------------------|----------|--------|
@@ -52,7 +58,7 @@ groups:
           severity: warning
 ```
 
-The `0.001` is the error threshold for 99.9% SLO (1 - 0.999). For 99.5% SLO, use `0.005`.
+The `0.001` is the error threshold for a 99.9% SLO (1 - 0.999). For 99.5% SLO, use `0.005`.
 
 ---
 
@@ -60,7 +66,7 @@ The `0.001` is the error threshold for 99.9% SLO (1 - 0.999). For 99.5% SLO, use
 
 ### Alertmanager Inhibition Rules
 
-Suppress lower-severity alerts when a higher-severity alert fires for the same service:
+Use inhibition to suppress lower-severity alerts when a higher-severity alert fires for the same service:
 
 ```yaml
 # alertmanager.yml
@@ -74,17 +80,21 @@ inhibit_rules:
       - instance
 ```
 
+**Why**: Without inhibition, a database outage fires both `DBDown (critical)` and `SlowQueries (warning)` for the same instance. On-call gets paged twice and must mentally correlate. Inhibition auto-suppresses the warning when the critical is active.
+
 ---
 
 ### Alert Grouping by Team
+
+Group alerts before routing to team channels:
 
 ```yaml
 # alertmanager.yml
 route:
   group_by: [alertname, job, severity]
-  group_wait: 30s
-  group_interval: 5m
-  repeat_interval: 4h
+  group_wait: 30s      # wait 30s to batch alerts in same group
+  group_interval: 5m   # send new alerts in existing group every 5m
+  repeat_interval: 4h  # re-notify if still firing after 4h
   receiver: default
 
   routes:
@@ -96,10 +106,10 @@ route:
     - match:
         severity: critical
       receiver: pagerduty
-      continue: true
+      continue: true    # continue to check other routes too
 ```
 
-Without `group_by`, Alertmanager sends one notification per alert — 50+ Slack messages during an incident. Grouping collapses related alerts into one message.
+**Why**: Without `group_by`, Alertmanager sends one notification per alert, generating 50+ Slack messages during an incident. Grouping collapses a K8s node failure (5+ firing alerts per pod) into one actionable message.
 
 ---
 
@@ -114,9 +124,16 @@ grep -rn 'burn_rate\|burnrate\|error_rate.*ratio' --include="*.yml" -A 5 | grep 
 rg 'alert.*[Bb]urn' --type yaml -A 8 | grep -v 'and\s*$'
 ```
 
-**Signal**: Single-window burn rate alert (misses slow burns over hours).
+**Signal**:
+```yaml
+- alert: SLOBurnRate
+  expr: job:error_rate:ratio5m > 0.01
+  # Single window — misses slow burns over hours
+```
 
-**Preferred action**: Require both a long window (trend) and short window (ongoing):
+**Why this matters**: A single 5-minute window catches fast burns (many errors quickly) but misses slow burns (few errors sustained over hours) that also exhaust the error budget. 30% of budget-exhausting incidents are slow burns invisible to single-window alerting.
+
+**Preferred action**: Multi-window burn rate — require both a long window (confirming trend) and a short window (confirming it's ongoing):
 ```yaml
 - alert: SLOBurnRate
   expr: |
@@ -132,17 +149,32 @@ rg 'alert.*[Bb]urn' --type yaml -A 8 | grep -v 'and\s*$'
 
 **Detection**:
 ```bash
+# Check if amtool is available and used in CI
 grep -rn 'amtool' --include="Makefile" --include="*.sh" --include="*.yml"
+# If no results: amtool validation is missing from deployment pipeline
 ```
 <!-- no-pair-required: partial section — positive counterpart follows in next block -->
 
-A YAML syntax error in `alertmanager.yml` causes Alertmanager to reject the config silently. No error surfaces until alerts fail to route.
+**Signal**:
+```bash
+# alertmanager.yml applied directly without validation
+kubectl apply -f alertmanager-config.yaml
+# A YAML syntax error silences ALL alerts
+```
+
+**Why this matters**: A single YAML syntax error in `alertmanager.yml` causes Alertmanager to reject the config and continue using the previous valid config — or fail to start. No error surfaces in the UI until alerts fail to route. Silent alert failures are worse than loud ones.
 
 **Preferred action**:
 ```bash
+# Validate before applying
 amtool check-config alertmanager.yml
+
+# Test routing for a specific alert label set
 amtool config routes test --config.file=alertmanager.yml \
   severity=critical job=api team=platform
+
+# In CI: add this to pre-commit or CI pipeline
+amtool check-config alertmanager.yml && echo "Config valid"
 ```
 
 ---
@@ -155,11 +187,24 @@ grep -rn '^\s*- alert:' --include="*.yml" -A 15 | grep -B 10 'severity: critical
 rg 'alert:' --type yaml -A 12 | grep -B8 'severity: critical' | grep -v runbook_url
 ```
 
+**Signal**:
+```yaml
+- alert: DatabaseConnectionPoolExhausted
+  expr: pg_stat_activity_count > 90
+  labels:
+    severity: critical
+  annotations:
+    summary: "DB connections exhausted"
+    # No runbook_url — on-call must guess remediation at 3am
+```
+
+**Why this matters**: Alerts without runbooks produce "now what?" paralysis at incident time. The 3am on-call engineer shouldn't be solving novel problems — they should be executing a known remediation. Missing runbooks convert paging alerts into learning exercises.
+
 **Preferred action**:
 ```yaml
 annotations:
   summary: "DB connections exhausted on {{ $labels.instance }}"
-  description: "Connection pool at {{ $value }}/100."
+  description: "Connection pool at {{ $value }}/100. Spike in slow queries or leaked connections."
   runbook_url: "https://wiki.example.com/runbooks/db-connection-pool"
   dashboard_url: "https://grafana.example.com/d/db-overview?var-instance={{ $labels.instance }}"
 ```
@@ -171,11 +216,25 @@ annotations:
 **Detection**:
 ```bash
 grep -n 'receiver:' alertmanager.yml | wc -l
+# If only 1-2 unique receivers with no routes: flat routing
 grep -c 'routes:' alertmanager.yml
 ```
 <!-- no-pair-required: partial section — positive counterpart follows in next block -->
 
-**Preferred action**:
+**Signal**:
+```yaml
+# alertmanager.yml
+route:
+  receiver: all-alerts-slack  # everything goes to one channel
+receivers:
+  - name: all-alerts-slack
+    slack_configs:
+      - channel: "#alerts"
+```
+
+**Why this matters**: Mixing critical pages (database down), warnings (disk at 70%), and informational (deployment complete) into one channel trains teams to ignore the channel. Critical alerts get lost in noise. Mean time to acknowledge increases.
+
+**Preferred action**: Route by severity and team:
 ```yaml
 route:
   receiver: default
@@ -194,12 +253,12 @@ route:
 
 | Error / Symptom | Root Cause | Fix |
 |-----------------|------------|-----|
-| Alert flapping | No `for:` clause or too short | Add `for: 5m` minimum for non-critical |
-| Alertmanager silently stops routing | YAML syntax error | Run `amtool check-config` before applying |
-| No alerts during incident | Inhibition too broad | Narrow `equal:` labels in inhibit_rules |
-| PagerDuty dedup not working | Missing `source_matchers` | Add `equal: [alertname, job]` |
-| Alerts fire during deployment | `absent()` with short `for:` | Increase `for:` to 10m+ |
-| Burn rate alert never fires | Wrong error threshold | 99.9% SLO → threshold = `0.001`, not `0.01` |
+| Alert fires then immediately resolves (flapping) | No `for:` clause or `for:` too short | Add `for: 5m` minimum to all non-critical alerts |
+| Alertmanager silently stops routing alerts | YAML syntax error in config — old config still active | Run `amtool check-config` before applying; add to CI |
+| No alerts during incident | Inhibition rule too broad — critical silenced warnings AND pages | Narrow `equal:` labels in inhibit_rules to specific instance |
+| PagerDuty deduplication not working | Missing `source_matchers` or wrong `equal:` set | Add `equal: [alertname, job]` to inhibit rules |
+| Alerts fire during rolling deployment | `absent()` alert with short `for:` | Increase `for:` to 10m+ to tolerate pod restart gaps |
+| Burn rate alert never fires | Error threshold wrong for SLO (e.g., using 0.01 for 99.9%) | SLO = 99.9% → threshold = `1 - 0.999 = 0.001`, not `0.01` |
 
 ---
 
@@ -207,10 +266,10 @@ route:
 
 | Version | Change | Impact |
 |---------|--------|--------|
-| Alertmanager 0.20 | `source_matchers` / `target_matchers` syntax | Old `source_match` deprecated in 0.22 |
-| Alertmanager 0.22 | `matchers` field for routes | `match:` still works but `matchers:` preferred |
-| Alertmanager 0.25 | `time_intervals` replaces mute_time_intervals key | Key rename causes silent ignore on upgrade |
-| Prometheus 2.28 | `for` clause resets on state change | Alerts that briefly resolve restart `for:` timer |
+| Alertmanager 0.20 | `inhibit_rules.source_matchers` / `target_matchers` syntax | Old `source_match` / `target_match` deprecated in 0.22 |
+| Alertmanager 0.22 | `matchers` field for routes (replaces `match` + `match_re`) | `match:` still works but `matchers:` is preferred |
+| Alertmanager 0.25 | `time_intervals` replaces `time_intervals` in mute_time_intervals | Check config if upgrading — key rename causes silent ignore |
+| Prometheus 2.28 | `for` clause resets on alert state change | Alerts that briefly resolve then re-fire restart the `for:` timer |
 
 ---
 
@@ -220,16 +279,16 @@ route:
 # Find alerts missing for: clause
 grep -rn '^\s*- alert:' --include="*.yml" -A 8 | grep -B 5 'expr:' | grep -v 'for:'
 
-# Find single-window burn rate alerts
+# Find single-window burn rate alerts (no 'and' multi-window)
 grep -rn 'burn_rate\|error_rate.*ratio' --include="*.yml" -A 6 | grep -v '^\s*and\s'
 
 # Find alerts without runbook annotations
 grep -rn 'severity: critical' --include="*.yml" -B 10 | grep -v runbook_url
 
-# Validate Alertmanager config
+# Validate Alertmanager config syntax
 amtool check-config /etc/alertmanager/alertmanager.yml
 
-# Test alert routing
+# Test alert routing for a label set
 amtool config routes test severity=critical job=api
 ```
 
@@ -237,5 +296,5 @@ amtool config routes test severity=critical job=api
 
 ## See Also
 
-- `promql-patterns.md` — PromQL query correctness, rate/irate pitfalls
-- `cardinality-management.md` — Label cardinality detection and reduction
+- `promql-patterns.md` — PromQL query correctness, rate/irate pitfalls, histogram_quantile usage
+- `cardinality-management.md` — Label cardinality detection and reduction before adding alert label dimensions

--- a/agents/prometheus-grafana-engineer/references/cardinality-management.md
+++ b/agents/prometheus-grafana-engineer/references/cardinality-management.md
@@ -1,21 +1,27 @@
 # Cardinality Management Reference
 
-> **Scope**: Label cardinality detection, TSDB analysis, relabeling to prevent OOM
-> **Version range**: Prometheus 2.0+ (TSDB analysis: 2.23+)
+> **Scope**: Label cardinality detection, TSDB analysis, and relabeling to prevent OOM
+> **Version range**: Prometheus 2.0+ (TSDB analysis tools: 2.23+)
 > **Generated**: 2026-04-09 — cardinality budgets depend on Prometheus memory allocation
+
+---
+
+## Overview
+
+High cardinality is the #1 cause of Prometheus OOM in production. Each unique combination of label values creates one time series. A metric with `{service, endpoint, status, user_id}` and 1,000 users × 100 endpoints × 5 statuses = 500,000 series — from one metric. The failure mode is gradual: query performance degrades first, then OOM kills under query load. Detection must be proactive, not reactive.
 
 ---
 
 ## Cardinality Budget Reference
 
-| Memory Available | Safe Series Count | Warning | Critical |
-|------------------|-------------------|---------|----------|
+| Memory Available | Safe Series Count | Warning Threshold | Critical Threshold |
+|------------------|-------------------|-------------------|--------------------|
 | 4 GB | ~1M series | 800K | 1.2M |
 | 8 GB | ~2M series | 1.6M | 2.4M |
 | 16 GB | ~4M series | 3.2M | 4.8M |
 | 32 GB | ~8M series | 6.4M | 9.6M |
 
-Rule of thumb: ~4KB per active time series for index + chunks.
+Rule of thumb: Prometheus uses ~4KB per active time series for index + chunks in memory.
 
 ---
 
@@ -24,7 +30,7 @@ Rule of thumb: ~4KB per active time series for index + chunks.
 ### Immediate Cardinality Check
 
 ```bash
-# Total active series count
+# Total active series count (requires HTTP API access)
 curl -s 'http://localhost:9090/api/v1/query?query=prometheus_tsdb_head_series' | \
   python3 -c "import json,sys; d=json.load(sys.stdin); print(d['data']['result'][0]['value'][1])"
 
@@ -44,10 +50,10 @@ counts.sort(key=lambda x: -x[1])
 for m, c in counts[:20]: print(f'{c:>10}  {m}')
 "
 
-# TSDB analysis (2.23+)
+# Prometheus TSDB analysis (requires promtool, Prometheus 2.23+)
 promtool tsdb analyze /path/to/prometheus-data
 
-# Via PromQL
+# Check series count by metric name via PromQL
 topk(20, count by (__name__)({__name__=~".+"}))
 ```
 
@@ -60,20 +66,32 @@ topk(20, count by (__name__)({__name__=~".+"}))
 
 **Detection**:
 ```bash
+# Find instrumentation code with potentially unbounded label values
 grep -rn 'user_id\|request_id\|session_id\|trace_id\|transaction_id' \
   --include="*.go" --include="*.py" --include="*.js" | grep -i 'label\|metric\|prometheus'
 
 rg 'WithLabelValues|labels\.Set|prometheus\.Labels' --type go -A 3 | \
   grep -i 'user\|request_id\|session\|trace'
 
-# Check actual cardinality in PromQL
-count by (user_id) (http_requests_total)
+# Check actual cardinality of suspect metrics in PromQL
+count by (user_id) (http_requests_total)  # should return 0 results if correctly designed
 ```
 
-**Signal**: `user_id` as label — 100K users × 50 endpoints × 5 status codes = 25M series = 100GB memory.
+**Signal**:
+```go
+// Go example — unbounded label
+httpRequests.With(prometheus.Labels{
+    "user_id": userID,      // WRONG: unbounded
+    "endpoint": endpoint,
+    "status":  strconv.Itoa(statusCode),
+}).Inc()
+```
+
+**Why this matters**: 100K users × 50 endpoints × 5 status codes = 25M series. Prometheus memory usage becomes `25M × 4KB = 100GB`. Queries against this metric scan all 25M series even with filters, because index lookup is by label, not by value range.
 
 **Preferred action**:
 ```go
+// Correct — bounded labels only
 httpRequests.With(prometheus.Labels{
     "endpoint": endpoint,   // bounded: known set of routes
     "status":  statusCode,  // bounded: 2xx/3xx/4xx/5xx
@@ -88,13 +106,27 @@ httpRequests.With(prometheus.Labels{
 
 **Detection**:
 ```bash
+# Check if prometheus.yml has any drop relabeling rules
 grep -n 'action: drop\|action: keep' prometheus.yml
+# If no results: no cardinality guardrails in scrape config
+
+# Check what labels are coming in from a target
 curl -s 'http://localhost:9090/api/v1/targets' | \
   python3 -c "import json,sys; d=json.load(sys.stdin); [print(t['labels']) for t in d['data']['activeTargets'][:5]]"
 ```
 <!-- no-pair-required: partial section — positive counterpart follows in next block -->
 
-Without `relabel_configs`, all K8s pod labels become Prometheus dimensions. A git commit hash label creates unique series per deployment.
+**Signal**:
+```yaml
+# prometheus.yml — no relabeling
+scrape_configs:
+  - job_name: 'kubernetes-pods'
+    kubernetes_sd_configs:
+      - role: pod
+    # No relabel_configs — ingests all labels from pod annotations
+```
+
+**Why this matters**: Kubernetes pods can expose dozens of labels (app, version, helm-release, git-commit, build-time, namespace). Without `relabel_configs`, all of these become Prometheus label dimensions. A git commit hash label creates unique series per deployment, exploding cardinality.
 
 **Preferred action**:
 ```yaml
@@ -103,12 +135,15 @@ scrape_configs:
     kubernetes_sd_configs:
       - role: pod
     relabel_configs:
+      # Keep only the labels you actually need
       - source_labels: [__meta_kubernetes_pod_label_app]
         target_label: app
       - source_labels: [__meta_kubernetes_namespace]
         target_label: namespace
+      # Drop all other __meta_ labels (they're huge and mostly unused)
       - regex: __meta_kubernetes_.*
         action: labeldrop
+      # Drop pods with no app label (system pods you don't care about)
       - source_labels: [app]
         regex: .+
         action: keep
@@ -120,15 +155,26 @@ scrape_configs:
 
 **Detection**:
 ```bash
+# Find recording rules that preserve high-cardinality labels
 grep -A 5 'record:' prometheus-rules.yml | grep 'by (' | grep -i 'user\|request_id\|pod_name'
 rg 'record:' --type yaml -A 5 | grep 'by\s*\(' | grep -v 'service\|job\|namespace\|status'
 ```
 
-**Preferred action**:
+**Signal**:
 ```yaml
 - record: job:http_requests:rate5m
+  expr: sum(rate(http_requests_total[5m])) by (job, user_id)
+  # Aggregates but still fans out by user_id — doesn't help
+```
+
+**Why this matters**: Recording rules are meant to reduce query cost by pre-aggregating. If the `by()` clause includes a high-cardinality label, the recording rule creates as many series as the original metric, with no benefit.
+
+**Preferred action**:
+```yaml
+# Drop high-cardinality dimensions in recording rules
+- record: job:http_requests:rate5m
   expr: sum(rate(http_requests_total[5m])) by (job, status, method)
-  # user_id intentionally excluded
+  # user_id intentionally excluded — aggregate user metrics in application layer
 ```
 
 ---
@@ -138,7 +184,12 @@ rg 'record:' --type yaml -A 5 | grep 'by\s*\(' | grep -v 'service\|job\|namespac
 **Detection**:
 ```bash
 grep -rn 'tsdb_head_series\|cardinality' --include="*.yml"
+# If no results: no proactive cardinality monitoring
 ```
+
+**Signal**: No alert for growing series count — OOM is the first signal.
+
+**Why this matters**: Cardinality growth is gradual. A new deployment adds 50K series per day unnoticed until Prometheus hits memory limits under query load 2 weeks later. By then, the causing deployment is long merged and difficult to identify.
 
 **Preferred action**:
 ```yaml
@@ -149,7 +200,7 @@ grep -rn 'tsdb_head_series\|cardinality' --include="*.yml"
     severity: warning
   annotations:
     summary: "Prometheus series count high: {{ $value | humanize }}"
-    description: "Run 'promtool tsdb analyze' to identify top contributors."
+    description: "Cardinality approaching memory limits. Run 'promtool tsdb analyze' to identify top contributors."
     runbook_url: "https://wiki.example.com/runbooks/prometheus-high-cardinality"
 
 - alert: PrometheusCardinalityCritical
@@ -163,25 +214,29 @@ grep -rn 'tsdb_head_series\|cardinality' --include="*.yml"
 
 ## Cardinality Reduction Playbook
 
+When `promtool tsdb analyze` identifies a high-cardinality metric:
+
 ```bash
 # Step 1: Identify top contributors
 promtool tsdb analyze /var/lib/prometheus --limit 20
 
-# Step 2: Check which labels drive cardinality
+# Step 2: Check which labels drive cardinality for a specific metric
 count by (label_name) (
   {__name__="suspect_metric_name"}
 )
 
-# Step 3: Find label with highest unique values
+# Step 3: Find the label with highest unique values
 topk(5, count by (user_id) (suspect_metric_name))
 
-# Step 4: Add metric_relabel_config to drop after scraping
+# Step 4: Add a metric_relabel_config to drop the label AFTER scraping
+# (metric_relabel_configs apply post-scrape, before storage)
 scrape_configs:
   - job_name: 'api'
     metric_relabel_configs:
       - source_labels: [__name__, user_id]
         regex: 'http_requests_total;.+'
         action: labeldrop
+        # or use replacement to bucket: user_id → user_tier
 ```
 
 ---
@@ -190,12 +245,12 @@ scrape_configs:
 
 | Error / Symptom | Root Cause | Fix |
 |-----------------|------------|-----|
-| Prometheus OOM | Series count exceeds memory | `promtool tsdb analyze`, drop/aggregate high-cardinality labels |
-| Queries timeout | Too many series scanned | Recording rules, reduce cardinality, more specific selectors |
-| Scrape duration > interval | Target exposes too many metrics | `metric_relabel_configs` to drop unused metrics |
-| `err="out of order"` | Clock skew | Sync NTP, check `timestamp()` in exposition |
-| `many-to-many matching` | Join without enough `on()` labels | Add explicit `on()` or `ignoring()` |
-| Memory grows despite stable series | Old series not GC'd | Check `--storage.tsdb.retention.time` |
+| Prometheus OOM killed | Series count exceeds memory budget | Run `promtool tsdb analyze`, drop or aggregate high-cardinality labels |
+| Queries timeout on dashboards | Too many series scanned per query | Add recording rules, reduce label cardinality, use more specific label selectors |
+| Scrape duration > scrape interval | Target exposes too many metrics or slow `/metrics` | Add `metric_relabel_configs` to drop unused metrics, check target performance |
+| `err="out of order"` in Prometheus logs | Clock skew between scrape target and Prometheus | Sync NTP on target, check if using `timestamp()` in exposition |
+| `many-to-many matching not allowed` | Join between two high-cardinality metrics without enough `on()` labels | Add explicit `on()` or `ignoring()` labels to the join expression |
+| Series count stable but memory grows | Old time series not being garbage collected | Check `--storage.tsdb.retention.time` — default 15d, may need to lower |
 
 ---
 
@@ -203,10 +258,10 @@ scrape_configs:
 
 | Version | Change | Impact |
 |---------|--------|--------|
-| 2.23 | `promtool tsdb analyze` added | First-class cardinality analysis |
-| 2.39 | Native histograms (stable) | Fixed cardinality regardless of bucket count |
-| 2.43 | `--storage.tsdb.head-chunks-write-queue-size` | Tune write queue for high-ingest |
-| 2.45 | `--query.max-samples` default changed | Queries >50M samples fail by default |
+| 2.23 | `promtool tsdb analyze` command added | First-class cardinality analysis without external tools |
+| 2.39 | Native histograms (stable) | Native histograms have fixed cardinality regardless of bucket count — major cardinality win |
+| 2.43 | `--storage.tsdb.head-chunks-write-queue-size` flag | Tune write queue for high-ingest scenarios |
+| 2.45 | `--query.max-samples` default changed | Queries that scan >50M samples now fail by default — catches runaway cardinality queries |
 
 ---
 
@@ -222,10 +277,10 @@ promtool tsdb analyze /var/lib/prometheus
 # Top metrics by series count (PromQL)
 topk(20, count by (__name__)({__name__=~".+"}))
 
-# Check for unbounded labels in code
+# Check for unbounded labels in instrumentation code
 grep -rn 'user_id\|request_id\|session_id' --include="*.go" | grep -i 'label\|prometheus'
 
-# Verify relabeling drops
+# Verify relabeling drops are in place
 grep -n 'action: drop\|action: keep\|labeldrop' prometheus.yml
 ```
 

--- a/agents/prometheus-grafana-engineer/references/promql-patterns.md
+++ b/agents/prometheus-grafana-engineer/references/promql-patterns.md
@@ -189,7 +189,7 @@ grep -rn 'increase(' --include="*.yml" --include="*.yaml" | grep -v 'record:'
 increase(http_requests_total[1h]) > increase(http_requests_total[24h]) * 0.1
 ```
 
-**Why this matters**: `increase()` results are not comparable across different window sizes without normalization. This expression always evaluates false since 1h increase is always < 24h × 0.1 for any reasonable traffic. Use `rate()` for comparisons.
+**Why this matters**: `increase()` results are not comparable across different window sizes without normalization. Under steady traffic, this expression typically evaluates false since 1h increase is usually < 24h × 0.1. Use `rate()` for cross-window comparisons — it normalizes to per-second values.
 
 **Preferred action**:
 ```promql

--- a/agents/prometheus-grafana-engineer/references/promql-patterns.md
+++ b/agents/prometheus-grafana-engineer/references/promql-patterns.md
@@ -1,8 +1,14 @@
 # PromQL Patterns Reference
 
-> **Scope**: PromQL query correctness, common mistakes, recording rule design
-> **Version range**: Prometheus 2.0+
-> **Generated**: 2026-04-09
+> **Scope**: PromQL query correctness, common expression mistakes, and recording rule design
+> **Version range**: Prometheus 2.0+ (most patterns apply to all 2.x)
+> **Generated**: 2026-04-09 — verify against current Prometheus release notes
+
+---
+
+## Overview
+
+PromQL is a functional query language where small mistakes produce silently wrong results rather than errors. The most common failure mode is using `rate()` or `increase()` incorrectly — queries return numbers that look plausible but are mathematically wrong. Detection requires knowing what correct output looks like, not just that the query runs.
 
 ---
 
@@ -14,7 +20,7 @@
 | `irate()` | 2.0+ | Instantaneous rate for spike detection | Alerting rules (too spiky, flaps) |
 | `increase()` | 2.0+ | Total count increase over a window | Comparing across different window sizes |
 | `histogram_quantile()` | 2.0+ | Latency percentiles from histograms | Summary metrics (different type) |
-| `absent()` | 2.0+ | Alert when metric stops being scraped | Checking if value is zero (use `== 0`) |
+| `absent()` | 2.0+ | Alert when a metric stops being scraped | Checking if a value is zero (use `== 0`) |
 | `subquery` `[5m:1m]` | 2.3+ | Range query over instant vector function | Ad-hoc use — always create recording rule |
 
 ---
@@ -23,36 +29,46 @@
 
 ### rate() Window Sizing
 
-Use a window at least 4x the scrape interval. For 15s scrape, minimum window is `1m`.
+Use a window at least 4x the scrape interval. For a 15s scrape interval, minimum window is `1m`.
 
 ```promql
+# Correct — 5m window with 15s scrape interval
 rate(http_requests_total[5m])
-rate(http_requests_total[1m])  # minimum for 15s scrape
+
+# Correct — 1m minimum window for 15s scrape
+rate(http_requests_total[1m])
 ```
 
-`rate()` requires at least 2 samples. With 15s scrape and 15s window, you often get 1 sample — no data.
+**Why**: `rate()` requires at least 2 samples in the window to compute a slope. With a 15s scrape interval and a 15s window, you often get only 1 sample, returning no data or stale results.
 
 ---
 
 ### histogram_quantile() with le Label
 
-Always aggregate over `le` when using `histogram_quantile()`:
+Always aggregate over the `le` label when using `histogram_quantile()`:
 
 ```promql
+# Correct — aggregate over le bucket boundaries
 histogram_quantile(0.99,
   sum(rate(http_request_duration_seconds_bucket[5m])) by (le, service)
 )
+
+# Correct — single service with explicit le
+histogram_quantile(0.95,
+  rate(http_request_duration_seconds_bucket{service="api"}[5m])
+)
 ```
 
-Omitting `le` collapses all buckets, producing meaningless quantile values.
+**Why**: Omitting `le` in the aggregation collapses all buckets together, producing meaningless quantile values. The `le` label defines the bucket boundaries that `histogram_quantile()` uses for interpolation.
 
 ---
 
 ### Recording Rules for Alert Expressions
 
-Pre-compute expensive aggregations as `level:metric:ops`:
+Pre-compute expensive aggregations as recording rules named by convention `level:metric:ops`:
 
 ```yaml
+# recording_rules.yml
 groups:
   - name: slo_rules
     interval: 30s
@@ -70,7 +86,7 @@ groups:
           job:http_requests_total:rate5m
 ```
 
-Recording rules reduce alert evaluation from O(N×samples) to O(1).
+**Why**: Alert expressions evaluated every 15-30s against raw counters scan all samples in the window repeatedly. Recording rules pre-aggregate, reducing evaluation from O(N×samples) to O(1).
 
 ---
 
@@ -86,13 +102,20 @@ rg 'irate\(' --type yaml
 ```
 <!-- no-pair-required: partial section — positive counterpart follows in next block -->
 
-`irate()` uses only the last two samples — extremely sensitive to single-scrape spikes. Alert rules flap on transient spikes.
+**Signal**:
+```yaml
+# alert_rules.yml
+- alert: HighErrorRate
+  expr: irate(http_requests_total{status=~"5.."}[5m]) > 0.01
+```
+
+**Why this matters**: `irate()` uses only the last two samples, making it extremely sensitive to single-scrape spikes. Alert rules evaluated every 30s will flap on transient spikes, generating spurious notifications. Production alert fatigue follows.
 
 **Preferred action**:
 ```yaml
 - alert: HighErrorRate
   expr: rate(http_requests_total{status=~"5.."}[5m]) > 0.01
-  for: 5m
+  for: 5m  # also add a for: clause to require sustained violation
 ```
 
 ---
@@ -105,13 +128,20 @@ grep -B5 'latency\|duration\|p99\|p95\|quantile' --include="*.yml" --include="*.
 rg 'alert:.*[Ll]atency' --type yaml -A 10 | grep -v 'for:'
 ```
 
-Without `for:`, a single evaluation above threshold fires immediately. Network hiccups produce immediate pages.
+**Signal**:
+```yaml
+- alert: HighLatency
+  expr: histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m])) > 0.5
+  # No for: clause!
+```
+
+**Why this matters**: Without `for:`, a single evaluation above the threshold fires the alert immediately. Network hiccups, deployment restarts, or pod scheduling create transient spikes that produce immediate pages. The signal-to-noise ratio degrades fast.
 
 **Preferred action**:
 ```yaml
 - alert: HighLatency
   expr: histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m])) > 0.5
-  for: 5m
+  for: 5m  # must sustain for 5 minutes before firing
   labels:
     severity: warning
 ```
@@ -127,12 +157,21 @@ rg 'histogram_quantile' --type yaml -A 3 | grep 'quantile='
 ```
 <!-- no-pair-required: partial section — positive counterpart follows in next block -->
 
-Summary metrics expose pre-computed quantiles via `quantile` label — cannot be re-aggregated. Passing to `histogram_quantile()` produces nonsense (expects `le` bucket labels).
-
-**Preferred action**:
+**Signal**:
 ```promql
+# Wrong — using histogram_quantile on a summary type metric
+histogram_quantile(0.99, rate(rpc_duration_seconds{quantile="0.99"}[5m]))
+```
+
+**Why this matters**: Summary metrics expose pre-computed quantiles (via the `quantile` label) that cannot be re-aggregated. Passing them to `histogram_quantile()` produces nonsense — the function expects `le` bucket labels, not pre-computed quantile values. The query may not error but will silently return wrong numbers.
+
+**Preferred action**: Use the pre-computed quantile label directly:
+```promql
+# Correct for summary metrics
 rpc_duration_seconds{quantile="0.99", job="grpc-server"}
 ```
+
+Version note: This confusion is extremely common when migrating from libraries that default to summary type. Check metric type with `{__name__="metric_name"}` metadata query.
 
 ---
 
@@ -144,10 +183,17 @@ grep -rn 'increase(' --include="*.yml" --include="*.yaml" | grep -v 'record:'
 ```
 <!-- no-pair-required: partial section — positive counterpart follows in next block -->
 
-`increase()` results are not comparable across different window sizes without normalization.
+**Signal**:
+```promql
+# Wrong — comparing increase over different windows
+increase(http_requests_total[1h]) > increase(http_requests_total[24h]) * 0.1
+```
+
+**Why this matters**: `increase()` results are not comparable across different window sizes without normalization. This expression always evaluates false since 1h increase is always < 24h × 0.1 for any reasonable traffic. Use `rate()` for comparisons.
 
 **Preferred action**:
 ```promql
+# Correct — compare rates
 rate(http_requests_total[1h]) > rate(http_requests_total[24h]) * 1.5
 ```
 
@@ -160,13 +206,20 @@ rate(http_requests_total[1h]) > rate(http_requests_total[24h]) * 1.5
 grep -rn 'absent(' --include="*.yml" --include="*.yaml" -A 5 | grep -v 'for:\s*[5-9][0-9]\|for:\s*[1-9][0-9][0-9]'
 ```
 
-Scrape targets have momentary gaps during pod restarts. A 1-minute `for:` fires during normal K8s pod recycling.
+**Signal**:
+```yaml
+- alert: MetricMissing
+  expr: absent(up{job="api"})
+  for: 1m  # too short — scrape gaps cause false positives
+```
+
+**Why this matters**: Scrape targets can have momentary gaps during pod restarts, rolling deployments, or network blips. A 1-minute `for:` fires during normal K8s pod recycling. This produces alert storms during every deployment.
 
 **Preferred action**:
 ```yaml
 - alert: MetricMissing
   expr: absent(up{job="api"})
-  for: 10m
+  for: 10m  # tolerate pod restarts and rolling updates
   labels:
     severity: warning
 ```
@@ -177,12 +230,12 @@ Scrape targets have momentary gaps during pod restarts. A 1-minute `for:` fires 
 
 | Error / Symptom | Root Cause | Fix |
 |-----------------|------------|-----|
-| Query returns no data | Window too short (< 2 scrape intervals) | Increase to 4× scrape interval |
-| `histogram_quantile` returns `NaN` | No samples or all buckets equal | Verify metric is histogram type, check le labels |
-| Alert flaps every 30-60s | `irate()` or missing `for:` | Switch to `rate()`, add `for: 5m` |
-| Recording rule `many-to-many` | Aggregation labels don't match join keys | Add explicit `by()` with matching labels |
-| `increase()` returns non-integer | Counter reset mid-window | Expected — `increase()` handles resets |
-| `rate()` returns 0 after reset | Window too short to span reset | Extend window or use `resets()` |
+| Query returns no data but metric exists | Window too short (< 2 scrape intervals) | Increase window to 4× scrape interval |
+| `histogram_quantile` returns `NaN` | No samples in bucket or all buckets equal | Check if metric is a histogram type, verify le labels exist |
+| Alert flaps every 30-60 seconds | Using `irate()` or missing `for:` clause | Switch to `rate()`, add `for: 5m` |
+| Recording rule shows `many-to-many` error | Aggregation labels don't match join keys | Add explicit `by()` clause with matching labels on both sides |
+| `increase()` shows non-integer values | Counter reset mid-window (pod restart) | Expected behavior — `increase()` handles resets but result is fractional |
+| `rate()` returns 0 after counter reset | Window too short to span the reset | Extend window or use `resets()` to detect reset count |
 
 ---
 
@@ -190,30 +243,30 @@ Scrape targets have momentary gaps during pod restarts. A 1-minute `for:` fires 
 
 | Version | Change | Impact |
 |---------|--------|--------|
-| 2.3 | Subquery syntax (`[5m:1m]`) | Expensive — always use recording rules |
-| 2.7 | `absent_over_time()` | Better than `absent()` for intermittent metrics |
-| 2.14 | Native histograms (experimental) | Different aggregation syntax |
-| 2.40 | Native histograms stable | `histogram_quantile()` uses `{}` not `le` buckets |
-| 2.45 | `limit_ratio()` added | Rate limiting for expensive federation queries |
+| 2.3 | Subquery syntax added (`[5m:1m]`) | Can run instant functions over ranges — expensive, always use recording rules |
+| 2.7 | `absent_over_time()` added | Better than `absent()` for intermittent metrics with irregular scrape |
+| 2.14 | Native histograms (experimental) | Different aggregation — `histogram_quantile()` syntax changes for native type |
+| 2.40 | Native histograms stable | `histogram_quantile()` on native histograms uses `{}` not `le` buckets |
+| 2.45 | `limit_ratio()` added | Rate limiting for query evaluation — useful for expensive federation queries |
 
 ---
 
 ## Detection Commands Reference
 
 ```bash
-# Find irate() in alert rules
+# Find irate() in alert rules (should use rate() instead)
 grep -rn 'irate(' --include="*.yml" --include="*.yaml"
 
 # Find alerts missing for: clause
 grep -rn '^\s*- alert:' --include="*.yml" -A 10 | grep -B5 'expr:' | grep -v 'for:'
 
-# Find histogram_quantile on summary metrics
+# Find histogram_quantile on summary metrics (has quantile= label)
 rg 'histogram_quantile' --type yaml -A 5 | grep 'quantile='
 
-# Find recording rules not following level:metric:ops naming
+# Find recording rules that don't follow level:metric:ops naming
 grep -rn '^\s*record:' --include="*.yml" | grep -v 'record: [a-z_]*:[a-z_]*:[a-z_]*'
 
-# Find absent() with short for: clause
+# Find absent() with short for: clause (< 5 minutes)
 grep -A 5 'absent(' --include="*.yml" -rn | grep 'for:\s*[1-4]m'
 ```
 
@@ -221,5 +274,5 @@ grep -A 5 'absent(' --include="*.yml" -rn | grep 'for:\s*[1-4]m'
 
 ## See Also
 
-- `alerting-patterns.md` — SLO burn rate, multi-window patterns, Alertmanager routing
-- `cardinality-management.md` — Label cardinality detection, relabeling, TSDB analysis
+- `alerting-patterns.md` — SLO burn rate alerts, multi-window patterns, Alertmanager routing
+- `cardinality-management.md` — Label cardinality detection, relabeling rules, TSDB analysis

--- a/agents/reviewer-code/references/code-quality.md
+++ b/agents/reviewer-code/references/code-quality.md
@@ -1,45 +1,48 @@
 # Code Quality Review
 
-Convention compliance, style enforcement, and bug detection with confidence-scored findings.
+Convention compliance, style guide enforcement, and code quality assessment with confidence-scored findings.
 
 ## Expertise
 
-- **Convention Enforcement**: CLAUDE.md rules, project style guides, linter rationale
-- **Bug Detection**: Real bugs vs style preferences, logic errors, off-by-one, resource leaks
-- **Code Quality Assessment**: Readability, maintainability, naming, structure
-- **Confidence Scoring**: Systematic 0-100 scoring; only 80+ reported
-- **Multi-Language Review**: Go, Python, TypeScript with language-specific idioms
+- **Convention Enforcement**: CLAUDE.md rules, project-specific style guides, linter rule rationale
+- **Bug Detection**: Real bugs vs stylistic preferences, logic errors, off-by-one mistakes, resource leaks
+- **Code Quality Assessment**: Readability, maintainability, naming, structure, documentation quality
+- **Confidence Scoring**: Systematic scoring (0-100) to separate high-signal findings from noise
+- **Multi-Language Review**: Go, Python, TypeScript, JavaScript, and language-specific idioms
 
 ## Methodology
 
-- Confidence-scored findings (80+ threshold only)
-- Evidence-based with file:line references
-- Severity: Critical (90-100), Important (80-89)
-- Separate guideline violations from bugs from style suggestions
+- Confidence-scored findings (only reports 80+ threshold)
+- Evidence-based analysis with specific file:line references
+- Severity classification: Critical (90-100), Important (80-89)
+- Separation of guideline violations from actual bugs from style suggestions
+- CLAUDE.md compliance as first-class review dimension
 
 ## Priorities
 
-1. **CLAUDE.md Compliance** — Project rules override generic style
-2. **Actual Bugs** — Real defects over style preferences
-3. **Confidence** — Only report 80+ findings
-4. **Evidence** — file:line references with code snippets
+1. **CLAUDE.md Compliance** - Project rules take precedence over generic style
+2. **Actual Bugs** - Real defects over stylistic preferences
+3. **Confidence** - Only report what you are highly confident about (80+)
+4. **Evidence** - Specific file:line references with code snippets
 
 ## Hardcoded Behaviors
 
-- **CLAUDE.md First**: Read CLAUDE.md before review. Its rules override generic style.
-- **Confidence Threshold**: Every finding needs 0-100 score. Only 80+ appears in report.
-- **Structured Output**: Use Code Quality Review Schema with VERDICT, severity, confidence.
-- **Evidence-Based**: Every issue cites file:line.
-- **Default Scope**: No files specified = review `git diff`. Files specified = review those files.
-- **Categorization**: Every finding: Guideline Compliance, Actual Bug, or Code Quality.
-- **Review-First Fix Mode**: When `--fix` requested, complete full review first, then apply corrections.
+- **CLAUDE.md Compliance**: Read and follow repository CLAUDE.md before review. CLAUDE.md rules override generic style preferences.
+- **Over-Engineering Prevention**: Report only findings with confidence 80+. Omit speculative or low-confidence issues.
+- **Confidence Threshold**: Every finding must include a confidence score (0-100). Only findings scoring 80 or above appear in the report.
+- **Structured Output**: All findings must use the Code Quality Review Schema with VERDICT, severity, and confidence scores.
+- **Evidence-Based Findings**: Every issue must cite specific code locations with file:line references.
+- **Default Scope**: When no files are specified, review unstaged changes via `git diff`. When files are specified, review those files directly.
+- **Issue Categorization**: Every finding must be categorized as one of: Guideline Compliance, Actual Bug, or Code Quality.
+- **Review-First in Fix Mode**: When `--fix` is requested, complete the full review first, present findings, then apply corrections.
 
 ## Default Behaviors
 
-- Fact-based analysis without editorializing
-- Git Diff Scope: `git diff` by default; `git diff --cached` for pre-commit
-- Severity: Critical (90-100) blocks merge; Important (80-89) fix before merge
-- Language-specific idiom checks applied per language
+- Fact-based analysis: Report findings without editorializing
+- Git Diff Scope: Review unstaged changes by default (`git diff`)
+- Staged Changes: Include staged changes (`git diff --cached`) when reviewing for pre-commit quality
+- Severity Classification: Critical (confidence 90-100) blocks merge. Important (confidence 80-89) should fix before merge.
+- Language-Specific Checks: Apply language-appropriate idiom checks
 
 ## Output Format
 
@@ -86,8 +89,8 @@ Convention compliance, style enforcement, and bug detection with confidence-scor
 ## Error Handling
 
 - **No CLAUDE.md Found**: Review against language-standard conventions. Note in report.
-- **No Unstaged Changes**: Check staged. If also empty, ask user which files.
-- **Ambiguous Convention**: Note both interpretations, flag for user decision.
+- **No Unstaged Changes**: Check staged changes. If also empty, ask user which files to review.
+- **Ambiguous Convention**: Note both interpretations and flag for user decision.
 
 ## Patterns to Detect and Fix
 

--- a/agents/reviewer-code/references/comments.md
+++ b/agents/reviewer-code/references/comments.md
@@ -1,41 +1,41 @@
 # Comment Analysis
 
-Verify comment accuracy, detect rot, and assess documentation quality via 5-step analysis.
+Verify comment accuracy, detect comment rot, and ensure documentation quality through systematic 5-step analysis.
 
 ## Expertise
 
-- **Accuracy Verification**: Cross-referencing comments with actual code behavior
-- **Rot Detection**: Stale, outdated, or misleading comments from code evolution
-- **Documentation Assessment**: Completeness, value, maintainability of inline docs
-- **Misleading Detection**: Comments that actively harm understanding
-- **Multi-Language**: Go (godoc), Python (docstrings/PEP 257), TypeScript (JSDoc/TSDoc)
+- **Comment Accuracy Verification**: Cross-referencing comments with actual code behavior
+- **Comment Rot Detection**: Identifying stale, outdated, or misleading comments from code evolution
+- **Documentation Assessment**: Evaluating completeness, value, and maintainability of inline documentation
+- **Misleading Element Detection**: Finding comments that actively harm understanding
+- **Multi-Language Comments**: Go (godoc conventions), Python (docstrings, PEP 257), TypeScript (JSDoc, TSDoc)
 
 ## 5-Step Methodology
 
-1. **Verify Factual Accuracy** — Cross-reference comments with code behavior
-2. **Assess Completeness** — Missing docs for public APIs, edge cases, gotchas
-3. **Evaluate Long-term Value** — Valuable context vs noise comments
-4. **Identify Misleading Elements** — Comments that harm understanding
-5. **Suggest Improvements** — Specific rewrites with corrected text
+1. **Verify Factual Accuracy** - Cross-reference comments with actual code behavior
+2. **Assess Completeness** - Missing documentation for public APIs, edge cases, gotchas
+3. **Evaluate Long-term Value** - Distinguish valuable context from noise comments
+4. **Identify Misleading Elements** - Comments that actively harm understanding
+5. **Suggest Improvements** - Specific comment rewrites with corrected text
 
 ## Priorities
 
-1. **Accuracy** — Does the comment match what the code does?
-2. **Harm Potential** — Could this mislead a future developer?
-3. **Completeness** — Are critical behaviors and gotchas documented?
-4. **Value** — Does this add info not obvious from the code?
+1. **Accuracy** - Does the comment match what the code actually does?
+2. **Harm Potential** - Could this comment mislead a future developer?
+3. **Completeness** - Are critical behaviors, edge cases, and gotchas documented?
+4. **Value** - Does this comment add information not obvious from the code?
 
 ## Hardcoded Behaviors
 
-- **5-Step Analysis**: Every review follows all 5 steps.
-- **Misleading Over Missing**: Fix misleading comments (actively harmful) before adding missing ones.
-- **External Behavior Claims**: Flag claims about library/service behavior as requiring verification against source or official docs.
+- **5-Step Analysis**: Every review must follow all 5 steps.
+- **Misleading Over Missing**: Prioritize fixing misleading comments (actively harmful) over adding missing comments.
+- **External Behavior Claims**: When a comment claims external library/service behavior, flag it as requiring verification against library source or official docs.
 
 ## Default Behaviors
 
-- Language convention checking (godoc, docstrings, JSDoc)
-- TODO/FIXME older than 6 months flagged as potential rot
-- Well-written comments noted as positive examples
+- Language Convention Checking: Verify comments follow language-specific conventions (godoc, docstrings, JSDoc).
+- TODO/FIXME Analysis: Flag TODOs older than 6 months as potential comment rot.
+- Positive Findings: Include well-written comments as positive examples.
 
 ## Output Format
 
@@ -69,9 +69,9 @@ Verify comment accuracy, detect rot, and assess documentation quality via 5-step
 
 ## Error Handling
 
-- **Cannot Verify References**: Note, ask user to confirm.
-- **Ambiguous Intent**: Report both interpretations, recommend clarifying.
-- **No Comments Found**: Report and assess whether public APIs need docs.
+- **Cannot Verify Requirement References**: Note reference cannot be verified, ask user to confirm.
+- **Ambiguous Comment Intent**: Report both interpretations, recommend clarifying.
+- **No Comments Found**: Report and assess whether public APIs need documentation.
 
 ## Patterns to Detect and Fix
 

--- a/agents/reviewer-code/references/config-safety.md
+++ b/agents/reviewer-code/references/config-safety.md
@@ -1,36 +1,37 @@
 # Configuration Safety
 
-Detect hardcoded secrets, missing env var validation, unsafe defaults, and config management gaps.
+Detect hardcoded secrets, missing environment variable validation, unsafe defaults, and configuration management gaps.
 
 ## Expertise
 
-- **Secret Detection**: API keys, passwords, tokens, connection strings in source
-- **Env Var Hygiene**: Missing validation, empty string defaults, runtime vs startup validation
-- **Unsafe Defaults**: Debug mode on, TLS off, localhost as prod default, verbose logging
-- **Config Management**: Environment-specific config, 12-factor compliance, secret management
-- **Fail-Fast Validation**: Required config at startup, not at first use
-- **Language Patterns**: Go (os.Getenv, envconfig), Python (os.environ, pydantic-settings), TypeScript (process.env, dotenv)
+- **Secret Detection**: API keys, passwords, tokens, connection strings, certificates in source code
+- **Environment Variable Hygiene**: Missing validation, empty string defaults, runtime vs startup validation
+- **Unsafe Defaults**: Debug mode enabled, TLS disabled, localhost as production default, verbose logging
+- **Configuration Management**: Environment-specific config, 12-factor app compliance, secret management
+- **Fail-Fast Validation**: Required config validated at startup, not at first use
+- **Language-Specific Patterns**: Go (os.Getenv, envconfig), Python (os.environ, pydantic-settings), TypeScript (process.env, dotenv)
 
 ## Methodology
 
-- Never store secrets in source
-- Validate env vars at startup; fail fast for required ones
-- Defaults must be production-safe
+- Never store secrets in source code
+- Validate all environment variables at startup, fail fast for required ones
+- Defaults must be production-safe (no localhost, no debug mode, TLS enabled)
+- Configuration should be documented (which vars, what they do, what's required)
 - Sensitive config must not appear in logs or error messages
 
 ## Hardcoded Behaviors
 
-- **Secret Detection Zero Tolerance**: Any secret in source is CRITICAL.
-- **Evidence-Based**: Show exact hardcoded value or missing validation.
-- **Wave 2 Context**: Use security and docs findings from Wave 1.
+- **Secret Detection Zero Tolerance**: Any secret, key, or credential in source code is CRITICAL.
+- **Evidence-Based Findings**: Every finding must show the exact hardcoded value or missing validation.
+- **Wave 2 Context Usage**: When Wave 1 findings are provided, use security and docs findings.
 
 ## Default Behaviors
 
-- Secret scan: API keys, passwords, tokens, connection strings
-- Env var validation check with safe defaults
-- Unsafe default detection: debug mode, TLS disabled, localhost
-- Fail-fast: required config validated at startup
-- Log exposure: secrets not in log statements
+- Secret Scanning: Scan for API keys, passwords, tokens, connection strings in source.
+- Env Var Validation: Check all env var reads for validation and safe defaults.
+- Unsafe Default Detection: Flag debug mode, TLS disabled, localhost defaults.
+- Fail-Fast Check: Verify required config is validated at startup.
+- Log Exposure Check: Verify secrets don't appear in log statements.
 
 ## Output Format
 
@@ -43,7 +44,7 @@ Detect hardcoded secrets, missing env var validation, unsafe defaults, and confi
 1. **[Secret Type]** - `file:LINE` - CRITICAL
    - **Pattern**: `apiKey = "sk-..."` (redacted)
    - **Risk**: [what an attacker could do]
-   - **Remediation**: Move to env var, rotate exposed secret
+   - **Remediation**: Move to environment variable, rotate the exposed secret
 
 ### Missing Validation
 1. **[Env Var]** - `file:LINE` - HIGH
@@ -73,8 +74,8 @@ Detect hardcoded secrets, missing env var validation, unsafe defaults, and confi
 
 ## Error Handling
 
-- **Test/Example Files**: Note if in test file. Add `// test-only` if fixture.
-- **Constants vs Configuration**: Only flag values that vary between environments. `maxRetries = 3` is acceptable.
+- **Test/Example Files**: Note if value is in test file. Add `// test-only` comment if fixture.
+- **Constants vs Configuration**: Only flag values that vary between environments. Constants like `maxRetries = 3` are acceptable.
 
 ## Patterns to Detect and Fix
 

--- a/agents/reviewer-code/references/dead-code.md
+++ b/agents/reviewer-code/references/dead-code.md
@@ -1,38 +1,38 @@
 # Dead Code Detection
 
-Identify unreachable code, unused exports, orphaned files, and artifacts that increase maintenance burden without value.
+Identify unreachable code, unused exports, orphaned files, and other code artifacts that increase maintenance burden without providing value.
 
 ## Expertise
 
 - **Unreachable Code**: Dead branches after early returns, impossible conditions, post-panic code
 - **Unused Exports**: Exported functions/types/constants with zero external call sites
-- **Orphaned Files**: Source files not imported by any other file
-- **Stale Feature Flags**: Always-on/off flags, flags with past expiry
-- **Commented-Out Code**: Code blocks in comments that belong in VCS history
-- **Obsolete TODOs**: TODOs referencing closed issues, past dates, completed work
-- **Language Tools**: Go (go vet, staticcheck), Python (vulture, pyflakes), TypeScript (ts-prune)
+- **Orphaned Files**: Source files not imported by any other file in the project
+- **Stale Feature Flags**: Always-on or always-off flags, flags with past expiry dates
+- **Commented-Out Code**: Code blocks in comments that should be in VCS history
+- **Obsolete TODOs**: TODOs referencing closed issues, past dates, or completed work
+- **Language-Specific Tools**: Go (go vet, staticcheck, unused), Python (vulture, pyflakes), TypeScript (ts-prune)
 
 ## Methodology
 
-- Trace import graphs for orphaned files
+- Trace import graphs to find orphaned files
 - Check exported symbol usage across all packages
 - Distinguish "unused now" from "public API surface"
-- Flag commented-out code >3 lines
-- Check TODO dates and issue references
+- Flag commented-out code >3 lines as dead code
+- Check TODO dates and issue references against current state
 
 ## Hardcoded Behaviors
 
-- **Commented Code Zero Tolerance**: Commented-out blocks >3 lines always reported.
-- **Evidence-Based**: Show unreferenced code and the search for references.
-- **Wave 2 Context**: Use code-quality and docs-validator findings from Wave 1.
+- **Commented Code Zero Tolerance**: Commented-out code blocks (>3 lines) must always be reported.
+- **Evidence-Based Findings**: Every finding must show the unreferenced code and the search for references.
+- **Wave 2 Context Usage**: When Wave 1 findings are provided, use code-quality and docs-validator findings.
 
 ## Default Behaviors
 
-- Import graph analysis for orphaned files
-- Export usage check across all packages
-- Commented code detection >3 lines
-- TODO staleness check against dates and issue references
-- Feature flag audit for always-on/off flags
+- Import Graph Analysis: Trace file-to-file imports to find orphaned files.
+- Export Usage Check: Search for call sites of all exported functions.
+- Commented Code Detection: Flag commented-out code blocks >3 lines.
+- TODO Staleness Check: Check TODO dates and issue references.
+- Feature Flag Audit: Identify always-on/always-off flags.
 
 ## Output Format
 
@@ -71,14 +71,14 @@ Identify unreachable code, unused exports, orphaned files, and artifacts that in
 
 ## Error Handling
 
-- **Reflection/Dynamic Usage**: Note if symbol may be used via reflection or plugin.
-- **Public API Surface**: Note if exported function is for external consumers.
+- **Reflection/Dynamic Usage**: Note if symbol may be used via reflection or plugin system.
+- **Public API Surface**: Note if exported function is intended for external consumers.
 
 ## Patterns to Detect and Fix
 
 | Rationalization | Why It's Wrong | Required Action |
 |-----------------|----------------|-----------------|
-| "Might need it later" | Git history exists | Delete now |
+| "Might need it later" | Git history exists for this | Delete now |
 | "It documents the old approach" | Use comments for intent, not old code | Delete code, add comment if needed |
-| "Someone might import it" | Check consumers first | If none, remove |
-| "TODO is still valid" | If valid, it would be done | Complete or delete |
+| "Someone might import it" | Check all consumers first | If no consumers, remove |
+| "TODO is still valid" | If it was valid, it would be done | Complete or delete |

--- a/agents/reviewer-code/references/language-checks.md
+++ b/agents/reviewer-code/references/language-checks.md
@@ -1,6 +1,6 @@
 # Language-Specific Checks Catalog
 
-Check catalogs for Go, Python, and TypeScript. Load after detecting language from file extensions.
+Complete check catalogs for Go, Python, and TypeScript. Load after detecting the language from file extensions.
 
 ## Go (when reviewing .go files)
 
@@ -10,134 +10,134 @@ Check catalogs for Go, Python, and TypeScript. Load after detecting language fro
 - `strings.CutPrefix`/`strings.CutSuffix` instead of `HasPrefix`+`TrimPrefix`
 - `min`/`max` builtins instead of custom helpers (Go 1.21+)
 - `for range N` loop syntax (Go 1.22+)
-- Flag `v := v` inside `for range` loops — unnecessary since Go 1.22, LLM tell
-- Flag `go func(x Type) { ... }(x)` capture patterns — per-iteration variables since Go 1.22
+- Loop variable capture fix (Go 1.22+): flag `v := v` or `item := item` inside `for range` loops — these are unnecessary since Go 1.22 and are an LLM tell
+- Loop variable capture fix (Go 1.22+): flag `go func(x Type) { ... }(x)` capture patterns — since Go 1.22, loop variables are per-iteration so the closure argument is unnecessary
 - `maps.Clone`, `maps.Keys` instead of manual map operations
 - `log/slog` instead of `log.Printf` for structured logging
 
-**Idioms**:
-- Error wrapping `%w` with `errors.Is`/`errors.As`
-- Receiver type consistency (all pointer or all value)
-- Package naming: lowercase, single-word, no underscores
+**Go idioms**:
+- Error wrapping with `%w` and checking with `errors.Is`/`errors.As`
+- Receiver type consistency (all pointer or all value, not mixed)
+- Package naming conventions (lowercase, single-word, no underscores)
 - Unexported types with exported constructors (`NewFoo()`)
 - Blank identifier only with explicit justification
 
 **Concurrency**:
 - Goroutine leaks: goroutines without shutdown path
-- Context cancellation: respect `context.Context`
-- Mutex per resource, not per struct
+- Context cancellation: functions accepting `context.Context` must respect cancellation
+- Mutex per resource, not per struct (fine-grained locking)
 - `sync.Once` for initialization, not `init()` with flags
 - Channel direction in function signatures
 
 **Resources**:
-- `defer Close()` after error check on open call
-- Connection pool sharing across requests
-- `http.DefaultClient` reuse vs new clients
-- File descriptor limits
+- `defer Close()` must come AFTER the error check on the open call
+- Connection pool sharing (reuse shared clients across requests)
+- `http.DefaultClient` reuse vs creating new clients
+- File descriptor limits awareness
 
 **Anti-patterns**:
-- Premature interface abstraction (one implementation)
-- Over-engineered error types for simple errors
-- Unnecessary channels when mutex suffices
-- `init()` for non-trivial work (I/O, network)
+- Premature interface abstraction (interface with one implementation)
+- Over-engineered error types (custom error types for simple errors)
+- Unnecessary channels when a mutex suffices
+- `init()` for non-trivial work (side effects, I/O, network calls)
 - Returning concrete types but accepting interfaces at boundaries
-- `MockXxx` types in production (non-test) files
-- Separate `*sql.DB` pools when shared pool should be injected
+- `MockXxx` types in production (non-test) files — test doubles belong in `_test.go` files
+- Creating separate `*sql.DB` connection pools when a shared pool should be injected
 
 **LLM tells**:
-- Functional options on 2-3 field types (struct literal suffices)
-- Table-driven tests for single-case scenarios
+- Functional options pattern on types with 2-3 fields (a simple struct literal suffices)
+- Table-driven tests everywhere, even for single-case scenarios
 - Excessive interface segregation (one-method interfaces for everything)
-- Config validation with reflection when `if` works
-- Overly verbose error messages repeating function name
-- Builder pattern for few-field structs
-- `v := v` loop variable shadowing in Go 1.22+
-- `defer rows.Close()` without checking `rows.Err()` after loop
-- Verbose error wrapping when error already has good context
+- Config validation layers with reflection when a simple `if` works
+- Overly verbose error messages repeating the function name
+- Builder pattern for structs with few fields
+- Loop variable shadowing (`v := v`) in Go 1.22+ projects — LLMs trained on older Go generate this
+- `defer rows.Close()` without checking `rows.Err()` after the iteration loop — LLMs miss the error check
+- Verbose `if err != nil { return fmt.Errorf("failed to X: %w", err) }` wrapping errors that already have good context (e.g., `strconv.ParseUint` already says what it was parsing)
 
 ## Python (when reviewing .py files)
 
 **Modern Python (3.10+, 3.11+, 3.12+)**:
-- Walrus operator `:=` in conditions
-- `match` for structural pattern matching (3.10+)
+- Walrus operator `:=` for assignment expressions in conditions
+- `match` statement for structural pattern matching (3.10+)
 - `type` statement for type aliases (3.12+)
 - `tomllib` for TOML parsing (3.11+)
 - `TaskGroup` for structured concurrency (3.11+)
-- `ExceptionGroup` and `except*` (3.11+)
+- `ExceptionGroup` and `except*` syntax (3.11+)
 - Generic syntax `def foo[T](x: T)` (3.12+)
 
-**Idioms**:
-- Comprehensions over `map`/`filter` with lambdas
-- Context managers (`with`) for resources
-- Generators for large dataset processing
-- `pathlib.Path` over `os.path`
-- `collections.defaultdict` over manual key checks
-- F-strings over `format()` or `%`
-- `dataclasses`/`attrs` over manual `__init__`
+**Python idioms**:
+- List/dict/set comprehensions over `map`/`filter` with lambdas
+- Context managers (`with`) for resource management
+- Generators and `yield` for large dataset processing
+- `pathlib.Path` over `os.path` for path manipulation
+- `collections.defaultdict` over manual key-existence checks
+- F-strings over `format()` or `%` formatting
+- `dataclasses` or `attrs` over manual `__init__` boilerplate
 
 **Concurrency**:
-- `asyncio`: proper `async with`, `async for`
-- `TaskGroup` over `gather` with manual cancellation
-- Cleanup in async context managers
-- Thread safety mixing sync and async
+- `asyncio` patterns: proper `async with`, `async for`
+- `TaskGroup` structured concurrency over `gather` with manual cancellation
+- Proper cleanup in async context managers
+- Thread safety when mixing sync and async code
 
 **Resources**:
-- Context managers for file handles, connections, locks
-- `atexit` for global cleanup
+- Context managers (`with`) for file handles, connections, locks
+- `atexit` handlers for global cleanup
 - Signal handling for graceful shutdown
-- `contextlib.suppress` over empty except
+- `contextlib.suppress` over empty except blocks
 
 **Anti-patterns**:
 - Mutable default arguments (`def foo(items=[])`)
 - Bare `except:` or `except Exception:` without re-raise
-- `import *`
+- `import *` polluting namespace
 - Global mutable state
-- Monkey patching in production
+- Monkey patching in production code
 - String concatenation in loops (use `join`)
 
 **LLM tells**:
-- Verbose type hints on obvious types (`x: int = 5`)
-- Unnecessary docstrings on self-documenting functions
-- Java-style getters/setters instead of properties
+- Overly verbose type hints on obvious types (`x: int = 5` when `x = 5` is clear)
+- Unnecessary docstrings on self-documenting simple functions
+- Java-style getter/setter methods instead of properties or direct access
 - Abstract base classes for single implementations
-- `typing.Optional` when `| None` exists (3.10+)
-- Over-engineered class hierarchies for simple transforms
+- Excessive use of `typing.Optional` when `| None` syntax exists (3.10+)
+- Over-engineered class hierarchies for simple data transformations
 
 ## TypeScript (when reviewing .ts/.tsx files)
 
 **Modern TypeScript (5.0+, 5.2+)**:
-- `satisfies` for type checking without widening
-- `const` type parameters for literal inference
-- `using` declarations for resources (5.2+)
-- Template literal types for string patterns
+- `satisfies` operator for type checking without widening
+- `const` type parameters for literal type inference
+- `using` declarations for resource management (5.2+)
+- Template literal types for string pattern types
 - `NoInfer<T>` utility type (5.4+)
 
-**Idioms**:
-- Discriminated unions over type casting
-- `Zod` or similar for runtime validation
-- Generic constraints (`extends`) over `any`
-- Mapped types and conditional types
-- `as const` for literal inference
+**TypeScript idioms**:
+- Discriminated unions over type casting for type narrowing
+- `Zod` or similar for runtime validation matching TypeScript types
+- Proper generic constraints (`extends`) over `any`
+- Mapped types and conditional types for type-level programming
+- `as const` for literal type inference
 
 **React (when reviewing .tsx)**:
-- React 19: no `forwardRef` (ref is regular prop), `useActionState`, `useOptimistic`
+- React 19 patterns: no `forwardRef` (ref is a regular prop), `useActionState`, `useOptimistic`
 - Proper hook dependency arrays (exhaustive deps)
 - `memo` only with measured performance justification
-- Server Components vs Client Components
-- Framework data loading instead of `useEffect` for fetching
+- Server Components vs Client Components distinction
+- Use framework data loading instead of `useEffect` for data fetching
 
 **Anti-patterns**:
-- `any` overuse instead of `unknown`
-- Type assertions (`as`) over type narrowing
-- Barrel file bloat causing circular deps
-- Circular dependencies
+- `any` overuse instead of proper types or `unknown`
+- Type assertions (`as`) over type narrowing with guards
+- Barrel file bloat causing circular dependencies
+- Circular dependencies between modules
 - Enum overuse when union types suffice
 - `namespace` in modern code
 
 **LLM tells**:
-- Abstract factory patterns for simple object creation
-- Class-based components in modern React
-- Redundant null checks when strict mode already narrows
-- Over-engineered DI frameworks
-- Excessive abstraction layers (repository wrapping simple fetch)
-- Generic utility types reimplementing built-ins
+- Overly abstract factory patterns for simple object creation
+- Unnecessary class-based components in modern React
+- Redundant null checks when TypeScript strict mode already narrows
+- Over-engineered dependency injection frameworks
+- Excessive abstraction layers (repository pattern wrapping simple fetch calls)
+- Generic utility types that reimplement built-in ones

--- a/agents/reviewer-code/references/language-specialist.md
+++ b/agents/reviewer-code/references/language-specialist.md
@@ -1,50 +1,51 @@
 # Language-Specific Review
 
-Expert analysis of Go, Python, and TypeScript against modern standards, idiomatic patterns, and LLM code tells. Adapts checks by language from file extensions.
+Expert-level analysis of Go, Python, and TypeScript code against modern standards, idiomatic patterns, and LLM-generated code tells. Adapts criteria based on the programming language detected from file extensions.
 
 ## Expertise
 
-- **Modern stdlib**: Outdated patterns when modern features exist (Go 1.22+, Python 3.12+, TypeScript 5.2+)
-- **Language idioms**: Code that reads like translation from another language
-- **Concurrency**: Language-specific patterns (goroutines, asyncio, Promises)
-- **Resource management**: Language-specific lifecycle (defer, context managers, AbortController)
-- **Anti-patterns**: Language-specific code smells
-- **LLM tells**: Patterns LLMs generate that experienced developers avoid
+- **Modern stdlib usage**: Identifying outdated patterns when modern language features exist (Go 1.22+, Python 3.12+, TypeScript 5.2+)
+- **Language idioms**: Detecting code that reads like it was translated from another language
+- **Concurrency correctness**: Language-specific concurrency patterns (goroutines, asyncio, Promises)
+- **Resource management**: Language-specific lifecycle patterns (defer, context managers, AbortController)
+- **Anti-patterns**: Language-specific code smells and traps unique to each ecosystem
+- **LLM code tells**: Patterns that LLMs generate by default that experienced developers would not write
 
 ## Methodology
 
-- Detect language from file extensions before applying checks
-- Cite version that introduced each recommended feature
-- Distinguish style preferences from genuine anti-patterns
-- Flag LLM tells with explanation of what experienced code looks like
-- Provide migration paths from old to modern patterns
+- Detect the language from file extensions before applying checks
+- Apply version-specific recommendations (cite the language version that introduced the feature)
+- Distinguish between style preferences and genuine anti-patterns
+- Flag LLM-generated code tells with explanation of what an experienced developer would write instead
+- Provide migration paths from old patterns to modern alternatives
 
 ## Priorities
 
-1. **Correctness** — Concurrency bugs, resource leaks, language traps
-2. **Modernity** — Outdated patterns with better alternatives
-3. **Idiom compliance** — Code fighting the language
-4. **LLM tells** — Patterns revealing AI-generated code
+1. **Correctness** - Concurrency bugs, resource leaks, subtle language traps
+2. **Modernity** - Using outdated patterns when better alternatives exist
+3. **Idiom compliance** - Code that fights the language rather than working with it
+4. **LLM tells** - Patterns that reveal AI-generated code to experienced reviewers
 
 ## Language-Specific Checks
 
-See [language-checks.md](language-checks.md) for Go, Python, and TypeScript check catalogs.
+See [language-checks.md](language-checks.md) for the complete Go, Python, and TypeScript check catalogs. Load this reference after detecting the language from file extensions.
 
 ## Hardcoded Behaviors
 
-- **Language Detection**: Detect from extensions (.go, .py, .ts, .tsx), apply corresponding checks.
-- **Version Citations**: Every modern stdlib recommendation cites the version that introduced it.
-- **Evidence-Based**: Show current code and the modern/idiomatic alternative.
-- **Review-First Fix Mode**: Complete full analysis first, then apply corrections.
+- **Language Detection**: Detect language from file extensions (.go, .py, .ts, .tsx) and apply corresponding checks.
+- **Version Citations**: Every modern stdlib recommendation must cite the language version that introduced the feature.
+- **Evidence-Based**: Every finding must show the current code and the modern/idiomatic alternative.
+- **Review-First in Fix Mode**: Complete the full analysis first, then apply corrections.
 
 ## Default Behaviors
 
-- **gopls MCP (Go)**: Use `go_file_context`, `go_symbol_references`, `go_diagnostics` when available.
-- Modern stdlib scan against latest stable features
-- Idiom analysis against language conventions
-- Concurrency review per language
-- Resource lifecycle verification
-- Anti-pattern and LLM tell detection
+- **gopls MCP Integration (Go reviews)**: When reviewing .go files with gopls MCP available, use `go_file_context`, `go_symbol_references`, and `go_diagnostics` for type-aware analysis.
+- Modern stdlib Scan: Check all standard library usage against the latest stable release features.
+- Idiom Analysis: Evaluate code structure, naming, and patterns against language-specific conventions.
+- Concurrency Review: Check goroutine safety, asyncio patterns, or Promise handling as appropriate.
+- Resource Lifecycle Check: Verify proper resource cleanup using language-appropriate mechanisms.
+- Anti-Pattern Detection: Flag known language-specific code smells with severity.
+- LLM Tell Detection: Identify patterns characteristic of LLM-generated code.
 
 ## Output Format
 
@@ -82,14 +83,14 @@ See [language-checks.md](language-checks.md) for Go, Python, and TypeScript chec
 ## Error Handling
 
 - **Unknown Language Version**: Default to latest stable. Note in report.
-- **Mixed Language Codebase**: Apply each language's checks independently.
-- **Framework-Specific Patterns**: Note when framework conventions differ from language idioms.
+- **Mixed Language Codebase**: Apply each language's checks independently to its own files.
+- **Framework-Specific Patterns**: Note when framework conventions differ from general language idioms.
 
 ## Patterns to Detect and Fix
 
 | Rationalization | Why It's Wrong | Required Action |
 |-----------------|----------------|-----------------|
 | "Old pattern still works" | Works != idiomatic; maintenance burden grows | Report with migration path |
-| "That's just style" | Idioms affect readability for the team | Report as idiom violation |
+| "That's just style" | Idioms affect readability for the whole team | Report as idiom violation |
 | "LLM generated is fine if correct" | LLM tells signal lack of expert review | Flag patterns |
-| "Framework overrides language" | Only for documented framework conventions | Verify framework requires it |
+| "Framework overrides language" | Only for documented framework conventions | Verify framework requires the pattern |

--- a/agents/reviewer-code/references/naming.md
+++ b/agents/reviewer-code/references/naming.md
@@ -1,37 +1,39 @@
 # Naming Consistency
 
-Detect naming convention drift, inconsistent casing, and terminology misalignment.
+Detect naming convention drift, inconsistent identifier casing, and terminology misalignment across codebases.
 
 ## Expertise
 
-- **Identifier Casing**: camelCase, PascalCase, snake_case, SCREAMING_SNAKE_CASE
-- **Acronym Casing**: ID vs Id, HTTP vs Http, URL vs Url
-- **Verb Consistency**: Get vs Fetch vs Retrieve, Create vs Add vs New
+- **Identifier Casing**: camelCase, PascalCase, snake_case, SCREAMING_SNAKE_CASE consistency
+- **Acronym Casing**: ID vs Id, HTTP vs Http, URL vs Url, API vs Api
+- **Verb Consistency**: Get vs Fetch vs Retrieve, Create vs Add vs New, Delete vs Remove
 - **Package/Module Naming**: Go (lowercase, single word), Python (snake_case), TypeScript (kebab-case)
-- **File Naming**: Consistent patterns within project
-- **Domain Term Consistency**: Same concept = same name everywhere
+- **File Naming**: Consistent patterns within a project (snake_case.go, kebab-case.ts)
+- **Domain Term Consistency**: Same concept = same name everywhere (user vs account vs member)
 
 ## Methodology
 
-- Establish dominant convention first, then flag deviations
-- Language conventions override personal preference
-- Consistency within codebase > any specific convention
-- Same concept = same name everywhere
+- Establish the dominant convention first, then flag deviations
+- Language conventions take precedence over personal preference
+- Consistency within a codebase matters more than any specific convention
+- Acronyms follow language-specific rules (Go: ID, HTTP; TypeScript: id, http depends on context)
+- Same concept should have same name everywhere in the codebase
 
 ## Hardcoded Behaviors
 
 - **Convention Discovery**: Establish dominant conventions BEFORE flagging deviations.
-- **Evidence-Based**: Show inconsistent name AND established convention.
-- **Wave 2 Context**: Use code-quality and language-specialist findings for baselines.
+- **Structured Output**: All findings must use the Naming Consistency Schema.
+- **Evidence-Based Findings**: Every finding must show the inconsistent name AND the established convention.
+- **Wave 2 Context Usage**: When Wave 1 findings are provided, use code-quality and language-specialist findings for baselines.
 
 ## Default Behaviors
 
-- Convention discovery: scan for dominant patterns
-- Acronym audit for consistent casing
-- Verb alignment for CRUD operations
-- Package naming per language conventions
-- File naming pattern check
-- Domain term audit for consistent terminology
+- Convention Discovery: Scan codebase to determine dominant naming patterns.
+- Acronym Audit: Check all acronyms for consistent casing.
+- Verb Alignment: Check CRUD operation verbs for consistency.
+- Package Naming: Verify package names follow language conventions.
+- File Naming: Check file names for consistent patterns.
+- Domain Term Audit: Verify same concepts use same terminology.
 
 ## Output Format
 
@@ -65,7 +67,7 @@ Detect naming convention drift, inconsistent casing, and terminology misalignmen
 ## Error Handling
 
 - **Multiple Valid Conventions**: Note intentional context differences (DB columns vs Go fields).
-- **Generated Code**: Skip generated files (protobuf, openapi).
+- **Generated Code**: Skip generated files (protobuf, openapi) in naming audit.
 
 ## Patterns to Detect and Fix
 

--- a/agents/reviewer-code/references/performance.md
+++ b/agents/reviewer-code/references/performance.md
@@ -1,36 +1,36 @@
 # Performance Analysis
 
-Detect runtime efficiency problems, algorithmic complexity issues, and resource waste.
+Detect runtime efficiency problems, algorithmic complexity issues, and resource waste across Go, Python, and TypeScript codebases.
 
 ## Expertise
 
-- **Algorithmic Complexity**: O(n^2) loops, nested iterations, quadratic string ops, unbounded growth
-- **Memory & Allocations**: Heap escapes, unnecessary copies, missing buffer reuse, hot-path allocations
-- **Database Performance**: N+1 queries, missing indexes, SELECT *, unoptimized JOINs, missing batch ops
-- **Caching Gaps**: Repeated expensive computations, missing memoization
+- **Algorithmic Complexity**: O(n^2) loops, nested iterations, quadratic string operations, unbounded growth
+- **Memory & Allocations**: Heap escapes, unnecessary copies, missing buffer reuse, allocation in hot paths
+- **Database Performance**: N+1 queries, missing indexes, SELECT *, unoptimized JOINs, missing batch operations
+- **Caching Gaps**: Repeated expensive computations, missing memoization, cache invalidation issues
 - **I/O Efficiency**: Unbuffered reads/writes, synchronous I/O in hot paths, missing connection pooling
-- **Language-Specific**: Go (sync.Pool, strings.Builder, pre-alloc slices), Python (generators, __slots__), TypeScript (memo, useMemo, virtual scrolling)
+- **Language-Specific Patterns**: Go (sync.Pool, strings.Builder, pre-alloc slices), Python (generators, __slots__, list comprehensions), TypeScript (memo, useMemo, virtual scrolling)
 
 ## Methodology
 
-- Evidence-based: exact code with complexity analysis
-- Impact-oriented: estimate relative cost (10x, 100x, 1000x)
-- Benchmark-aware: recommend specific benchmarks
+- Evidence-based: show the exact code with complexity analysis
+- Impact-oriented: estimate relative cost (10x, 100x, 1000x improvement potential)
+- Benchmark-aware: recommend specific benchmarks for validation
 - Context-sensitive: hot path vs cold path determines severity
 
 ## Hardcoded Behaviors
 
-- **Hot Path Focus**: Prioritize frequently-executed paths over one-time init.
-- **Evidence-Based**: Include complexity analysis (current vs optimal).
-- **Wave 2 Context**: Use architecture and code quality findings to identify critical paths.
+- **Hot Path Focus**: Prioritize issues in frequently-executed code paths over one-time initialization.
+- **Evidence-Based Findings**: Every finding must include complexity analysis (current vs optimal).
+- **Wave 2 Context Usage**: When Wave 1 findings are provided, use architecture and code quality findings to identify critical paths.
 
 ## Default Behaviors
 
-- Big-O calculation for flagged loops/algorithms
-- Heap allocation tracking in hot paths
-- Database call tracing through handler/service/repository
-- Cache opportunity detection for repeated expensive computations
-- Benchmark recommendations per finding
+- Complexity Analysis: Calculate Big-O for flagged loops and algorithms.
+- Allocation Tracking: Identify heap allocations in hot paths.
+- Query Pattern Detection: Trace database calls through handler/service/repository layers.
+- Cache Opportunity Detection: Flag repeated expensive computations without memoization.
+- Benchmark Recommendations: Suggest specific benchmark tests for each finding.
 
 ## Output Format
 
@@ -67,8 +67,8 @@ Detect runtime efficiency problems, algorithmic complexity issues, and resource 
 
 ## Error Handling
 
-- **Premature Optimization Concern**: Cold-path findings = LOW severity. Validate with profiling.
-- **Missing Hot Path Context**: Flag all O(n^2)+ as at least MEDIUM. Assumes warm/hot path.
+- **Premature Optimization Concern**: Note cold-path findings as LOW severity. Validate with profiling.
+- **Missing Context for Hot Path Detection**: Flag all O(n^2)+ as at least MEDIUM. Note severity assumes warm/hot path.
 
 ## Patterns to Detect and Fix
 

--- a/agents/reviewer-code/references/simplifier.md
+++ b/agents/reviewer-code/references/simplifier.md
@@ -1,46 +1,48 @@
 # Code Simplification
 
-Reduce complexity and improve clarity while preserving exact functionality. Actively modifies code — simplification is a modification task.
+Reduce complexity and improve code clarity while preserving exact functionality. Unlike read-only reviewers, this dimension actively modifies code as simplification is inherently a modification task.
 
 ## Expertise
 
-- **Complexity Reduction**: Cyclomatic complexity, nesting depth, cognitive load
+- **Complexity Reduction**: Cyclomatic complexity, nesting depth, cognitive load analysis
 - **Clarity Patterns**: Explicit control flow, clear naming, readable structure
-- **Refactoring**: Extract function, flatten conditionals, simplify expressions, guard clauses
-- **Language Idioms**: Go, Python, TypeScript idiomatic simplification
-- **Behavior Preservation**: Refactored code must produce identical results
+- **Refactoring Techniques**: Extract function, flatten conditionals, simplify expressions, guard clauses
+- **Language Idioms**: Go, Python, TypeScript, JavaScript idiomatic simplification
+- **Behavior Preservation**: Ensuring refactored code produces identical results
 
 ## Methodology
 
-- Clarity over brevity: readable beats clever
+- Clarity over brevity: readable code beats clever code
 - No nested ternaries: use explicit if/else
 - Guard clauses over deep nesting
 - Early returns to reduce indentation
+- CLAUDE.md standards as simplification guide
 - One simplification at a time with verification
 
 ## Priorities
 
-1. **Preserve Behavior** — Exact same functionality after simplification
-2. **Reduce Cognitive Load** — Lower nesting, clearer flow, better names
-3. **Follow Conventions** — CLAUDE.md and language idioms
-4. **Verify** — Run tests after each simplification
+1. **Preserve Behavior** - Exact same functionality after simplification
+2. **Reduce Cognitive Load** - Lower nesting, clearer flow, better names
+3. **Follow Conventions** - CLAUDE.md and language idioms guide structure
+4. **Verify** - Run tests after each simplification to confirm correctness
 
 ## Hardcoded Behaviors
 
-- **Behavior Preservation**: No behavioral changes allowed.
-- **Test Verification**: Run tests after simplification. Revert on failure.
-- **Default Scope**: No files specified = simplify `git diff --name-only`.
-- **No Nested Ternaries**: Replace with explicit if/else.
-- **One Change at a Time**: Incremental, verified simplifications.
+- **Behavior Preservation**: Every simplification must preserve exact functionality. No behavioral changes allowed.
+- **Test Verification**: Run existing tests after simplification. If tests fail, revert the change.
+- **Default Scope**: When no files are specified, simplify recently modified code (files in `git diff --name-only`).
+- **No Nested Ternaries**: Replace all nested ternary expressions with explicit if/else.
+- **Explicit Over Implicit**: Prefer explicit control flow over clever constructs.
+- **One Change at a Time**: Apply simplifications incrementally, verifying each before proceeding.
 
 ## Default Behaviors
 
-- Before/after code comparisons
-- Guard clauses: convert deep nesting to early returns
-- Extract functions: complex inline logic into named functions
-- Flatten conditionals: invert conditions, return early
-- Naming improvements when names obscure intent
-- Remove dead code, unused variables, commented-out blocks
+- Show before/after code comparisons
+- Guard Clauses: Convert deep nesting to early returns
+- Extract Functions: Extract complex inline logic into named functions when it improves readability
+- Flatten Conditionals: Reduce nesting depth by inverting conditions and returning early
+- Naming Improvements: Suggest better variable/function names when current names obscure intent
+- Remove Dead Code: Remove unreachable code, unused variables, commented-out code blocks
 
 ## Output Format
 
@@ -57,7 +59,7 @@ Reduce complexity and improve clarity while preserving exact functionality. Acti
 
 **Before**: [code]
 **After**: [code]
-**Why**: [clarity improvement]
+**Why**: [Explanation of clarity improvement]
 **Complexity Change**: [metric]
 
 ### Summary
@@ -76,8 +78,8 @@ Reduce complexity and improve clarity while preserving exact functionality. Acti
 
 ## Error Handling
 
-- **Tests Fail**: Immediately revert. Report the simplification caused failure.
-- **Complex for a Reason**: Report complexity but note business rules resist simplification.
+- **Tests Fail After Simplification**: Immediately revert. Report the simplification caused test failure.
+- **Complex Code Is Complex for a Reason**: Report complexity but note business rules resist simplification.
 - **No Recent Changes**: Ask user which files to simplify.
 
 ## Patterns to Detect and Fix
@@ -85,7 +87,7 @@ Reduce complexity and improve clarity while preserving exact functionality. Acti
 | Rationalization | Why It's Wrong | Required Action |
 |-----------------|----------------|-----------------|
 | "Shorter is simpler" | Brevity != clarity | Optimize for readability |
-| "Tests still pass" | Tests may not cover changed behavior | Verify coverage of modified paths |
+| "Tests still pass" | Tests may not cover changed behavior | Verify test coverage of modified paths |
 | "It's just a refactor" | Refactors can change behavior | Run tests after every change |
 | "The original was bad" | Bad doesn't justify risky changes | Incremental improvement with verification |
 
@@ -93,5 +95,5 @@ Reduce complexity and improve clarity while preserving exact functionality. Acti
 
 - No tests exist for target code
 - Complex business logic encoding
-- Multiple valid approaches (ask user)
+- Multiple valid simplification approaches (ask user)
 - Simplification changes public API

--- a/agents/reviewer-code/references/test-analyzer.md
+++ b/agents/reviewer-code/references/test-analyzer.md
@@ -1,46 +1,46 @@
 # Test Coverage Analysis
 
-Evaluate test quality, identify coverage gaps, and assess resilience with a pragmatic, behavior-focused approach.
+Evaluate test quality, identify coverage gaps, and assess test resilience with a pragmatic, behavior-focused approach.
 
 ## Expertise
 
-- **Behavioral Coverage**: Testing behaviors and outcomes, not just line execution
-- **Critical Path Identification**: Most important untested code paths
-- **Resilience Assessment**: Whether tests survive refactoring without false failures
-- **Negative Case Coverage**: Error paths, boundary conditions, invalid inputs
-- **Test Quality Patterns**: Table-driven (Go), parameterized (pytest), factories, fixtures
-- **Anti-Pattern Detection**: Brittle tests, implementation coupling, interdependencies
+- **Behavioral Coverage Analysis**: Testing behaviors and outcomes, not just line execution
+- **Critical Path Identification**: Finding the most important untested code paths
+- **Test Resilience Assessment**: Evaluating whether tests survive refactoring without false failures
+- **Negative Case Coverage**: Verifying error paths, boundary conditions, and invalid inputs are tested
+- **Test Quality Patterns**: Table-driven tests (Go), parameterized tests (Python/pytest), test factories, fixtures
+- **Anti-Pattern Detection**: Brittle tests, implementation coupling, test interdependencies
 
 ## Methodology
 
 - Pragmatic testing over academic completeness
 - Behavioral coverage over line coverage
-- 1-10 scoring for gap prioritization
-- Focus on tests that catch bugs
-- Language-specific conventions (Go table-driven, pytest fixtures)
+- Scoring system (1-10) for prioritizing gaps
+- Focus on tests that actually catch bugs
+- Language-specific test conventions (Go table-driven, pytest fixtures)
 
 ## Priorities
 
-1. **Critical Gaps** — Untested paths causing production incidents
-2. **Behavioral Coverage** — Is behavior X tested, not line N?
-3. **Resilience** — Will tests break on implementation changes?
-4. **Pragmatism** — Tests catching real bugs, not chasing coverage metrics
+1. **Critical Gaps** - Untested paths that could cause production incidents
+2. **Behavioral Coverage** - Does behavior X get tested, not does line N execute
+3. **Resilience** - Will tests break on implementation changes (false positives)?
+4. **Pragmatism** - Tests that catch real bugs, not tests for test coverage metrics
 
 ## Hardcoded Behaviors
 
-- **Behavioral Focus**: Evaluate behaviors tested, not lines executed.
-- **Scoring**: Every gap gets severity 1-10: Critical (9-10), Important (7-8), Valuable (5-6), Optional (3-4), Minor (1-2).
-- **Pragmatic Tests**: Recommend tests catching real bugs, not coverage-padding.
-- **Assertion Depth**: For security-sensitive code (auth, filtering, tenant isolation), verify actual VALUE matches expected input.
-- **Review-First Fix Mode**: Complete full analysis first, then write tests.
+- **Behavioral Focus**: Evaluate what behaviors are tested, not what lines execute.
+- **Scoring System**: Every gap must include a severity score (1-10): Critical (9-10), Important (7-8), Valuable (5-6), Optional (3-4), Minor (1-2).
+- **Pragmatic Tests**: Recommend tests that catch real bugs, not tests that only increase coverage numbers.
+- **Assertion Depth Check**: For security-sensitive code (auth, filtering, tenant isolation), presence-only assertions are INSUFFICIENT. Tests MUST verify the actual VALUE matches expected input.
+- **Review-First in Fix Mode**: Complete the full analysis first, then write tests.
 
 ## Default Behaviors
 
-- Follow existing test patterns in codebase
-- Prioritize negative case checks (error paths, boundaries, invalid input)
-- Flag test interdependencies and execution-order dependence
-- Assess mock/stub appropriateness vs integration tests
-- Evaluate quality of existing tests, not just missing ones
+- Test Pattern Matching: Identify and follow existing test patterns in the codebase.
+- Negative Case Priority: Specifically check for error path tests, boundary tests, and invalid input tests.
+- Test Independence Check: Flag tests that depend on other tests or execution order.
+- Mock/Stub Assessment: Evaluate whether mocking is appropriate or if integration tests are needed.
+- Existing Test Quality: Assess quality of existing tests, not just missing ones.
 
 ## Output Format
 
@@ -85,9 +85,9 @@ Evaluate test quality, identify coverage gaps, and assess resilience with a prag
 
 ## Error Handling
 
-- **No Test Files**: Report as Critical gap (Score 10).
-- **Trivial Tests**: Score behavioral gaps individually. Note happy-path-only coverage.
-- **Complex Mocking**: Note uncertainty, recommend integration tests.
+- **No Test Files Found**: Report as Critical gap (Score 10).
+- **Tests Are Trivial**: Score behavioral gaps individually. Note happy-path-only coverage.
+- **Complex Mocking Makes Analysis Difficult**: Note uncertainty and recommend integration tests.
 
 ## Patterns to Detect and Fix
 
@@ -100,4 +100,4 @@ Evaluate test quality, identify coverage gaps, and assess resilience with a prag
 
 ## Note on Fix Mode
 
-Fix mode CAN use Write for new test files. Test files are additive and preserve existing code.
+Fix mode CAN use Write for creating new test files, unlike other review dimensions. Test files are additive and preserve existing code.

--- a/agents/reviewer-code/references/type-design.md
+++ b/agents/reviewer-code/references/type-design.md
@@ -1,45 +1,45 @@
 # Type Design Analysis
 
-Evaluate type quality, invariant expression, encapsulation, and compile-time safety with a 4-dimension rating system.
+Evaluate type quality, invariant expression, encapsulation patterns, and compile-time safety guarantees with a structured 4-dimension rating system.
 
 ## Expertise
 
-- **Encapsulation**: Field visibility, accessor patterns, internal state protection
-- **Invariant Expression**: How well types encode business rules and constraints
-- **Invariant Usefulness**: Whether invariants prevent real bugs vs theoretical concerns
-- **Invariant Enforcement**: Constructor validation, factory methods, type-state patterns
-- **Language Type Systems**: Go (struct embedding, interfaces), TypeScript (discriminated unions, branded types), Python (dataclasses, pydantic)
+- **Encapsulation Analysis**: Field visibility, accessor patterns, internal state protection, information hiding
+- **Invariant Expression**: How well types encode business rules, constraint expression, validity guarantees
+- **Invariant Usefulness**: Whether expressed invariants prevent real bugs vs theoretical concerns
+- **Invariant Enforcement**: Constructor validation, factory methods, builder patterns, type-state patterns
+- **Language-Specific Type Systems**: Go (struct embedding, interfaces), TypeScript (discriminated unions, branded types), Python (dataclasses, pydantic), Rust (ownership, enums)
 
 ## 4-Dimension Rating System
 
-Every type gets ratings (1-10) for:
-1. **Encapsulation** — Field visibility, state protection
-2. **Invariant Expression** — How well types encode constraints
-3. **Invariant Usefulness** — Whether invariants prevent real bugs
-4. **Invariant Enforcement** — Constructor validation, immutability
+Every type analyzed receives ratings (1-10) for:
+1. **Encapsulation** - Field visibility, state protection
+2. **Invariant Expression** - How well types encode constraints
+3. **Invariant Usefulness** - Whether invariants prevent real bugs
+4. **Invariant Enforcement** - Constructor validation, immutability
 
 ## Priorities
 
-1. **Illegal States** — Can the type represent invalid states?
-2. **Constructor Validation** — Are invariants enforced at construction?
-3. **Encapsulation** — Is internal state protected from external mutation?
-4. **Compile-Time Safety** — Can the compiler prevent misuse?
+1. **Illegal States** - Can the type represent invalid states? If yes, how to prevent it
+2. **Constructor Validation** - Are invariants enforced at construction time?
+3. **Encapsulation** - Is internal state properly protected from external mutation?
+4. **Compile-Time Safety** - Can the compiler prevent misuse?
 
 ## Hardcoded Behaviors
 
-- **4-Dimension Rating**: Every type rated 1-10 on all 4 dimensions.
-- **Compile-Time Preference**: Prefer compile-time guarantees over runtime checks.
-- **Clarity Over Cleverness**: Simple designs beat clever ones.
-- **Review-First Fix Mode**: Complete full analysis first, then improve.
+- **4-Dimension Rating**: Every type must receive ratings (1-10) for all 4 dimensions.
+- **Compile-Time Preference**: Recommend compile-time guarantees over runtime checks where the language supports it.
+- **Clarity Over Cleverness**: Simple type designs that are easy to understand beat clever designs.
+- **Review-First in Fix Mode**: Complete the full 4-dimension analysis first, then apply improvements.
 
 ## Default Behaviors
 
-- Constructor/factory validation check for invariants
-- Mutability assessment: should mutable fields be immutable?
-- Zero-value analysis (Go): are zero-value structs valid or dangerous?
-- Discriminated union check (TypeScript): tagged unions for state modeling
-- Public field audit: encapsulate exposed fields
-- Nil/null safety: types that can be nil when they should not be
+- Constructor Analysis: Check every constructor/factory for validation of invariants.
+- Mutability Assessment: Evaluate whether mutable fields should be immutable.
+- Zero-Value Analysis (Go): Check if zero-value structs are valid or dangerous.
+- Discriminated Union Check (TypeScript): Verify tagged unions are used for state modeling.
+- Public Field Audit: Flag publicly exposed fields that should be encapsulated.
+- Nil/Null Safety: Check for types that can be nil/null when they should not be.
 
 ## Output Format
 
@@ -76,15 +76,15 @@ Every type gets ratings (1-10) for:
 
 ## Error Handling
 
-- **Language Lacks Features**: Note limitation, recommend best alternative.
+- **Language Lacks Type System Features**: Note limitation and recommend best available alternative.
 - **Dynamic Types Without Annotations**: Recommend adding type hints. Note limited analysis.
-- **Serialization Types**: Note DTO vs domain model. Public fields acceptable for serialization.
+- **Types Designed for Serialization**: Note DTO vs domain model distinction. Public fields acceptable for serialization.
 
 ## Patterns to Detect and Fix
 
 | Rationalization | Why It's Wrong | Required Action |
 |-----------------|----------------|-----------------|
-| "Validation happens elsewhere" | Types should self-validate | Add constructor validation |
-| "Too much ceremony" | Ceremony prevents bugs | Evaluate bug prevention value |
+| "Validation happens elsewhere" | Types should be self-validating | Add constructor validation |
+| "Too much ceremony" | Ceremony prevents bugs | Evaluate actual bug prevention value |
 | "Language doesn't support it" | Use best available alternative | Document limitation, use workaround |
-| "Tests catch invalid states" | Compile-time > test-time | Prefer type-level enforcement |
+| "Tests catch invalid states" | Compile-time prevention > test-time detection | Prefer type-level enforcement |

--- a/agents/reviewer-code/references/type-design.md
+++ b/agents/reviewer-code/references/type-design.md
@@ -8,7 +8,7 @@ Evaluate type quality, invariant expression, encapsulation patterns, and compile
 - **Invariant Expression**: How well types encode business rules, constraint expression, validity guarantees
 - **Invariant Usefulness**: Whether expressed invariants prevent real bugs vs theoretical concerns
 - **Invariant Enforcement**: Constructor validation, factory methods, builder patterns, type-state patterns
-- **Language-Specific Type Systems**: Go (struct embedding, interfaces), TypeScript (discriminated unions, branded types), Python (dataclasses, pydantic), Rust (ownership, enums)
+- **Language-Specific Type Systems**: Go (struct embedding, interfaces), TypeScript (discriminated unions, branded types), Python (dataclasses, pydantic)
 
 ## 4-Dimension Rating System
 

--- a/agents/testing-automation-engineer/references/async-testing.md
+++ b/agents/testing-automation-engineer/references/async-testing.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Primary source of flaky tests: (1) asserting before async state updates, (2) arbitrary `setTimeout` delays. RTL `waitFor` and Playwright auto-waiting locators eliminate both.
+Async testing is the primary source of flaky tests. The two failure modes are (1) not waiting for async state updates before asserting, and (2) adding arbitrary `setTimeout` delays instead of waiting for a deterministic condition. RTL's `waitFor` and Playwright's auto-waiting locators eliminate both — when used correctly.
 
 ---
 
@@ -47,7 +47,7 @@ it('shows success message after form submission', async () => {
 })
 ```
 
-**Why**: Click triggers event but state update (API -> response -> re-render) is async. Without `waitFor`, assertion runs before re-render.
+**Why**: `userEvent.click` triggers the event but the state update (API call → response → re-render) happens asynchronously. Without `waitFor`, the assertion runs before the component re-renders.
 
 ---
 
@@ -66,7 +66,7 @@ it('loads and displays user data', async () => {
 })
 ```
 
-**Why**: `findBy*` = `waitFor(() => getBy*(...))`. Use when element appears after data fetch. After first `findBy*` resolves, use `getBy*` synchronously.
+**Why**: `findBy*` is shorthand for `waitFor(() => getBy*(...))`. Use it when an element is absent at render and appears after a data fetch. After the first `findBy*` resolves, subsequent assertions can use `getBy*` synchronously.
 
 ---
 
@@ -103,7 +103,7 @@ it('shows error when user not found', async () => {
 })
 ```
 
-**Why**: MSW intercepts at network layer. Real `fetch` runs — error handling, parsing, timeouts exercised. `onUnhandledRequest: 'error'` catches unexpected API calls.
+**Why**: MSW intercepts at the network layer, not the module layer. The component's actual `fetch` call runs, so error handling, response parsing, and timeout logic are all exercised. `onUnhandledRequest: 'error'` catches unexpected API calls that would otherwise silently return `undefined`.
 
 ---
 
@@ -136,7 +136,7 @@ test('submits form and shows confirmation', async ({ page }) => {
 })
 ```
 
-**Why**: Playwright `expect(locator).toBeVisible()` auto-waits. `waitForTimeout()` is an anti-pattern — slow on fast machines, flaky on slow ones.
+**Why**: Playwright's `expect(locator).toBeVisible()` auto-waits. Using `page.waitForSelector()` manually or `page.waitForTimeout(2000)` is an anti-pattern — fixed delays are slow on fast machines and flaky on slow ones.
 
 ---
 
@@ -164,7 +164,7 @@ await page.waitForTimeout(2000)
 expect(await page.textContent('.result')).toBe('Done')
 ```
 
-**Why this matters**: Arbitrary delays are slow on fast machines, flaky on slow ones. 600ms instead of 500ms (CI under load) = failure.
+**Why this matters**: Arbitrary delays make tests slow on fast machines and flaky on slow ones. If the operation takes 600ms instead of 500ms (CI under load), the test fails. These tests hide timing bugs rather than revealing them.
 
 **Preferred action:**
 ```typescript
@@ -196,7 +196,7 @@ user.type(input, 'hello')
 expect(screen.getByText(/hello/i)).toBeInTheDocument()
 ```
 
-**Why this matters**: RTL 14+ `userEvent.setup()` returns async methods. Without `await`, state updates haven't processed before assertions. Flaky, not immediate errors.
+**Why this matters**: `userEvent.setup()` returns async methods in RTL 14+. Without `await`, the events fire but React state updates haven't processed before assertions run. Test passes inconsistently depending on microtask scheduling.
 
 **Preferred action:**
 ```typescript
@@ -205,6 +205,8 @@ await user.click(button)
 await user.type(input, 'hello')
 await screen.findByText(/hello/i)
 ```
+
+**Version note**: RTL 13 and earlier used synchronous `userEvent`. RTL 14+ switched to async. Un-awaited calls produce flaky tests, not immediate errors — the breakage is subtle.
 
 ---
 
@@ -221,7 +223,7 @@ await user.click(screen.getByRole('button', { name: /save/i }))
 expect(screen.getByText(/saved/i)).toBeInTheDocument()  // may not exist yet
 ```
 
-**Why this matters**: `user.click` resolves after dispatch, not after React re-renders from async work. `getByText` runs synchronously, element absent.
+**Why this matters**: `user.click` resolves after the event dispatches, not after React re-renders from async work (API calls, state transitions). The `getByText` assertion runs synchronously and finds the element absent.
 
 **Preferred action:**
 ```typescript
@@ -244,7 +246,7 @@ rg 'setupServer' --type ts -l | xargs rg -L 'onUnhandledRequest'
 server.listen()  // no onUnhandledRequest — silent network failures
 ```
 
-**Why this matters**: Unexpected API calls (wrong path, typo) pass through silently. Component renders broken UI, test passes, bug hidden until production.
+**Why this matters**: When a component makes an unexpected API call (wrong path, URL typo), MSW passes it through or returns undefined without failing the test. The component renders broken UI, tests assert on something unrelated, and the bug is hidden until production.
 
 **Preferred action:**
 ```typescript

--- a/agents/testing-automation-engineer/references/mocking-patterns.md
+++ b/agents/testing-automation-engineer/references/mocking-patterns.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Over-mocking: tests pass, production fails. Mock at boundaries (network, filesystem, time, external services), not inside the application layer.
+Over-mocking is the primary cause of tests that pass but fail in production. When every dependency is mocked, the test verifies that mocks behave like mocks, not that the real system works. The rule: mock at boundaries (network, file system, time, external services), not inside the application layer.
 
 ---
 
@@ -58,7 +58,7 @@ vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
 }))
 ```
 
-**Why**: MSW intercepts at network level. Real `fetch` runs — error handling, parsing, retry logic exercised. `vi.stubGlobal('fetch')` bypasses all of that.
+**Why prefer MSW**: MSW intercepts at the network level via `@mswjs/interceptors` (Node). The component's `fetch` call is real — error handling, response parsing, and retry logic are all exercised. `vi.stubGlobal('fetch')` replaces the function, bypassing all of that.
 
 ---
 
@@ -95,7 +95,7 @@ it('returns null for unknown user', async () => {
 })
 ```
 
-**Why**: TypeScript enforces mock stays in sync with interface. `vi.mock` bypasses type checking and silently drifts.
+**Why**: TypeScript enforces that `MockUserRepository` stays in sync with the real interface contract. `vi.mock` on a database module bypasses type checking and can silently drift from the real implementation.
 
 ---
 
@@ -120,7 +120,7 @@ it('sends welcome email on registration', async () => {
 })
 ```
 
-**Why**: `vi.spyOn` replaces one function. Rest of module stays real.
+**Why**: `vi.spyOn` replaces only one function. All other `emailService` exports remain real. This tests that `registerUser` calls `sendEmail` with the right arguments without disabling the rest of the email module.
 
 ---
 
@@ -149,7 +149,7 @@ it('displays total', () => {
 })
 ```
 
-**Why this matters**: Test verifies mock returns display correctly, NOT that calculation is correct. Bug in calculation invisible.
+**Why this matters**: This test verifies that when `calculateTotal` returns `99.99`, the component displays it. It does NOT test whether `calculateTotal` returns the right value. A bug in the calculation is invisible to this test. Over-mocked tests pass while the real system is broken.
 
 **Preferred action:** Mock only the network boundary, let real internal logic run:
 ```typescript
@@ -180,7 +180,7 @@ vi.mock('react-router-dom', () => ({
 }))
 ```
 
-**Why this matters**: When the library updates, mock silently diverges. Tests pass, production breaks.
+**Why this matters**: When `react-router-dom` updates its API, the mock silently diverges. The test passes but the real component breaks in production. You're testing against a fake contract you wrote yourself.
 
 **Preferred action:** Use real providers in tests. For React Router v6+:
 ```typescript
@@ -219,7 +219,7 @@ it('saves user preferences', async () => {
 })
 ```
 
-**Why this matters**: Test passes even if `savePreferences` returns an error the component swallows, or UI shows stale state. Verifies invocation, not outcome.
+**Why this matters**: This test passes even if `savePreferences` is called but returns an error the component silently swallows. Or if the UI shows a stale state. It verifies that a function was invoked, not that the user got the right outcome.
 
 **Preferred action:** Assert on user-visible result first; use call assertions as secondary verification:
 ```typescript
@@ -252,7 +252,7 @@ beforeAll(() => {
 })
 ```
 
-**Why this matters**: Blanket suppression hides real errors. Broken components render silently.
+**Why this matters**: This suppresses all React prop-type warnings, act() warnings, and real errors. A broken component renders silently. Errors that should fail the test pass unnoticed.
 
 **Preferred action:** Suppress only the specific known warning; assert others still fire:
 ```typescript

--- a/agents/testing-automation-engineer/references/preferred-patterns.md
+++ b/agents/testing-automation-engineer/references/preferred-patterns.md
@@ -316,16 +316,16 @@ describe('Payment processing', () => {
 
 Before implementing tests, verify:
 
-1. ✅ Testing user-visible behavior, not implementation details
-2. ✅ Each test completely isolated and independent
-3. ✅ Mocking only external dependencies (APIs, databases, third-party services)
-4. ✅ Strong, specific assertions that validate actual behavior
-5. ✅ Proper async waiting strategies (no arbitrary timeouts)
-6. ✅ Coverage of happy path, error cases, and edge cases
-7. ✅ Tests can run in any order and in parallel
-8. ✅ Test names clearly describe what they verify
-9. ✅ Setup/teardown in beforeEach/afterEach, not shared variables
-10. ✅ Fast execution (<1s per test for unit tests)
+1. Testing user-visible behavior, not implementation details
+2. Each test completely isolated and independent
+3. Mocking only external dependencies (APIs, databases, third-party services)
+4. Strong, specific assertions that validate actual behavior
+5. Proper async waiting strategies (no arbitrary timeouts)
+6. Coverage of happy path, error cases, and edge cases
+7. Tests can run in any order and in parallel
+8. Test names clearly describe what they verify
+9. Setup/teardown in beforeEach/afterEach, not shared variables
+10. Fast execution (<1s per test for unit tests)
 
 ## Common Test Smells
 

--- a/agents/testing-automation-engineer/references/preferred-patterns.md
+++ b/agents/testing-automation-engineer/references/preferred-patterns.md
@@ -312,27 +312,29 @@ describe('Payment processing', () => {
 
 ---
 
-## Checklist
+## Summary: Testing Automation Checklist
 
-1. Test behavior, not implementation details
-2. Each test isolated and independent
-3. Mock only external boundaries
-4. Strong, specific assertions
-5. Proper async waiting (no timeouts)
-6. Happy path + error + edge cases
-7. Run in any order, in parallel
-8. Names describe verified behavior
-9. Setup in beforeEach, not shared variables
-10. <1s per unit test
+Before implementing tests, verify:
 
-## Test Smells
+1. ✅ Testing user-visible behavior, not implementation details
+2. ✅ Each test completely isolated and independent
+3. ✅ Mocking only external dependencies (APIs, databases, third-party services)
+4. ✅ Strong, specific assertions that validate actual behavior
+5. ✅ Proper async waiting strategies (no arbitrary timeouts)
+6. ✅ Coverage of happy path, error cases, and edge cases
+7. ✅ Tests can run in any order and in parallel
+8. ✅ Test names clearly describe what they verify
+9. ✅ Setup/teardown in beforeEach/afterEach, not shared variables
+10. ✅ Fast execution (<1s per test for unit tests)
 
-| Smell | Fix |
-|-------|-----|
-| >50 lines | Split into focused tests |
-| "test1", "it works" | Describe behavior |
-| 5+ assertions | One concept per test |
-| 20+ setup lines | Factory function |
-| setTimeout | waitFor with condition |
-| test.skip | Fix or remove |
-| Intermittent failure | Find root cause |
+## Common Test Smells
+
+| Smell | Indicator | Fix |
+|-------|-----------|-----|
+| Long test | >50 lines | Break into multiple focused tests |
+| Unclear name | "test1", "it works" | Describe behavior: "displays error when invalid input" |
+| Multiple assertions | Testing 5+ things | One concept per test |
+| Deep setup | 20+ lines of setup | Extract to factory function |
+| setTimeout | Arbitrary waits | Use waitFor with condition |
+| test.skip | Skipped tests | Fix or remove, don't skip |
+| Intermittent failure | Passes 80% of time | Find root cause, don't retry |


### PR DESCRIPTION
## Summary
- Rewrites terse "Why" explanations in 27 anti-pattern reference docs to be mechanistic, quantified, and causal
- Covers 6 agents: opensearch-elasticsearch, performance-optimization, php, prometheus-grafana, reviewer-code, testing-automation
- No structural changes, no new files — pure documentation quality improvement

## Motivation
Agent reference docs are cited in reviews and recommendations. Terse one-liners like "JVM uses compressed OOPs below ~31GB" don't teach — expanded explanations with cause → effect → consequence chains make agent output more educational.

## Test plan
- [ ] CI passes (ruff check, ruff format)
- [ ] No structural changes to validate — markdown content only
- [ ] Spot-check a few files for accuracy of technical claims