### PR TITLE
feat: add deterministic pre-router for /do dispatch

### DIFF
--- a/scripts/pre-route.py
+++ b/scripts/pre-route.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Deterministic pre-router for /do dispatch.
+
+Pattern-matches user requests against trigger keywords from INDEX.json
+files BEFORE the Haiku LLM routing agent. High-confidence matches skip
+LLM routing entirely; low-confidence or unmatched requests fall through.
+
+Usage:
+    python3 scripts/pre-route.py --request "run go tests"
+    python3 scripts/pre-route.py --request "create a PR" --json-compact
+
+Exit codes:
+    0 -- always (output is JSON to stdout)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _resolve_index(tracked: Path, local_name: str) -> Path:
+    """Return the local override path when it exists, otherwise the tracked path."""
+    local = tracked.parent / local_name
+    return local if local.exists() else tracked
+
+
+INDEX_PATHS = {
+    "skills": _resolve_index(REPO_ROOT / "skills" / "INDEX.json", "INDEX.local.json"),
+    "agents": _resolve_index(REPO_ROOT / "agents" / "INDEX.json", "INDEX.local.json"),
+}
+
+# Phrases that look like trigger matches but are common English idioms
+# unrelated to the skill. Keyed by skill name -> set of disqualifying context words.
+SEMANTIC_GUARDS: dict[str, set[str]] = {
+    "pr-workflow": {"back", "pressure", "pushback", "pushed", "pushing"},
+    "fish-shell-config": {"for", "bugs", "compliments", "information", "ideas", "answers"},
+}
+
+
+@dataclass
+class MatchEntry:
+    """A single trigger-to-target mapping."""
+
+    name: str
+    entry_type: str  # "skill" or "agent"
+    agent: str | None
+    force_route: bool
+    trigger: str
+    pattern: re.Pattern[str]
+
+
+@dataclass
+class ScoredMatch:
+    """A candidate match with computed score."""
+
+    name: str
+    entry_type: str
+    agent: str | None
+    force_route: bool
+    matched_triggers: list[str] = field(default_factory=list)
+    total_chars: int = 0
+    score: float = 0.0
+
+
+def load_entries() -> list[dict]:
+    """Load all INDEX entries into a flat list."""
+    entries: list[dict] = []
+
+    for index_type, path in INDEX_PATHS.items():
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+
+        items = raw.get(index_type, {})
+        if not isinstance(items, dict):
+            continue
+
+        for name, data in items.items():
+            if not isinstance(data, dict):
+                continue
+            entries.append(
+                {
+                    "name": name,
+                    "type": "skill" if index_type == "skills" else "agent",
+                    "triggers": data.get("triggers", []),
+                    "agent": data.get("agent"),
+                    "force_route": bool(data.get("force_route", False)),
+                }
+            )
+
+    return entries
+
+
+def _build_pattern(trigger_lower: str) -> re.Pattern[str]:
+    """Build a regex pattern for a trigger phrase.
+
+    Single-word triggers: exact word-boundary match.
+    Multi-word triggers: each word must appear in order with up to 2
+    intervening words allowed (handles "create a PR" matching trigger
+    "create PR", or "run the go tests" matching "go test").
+    """
+    words = trigger_lower.split()
+    if len(words) == 1:
+        escaped = re.escape(words[0])
+        return re.compile(rf"\b{escaped}\b", re.IGNORECASE)
+
+    # Multi-word: allow up to 2 words between each trigger word.
+    # Also allow the last trigger word to be a prefix (e.g. "test" matches "tests").
+    parts = []
+    for i, word in enumerate(words):
+        escaped = re.escape(word)
+        if i == len(words) - 1:
+            # Last word: allow plural/suffix (word boundary after stem)
+            parts.append(rf"\b{escaped}\w*\b")
+        else:
+            parts.append(rf"\b{escaped}\b")
+
+    # Join with "up to 2 intervening words" gap
+    gap = r"(?:\s+\S+){0,2}\s+"
+    full_pattern = gap.join(parts)
+    return re.compile(full_pattern, re.IGNORECASE)
+
+
+def build_match_table(entries: list[dict]) -> list[MatchEntry]:
+    """Compile trigger keywords into regex patterns.
+
+    Single-word triggers use exact word-boundary match.
+    Multi-word triggers allow up to 2 intervening words between
+    trigger words (e.g. "create PR" matches "create a PR").
+    """
+    table: list[MatchEntry] = []
+
+    for entry in entries:
+        name = entry["name"]
+        entry_type = entry["type"]
+        agent = entry.get("agent")
+        force_route = entry.get("force_route", False)
+
+        for trigger in entry.get("triggers", []):
+            trigger_lower = trigger.lower()
+            pattern = _build_pattern(trigger_lower)
+
+            table.append(
+                MatchEntry(
+                    name=name,
+                    entry_type=entry_type,
+                    agent=agent,
+                    force_route=force_route,
+                    trigger=trigger_lower,
+                    pattern=pattern,
+                )
+            )
+
+    return table
+
+
+def _is_semantically_guarded(skill_name: str, request_lower: str, matched_trigger: str) -> bool:
+    """Check if the match is a false positive due to common English idioms.
+
+    Returns True if the match should be discarded.
+    """
+    guards = SEMANTIC_GUARDS.get(skill_name)
+    if not guards:
+        return False
+
+    # Check if any guard word appears near the matched trigger in the request.
+    # "near" = within 3 words before or after the trigger phrase.
+    trigger_pos = request_lower.find(matched_trigger)
+    if trigger_pos == -1:
+        return False
+
+    # Extract context window: 60 chars before and after the trigger
+    ctx_start = max(0, trigger_pos - 60)
+    ctx_end = min(len(request_lower), trigger_pos + len(matched_trigger) + 60)
+    context = request_lower[ctx_start:ctx_end]
+
+    words_in_context = set(re.findall(r"\b\w+\b", context))
+    return bool(words_in_context & guards)
+
+
+def score_matches(table: list[MatchEntry], request: str) -> dict[str, ScoredMatch]:
+    """Score each entry by matching triggers against the request.
+
+    Scoring:
+    - Each matched trigger adds 1.0 to score
+    - Force-route entries get a 2.0 bonus
+    - Longer triggers get a specificity bonus (len/100)
+    """
+    request_lower = request.lower()
+    candidates: dict[str, ScoredMatch] = {}
+
+    for entry in table:
+        if not entry.pattern.search(request_lower):
+            continue
+
+        # Semantic guard check
+        if _is_semantically_guarded(entry.name, request_lower, entry.trigger):
+            continue
+
+        key = f"{entry.entry_type}:{entry.name}"
+        if key not in candidates:
+            candidates[key] = ScoredMatch(
+                name=entry.name,
+                entry_type=entry.entry_type,
+                agent=entry.agent,
+                force_route=entry.force_route,
+            )
+
+        match = candidates[key]
+        match.matched_triggers.append(entry.trigger)
+        match.total_chars += len(entry.trigger)
+
+    # Compute final scores
+    for match in candidates.values():
+        trigger_count = len(match.matched_triggers)
+        specificity_bonus = match.total_chars / 100.0
+        force_bonus = 2.0 if match.force_route else 0.0
+        match.score = trigger_count + specificity_bonus + force_bonus
+
+    return candidates
+
+
+def determine_confidence(match: ScoredMatch) -> str:
+    """Determine confidence level based on match characteristics.
+
+    Thresholds:
+    - force_route + 2+ trigger matches -> "high"
+    - force_route + 1 trigger match -> "medium"
+    - non-force + 3+ trigger matches -> "medium"
+    - anything less -> "low" (fall through)
+    """
+    trigger_count = len(match.matched_triggers)
+
+    if match.force_route and trigger_count >= 2:
+        return "high"
+    if match.force_route and trigger_count >= 1:
+        return "medium"
+    if not match.force_route and trigger_count >= 3:
+        return "medium"
+    return "low"
+
+
+def route(request: str, entries: list[dict] | None = None) -> dict:
+    """Run the pre-router on a request string.
+
+    Args:
+        request: The user's request text.
+        entries: Optional pre-loaded INDEX entries. Loaded from disk if None.
+
+    Returns:
+        Routing decision dict with matched, agent, skill, confidence,
+        match_type, and reasoning fields.
+    """
+    if entries is None:
+        entries = load_entries()
+
+    table = build_match_table(entries)
+    candidates = score_matches(table, request)
+
+    if not candidates:
+        return {
+            "matched": False,
+            "agent": None,
+            "skill": None,
+            "confidence": "low",
+            "match_type": "fallthrough",
+            "reasoning": "no trigger keywords matched",
+        }
+
+    # Sort by score descending
+    ranked = sorted(candidates.values(), key=lambda m: m.score, reverse=True)
+    top = ranked[0]
+    confidence = determine_confidence(top)
+
+    if confidence == "low":
+        return {
+            "matched": False,
+            "agent": top.agent,
+            "skill": top.name if top.entry_type == "skill" else None,
+            "confidence": "low",
+            "match_type": "fallthrough",
+            "reasoning": f"weak match on {top.matched_triggers!r} for {top.name} (score={top.score:.2f})",
+        }
+
+    # Determine agent and skill from the match
+    agent = top.agent
+    skill = top.name if top.entry_type == "skill" else None
+
+    # If matched entry is an agent (not skill), set agent from name
+    if top.entry_type == "agent":
+        agent = top.name
+        skill = None
+
+    match_type = "force_route" if top.force_route else "trigger_keyword"
+    triggers_str = ", ".join(f"'{t}'" for t in top.matched_triggers)
+
+    return {
+        "matched": True,
+        "agent": agent,
+        "skill": skill,
+        "confidence": confidence,
+        "match_type": match_type,
+        "reasoning": f"matched triggers [{triggers_str}] for {top.name}",
+    }
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Deterministic pre-router for /do dispatch.",
+    )
+    parser.add_argument(
+        "--request",
+        required=True,
+        help="The user request string to route.",
+    )
+    parser.add_argument(
+        "--json-compact",
+        action="store_true",
+        help="Output compact JSON (no indentation).",
+    )
+    args = parser.parse_args()
+
+    result = route(args.request)
+
+    indent = None if args.json_compact else 2
+    print(json.dumps(result, indent=indent))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pre-route.py
+++ b/scripts/pre-route.py
@@ -162,8 +162,14 @@ def build_match_table(entries: list[dict]) -> list[MatchEntry]:
     return table
 
 
-def _is_semantically_guarded(skill_name: str, request_lower: str, matched_trigger: str) -> bool:
+def _is_semantically_guarded(
+    skill_name: str, request_lower: str, matched_trigger: str, trigger_pattern: re.Pattern[str]
+) -> bool:
     """Check if the match is a false positive due to common English idioms.
+
+    Uses the trigger's compiled regex pattern to locate the match position,
+    which correctly handles multi-word triggers with intervening words
+    (e.g. "create a PR" matching trigger "create pr").
 
     Returns True if the match should be discarded.
     """
@@ -171,15 +177,18 @@ def _is_semantically_guarded(skill_name: str, request_lower: str, matched_trigge
     if not guards:
         return False
 
-    # Check if any guard word appears near the matched trigger in the request.
-    # "near" = within 3 words before or after the trigger phrase.
-    trigger_pos = request_lower.find(matched_trigger)
-    if trigger_pos == -1:
+    # Use the regex pattern to find the trigger match position, not str.find().
+    # str.find() fails for multi-word triggers with intervening words.
+    m = trigger_pattern.search(request_lower)
+    if m is None:
         return False
 
-    # Extract context window: 60 chars before and after the trigger
+    trigger_pos = m.start()
+    match_len = m.end() - m.start()
+
+    # Extract context window: 60 chars before and after the trigger match
     ctx_start = max(0, trigger_pos - 60)
-    ctx_end = min(len(request_lower), trigger_pos + len(matched_trigger) + 60)
+    ctx_end = min(len(request_lower), trigger_pos + match_len + 60)
     context = request_lower[ctx_start:ctx_end]
 
     words_in_context = set(re.findall(r"\b\w+\b", context))
@@ -202,7 +211,7 @@ def score_matches(table: list[MatchEntry], request: str) -> dict[str, ScoredMatc
             continue
 
         # Semantic guard check
-        if _is_semantically_guarded(entry.name, request_lower, entry.trigger):
+        if _is_semantically_guarded(entry.name, request_lower, entry.trigger, entry.pattern):
             continue
 
         key = f"{entry.entry_type}:{entry.name}"
@@ -275,8 +284,8 @@ def route(request: str, entries: list[dict] | None = None) -> dict:
             "reasoning": "no trigger keywords matched",
         }
 
-    # Sort by score descending
-    ranked = sorted(candidates.values(), key=lambda m: m.score, reverse=True)
+    # Sort by score descending, then by name ascending for deterministic tie-breaking
+    ranked = sorted(candidates.values(), key=lambda m: (-m.score, m.name))
     top = ranked[0]
     confidence = determine_confidence(top)
 

--- a/scripts/tests/test_pre_route.py
+++ b/scripts/tests/test_pre_route.py
@@ -1,0 +1,333 @@
+"""Tests for scripts/pre-route.py deterministic pre-router."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "pre-route.py"
+
+# ---------------------------------------------------------------------------
+# Import the module for unit testing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pre_route(monkeypatch: pytest.MonkeyPatch):
+    """Import pre_route module with real INDEX files."""
+    monkeypatch.syspath_prepend(str(REPO_ROOT / "scripts"))
+    # Use importlib to avoid name collision with hyphenated filename
+    import importlib
+
+    mod = importlib.import_module("pre-route")
+    return mod
+
+
+@pytest.fixture
+def real_entries(pre_route):
+    """Load real entries from INDEX.json files."""
+    return pre_route.load_entries()
+
+
+# ---------------------------------------------------------------------------
+# Core routing tests (from spec)
+# ---------------------------------------------------------------------------
+
+
+class TestSpecifiedRoutes:
+    """Test cases from the task specification."""
+
+    def test_go_tests_matches_go_patterns(self, pre_route, real_entries) -> None:
+        """'run the go tests' should match go-patterns or golang-general-engineer."""
+        result = pre_route.route("run the go tests", entries=real_entries)
+        assert result["matched"] is True
+        # Should match go-patterns (force-route skill with "go test" trigger)
+        assert result["skill"] == "go-patterns" or result["agent"] == "golang-general-engineer"
+
+    def test_create_pr_matches_pr_workflow(self, pre_route, real_entries) -> None:
+        """'create a PR' should match pr-workflow (force-route)."""
+        result = pre_route.route("create a PR", entries=real_entries)
+        assert result["matched"] is True
+        assert result["skill"] == "pr-workflow"
+        assert result["match_type"] == "force_route"
+
+    def test_push_changes_matches_pr_workflow(self, pre_route, real_entries) -> None:
+        """'push my changes' should match pr-workflow (force-route)."""
+        result = pre_route.route("push my changes", entries=real_entries)
+        assert result["matched"] is True
+        assert result["skill"] == "pr-workflow"
+        assert result["match_type"] == "force_route"
+
+    def test_quantum_physics_falls_through(self, pre_route, real_entries) -> None:
+        """'tell me about quantum physics' should fall through."""
+        result = pre_route.route("tell me about quantum physics", entries=real_entries)
+        assert result["matched"] is False
+        assert result["match_type"] == "fallthrough"
+
+    def test_quick_fix_matches_quick(self, pre_route, real_entries) -> None:
+        """'quick fix the login page' should match quick (force-route)."""
+        result = pre_route.route("quick fix the login page", entries=real_entries)
+        assert result["matched"] is True
+        assert result["skill"] == "quick"
+        assert result["match_type"] == "force_route"
+
+    def test_fish_shell_matches_fish_config(self, pre_route, real_entries) -> None:
+        """'configure my fish shell' should match fish-shell-config (force-route)."""
+        result = pre_route.route("configure my fish shell", entries=real_entries)
+        assert result["matched"] is True
+        assert result["skill"] == "fish-shell-config"
+        assert result["match_type"] == "force_route"
+
+    def test_review_code_ambiguous_falls_through(self, pre_route, real_entries) -> None:
+        """'review this code' is ambiguous (1 non-force trigger) -- correctly falls through."""
+        result = pre_route.route("review this code", entries=real_entries)
+        # Single non-force trigger match -> low confidence -> fallthrough
+        assert result["matched"] is False
+        assert result["confidence"] == "low"
+
+    def test_structured_code_review_matches(self, pre_route, real_entries) -> None:
+        """'do a structured code review and code audit' has 3+ triggers -> matches."""
+        result = pre_route.route("do a structured code review and code audit", entries=real_entries)
+        assert result["matched"] is True
+        assert "review" in (result["skill"] or "")
+
+    def test_weather_falls_through(self, pre_route, real_entries) -> None:
+        """'what's the weather like' should fall through."""
+        result = pre_route.route("what's the weather like", entries=real_entries)
+        assert result["matched"] is False
+        assert result["match_type"] == "fallthrough"
+
+
+# ---------------------------------------------------------------------------
+# Semantic safety tests (false positive prevention)
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticSafety:
+    """Test that common English idioms don't trigger false positives."""
+
+    def test_push_back_does_not_match_pr_workflow(self, pre_route, real_entries) -> None:
+        """'push back on this design' should NOT match pr-workflow."""
+        result = pre_route.route("push back on this design", entries=real_entries)
+        if result["matched"]:
+            assert result["skill"] != "pr-workflow", f"'push back on this design' falsely matched pr-workflow: {result}"
+
+    def test_fish_for_bugs_does_not_match_fish_config(self, pre_route, real_entries) -> None:
+        """'fish for bugs' should NOT match fish-shell-config."""
+        result = pre_route.route("fish for bugs", entries=real_entries)
+        if result["matched"]:
+            assert result["skill"] != "fish-shell-config", (
+                f"'fish for bugs' falsely matched fish-shell-config: {result}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Output schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestOutputSchema:
+    """Verify the output JSON schema is correct."""
+
+    REQUIRED_KEYS: ClassVar[set[str]] = {"matched", "agent", "skill", "confidence", "match_type", "reasoning"}
+
+    def test_matched_output_has_all_keys(self, pre_route, real_entries) -> None:
+        """Matched result contains all required keys."""
+        result = pre_route.route("create a PR", entries=real_entries)
+        assert set(result.keys()) >= self.REQUIRED_KEYS
+
+    def test_fallthrough_output_has_all_keys(self, pre_route, real_entries) -> None:
+        """Fallthrough result contains all required keys."""
+        result = pre_route.route("tell me about quantum physics", entries=real_entries)
+        assert set(result.keys()) >= self.REQUIRED_KEYS
+
+    def test_confidence_values(self, pre_route, real_entries) -> None:
+        """Confidence is one of high/medium/low."""
+        for req in ["create a PR", "push my changes", "quantum physics"]:
+            result = pre_route.route(req, entries=real_entries)
+            assert result["confidence"] in {"high", "medium", "low"}
+
+    def test_match_type_values(self, pre_route, real_entries) -> None:
+        """match_type is one of force_route/trigger_keyword/fallthrough."""
+        for req in ["create a PR", "review this code", "quantum physics"]:
+            result = pre_route.route(req, entries=real_entries)
+            assert result["match_type"] in {"force_route", "trigger_keyword", "fallthrough"}
+
+
+# ---------------------------------------------------------------------------
+# Confidence threshold tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfidence:
+    """Test confidence determination logic."""
+
+    def test_force_route_high_confidence(self, pre_route) -> None:
+        """Force-route with 2+ triggers -> high."""
+        from dataclasses import field as _field
+
+        match = pre_route.ScoredMatch(
+            name="test",
+            entry_type="skill",
+            agent=None,
+            force_route=True,
+            matched_triggers=["a", "b"],
+        )
+        assert pre_route.determine_confidence(match) == "high"
+
+    def test_force_route_medium_confidence(self, pre_route) -> None:
+        """Force-route with 1 trigger -> medium."""
+        match = pre_route.ScoredMatch(
+            name="test",
+            entry_type="skill",
+            agent=None,
+            force_route=True,
+            matched_triggers=["a"],
+        )
+        assert pre_route.determine_confidence(match) == "medium"
+
+    def test_non_force_medium_confidence(self, pre_route) -> None:
+        """Non-force with 3+ triggers -> medium."""
+        match = pre_route.ScoredMatch(
+            name="test",
+            entry_type="skill",
+            agent=None,
+            force_route=False,
+            matched_triggers=["a", "b", "c"],
+        )
+        assert pre_route.determine_confidence(match) == "medium"
+
+    def test_non_force_low_confidence(self, pre_route) -> None:
+        """Non-force with <3 triggers -> low."""
+        match = pre_route.ScoredMatch(
+            name="test",
+            entry_type="skill",
+            agent=None,
+            force_route=False,
+            matched_triggers=["a", "b"],
+        )
+        assert pre_route.determine_confidence(match) == "low"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for internal functions
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMatchTable:
+    """Test match table construction."""
+
+    def test_builds_from_entries(self, pre_route) -> None:
+        """Match table is built from entries with patterns."""
+        entries = [
+            {
+                "name": "test-skill",
+                "type": "skill",
+                "triggers": ["go test", "run tests"],
+                "agent": "golang-general-engineer",
+                "force_route": True,
+            }
+        ]
+        table = pre_route.build_match_table(entries)
+        assert len(table) == 2
+        assert table[0].trigger == "go test"
+        assert table[0].force_route is True
+        assert table[0].pattern.search("let's run go test now") is not None
+
+    def test_empty_triggers(self, pre_route) -> None:
+        """Entry with no triggers produces no match entries."""
+        entries = [{"name": "empty", "type": "skill", "triggers": [], "agent": None, "force_route": False}]
+        table = pre_route.build_match_table(entries)
+        assert len(table) == 0
+
+
+class TestScoreMatches:
+    """Test the scoring logic."""
+
+    def test_force_route_bonus(self, pre_route) -> None:
+        """Force-route entries get a 2.0 bonus."""
+        entries = [
+            {"name": "forced", "type": "skill", "triggers": ["deploy"], "agent": None, "force_route": True},
+            {"name": "normal", "type": "skill", "triggers": ["deploy"], "agent": None, "force_route": False},
+        ]
+        table = pre_route.build_match_table(entries)
+        candidates = pre_route.score_matches(table, "deploy now")
+        forced = candidates["skill:forced"]
+        normal = candidates["skill:normal"]
+        assert forced.score > normal.score
+
+    def test_more_triggers_higher_score(self, pre_route) -> None:
+        """More matched triggers = higher score."""
+        entries = [
+            {"name": "multi", "type": "skill", "triggers": ["run", "test", "go"], "agent": None, "force_route": False},
+            {"name": "single", "type": "skill", "triggers": ["run"], "agent": None, "force_route": False},
+        ]
+        table = pre_route.build_match_table(entries)
+        candidates = pre_route.score_matches(table, "run go test")
+        assert candidates["skill:multi"].score > candidates["skill:single"].score
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    """Test the script as a subprocess."""
+
+    @pytest.mark.slow
+    def test_cli_matched(self) -> None:
+        """CLI returns valid JSON for a matched request."""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--request", "create a PR"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["matched"] is True
+        assert data["skill"] == "pr-workflow"
+
+    @pytest.mark.slow
+    def test_cli_fallthrough(self) -> None:
+        """CLI returns valid JSON for a fallthrough request."""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--request", "what is the meaning of life"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["matched"] is False
+
+    @pytest.mark.slow
+    def test_cli_compact_json(self) -> None:
+        """--json-compact outputs single-line JSON."""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--request", "create a PR", "--json-compact"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        assert result.returncode == 0
+        lines = result.stdout.strip().split("\n")
+        assert len(lines) == 1
+
+    @pytest.mark.slow
+    def test_cli_missing_request_fails(self) -> None:
+        """Missing --request arg fails."""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        assert result.returncode != 0

--- a/scripts/tests/test_pre_route.py
+++ b/scripts/tests/test_pre_route.py
@@ -126,6 +126,41 @@ class TestSemanticSafety:
                 f"'fish for bugs' falsely matched fish-shell-config: {result}"
             )
 
+    def test_semantic_guard_works_with_multi_word_triggers(self, pre_route) -> None:
+        """Semantic guard must work when multi-word trigger matches with intervening words.
+
+        E.g. trigger 'push changes' matching 'push back on changes' should be guarded
+        because 'back' is a guard word for pr-workflow.
+        """
+        entries = [
+            {
+                "name": "pr-workflow",
+                "type": "skill",
+                "triggers": ["push changes"],
+                "agent": None,
+                "force_route": True,
+            }
+        ]
+        table = pre_route.build_match_table(entries)
+        candidates = pre_route.score_matches(table, "push back on changes")
+        # "back" is a guard word for pr-workflow, so this should be filtered out
+        assert "skill:pr-workflow" not in candidates
+
+    def test_semantic_guard_allows_legitimate_multi_word_match(self, pre_route) -> None:
+        """Multi-word trigger without guard words should match normally."""
+        entries = [
+            {
+                "name": "pr-workflow",
+                "type": "skill",
+                "triggers": ["push changes"],
+                "agent": None,
+                "force_route": True,
+            }
+        ]
+        table = pre_route.build_match_table(entries)
+        candidates = pre_route.score_matches(table, "push my changes now")
+        assert "skill:pr-workflow" in candidates
+
 
 # ---------------------------------------------------------------------------
 # Output schema tests
@@ -271,6 +306,18 @@ class TestScoreMatches:
         table = pre_route.build_match_table(entries)
         candidates = pre_route.score_matches(table, "run go test")
         assert candidates["skill:multi"].score > candidates["skill:single"].score
+
+    def test_deterministic_tie_breaking(self, pre_route) -> None:
+        """Equal-score candidates are ordered deterministically by name."""
+        entries = [
+            {"name": "zebra", "type": "skill", "triggers": ["deploy"], "agent": None, "force_route": True},
+            {"name": "alpha", "type": "skill", "triggers": ["deploy"], "agent": None, "force_route": True},
+        ]
+        # Run multiple times to verify determinism
+        for _ in range(5):
+            result = pre_route.route("deploy now", entries=entries)
+            # Both have identical scores; alpha should win deterministically
+            assert result["skill"] == "alpha", f"Expected 'alpha' but got {result['skill']}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `scripts/pre-route.py` — pattern-matches requests against INDEX.json triggers before Haiku LLM routing
- Force-route skills + high-frequency patterns skip LLM entirely; ambiguous requests fall through to Haiku
- Semantic guards prevent false positives ("push back" ≠ git push, "fish for bugs" ≠ fish-shell-config)
- ADR: `adr/deterministic-pre-router.md`

## Test plan
- [x] 27 unit tests (spec routes, semantic safety, schema validation, confidence thresholds, CLI)
- [x] Integration: real INDEX.json routing for Go, PR, semantic guard, unmatched requests
- [ ] A/B test: 50 requests with pre-router vs 50 without (post-merge validation)