### PR TITLE
feat: add instruction compliance measurement and skip-rate dashboard

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -281,7 +281,7 @@ Environment variables set in `.claude/settings.json` under `"env"`:
 | Variable | Recommended Value | Why |
 |----------|-------------------|-----|
 | `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | `400000` | Prompt cache TTL is 5 minutes (not 1 hour). Larger conversations miss cache frequently, making each turn reprocess the full context at full cost. Compacting at 400k keeps conversations in the cache-friendly zone. ([anthropics/claude-code#45756](https://github.com/anthropics/claude-code/issues/45756#issuecomment-4231739206)) |
-| `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` | `1` | **Deprecated on Opus 4.7 (no-op).** Opus 4.7 removed the fixed-budget option; this variable has no effect on the current model. See the deprecation notice in `docs/PHILOSOPHY.md` under "Prompt Phrasing Does Not Replace Domain Knowledge" (Experiment 4). Users migrating from Opus 4.6 can leave this set; it is harmless but inactive. |
+| `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` | `1` | **Deprecated (no-op).** The fixed-budget option no longer exists; this variable has no effect. Safe to leave set — harmless but inactive. |
 
 **Context on `AUTO_COMPACT_WINDOW`:** Anthropic's prompt caching currently uses a 5-minute TTL. When conversations grow large and cache entries expire between turns, each API call re-processes the full conversation at uncached token prices. Even though Claude supports a 1M token context window, using the full window without cache hits is prohibitively expensive. Setting `AUTO_COMPACT_WINDOW=400000` triggers compaction earlier, keeping the active context within a size that cache hits can cover. Anthropic is aware of this issue and exploring improvements. Credit: [@bcherny](https://github.com/bcherny).
 

--- a/hooks/instruction-compliance.py
+++ b/hooks/instruction-compliance.py
@@ -23,7 +23,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import empty_output, get_session_id, get_tool_output, get_tool_result
-from learning_db_v2 import record_learning
+from learning_db_v2 import record_instruction_compliance
 from stdin_timeout import read_stdin
 
 EVENT_NAME = "PostToolUse"
@@ -95,23 +95,18 @@ def record_compliance(
 ) -> None:
     """Record a single instruction compliance observation to learning.db.
 
+    Each call INSERTs a new row into the instruction_compliance table.
+    Observations accumulate — they never overwrite previous entries.
+
     Args:
         instr_id: Instruction identifier (e.g. "M01").
-        instr_name: Human-readable instruction name.
+        instr_name: Human-readable instruction name (unused, kept for API compat).
         compliant: Whether the instruction was followed.
         session_id: Current session identifier.
     """
-    key = f"{instr_id}:{instr_name.lower().replace(' ', '-')}"
-    value = f"compliant={compliant} session={session_id}"
-
-    record_learning(
-        topic="instruction-compliance",
-        key=key,
-        value=value,
-        category="effectiveness",
-        tags=[f"instruction:{instr_id}"],
-        source="hook:instruction-compliance",
-        source_detail=f"{'compliant' if compliant else 'non-compliant'}",
+    record_instruction_compliance(
+        instruction_id=instr_id,
+        compliant=compliant,
         session_id=session_id,
     )
 

--- a/hooks/instruction-compliance.py
+++ b/hooks/instruction-compliance.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""PostToolUse Hook: Instruction Compliance Measurement
+
+Fires after Agent tool dispatches to check whether MANDATORY instructions
+(M01-M09 from ADR instruction-skip-rate-measurement) were followed.
+
+Records compliance observations to learning.db for skip-rate dashboard.
+
+Design Principles:
+- Informational only (always exits 0, never blocks)
+- Lightweight string-presence checks (<50ms)
+- Multiple signal patterns per instruction for reduced false negatives
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Add lib directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+
+from hook_utils import empty_output, get_session_id, get_tool_output, get_tool_result
+from learning_db_v2 import record_learning
+from stdin_timeout import read_stdin
+
+EVENT_NAME = "PostToolUse"
+
+# ─── Instruction Definitions ─────────────────────────────────────
+
+INSTRUCTIONS: dict[str, dict[str, str | list[re.Pattern[str]]]] = {
+    "M01": {
+        "name": "Phase Banners",
+        "patterns": [
+            re.compile(r"##\s*Phase\s+\d", re.IGNORECASE),
+            re.compile(r"Phase\s+\d\s*:", re.IGNORECASE),
+        ],
+    },
+    "M03": {
+        "name": "Routing Decision",
+        "patterns": [
+            re.compile(r"={3,}"),
+            re.compile(r"ROUTING\s*:", re.IGNORECASE),
+            re.compile(r"Selected\s*:", re.IGNORECASE),
+        ],
+    },
+    "M04": {
+        "name": "Reference Loading",
+        "patterns": [
+            re.compile(r"Reference\s+Loading", re.IGNORECASE),
+            re.compile(r"reference.*table", re.IGNORECASE),
+        ],
+    },
+    "M05": {
+        "name": "Completeness",
+        "patterns": [
+            re.compile(r"deliver\s+the\s+finished\s+product", re.IGNORECASE),
+            re.compile(r"ship\s+the\s+complete\s+thing", re.IGNORECASE),
+        ],
+    },
+    "M06": {
+        "name": "Density Standard",
+        "patterns": [
+            re.compile(r"write\s+dense", re.IGNORECASE),
+            re.compile(r"high\s+fidelity,?\s+minimum\s+words", re.IGNORECASE),
+        ],
+    },
+}
+
+
+def check_compliance(text: str) -> dict[str, bool]:
+    """Check agent output against all instrumented instructions.
+
+    Args:
+        text: Combined agent prompt and output text to scan.
+
+    Returns:
+        Dict mapping instruction ID to compliance boolean.
+    """
+    results: dict[str, bool] = {}
+    for instr_id, instr in INSTRUCTIONS.items():
+        patterns: list[re.Pattern[str]] = instr["patterns"]  # type: ignore[assignment]
+        compliant = any(p.search(text) for p in patterns)
+        results[instr_id] = compliant
+    return results
+
+
+def record_compliance(
+    instr_id: str,
+    instr_name: str,
+    compliant: bool,
+    session_id: str,
+) -> None:
+    """Record a single instruction compliance observation to learning.db.
+
+    Args:
+        instr_id: Instruction identifier (e.g. "M01").
+        instr_name: Human-readable instruction name.
+        compliant: Whether the instruction was followed.
+        session_id: Current session identifier.
+    """
+    key = f"{instr_id}:{instr_name.lower().replace(' ', '-')}"
+    value = f"compliant={compliant} session={session_id}"
+
+    record_learning(
+        topic="instruction-compliance",
+        key=key,
+        value=value,
+        category="effectiveness",
+        tags=[f"instruction:{instr_id}"],
+        source="hook:instruction-compliance",
+        source_detail=f"{'compliant' if compliant else 'non-compliant'}",
+        session_id=session_id,
+    )
+
+
+def main() -> None:
+    """Process PostToolUse events for Agent instruction compliance.
+
+    Flow:
+    1. Read stdin JSON
+    2. Extract agent output text
+    3. Check each instruction for compliance signals
+    4. Record observations to learning.db
+    5. Exit silently (informational, never blocks)
+    """
+    try:
+        event_data = read_stdin(timeout=2)
+        if not event_data:
+            empty_output(EVENT_NAME).print_and_exit()
+
+        event = json.loads(event_data)
+        session_id = event.get("session_id") or get_session_id()
+
+        # Extract agent output text
+        tool_result = get_tool_result(event)
+        if isinstance(tool_result, dict):
+            output_text = get_tool_output(tool_result)
+        elif isinstance(tool_result, str):
+            output_text = tool_result
+        else:
+            output_text = ""
+
+        # Also check tool_input (agent prompt) for M04/M05/M06
+        tool_input = event.get("tool_input", event.get("input", ""))
+        if isinstance(tool_input, dict):
+            tool_input = json.dumps(tool_input)
+        elif not isinstance(tool_input, str):
+            tool_input = ""
+
+        combined_text = f"{tool_input}\n{output_text}"
+
+        if not combined_text.strip():
+            empty_output(EVENT_NAME).print_and_exit()
+
+        # Check and record compliance for each instruction
+        results = check_compliance(combined_text)
+        for instr_id, compliant in results.items():
+            instr_name: str = INSTRUCTIONS[instr_id]["name"]  # type: ignore[assignment]
+            record_compliance(instr_id, instr_name, compliant, session_id)
+
+        empty_output(EVENT_NAME).print_and_exit()
+
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[instruction-compliance] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+    finally:
+        sys.exit(0)  # Never block
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/instruction-compliance.py
+++ b/hooks/instruction-compliance.py
@@ -23,7 +23,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from hook_utils import empty_output, get_session_id, get_tool_output, get_tool_result
-from learning_db_v2 import record_instruction_compliance
+from learning_db_v2 import record_instruction_compliance_batch
 from stdin_timeout import read_stdin
 
 EVENT_NAME = "PostToolUse"
@@ -41,8 +41,8 @@ INSTRUCTIONS: dict[str, dict[str, str | list[re.Pattern[str]]]] = {
     "M03": {
         "name": "Routing Decision",
         "patterns": [
-            re.compile(r"={3,}"),
-            re.compile(r"ROUTING\s*:", re.IGNORECASE),
+            re.compile(r"^={3,}\s*$", re.MULTILINE),
+            re.compile(r"(?:^|\s)ROUTING\s*:", re.IGNORECASE | re.MULTILINE),
             re.compile(r"Selected\s*:", re.IGNORECASE),
         ],
     },
@@ -51,6 +51,8 @@ INSTRUCTIONS: dict[str, dict[str, str | list[re.Pattern[str]]]] = {
         "patterns": [
             re.compile(r"Reference\s+Loading", re.IGNORECASE),
             re.compile(r"reference.*table", re.IGNORECASE),
+            re.compile(r"Before\s+starting\s+work", re.IGNORECASE),
+            re.compile(r"Load\s+EVERY\s+reference\s+file", re.IGNORECASE),
         ],
     },
     "M05": {
@@ -58,6 +60,8 @@ INSTRUCTIONS: dict[str, dict[str, str | list[re.Pattern[str]]]] = {
         "patterns": [
             re.compile(r"deliver\s+the\s+finished\s+product", re.IGNORECASE),
             re.compile(r"ship\s+the\s+complete\s+thing", re.IGNORECASE),
+            re.compile(r"Ship\s+the\s+complete", re.IGNORECASE),
+            re.compile(r"Deliver\s+the\s+finished", re.IGNORECASE),
         ],
     },
     "M06": {
@@ -87,28 +91,18 @@ def check_compliance(text: str) -> dict[str, bool]:
     return results
 
 
-def record_compliance(
-    instr_id: str,
-    instr_name: str,
-    compliant: bool,
+def record_compliance_batch(
+    results: dict[str, bool],
     session_id: str,
 ) -> None:
-    """Record a single instruction compliance observation to learning.db.
-
-    Each call INSERTs a new row into the instruction_compliance table.
-    Observations accumulate — they never overwrite previous entries.
+    """Record all instruction compliance observations in one transaction.
 
     Args:
-        instr_id: Instruction identifier (e.g. "M01").
-        instr_name: Human-readable instruction name (unused, kept for API compat).
-        compliant: Whether the instruction was followed.
+        results: Dict mapping instruction ID to compliance boolean.
         session_id: Current session identifier.
     """
-    record_instruction_compliance(
-        instruction_id=instr_id,
-        compliant=compliant,
-        session_id=session_id,
-    )
+    records = [(instr_id, compliant, session_id) for instr_id, compliant in results.items()]
+    record_instruction_compliance_batch(records)
 
 
 def main() -> None:
@@ -150,11 +144,9 @@ def main() -> None:
         if not combined_text.strip():
             empty_output(EVENT_NAME).print_and_exit()
 
-        # Check and record compliance for each instruction
+        # Check and record compliance for all instructions in one transaction
         results = check_compliance(combined_text)
-        for instr_id, compliant in results.items():
-            instr_name: str = INSTRUCTIONS[instr_id]["name"]  # type: ignore[assignment]
-            record_compliance(instr_id, instr_name, compliant, session_id)
+        record_compliance_batch(results, session_id)
 
         empty_output(EVENT_NAME).print_and_exit()
 

--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -795,18 +795,33 @@ def record_instruction_compliance(
     """Record a single instruction compliance observation.
 
     Each call INSERTs a new row — observations accumulate, never overwrite.
+    For multiple observations, prefer record_instruction_compliance_batch().
 
     Args:
         instruction_id: Instruction identifier (e.g. "M01").
         compliant: Whether the instruction was followed.
         session_id: Current session identifier.
     """
+    record_instruction_compliance_batch([(instruction_id, compliant, session_id)])
+
+
+def record_instruction_compliance_batch(
+    records: list[tuple[str, bool, str | None]],
+) -> None:
+    """Record multiple instruction compliance observations in one transaction.
+
+    Args:
+        records: List of (instruction_id, compliant, session_id) tuples.
+    """
+    if not records:
+        return
     init_db()
     now = datetime.now().isoformat()
+    rows = [(instr_id, compliant, sid, now) for instr_id, compliant, sid in records]
     with get_connection() as conn:
-        conn.execute(
+        conn.executemany(
             "INSERT INTO instruction_compliance (instruction_id, compliant, session_id, timestamp) VALUES (?, ?, ?, ?)",
-            (instruction_id, compliant, session_id, now),
+            rows,
         )
         conn.commit()
 

--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 _DEFAULT_DB_DIR = Path.home() / ".claude" / "learning"
 
-_CURRENT_SCHEMA_VERSION = 3
+_CURRENT_SCHEMA_VERSION = 4
 
 CATEGORY_DEFAULTS = {
     "error": 0.55,
@@ -150,6 +150,27 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
         conn.execute(
             "INSERT OR IGNORE INTO schema_migrations (version, description) "
             "VALUES (3, 'add timestamp and cohort indexes for query performance')"
+        )
+
+    if current < 4:
+        # v3 -> v4: Add instruction_compliance table for per-observation tracking
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS instruction_compliance (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                instruction_id TEXT NOT NULL,
+                compliant BOOLEAN NOT NULL,
+                session_id TEXT,
+                timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+            """
+        )
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_ic_instruction_id ON instruction_compliance(instruction_id)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_ic_timestamp ON instruction_compliance(timestamp)")
+        conn.execute("PRAGMA user_version = 4")
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version, description) "
+            "VALUES (4, 'add instruction_compliance table for per-observation tracking')"
         )
 
     conn.commit()
@@ -330,6 +351,17 @@ CREATE INDEX IF NOT EXISTS idx_gov_session   ON governance_events(session_id);
 CREATE INDEX IF NOT EXISTS idx_gov_type      ON governance_events(event_type);
 CREATE INDEX IF NOT EXISTS idx_gov_severity  ON governance_events(severity);
 CREATE INDEX IF NOT EXISTS idx_gov_created   ON governance_events(created_at);
+
+CREATE TABLE IF NOT EXISTS instruction_compliance (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    instruction_id TEXT NOT NULL,
+    compliant BOOLEAN NOT NULL,
+    session_id TEXT,
+    timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ic_instruction_id ON instruction_compliance(instruction_id);
+CREATE INDEX IF NOT EXISTS idx_ic_timestamp ON instruction_compliance(timestamp);
 
 CREATE TABLE IF NOT EXISTS schema_migrations (
     version INTEGER PRIMARY KEY,
@@ -753,6 +785,69 @@ def record_activation(
     Thin wrapper around record_activations() for single-entry convenience.
     """
     record_activations([(topic, key)], session_id, outcome)
+
+
+def record_instruction_compliance(
+    instruction_id: str,
+    compliant: bool,
+    session_id: str | None = None,
+) -> None:
+    """Record a single instruction compliance observation.
+
+    Each call INSERTs a new row — observations accumulate, never overwrite.
+
+    Args:
+        instruction_id: Instruction identifier (e.g. "M01").
+        compliant: Whether the instruction was followed.
+        session_id: Current session identifier.
+    """
+    init_db()
+    now = datetime.now().isoformat()
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT INTO instruction_compliance (instruction_id, compliant, session_id, timestamp) VALUES (?, ?, ?, ?)",
+            (instruction_id, compliant, session_id, now),
+        )
+        conn.commit()
+
+
+def query_instruction_skip_rate(days: int = 30) -> list[dict]:
+    """Query instruction compliance skip rates from the dedicated table.
+
+    Args:
+        days: Look back window in days (default 30).
+
+    Returns:
+        List of dicts with instruction_id, observations, non_compliant, skip_rate.
+    """
+    init_db()
+    with get_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT instruction_id,
+                   COUNT(*) as observations,
+                   SUM(CASE WHEN NOT compliant THEN 1 ELSE 0 END) as non_compliant
+            FROM instruction_compliance
+            WHERE timestamp > datetime('now', ?)
+            GROUP BY instruction_id
+            ORDER BY instruction_id
+            """,
+            (f"-{days} days",),
+        ).fetchall()
+        results = []
+        for row in rows:
+            obs = row["observations"]
+            nc = row["non_compliant"]
+            skip_rate = (nc / obs * 100) if obs > 0 else 0.0
+            results.append(
+                {
+                    "instruction_id": row["instruction_id"],
+                    "observations": obs,
+                    "non_compliant": nc,
+                    "skip_rate": round(skip_rate, 1),
+                }
+            )
+        return results
 
 
 def boost_confidence(topic: str, key: str, delta: float = 0.10) -> float:

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -29,6 +29,7 @@ Usage:
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --failure --reason "user re-routed"
     python3 scripts/learning-db.py backfill-routing-outcomes
     python3 scripts/learning-db.py route-health
+    python3 scripts/learning-db.py skip-rate [--json] [--include-test]
 """
 
 import argparse
@@ -689,6 +690,102 @@ def cmd_backfill_routing_outcomes(args: argparse.Namespace) -> None:
     print(f"  Unchanged: {unchanged}")
 
 
+def cmd_skip_rate(args: argparse.Namespace) -> None:
+    """Display instruction skip-rate report from compliance observations.
+
+    Queries learning.db for instruction-compliance entries and computes
+    skip rate per instruction. Flags instructions with >20% skip rate
+    over 30+ observations for conversion to programmatic gates.
+    """
+    init_db()
+    results = query_learnings(
+        topic="instruction-compliance",
+        category="effectiveness",
+        min_confidence=0.0,
+        limit=10000,
+        exclude_graduated=False,
+        exclude_test_sources=not args.include_test,
+    )
+
+    if not results:
+        print("No instruction compliance data found. Run sessions to collect data.")
+        return
+
+    # Group observations by instruction ID
+    instruction_stats: dict[str, dict[str, int | str]] = {}
+    for r in results:
+        key = r["key"]  # e.g. "M01:phase-banners"
+        parts = key.split(":", 1)
+        instr_id = parts[0] if parts else key
+        instr_name = parts[1].replace("-", " ").title() if len(parts) > 1 else key
+
+        if instr_id not in instruction_stats:
+            instruction_stats[instr_id] = {
+                "name": instr_name,
+                "total": 0,
+                "non_compliant": 0,
+            }
+
+        # Each observation_count increment = 1 check. Count non-compliant from value.
+        obs_count = r.get("observation_count", 1)
+        instruction_stats[instr_id]["total"] = obs_count  # type: ignore[assignment]
+
+        # Check latest value for compliance status
+        value = r.get("value", "")
+        if "compliant=False" in value:
+            instruction_stats[instr_id]["non_compliant"] = obs_count  # type: ignore[assignment]
+
+    if args.json:
+        report = []
+        for instr_id in sorted(instruction_stats):
+            stats = instruction_stats[instr_id]
+            total = int(stats["total"])
+            non_compliant = int(stats["non_compliant"])
+            skip_rate = (non_compliant / total * 100) if total > 0 else 0.0
+            report.append(
+                {
+                    "id": instr_id,
+                    "name": stats["name"],
+                    "observations": total,
+                    "non_compliant": non_compliant,
+                    "skip_rate": round(skip_rate, 1),
+                    "status": "CONVERT_TO_GATE" if skip_rate > 20 and total >= 30 else "OK",
+                }
+            )
+        print(json.dumps(report, indent=2))
+        return
+
+    # Human-readable output
+    print("Instruction Skip Rate Report")
+    print("=" * 72)
+    print(f"{'ID':<6}{'Instruction':<22}{'Observations':>14}{'Skip Rate':>12}{'Status':>18}")
+    print("-" * 72)
+
+    for instr_id in sorted(instruction_stats):
+        stats = instruction_stats[instr_id]
+        total = int(stats["total"])
+        non_compliant = int(stats["non_compliant"])
+        skip_rate = (non_compliant / total * 100) if total > 0 else 0.0
+
+        if skip_rate > 20 and total >= 30:
+            status = "CONVERT TO GATE"
+        else:
+            status = "OK"
+
+        print(f"{instr_id:<6}{stats['name']:<22}{total:>14}{skip_rate:>11.1f}%{status:>17}")
+
+    print("-" * 72)
+    flagged = sum(
+        1
+        for s in instruction_stats.values()
+        if int(s["non_compliant"]) / max(int(s["total"]), 1) * 100 > 20 and int(s["total"]) >= 30
+    )
+    if flagged:
+        print(f"{flagged} instruction(s) flagged for conversion to programmatic gates (>20% skip, 30+ obs)")
+    else:
+        print("No instructions flagged. Threshold: >20% skip rate over 30+ observations.")
+
+
 def cmd_route_health(args: argparse.Namespace) -> None:
     """Display a quick health summary of routing entries."""
     init_db()
@@ -1006,6 +1103,12 @@ def main():
         "backfill-routing-outcomes", help="Retroactively score routing entries from existing data"
     )
     p_backfill.set_defaults(func=cmd_backfill_routing_outcomes)
+
+    # skip-rate
+    p_skip_rate = subparsers.add_parser("skip-rate", help="Show instruction skip-rate report")
+    p_skip_rate.add_argument("--json", action="store_true", help="Output as JSON")
+    p_skip_rate.add_argument("--include-test", action="store_true", help="Include test-source entries in report")
+    p_skip_rate.set_defaults(func=cmd_skip_rate)
 
     # route-health
     p_route_health = subparsers.add_parser("route-health", help="Quick routing feedback loop health check")

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -60,6 +60,7 @@ from learning_db_v2 import (
     init_db,
     mark_graduated,
     prune,
+    query_instruction_skip_rate,
     query_learnings,
     record_learning,
     search_learnings,
@@ -691,65 +692,41 @@ def cmd_backfill_routing_outcomes(args: argparse.Namespace) -> None:
 
 
 def cmd_skip_rate(args: argparse.Namespace) -> None:
-    """Display instruction skip-rate report from compliance observations.
+    """Display instruction skip-rate report from the instruction_compliance table.
 
-    Queries learning.db for instruction-compliance entries and computes
-    skip rate per instruction. Flags instructions with >20% skip rate
-    over 30+ observations for conversion to programmatic gates.
+    Queries the dedicated instruction_compliance table for per-observation
+    data and computes skip rate per instruction. Flags instructions with
+    >20% skip rate over 30+ observations for conversion to programmatic gates.
     """
     init_db()
-    results = query_learnings(
-        topic="instruction-compliance",
-        category="effectiveness",
-        min_confidence=0.0,
-        limit=10000,
-        exclude_graduated=False,
-        exclude_test_sources=not args.include_test,
-    )
+
+    # Instruction ID -> human-readable name mapping
+    instr_names: dict[str, str] = {
+        "M01": "Phase Banners",
+        "M03": "Routing Decision",
+        "M04": "Reference Loading",
+        "M05": "Completeness",
+        "M06": "Density Standard",
+    }
+
+    results = query_instruction_skip_rate(days=30)
 
     if not results:
         print("No instruction compliance data found. Run sessions to collect data.")
         return
 
-    # Group observations by instruction ID
-    instruction_stats: dict[str, dict[str, int | str]] = {}
-    for r in results:
-        key = r["key"]  # e.g. "M01:phase-banners"
-        parts = key.split(":", 1)
-        instr_id = parts[0] if parts else key
-        instr_name = parts[1].replace("-", " ").title() if len(parts) > 1 else key
-
-        if instr_id not in instruction_stats:
-            instruction_stats[instr_id] = {
-                "name": instr_name,
-                "total": 0,
-                "non_compliant": 0,
-            }
-
-        # Each observation_count increment = 1 check. Count non-compliant from value.
-        obs_count = r.get("observation_count", 1)
-        instruction_stats[instr_id]["total"] = obs_count  # type: ignore[assignment]
-
-        # Check latest value for compliance status
-        value = r.get("value", "")
-        if "compliant=False" in value:
-            instruction_stats[instr_id]["non_compliant"] = obs_count  # type: ignore[assignment]
-
     if args.json:
         report = []
-        for instr_id in sorted(instruction_stats):
-            stats = instruction_stats[instr_id]
-            total = int(stats["total"])
-            non_compliant = int(stats["non_compliant"])
-            skip_rate = (non_compliant / total * 100) if total > 0 else 0.0
+        for r in results:
+            instr_id = r["instruction_id"]
             report.append(
                 {
                     "id": instr_id,
-                    "name": stats["name"],
-                    "observations": total,
-                    "non_compliant": non_compliant,
-                    "skip_rate": round(skip_rate, 1),
-                    "status": "CONVERT_TO_GATE" if skip_rate > 20 and total >= 30 else "OK",
+                    "name": instr_names.get(instr_id, instr_id),
+                    "observations": r["observations"],
+                    "non_compliant": r["non_compliant"],
+                    "skip_rate": r["skip_rate"],
+                    "status": "CONVERT_TO_GATE" if r["skip_rate"] > 20 and r["observations"] >= 30 else "OK",
                 }
             )
         print(json.dumps(report, indent=2))
@@ -761,25 +738,20 @@ def cmd_skip_rate(args: argparse.Namespace) -> None:
     print(f"{'ID':<6}{'Instruction':<22}{'Observations':>14}{'Skip Rate':>12}{'Status':>18}")
     print("-" * 72)
 
-    for instr_id in sorted(instruction_stats):
-        stats = instruction_stats[instr_id]
-        total = int(stats["total"])
-        non_compliant = int(stats["non_compliant"])
-        skip_rate = (non_compliant / total * 100) if total > 0 else 0.0
+    for r in results:
+        instr_id = r["instruction_id"]
+        name = instr_names.get(instr_id, instr_id)
+        skip_rate = r["skip_rate"]
 
-        if skip_rate > 20 and total >= 30:
+        if skip_rate > 20 and r["observations"] >= 30:
             status = "CONVERT TO GATE"
         else:
             status = "OK"
 
-        print(f"{instr_id:<6}{stats['name']:<22}{total:>14}{skip_rate:>11.1f}%{status:>17}")
+        print(f"{instr_id:<6}{name:<22}{r['observations']:>14}{skip_rate:>11.1f}%{status:>17}")
 
     print("-" * 72)
-    flagged = sum(
-        1
-        for s in instruction_stats.values()
-        if int(s["non_compliant"]) / max(int(s["total"]), 1) * 100 > 20 and int(s["total"]) >= 30
-    )
+    flagged = sum(1 for r in results if r["skip_rate"] > 20 and r["observations"] >= 30)
     if flagged:
         print(f"{flagged} instruction(s) flagged for conversion to programmatic gates (>20% skip, 30+ obs)")
     else:
@@ -1107,7 +1079,7 @@ def main():
     # skip-rate
     p_skip_rate = subparsers.add_parser("skip-rate", help="Show instruction skip-rate report")
     p_skip_rate.add_argument("--json", action="store_true", help="Output as JSON")
-    p_skip_rate.add_argument("--include-test", action="store_true", help="Include test-source entries in report")
+    p_skip_rate.add_argument("--include-test", action="store_true", help="Ignored (kept for backward compat)")
     p_skip_rate.set_defaults(func=cmd_skip_rate)
 
     # route-health

--- a/scripts/tests/test_instruction_compliance.py
+++ b/scripts/tests/test_instruction_compliance.py
@@ -9,6 +9,7 @@ Covers:
 - Multiple instructions in single output
 - Empty/malformed input graceful handling
 - skip-rate command formatted output
+- Accurate skip-rate calculation across multiple observations
 """
 
 import importlib.util
@@ -168,30 +169,24 @@ class TestCheckCompliance:
 
 
 class TestRecordCompliance:
-    """Test compliance recording to learning.db."""
+    """Test compliance recording to instruction_compliance table."""
 
     def test_record_compliant(self, tmp_path: Path) -> None:
-        """Recording a compliant observation calls record_learning correctly."""
+        """Recording a compliant observation inserts into instruction_compliance."""
         with patch.dict(os.environ, {"CLAUDE_LEARNING_DIR": str(tmp_path)}):
-            # Reset init state
             import learning_db_v2
 
             learning_db_v2._initialized = False
 
             record_compliance("M01", "Phase Banners", True, "test-session-123")
 
-            # Verify it was recorded
-            from learning_db_v2 import query_learnings
+            from learning_db_v2 import get_connection
 
-            results = query_learnings(
-                topic="instruction-compliance",
-                min_confidence=0.0,
-                exclude_test_sources=False,
-            )
-            assert len(results) >= 1
-            entry = results[0]
-            assert entry["key"] == "M01:phase-banners"
-            assert "compliant=True" in entry["value"]
+            with get_connection() as conn:
+                rows = conn.execute("SELECT * FROM instruction_compliance WHERE instruction_id = 'M01'").fetchall()
+                assert len(rows) == 1
+                assert rows[0]["compliant"] == 1  # SQLite stores True as 1
+                assert rows[0]["session_id"] == "test-session-123"
 
     def test_record_non_compliant(self, tmp_path: Path) -> None:
         """Recording a non-compliant observation."""
@@ -202,16 +197,29 @@ class TestRecordCompliance:
 
             record_compliance("M01", "Phase Banners", False, "test-session-456")
 
-            from learning_db_v2 import query_learnings
+            from learning_db_v2 import get_connection
 
-            results = query_learnings(
-                topic="instruction-compliance",
-                min_confidence=0.0,
-                exclude_test_sources=False,
-            )
-            assert len(results) >= 1
-            entry = results[0]
-            assert "compliant=False" in entry["value"]
+            with get_connection() as conn:
+                rows = conn.execute("SELECT * FROM instruction_compliance WHERE instruction_id = 'M01'").fetchall()
+                assert len(rows) == 1
+                assert rows[0]["compliant"] == 0  # SQLite stores False as 0
+
+    def test_observations_accumulate(self, tmp_path: Path) -> None:
+        """Multiple calls INSERT separate rows — never overwrite."""
+        with patch.dict(os.environ, {"CLAUDE_LEARNING_DIR": str(tmp_path)}):
+            import learning_db_v2
+
+            learning_db_v2._initialized = False
+
+            record_compliance("M01", "Phase Banners", True, "s1")
+            record_compliance("M01", "Phase Banners", False, "s2")
+            record_compliance("M01", "Phase Banners", True, "s3")
+
+            from learning_db_v2 import get_connection
+
+            with get_connection() as conn:
+                rows = conn.execute("SELECT * FROM instruction_compliance WHERE instruction_id = 'M01'").fetchall()
+                assert len(rows) == 3
 
 
 # ─── Hook stdin integration tests ────────────────────────────────
@@ -284,7 +292,7 @@ class TestSkipRateCommand:
         return subprocess.run(cmd, capture_output=True, text=True, timeout=10, env=env)
 
     def _seed_compliance_data(self, tmp_dir: str) -> None:
-        """Seed learning.db with test compliance records."""
+        """Seed instruction_compliance table with test observations."""
         with patch.dict(os.environ, {"CLAUDE_LEARNING_DIR": tmp_dir}):
             import learning_db_v2
 
@@ -299,14 +307,14 @@ class TestSkipRateCommand:
 
     def test_no_data_message(self, tmp_path: Path) -> None:
         """No compliance data -> informative message."""
-        result = self._run_skip_rate(str(tmp_path), ["--include-test"])
+        result = self._run_skip_rate(str(tmp_path))
         assert result.returncode == 0
         assert "No instruction compliance data found" in result.stdout
 
     def test_formatted_output(self, tmp_path: Path) -> None:
         """With data, produces formatted table."""
         self._seed_compliance_data(str(tmp_path))
-        result = self._run_skip_rate(str(tmp_path), ["--include-test"])
+        result = self._run_skip_rate(str(tmp_path))
         assert result.returncode == 0
         assert "Instruction Skip Rate Report" in result.stdout
         assert "M01" in result.stdout
@@ -314,10 +322,33 @@ class TestSkipRateCommand:
     def test_json_output(self, tmp_path: Path) -> None:
         """--json flag produces valid JSON."""
         self._seed_compliance_data(str(tmp_path))
-        result = self._run_skip_rate(str(tmp_path), ["--json", "--include-test"])
+        result = self._run_skip_rate(str(tmp_path), ["--json"])
         assert result.returncode == 0
         data = json.loads(result.stdout)
         assert isinstance(data, list)
         assert len(data) > 0
         assert "id" in data[0]
         assert "skip_rate" in data[0]
+
+    def test_skip_rate_40_percent(self, tmp_path: Path) -> None:
+        """3 compliant + 2 non-compliant for M01 -> 40% skip rate."""
+        with patch.dict(os.environ, {"CLAUDE_LEARNING_DIR": str(tmp_path)}):
+            import learning_db_v2
+
+            learning_db_v2._initialized = False
+
+            # 3 compliant
+            record_compliance("M01", "Phase Banners", True, "s1")
+            record_compliance("M01", "Phase Banners", True, "s2")
+            record_compliance("M01", "Phase Banners", True, "s3")
+            # 2 non-compliant
+            record_compliance("M01", "Phase Banners", False, "s4")
+            record_compliance("M01", "Phase Banners", False, "s5")
+
+        result = self._run_skip_rate(str(tmp_path), ["--json"])
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        m01 = next(r for r in data if r["id"] == "M01")
+        assert m01["observations"] == 5
+        assert m01["non_compliant"] == 2
+        assert m01["skip_rate"] == 40.0

--- a/scripts/tests/test_instruction_compliance.py
+++ b/scripts/tests/test_instruction_compliance.py
@@ -258,9 +258,14 @@ class TestRecordCompliance:
     def test_batch_recording(self, tmp_path: Path) -> None:
         """Batch recording inserts all results in one transaction."""
         with patch.dict(os.environ, {"CLAUDE_LEARNING_DIR": str(tmp_path)}):
+            # Reset _initialized on ALL module references (hook's import + test's import)
             import learning_db_v2
 
             learning_db_v2._initialized = False
+            # Also reset via sys.modules to catch any aliased imports
+            for mod in sys.modules.values():
+                if hasattr(mod, "_initialized") and hasattr(mod, "record_instruction_compliance_batch"):
+                    mod._initialized = False
 
             results = {"M01": True, "M03": False, "M04": True, "M05": False, "M06": True}
             record_compliance_batch(results, "batch-session")

--- a/scripts/tests/test_instruction_compliance.py
+++ b/scripts/tests/test_instruction_compliance.py
@@ -32,8 +32,16 @@ _module = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_module)
 
 check_compliance = _module.check_compliance
-record_compliance = _module.record_compliance
+record_compliance_batch = _module.record_compliance_batch
 INSTRUCTIONS = _module.INSTRUCTIONS
+
+
+def record_compliance(instr_id: str, instr_name: str, compliant: bool, session_id: str) -> None:
+    """Thin wrapper for tests: single-observation convenience using batch API."""
+    from learning_db_v2 import record_instruction_compliance
+
+    record_instruction_compliance(instruction_id=instr_id, compliant=compliant, session_id=session_id)
+
 
 # ─── check_compliance unit tests ──────────────────────────────────
 
@@ -60,10 +68,22 @@ class TestCheckCompliance:
         assert results["M01"] is False
 
     def test_m03_routing_decision_compliant_equals(self) -> None:
-        """Triple equals separator signals routing table."""
+        """Triple equals on standalone line signals routing table."""
         text = "===\nAgent: golang-general-engineer\nSkill: go-patterns\n==="
         results = check_compliance(text)
         assert results["M03"] is True
+
+    def test_m03_no_false_positive_js_strict_equals(self) -> None:
+        """JS === operator must NOT trigger M03 (false positive guard)."""
+        text = "if (value === 'test') { return true; }"
+        results = check_compliance(text)
+        assert results["M03"] is False
+
+    def test_m03_no_false_positive_markdown_separator(self) -> None:
+        """Inline markdown === must NOT trigger M03 when not standalone."""
+        text = "Some heading\n===continued text"
+        results = check_compliance(text)
+        assert results["M03"] is False
 
     def test_m03_routing_decision_compliant_keyword(self) -> None:
         """ROUTING: keyword signals routing decision."""
@@ -92,6 +112,18 @@ class TestCheckCompliance:
     def test_m04_reference_loading_table_variant(self) -> None:
         """Reference table variant also detected."""
         text = "Loaded reference table entries for error patterns."
+        results = check_compliance(text)
+        assert results["M04"] is True
+
+    def test_m04_before_starting_work_variant(self) -> None:
+        """'Before starting work' prompt injection marker -> M04 compliant."""
+        text = "Before starting work, read your agent .md file to find the Reference Loading Table."
+        results = check_compliance(text)
+        assert results["M04"] is True
+
+    def test_m04_load_every_reference_variant(self) -> None:
+        """'Load EVERY reference file' prompt marker -> M04 compliant."""
+        text = "Load EVERY reference file whose signal matches this task."
         results = check_compliance(text)
         assert results["M04"] is True
 
@@ -141,7 +173,9 @@ class TestCheckCompliance:
         """Multiple instructions detected in single output."""
         text = (
             "## Phase 1: Analysis\n"
-            "===\nROUTING: python-general-engineer\n===\n"
+            "===\n"
+            "ROUTING: python-general-engineer\n"
+            "===\n"
             "Reference Loading Table checked.\n"
             "Deliver the finished product.\n"
             "Write dense.\n"
@@ -220,6 +254,24 @@ class TestRecordCompliance:
             with get_connection() as conn:
                 rows = conn.execute("SELECT * FROM instruction_compliance WHERE instruction_id = 'M01'").fetchall()
                 assert len(rows) == 3
+
+    def test_batch_recording(self, tmp_path: Path) -> None:
+        """Batch recording inserts all results in one transaction."""
+        with patch.dict(os.environ, {"CLAUDE_LEARNING_DIR": str(tmp_path)}):
+            import learning_db_v2
+
+            learning_db_v2._initialized = False
+
+            results = {"M01": True, "M03": False, "M04": True, "M05": False, "M06": True}
+            record_compliance_batch(results, "batch-session")
+
+            from learning_db_v2 import get_connection
+
+            with get_connection() as conn:
+                rows = conn.execute("SELECT * FROM instruction_compliance").fetchall()
+                assert len(rows) == 5
+                ids = {r["instruction_id"] for r in rows}
+                assert ids == {"M01", "M03", "M04", "M05", "M06"}
 
 
 # ─── Hook stdin integration tests ────────────────────────────────

--- a/scripts/tests/test_instruction_compliance.py
+++ b/scripts/tests/test_instruction_compliance.py
@@ -258,21 +258,16 @@ class TestRecordCompliance:
     def test_batch_recording(self, tmp_path: Path) -> None:
         """Batch recording inserts all results in one transaction."""
         with patch.dict(os.environ, {"CLAUDE_LEARNING_DIR": str(tmp_path)}):
-            # Reset _initialized on ALL module references (hook's import + test's import)
             import learning_db_v2
 
+            # Force full re-initialization in the temp directory
             learning_db_v2._initialized = False
-            # Also reset via sys.modules to catch any aliased imports
-            for mod in sys.modules.values():
-                if hasattr(mod, "_initialized") and hasattr(mod, "record_instruction_compliance_batch"):
-                    mod._initialized = False
+            learning_db_v2.init_db()
 
             results = {"M01": True, "M03": False, "M04": True, "M05": False, "M06": True}
             record_compliance_batch(results, "batch-session")
 
-            from learning_db_v2 import get_connection
-
-            with get_connection() as conn:
+            with learning_db_v2.get_connection() as conn:
                 rows = conn.execute("SELECT * FROM instruction_compliance").fetchall()
                 assert len(rows) == 5
                 ids = {r["instruction_id"] for r in rows}

--- a/scripts/tests/test_instruction_compliance.py
+++ b/scripts/tests/test_instruction_compliance.py
@@ -1,0 +1,323 @@
+"""Tests for instruction compliance hook and skip-rate dashboard command.
+
+Covers:
+- M01 phase banner detection (compliant and non-compliant)
+- M03 routing decision detection
+- M04 reference loading detection
+- M05 completeness standard detection
+- M06 density standard detection
+- Multiple instructions in single output
+- Empty/malformed input graceful handling
+- skip-rate command formatted output
+"""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Add hooks/lib to path for learning_db_v2 imports
+_repo_root = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(_repo_root / "hooks" / "lib"))
+
+# Import hook module with hyphenated filename via importlib
+_hook_path = _repo_root / "hooks" / "instruction-compliance.py"
+_spec = importlib.util.spec_from_file_location("instruction_compliance", _hook_path)
+assert _spec is not None and _spec.loader is not None
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+check_compliance = _module.check_compliance
+record_compliance = _module.record_compliance
+INSTRUCTIONS = _module.INSTRUCTIONS
+
+# ─── check_compliance unit tests ──────────────────────────────────
+
+
+class TestCheckCompliance:
+    """Test compliance detection for each instruction."""
+
+    def test_m01_phase_banner_compliant(self) -> None:
+        """Agent output with phase banners -> M01 compliant."""
+        text = "## Phase 1: Understanding\nSome content\n## Phase 2: Implementation"
+        results = check_compliance(text)
+        assert results["M01"] is True
+
+    def test_m01_phase_banner_variant(self) -> None:
+        """Phase N: variant also detected."""
+        text = "Phase 1: Analysis\nPhase 2: Build"
+        results = check_compliance(text)
+        assert results["M01"] is True
+
+    def test_m01_phase_banner_non_compliant(self) -> None:
+        """Agent output WITHOUT phase banners -> M01 non-compliant."""
+        text = "I analyzed the code and made changes. The tests pass now."
+        results = check_compliance(text)
+        assert results["M01"] is False
+
+    def test_m03_routing_decision_compliant_equals(self) -> None:
+        """Triple equals separator signals routing table."""
+        text = "===\nAgent: golang-general-engineer\nSkill: go-patterns\n==="
+        results = check_compliance(text)
+        assert results["M03"] is True
+
+    def test_m03_routing_decision_compliant_keyword(self) -> None:
+        """ROUTING: keyword signals routing decision."""
+        text = "ROUTING: golang-general-engineer -> go-patterns"
+        results = check_compliance(text)
+        assert results["M03"] is True
+
+    def test_m03_routing_decision_compliant_selected(self) -> None:
+        """Selected: keyword signals routing decision."""
+        text = "Selected: python-general-engineer with quick skill"
+        results = check_compliance(text)
+        assert results["M03"] is True
+
+    def test_m03_routing_decision_non_compliant(self) -> None:
+        """No routing markers -> M03 non-compliant."""
+        text = "I'll help you with that Go code refactoring."
+        results = check_compliance(text)
+        assert results["M03"] is False
+
+    def test_m04_reference_loading_compliant(self) -> None:
+        """Reference Loading mention -> M04 compliant."""
+        text = "Check the Reference Loading Table for signals matching this task."
+        results = check_compliance(text)
+        assert results["M04"] is True
+
+    def test_m04_reference_loading_table_variant(self) -> None:
+        """Reference table variant also detected."""
+        text = "Loaded reference table entries for error patterns."
+        results = check_compliance(text)
+        assert results["M04"] is True
+
+    def test_m04_reference_loading_non_compliant(self) -> None:
+        """No reference loading mention -> M04 non-compliant."""
+        text = "I read the file and fixed the bug."
+        results = check_compliance(text)
+        assert results["M04"] is False
+
+    def test_m05_completeness_compliant(self) -> None:
+        """'deliver the finished product' -> M05 compliant."""
+        text = "Your task: deliver the finished product. No partial work."
+        results = check_compliance(text)
+        assert results["M05"] is True
+
+    def test_m05_completeness_ship_variant(self) -> None:
+        """'ship the complete thing' variant also detected."""
+        text = "Ship the complete thing before reporting done."
+        results = check_compliance(text)
+        assert results["M05"] is True
+
+    def test_m05_completeness_non_compliant(self) -> None:
+        """No completeness signal -> M05 non-compliant."""
+        text = "Here's the implementation you requested."
+        results = check_compliance(text)
+        assert results["M05"] is False
+
+    def test_m06_density_compliant(self) -> None:
+        """'write dense' -> M06 compliant."""
+        text = "Write dense. Cut filler. Prefer tables over paragraphs."
+        results = check_compliance(text)
+        assert results["M06"] is True
+
+    def test_m06_density_variant(self) -> None:
+        """'high fidelity, minimum words' variant also detected."""
+        text = "High fidelity, minimum words. Report what changed."
+        results = check_compliance(text)
+        assert results["M06"] is True
+
+    def test_m06_density_non_compliant(self) -> None:
+        """No density signal -> M06 non-compliant."""
+        text = "Let me provide a detailed explanation of every change."
+        results = check_compliance(text)
+        assert results["M06"] is False
+
+    def test_multiple_instructions_single_output(self) -> None:
+        """Multiple instructions detected in single output."""
+        text = (
+            "## Phase 1: Analysis\n"
+            "===\nROUTING: python-general-engineer\n===\n"
+            "Reference Loading Table checked.\n"
+            "Deliver the finished product.\n"
+            "Write dense.\n"
+        )
+        results = check_compliance(text)
+        assert results["M01"] is True
+        assert results["M03"] is True
+        assert results["M04"] is True
+        assert results["M05"] is True
+        assert results["M06"] is True
+
+    def test_empty_text(self) -> None:
+        """Empty text -> all non-compliant."""
+        results = check_compliance("")
+        assert all(v is False for v in results.values())
+
+    def test_all_instruction_ids_present(self) -> None:
+        """All 5 instrumented instructions are checked."""
+        results = check_compliance("anything")
+        expected_ids = {"M01", "M03", "M04", "M05", "M06"}
+        assert set(results.keys()) == expected_ids
+
+
+# ─── record_compliance unit tests ────────────────────────────────
+
+
+class TestRecordCompliance:
+    """Test compliance recording to learning.db."""
+
+    def test_record_compliant(self, tmp_path: Path) -> None:
+        """Recording a compliant observation calls record_learning correctly."""
+        with patch.dict(os.environ, {"CLAUDE_LEARNING_DIR": str(tmp_path)}):
+            # Reset init state
+            import learning_db_v2
+
+            learning_db_v2._initialized = False
+
+            record_compliance("M01", "Phase Banners", True, "test-session-123")
+
+            # Verify it was recorded
+            from learning_db_v2 import query_learnings
+
+            results = query_learnings(
+                topic="instruction-compliance",
+                min_confidence=0.0,
+                exclude_test_sources=False,
+            )
+            assert len(results) >= 1
+            entry = results[0]
+            assert entry["key"] == "M01:phase-banners"
+            assert "compliant=True" in entry["value"]
+
+    def test_record_non_compliant(self, tmp_path: Path) -> None:
+        """Recording a non-compliant observation."""
+        with patch.dict(os.environ, {"CLAUDE_LEARNING_DIR": str(tmp_path)}):
+            import learning_db_v2
+
+            learning_db_v2._initialized = False
+
+            record_compliance("M01", "Phase Banners", False, "test-session-456")
+
+            from learning_db_v2 import query_learnings
+
+            results = query_learnings(
+                topic="instruction-compliance",
+                min_confidence=0.0,
+                exclude_test_sources=False,
+            )
+            assert len(results) >= 1
+            entry = results[0]
+            assert "compliant=False" in entry["value"]
+
+
+# ─── Hook stdin integration tests ────────────────────────────────
+
+
+class TestHookIntegration:
+    """Test the hook script end-to-end via subprocess."""
+
+    def _run_hook(self, stdin_data: str, tmp_dir: str) -> subprocess.CompletedProcess[str]:
+        """Run the hook script with given stdin."""
+        hook_path = _repo_root / "hooks" / "instruction-compliance.py"
+        env = {
+            **os.environ,
+            "CLAUDE_LEARNING_DIR": tmp_dir,
+            "PYTHONPATH": str(_repo_root / "hooks" / "lib"),
+        }
+        return subprocess.run(
+            [sys.executable, str(hook_path)],
+            input=stdin_data,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+
+    def test_empty_stdin_exits_zero(self, tmp_path: Path) -> None:
+        """Empty stdin -> graceful exit 0."""
+        result = self._run_hook("", str(tmp_path))
+        assert result.returncode == 0
+
+    def test_malformed_json_exits_zero(self, tmp_path: Path) -> None:
+        """Malformed JSON -> graceful exit 0, no crash."""
+        result = self._run_hook("not json at all", str(tmp_path))
+        assert result.returncode == 0
+
+    def test_valid_agent_output_records(self, tmp_path: Path) -> None:
+        """Valid agent output with phase banners records compliance."""
+        event = {
+            "tool_name": "Agent",
+            "tool_result": {"output": "## Phase 1: Analysis\nRouting: selected agent\n"},
+            "tool_input": "Write dense. Deliver the finished product.",
+        }
+        result = self._run_hook(json.dumps(event), str(tmp_path))
+        assert result.returncode == 0
+
+    def test_empty_tool_result_exits_zero(self, tmp_path: Path) -> None:
+        """Event with empty tool result -> graceful exit 0."""
+        event = {"tool_name": "Agent", "tool_result": {}}
+        result = self._run_hook(json.dumps(event), str(tmp_path))
+        assert result.returncode == 0
+
+
+# ─── skip-rate command tests ─────────────────────────────────────
+
+
+class TestSkipRateCommand:
+    """Test the skip-rate dashboard command."""
+
+    def _run_skip_rate(self, tmp_dir: str, extra_args: list[str] | None = None) -> subprocess.CompletedProcess[str]:
+        """Run the skip-rate command."""
+        script_path = _repo_root / "scripts" / "learning-db.py"
+        cmd = [sys.executable, str(script_path), "skip-rate"]
+        if extra_args:
+            cmd.extend(extra_args)
+        env = {
+            **os.environ,
+            "CLAUDE_LEARNING_DIR": tmp_dir,
+            "PYTHONPATH": str(_repo_root / "hooks" / "lib"),
+        }
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=10, env=env)
+
+    def _seed_compliance_data(self, tmp_dir: str) -> None:
+        """Seed learning.db with test compliance records."""
+        with patch.dict(os.environ, {"CLAUDE_LEARNING_DIR": tmp_dir}):
+            import learning_db_v2
+
+            learning_db_v2._initialized = False
+
+            # Record some compliant and non-compliant observations
+            record_compliance("M01", "Phase Banners", True, "seed-session")
+            record_compliance("M03", "Routing Decision", True, "seed-session")
+            record_compliance("M04", "Reference Loading", False, "seed-session")
+            record_compliance("M05", "Completeness", False, "seed-session")
+            record_compliance("M06", "Density Standard", True, "seed-session")
+
+    def test_no_data_message(self, tmp_path: Path) -> None:
+        """No compliance data -> informative message."""
+        result = self._run_skip_rate(str(tmp_path), ["--include-test"])
+        assert result.returncode == 0
+        assert "No instruction compliance data found" in result.stdout
+
+    def test_formatted_output(self, tmp_path: Path) -> None:
+        """With data, produces formatted table."""
+        self._seed_compliance_data(str(tmp_path))
+        result = self._run_skip_rate(str(tmp_path), ["--include-test"])
+        assert result.returncode == 0
+        assert "Instruction Skip Rate Report" in result.stdout
+        assert "M01" in result.stdout
+
+    def test_json_output(self, tmp_path: Path) -> None:
+        """--json flag produces valid JSON."""
+        self._seed_compliance_data(str(tmp_path))
+        result = self._run_skip_rate(str(tmp_path), ["--json", "--include-test"])
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        assert "id" in data[0]
+        assert "skip_rate" in data[0]

--- a/skills/content/wordpress-live-validation/SKILL.md
+++ b/skills/content/wordpress-live-validation/SKILL.md
@@ -108,7 +108,7 @@ See `references/phase-checks.md` "Phase 1: NAVIGATE — Detailed Steps" for the 
 
 ### Phase 2: VALIDATE
 
-> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
 
 **Goal**: Inspect rendered DOM and network activity for content integrity and SEO completeness. Run all checks without stopping on individual failures.
 

--- a/skills/infrastructure/endpoint-validator/SKILL.md
+++ b/skills/infrastructure/endpoint-validator/SKILL.md
@@ -89,7 +89,7 @@ Make a single request to `base_url` before running the full suite. If unreachabl
 
 ### Phase 2: VALIDATE
 
-> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
 
 **Goal**: Test each endpoint against its expected criteria and collect structured results.
 

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -92,7 +92,7 @@ Read and follow the repository CLAUDE.md before making any routing decision, bec
 
 **Trivial = reading a file the user named by exact path.** Everything else is Simple+ and MUST route. When uncertain, classify UP.
 
-**Opus 4.7 override:** The model defaults to fewer subagents and more direct handling. That default is wrong here. /do is a delegation machine. Classify Simple+ tasks to agents without reasoning about whether you could handle them directly. Anything beyond reading a user-named file MUST route.
+**Delegation is mandatory.** /do is a delegation machine. Classify Simple+ tasks to agents without reasoning about whether you could handle them directly. Anything beyond reading a user-named file MUST route.
 
 **Progressive Depth**: For ambiguous complexity, start shallow and let the agent escalate. See `references/progressive-depth.md`.
 
@@ -102,7 +102,7 @@ Read and follow the repository CLAUDE.md before making any routing decision, bec
 
 **Check for parallel patterns FIRST**: 2+ independent failures or 3+ subtasks → `dispatching-parallel-agents`; broad research → `research-coordinator-engineer`; multi-agent coordination → `project-coordinator-engineer`; plan + "execute" → `subagent-driven-development`; new feature → `feature-lifecycle` (check `.feature/` directory; if present, run `feature-state.py status`).
 
-**Opus 4.7 parallel override:** When the router detects 2+ independent items, dispatch all in parallel in a single message. Do not consolidate into one agent — that is the model's default and it is wrong here.
+**Parallel dispatch is mandatory.** When the router detects 2+ independent items, dispatch all in parallel in a single message. Do not consolidate into one agent.
 
 **Optional: Force Direct** — OFF by default. Only applies when user explicitly requests it.
 
@@ -293,7 +293,7 @@ Does NOT apply when: Trivial/Simple (use `quick`), review-only/research/debuggin
 
 Dispatch the agent. MCP tool discovery is the agent's responsibility — do not inject MCP instructions from /do.
 
-**Opus 4.7: Prepend Task Specification for Medium+ tasks.** The router has upstream context the agent lacks. Compose and prepend this block. For Simple tasks, include Intent and Acceptance if extractable. Do not invent criteria or expand scope.
+**Prepend Task Specification for Medium+ tasks.** The router has upstream context the agent lacks. Compose and prepend this block. For Simple tasks, include Intent and Acceptance if extractable. Do not invent criteria or expand scope.
 
 ```
 ## Task Specification (auto-extracted)
@@ -313,7 +313,7 @@ Extraction: Intent from verb+object. Constraints include branch safety (never me
 
 **MANDATORY: Inject density standard for ALL Simple+ dispatches.** Every agent prompt MUST include: "Write dense: high fidelity, minimum words. Cut filler, prefer tables over paragraphs, report what changed — not how."
 
-**Opus 4.7: Inject thinking directive.** Prepend verbatim, no framing:
+**Inject thinking directive.** Prepend verbatim, no framing:
 
 | Complexity | Thinking Directive |
 |---|---|

--- a/skills/meta/do/references/quality-loop.md
+++ b/skills/meta/do/references/quality-loop.md
@@ -97,7 +97,7 @@ This artifact is read by PHASE 5 (intent verification), PHASE 7 (fix agent selec
 
 ### PHASE 3 — TEST
 
-> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
 
 Run deterministic test suite. Language auto-detected from changed files.
 
@@ -135,7 +135,7 @@ Each reviewer produces findings as:
 
 ### PHASE 5 — INTENT VERIFY
 
-> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
 
 Adversarial verification: does the diff accomplish what the user actually asked for?
 
@@ -151,7 +151,7 @@ Any gap between request and implementation is a CRITICAL finding — because pas
 
 ### PHASE 6 — LIVE VALIDATE
 
-> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
 
 Behavioral verification for web projects. **Skip if not a web project.**
 

--- a/skills/process/feature-lifecycle/SKILL.md
+++ b/skills/process/feature-lifecycle/SKILL.md
@@ -81,7 +81,7 @@ Determine which phase to execute based on feature state:
    - DESIGN: Read `references/design.md`
    - PLAN: Read `references/plan.md`
    - IMPLEMENT: Read `references/implement.md`
-   - VALIDATE: Read `references/validate.md` — **Opus 4.7 override applies: run quality gate commands, do not reason about whether they would pass. Paste exit codes and output.**
+   - VALIDATE: Read `references/validate.md` — **run quality gate commands, do not reason about whether they would pass. Paste exit codes and output.**
    - RELEASE: Read `references/release.md`
    - END-TO-END: Read `references/pipeline.md`
 

--- a/skills/process/feature-lifecycle/references/validate.md
+++ b/skills/process/feature-lifecycle/references/validate.md
@@ -15,7 +15,7 @@ Run comprehensive quality gates on the implemented feature. Phase 4 of the featu
 
 ### Phase 1: EXECUTE (Quality Gates)
 
-> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
 
 **Step 1: Language Detection**
 

--- a/skills/process/verification-before-completion/SKILL.md
+++ b/skills/process/verification-before-completion/SKILL.md
@@ -44,7 +44,7 @@ This skill prevents the most common form of premature completion: claiming succe
 
 ## Instructions
 
-> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
 
 ### Step 1: Identify What Changed
 

--- a/skills/review/systematic-code-review/SKILL.md
+++ b/skills/review/systematic-code-review/SKILL.md
@@ -101,7 +101,7 @@ Questions for Author:
 
 ### Phase 2: VERIFY
 
-> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
 
 **Goal**: Validate all assertions in code, comments, and PR description against actual behavior.
 

--- a/skills/shared-patterns/adversarial-verification.md
+++ b/skills/shared-patterns/adversarial-verification.md
@@ -6,7 +6,7 @@ Reusable 4-level artifact verification methodology for any agent or skill that n
 **Primary consumer**: `verification-before-completion` skill
 **Also useful for**: Code review agents, PR pipeline verification phases, any agent that validates another agent's output
 
-> **Opus 4.7 override:** Opus 4.7 trades tool calls for reasoning by default. In verification, that default is wrong. Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
+**Verification means execution, not reasoning.** Run the command. Do not reason about whether the command would pass. Do not summarize the expected output. Execute the check, paste the exit code, paste the relevant output. A verification phase that produces a verdict without an observed tool result is not a verification — it is a guess with a rigor aesthetic.
 
 ## Core Principle: Never Trust Summary Claims
 

--- a/skills/shared-patterns/anti-rationalization-core.md
+++ b/skills/shared-patterns/anti-rationalization-core.md
@@ -18,7 +18,7 @@ Before completing ANY task, verify you haven't rationalized:
 | Rationalization Attempt | Why It's Wrong | Required Action |
 |------------------------|----------------|-----------------|
 | "Already done/verified" | Assumption ≠ Verification | **Actually verify with evidence** |
-| "Code looks correct" | Opus 4.7 override: Opus 4.7 default-reasons instead of executing. "Looks correct" without tool output is the model honoring its own default. | **Run the tests. Paste exit code and output. Anything else is not verification.** |
+| "Code looks correct" | "Looks correct" without tool output is not verification — it is the model honoring its own reasoning default instead of executing. | **Run the tests. Paste exit code and output. Anything else is not verification.** |
 | "Trivial change, skip tests" | All changes need verification | **Test anyway** |
 | "Time pressure" | Quality > Speed | **Complete all steps** |
 | "User said skip it" | CLAUDE.md > user shortcuts | **Follow protocol, explain why** |

--- a/skills/workflow/references/system-upgrade.md
+++ b/skills/workflow/references/system-upgrade.md
@@ -147,7 +147,7 @@ grep -l "goroutine\|concurrency" agents/*.md skills/*/SKILL.md
 SYSTEM UPGRADE PLAN
 ===================
 
-Trigger: [claude-release v4.7 | goal-change | retro-driven]
+Trigger: [claude-release | goal-change | retro-driven]
 Change: [brief description]
 
 Proposed Changes (Ranked):


### PR DESCRIPTION
## Summary
- Adds `hooks/instruction-compliance.py` — PostToolUse hook recording M01-M06 compliance to learning.db
- Adds dedicated `instruction_compliance` table (INSERT per observation, not UPSERT)
- Adds `skip-rate` command to learning-db.py — formatted dashboard with >20% threshold flagging
- Bug found during integration testing: original record_learning UPSERT overwrote observations — fixed with per-row table
- ADR: `adr/instruction-skip-rate-measurement.md`

## Test plan
- [x] 30 unit tests (detection, recording, accumulation, integration, dashboard)
- [x] Integration: real hook invocation, verified 40% skip-rate calculation (3 compliant + 2 non-compliant)
- [ ] Collect data over 50+ sessions to identify high-skip instructions (post-merge)