### PR TITLE
feat: add auto-test PostToolUse hook for source file edits

### DIFF
--- a/hooks/posttool-auto-test.py
+++ b/hooks/posttool-auto-test.py
@@ -6,13 +6,17 @@ Fires after successful Write/Edit on source files. Detects language from
 file extension, runs the matching test command, and returns truncated
 results as additionalContext so the agent sees failures immediately.
 
-Non-blocking (informational only). Debounced at 10s. 30s timeout.
+Non-blocking (informational only). Debounced at 10s. 15s timeout.
+Sanitizes output to strip potential secrets before returning context.
 
 ADR: adr/auto-test-after-edit-hook.md
 """
 
+import fcntl
 import json
 import os
+import re
+import signal
 import subprocess
 import sys
 import time
@@ -36,9 +40,31 @@ _SKIP_EXTENSIONS: set[str] = {
 }
 
 _DEBOUNCE_FILE = Path("/tmp/auto-test-last-run")
+_DEBOUNCE_LOCK = Path("/tmp/auto-test-last-run.lock")
 _DEBOUNCE_SECONDS = 10
-_TIMEOUT_SECONDS = 30
+_TIMEOUT_SECONDS = 15
 _MAX_OUTPUT_LINES = 20
+
+# Patterns for lines that may contain secrets (matched case-insensitively)
+_SECRET_LINE_RE = re.compile(
+    r"^[A-Z][A-Z0-9_]*=",  # ANY_CAPS_KEY=value
+)
+_SECRET_KEY_WORDS = frozenset(
+    {
+        "PASSWORD",
+        "TOKEN",
+        "SECRET",
+        "SECRET_KEY",
+        "API_KEY",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "DATABASE_URL",
+        "PRIVATE_KEY",
+        "CREDENTIAL",
+    }
+)
 
 
 def _should_skip_extension(file_path: str) -> bool:
@@ -47,61 +73,115 @@ def _should_skip_extension(file_path: str) -> bool:
     return ext in _SKIP_EXTENSIONS or ext == ""
 
 
-def _is_debounced() -> bool:
-    """Return True if last test run was less than _DEBOUNCE_SECONDS ago."""
-    try:
-        if _DEBOUNCE_FILE.exists():
-            last_run = float(_DEBOUNCE_FILE.read_text().strip())
-            return (time.time() - last_run) < _DEBOUNCE_SECONDS
-    except (ValueError, OSError):
-        pass
-    return False
+def _debounce_check_and_update() -> bool:
+    """Atomically check debounce and update if not debounced.
 
-
-def _update_debounce() -> None:
-    """Write current timestamp to debounce file."""
+    Uses fcntl.flock so two concurrent hooks cannot both pass the check.
+    Returns True if this invocation should proceed (not debounced).
+    Returns False if debounced (caller should skip).
+    """
     try:
-        _DEBOUNCE_FILE.write_text(str(time.time()))
+        fd = os.open(str(_DEBOUNCE_LOCK), os.O_CREAT | os.O_RDWR, 0o644)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            # Read existing timestamp
+            now = time.time()
+            try:
+                if _DEBOUNCE_FILE.exists():
+                    last_run = float(_DEBOUNCE_FILE.read_text().strip())
+                    if (now - last_run) < _DEBOUNCE_SECONDS:
+                        return False
+            except (ValueError, OSError):
+                pass
+            # Not debounced — claim the slot
+            _DEBOUNCE_FILE.write_text(str(now))
+            return True
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
     except OSError:
-        pass
+        # If locking fails, proceed anyway (fail-open for hooks)
+        return True
 
 
-def _get_test_command(file_path: str) -> str | None:
-    """Map file extension to a test command. Returns None for unsupported languages."""
+def _get_test_command(file_path: str) -> list[list[str]] | None:
+    """Map file extension to test commands as argument lists.
+
+    Returns a list of command arg-lists, or None for unsupported languages.
+    Each inner list is passed to subprocess with shell=False.
+    """
     ext = Path(file_path).suffix.lower()
 
     if ext == ".py":
-        # Check if pyproject.toml exists for ruff config
         has_pyproject = Path("pyproject.toml").exists()
-        ruff_config = " --config pyproject.toml" if has_pyproject else ""
-        return (
-            f"ruff check {file_path}{ruff_config} 2>&1 | tail -20; "
-            f"python -m pytest --lf -x -q --tb=short 2>&1 | tail -20"
-        )
+        ruff_cmd = ["ruff", "check", file_path]
+        if has_pyproject:
+            ruff_cmd.extend(["--config", "pyproject.toml"])
+        pytest_cmd = ["python", "-m", "pytest", "--lf", "-x", "-q", "--tb=short"]
+        return [ruff_cmd, pytest_cmd]
     if ext == ".go":
         pkg_dir = str(Path(file_path).parent)
-        return f"go test ./{pkg_dir}/... 2>&1 | tail -20"
+        return [["go", "test", f"./{pkg_dir}/..."]]
 
     return None
 
 
-def _run_tests(command: str) -> tuple[bool, str]:
-    """Run test command with timeout. Returns (success, truncated_output)."""
+def _sanitize_output(text: str) -> str:
+    """Strip lines that may contain secrets or env-var assignments."""
+    safe_lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        # Skip lines matching ALL_CAPS_KEY=value pattern
+        if _SECRET_LINE_RE.match(stripped):
+            # Check if the key portion contains a known secret keyword
+            key = stripped.split("=", 1)[0]
+            if any(word in key.upper() for word in _SECRET_KEY_WORDS):
+                safe_lines.append(f"{key}=<REDACTED>")
+                continue
+        safe_lines.append(line)
+    return "\n".join(safe_lines)
+
+
+def _run_single_command(cmd: list[str], cwd: str) -> tuple[int, str]:
+    """Run a single command with timeout, killing the process group on timeout."""
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        cwd=cwd,
+        start_new_session=True,
+    )
     try:
-        result = subprocess.run(
-            command,
-            shell=True,
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT_SECONDS,
-            cwd=os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()),
-        )
-        output = result.stdout + result.stderr
-        lines = output.strip().splitlines()
-        truncated = "\n".join(lines[-_MAX_OUTPUT_LINES:])
-        return result.returncode == 0, truncated
+        stdout, _ = proc.communicate(timeout=_TIMEOUT_SECONDS)
+        return proc.returncode, stdout or ""
     except subprocess.TimeoutExpired:
-        return False, f"Tests timed out (>{_TIMEOUT_SECONDS}s), skipping auto-test"
+        # Kill the entire process group to avoid orphans
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except OSError:
+            pass
+        proc.wait(timeout=5)
+        return -1, f"Command timed out (>{_TIMEOUT_SECONDS}s)"
+
+
+def _run_tests(commands: list[list[str]]) -> tuple[bool, str]:
+    """Run test commands sequentially. Returns (all_passed, truncated_output)."""
+    cwd = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    all_output: list[str] = []
+    all_passed = True
+
+    for cmd in commands:
+        returncode, output = _run_single_command(cmd, cwd)
+        all_output.append(output)
+        if returncode != 0:
+            all_passed = False
+
+    combined = "\n".join(all_output)
+    sanitized = _sanitize_output(combined)
+    lines = sanitized.strip().splitlines()
+    truncated = "\n".join(lines[-_MAX_OUTPUT_LINES:])
+    return all_passed, truncated
 
 
 def _format_result(file_path: str, success: bool, output: str) -> dict:
@@ -134,18 +214,17 @@ def main() -> None:
     if _should_skip_extension(file_path):
         return
 
-    # Debounce
-    if _is_debounced():
+    # Language detection (before debounce to avoid claiming the slot for unsupported files)
+    commands = _get_test_command(file_path)
+    if commands is None:
         return
 
-    # Language detection
-    command = _get_test_command(file_path)
-    if command is None:
+    # Atomic debounce check-and-update
+    if not _debounce_check_and_update():
         return
 
     # Run tests
-    _update_debounce()
-    success, output = _run_tests(command)
+    success, output = _run_tests(commands)
 
     # Emit results
     result = _format_result(file_path, success, output)

--- a/hooks/posttool-auto-test.py
+++ b/hooks/posttool-auto-test.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""PostToolUse Hook: Auto-run tests after source file edits.
+
+Fires after successful Write/Edit on source files. Detects language from
+file extension, runs the matching test command, and returns truncated
+results as additionalContext so the agent sees failures immediately.
+
+Non-blocking (informational only). Debounced at 10s. 30s timeout.
+
+ADR: adr/auto-test-after-edit-hook.md
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
+# Extensions to skip (non-source files)
+_SKIP_EXTENSIONS: set[str] = {
+    ".md",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".cfg",
+    ".txt",
+    ".csv",
+    ".lock",
+    ".gitignore",
+}
+
+_DEBOUNCE_FILE = Path("/tmp/auto-test-last-run")
+_DEBOUNCE_SECONDS = 10
+_TIMEOUT_SECONDS = 30
+_MAX_OUTPUT_LINES = 20
+
+
+def _should_skip_extension(file_path: str) -> bool:
+    """Return True if the file extension is in the skip list."""
+    ext = Path(file_path).suffix.lower()
+    return ext in _SKIP_EXTENSIONS or ext == ""
+
+
+def _is_debounced() -> bool:
+    """Return True if last test run was less than _DEBOUNCE_SECONDS ago."""
+    try:
+        if _DEBOUNCE_FILE.exists():
+            last_run = float(_DEBOUNCE_FILE.read_text().strip())
+            return (time.time() - last_run) < _DEBOUNCE_SECONDS
+    except (ValueError, OSError):
+        pass
+    return False
+
+
+def _update_debounce() -> None:
+    """Write current timestamp to debounce file."""
+    try:
+        _DEBOUNCE_FILE.write_text(str(time.time()))
+    except OSError:
+        pass
+
+
+def _get_test_command(file_path: str) -> str | None:
+    """Map file extension to a test command. Returns None for unsupported languages."""
+    ext = Path(file_path).suffix.lower()
+
+    if ext == ".py":
+        # Check if pyproject.toml exists for ruff config
+        has_pyproject = Path("pyproject.toml").exists()
+        ruff_config = " --config pyproject.toml" if has_pyproject else ""
+        return (
+            f"ruff check {file_path}{ruff_config} 2>&1 | tail -20; "
+            f"python -m pytest --lf -x -q --tb=short 2>&1 | tail -20"
+        )
+    if ext == ".go":
+        pkg_dir = str(Path(file_path).parent)
+        return f"go test ./{pkg_dir}/... 2>&1 | tail -20"
+
+    return None
+
+
+def _run_tests(command: str) -> tuple[bool, str]:
+    """Run test command with timeout. Returns (success, truncated_output)."""
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_SECONDS,
+            cwd=os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()),
+        )
+        output = result.stdout + result.stderr
+        lines = output.strip().splitlines()
+        truncated = "\n".join(lines[-_MAX_OUTPUT_LINES:])
+        return result.returncode == 0, truncated
+    except subprocess.TimeoutExpired:
+        return False, f"Tests timed out (>{_TIMEOUT_SECONDS}s), skipping auto-test"
+
+
+def _format_result(file_path: str, success: bool, output: str) -> dict:
+    """Format test results as additionalContext JSON."""
+    filename = Path(file_path).name
+    status = "PASS" if success else "FAIL"
+    context = f"Auto-test results for {filename}:\n{status}\n{output}"
+    return {"additionalContext": context}
+
+
+def main() -> None:
+    """Parse stdin, check conditions, run tests, emit results."""
+    raw = read_stdin(timeout=2)
+    if not raw:
+        return
+
+    try:
+        event = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return
+
+    # Extract file path from tool input
+    tool_input = event.get("tool_input", event.get("input", {}))
+    file_path = tool_input.get("file_path", "")
+
+    if not file_path:
+        return
+
+    # Skip non-source files
+    if _should_skip_extension(file_path):
+        return
+
+    # Debounce
+    if _is_debounced():
+        return
+
+    # Language detection
+    command = _get_test_command(file_path)
+    if command is None:
+        return
+
+    # Run tests
+    _update_debounce()
+    success, output = _run_tests(command)
+
+    # Emit results
+    result = _format_result(file_path, success, output)
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"[auto-test] HOOK-CRASH: {type(e).__name__}: {e}", file=sys.stderr)
+    finally:
+        sys.exit(0)

--- a/scripts/tests/test_auto_test_hook.py
+++ b/scripts/tests/test_auto_test_hook.py
@@ -1,0 +1,252 @@
+"""Tests for hooks/posttool-auto-test.py.
+
+Tests the logic (file detection, debounce, language mapping, output formatting)
+without actually running test commands — subprocess.run is mocked throughout.
+
+Run with: python -m pytest scripts/tests/test_auto_test_hook.py -v
+"""
+
+import importlib.util
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ── Import hook module (hyphenated filename) ─────────────────────
+
+HOOK_PATH = Path(__file__).resolve().parent.parent.parent / "hooks" / "posttool-auto-test.py"
+spec = importlib.util.spec_from_file_location("posttool_auto_test", HOOK_PATH)
+hook_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hook_mod)
+
+_mod = "posttool_auto_test"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clean_debounce(tmp_path, monkeypatch):
+    """Redirect debounce file to tmp_path and ensure clean state."""
+    debounce = tmp_path / "auto-test-last-run"
+    monkeypatch.setattr(hook_mod, "_DEBOUNCE_FILE", debounce)
+    return debounce
+
+
+def _make_event(file_path: str) -> str:
+    """Build a minimal PostToolUse event JSON string."""
+    return json.dumps(
+        {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": file_path},
+        }
+    )
+
+
+# ── Extension detection ──────────────────────────────────────────
+
+
+class TestShouldSkipExtension:
+    def test_skip_markdown(self):
+        assert hook_mod._should_skip_extension("docs/README.md") is True
+
+    def test_skip_json(self):
+        assert hook_mod._should_skip_extension("config.json") is True
+
+    def test_skip_yaml(self):
+        assert hook_mod._should_skip_extension("deploy.yaml") is True
+
+    def test_skip_toml(self):
+        assert hook_mod._should_skip_extension("pyproject.toml") is True
+
+    def test_skip_no_extension(self):
+        assert hook_mod._should_skip_extension("Makefile") is True
+
+    def test_allow_python(self):
+        assert hook_mod._should_skip_extension("app.py") is False
+
+    def test_allow_go(self):
+        assert hook_mod._should_skip_extension("main.go") is False
+
+
+# ── Language mapping ─────────────────────────────────────────────
+
+
+class TestGetTestCommand:
+    def test_python_with_pyproject(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        cmd = hook_mod._get_test_command("src/app.py")
+        assert cmd is not None
+        assert "ruff check" in cmd
+        assert "--config pyproject.toml" in cmd
+        assert "pytest" in cmd
+
+    def test_python_without_pyproject(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cmd = hook_mod._get_test_command("src/app.py")
+        assert cmd is not None
+        assert "--config pyproject.toml" not in cmd
+        assert "pytest" in cmd
+
+    def test_go_file(self):
+        cmd = hook_mod._get_test_command("pkg/server/handler.go")
+        assert cmd is not None
+        assert "go test" in cmd
+        assert "pkg/server" in cmd
+
+    def test_unknown_extension_returns_none(self):
+        assert hook_mod._get_test_command("lib.rs") is None
+
+    def test_typescript_returns_none(self):
+        assert hook_mod._get_test_command("app.ts") is None
+
+
+# ── Debounce ─────────────────────────────────────────────────────
+
+
+class TestDebounce:
+    def test_no_debounce_file(self):
+        assert hook_mod._is_debounced() is False
+
+    def test_recent_run_is_debounced(self, _clean_debounce):
+        _clean_debounce.write_text(str(time.time()))
+        assert hook_mod._is_debounced() is True
+
+    def test_old_run_not_debounced(self, _clean_debounce):
+        _clean_debounce.write_text(str(time.time() - 20))
+        assert hook_mod._is_debounced() is False
+
+    def test_update_debounce_writes_file(self, _clean_debounce):
+        hook_mod._update_debounce()
+        assert _clean_debounce.exists()
+        ts = float(_clean_debounce.read_text())
+        assert time.time() - ts < 2
+
+
+# ── Test execution ───────────────────────────────────────────────
+
+
+class TestRunTests:
+    @patch.object(hook_mod.subprocess, "run")
+    def test_success(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="3 passed\n", stderr="")
+        success, output = hook_mod._run_tests("pytest")
+        assert success is True
+        assert "3 passed" in output
+
+    @patch.object(hook_mod.subprocess, "run")
+    def test_failure(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stdout="FAILED test_foo\n", stderr="")
+        success, output = hook_mod._run_tests("pytest")
+        assert success is False
+        assert "FAILED" in output
+
+    @patch.object(hook_mod.subprocess, "run")
+    def test_timeout(self, mock_run):
+        from subprocess import TimeoutExpired
+
+        mock_run.side_effect = TimeoutExpired("pytest", 30)
+        success, output = hook_mod._run_tests("pytest")
+        assert success is False
+        assert "timed out" in output.lower()
+
+    @patch.object(hook_mod.subprocess, "run")
+    def test_output_truncation(self, mock_run):
+        long_output = "\n".join(f"line {i}" for i in range(50))
+        mock_run.return_value = MagicMock(returncode=0, stdout=long_output, stderr="")
+        _, output = hook_mod._run_tests("pytest")
+        assert len(output.splitlines()) <= 20
+
+
+# ── Output formatting ────────────────────────────────────────────
+
+
+class TestFormatResult:
+    def test_pass_format(self):
+        result = hook_mod._format_result("src/app.py", True, "3 passed")
+        assert "additionalContext" in result
+        assert "PASS" in result["additionalContext"]
+        assert "app.py" in result["additionalContext"]
+
+    def test_fail_format(self):
+        result = hook_mod._format_result("src/app.py", False, "FAILED test_foo")
+        assert "FAIL" in result["additionalContext"]
+
+
+# ── End-to-end main() ───────────────────────────────────────────
+
+
+class TestMain:
+    @patch.object(hook_mod, "_run_tests", return_value=(True, "3 passed"))
+    @patch.object(hook_mod, "_get_test_command", return_value="pytest")
+    @patch.object(hook_mod, "read_stdin")
+    def test_python_file_runs_tests(self, mock_stdin, mock_cmd, mock_run, capsys):
+        mock_stdin.return_value = _make_event("src/app.py")
+        hook_mod.main()
+        mock_run.assert_called_once()
+        out = capsys.readouterr().out
+        result = json.loads(out)
+        assert "PASS" in result["additionalContext"]
+
+    @patch.object(hook_mod, "read_stdin")
+    def test_markdown_file_skipped(self, mock_stdin, capsys):
+        mock_stdin.return_value = _make_event("README.md")
+        hook_mod.main()
+        assert capsys.readouterr().out == ""
+
+    @patch.object(hook_mod, "_run_tests", return_value=(True, "ok"))
+    @patch.object(hook_mod, "_get_test_command", return_value="go test ./...")
+    @patch.object(hook_mod, "read_stdin")
+    def test_go_file_runs_tests(self, mock_stdin, mock_cmd, mock_run, capsys):
+        mock_stdin.return_value = _make_event("pkg/handler.go")
+        hook_mod.main()
+        mock_run.assert_called_once()
+
+    @patch.object(hook_mod, "read_stdin")
+    def test_unknown_extension_skipped(self, mock_stdin, capsys):
+        mock_stdin.return_value = _make_event("lib.rs")
+        hook_mod.main()
+        assert capsys.readouterr().out == ""
+
+    @patch.object(hook_mod, "read_stdin")
+    def test_debounce_skips_second_call(self, mock_stdin, capsys):
+        """Second call within debounce window is skipped."""
+        hook_mod._update_debounce()
+        mock_stdin.return_value = _make_event("src/app.py")
+        hook_mod.main()
+        assert capsys.readouterr().out == ""
+
+    @patch.object(hook_mod, "_run_tests", return_value=(True, "ok"))
+    @patch.object(hook_mod, "_get_test_command", return_value="pytest")
+    @patch.object(hook_mod, "read_stdin")
+    def test_debounce_allows_after_window(self, mock_stdin, mock_cmd, mock_run, _clean_debounce, capsys):
+        """Call after debounce window runs tests."""
+        _clean_debounce.write_text(str(time.time() - 20))
+        mock_stdin.return_value = _make_event("src/app.py")
+        hook_mod.main()
+        mock_run.assert_called_once()
+
+    @patch.object(hook_mod, "read_stdin")
+    def test_malformed_stdin_exits_cleanly(self, mock_stdin, capsys):
+        mock_stdin.return_value = "not json at all {"
+        hook_mod.main()
+        assert capsys.readouterr().out == ""
+
+    @patch.object(hook_mod, "read_stdin")
+    def test_empty_stdin_exits_cleanly(self, mock_stdin, capsys):
+        mock_stdin.return_value = ""
+        hook_mod.main()
+        assert capsys.readouterr().out == ""
+
+    @patch.object(hook_mod, "_run_tests", return_value=(False, "Tests timed out (>30s), skipping auto-test"))
+    @patch.object(hook_mod, "_get_test_command", return_value="pytest")
+    @patch.object(hook_mod, "read_stdin")
+    def test_timeout_returns_message(self, mock_stdin, mock_cmd, mock_run, capsys):
+        mock_stdin.return_value = _make_event("src/app.py")
+        hook_mod.main()
+        out = capsys.readouterr().out
+        result = json.loads(out)
+        assert "timed out" in result["additionalContext"].lower()

--- a/scripts/tests/test_auto_test_hook.py
+++ b/scripts/tests/test_auto_test_hook.py
@@ -1,7 +1,8 @@
 """Tests for hooks/posttool-auto-test.py.
 
-Tests the logic (file detection, debounce, language mapping, output formatting)
-without actually running test commands — subprocess.run is mocked throughout.
+Tests the logic (file detection, debounce, language mapping, output formatting,
+output sanitization, shell safety) without actually running test commands —
+subprocess.Popen is mocked throughout.
 
 Run with: python -m pytest scripts/tests/test_auto_test_hook.py -v
 """
@@ -29,9 +30,11 @@ _mod = "posttool_auto_test"
 
 @pytest.fixture(autouse=True)
 def _clean_debounce(tmp_path, monkeypatch):
-    """Redirect debounce file to tmp_path and ensure clean state."""
+    """Redirect debounce file and lock to tmp_path and ensure clean state."""
     debounce = tmp_path / "auto-test-last-run"
+    lock = tmp_path / "auto-test-last-run.lock"
     monkeypatch.setattr(hook_mod, "_DEBOUNCE_FILE", debounce)
+    monkeypatch.setattr(hook_mod, "_DEBOUNCE_LOCK", lock)
     return debounce
 
 
@@ -78,24 +81,31 @@ class TestGetTestCommand:
     def test_python_with_pyproject(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
-        cmd = hook_mod._get_test_command("src/app.py")
-        assert cmd is not None
-        assert "ruff check" in cmd
-        assert "--config pyproject.toml" in cmd
-        assert "pytest" in cmd
+        cmds = hook_mod._get_test_command("src/app.py")
+        assert cmds is not None
+        assert len(cmds) == 2
+        # First command is ruff
+        assert "ruff" in cmds[0]
+        assert "--config" in cmds[0]
+        assert "pyproject.toml" in cmds[0]
+        # Second command is pytest
+        assert "pytest" in cmds[1]
 
     def test_python_without_pyproject(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        cmd = hook_mod._get_test_command("src/app.py")
-        assert cmd is not None
-        assert "--config pyproject.toml" not in cmd
-        assert "pytest" in cmd
+        cmds = hook_mod._get_test_command("src/app.py")
+        assert cmds is not None
+        assert len(cmds) == 2
+        assert "--config" not in cmds[0]
+        assert "pytest" in cmds[1]
 
     def test_go_file(self):
-        cmd = hook_mod._get_test_command("pkg/server/handler.go")
-        assert cmd is not None
-        assert "go test" in cmd
-        assert "pkg/server" in cmd
+        cmds = hook_mod._get_test_command("pkg/server/handler.go")
+        assert cmds is not None
+        assert len(cmds) == 1
+        assert "go" in cmds[0]
+        assert "test" in cmds[0]
+        assert "pkg/server" in cmds[0][2]
 
     def test_unknown_extension_returns_none(self):
         assert hook_mod._get_test_command("lib.rs") is None
@@ -103,62 +113,213 @@ class TestGetTestCommand:
     def test_typescript_returns_none(self):
         assert hook_mod._get_test_command("app.ts") is None
 
+    def test_returns_list_args_not_shell_string(self, tmp_path, monkeypatch):
+        """Commands are lists (shell=False safe), not shell strings."""
+        monkeypatch.chdir(tmp_path)
+        cmds = hook_mod._get_test_command("src/app.py")
+        assert cmds is not None
+        for cmd in cmds:
+            assert isinstance(cmd, list)
+            for arg in cmd:
+                assert isinstance(arg, str)
+
+    def test_file_path_with_spaces_in_args(self, tmp_path, monkeypatch):
+        """File paths with shell metacharacters are passed as single list elements."""
+        monkeypatch.chdir(tmp_path)
+        tricky_path = "src/my file; rm -rf.py"
+        cmds = hook_mod._get_test_command(tricky_path)
+        assert cmds is not None
+        # The file path must appear as a single element, not split by shell
+        ruff_cmd = cmds[0]
+        assert tricky_path in ruff_cmd
+
 
 # ── Debounce ─────────────────────────────────────────────────────
 
 
 class TestDebounce:
-    def test_no_debounce_file(self):
-        assert hook_mod._is_debounced() is False
+    def test_no_debounce_file_proceeds(self):
+        assert hook_mod._debounce_check_and_update() is True
 
     def test_recent_run_is_debounced(self, _clean_debounce):
         _clean_debounce.write_text(str(time.time()))
-        assert hook_mod._is_debounced() is True
+        assert hook_mod._debounce_check_and_update() is False
 
     def test_old_run_not_debounced(self, _clean_debounce):
         _clean_debounce.write_text(str(time.time() - 20))
-        assert hook_mod._is_debounced() is False
+        assert hook_mod._debounce_check_and_update() is True
 
-    def test_update_debounce_writes_file(self, _clean_debounce):
-        hook_mod._update_debounce()
+    def test_atomic_update_writes_file(self, _clean_debounce):
+        hook_mod._debounce_check_and_update()
         assert _clean_debounce.exists()
         ts = float(_clean_debounce.read_text())
         assert time.time() - ts < 2
+
+    def test_second_call_within_window_blocked(self, _clean_debounce):
+        """First call proceeds, second within window is blocked."""
+        assert hook_mod._debounce_check_and_update() is True
+        assert hook_mod._debounce_check_and_update() is False
+
+
+# ── Output sanitization ─────────────────────────────────────────
+
+
+class TestSanitizeOutput:
+    def test_normal_output_unchanged(self):
+        text = "3 passed in 0.5s\nFAILED test_foo"
+        assert hook_mod._sanitize_output(text) == text
+
+    def test_redacts_password(self):
+        text = "loading config\nDATABASE_PASSWORD=hunter2\nstarting"
+        result = hook_mod._sanitize_output(text)
+        assert "hunter2" not in result
+        assert "DATABASE_PASSWORD=<REDACTED>" in result
+
+    def test_redacts_api_key(self):
+        text = "ANTHROPIC_API_KEY=sk-ant-1234\nOPENAI_API_KEY=sk-5678"
+        result = hook_mod._sanitize_output(text)
+        assert "sk-ant-1234" not in result
+        assert "sk-5678" not in result
+        assert "ANTHROPIC_API_KEY=<REDACTED>" in result
+        assert "OPENAI_API_KEY=<REDACTED>" in result
+
+    def test_redacts_aws_keys(self):
+        text = "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI\nAWS_ACCESS_KEY_ID=AKIAIOSFODNN"
+        result = hook_mod._sanitize_output(text)
+        assert "wJalrXUtnFEMI" not in result
+        assert "AKIAIOSFODNN" not in result
+
+    def test_redacts_token(self):
+        text = "AUTH_TOKEN=abc123secret"
+        result = hook_mod._sanitize_output(text)
+        assert "abc123secret" not in result
+        assert "AUTH_TOKEN=<REDACTED>" in result
+
+    def test_non_secret_caps_key_preserved(self):
+        """ALL_CAPS=value lines without secret keywords are kept."""
+        text = "PYTHONPATH=/usr/local/lib\nPATH=/usr/bin"
+        result = hook_mod._sanitize_output(text)
+        assert result == text
+
+    def test_lowercase_lines_preserved(self):
+        """Regular test output lines are not stripped."""
+        text = "test_foo.py::test_bar PASSED\npassword=foo in test fixture"
+        result = hook_mod._sanitize_output(text)
+        assert result == text
+
+    def test_redacts_database_url(self):
+        text = "DATABASE_URL=postgres://user:pass@host/db"
+        result = hook_mod._sanitize_output(text)
+        assert "postgres://user:pass@host/db" not in result
+        assert "DATABASE_URL=<REDACTED>" in result
 
 
 # ── Test execution ───────────────────────────────────────────────
 
 
 class TestRunTests:
-    @patch.object(hook_mod.subprocess, "run")
-    def test_success(self, mock_run):
-        mock_run.return_value = MagicMock(returncode=0, stdout="3 passed\n", stderr="")
-        success, output = hook_mod._run_tests("pytest")
+    @patch.object(hook_mod.subprocess, "Popen")
+    def test_success(self, mock_popen):
+        proc = MagicMock()
+        proc.communicate.return_value = ("3 passed\n", None)
+        proc.returncode = 0
+        mock_popen.return_value = proc
+        success, output = hook_mod._run_tests([["pytest"]])
         assert success is True
         assert "3 passed" in output
 
-    @patch.object(hook_mod.subprocess, "run")
-    def test_failure(self, mock_run):
-        mock_run.return_value = MagicMock(returncode=1, stdout="FAILED test_foo\n", stderr="")
-        success, output = hook_mod._run_tests("pytest")
+    @patch.object(hook_mod.subprocess, "Popen")
+    def test_failure(self, mock_popen):
+        proc = MagicMock()
+        proc.communicate.return_value = ("FAILED test_foo\n", None)
+        proc.returncode = 1
+        mock_popen.return_value = proc
+        success, output = hook_mod._run_tests([["pytest"]])
         assert success is False
         assert "FAILED" in output
 
-    @patch.object(hook_mod.subprocess, "run")
-    def test_timeout(self, mock_run):
+    @patch("os.killpg")
+    @patch.object(hook_mod.subprocess, "Popen")
+    def test_timeout_kills_process_group(self, mock_popen, mock_killpg):
         from subprocess import TimeoutExpired
 
-        mock_run.side_effect = TimeoutExpired("pytest", 30)
-        success, output = hook_mod._run_tests("pytest")
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.communicate.side_effect = TimeoutExpired("pytest", 15)
+        proc.wait.return_value = None
+        mock_popen.return_value = proc
+        success, output = hook_mod._run_tests([["pytest"]])
         assert success is False
         assert "timed out" in output.lower()
+        # Verify process group was killed
+        mock_killpg.assert_called_once_with(12345, hook_mod.signal.SIGTERM)
 
-    @patch.object(hook_mod.subprocess, "run")
-    def test_output_truncation(self, mock_run):
+    @patch.object(hook_mod.subprocess, "Popen")
+    def test_output_truncation(self, mock_popen):
         long_output = "\n".join(f"line {i}" for i in range(50))
-        mock_run.return_value = MagicMock(returncode=0, stdout=long_output, stderr="")
-        _, output = hook_mod._run_tests("pytest")
+        proc = MagicMock()
+        proc.communicate.return_value = (long_output, None)
+        proc.returncode = 0
+        mock_popen.return_value = proc
+        _, output = hook_mod._run_tests([["pytest"]])
         assert len(output.splitlines()) <= 20
+
+    @patch.object(hook_mod.subprocess, "Popen")
+    def test_multiple_commands_all_pass(self, mock_popen):
+        proc = MagicMock()
+        proc.communicate.return_value = ("ok\n", None)
+        proc.returncode = 0
+        mock_popen.return_value = proc
+        success, _ = hook_mod._run_tests([["ruff", "check"], ["pytest"]])
+        assert success is True
+        assert mock_popen.call_count == 2
+
+    @patch.object(hook_mod.subprocess, "Popen")
+    def test_multiple_commands_one_fails(self, mock_popen):
+        pass_proc = MagicMock()
+        pass_proc.communicate.return_value = ("ok\n", None)
+        pass_proc.returncode = 0
+        fail_proc = MagicMock()
+        fail_proc.communicate.return_value = ("FAIL\n", None)
+        fail_proc.returncode = 1
+        mock_popen.side_effect = [pass_proc, fail_proc]
+        success, _ = hook_mod._run_tests([["ruff", "check"], ["pytest"]])
+        assert success is False
+
+    @patch.object(hook_mod.subprocess, "Popen")
+    def test_output_sanitized(self, mock_popen):
+        """Secrets in test output are redacted before returning."""
+        proc = MagicMock()
+        proc.communicate.return_value = ("ok\nANTHROPIC_API_KEY=sk-secret-123\ndone\n", None)
+        proc.returncode = 0
+        mock_popen.return_value = proc
+        _, output = hook_mod._run_tests([["pytest"]])
+        assert "sk-secret-123" not in output
+        assert "ANTHROPIC_API_KEY=<REDACTED>" in output
+
+    @patch.object(hook_mod.subprocess, "Popen")
+    def test_popen_uses_shell_false(self, mock_popen):
+        """Popen is called without shell=True (list args, no shell)."""
+        proc = MagicMock()
+        proc.communicate.return_value = ("ok\n", None)
+        proc.returncode = 0
+        mock_popen.return_value = proc
+        hook_mod._run_tests([["pytest", "-v"]])
+        call_kwargs = mock_popen.call_args
+        # shell should not be in kwargs, or should be False
+        assert call_kwargs.kwargs.get("shell", False) is False
+        # First positional arg should be the list
+        assert call_kwargs.args[0] == ["pytest", "-v"]
+
+    @patch.object(hook_mod.subprocess, "Popen")
+    def test_popen_starts_new_session(self, mock_popen):
+        """Popen is called with start_new_session=True for process group cleanup."""
+        proc = MagicMock()
+        proc.communicate.return_value = ("ok\n", None)
+        proc.returncode = 0
+        mock_popen.return_value = proc
+        hook_mod._run_tests([["pytest"]])
+        assert mock_popen.call_args.kwargs.get("start_new_session") is True
 
 
 # ── Output formatting ────────────────────────────────────────────
@@ -181,7 +342,7 @@ class TestFormatResult:
 
 class TestMain:
     @patch.object(hook_mod, "_run_tests", return_value=(True, "3 passed"))
-    @patch.object(hook_mod, "_get_test_command", return_value="pytest")
+    @patch.object(hook_mod, "_get_test_command", return_value=[["pytest"]])
     @patch.object(hook_mod, "read_stdin")
     def test_python_file_runs_tests(self, mock_stdin, mock_cmd, mock_run, capsys):
         mock_stdin.return_value = _make_event("src/app.py")
@@ -198,7 +359,7 @@ class TestMain:
         assert capsys.readouterr().out == ""
 
     @patch.object(hook_mod, "_run_tests", return_value=(True, "ok"))
-    @patch.object(hook_mod, "_get_test_command", return_value="go test ./...")
+    @patch.object(hook_mod, "_get_test_command", return_value=[["go", "test", "./..."]])
     @patch.object(hook_mod, "read_stdin")
     def test_go_file_runs_tests(self, mock_stdin, mock_cmd, mock_run, capsys):
         mock_stdin.return_value = _make_event("pkg/handler.go")
@@ -211,16 +372,21 @@ class TestMain:
         hook_mod.main()
         assert capsys.readouterr().out == ""
 
+    @patch.object(hook_mod, "_run_tests", return_value=(True, "ok"))
+    @patch.object(hook_mod, "_get_test_command", return_value=[["pytest"]])
     @patch.object(hook_mod, "read_stdin")
-    def test_debounce_skips_second_call(self, mock_stdin, capsys):
-        """Second call within debounce window is skipped."""
-        hook_mod._update_debounce()
+    def test_debounce_skips_second_call(self, mock_stdin, mock_cmd, mock_run, capsys):
+        """First call proceeds; second within debounce window is skipped."""
+        mock_stdin.return_value = _make_event("src/app.py")
+        hook_mod.main()
+        assert capsys.readouterr().out != ""
+        # Second call within debounce window
         mock_stdin.return_value = _make_event("src/app.py")
         hook_mod.main()
         assert capsys.readouterr().out == ""
 
     @patch.object(hook_mod, "_run_tests", return_value=(True, "ok"))
-    @patch.object(hook_mod, "_get_test_command", return_value="pytest")
+    @patch.object(hook_mod, "_get_test_command", return_value=[["pytest"]])
     @patch.object(hook_mod, "read_stdin")
     def test_debounce_allows_after_window(self, mock_stdin, mock_cmd, mock_run, _clean_debounce, capsys):
         """Call after debounce window runs tests."""
@@ -241,8 +407,8 @@ class TestMain:
         hook_mod.main()
         assert capsys.readouterr().out == ""
 
-    @patch.object(hook_mod, "_run_tests", return_value=(False, "Tests timed out (>30s), skipping auto-test"))
-    @patch.object(hook_mod, "_get_test_command", return_value="pytest")
+    @patch.object(hook_mod, "_run_tests", return_value=(False, "Command timed out (>15s)"))
+    @patch.object(hook_mod, "_get_test_command", return_value=[["pytest"]])
     @patch.object(hook_mod, "read_stdin")
     def test_timeout_returns_message(self, mock_stdin, mock_cmd, mock_run, capsys):
         mock_stdin.return_value = _make_event("src/app.py")


### PR DESCRIPTION
## Summary
- Adds `hooks/posttool-auto-test.py` — PostToolUse hook on Write/Edit that auto-runs tests
- Python: ruff check + pytest. Go: go test (package-scoped)
- 30s timeout, 10s debounce, 20-line truncation, non-blocking (additionalContext only)
- Skips non-source files (.md, .json, .yaml, .toml, etc.)
- ADR: `adr/auto-test-after-edit-hook.md`

## Test plan
- [x] 31 unit tests (extension detection, language mapping, debounce, timeout, integration)
- [x] Integration: real hook invocation — Python detected + ruff ran, markdown skipped, debounce worked
- [ ] A/B test: 20 coding tasks with auto-test vs 20 without (post-merge validation)