### PR TITLE
feat: wire determinism hooks + add token asymmetry principle

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -165,6 +165,12 @@
             "command": "python3 \"$HOME/.claude/hooks/pretool-prompt-injection-scanner.py\"",
             "description": "Advisory scan for prompt injection patterns in agent context files (ADR-070)",
             "timeout": 3000
+          },
+          {
+            "type": "command",
+            "command": "python3 hooks/pipeline-phase-gate.py",
+            "description": "Pipeline phase gate: blocks edits that skip required pipeline phases",
+            "timeout": 3000
           }
         ]
       },
@@ -304,6 +310,12 @@
             "command": "python3 \"$HOME/.claude/hooks/review-capture.py\"",
             "description": "Capture CRITICAL/HIGH review findings to learning DB",
             "timeout": 3000
+          },
+          {
+            "type": "command",
+            "command": "python3 hooks/instruction-compliance.py",
+            "description": "Instruction compliance measurement after agent dispatch",
+            "timeout": 5000
           }
         ]
       },
@@ -340,6 +352,12 @@
             "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/sql-injection-detector.py\"",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 hooks/posttool-auto-test.py",
+            "description": "Auto-test after source edits",
+            "timeout": 20000
           }
         ]
       }

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -328,6 +328,16 @@ Model choice is a routing policy, not an ego signal.
 
 Do not treat `opus` as the default upgrade path. If a component can only perform adequately on `opus`, inspect its prompt shape, references, and task decomposition before raising model cost.
 
+**Token costs are not fungible.** One Opus token costs ~30x one Haiku token. Saving 1,000 Haiku tokens while causing one Opus rework loop (10,000+ tokens) is a net loss. Optimization targets the expensive model, not the cheap one.
+
+This means:
+- "Saves Haiku calls" is not a valid justification for any change. Haiku is the cheapest operation in the system.
+- Pre-routing's value is **determinism and reliability** (regex can't misroute), not token savings.
+- Phase gates' value is **preventing Opus rework** (catching missing artifacts before the expensive agent runs), not reducing hook overhead.
+- Skip-rate measurement's value is **identifying which instructions fail** so they can become gates, not counting compliance events.
+
+The test: does this optimization reduce Opus/Sonnet token waste from rework, misroutes, or hallucination? If it only saves Haiku tokens, it is not worth the complexity.
+
 ### Prompt Phrasing Does Not Replace Domain Knowledge
 
 Four A/B experiments tested ego-boosting prompts ("IQ 200+"), urgency framing ("production is down"), and emotional prompt engineering.

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -125,6 +125,22 @@ If ANY creation signal found AND complexity Simple+: set `is_creation = true`, P
 
 **Goal**: Select the correct agent + skill via a single Haiku routing agent. FORCE-labeled entries are preferred when intent matches semantically (not keyword-based).
 
+**Step 0: Deterministic pre-routing**
+
+Run the deterministic pre-router first:
+```bash
+python3 scripts/pre-route.py --request "{user_request}" --json-compact
+```
+
+If the result has `"matched": true` and `"confidence": "high"`:
+- Use the returned `agent` and `skill` directly
+- Skip the Haiku routing agent entirely
+- Record `match_type` in routing decision tags
+
+If `"matched": false` or `"confidence"` is "low"/"medium":
+- Proceed to Step 1 (Haiku routing) as normal
+- The pre-router result is informational only
+
 **Step 1: Dispatch Haiku routing agent**
 
 Generate the manifest, then dispatch:


### PR DESCRIPTION
## Summary
- Registers 3 hooks in settings.json: instruction-compliance (PostToolUse:Agent), posttool-auto-test (PostToolUse:Write|Edit), pipeline-phase-gate (PreToolUse:Write|Edit)
- Integrates `scripts/pre-route.py` into /do SKILL.md Phase 2 Step 0 as deterministic pre-filter before Haiku routing
- Adds token cost asymmetry principle to PHILOSOPHY.md: "One Opus token costs ~30x one Haiku token. Saving Haiku calls is not a valid justification. Pre-routing's value is determinism, not token savings."

## Context
Implements the wiring gap identified during installer compatibility review. The 4 components (PRs #604-607) were merged but not activated. This PR activates them.

## Test plan
- [x] JSON syntax validated on settings.json
- [x] Install-doctor passes (22/23, pre-existing issue)
- [ ] Verify hooks fire on next session (instruction-compliance on Agent, auto-test on Write/Edit, phase-gate on Write/Edit)