### PR TITLE
fix: handle broken symlinks in emergency hook copy and install-doctor

### DIFF
--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -586,7 +586,14 @@ def main():
                     f"but missing from ~/.claude/hooks/: {', '.join(missing_hooks)}",
                     file=sys.stderr,
                 )
-                # Attempt emergency copy from repo hooks/ for any missing files
+                # Attempt emergency copy from repo hooks/ for any missing files.
+                # First, ensure hooks_dir is a usable directory — it may be a
+                # broken symlink (target repo was renamed/moved) which causes
+                # mkdir(exist_ok=True) to raise FileExistsError.
+                if hooks_dir.is_symlink() and not hooks_dir.exists():
+                    hooks_dir.unlink()  # Remove broken symlink
+                    print("[sync] Removed broken hooks symlink", file=sys.stderr)
+                hooks_dir.mkdir(parents=True, exist_ok=True)
                 for py_file in missing_hooks:
                     repo_hook = repo_root / "hooks" / py_file
                     if repo_hook.exists():

--- a/scripts/install-doctor.py
+++ b/scripts/install-doctor.py
@@ -71,7 +71,24 @@ def check_components_installed() -> list[dict]:
         target = CLAUDE_DIR / comp
         is_symlink = target.is_symlink()
         is_dir = target.is_dir()
+        is_file = target.is_file() and not is_symlink  # Regular file (not a symlink)
         exists = is_symlink or is_dir
+
+        if is_file:
+            # A regular file where a directory/symlink is expected — broken state.
+            # This can happen from interrupted installs or shell misuse.
+            results.append(
+                {
+                    "name": f"component_{comp}",
+                    "label": f"~/.claude/{comp}",
+                    "passed": False,
+                    "detail": (
+                        f"EXISTS AS REGULAR FILE (expected directory or symlink). "
+                        f"Fix: rm ~/.claude/{comp} && install.sh --symlink"
+                    ),
+                }
+            )
+            continue
 
         if is_symlink:
             try:


### PR DESCRIPTION
## Summary
- **sync-to-user-claude.py**: Emergency hook copy path now detects and removes broken symlinks before `mkdir(exist_ok=True)`. Previously, a broken symlink (e.g., from repo rename) caused `FileExistsError` which was silently caught, leaving hooks permanently broken with no safety net.
- **install-doctor.py**: New detection for components that are regular files instead of expected directory/symlink, with actionable fix guidance.

## Context
When `~/.claude/hooks` is a broken symlink (target repo renamed/moved), `mkdir(exist_ok=True)` raises `FileExistsError` because the dangling symlink inode exists but isn't a directory. The main sync path handles this via `_ensure_symlink()`, but the emergency fallback path did not — meaning if the main sync failed for any reason, the fallback also failed silently.

## Test plan
- [ ] Verify `ruff check` and `ruff format --check` pass
- [ ] Create a broken symlink at `~/.claude/hooks` → verify sync recovers
- [ ] Run `install-doctor.py check` with a regular file at `~/.claude/hooks` → verify detection