### PR TITLE
docs: add Go abstraction boundary patterns from PR #220

### DIFF
--- a/agents/reviewer-code/references/simplifier.md
+++ b/agents/reviewer-code/references/simplifier.md
@@ -107,7 +107,7 @@ Patterns where unnecessary complexity can be removed while preserving behavior. 
 | Signal | Grep / Structural Check | Simplification |
 |--------|------------------------|----------------|
 | Defensive copy on fresh slice | `make([]T, len(x)+N)` + `copy(result, x)` where x is freshly allocated | Replace with `append(x, element)` |
-| Coupling comment | `grep -rn "must be called after\|must always follow\|INVARIANT.*call.*after" --include="*.go"` | Merge the "always follows" logic into the prerequisite function |
+| Coupling comment | `grep -rn "must be called after\|must always follow\|INVARIANT.*call" --include="*.go"` | Merge the "always follows" logic into the prerequisite function |
 | Same-pair call pattern | `helperB(result)` appears after every `result := functionA()` call site | Move `helperB` logic inside `functionA` |
 
 ### Coupling Comment Fix

--- a/agents/reviewer-code/references/simplifier.md
+++ b/agents/reviewer-code/references/simplifier.md
@@ -97,3 +97,30 @@ Reduce complexity and improve code clarity while preserving exact functionality.
 - Complex business logic encoding
 - Multiple valid simplification approaches (ask user)
 - Simplification changes public API
+
+## Abstraction Boundary Patterns
+
+Patterns where unnecessary complexity can be removed while preserving behavior. See `skills/engineering/go-patterns/references/preferred-patterns/code-examples.md` AP-8 for full before/after examples.
+
+### Detection Signals
+
+| Signal | Grep / Structural Check | Simplification |
+|--------|------------------------|----------------|
+| Defensive copy on fresh slice | `make([]T, len(x)+N)` + `copy(result, x)` where x is freshly allocated | Replace with `append(x, element)` |
+| Coupling comment | `grep -rn "must be called after\|must always follow\|INVARIANT.*call.*after" --include="*.go"` | Merge the "always follows" logic into the prerequisite function |
+| Same-pair call pattern | `helperB(result)` appears after every `result := functionA()` call site | Move `helperB` logic inside `functionA` |
+
+### Coupling Comment Fix
+
+When a comment says "must be called after X", the fix is to move that logic inside X. The comment documents a coupling that code structure should eliminate.
+
+```go
+// Before: Comment documents what code should enforce
+labelKey, vals := scopeToLabel(req, ks)
+vals = appendSentinel(vals) // forget this = silent bug
+
+// After: Coupling eliminated — impossible to forget
+labelKey, vals := scopeToLabel(req, ks) // sentinel included automatically
+```
+
+**Origin**: PR #220 — Stefan Majewsky.

--- a/skills/engineering/go-patterns/references/code-review/common-review-comments.md
+++ b/skills/engineering/go-patterns/references/code-review/common-review-comments.md
@@ -272,3 +272,48 @@ if apiKey == storedKey { ... }
 import "crypto/subtle"
 if subtle.ConstantTimeCompare([]byte(apiKey), []byte(storedKey)) == 1 { ... }
 ```
+
+---
+
+## Abstraction Boundaries
+
+### Shotgun Surgery / Always-Follows Pattern
+
+```go
+// Bad: Helper must be called at every call site of another function
+labelKey, vals := scopeToLabelConstraint(req, ks)
+vals = appendSentinelValue(vals) // forget this = silent bug
+
+// Good: Helper merged into the producing function
+labelKey, vals := scopeToLabelConstraint(req, ks)
+// sentinel is always included — impossible to forget
+```
+
+**Review comment**: "If `appendSentinelValue` must follow every `scopeToLabelConstraint` call, it belongs inside `scopeToLabelConstraint`. The coupling comment is a code smell, not a safety measure."
+
+### Defensive Copy of Fresh Slices
+
+```go
+// Bad: make+copy on a slice that was just allocated
+result := make([]string, len(vals)+1)
+copy(result, vals)
+result[len(result)-1] = sentinel
+
+// Good: append — no shared backing array on fresh slices
+return append(vals, sentinel)
+```
+
+**Review comment**: "This slice was just allocated — no other reference exists. The `make`+`copy` protects against a problem that cannot occur. Use `append`."
+
+### Coupling Comment Smell
+
+**Detect**: `grep -rn "must be called after\|must always follow\|INVARIANT.*call" --include="*.go"`
+
+```go
+// Bad: Comment documents what code structure should enforce
+// INVARIANT: This function must be called after every scopeToLabelConstraint() call.
+
+// Good: No comment needed — coupling is inside the function
+```
+
+**Review comment**: "INVARIANT comments that document call ordering are a signal the abstraction boundary is wrong. Move the dependent logic into the prerequisite function."

--- a/skills/engineering/go-patterns/references/preferred-patterns/code-examples.md
+++ b/skills/engineering/go-patterns/references/preferred-patterns/code-examples.md
@@ -360,3 +360,94 @@ func (opts AuditorOpts) buildConnectionURL() (string, error) {
 | Logical complexity | Distinct operation | Obvious step |
 | Testing need | Needs independent tests | Tested via caller |
 | Name value | Name adds understanding | Name restates code |
+
+---
+
+## AP-8: Shotgun Surgery / Wrong Abstraction Boundary (Extended)
+
+When a helper must be called at every call site of another function, the helper belongs inside the original function. An INVARIANT comment documenting this coupling is a code smell, not a safety measure.
+
+### Full Bad Example
+
+```go
+func scopeToLabelConstraint(req *http.Request, ks keystone.Driver) (string, []string) {
+    if projectID := req.Header.Get("X-Project-Id"); projectID != "" {
+        children, err := ks.ChildProjects(ctx, projectID)
+        if err != nil { panic(err) }
+        return "project_id", append([]string{projectID}, children...)
+    }
+    return "domain_id", []string{req.Header.Get("X-Domain-Id")}
+}
+
+// INVARIANT: This function must be called after every scopeToLabelConstraint() call.
+func appendSentinelValue(labelValues []string) []string {
+    if sentinelValue != "" {
+        result := make([]string, len(labelValues)+1)
+        copy(result, labelValues)
+        result[len(result)-1] = sentinelValue
+        return result
+    }
+    return labelValues
+}
+
+// Every caller must remember the two-step dance:
+func (p *v1Provider) Query(w http.ResponseWriter, req *http.Request) {
+    labelKey, labelValue := scopeToLabelConstraint(req, ks)
+    labelValue = appendSentinelValue(labelValue) // forget this = silent bug
+    // ...
+}
+```
+
+**Three compounding problems:**
+
+| Problem | Detail |
+|---------|--------|
+| Shotgun surgery | A 5th caller that forgets `appendSentinelValue` silently breaks global metrics |
+| Defensive copy on fresh slice | `make`+`copy` protects against mutation of a slice that was just allocated — no shared backing array exists |
+| Over-testing trivial code | 74-line test for a 3-line `append` wrapper with cyclomatic complexity 2 |
+
+### Full Good Example
+
+```go
+func scopeToLabelConstraint(req *http.Request, ks keystone.Driver) (string, []string) {
+    if projectID := req.Header.Get("X-Project-Id"); projectID != "" {
+        children, err := ks.ChildProjects(ctx, projectID)
+        if err != nil { panic(err) }
+        return "project_id", appendSentinelValue(append([]string{projectID}, children...))
+    }
+    return "domain_id", appendSentinelValue([]string{req.Header.Get("X-Domain-Id")})
+}
+
+func appendSentinelValue(labelValues []string) []string {
+    if sentinelValue != "" {
+        return append(labelValues, sentinelValue)
+    }
+    return labelValues
+}
+
+// Callers just use scopeToLabelConstraint — sentinel is always included:
+func (p *v1Provider) Query(w http.ResponseWriter, req *http.Request) {
+    labelKey, labelValue := scopeToLabelConstraint(req, ks)
+    // no second step needed — impossible to forget
+    // ...
+}
+```
+
+### Detection Signals
+
+| Signal | Detection | Fix |
+|--------|-----------|-----|
+| Coupling comment | `grep -rn "must be called after\|must always follow\|INVARIANT.*call" --include="*.go"` | Merge the "always follows" logic into the prerequisite function |
+| Same-pair call pattern | `helperB(result)` after every `result := functionA()` | Move `helperB` inside `functionA` |
+| Defensive copy on fresh slice | `make([]T, len(x)+N)` + `copy(result, x)` where x is freshly allocated | Replace with `append(x, elements...)` |
+| Over-tested trivial code | Test LOC > 10x function LOC, cyclomatic complexity <= 2 | Integration tests likely cover it; delete or reduce |
+
+### Triple-Validation
+
+| Check | Evidence |
+|-------|----------|
+| Recurrence | Appears in SAP CC PRs (maia, limes, keppel) and general Go codebases — any function pair with always-follows coupling |
+| Generative power | Predicts new bugs: any future caller of `functionA` that omits `helperB` |
+| Exclusivity | Distinguishes from generic "extract function" advice — specifically targets the case where extraction creates mandatory call-site coupling |
+
+**Origin**: [PR #220](https://github.com/SAP-cloud-infrastructure/maia/pull/220) — Stefan Majewsky. `appendSentinelValue` called at 4 sites after `scopeToLabelConstraint`; refactor moved sentinel inside `scopeToLabelConstraint`.

--- a/skills/engineering/sapcc-review/references/agent-dispatch-prompts.md
+++ b/skills/engineering/sapcc-review/references/agent-dispatch-prompts.md
@@ -236,3 +236,18 @@ Write ALL findings to: [output file path]
 - Test setup in `TestMain` instead of per-test
 - Verbose error checking instead of `assert.ErrEqual` / `must.SucceedT`
 - **Extraction without guard transfer**: When inline code is extracted into a named helper, ALL defensive checks that relied on "the caller handles it" must be re-evaluated. A missing guard rated LOW as inline code becomes MEDIUM as a reusable function. Flag extracted helpers that lack self-contained validation.
+
+---
+
+## Cross-Agent Rule: Abstraction Boundary Violations (All Agents)
+
+Flag these patterns regardless of which domain agent encounters them. Full examples: `go-patterns/references/preferred-patterns/code-examples.md` AP-8.
+
+| Pattern | Detection | Severity | Fix |
+|---------|-----------|----------|-----|
+| Shotgun surgery / always-follows | `grep -rn "must be called after\|must always follow\|INVARIANT.*call" --include="*.go"` | MEDIUM (new) / LOW (existing) | Merge helper into prerequisite function |
+| Same-pair call pattern | `helperB(result)` after every `result := functionA()` | MEDIUM (new) / LOW (existing) | Move `helperB` inside `functionA` |
+| Defensive copy on fresh slice | `make([]T, len(x)+N)` + `copy` where x is freshly allocated | LOW | Replace with `append(x, element)` |
+| Over-tested trivial function | Test LOC > 10x function LOC, complexity <= 2 | LOW | Integration tests likely suffice |
+
+**Origin**: PR #220 — Stefan Majewsky.


### PR DESCRIPTION
## Summary
- Add abstraction boundary violation detection patterns (shotgun surgery, defensive copy on fresh slices, coupling-comment smells) sourced from Stefan Majewsky's review on SAP CC PR #220
- Patterns distributed across 4 reference files, each carrying only what its role requires: `simplifier.md` (detection table), `common-review-comments.md` (reviewer comment templates), `code-examples.md` (canonical AP-8 full example with triple-validation), `agent-dispatch-prompts.md` (cross-agent detection table)
- Also fixes `--model claude-sonnet-4-7` → `--model sonnet` in 5 cron scripts (reddit-automod, auto-dream, toolkit-evolution, reference-enrichment, kb-compile)

## Test plan
- [ ] Verify no duplicate content across the 4 reference files
- [ ] Confirm grep detection commands in the patterns are valid
- [ ] Validate cron scripts use correct model identifier
- [ ] Check PHILOSOPHY.md compliance (density, triple-validation, deterministic detection)