### PR TITLE
fix: update invalid model name in cron scripts

### DIFF
--- a/scripts/auto-dream-cron.sh
+++ b/scripts/auto-dream-cron.sh
@@ -98,7 +98,7 @@ claude -p "$PROMPT" \
     --dangerously-skip-permissions \
     --max-budget-usd "$MAX_BUDGET" \
     --no-session-persistence \
-    --model claude-sonnet-4-7 \
+    --model sonnet \
     2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 EXIT_CODE=${PIPESTATUS[0]}
 set -e

--- a/scripts/reference-enrichment-cron.sh
+++ b/scripts/reference-enrichment-cron.sh
@@ -182,7 +182,7 @@ if [ -n "$DECOMPOSE" ]; then
         --dangerously-skip-permissions \
         --max-budget-usd "$MAX_BUDGET" \
         --no-session-persistence \
-        --model claude-sonnet-4-7 \
+        --model sonnet \
         2>&1 | tee "$LOG_DIR/decomp-$(date +%Y%m%d-%H%M%S).log"
     EXIT_CODE=${PIPESTATUS[0]}
     set -e
@@ -298,7 +298,7 @@ else
         --dangerously-skip-permissions \
         --max-budget-usd "$MAX_BUDGET" \
         --no-session-persistence \
-        --model claude-sonnet-4-7 \
+        --model sonnet \
         2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
     EXIT_CODE=${PIPESTATUS[0]}
     set -e

--- a/scripts/toolkit-evolution-cron.sh
+++ b/scripts/toolkit-evolution-cron.sh
@@ -117,7 +117,7 @@ claude -p "$PROMPT" \
     --dangerously-skip-permissions \
     --max-budget-usd "$MAX_BUDGET" \
     --no-session-persistence \
-    --model claude-sonnet-4-7 \
+    --model sonnet \
     2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 EXIT_CODE=${PIPESTATUS[0]}
 set -e

--- a/skills/content/reddit-moderate/scripts/reddit-automod-cron.sh
+++ b/skills/content/reddit-moderate/scripts/reddit-automod-cron.sh
@@ -12,8 +12,10 @@
 # Cron example (twice daily at 8am and 8pm):
 #   0 8,20 * * * /home/feedgen/vexjoy-agent/skills/content/reddit-moderate/scripts/reddit-automod-cron.sh --execute >> /home/feedgen/vexjoy-agent/reddit-data/sap/cron-log/cron.log 2>&1
 
-# Ensure claude CLI is in PATH (cron doesn't inherit user PATH)
-export PATH="$HOME/.local/bin:$HOME/.nvm/versions/node/$(ls $HOME/.nvm/versions/node/ 2>/dev/null | tail -1)/bin:$PATH"
+# Ensure claude CLI and venv python are in PATH (cron doesn't inherit user PATH)
+# Venv python first so `python3` resolves to the venv with praw installed
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+export PATH="$REPO_ROOT/venv/bin:$HOME/.local/bin:$HOME/.nvm/versions/node/$(ls $HOME/.nvm/versions/node/ 2>/dev/null | tail -1)/bin:$PATH"
 
 set -euo pipefail
 
@@ -89,7 +91,7 @@ claude -p "$PROMPT" \
     --permission-mode auto \
     --max-budget-usd "$MAX_BUDGET" \
     --no-session-persistence \
-    --model claude-sonnet-4-7 \
+    --model sonnet \
     2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 
 EXIT_CODE=${PIPESTATUS[0]}

--- a/skills/content/reddit-moderate/scripts/reddit-automod-cron.sh
+++ b/skills/content/reddit-moderate/scripts/reddit-automod-cron.sh
@@ -14,7 +14,7 @@
 
 # Ensure claude CLI and venv python are in PATH (cron doesn't inherit user PATH)
 # Venv python first so `python3` resolves to the venv with praw installed
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 export PATH="$REPO_ROOT/venv/bin:$HOME/.local/bin:$HOME/.nvm/versions/node/$(ls $HOME/.nvm/versions/node/ 2>/dev/null | tail -1)/bin:$PATH"
 
 set -euo pipefail

--- a/skills/kb/scripts/kb-compile-cron.sh
+++ b/skills/kb/scripts/kb-compile-cron.sh
@@ -106,7 +106,7 @@ claude -p "$PROMPT" \
     --dangerously-skip-permissions \
     --max-budget-usd "$MAX_BUDGET" \
     --no-session-persistence \
-    --model claude-sonnet-4-7 \
+    --model sonnet \
     2>&1 | tee "$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 EXIT_CODE=${PIPESTATUS[0]}
 set -e


### PR DESCRIPTION
## Summary
- Replace `--model claude-sonnet-4-7` with `--model sonnet` in 5 cron scripts — the old identifier is invalid, causing all headless cron jobs to fail at startup
- Add venv PATH to reddit-automod-cron.sh so `python3` resolves to the venv with `praw` installed

## Files changed
- `scripts/auto-dream-cron.sh`
- `scripts/reference-enrichment-cron.sh`
- `scripts/toolkit-evolution-cron.sh`
- `skills/content/reddit-moderate/scripts/reddit-automod-cron.sh`
- `skills/kb/scripts/kb-compile-cron.sh`

## Test plan
- [x] Validated reddit-automod dry-run: praw imports, Reddit API connects, modqueue returns valid JSON
- [x] Validated auto-dream dry-run: exit 0, injection payload written, 50 sessions analyzed
- [x] `--model sonnet` confirmed valid via `claude -p` test