### PR TITLE
fix: detect hooks registered with relative paths

### DIFF
--- a/scripts/install-doctor.py
+++ b/scripts/install-doctor.py
@@ -370,27 +370,33 @@ def check_hook_files() -> list[dict]:
     results = []
 
     if relative_path_hooks:
-        results.append({
-            "name": "hook_relative_paths",
-            "label": "No hooks use relative paths",
-            "passed": False,
-            "detail": f"{len(relative_path_hooks)} hook(s) use relative paths (break outside toolkit repo): {', '.join(relative_path_hooks[:5])}. Fix: use $HOME/.claude/hooks/ prefix.",
-        })
+        results.append(
+            {
+                "name": "hook_relative_paths",
+                "label": "No hooks use relative paths",
+                "passed": False,
+                "detail": f"{len(relative_path_hooks)} hook(s) use relative paths (break outside toolkit repo): {', '.join(relative_path_hooks[:5])}. Fix: use $HOME/.claude/hooks/ prefix.",
+            }
+        )
 
     if missing:
-        results.append({
-            "name": "hook_files",
-            "label": "Hook script files exist",
-            "passed": False,
-            "detail": f"{found} found, {len(missing)} missing: {', '.join(missing[:5])}",
-        })
+        results.append(
+            {
+                "name": "hook_files",
+                "label": "Hook script files exist",
+                "passed": False,
+                "detail": f"{found} found, {len(missing)} missing: {', '.join(missing[:5])}",
+            }
+        )
     else:
-        results.append({
-            "name": "hook_files",
-            "label": "Hook script files exist",
-            "passed": True,
-            "detail": f"All {found} hook scripts found",
-        })
+        results.append(
+            {
+                "name": "hook_files",
+                "label": "Hook script files exist",
+                "passed": True,
+                "detail": f"All {found} hook scripts found",
+            }
+        )
 
     return results
 

--- a/scripts/install-doctor.py
+++ b/scripts/install-doctor.py
@@ -354,32 +354,45 @@ def check_hook_files() -> list[dict]:
                 commands.extend(extract_hook_commands(item))
         return commands
 
+    relative_path_hooks = []
     for event, hook_list in hooks.items():
         for cmd in extract_hook_commands(hook_list):
+            # Flag hooks using relative paths — they break outside the toolkit repo
+            if ("python3 hooks/" in cmd or 'python3 "hooks/' in cmd) and "$HOME" not in cmd:
+                hook_file = cmd.split("hooks/")[-1].rstrip('"').rstrip("'")
+                relative_path_hooks.append(f"{event}: {hook_file}")
             for path in extract_python_paths(cmd):
                 if path.exists():
                     found += 1
                 else:
                     missing.append(f"{event}: {path.name}")
 
-    if missing:
-        return [
-            {
-                "name": "hook_files",
-                "label": "Hook script files exist",
-                "passed": False,
-                "detail": f"{found} found, {len(missing)} missing: {', '.join(missing[:5])}",
-            }
-        ]
+    results = []
 
-    return [
-        {
+    if relative_path_hooks:
+        results.append({
+            "name": "hook_relative_paths",
+            "label": "No hooks use relative paths",
+            "passed": False,
+            "detail": f"{len(relative_path_hooks)} hook(s) use relative paths (break outside toolkit repo): {', '.join(relative_path_hooks[:5])}. Fix: use $HOME/.claude/hooks/ prefix.",
+        })
+
+    if missing:
+        results.append({
+            "name": "hook_files",
+            "label": "Hook script files exist",
+            "passed": False,
+            "detail": f"{found} found, {len(missing)} missing: {', '.join(missing[:5])}",
+        })
+    else:
+        results.append({
             "name": "hook_files",
             "label": "Hook script files exist",
             "passed": True,
             "detail": f"All {found} hook scripts found",
-        }
-    ]
+        })
+
+    return results
 
 
 def check_python_version() -> dict:

--- a/scripts/register-hook.py
+++ b/scripts/register-hook.py
@@ -183,6 +183,11 @@ def cmd_validate(args: argparse.Namespace) -> None:
             for h in group.get("hooks", []):
                 cmd = h.get("command", "")
                 if "$HOME/.claude/hooks/" not in cmd:
+                    # Flag hooks using relative paths — they break in non-toolkit repos
+                    if "python3 hooks/" in cmd or "python3 \"hooks/" in cmd:
+                        hook_file = cmd.split("hooks/")[-1].rstrip('"').rstrip("'")
+                        issues.append((event, hook_file, "RELATIVE PATH"))
+                        print(f"  FAIL: {event} -> {hook_file} — uses relative path (breaks outside toolkit repo)")
                     continue
                 # Extract filename
                 name = cmd.split("$HOME/.claude/hooks/")[-1].rstrip('"')

--- a/scripts/register-hook.py
+++ b/scripts/register-hook.py
@@ -184,7 +184,7 @@ def cmd_validate(args: argparse.Namespace) -> None:
                 cmd = h.get("command", "")
                 if "$HOME/.claude/hooks/" not in cmd:
                     # Flag hooks using relative paths — they break in non-toolkit repos
-                    if "python3 hooks/" in cmd or "python3 \"hooks/" in cmd:
+                    if "python3 hooks/" in cmd or 'python3 "hooks/' in cmd:
                         hook_file = cmd.split("hooks/")[-1].rstrip('"').rstrip("'")
                         issues.append((event, hook_file, "RELATIVE PATH"))
                         print(f"  FAIL: {event} -> {hook_file} — uses relative path (breaks outside toolkit repo)")


### PR DESCRIPTION
## Summary
- `register-hook.py validate` now flags hooks using relative paths (`python3 hooks/foo.py`) as FAIL — these break outside the toolkit repo
- `install-doctor.py` adds a new named check ("No hooks use relative paths") that catches this at session startup
- Root cause: 3 hooks were registered by agents that manually edited settings.json instead of using `register-hook.py`, bypassing its absolute-path generation

## Test plan
- [x] `register-hook.py validate` passes after fixing settings.json
- [x] `install-doctor.py` reports no relative-path hooks after fix
- [ ] CI passes (ruff lint + tests)