### PR TITLE
feat: hook validation structured output + skill index automation

### DIFF
--- a/hooks/posttooluse-sync-skill-index.py
+++ b/hooks/posttooluse-sync-skill-index.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+PostToolUse Hook: Auto-sync INDEX.json on SKILL.md frontmatter changes
+
+Triggered by Write|Edit events. Checks whether the written file is a
+skills/**/SKILL.md. If yes, regenerates skills/INDEX.json by running
+scripts/generate-skill-index.py. Silent on unrelated file writes.
+
+Registration (add to ~/.claude/settings.json under hooks.PostToolUse):
+    {
+      "matcher": "Write|Edit",
+      "hooks": [{
+        "type": "command",
+        "command": "python3 \"$HOME/.claude/hooks/posttooluse-sync-skill-index.py\"",
+        "description": "Regenerate INDEX.json when a SKILL.md is written",
+        "timeout": 15000
+      }]
+    }
+
+Design:
+- Silent unless a SKILL.md was touched (zero cost for unrelated edits)
+- Advisory: always exits 0 (never blocks Claude Code)
+- Runs with a 15-second timeout budget (index gen completes in <2s for 100+ skills)
+- Emits a one-line summary on success; full stderr on failure
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from stdin_timeout import read_stdin
+
+# Matches skills/**/SKILL.md (flat and nested category layouts)
+SKILL_FILE_RE = re.compile(r"skills/(?:[^/]+/)+SKILL\.md$")
+
+
+def main() -> None:
+    """Process PostToolUse hook event."""
+    try:
+        event_data = read_stdin(timeout=2)
+        if not event_data.strip():
+            return
+
+        event = json.loads(event_data)
+        tool_input = event.get("tool_input", {})
+        file_path = tool_input.get("file_path", "")
+
+        if not file_path:
+            return
+
+        # Only act on skills/**/SKILL.md files
+        if not SKILL_FILE_RE.search(file_path):
+            return
+
+        # Resolve repo root: hooks/ is one level below repo root
+        hook_dir = Path(__file__).resolve().parent
+        repo_root = hook_dir.parent
+        generator = repo_root / "scripts" / "generate-skill-index.py"
+
+        if not generator.exists():
+            print(
+                f"[sync-skill-index] generator not found: {generator}",
+                file=sys.stderr,
+            )
+            return
+
+        result = subprocess.run(
+            [sys.executable, str(generator)],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+            timeout=12,
+        )
+
+        if result.returncode == 0:
+            # Emit a brief confirmation — model sees this as context
+            skill_name = Path(file_path).parent.name
+            print(f"[sync-skill-index] INDEX.json regenerated after {skill_name}/SKILL.md edit")
+        else:
+            print(
+                f"[sync-skill-index] generator failed (exit {result.returncode})",
+                file=sys.stderr,
+            )
+            if result.stderr.strip():
+                for line in result.stderr.strip().splitlines()[:10]:
+                    print(f"  {line}", file=sys.stderr)
+
+    except subprocess.TimeoutExpired:
+        print("[sync-skill-index] generator timed out after 12s", file=sys.stderr)
+    except Exception as e:
+        print(f"[sync-skill-index] hook error: {e}", file=sys.stderr)
+    finally:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install-doctor.py
+++ b/scripts/install-doctor.py
@@ -831,13 +831,18 @@ def run_all_checks() -> list[dict]:
 
 
 def print_results(results: list[dict]) -> bool:
-    """Print results in human-readable format. Returns True if all passed."""
+    """Print results in human-readable format. Returns True if all passed.
+
+    Failures also emit machine-parseable [FAIL] lines to stderr so CI and
+    cron wrappers can detect problems with a simple grep for '[FAIL]'.
+    """
     all_passed = True
     for r in results:
         icon = "\u2713" if r["passed"] else "\u2717"
         print(f"  [{icon}] {r['label']}: {r['detail']}")
         if not r["passed"]:
             all_passed = False
+            print(f"[FAIL] {r['name']}: {r['detail']}", file=sys.stderr)
     return all_passed
 
 

--- a/scripts/register-hook.py
+++ b/scripts/register-hook.py
@@ -171,7 +171,11 @@ def cmd_list(args: argparse.Namespace) -> None:
 
 
 def cmd_validate(args: argparse.Namespace) -> None:
-    """Validate all registered hooks have backing files."""
+    """Validate all registered hooks have backing files.
+
+    Emits one [PASS]/[FAIL] line per hook so CI and cron wrappers can
+    detect problems by grepping for '[FAIL]'.
+    """
     settings = load_settings()
     hooks = settings.get("hooks", {})
     issues = []
@@ -187,21 +191,21 @@ def cmd_validate(args: argparse.Namespace) -> None:
                     if "python3 hooks/" in cmd or 'python3 "hooks/' in cmd:
                         hook_file = cmd.split("hooks/")[-1].rstrip('"').rstrip("'")
                         issues.append((event, hook_file, "RELATIVE PATH"))
-                        print(f"  FAIL: {event} -> {hook_file} — uses relative path (breaks outside toolkit repo)")
+                        print(f"[FAIL] {event}/{hook_file}: uses relative path (breaks outside toolkit repo)")
                     continue
                 # Extract filename
                 name = cmd.split("$HOME/.claude/hooks/")[-1].rstrip('"')
                 target = HOOKS_DIR / name
                 if not target.exists():
                     issues.append((event, name, "FILE MISSING"))
-                    print(f"  FAIL: {event} -> {name} — file does not exist at {target}")
+                    print(f"[FAIL] {event}/{name}: file does not exist at {target}")
                 else:
-                    print(f"  OK:   {event} -> {name}")
+                    print(f"[PASS] {event}/{name}")
 
     if issues:
-        print(f"\n{len(issues)} hook(s) registered without backing files!")
-        print("This WILL deadlock Claude Code (Python exit 2 = BLOCK).")
-        print("Fix: create the missing files or unregister the hooks.")
+        print(f"\n{len(issues)} hook(s) registered without backing files!", file=sys.stderr)
+        print("This WILL deadlock Claude Code (Python exit 2 = BLOCK).", file=sys.stderr)
+        print("Fix: create the missing files or unregister the hooks.", file=sys.stderr)
         sys.exit(2)
     else:
         print("\nAll registered hooks have backing files.")


### PR DESCRIPTION
## Summary

Two evolution cycle winners from the 2026-05-09 nightly toolkit-evolution cycle. Both received unanimous STRONG consensus (3.0/3.0) across Pragmatist, Purist, and User Advocate personas and passed all A/B validation tests.

### Change 1: Structured [PASS]/[FAIL] output for hook validation

- `scripts/install-doctor.py`: failures now emit `[FAIL] name: detail` to stderr alongside existing human-readable stdout — CI and cron wrappers can detect problems by grepping `[FAIL]`
- `scripts/register-hook.py validate`: normalized per-hook output from ad-hoc `FAIL:`/`OK:` format to consistent `[PASS]`/`[FAIL]` bracketed format matching install-doctor convention

**Evidence**: 4 hook-related PRs in 2 weeks (#614, #617, plus 7 edits to install-doctor.py). Silent hook failures were the recurring root cause.

### Change 2: PostToolUse hook for automatic INDEX.json sync

- `hooks/posttooluse-sync-skill-index.py`: detects Write|Edit events on `skills/**/SKILL.md`, runs `scripts/generate-skill-index.py`, emits a one-line confirmation on success, silent on unrelated edits, advisory (always exits 0)

**Evidence**: INDEX.json was the most churned file in the repo at 23 edits in 2 weeks — one manual regeneration per skill addition.

**Registration needed after merge** (add to `~/.claude/settings.json` under `hooks.PostToolUse`):
```json
{
  "matcher": "Write|Edit",
  "hooks": [{
    "type": "command",
    "command": "python3 \"$HOME/.claude/hooks/posttooluse-sync-skill-index.py\"",
    "description": "Regenerate INDEX.json when a SKILL.md is written",
    "timeout": 15000
  }]
}
```

## Consensus Scores

| Proposal | Pragmatist | Purist | User Advocate | Avg |
|----------|-----------|--------|---------------|-----|
| hook-lifecycle-validator | STRONG | STRONG | STRONG | **3.0** |
| skill-index-automation | STRONG | STRONG | STRONG | **3.0** |

## Validation Results

| Test | Result |
|------|--------|
| `register-hook.py validate` emits `[PASS]` per hook | PASS |
| `install-doctor.py` exits 0, no `[FAIL]` on clean install | PASS |
| sync hook fires on `skills/**/SKILL.md` write | PASS |
| sync hook silent on unrelated file writes | PASS |
| `ruff check` all modified files | PASS |
| `python3 -m py_compile` all modified files | PASS |

## Evolution Cycle
Generated and validated by the toolkit-evolution skill (2026-05-09 nightly cycle).