### PR TITLE
feat(refs): perses-engineer — dashboard DaC, plugin dev, operator CRDs (Level 0→3)

### DIFF
--- a/agents/perses-engineer.md
+++ b/agents/perses-engineer.md
@@ -75,7 +75,7 @@ After making changes to CRDs, Helm values, or operator configuration, STOP and a
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `core.md` | Loads detailed guidance from `core.md`. |
-| tasks related to this reference | `dashboard.md` | Loads detailed guidance from `dashboard.md`. |
-| tasks related to this reference | `operator.md` | Loads detailed guidance from `operator.md`. |
-| tasks related to this reference | `plugin.md` | Loads detailed guidance from `plugin.md`. |
+| Go backend, React frontend, CUE schemas, auth, build, contribution, architecture, API handlers, storage | `references/core.md` | Core Perses development patterns |
+| dashboard, DaC, Dashboard-as-Code, percli, variable, query, datasource, PromQL, panel, timeseries, migrate Grafana | `references/dashboard.md` | Dashboard creation and DaC SDK patterns |
+| Kubernetes, CRD, operator, Helm, k8s, PersesDashboard, PersesProject, RBAC, cert-manager, manifest | `references/operator.md` | Kubernetes operator CRDs and deployment |
+| plugin, Module Federation, CUE schema, scaffold, panel plugin, datasource plugin, percli plugin, webpack | `references/plugin.md` | Plugin development, CUE schemas, and React components |

--- a/agents/perses-engineer/references/dashboard.md
+++ b/agents/perses-engineer/references/dashboard.md
@@ -1,0 +1,287 @@
+# Perses Dashboard Reference
+
+> **Scope**: Dashboard-as-Code (DaC) patterns, Go/CUE SDK usage, percli CLI, variables, panels, and datasource wiring. Does not cover operator CRDs or plugin development.
+> **Version range**: Perses v0.47+ (CRD v1alpha2, Go SDK v0.47+)
+> **Generated**: 2026-05-09 — verify against https://github.com/perses/perses/releases
+
+---
+
+## Overview
+
+Perses dashboards are defined as JSON/YAML documents validated against CUE schemas. Dashboard-as-Code (DaC) lets you generate these documents programmatically using the Go SDK or CUE, avoiding hand-edited JSON drift. The most common failure mode is referencing a datasource name or variable name that doesn't match the project's registered datasources — Perses fails silently on missing refs.
+
+---
+
+## Pattern Table
+
+| Pattern | Version | Use When | Avoid When |
+|---------|---------|----------|------------|
+| Go SDK (`go/sdk`) | `v0.47+` | Generating dashboards from code | The dashboard is one-off or manually curated |
+| CUE schemas | all | Validating dashboard JSON | You need Go type safety across multiple dashboards |
+| `percli apply -f` | all | Pushing dashboards to a live server | Dry-runs — use `--dry-run` flag |
+| `percli export` | all | Pulling existing dashboards to DaC | Initial migration from UI-created dashboards |
+| `percli migrate` | `v0.40+` | Converting Grafana dashboards | Only Grafana JSON v8+ is supported |
+
+---
+
+## Dashboard-as-Code: Go SDK
+
+### Minimal working dashboard
+
+```go
+import (
+    "github.com/perses/perses/go/sdk/dashboard"
+    "github.com/perses/perses/go/sdk/panel/timeseries"
+    listvar "github.com/perses/perses/go/sdk/variable/listvar"
+    prometheustarget "github.com/perses/perses/go/sdk/prometheus/query"
+)
+
+builder, err := dashboard.New("My Dashboard",
+    dashboard.ProjectName("my-project"),
+    dashboard.Duration("1h"),
+    dashboard.RefreshInterval("30s"),
+    dashboard.AddVariable(
+        listvar.New("namespace",
+            listvar.DisplayName("Namespace"),
+            listvar.CapturingRegexp("(.+)"),
+            listvar.AllowAllValue(true),
+            listvar.AllowMultiple(false),
+        ),
+    ),
+    dashboard.AddPanelGroup("Overview",
+        dashboard.AddPanel("Requests/sec",
+            timeseries.New("Requests/sec",
+                timeseries.WithPrometheusTarget(
+                    `rate(http_requests_total{namespace="$namespace"}[5m])`,
+                    prometheustarget.Legend("{{handler}}"),
+                ),
+            ),
+        ),
+    ),
+)
+```
+
+**Why**: The SDK enforces schema at compile time. Mistyped field names are caught before `percli apply` runs.
+
+---
+
+### Variable types
+
+```go
+// Text variable — free-form input
+textvar.New("cluster",
+    textvar.DisplayName("Cluster"),
+    textvar.Value("prod"),  // default value
+)
+
+// List variable — query-driven options
+listvar.New("namespace",
+    listvar.PrometheusLabelValuesQuery("namespace", "kube_pod_info"),
+    listvar.AllowAllValue(true),
+    listvar.AllowMultiple(true),
+    listvar.Sort(listvar.AlphabeticalAsc),
+)
+
+// Constant variable — fixed value, often hidden
+constantvar.New("datasource",
+    constantvar.Value("PrometheusDemo"),
+    constantvar.Hide(true),
+)
+```
+
+**Why**: List variables using `AllowMultiple(true)` must use `=~` (regex match) in PromQL, not `=`. Mixing `=` with a multi-value variable silently uses only the first selected value.
+
+---
+
+### Panel types and imports
+
+| Panel | Import path suffix | Key option |
+|-------|-------------|-----------|
+| TimeSeriesChart | `panel/timeseries` | `.WithPrometheusTarget()` |
+| GaugeChart | `panel/gauge` | `.Thresholds()` |
+| StatChart | `panel/stat` | `.Format()`, `.Sparkline()` |
+| BarChart | `panel/barchart` | `.XAxis()` |
+| Markdown | `panel/markdown` | `.Text()` |
+| ScatterChart | `panel/scatterchart` | `.WithPrometheusTarget()` |
+| Table | `panel/table` | `.ColumnSettings()` |
+
+---
+
+## Pattern Catalog: Detection and Fixes
+
+### Hardcoded datasource name (breaks across projects)
+
+**Detection**:
+```bash
+grep -rn '"default"' --include="*.go" | grep -i datasource
+grep -rn 'datasource.*"prometheus"' --include="*.cue"
+rg 'datasourceName.*"[A-Za-z]+"' --type go
+```
+
+**Signal**:
+```go
+// Hardcoded datasource name — breaks when deployed to a project
+// that registered the datasource under a different name
+timeseries.WithPrometheusTarget(
+    "up",
+    prometheustarget.Datasource("default"),  // "default" may not exist
+)
+```
+
+**Why it matters**: Datasource names are scoped to a project. A dashboard deployed to project `team-a` expecting `"default"` fails if that project registered the datasource as `"prometheus-prod"`. The panel renders empty with no error in the UI.
+
+**Preferred action**:
+```go
+// Use a variable reference for datasource selection
+constantvar.New("datasource", constantvar.Value("PrometheusDemo"))
+// Then reference it:
+prometheustarget.Datasource("$datasource")
+```
+
+---
+
+### Multi-value variable with equality operator
+
+**Detection**:
+```bash
+grep -rn 'AllowMultiple(true)' --include="*.go" -A5 | grep -v '=~'
+rg '\$\w+[^~]' --type json | grep -i 'expr\|query'
+```
+
+**Signal**:
+```go
+listvar.New("namespace", listvar.AllowMultiple(true))
+// ...then in query:
+`kube_pod_info{namespace="$namespace"}`  // = operator, not =~
+```
+
+**Why it matters**: When multiple namespaces are selected, `$namespace` expands to `ns1|ns2|ns3`. The `=` operator treats this as a literal string match, always returning no results. The `=~` operator applies regex matching.
+
+**Preferred action**:
+```go
+`kube_pod_info{namespace=~"$namespace"}`  // regex match for multi-value
+```
+
+---
+
+### Missing `dashboard.Duration` / `RefreshInterval`
+
+**Detection**:
+```bash
+rg 'dashboard\.New\(' --type go -A 10 | grep -c 'Duration\|Refresh'
+grep -rn 'dashboard.New(' --include="*.go" -A 8 | grep -v 'Duration'
+```
+
+**Signal**:
+```go
+dashboard.New("My Dashboard",
+    dashboard.ProjectName("my-project"),
+    // No Duration or RefreshInterval — uses server defaults (may be 6h)
+)
+```
+
+**Why it matters**: Without explicit duration, the dashboard opens with the server's default time range, which may be 6h or 24h. Users expect the dashboard designer's intended time range.
+
+**Preferred action**:
+```go
+dashboard.New("My Dashboard",
+    dashboard.Duration("1h"),
+    dashboard.RefreshInterval("30s"),
+)
+```
+
+---
+
+### Using `percli apply` without `--project`
+
+**Detection**:
+```bash
+grep -rn 'percli apply' --include="*.sh" | grep -v '\-\-project\|-p '
+grep -rn 'percli apply' Makefile | grep -v '\-\-project\|-p '
+```
+
+**Signal**:
+```bash
+percli apply -f dashboard.json  # applies to project embedded in JSON, may be wrong env
+```
+
+**Why it matters**: Without `--project`, percli uses the project name embedded in the dashboard JSON. A dashboard exported from `dev` and re-applied without `--project` silently creates/updates a dashboard in the wrong project in `prod`.
+
+**Preferred action**:
+```bash
+percli apply -f dashboard.yaml --project my-project --server https://perses.prod
+```
+
+---
+
+## percli Command Reference
+
+```bash
+# Export dashboard from server to local JSON
+percli export dashboard my-dashboard --project my-project --output json > dashboard.json
+
+# Apply (create or update) from file
+percli apply -f dashboard.yaml --project my-project
+
+# Dry-run validation without applying
+percli apply -f dashboard.yaml --project my-project --dry-run
+
+# Migrate Grafana dashboard JSON to Perses format
+percli migrate -f grafana-dashboard.json --output json > perses-dashboard.json
+
+# List all dashboards in a project
+percli get dashboard --project my-project
+
+# Delete a dashboard
+percli delete dashboard my-dashboard --project my-project
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|------------|-----|
+| `datasource "X" not found` | Dashboard references a datasource name not registered in project | Register datasource in project or use `$datasource` variable |
+| `variable "X" not defined` | Panel query uses `$varname` not declared in dashboard variables | Add variable to `dashboard.AddVariable(...)` |
+| Panel shows "No data" (no error) | Multi-value variable used with `=` instead of `=~` | Change PromQL query to use `=~` operator |
+| `percli apply: 409 Conflict` | Dashboard already exists and `--force` not set | Add `--force` flag or delete existing first |
+| `cue: schema validation failed` | Dashboard JSON doesn't match CUE schema | Run `cue vet` with Perses schemas to find exact field violation |
+| `migrate: unsupported panel type` | Grafana panel type has no Perses equivalent | Replace with StatChart or Markdown manually post-migration |
+
+---
+
+## Version-Specific Notes
+
+| Version | Change | Impact |
+|---------|--------|--------|
+| `v0.47` | `GridLayout` became the only supported layout type | Remove legacy `FlexLayout` references |
+| `v0.45` | Go SDK `dashboard.AddPanelGroup` replaced `dashboard.AddRow` | Update DaC code using old API |
+| `v0.43` | `percli migrate` added `--keep-unsupported` flag | Grafana dashboards with unsupported panels no longer abort migration |
+| `v0.40` | CRD promoted to `v1alpha2` | Update `apiVersion: perses.dev/v1alpha1` to `v1alpha2` in all manifests |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Hardcoded datasource names
+grep -rn 'datasourceName.*"[A-Za-z]+"' --include="*.go"
+
+# Multi-value variable without regex match operator
+grep -rn 'AllowMultiple(true)' --include="*.go"
+
+# Missing time range in DaC dashboards
+rg 'dashboard\.New\(' --type go -A 10 | grep -v 'Duration'
+
+# percli apply without explicit project
+grep -rn 'percli apply' --include="*.sh" | grep -v '\-\-project\|-p '
+```
+
+---
+
+## See Also
+
+- `plugin.md` — Panel plugin development and CUE schema authoring
+- `operator.md` — Kubernetes CRDs for managing dashboards declaratively
+- `core.md` — Go backend API and React frontend architecture

--- a/agents/perses-engineer/references/operator.md
+++ b/agents/perses-engineer/references/operator.md
@@ -1,0 +1,336 @@
+# Perses Operator Reference
+
+> **Scope**: Kubernetes CRDs (v1alpha2), Helm chart deployment, RBAC, cert-manager TLS, monitoring, and multi-instance management. Does not cover dashboard content or plugin development.
+> **Version range**: Perses Operator v0.4+ (CRD v1alpha2); Helm chart `perses-dev/perses`
+> **Generated**: 2026-05-09 — verify against https://github.com/perses/perses-operator
+
+---
+
+## Overview
+
+The Perses Operator manages Perses server instances and their associated resources (dashboards, datasources, variables) as Kubernetes CRDs. The operator reconciles `PersesDashboard`, `PersesProject`, `PersesGlobalDatasource`, and `PersesGlobalVariable` objects against the Perses API. The most common failure mode is deploying a `PersesDashboard` before the `PersesProject` it references exists — the operator queues retries silently.
+
+---
+
+## Pattern Table
+
+| CRD Kind | Scope | Purpose | Requires |
+|----------|-------|---------|---------|
+| `Perses` | Namespaced | Manages a Perses server instance | cert-manager (if TLS) |
+| `PersesProject` | Namespaced | Creates a project in the Perses API | `Perses` instance |
+| `PersesDashboard` | Namespaced | Syncs a dashboard to a project | `PersesProject` |
+| `PersesGlobalDatasource` | Namespaced | Registers a global datasource | `Perses` instance |
+| `PersesGlobalVariable` | Namespaced | Registers a global variable | `Perses` instance |
+| `PersesDatasource` | Namespaced | Project-scoped datasource | `PersesProject` |
+
+---
+
+## CRD Examples
+
+### Perses instance (server deployment)
+
+```yaml
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses
+  namespace: monitoring
+spec:
+  # Use StatefulSet when using filesystem storage (default)
+  # Use Deployment when using database/etcd storage
+  containerPort: 8080
+  config:
+    database:
+      # file-based storage — use PVC for persistence
+      file:
+        folder: /etc/perses/storage
+        extension: json
+  security:
+    # Enable auth — requires OIDC or native user config
+    enableAuth: false
+  # TLS via cert-manager
+  # tls:
+  #   enabled: true
+  #   caSecretName: perses-ca
+```
+
+**Why**: `file` storage requires a PVC; without one, pod restarts lose all dashboards. For production use either a PVC or configure etcd.
+
+---
+
+### PersesProject
+
+```yaml
+apiVersion: perses.dev/v1alpha2
+kind: PersesProject
+metadata:
+  name: my-team
+  namespace: monitoring
+spec:
+  # instanceRef points to the Perses CR in the same namespace
+  instanceRef:
+    name: perses
+```
+
+---
+
+### PersesDashboard
+
+```yaml
+apiVersion: perses.dev/v1alpha2
+kind: PersesDashboard
+metadata:
+  name: cluster-overview
+  namespace: monitoring
+spec:
+  instanceRef:
+    name: perses
+  # project must match an existing PersesProject .metadata.name
+  project: my-team
+  # dashboard is the full Perses dashboard spec (same as percli export output)
+  dashboard:
+    display:
+      name: "Cluster Overview"
+    duration: "1h"
+    refreshInterval: "30s"
+    variables: []
+    panels: {}
+    layouts: []
+```
+
+**Why**: `spec.project` is the Perses project name (from `PersesProject.metadata.name`), not the Kubernetes namespace. Confusing these is the most common misconfiguration.
+
+---
+
+### PersesGlobalDatasource
+
+```yaml
+apiVersion: perses.dev/v1alpha2
+kind: PersesGlobalDatasource
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  instanceRef:
+    name: perses
+  datasource:
+    display:
+      name: "Prometheus"
+    default: true
+    plugin:
+      kind: PrometheusDatasource
+      spec:
+        # directUrl proxies through the Perses backend
+        directUrl: "http://prometheus.monitoring.svc:9090"
+```
+
+---
+
+## Helm Chart Deployment
+
+### Add the Perses Helm repo
+
+```bash
+helm repo add perses-dev https://perses-dev.github.io/helm-charts
+helm repo update
+helm search repo perses-dev/perses --versions | head -5
+```
+
+### Minimal values.yaml
+
+```yaml
+# values.yaml
+perses:
+  config:
+    database:
+      file:
+        folder: /etc/perses/storage
+        extension: json
+  persistence:
+    enabled: true
+    size: 5Gi
+
+# Expose via Ingress
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: perses.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+
+# ServiceMonitor for Prometheus scraping
+serviceMonitor:
+  enabled: true
+  interval: 30s
+```
+
+```bash
+helm upgrade --install perses perses-dev/perses \
+  --namespace monitoring \
+  --create-namespace \
+  --values values.yaml
+```
+
+---
+
+### Operator installation
+
+```bash
+# Install the CRDs and operator
+helm upgrade --install perses-operator perses-dev/perses-operator \
+  --namespace perses-operator \
+  --create-namespace
+
+# Verify operator is running
+kubectl get pods -n perses-operator
+kubectl get crds | grep perses.dev
+```
+
+---
+
+## Pattern Catalog: Detection and Fixes
+
+### PersesDashboard deployed before PersesProject
+
+**Detection**:
+```bash
+kubectl get persesdashboard -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: project={.spec.project}{"\n"}{end}'
+kubectl get persesproject -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}'
+# Compare: every .spec.project in dashboards must have a matching PersesProject .metadata.name
+```
+
+**Signal**:
+```
+kubectl get persesdashboard cluster-overview -n monitoring
+# STATUS: Pending (retrying)
+```
+
+**Why it matters**: The operator queues the dashboard sync for retry but doesn't surface a clear error. The dashboard never appears in Perses UI and the operator log shows `project "my-team" not found` at debug level only.
+
+**Preferred action**: Apply `PersesProject` in the same manifest before `PersesDashboard`. Use Helm hooks or Argo CD sync waves to enforce ordering.
+
+---
+
+### Using `Deployment` with file-based storage
+
+**Detection**:
+```bash
+kubectl get perses -A -o jsonpath='{range .items[*]}{.metadata.name}: {.spec.config.database}{"\n"}{end}'
+kubectl get perses -A -o yaml | grep -A3 'database:' | grep -v StatefulSet
+```
+
+**Signal**:
+```yaml
+spec:
+  config:
+    database:
+      file:
+        folder: /etc/perses/storage
+# But workload is a Deployment, not StatefulSet — no stable pod identity/PVC
+```
+
+**Why it matters**: Deployments may run multiple replicas or reschedule pods, causing multiple instances to write to the same file-based storage without locking. This corrupts dashboard JSON files silently.
+
+**Preferred action**: Use `StatefulSet` with file-based storage (operator default). Set `replicas: 1` for file storage. For HA, switch to etcd or database storage.
+
+---
+
+### Missing RBAC for operator to manage CRDs
+
+**Detection**:
+```bash
+kubectl auth can-i list persesdashboards --as=system:serviceaccount:perses-operator:perses-operator -A
+kubectl get clusterrolebinding | grep perses-operator
+```
+
+**Signal**:
+```
+Error from server (Forbidden): persesdashboards.perses.dev is forbidden:
+User "system:serviceaccount:perses-operator:perses-operator" cannot list resource
+```
+
+**Why it matters**: If the operator's ServiceAccount lacks permissions to list/watch/update its own CRDs, it silently stops reconciling. No error surfaces to the user's dashboard objects.
+
+**Preferred action**: Reinstall the operator Helm chart — RBAC is managed by the chart. If using custom RBAC, ensure `ClusterRole` includes verbs `get,list,watch,create,update,patch,delete` on all `perses.dev` API groups.
+
+---
+
+### TLS cert-manager not installed before Perses TLS enabled
+
+**Detection**:
+```bash
+kubectl get crds | grep cert-manager.io
+kubectl get issuer,clusterissuer -A 2>/dev/null | head -5
+```
+
+**Signal**:
+```yaml
+spec:
+  tls:
+    enabled: true
+    caSecretName: perses-ca
+# cert-manager CRDs not present
+```
+
+**Why it matters**: Perses with TLS enabled requires cert-manager to issue certificates. Without cert-manager, the Perses pod stays in `Init:0/1` indefinitely with no clear error message in pod events.
+
+**Preferred action**:
+```bash
+# Install cert-manager first
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+kubectl wait --for=condition=Ready pod -l app=cert-manager -n cert-manager --timeout=120s
+# Then install Perses with TLS
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|------------|-----|
+| `project "X" not found` in operator logs | `PersesDashboard.spec.project` references non-existent `PersesProject` | Apply `PersesProject` first; use sync waves in GitOps |
+| Pod stuck in `Init:0/1` | TLS enabled but cert-manager not installed | Install cert-manager before deploying Perses with TLS |
+| Operator not reconciling CRDs | ServiceAccount lacks RBAC for `perses.dev` API group | Reinstall operator Helm chart or fix ClusterRole |
+| Dashboards lost after pod restart | File storage without PVC | Add `persistence.enabled: true` in Helm values |
+| `unknown field "X"` in CRD status | Deploying v1alpha1 manifest to v1alpha2 CRD | Update `apiVersion: perses.dev/v1alpha2` in all CRD manifests |
+| `PersesDashboard` stuck in `Pending` | Perses API unreachable from operator pod | Check NetworkPolicy; operator needs egress to Perses service on port 8080 |
+
+---
+
+## Version-Specific Notes
+
+| Version | Change | Impact |
+|---------|--------|--------|
+| `v0.4` (operator) | CRD `v1alpha2` became default | Change all `apiVersion: perses.dev/v1alpha1` to `v1alpha2` |
+| `v0.3` (operator) | `PersesGlobalDatasource` added | Global datasources now manageable via CRD (was API-only) |
+| `v0.2` (operator) | `instanceRef` field added to all CRDs | Enables multiple Perses instances in the same namespace |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# List all Perses CRDs installed
+kubectl get crds | grep perses.dev
+
+# Check reconciliation status of all PersesDashboards
+kubectl get persesdashboard -A
+
+# Verify project-dashboard alignment
+kubectl get persesdashboard -A -o jsonpath='{range .items[*]}{.spec.project}{"\n"}{end}' | sort -u
+
+# Check operator logs for reconciliation errors
+kubectl logs -n perses-operator -l app.kubernetes.io/name=perses-operator --tail=50 | grep -i error
+
+# Verify ServiceMonitor is working
+kubectl get servicemonitor -n monitoring | grep perses
+```
+
+---
+
+## See Also
+
+- `dashboard.md` — Dashboard content, DaC patterns, and percli
+- `core.md` — Perses server configuration and auth setup

--- a/agents/perses-engineer/references/plugin.md
+++ b/agents/perses-engineer/references/plugin.md
@@ -1,0 +1,309 @@
+# Perses Plugin Development Reference
+
+> **Scope**: Plugin scaffolding, CUE schema authoring, React component patterns, archive packaging, and percli plugin commands. Does not cover dashboard consumption of plugins.
+> **Version range**: Perses v0.45+ (Module Federation plugin architecture)
+> **Generated**: 2026-05-09 — verify against https://github.com/perses/perses/tree/main/docs/plugins
+
+---
+
+## Overview
+
+Perses plugins are independently deployable modules that extend the platform with new panel types, datasources, query types, or variable resolvers. Each plugin has three layers: a CUE schema (defines the spec shape), a Go backend (optional — only for datasource/query plugins), and a React/TypeScript frontend component. The most common failure mode is a mismatch between the CUE schema field names and the TypeScript prop names — the backend validates schema but the frontend silently ignores unknown fields.
+
+---
+
+## Pattern Table
+
+| Plugin Type | Has Backend | Frontend Component | CUE Schema Required |
+|------------|-------------|-------------------|---------------------|
+| Panel | No | Yes — renders data | Yes |
+| Datasource | Yes — handles HTTP proxying | Yes — editor UI | Yes |
+| Query | Yes — transforms raw data | Yes — query editor | Yes |
+| Variable | Yes (optional) | Yes — variable editor | Yes |
+| Explore | No | Yes — explore view | Yes |
+
+---
+
+## Plugin Scaffolding: percli
+
+### Generate a new plugin
+
+```bash
+# Scaffold a panel plugin
+percli plugin generate --type panel --name my-chart --output ./plugins/my-chart
+
+# Scaffold a datasource plugin
+percli plugin generate --type datasource --name my-datasource --output ./plugins/my-datasource
+
+# Build plugin archive for distribution
+percli plugin build --dir ./plugins/my-chart --output ./dist/my-chart.tar.gz
+```
+
+### Plugin directory structure (panel example)
+
+```
+plugins/my-chart/
+├── plugin.json          # Plugin manifest — name, version, type
+├── cue/
+│   └── schemas/
+│       └── my-chart.cue # CUE schema for panel spec
+├── src/
+│   ├── index.tsx        # Plugin entry point — exports PanelPlugin
+│   ├── MyChart.tsx      # React component
+│   └── types.ts         # TypeScript types matching CUE schema
+├── package.json
+└── webpack.config.js    # Module Federation config
+```
+
+---
+
+## CUE Schema Authoring
+
+### Minimal panel spec schema
+
+```cue
+// cue/schemas/my-chart.cue
+package schemas
+
+// MyChartSpec defines the configuration for the MyChart panel.
+#MyChartSpec: {
+    // query is required — references a query variable or inline query
+    query: string
+
+    // thresholds are optional visual thresholds
+    thresholds?: [...{
+        value: number
+        color: string
+    }]
+
+    // legend controls display; defaults to true
+    showLegend?: bool | *true
+}
+```
+
+**Why**: Field names in CUE must exactly match the JSON keys sent by the frontend. A field named `showLegend` in CUE but `show_legend` in TypeScript will validate but never populate — the JSON key mismatch is silent.
+
+---
+
+### CUE schema validation
+
+```bash
+# Validate a dashboard JSON against Perses CUE schemas
+cue vet -d '#Dashboard' ./schemas/ dashboard.json
+
+# Validate a plugin spec specifically
+cue vet -d '#MyChartSpec' ./plugins/my-chart/cue/schemas/ spec.json
+
+# Export CUE schema as JSON Schema for editor tooling
+cue export --out json ./plugins/my-chart/cue/schemas/
+```
+
+---
+
+## React/TypeScript Frontend Patterns
+
+### Plugin entry point (index.tsx)
+
+```tsx
+import { PanelPlugin } from '@perses-dev/plugin-system';
+import { MyChart } from './MyChart';
+import { MyChartEditor } from './MyChartEditor';
+import type { MyChartSpec } from './types';
+
+export const MyChartPanel: PanelPlugin<MyChartSpec> = {
+    PanelComponent: MyChart,
+    spec: {
+        // Default spec used when panel is first added
+        initSpec: (): MyChartSpec => ({
+            query: '',
+            showLegend: true,
+        }),
+    },
+    editor: {
+        EditorComponent: MyChartEditor,
+    },
+};
+```
+
+**Why**: The `initSpec` function must return a valid default that matches the CUE schema. A missing required field in `initSpec` causes the panel editor to open with a validation error before the user touches anything.
+
+---
+
+### Accessing query data in a panel component
+
+```tsx
+import { useDataQueries } from '@perses-dev/plugin-system';
+import type { TimeSeriesData } from '@perses-dev/core';
+
+export function MyChart({ spec }: PanelProps<MyChartSpec>) {
+    const { queryResults, isFetching, error } = useDataQueries('TimeSeriesQuery');
+
+    if (isFetching) return <LoadingOverlay />;
+    if (error) return <ErrorAlert error={error} />;
+
+    const data = queryResults[0]?.data as TimeSeriesData | undefined;
+    if (!data) return <NoDataOverlay />;
+
+    return <canvas>{/* render data.series */}</canvas>;
+}
+```
+
+**Why**: Always handle all three states (`isFetching`, `error`, `!data`). A panel that only handles the happy path shows a blank panel during loading and crashes on query errors, degrading the whole dashboard view.
+
+---
+
+### Plugin manifest (plugin.json)
+
+```json
+{
+    "name": "my-chart",
+    "displayName": "My Chart",
+    "version": "0.1.0",
+    "pluginType": "Panel",
+    "components": [
+        {
+            "kind": "MyChart",
+            "display": {
+                "name": "My Chart",
+                "description": "A custom chart panel"
+            }
+        }
+    ]
+}
+```
+
+**Why**: The `kind` field in `plugin.json` must match the `kind` string used in dashboard JSON panel specs. A mismatch causes the panel to render as "Unknown Panel Type" with no useful error.
+
+---
+
+## Pattern Catalog: Detection and Fixes
+
+### CUE/TypeScript field name mismatch
+
+**Detection**:
+```bash
+# Extract CUE field names
+grep -rn '^\s*\w\+?:' --include="*.cue" | sed 's/:.*//' | tr -d ' '
+
+# Compare against TypeScript interface fields
+grep -rn '^\s*\w\+\?:' --include="*.ts" | sed 's/:.*//' | tr -d ' '
+```
+
+**Signal**:
+```cue
+// CUE schema:
+#Spec: { showLegend?: bool }
+```
+```typescript
+// TypeScript type:
+interface Spec { show_legend?: boolean }  // snake_case mismatch
+```
+
+**Why it matters**: The Perses backend validates the CUE schema against the stored JSON. The frontend reads from the same JSON. If the TypeScript uses `show_legend` but CUE expects `showLegend`, the frontend sends `show_legend` in JSON, which fails CUE validation. The panel saves but won't load.
+
+**Preferred action**: Use camelCase in both CUE and TypeScript. Run `cue vet` against real panel JSON in tests.
+
+---
+
+### Missing `initSpec` required fields
+
+**Detection**:
+```bash
+grep -rn 'initSpec' --include="*.tsx" --include="*.ts" -A 5
+# Then check CUE for required (non-optional) fields
+grep -rn '^\s*\w\+:' --include="*.cue" | grep -v '?'
+```
+
+**Signal**:
+```typescript
+initSpec: (): MyChartSpec => ({
+    // Missing required 'query' field defined as non-optional in CUE
+    showLegend: true,
+}),
+```
+
+**Why it matters**: When a user adds the panel to a dashboard, Perses immediately validates the initSpec against the CUE schema. A missing required field causes a validation error on first render before any user interaction.
+
+**Preferred action**: Every non-optional field in the CUE schema must have a default in `initSpec`. Add integration test that validates `initSpec()` output against CUE schema.
+
+---
+
+### Webpack Module Federation missing shared dependencies
+
+**Detection**:
+```bash
+grep -rn 'shared:' --include="webpack.config.js" | grep -v 'react\|@perses-dev'
+```
+
+**Signal**:
+```javascript
+// webpack.config.js
+new ModuleFederationPlugin({
+    shared: {
+        react: { singleton: true },
+        // Missing '@perses-dev/plugin-system' as shared singleton
+    }
+})
+```
+
+**Why it matters**: If `@perses-dev/plugin-system` is not declared as a shared singleton, the plugin bundles its own copy. Two versions of the plugin system running simultaneously causes `useDataQueries` to silently return empty results because it's reading from a different React context instance.
+
+**Preferred action**:
+```javascript
+shared: {
+    react: { singleton: true, requiredVersion: deps.react },
+    'react-dom': { singleton: true },
+    '@perses-dev/plugin-system': { singleton: true },
+    '@perses-dev/core': { singleton: true },
+}
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error | Root Cause | Fix |
+|-------|------------|-----|
+| Panel renders as "Unknown Panel Type" | `kind` in `plugin.json` doesn't match `kind` in dashboard spec | Align `kind` across `plugin.json`, CUE schema, and TypeScript `PanelPlugin` export |
+| `cue vet` fails on panel spec | CUE field names don't match JSON keys from frontend | Use camelCase consistently in both CUE and TypeScript |
+| `useDataQueries` always returns empty | `@perses-dev/plugin-system` not shared as singleton in Webpack config | Add `singleton: true` to shared config |
+| Panel editor opens with validation error | `initSpec()` returns object missing required CUE field | Add all non-optional CUE fields to `initSpec()` return value |
+| `percli plugin build` fails | `plugin.json` missing required fields or `src/index.tsx` not found | Verify directory structure matches scaffold output |
+| Plugin not visible in panel picker | Plugin archive not loaded in Perses server config | Add plugin path to `plugins` array in `perses.yaml` server config |
+
+---
+
+## Version-Specific Notes
+
+| Version | Change | Impact |
+|---------|--------|--------|
+| `v0.45` | Module Federation replaced legacy plugin loading | Plugins must export via `index.tsx` with `PanelPlugin` type |
+| `v0.44` | `@perses-dev/plugin-system` package split from `@perses-dev/core` | Update imports from `@perses-dev/core` to `@perses-dev/plugin-system` |
+| `v0.43` | CUE schemas moved from `cue/schemas/` to `schemas/` in archive | Update `percli plugin build` path configuration |
+| `v0.40` | `PanelPlugin.spec.initSpec` changed from object to function | Convert `initSpec: { ... }` to `initSpec: () => ({ ... })` |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# CUE required fields (non-optional — must be in initSpec)
+grep -rn '^\s*\w\+:' --include="*.cue" | grep -v '?' | grep -v '//'
+
+# Webpack shared singleton check
+grep -rn 'singleton' --include="webpack.config.js"
+
+# Plugin manifest kind fields
+grep -rn '"kind"' --include="plugin.json"
+
+# TypeScript type vs CUE schema field comparison
+diff <(grep -h '^\s*\w' plugins/*/src/types.ts | tr -d ' ?: ') \
+     <(grep -h '^\s*\w' plugins/*/cue/schemas/*.cue | tr -d ' ?:')
+```
+
+---
+
+## See Also
+
+- `dashboard.md` — Consuming panel plugins in dashboards
+- `core.md` — Perses React/TypeScript frontend architecture and build system


### PR DESCRIPTION
## Summary

- **Target**: `perses-engineer` agent
- **Level before**: 0 (no reference files)
- **Level after**: 3 (deep — detection commands, code examples, error-fix tables)

## New Reference Files

| File | Lines | Domain |
|------|-------|--------|
| `agents/perses-engineer/references/dashboard.md` | 287 | Dashboard-as-Code Go SDK, variables, percli CLI, multi-value variable `=~` pitfall |
| `agents/perses-engineer/references/plugin.md` | 309 | Module Federation singleton sharing, CUE/TypeScript field alignment, `initSpec` completeness |
| `agents/perses-engineer/references/operator.md` | 336 | Kubernetes CRDs v1alpha2, Helm deployment, project-before-dashboard ordering, PVC requirement |

## Loading Table Update

Updated `agents/perses-engineer.md` loading table from generic placeholder signals (`"tasks related to this reference"`) to concrete keyword matchers (`dashboard, DaC, percli, variable`, etc.) so signal detection actually discriminates between files.

## Validation Gate (Phase 2.5)

All 3 test queries route correctly to the appropriate reference file. All references contain Perses-specific patterns (not generic advice): the `AllowMultiple + =~` PromQL mismatch, Module Federation singleton requirement, `PersesProject`-before-`PersesDashboard` ordering constraint.

Decision: **KEEP** — concrete, signal-matched, domain-specific knowledge.

## Run ID
`2026-05-09-0407` (ADR-173 automated enrichment)