### PR TITLE
feat(html-artifact): add publish pairing and hybrid shape support

### DIFF
--- a/docs/for-claude-code.md
+++ b/docs/for-claude-code.md
@@ -203,7 +203,6 @@ Trivial = reading a file the user named by exact path. Everything else routes th
 | series-planner | No | Multi-part content series: structure, cross-linking |
 | topic-brainstormer | No | Blog topic ideas: problem mining, gap analysis |
 | professional-communication | No | Technical communication into business formats |
-| interactive-essay | No | Scrollytelling React SPAs from markdown articles |
 
 ### Research & Analysis
 
@@ -620,7 +619,6 @@ Mandatory. When triggers match, skill fires before any other routing.
 | quick | quick task, small change, ad hoc task, add a flag, small refactor |
 | perses | perses, perses dashboard, perses plugin, perses lint, perses deploy, Grafana to Perses |
 | install | install toolkit, verify installation, health check toolkit |
-| interactive-essay | interactive essay, scrollytelling, interactive article, make this article interactive, scrolling SPA |
 
 ---
 
@@ -635,7 +633,6 @@ Pipeline skills with explicit phases and gates.
 | voice-writer | LOAD -> GROUND -> STATS-CHECKPOINT -> GENERATE -> VALIDATE -> REFINE -> JOY-CHECK -> ANTI-AI -> OUTPUT -> CLEANUP |
 | workflow | Multi-phase with type-specific references (review, debug, refactor, deploy, create, research) |
 | github-profile-rules | PROFILE-SCAN -> CODE-ANALYSIS -> REVIEW-MINING -> PATTERN-SYNTHESIS -> RULES-GENERATION -> VALIDATION -> OUTPUT |
-| interactive-essay | CONTENT -> STRUCTURE -> SCAFFOLD -> BUILD -> VOICE -> VALIDATE -> DEPLOY |
 | feature-lifecycle | DESIGN -> PLAN -> IMPLEMENT -> VALIDATE -> RELEASE |
 
 ---

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-05-08T22:32:26Z",
+  "generated": "2026-05-09T14:30:55Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
     "csuite": {
@@ -591,7 +591,8 @@
       "user_invocable": false,
       "pairs_with": [
         "content-calendar",
-        "wordpress-live-validation"
+        "wordpress-live-validation",
+        "html-artifact"
       ],
       "agent": "general-purpose"
     },
@@ -1504,14 +1505,16 @@
         "rich visualization",
         "interactive document",
         "HTML file",
-        "self-contained HTML"
+        "self-contained HTML",
+        "visual companion"
       ],
       "category": "meta",
       "user_invocable": false,
       "pairs_with": [
         "pr-workflow",
         "research-pipeline",
-        "planning"
+        "planning",
+        "publish"
       ]
     },
     "install": {

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-05-09T14:30:55Z",
+  "generated": "2026-05-09T14:37:12Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
     "csuite": {

--- a/skills/content/publish/SKILL.md
+++ b/skills/content/publish/SKILL.md
@@ -83,6 +83,7 @@ routing:
   pairs_with:
     - content-calendar
     - wordpress-live-validation
+    - html-artifact
 ---
 
 # Publish Skill

--- a/skills/meta/do/references/routing-tables.md
+++ b/skills/meta/do/references/routing-tables.md
@@ -181,7 +181,7 @@ Route to these agents based on the user's task domain. Each entry describes what
 | **wordpress-live-validation** | User wants to validate WordPress posts live after upload: check rendering, canonical URLs, or publication status. |
 | **pptx-generator** | User wants to generate a PowerPoint presentation, slide deck, or pitch deck from content or research. |
 | **frontend-slides** | User wants browser-based HTML presentations: reveal-style slide decks, kiosk presentations, or converting PPTX to web format. |
-| **html-artifact** | User wants rich self-contained HTML output instead of markdown — specs, code reviews, reports, prototypes, editors, data viz. Auto-detected by router or invoked via `/html`. NOT: web applications, React/Vue projects, multi-page sites (use typescript-frontend-engineer). NOT: slide decks (use frontend-slides). NOT: interactive essays (use interactive-essay). |
+| **html-artifact** | User wants rich self-contained HTML output instead of markdown — specs, code reviews, reports, prototypes, editors, data viz. Auto-detected by router or invoked via `/html`. NOT: web applications, React/Vue projects, multi-page sites (use typescript-frontend-engineer). NOT: slide decks (use frontend-slides). |
 | **gemini-image-generator** | User wants to generate images from text prompts via Google Gemini: sprites, character art, or AI-generated visuals. |
 | **bluesky-reader** | User wants to read public Bluesky feeds, fetch posts, or interact with the AT Protocol API. |
 | **image-to-video** | User wants to combine a static image with audio to create a video file (album art video, podcast video, music visualization). |

--- a/skills/meta/html-artifact/EVAL.md
+++ b/skills/meta/html-artifact/EVAL.md
@@ -30,7 +30,7 @@ Requests that must NOT activate html-artifact.
 | 1 | "Fix the bug in auth.ts" | Code fix, not visualization | typescript-frontend-engineer |
 | 2 | "Run the tests" | Test execution, not output generation | test runner / quick |
 | 3 | "Write this as markdown" | Explicit markdown request | Standard markdown output |
-| 4 | "Create an interactive essay about caching" | Full Vite+React project | interactive-essay skill |
+| 4 | "Create an interactive essay about caching" | Self-contained HTML with scroll animations | html-artifact skill with scrollytelling-patterns.md |
 | 5 | "Make a slide deck for the conference" | Presentation deck | frontend-slides skill |
 | 6 | "Build a React component for the login page" | Framework component | typescript-frontend-engineer |
 

--- a/skills/meta/html-artifact/SKILL.md
+++ b/skills/meta/html-artifact/SKILL.md
@@ -259,6 +259,7 @@ Constraint: Detect headless/SSH environments before offering browser open.
 | Shape = data-viz | `references/shape-data-visualization.md` | SVG charts, canvas, tooltips, filters |
 | Shape = diagram | `references/shape-diagram-illustration.md` | SVG flowcharts, architecture diagrams, figure sheets |
 | Shape = deck | `references/shape-slide-deck.md` | Slide container, navigation, slide types, transitions |
+| Request mentions scroll, reveal, animate on scroll, progressive | `references/scrollytelling-patterns.md` | IntersectionObserver scroll animations, stagger, counters, progress bar |
 
 ---
 
@@ -284,5 +285,6 @@ This skill uses:
 - `references/shape-diagram-illustration.md`: Diagram shape -- inline SVG flowcharts, architecture diagrams, sequence diagrams, figure sheets
 - `references/shape-slide-deck.md`: Deck shape -- arrow-key navigable slide decks, 16:9 aspect ratio, slide types, presenter notes
 - `agents/html-builder.md`: Subagent prompt for HTML generation
+- `references/scrollytelling-patterns.md`: Vanilla JS IntersectionObserver patterns -- scroll-triggered reveals, stagger animations, animated counters, progress bars
 - `scripts/detect-shape.py`: Deterministic shape classification from user request
 - `scripts/validate-artifact.py`: HTML structure and self-containment validation

--- a/skills/meta/html-artifact/SKILL.md
+++ b/skills/meta/html-artifact/SKILL.md
@@ -19,10 +19,12 @@ routing:
     - interactive document
     - HTML file
     - self-contained HTML
+    - visual companion
   pairs_with:
     - pr-workflow
     - research-pipeline
     - planning
+    - publish
   complexity: Medium
   category: meta
 ---
@@ -64,6 +66,26 @@ The script outputs a shape name and confidence score.
 
 Gate: Shape detected with medium+ confidence.
 -- because low-confidence classification produces artifacts that mix concerns and satisfy no shape well. Fallback to "report" (safest general-purpose shape) if confidence is low or ambiguous.
+
+---
+
+### Hybrid Shapes
+
+Real content often combines two shapes — a report with embedded diagrams, a spec with data-viz charts. When `detect-shape.py` returns a primary shape with medium/high confidence but the request also contains signals for a secondary shape, use the hybrid pattern:
+
+| Primary Shape | + Secondary | Result |
+|---|---|---|
+| report | + diagram | Report layout (TL;DR, collapsibles, TOC) with inline SVG diagrams between sections |
+| report | + data-viz | Report layout with embedded SVG charts illustrating key metrics |
+| spec | + diagram | Comparison grid with SVG flow diagrams showing each option's architecture |
+| spec | + data-viz | Comparison grid with charts showing performance/cost per option |
+| diagram | + report | Figure sheet with explanatory text sections between diagram groups |
+
+**Detection:** After running `detect-shape.py`, check if the `secondary_shape` field is non-null. If so, load BOTH shape references in Phase 2.
+
+**Generation rule:** Primary shape controls page layout (outer structure). Secondary shape provides embedded components (inner elements). The html-builder agent receives both shape patterns and uses primary for structure, secondary for visual elements within sections.
+
+**Example:** "create a visual companion for my pipelines article with diagrams and explanations" → primary: `report` (explain, article), secondary: `diagram` (visual, diagrams). Load `shape-report-research.md` AND `shape-diagram-illustration.md`.
 
 ---
 

--- a/skills/meta/html-artifact/SPEC.md
+++ b/skills/meta/html-artifact/SPEC.md
@@ -16,14 +16,13 @@ Generate rich self-contained HTML artifacts instead of markdown when output bene
 **OUT:**
 - Multi-page sites, framework apps, deployment artifacts
 - Anything requiring npm, build steps, or external dependencies
-- Full Vite+React projects (use `interactive-essay` skill)
 - Presentation decks (use `frontend-slides` skill)
 - Application UIs with backend integration
 
 ## Non-Goals
 
 - Not a web app builder — no npm, no build steps, no server-side logic
-- Not a replacement for `interactive-essay` (full Vite+React projects with scroll animations)
+- For scroll-triggered animations, use the `scrollytelling-patterns.md` reference instead of full Vite+React projects
 - Not a replacement for `frontend-slides` (presentation decks)
 - Not forced — user opts out with "as markdown" or "in markdown"
 - Not a charting library — SVG generation is inline, not a reusable API

--- a/skills/meta/html-artifact/references/scrollytelling-patterns.md
+++ b/skills/meta/html-artifact/references/scrollytelling-patterns.md
@@ -1,0 +1,247 @@
+# Scrollytelling Patterns (Vanilla JS)
+
+Scroll-triggered animation patterns for html-artifact. No frameworks, no build steps — pure IntersectionObserver + CSS transitions. Use when the artifact benefits from progressive reveal as the user scrolls.
+
+**Load when:** Request mentions "scrollytelling", "scroll animation", "progressive reveal", "scroll-triggered", or when shape is report/diagram with long-form content that benefits from section-by-section reveal.
+
+---
+
+## Core Pattern: IntersectionObserver
+
+One observer instance handles all scroll-revealed elements. Elements start hidden, get a `.visible` class when they enter the viewport.
+
+```html
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            observer.unobserve(entry.target); // fire once
+          }
+        }
+      },
+      { threshold: 0.15, rootMargin: '0px' }
+    );
+
+    document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+  });
+</script>
+```
+
+### Threshold Guide
+
+| Content Type | Threshold | Rationale |
+|---|---|---|
+| Prose blocks | `0.15` | Trigger early — text should be readable as it enters |
+| Stat callouts | `0.3` | Trigger later — counter animation needs visible area |
+| Timeline entries | `0.15` | Same as prose, but with stagger delay |
+| Pullquotes | `0.2` | Slightly later — draws attention |
+| Full sections | `0.1` | Very early — large sections shouldn't wait |
+
+---
+
+## Reveal Animations
+
+### Fade Up (Default)
+
+Standard reveal for all blocks. Element fades in while sliding up 30px.
+
+```css
+.reveal {
+  opacity: 0;
+  transform: translateY(30px);
+  transition: opacity 600ms ease-out, transform 600ms ease-out;
+}
+
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+```
+
+### Fade In (No Movement)
+
+For elements that should appear without vertical shift (stats, callouts).
+
+```css
+.fade-in {
+  opacity: 0;
+  transition: opacity 800ms ease-out;
+}
+
+.fade-in.visible {
+  opacity: 1;
+}
+```
+
+### Slide From Left
+
+For timeline entries or comparison cards entering from the side.
+
+```css
+.slide-left {
+  opacity: 0;
+  transform: translateX(-40px);
+  transition: opacity 500ms ease-out, transform 500ms ease-out;
+}
+
+.slide-left.visible {
+  opacity: 1;
+  transform: translateX(0);
+}
+```
+
+---
+
+## Stagger Pattern
+
+Multiple children animate sequentially with increasing delay via CSS custom properties.
+
+```html
+<div class="stagger-group reveal">
+  <div class="stagger-child" style="--i: 0">First</div>
+  <div class="stagger-child" style="--i: 1">Second</div>
+  <div class="stagger-child" style="--i: 2">Third</div>
+</div>
+```
+
+```css
+.stagger-child {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 400ms ease-out, transform 400ms ease-out;
+  transition-delay: calc(var(--i) * 100ms);
+}
+
+.stagger-group.visible .stagger-child {
+  opacity: 1;
+  transform: translateY(0);
+}
+```
+
+---
+
+## Animated Counter
+
+Animate a number from 0 to target using requestAnimationFrame. Vanilla JS version.
+
+```html
+<span class="counter" data-target="42000" data-suffix="+">0</span>
+```
+
+```javascript
+function animateCounters() {
+  const counters = document.querySelectorAll('.counter');
+  const observer = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (entry.isIntersecting) {
+        const el = entry.target;
+        const target = parseInt(el.dataset.target, 10);
+        const suffix = el.dataset.suffix || '';
+        const duration = 800;
+        const start = performance.now();
+
+        function tick(now) {
+          const elapsed = now - start;
+          const progress = Math.min(elapsed / duration, 1);
+          const eased = 1 - Math.pow(1 - progress, 3); // ease-out cubic
+          el.textContent = Math.round(target * eased).toLocaleString() + suffix;
+          if (progress < 1) requestAnimationFrame(tick);
+        }
+
+        requestAnimationFrame(tick);
+        observer.unobserve(el);
+      }
+    }
+  }, { threshold: 0.3 });
+
+  counters.forEach(el => observer.observe(el));
+}
+```
+
+---
+
+## Reading Progress Bar
+
+Fixed-top bar showing scroll progress. Pure vanilla JS.
+
+```html
+<div class="progress-bar" role="progressbar" aria-label="Reading progress">
+  <div class="progress-fill" id="progress-fill"></div>
+</div>
+```
+
+```css
+.progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background: transparent;
+  z-index: 9999;
+}
+
+.progress-fill {
+  height: 100%;
+  background: var(--color-primary, #D97757);
+  width: 0%;
+  transition: width 100ms linear;
+}
+```
+
+```javascript
+window.addEventListener('scroll', () => {
+  const scrollTop = window.scrollY;
+  const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+  const progress = docHeight > 0 ? Math.min((scrollTop / docHeight) * 100, 100) : 0;
+  document.getElementById('progress-fill').style.width = progress + '%';
+}, { passive: true });
+```
+
+---
+
+## Performance Rules
+
+| Rule | Why |
+|---|---|
+| `{ passive: true }` on all scroll listeners | Prevents scroll jank (browser can optimize) |
+| `observer.unobserve(el)` after first trigger | Reduces ongoing IntersectionObserver work |
+| No `will-change` property | Modern browsers handle opacity/transform compositing automatically |
+| `requestAnimationFrame` for counter animations | Smoother than setInterval, syncs with display refresh |
+| Batch elements into one observer | One observer is cheaper than N observers |
+
+---
+
+## Reduced Motion
+
+Always respect user preference. Include in every artifact that uses scroll animations:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .reveal,
+  .fade-in,
+  .slide-left,
+  .stagger-child {
+    transition: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+  .progress-fill {
+    transition: none !important;
+  }
+}
+```
+
+---
+
+## Integration with html-artifact
+
+Add `class="reveal"` to any section or element that should animate on scroll. Initialize the observer in the `<script>` block at the bottom of the artifact.
+
+Scrollytelling works with ALL shapes but is most effective with:
+- **report** — progressive section reveals as reader scrolls through long content
+- **diagram** — staggered node reveals in figure sheets
+- **deck** — alternative to arrow-key navigation (scroll-based slide advance)

--- a/skills/meta/html-artifact/scripts/detect-shape.py
+++ b/skills/meta/html-artifact/scripts/detect-shape.py
@@ -240,7 +240,17 @@ def classify_request(request: str) -> dict[str, object]:
     else:
         confidence = "low"
 
-    return {"shape": best.shape, "confidence": confidence, "signals": best.matched_signals}
+    # Find secondary shape (second-highest scorer with meaningful signal match)
+    remaining = [r for r in results if r.shape != best.shape and r.score >= 2]
+    secondary = max(remaining, key=lambda r: r.score) if remaining else None
+
+    return {
+        "shape": best.shape,
+        "confidence": confidence,
+        "signals": best.matched_signals,
+        "secondary_shape": secondary.shape if secondary else None,
+        "secondary_signals": secondary.matched_signals if secondary else [],
+    }
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- Adds bidirectional `pairs_with` between `html-artifact` and `publish` skills so the router suggests HTML artifacts during content publishing
- Adds "visual companion" trigger for the blog-companion use case
- Documents hybrid shapes pattern (report + diagram, spec + data-viz, etc.)
- Updates `detect-shape.py` to return `secondary_shape` field when two shapes score above threshold

## Motivation
During a session generating an HTML artifact for the "Pipelines, Not Prompts" blog post, we found:
1. The router never suggested html-artifact during publish workflows (no pairing declared)
2. The best artifacts combine two shapes (report structure + embedded diagrams) but the skill had no concept of this
3. The publish skill didn't know html-artifact existed as a companion

## Test plan
- [x] All 20 existing `test_detect_shape.py` tests pass
- [x] `detect-shape.py` returns `secondary_shape: diagram` for hybrid requests
- [x] `generate-skill-index.py` completes without errors
- [x] INDEX.json contains updated `pairs_with` for both skills