### PR TITLE
refactor(hooks): condense injections, tighten matchers, merge security scans

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,13 +61,6 @@
           },
           {
             "type": "command",
-            "command": "python3 \"$HOME/.claude/hooks/retro-knowledge-injector.py\"",
-            "description": "Inject top accumulated retro knowledge once at session start for cache-stable context",
-            "timeout": 2000,
-            "once": true
-          },
-          {
-            "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/session-github-briefing.py\"",
             "description": "Inject GitHub briefing at session start (opt-in: CLAUDE_KAIROS_ENABLED=true)",
             "timeout": 2000,
@@ -79,11 +72,6 @@
     "UserPromptSubmit": [
       {
         "hooks": [
-          {
-            "type": "command",
-            "command": "python3 \"$HOME/.claude/hooks/instruction-reminder.py\"",
-            "description": "Re-inject instruction files to combat context drift"
-          },
           {
             "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/pipeline-context-detector.py\"",
@@ -243,7 +231,7 @@
           {
             "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/posttool-security-scan.py\"",
-            "description": "Advisory scan for credentials and SQL injection in Write/Edit output",
+            "description": "Advisory scan for credentials, SQL injection, and command injection in Write/Edit output",
             "timeout": 3000
           },
           {
@@ -320,6 +308,7 @@
         ]
       },
       {
+        "matcher": "Bash|Write|Edit|Agent",
         "hooks": [
           {
             "type": "command",
@@ -348,11 +337,6 @@
       {
         "matcher": "Write|Edit",
         "hooks": [
-          {
-            "type": "command",
-            "command": "python3 \"$HOME/.claude/hooks/sql-injection-detector.py\"",
-            "timeout": 5000
-          },
           {
             "type": "command",
             "command": "python3 hooks/posttool-auto-test.py",

--- a/hooks/fish-shell-detector.py
+++ b/hooks/fish-shell-detector.py
@@ -60,21 +60,12 @@ def is_fish_shell() -> bool:
 
 
 def get_fish_injection() -> str:
-    """Get the context injection for Fish shell users."""
-    return """
-[fish-shell] Detected Fish shell user
-[auto-skill] fish-shell-config
+    """Get the context injection for Fish shell users.
 
-The user is running Fish shell. When providing shell commands or configuration:
-- Fish 3.0+ supports both $() and () for command substitution
-- Fish 3.0+ supports both && / || and ; and / ; or for chaining
-- Fish uses `set` for variables, not `export`
-- Fish config is in ~/.config/fish/config.fish
-- Functions go in ~/.config/fish/functions/
-- Use `string` commands for string manipulation
-
-Consider loading the fish-shell-config skill for detailed Fish patterns.
-"""
+    Emits only tags. The fish-shell-config skill carries its own knowledge.
+    ADR hook-injection-condensation: removed tutorial block.
+    """
+    return "[fish-shell] Detected Fish shell user\n[auto-skill] fish-shell-config"
 
 
 def main():

--- a/hooks/operator-context-detector.py
+++ b/hooks/operator-context-detector.py
@@ -240,25 +240,24 @@ def detect_profile() -> tuple[str, str]:
         return "work", org_reason
 
     # 6. Default
-    return "personal", "default (no signals detected)"
+    return "personal", "default"
 
 
 def get_profile_injection(profile: str, detection: str) -> str:
-    """Build the context injection string for the detected profile."""
-    guidance = PROFILE_GUIDANCE.get(profile, PROFILE_GUIDANCE["personal"])
+    """Build the context injection string for the detected profile.
 
-    return f"""[operator-context] Profile: {profile}
-[operator-context] Detection: {detection}
+    Injects only the active profile's one-line summary (not all 4 profiles).
+    ADR hook-injection-condensation: ~130 chars instead of ~616 chars.
+    """
+    summaries = {
+        "personal": "Full autonomy. No approval gates. Branch safety only.",
+        "work": "Convention-enforced. APPROVE for production changes.",
+        "ci": "Fully autonomous, disposable environment. Database ungated.",
+        "production": "Maximum gates. APPROVE mandatory. SNAPSHOT before changes.",
+    }
+    summary = summaries.get(profile, summaries["personal"])
 
-Operator Profile: {profile}
-- personal: Full autonomy. No approval gates. Branch safety only.
-- work: Convention-enforced. APPROVE for production changes.
-- ci: Fully autonomous, disposable environment. Database ungated.
-- production: Maximum gates. APPROVE mandatory. SNAPSHOT before changes.
-
-Current profile ({profile}) means:
-{guidance}
-"""
+    return f"[operator-context] Profile: {profile} — {summary}\n[operator-context] Detection: {detection}"
 
 
 def main():

--- a/hooks/pipeline-context-detector.py
+++ b/hooks/pipeline-context-detector.py
@@ -333,9 +333,6 @@ def build_environmental_state(prompt: str, base_dir: Path) -> dict:
         "request": prompt,
         "related_agents": related["related_agents"],
         "related_skills": related["related_skills"],
-        "all_agents": [a["name"] for a in agents],
-        "all_skills": [s["name"] for s in skills],
-        "all_hooks": [h["name"] for h in hooks],
         "agent_count": len(agents),
         "skill_count": len(skills),
         "hook_count": len(hooks),
@@ -367,29 +364,18 @@ def main():
                 file=sys.stderr,
             )
 
-        # Build context injection
-        state_json = json.dumps(state, indent=2)
-        injection = f"""[pipeline-creator] Detected pipeline creation request
-[auto-skill] pipeline-scaffolder
-
-## Environmental State
-
-The following JSON describes the current repository state. Use this to
-identify existing components that can be reused and to prevent duplication.
-
-```json
-{state_json}
-```
-
-### Related Components
-- Related agents: {", ".join(state["related_agents"]) or "none found"}
-- Related skills: {", ".join(state["related_skills"]) or "none found"}
-
-### Inventory
-- Total agents: {state["agent_count"]}
-- Total skills: {state["skill_count"]}
-- Total hooks: {state["hook_count"]}
-"""
+        # Build context injection — counts only, not full name arrays
+        # ADR hook-injection-condensation: emit counts to save ~4,700 chars
+        related_agents = ", ".join(state["related_agents"]) or "none"
+        related_skills = ", ".join(state["related_skills"]) or "none"
+        injection = (
+            f"[pipeline-creator] Detected pipeline creation request\n"
+            f"[auto-skill] pipeline-scaffolder\n"
+            f"[pipeline-creator] Inventory: {state['agent_count']} agents, "
+            f"{state['skill_count']} skills, {state['hook_count']} hooks\n"
+            f"[pipeline-creator] Related agents: {related_agents}\n"
+            f"[pipeline-creator] Related skills: {related_skills}"
+        )
 
         context_output(EVENT_NAME, injection).print_and_exit()
 

--- a/hooks/posttool-security-scan.py
+++ b/hooks/posttool-security-scan.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python3
 # hook-version: 1.0.0
 """
-PostToolUse:Write,Edit Hook: Lightweight Security Pattern Scanner
+PostToolUse:Write,Edit Hook: Unified Security Pattern Scanner
 
 Scans edited/written code files for common security vulnerability patterns
 after each modification. Outputs informational warnings — never blocks.
 
 Categories scanned:
 1. Hardcoded credentials (credential-named variables with string literals)
-2. Injection risks (string interpolation in queries, unsanitized shell calls)
-3. Path traversal (unvalidated relative path components)
-4. Unsafe deserialization (loading without safe loaders)
+2. SQL injection (f-strings, format(), concatenation, sprintf in SQL context)
+3. Command injection (shell=True, os.system)
+4. Path traversal (unvalidated relative path components)
+5. Unsafe deserialization (loading without safe loaders)
+
+Merged from posttool-security-scan.py + sql-injection-detector.py per
+ADR hook-injection-condensation.
 
 Design:
 - PostToolUse (informational only, never blocks)
@@ -19,7 +23,7 @@ Design:
 - Reads file content from disk (tool_result may be truncated)
 - Skips files >10,000 lines
 
-ADR: adr/018-post-edit-security-scan.md
+ADR: adr/018-post-edit-security-scan.md, adr/134-sql-injection-detector-hook.md
 """
 
 import json
@@ -75,6 +79,22 @@ def _build_patterns() -> list[tuple[re.Pattern[str], str, str]]:
         ]
     )
 
+    # Extended SQL keywords for broader coverage (merged from sql-injection-detector.py)
+    sql_kw = "|".join(
+        [
+            "SELECT",
+            "INSERT",
+            "UPDATE",
+            "DELETE",
+            "DROP",
+            "WHERE",
+            "FROM",
+            "JOIN",
+            "SET",
+            "VALUES",
+        ]
+    )
+
     return [
         # Hardcoded credentials — variable assignment with string literal
         (
@@ -101,6 +121,78 @@ def _build_patterns() -> list[tuple[re.Pattern[str], str, str]]:
             ),
             "sql-injection",
             "Use parameterized queries instead of % formatting in SQL",
+        ),
+        # SQL injection — string concatenation: "...SQL..." + variable
+        (
+            re.compile(
+                rf"""['"](?:[^'"]*\b(?:{sql_kw})\b[^'"]*)['"]\s*\+""",
+                re.IGNORECASE,
+            ),
+            "sql-injection",
+            "Use parameterized queries (e.g., cursor.execute(sql, params))",
+        ),
+        # SQL injection — variable + "...SQL..."
+        (
+            re.compile(
+                rf"""\+\s*['"](?:[^'"]*\b(?:{sql_kw})\b[^'"]*)['"]\s*(?:\+|$|;|\)|,)""",
+                re.IGNORECASE,
+            ),
+            "sql-injection",
+            "Use parameterized queries (e.g., cursor.execute(sql, params))",
+        ),
+        # SQL injection — .format() call on a SQL string
+        (
+            re.compile(
+                rf"""['"](?:[^'"]*\b(?:{sql_kw})\b[^'"]*\{{[^'"]*)['"]\s*\.format\s*\(""",
+                re.IGNORECASE,
+            ),
+            "sql-injection",
+            "Use parameterized queries instead of .format() in SQL strings",
+        ),
+        # SQL injection — Go fmt.Sprintf with SQL percent placeholders
+        (
+            re.compile(
+                rf"""fmt\.Sprintf\s*\(\s*['"`](?:[^'"`]*\b(?:{sql_kw})\b[^'"`]*%[sdvfq][^'"`]*)[`'"]\s*,""",
+                re.IGNORECASE,
+            ),
+            "sql-injection",
+            "Use db.Query with ? or $N placeholders and pass values as arguments",
+        ),
+        # SQL injection — Java String.format with SQL percent placeholders
+        (
+            re.compile(
+                rf"""String\.format\s*\(\s*["'](?:[^"']*\b(?:{sql_kw})\b[^"']*%[sdnf][^"']*)['"]\s*,""",
+                re.IGNORECASE,
+            ),
+            "sql-injection",
+            "Use PreparedStatement with ? placeholders instead of String.format",
+        ),
+        # SQL injection — PHP sprintf with SQL percent placeholders
+        (
+            re.compile(
+                rf"""(?<!\w)sprintf\s*\(\s*["'](?:[^"']*\b(?:{sql_kw})\b[^"']*%[sduf][^"']*)['"]\s*,""",
+                re.IGNORECASE,
+            ),
+            "sql-injection",
+            "Use PDO prepared statements with ? placeholders instead of sprintf",
+        ),
+        # SQL injection — f-string with extended SQL keywords (WHERE, FROM, JOIN, SET, VALUES)
+        (
+            re.compile(
+                r"""f['"]{1,3}(?:[^'"]*\b(?:WHERE|FROM|JOIN|SET|VALUES)\b[^'"]*)\{""",
+                re.IGNORECASE,
+            ),
+            "sql-injection",
+            "Use parameterized queries instead of f-string interpolation in SQL",
+        ),
+        # SQL injection — multi-line SQL building via += concatenation
+        (
+            re.compile(
+                rf"""\b\w+\s*\+=\s*(?:f?['"][^'"]*\b(?:{sql_kw})\b)""",
+                re.IGNORECASE,
+            ),
+            "sql-injection",
+            "Build SQL with parameterized placeholders; collect params in a list",
         ),
         # Command injection — shell=True with variable input
         (
@@ -183,11 +275,11 @@ def main() -> None:
                     break  # One finding per line max
 
         if findings:
-            # Limit output to first 3 findings to avoid noise
-            for finding in findings[:3]:
+            # Limit output to first 5 findings to avoid noise
+            for finding in findings[:5]:
                 print(finding)
-            if len(findings) > 3:
-                print(f"  ... and {len(findings) - 3} more security hints")
+            if len(findings) > 5:
+                print(f"  ... and {len(findings) - 5} more security hints")
 
     except (json.JSONDecodeError, Exception) as e:
         if os.environ.get("CLAUDE_HOOKS_DEBUG"):

--- a/hooks/pretool-subagent-warmstart.py
+++ b/hooks/pretool-subagent-warmstart.py
@@ -14,7 +14,7 @@ Design Principles:
 - Non-blocking (always exits 0)
 - Sub-50ms execution (file reads only, no subprocess)
 - Graceful degradation on missing files
-- Caps output at ~8000 chars (~2000 tokens)
+- Caps output at ~4000 chars (~1000 tokens)
 """
 
 import json
@@ -34,8 +34,8 @@ TASK_PLAN_FILE = "task_plan.md"
 ADR_SESSION_FILE = ".adr-session.json"
 DISCOVERIES_DIR = ".planning/discoveries"
 
-MAX_OUTPUT_CHARS = 8000
-MAX_FILES_SHOWN = 20
+MAX_OUTPUT_CHARS = 4000
+MAX_FILES_SHOWN = 10
 
 
 def load_recent_reads(reads_path: Path, max_count: int = MAX_FILES_SHOWN) -> list[str]:

--- a/hooks/sapcc-go-detector.py
+++ b/hooks/sapcc-go-detector.py
@@ -105,23 +105,12 @@ def detect_sapcc_project(go_mod_path: Path) -> tuple[bool, str]:
 
 
 def get_sapcc_injection(module_name: str) -> str:
-    """Get the context injection for SAP CC Go projects."""
-    return f"""
-[sapcc-go] Detected SAP CC Go project: {module_name}
-[auto-skill] go-patterns
+    """Get the context injection for SAP CC Go projects.
 
-This project uses SAP Converged Cloud Go conventions. Key rules:
-- Use sapcc/go-bits (assert, must, logg, easypg, respondwith, errext)
-- FORBIDDEN: testify, zap/zerolog/slog, gin/echo, gorm/sqlx, viper, gomock
-- Anti-over-engineering: no throwaway struct types for simple JSON
-- Error messages must be actionable (not just "internal server error")
-- Table-driven tests with assert.HTTPRequest for HTTP endpoints
-- go-makefile-maker generates Makefile, .golangci.yaml, CI config
-- Pluggable driver pattern via go-bits/pluggable for extensibility
-- Lead review rejects unnecessary abstractions; secondary review catches config safety gaps
-
-Load the go-patterns skill for comprehensive rules.
-"""
+    Emits only tags. The go-patterns skill carries its own conventions.
+    ADR hook-injection-condensation: removed conventions summary.
+    """
+    return f"[sapcc-go] Detected SAP CC Go project: {module_name}\n[auto-skill] go-patterns"
 
 
 def main():


### PR DESCRIPTION
## Summary
- Remove 2 registered stub hooks (`retro-knowledge-injector`, `instruction-reminder`) that spawn processes doing nothing
- Condense `operator-context-detector` output from 14 lines (all 4 profiles) to 2 lines (active profile only)
- Halve `pretool-subagent-warmstart` caps: MAX_OUTPUT_CHARS 8000→4000, MAX_FILES_SHOWN 20→10
- Strip redundant tutorial blocks from `fish-shell-detector` and `sapcc-go-detector` (skills handle this)
- Add `Bash|Write|Edit|Agent` matcher to 4 PostToolUse hooks that were firing on every tool call
- Merge `sql-injection-detector` patterns into `posttool-security-scan` (single hook, one process)
- Condense `pipeline-context-detector` to emit counts instead of full name arrays

## Impact
- ~2,400 tokens/session from injection condensation
- 6 fewer process spawns per Read/Grep/Glob tool call
- 2 stub process spawns eliminated entirely

## ADR
`adr/hook-injection-condensation.md` — grounded in PHILOSOPHY.md "Density" + "Structural Enforcement"

## Test plan
- [ ] Hooks still fire correctly (operator-context on SessionStart, security scan on Write/Edit)
- [ ] No regression in error detection (error-learner still captures Bash failures)
- [ ] ruff check + ruff format pass