### PR TITLE
fix(evolve): update routing drift diagnostic to use check-routing-drift.py

### DIFF
--- a/skills/meta/do/references/routing-guide.md
+++ b/skills/meta/do/references/routing-guide.md
@@ -34,4 +34,4 @@ These skills **MUST** be invoked when their triggers appear:
 | Improve toolkit, evaluate repo, audit system, self-improvement | `toolkit-improvement` |
 | Perses dashboards, plugins, deployment, migration | `perses` |
 
-> For full routing tables with all agents and skills, see `skills/meta/do/references/routing-tables.md`.
+> Routing triggers are embedded in `skills/INDEX.json` (via the `triggers` key per skill) and verified by `python3 scripts/check-routing-drift.py`.

--- a/skills/meta/toolkit-evolution/SKILL.md
+++ b/skills/meta/toolkit-evolution/SKILL.md
@@ -107,7 +107,7 @@ Mark an insight as STALE if: (a) it names a file that no longer exists, OR (b) i
 
 **Step 4: Check routing-table drift**
 
-Skills present in `skills/INDEX.json` but absent from `skills/meta/do/references/routing-tables.md` represent a documentation gap. Run the routing-drift check from `references/diagnose-scripts.md` § DIAGNOSE Step 4.
+Skills present in `skills/INDEX.json` but absent from the routing manifest represent a documentation gap. Run the routing-drift check from `references/diagnose-scripts.md` § DIAGNOSE Step 4.
 
 **Step 4b: Check for orphaned ADR session files**
 

--- a/skills/meta/toolkit-evolution/references/diagnose-scripts.md
+++ b/skills/meta/toolkit-evolution/references/diagnose-scripts.md
@@ -116,24 +116,10 @@ Only forward dream insights where at least one current-state check passes.
 ## DIAGNOSE Step 4: Routing-Table Drift Check
 
 ```bash
-python3 -c "
-import json, re
-with open('skills/INDEX.json') as f:
-    idx = json.load(f)
-index_skills = set(idx.get('skills', {}).keys())
-
-with open('skills/meta/do/references/routing-tables.md') as f:
-    table_text = f.read()
-
-missing = [s for s in sorted(index_skills) if s not in table_text]
-if missing:
-    print(f'{len(missing)} skill(s) in INDEX.json absent from routing-tables.md:')
-    for s in missing:
-        print(f'  {s}')
-else:
-    print('routing-tables.md is in sync with INDEX.json')
-"
+python3 scripts/check-routing-drift.py --verbose
 ```
+
+The `--verbose` flag prints each skill checked plus the final PASS/FAIL. Exit code 1 means skills are missing from the routing manifest.
 
 ## DIAGNOSE Step 4b: Orphaned ADR Session Check
 


### PR DESCRIPTION
## Summary
- Evolution cycle proposal: Fix broken routing drift check in diagnose-scripts.md
- Consensus score: 3.0 (Pragmatist: STRONG, Purist: STRONG, User Advocate: STRONG)
- A/B result: 3/3 tests pass (drift check exits 0, Step 4 uses script, no stale references)

## Changes
- `skills/meta/toolkit-evolution/references/diagnose-scripts.md`: Replace 20-line inline Python routing check (opens deleted `routing-tables.md`) with `python3 scripts/check-routing-drift.py --verbose`
- `skills/meta/do/references/routing-guide.md`: Replace dead pointer to `routing-tables.md` with correct guidance about INDEX.json triggers
- `skills/meta/toolkit-evolution/SKILL.md`: Remove stale `routing-tables.md` reference from Step 4 description

## Test Results
| Test Case | Result |
|-----------|--------|
| `check-routing-drift.py --verbose` exits 0 (115 skills, 0 missing) | PASS |
| DIAGNOSE Step 4 section uses `check-routing-drift.py` script | PASS |
| No remaining `routing-tables.md` refs in toolkit-evolution/ | PASS |
| `ruff check` + `ruff format --check` | PASS |

## Evolution Cycle
This PR was generated and validated by the toolkit-evolution skill (2026-05-10 cycle).
Root cause: PR #626 deleted routing-tables.md but diagnose-scripts.md was not updated to match.