### PR TITLE
feat(hooks): register posttooluse-sync-skill-index.py to auto-sync INDEX.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -239,6 +239,12 @@
             "command": "python3 \"$HOME/.claude/hooks/posttool-skill-frontmatter-check.py\"",
             "description": "Validate skill YAML frontmatter after Write/Edit on SKILL.md files",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/posttooluse-sync-skill-index.py\"",
+            "description": "Auto-regenerate INDEX.json when SKILL.md is written or edited",
+            "timeout": 15000
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Evolution cycle proposal: Wire the deployed-but-unwired skill-index auto-sync hook
- Consensus score: 2.67 (Pragmatist: STRONG, Purist: STRONG, User Advocate: MODERATE)
- A/B result: 3/3 tests pass (JSON valid, fires on SKILL.md writes, silent otherwise)

## Changes
- `.claude/settings.json`: Add `posttooluse-sync-skill-index.py` to PostToolUse `Write|Edit` hooks block

The hook file was deployed in PR #618 but never registered. It auto-regenerates `skills/INDEX.json` when any `SKILL.md` file is written or edited, preventing silent INDEX drift when new skills are created or modified.

## Test Results
| Test Case | Result |
|-----------|--------|
| `settings.json` JSON remains valid after change | PASS |
| Hook fires and regenerates INDEX.json on SKILL.md write | PASS |
| Hook is silent (exit 0, no output) for non-SKILL.md writes | PASS |

## Evolution Cycle
This PR was generated and validated by the toolkit-evolution skill (2026-05-10 cycle).
Prior cycle (2026-05-09) listed this as the #1 next-cycle recommendation after PR #618 deployed the hook without wiring it.