### PR TITLE
feat: joy-check public migration with 100% CI gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,3 +50,14 @@ jobs:
         with:
           python-version: "3.12"
       - run: python scripts/check-routing-drift.py --verbose
+
+  joy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install pytest
+      - name: Joy-check golden fixtures and fleet scan (agents + SKILL.md)
+        run: python -m pytest scripts/tests/test_joy_check_instruction_mode.py -v --tb=short

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -175,6 +175,30 @@ Everything a skill needs lives inside its directory: scripts, viewer templates, 
 
 Skill documents place the workflow immediately after frontmatter. Constraints appear inline within the phases they govern, with reasoning ("because X"). A/B/C testing: workflow-first swept constraints-first 3-0 across all complexity levels.
 
+### Positive Framing as CI Gate
+
+Instructions tell the reader what to do, not what to avoid. An LLM reading "NEVER edit code directly" has learned a boundary but not a target action. "Route all code modifications to domain agents" gives the same boundary and the action.
+
+**The 100% requirement.** Every agent and skill in the fleet must pass instruction-mode joy-check with zero primary negative patterns. 60% pass was the prototype threshold. 100% is the CI gate. Below 100%, the framing debt accumulates — each `FORBIDDEN` or `Don't` added to a skill reduces the signal quality for every downstream invocation.
+
+**What the CI gate catches:**
+
+| Pattern | Example | Positive rewrite |
+|---------|---------|-----------------|
+| `NEVER` (caps) | "NEVER edit code directly" | "Route all code modifications to domain agents" |
+| `do NOT` / `Do NOT` | "Do NOT use git add -A" | "Stage files by name: `git add specific-file.py`" |
+| `must NOT` | "Hooks must NOT block tools" | "exit 0 on errors to keep tools available" |
+| `FORBIDDEN` | "FORBIDDEN Patterns" | "Hard Gate Patterns" |
+| `Don't` at instruction start | "Don't skip validation" | "Run validation before marking complete" |
+| `Avoid` heading/bullet | "### Patterns to Avoid" | "### Preferred Patterns" |
+| `Anti-Pattern` heading | "## Anti-Patterns" | "## Preferred Patterns" |
+
+**Contextual exceptions** (not flagged): subordinate negatives after a positive instruction ("Credentials stay in .env files, never in code"), negatives in fenced code blocks, blockquoted lines, technical terms.
+
+**Implementation:** `scripts/validate_positive_instruction_docs.py` is the deterministic engine. `scripts/tests/test_joy_check_instruction_mode.py` runs golden fixtures (each pattern, each exception) and a parametrized fleet scan. The `joy-check` CI job in `.github/workflows/test.yml` gates all PRs.
+
+**Test:** Run `python3 scripts/validate_positive_instruction_docs.py` — exit code 1 means violations exist. Fix them before merging.
+
 ### Both Deterministic AND LLM Evaluation
 
 **Tier 1 (fast, free, CI-friendly):** Frontmatter parses? Files exist? Required sections present?

--- a/hooks/voice-output-gate.py
+++ b/hooks/voice-output-gate.py
@@ -62,7 +62,7 @@ VOICE_PATTERNS = [
 ]
 
 SCAN_SCRIPT = Path.home() / "pgh/vexjoy-agent/scripts/scan-ai-patterns.py"
-JOY_CHECK_RUBRIC = Path.home() / ".claude/skills/joy-check/references/writing-rubric.md"
+JOY_CHECK_RUBRIC = Path(__file__).resolve().parent.parent / "skills/code-quality/joy-check/references/writing-rubric.md"
 
 
 def detect_external_text(prompt: str) -> bool:

--- a/scripts/migrate-skills-to-folders.py
+++ b/scripts/migrate-skills-to-folders.py
@@ -33,6 +33,7 @@ SKILL_MAPPING: dict[str, str] = {
     "code-linting": "code-quality",
     "comment-quality": "code-quality",
     "condense": "code-quality",
+    "joy-check": "code-quality",
     "python-quality-gate": "code-quality",
     "typescript-check": "code-quality",
     "universal-quality-gate": "code-quality",

--- a/scripts/tests/test_joy_check_instruction_mode.py
+++ b/scripts/tests/test_joy_check_instruction_mode.py
@@ -1,0 +1,246 @@
+"""Deterministic joy-check tests for instruction-mode patterns.
+
+Two scopes:
+1. Golden fixture tests -- small .md snippets that exercise each of the 7
+   primary patterns from skills/voice/skills/joy-check/references/
+   instruction-rubric.md, plus contextual exceptions that must pass.
+2. Fleet scan -- parametrized test across all agents/*.md and
+   skills/**/SKILL.md.  Known violations in voice-corpus files are covered
+   by the allowlist in validate_positive_instruction_docs.py; any new
+   violation in the fleet causes an explicit failure.
+
+Run with:
+    python3 -m pytest scripts/tests/test_joy_check_instruction_mode.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module loading
+# ---------------------------------------------------------------------------
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _SCRIPTS_DIR.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "validate_positive_instruction_docs",
+    _SCRIPTS_DIR / "validate_positive_instruction_docs.py",
+)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["validate_positive_instruction_docs"] = _mod
+_spec.loader.exec_module(_mod)  # type: ignore[attr-defined]
+
+scan_file = _mod.scan_file
+should_skip = _mod.should_skip
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, content: str, name: str = "sample.md") -> Path:
+    """Write content to a temp file and return its path."""
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    # Override REPO_ROOT so relative-path logic works from tmp_path
+    _mod.REPO_ROOT = tmp_path
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Golden fixture tests -- each primary pattern
+# ---------------------------------------------------------------------------
+
+
+class TestPrimaryPatterns:
+    """Each of the 7 primary patterns from the instruction rubric must be flagged."""
+
+    def test_anti_pattern_heading_fails(self, tmp_path: Path) -> None:
+        """Heading containing 'Anti-Pattern' is flagged."""
+        p = _write(tmp_path, "## Anti-Patterns\n\nSome description.\n")
+        violations = scan_file(p)
+        assert any(v.pattern == "Anti-Pattern" for v in violations), (
+            f"Expected Anti-Pattern violation, got: {violations}"
+        )
+
+    def test_forbidden_caps_fails(self, tmp_path: Path) -> None:
+        """FORBIDDEN in instruction context is flagged."""
+        p = _write(tmp_path, "- FORBIDDEN: Do not commit credentials.\n")
+        violations = scan_file(p)
+        assert any(v.pattern == "FORBIDDEN" for v in violations), f"Expected FORBIDDEN violation, got: {violations}"
+
+    def test_never_caps_fails(self, tmp_path: Path) -> None:
+        """NEVER in instruction context is flagged."""
+        p = _write(tmp_path, "NEVER edit code directly.\n")
+        violations = scan_file(p)
+        assert any(v.pattern == "NEVER" for v in violations), f"Expected NEVER violation, got: {violations}"
+
+    def test_do_not_fails(self, tmp_path: Path) -> None:
+        """'do NOT' (lowercase d) is flagged."""
+        p = _write(tmp_path, "do NOT use git add -A.\n")
+        violations = scan_file(p)
+        assert any(v.pattern == "do NOT" for v in violations), f"Expected 'do NOT' violation, got: {violations}"
+
+    def test_do_not_caps_fails(self, tmp_path: Path) -> None:
+        """'Do NOT' (capital D) is flagged."""
+        p = _write(tmp_path, "Do NOT skip tests.\n")
+        violations = scan_file(p)
+        assert any(v.pattern == "do NOT" for v in violations), (
+            f"Expected 'do NOT' violation for 'Do NOT', got: {violations}"
+        )
+
+    def test_must_not_fails(self, tmp_path: Path) -> None:
+        """'must NOT' is flagged."""
+        p = _write(tmp_path, "Hooks must NOT block tools.\n")
+        violations = scan_file(p)
+        assert any(v.pattern == "must NOT" for v in violations), f"Expected 'must NOT' violation, got: {violations}"
+
+    def test_dont_instruction_start_fails(self, tmp_path: Path) -> None:
+        """Line starting with Don't is flagged."""
+        p = _write(tmp_path, "- Don't mock the database.\n")
+        violations = scan_file(p)
+        assert any(v.pattern == "Don't" for v in violations), f"Expected Don't violation, got: {violations}"
+
+    def test_avoid_heading_fails(self, tmp_path: Path) -> None:
+        """Heading containing 'Avoid' is flagged."""
+        p = _write(tmp_path, "### Patterns to Avoid\n\nSome content.\n")
+        violations = scan_file(p)
+        assert any(v.pattern == "Avoid" for v in violations), f"Expected Avoid violation, got: {violations}"
+
+    def test_avoid_as_bullet_start_fails(self, tmp_path: Path) -> None:
+        """Bullet starting with 'Avoid' is flagged."""
+        p = _write(tmp_path, "- Avoid using global state.\n")
+        violations = scan_file(p)
+        assert any(v.pattern == "Avoid" for v in violations), f"Expected Avoid violation for bullet, got: {violations}"
+
+
+# ---------------------------------------------------------------------------
+# Contextual exceptions -- must PASS (no violations)
+# ---------------------------------------------------------------------------
+
+
+class TestContextualExceptions:
+    """Patterns inside fenced code blocks and subordinate positions must not be flagged."""
+
+    def test_never_in_fenced_code_block_passes(self, tmp_path: Path) -> None:
+        """NEVER inside a fenced code block is skipped."""
+        content = "```python\n# NEVER do this\nrm -rf /\n```\n"
+        p = _write(tmp_path, content)
+        violations = scan_file(p)
+        assert violations == [], f"Expected no violations for fenced NEVER, got: {violations}"
+
+    def test_do_not_in_fenced_code_block_passes(self, tmp_path: Path) -> None:
+        """do NOT inside a fenced block is skipped."""
+        content = "```bash\n# do NOT run as root\nsudo command\n```\n"
+        p = _write(tmp_path, content)
+        violations = scan_file(p)
+        assert violations == [], f"Expected no violations for fenced 'do NOT', got: {violations}"
+
+    def test_anti_pattern_in_fenced_block_passes(self, tmp_path: Path) -> None:
+        """Anti-Pattern heading inside fenced code is skipped."""
+        content = "```md\n## Anti-Patterns\nBad thing.\n```\n"
+        p = _write(tmp_path, content)
+        violations = scan_file(p)
+        assert violations == [], f"Expected no violations for fenced Anti-Pattern, got: {violations}"
+
+    def test_clean_file_passes(self, tmp_path: Path) -> None:
+        """A file with positive-only framing produces zero violations."""
+        content = (
+            "# My Skill\n\n"
+            "## Preferred Patterns\n\n"
+            "Route code modifications to domain agents.\n\n"
+            "Create feature branches for all commits.\n\n"
+            "Use `git add specific-file.py` to stage by name.\n"
+        )
+        p = _write(tmp_path, content)
+        violations = scan_file(p)
+        assert violations == [], f"Expected no violations for clean file, got: {violations}"
+
+    def test_subordinate_never_in_positive_instruction_passes(self, tmp_path: Path) -> None:
+        """'never in code' subordinate to positive instruction does not trigger NEVER pattern.
+
+        The regex matches \\bNEVER\\b (uppercase). Lowercase 'never' is not
+        flagged -- this is the intended behaviour for subordinate negatives
+        like 'Credentials stay in .env files, never in code.'
+        """
+        content = "Credentials stay in .env files, never in code or logs.\n"
+        p = _write(tmp_path, content)
+        violations = scan_file(p)
+        assert violations == [], f"Expected no violations for subordinate lowercase 'never', got: {violations}"
+
+    def test_blockquote_line_passes(self, tmp_path: Path) -> None:
+        """Lines starting with > (blockquote) are skipped."""
+        content = "> Do NOT copy this pattern.\n> NEVER do this in production.\n"
+        p = _write(tmp_path, content)
+        violations = scan_file(p)
+        assert violations == [], f"Expected no violations for blockquote lines, got: {violations}"
+
+
+# ---------------------------------------------------------------------------
+# Positive rewrite examples -- positive framing must not be flagged
+# ---------------------------------------------------------------------------
+
+
+class TestPositiveRewrites:
+    """Positive rewrites from the rubric must produce zero violations."""
+
+    def test_route_to_agents_positive(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "Route all code modifications to domain agents.\n")
+        assert scan_file(p) == []
+
+    def test_feature_branch_positive(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "Create feature branches for all commits.\n")
+        assert scan_file(p) == []
+
+    def test_preferred_heading_positive(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "## Preferred Patterns\n\nUse this approach.\n")
+        assert scan_file(p) == []
+
+    def test_hard_gate_heading_positive(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "### Hard Gate Patterns\n\nEnforced by hooks.\n")
+        assert scan_file(p) == []
+
+
+# ---------------------------------------------------------------------------
+# Fleet scan -- parametrized across agents/*.md and skills/**/SKILL.md
+# ---------------------------------------------------------------------------
+
+_AGENT_FILES = sorted(_REPO_ROOT.glob("agents/*.md"))
+_SKILL_FILES = sorted(_REPO_ROOT.glob("skills/**/SKILL.md"))
+_FLEET = _AGENT_FILES + _SKILL_FILES
+
+# Build fleet parameter list, skipping allowlisted files.
+# Use a sentinel so pytest reports "skipped (allowlisted)" rather than collecting 0 params.
+_fleet_params = []
+for _f in _FLEET:
+    _rel = str(_f.relative_to(_REPO_ROOT))
+    if should_skip(_f):
+        _fleet_params.append(pytest.param(_f, marks=pytest.mark.skip(reason=f"allowlisted: {_rel}")))
+    else:
+        _fleet_params.append(pytest.param(_f, id=_rel))
+
+
+@pytest.mark.parametrize("md_file", _fleet_params)
+def test_fleet_joy_check(md_file: Path) -> None:
+    """Every non-allowlisted agent and skill must pass instruction-mode joy check.
+
+    Failure means the file contains a primary negative-framing pattern that
+    should be rewritten to positive framing per instruction-rubric.md.
+    Run `python3 scripts/validate_positive_instruction_docs.py` for the full
+    violation list with line numbers.
+    """
+    _mod.REPO_ROOT = _REPO_ROOT
+    violations = scan_file(md_file)
+    rel = str(md_file.relative_to(_REPO_ROOT))
+    assert violations == [], (
+        f"Joy-check failure in {rel}: {len(violations)} violation(s).\n"
+        + "\n".join(f"  L{v.line} [{v.pattern}] {v.text}" for v in violations[:10])
+        + ("\n  ..." if len(violations) > 10 else "")
+    )

--- a/scripts/tests/test_joy_check_instruction_mode.py
+++ b/scripts/tests/test_joy_check_instruction_mode.py
@@ -2,7 +2,7 @@
 
 Two scopes:
 1. Golden fixture tests -- small .md snippets that exercise each of the 7
-   primary patterns from skills/voice/skills/joy-check/references/
+   primary patterns from skills/code-quality/joy-check/references/
    instruction-rubric.md, plus contextual exceptions that must pass.
 2. Fleet scan -- parametrized test across all agents/*.md and
    skills/**/SKILL.md.  Known violations in voice-corpus files are covered

--- a/scripts/validate_positive_instruction_docs.py
+++ b/scripts/validate_positive_instruction_docs.py
@@ -21,9 +21,13 @@ SCAN_PATTERNS = [
 NEGATIVE_PATTERNS = [
     ("Anti-Pattern", re.compile(r"^\s*#{1,6}.*[Aa]nti-[Pp]attern")),
     ("FORBIDDEN", re.compile(r"\bFORBIDDEN\b")),
+    ("NEVER", re.compile(r"\bNEVER\b")),
     ("do NOT", re.compile(r"\b[Dd]o NOT\b")),
     ("must NOT", re.compile(r"\bmust NOT\b")),
-    ("Avoid", re.compile(r"^\s*#{1,6}.*Avoid|^\s*[-*]?\s*Avoid\b", re.IGNORECASE)),
+    ("Don't", re.compile(r"^-?\s*Don't\b")),
+    # Heading: "Avoid" as leading verb ("### Avoid X") or terminal verb ("### X to Avoid").
+    # Not matched: "### Prefetch Data to Avoid N+1" — "Avoid" embedded in technical phrase.
+    ("Avoid", re.compile(r"^\s*#{1,6}\s+Avoid\b|^\s*#{1,6}.*\bAvoid\s*$|^\s*[-*]?\s*Avoid\b", re.IGNORECASE)),
 ]
 ALLOWLIST = (
     "anti-ai-editor",
@@ -32,6 +36,10 @@ ALLOWLIST = (
     "extract_negative_instruction_blocks.py",
     "validate_positive_instruction_docs.py",
     "bulk_fix_instruction_joy.py",
+    # Voice corpus files: NEVER/Don't document voice rules (what the voice itself avoids),
+    # not toolkit operator instructions. Contextual exception per instruction-rubric.md.
+    "voice-andy-nemmity",
+    "voice-vexjoy",
 )
 
 

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -3,6 +3,322 @@
   "generated": "2026-05-09T21:30:03Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
+    "adr-consultation": {
+      "file": "skills/process/adr-consultation/SKILL.md",
+      "description": "Multi-agent consultation for architecture decisions.",
+      "triggers": [
+        "consult on ADR",
+        "challenge this design",
+        "review before implementing",
+        "multi-agent consultation",
+        "architecture consultation",
+        "should we proceed",
+        "adr consultation"
+      ],
+      "category": "meta",
+      "user_invocable": false,
+      "pairs_with": [
+        "feature-lifecycle"
+      ]
+    },
+    "agent-comparison": {
+      "file": "skills/meta/agent-comparison/SKILL.md",
+      "description": "A/B test agent variants for quality and token cost.",
+      "triggers": [
+        "compare agents",
+        "A/B test agents",
+        "benchmark agents",
+        "optimize skill",
+        "optimize description",
+        "run autoresearch"
+      ],
+      "category": "meta-tooling",
+      "user_invocable": false,
+      "pairs_with": [
+        "agent-evaluation",
+        "skill-eval"
+      ]
+    },
+    "agent-evaluation": {
+      "file": "skills/meta/agent-evaluation/SKILL.md",
+      "description": "Evaluate agents and skills for quality and standards compliance.",
+      "triggers": [
+        "evaluate agent",
+        "audit agent",
+        "score skill",
+        "check quality",
+        "grade agent",
+        "agent quality"
+      ],
+      "category": "meta-tooling",
+      "user_invocable": false,
+      "pairs_with": [
+        "agent-comparison",
+        "skill-eval",
+        "skill-creator"
+      ]
+    },
+    "architecture-deepening": {
+      "file": "skills/research/architecture-deepening/SKILL.md",
+      "description": "Proactive architecture improvement: find shallow modules, propose deepening opportunities, design conversation.",
+      "triggers": [
+        "deepen architecture",
+        "find shallow modules",
+        "architecture improvement",
+        "module depth analysis",
+        "deepening opportunities",
+        "improve module interfaces",
+        "reduce complexity",
+        "architecture deepening"
+      ],
+      "category": "analysis",
+      "user_invocable": true,
+      "pairs_with": [
+        "full-repo-review",
+        "adr-consultation",
+        "codebase-overview"
+      ]
+    },
+    "auto-dream": {
+      "file": "skills/meta/auto-dream/SKILL.md",
+      "description": "Background memory consolidation and learning graduation \u2014 overnight knowledge lifecycle.",
+      "triggers": [
+        "dream",
+        "consolidate memories",
+        "clean up memories",
+        "memory maintenance",
+        "memory consolidation",
+        "deduplicate memories",
+        "graduate learnings",
+        "promote learnings"
+      ],
+      "category": "meta-tooling",
+      "user_invocable": true,
+      "pairs_with": []
+    },
+    "bluesky-reader": {
+      "file": "skills/content/bluesky-reader/SKILL.md",
+      "description": "Read public Bluesky feeds via AT Protocol API.",
+      "triggers": [
+        "read Bluesky",
+        "fetch Bluesky posts",
+        "AT Protocol",
+        "Bluesky feed",
+        "bsky"
+      ],
+      "category": "research",
+      "user_invocable": false,
+      "pairs_with": [
+        "content-engine"
+      ],
+      "agent": "python-general-engineer"
+    },
+    "cobalt-core": {
+      "file": "skills/engineering/cobalt-core/SKILL.md",
+      "description": "Cobalt Core infrastructure knowledge: KVM exporters, hypervisor tooling, OpenStack compute.",
+      "triggers": [
+        "cobalt core",
+        "cobaltcore",
+        "kvm-exporter",
+        "kvm exporter",
+        "hypervisor metrics",
+        "libvirt exporter",
+        "cloud hypervisor"
+      ],
+      "category": "infrastructure",
+      "user_invocable": true,
+      "pairs_with": [
+        "go-patterns",
+        "prometheus-grafana-engineer",
+        "kubernetes-helm-engineer"
+      ],
+      "agent": "kubernetes-helm-engineer"
+    },
+    "code-cleanup": {
+      "file": "skills/code-quality/code-cleanup/SKILL.md",
+      "description": "Detect stale TODOs, unused imports, and dead code.",
+      "triggers": [
+        "find dead code",
+        "stale TODOs",
+        "unused imports",
+        "clean up",
+        "tidy code",
+        "remove dead code",
+        "find unused"
+      ],
+      "category": "code-quality",
+      "user_invocable": false,
+      "pairs_with": [
+        "code-linting",
+        "universal-quality-gate",
+        "comment-quality"
+      ]
+    },
+    "code-linting": {
+      "file": "skills/code-quality/code-linting/SKILL.md",
+      "description": "Run Python (ruff) and JavaScript (Biome) linting.",
+      "triggers": [
+        "lint code",
+        "run ruff",
+        "run biome",
+        "format code",
+        "lint errors"
+      ],
+      "category": "code-quality",
+      "user_invocable": false,
+      "pairs_with": [
+        "code-cleanup",
+        "universal-quality-gate",
+        "python-quality-gate"
+      ]
+    },
+    "codebase-analyzer": {
+      "file": "skills/research/codebase-analyzer/SKILL.md",
+      "description": "Statistical rule discovery from Go codebase patterns.",
+      "triggers": [
+        "analyze codebase",
+        "discover patterns",
+        "style vector",
+        "code cartographer",
+        "pattern frequency",
+        "structural metrics"
+      ],
+      "category": "analysis",
+      "user_invocable": false,
+      "pairs_with": [
+        "codebase-overview",
+        "go-patterns"
+      ]
+    },
+    "codebase-overview": {
+      "file": "skills/research/codebase-overview/SKILL.md",
+      "description": "Systematic codebase exploration and architecture mapping.",
+      "triggers": [
+        "onboard to codebase",
+        "codebase structure",
+        "what does this project do",
+        "give me an overview",
+        "summarize this repo",
+        "understand this codebase"
+      ],
+      "category": "analysis",
+      "user_invocable": false,
+      "pairs_with": [
+        "codebase-analyzer",
+        "generate-claudemd"
+      ]
+    },
+    "comment-quality": {
+      "file": "skills/code-quality/comment-quality/SKILL.md",
+      "description": "Review and fix temporal references in code comments.",
+      "triggers": [
+        "review comments",
+        "fix temporal references",
+        "comment quality",
+        "stale comments",
+        "outdated comment"
+      ],
+      "category": "code-quality",
+      "user_invocable": false,
+      "pairs_with": [
+        "code-cleanup",
+        "systematic-code-review"
+      ]
+    },
+    "condense": {
+      "file": "skills/code-quality/condense/SKILL.md",
+      "description": "Maximize information density: preserve all instructions, remove prose filler.",
+      "triggers": [
+        "condense",
+        "reduce words",
+        "clarity pass",
+        "information density",
+        "remove prose",
+        "tighten",
+        "fewer words"
+      ],
+      "category": "code-quality",
+      "user_invocable": true,
+      "pairs_with": [
+        "skill-creator",
+        "anti-ai-editor"
+      ]
+    },
+    "condition-based-waiting": {
+      "file": "skills/process/condition-based-waiting/SKILL.md",
+      "description": "Polling, retry, and backoff patterns.",
+      "triggers": [
+        "exponential backoff",
+        "health check polling",
+        "retry pattern",
+        "wait for",
+        "keep trying until",
+        "poll until ready",
+        "retry until success"
+      ],
+      "category": "process",
+      "user_invocable": false,
+      "pairs_with": [
+        "shell-process-patterns",
+        "service-health-check"
+      ]
+    },
+    "content-calendar": {
+      "file": "skills/content/content-calendar/SKILL.md",
+      "description": "Manage editorial content through 6 pipeline stages.",
+      "triggers": [
+        "content pipeline",
+        "editorial calendar",
+        "publishing schedule",
+        "content schedule",
+        "publication plan"
+      ],
+      "category": "content-creation",
+      "user_invocable": false,
+      "pairs_with": [
+        "topic-brainstormer",
+        "series-planner",
+        "publish"
+      ]
+    },
+    "content-engine": {
+      "file": "skills/content/content-engine/SKILL.md",
+      "description": "Repurpose source assets into platform-native social content.",
+      "triggers": [
+        "repurpose this",
+        "adapt for social",
+        "turn this into posts",
+        "content from article",
+        "content from demo",
+        "content from doc",
+        "write variants for",
+        "social content from",
+        "platform variants",
+        "repurpose for"
+      ],
+      "category": "content",
+      "user_invocable": false,
+      "pairs_with": [
+        "x-api"
+      ]
+    },
+    "cron-job-auditor": {
+      "file": "skills/infrastructure/cron-job-auditor/SKILL.md",
+      "description": "Audit cron scripts for reliability and safety.",
+      "triggers": [
+        "audit cron jobs",
+        "review scheduled scripts",
+        "cron safety",
+        "cron reliability",
+        "scheduled task safety"
+      ],
+      "category": "infrastructure",
+      "user_invocable": false,
+      "pairs_with": [
+        "shell-process-patterns",
+        "headless-cron-creator"
+      ]
+    },
     "csuite": {
       "file": "skills/business/csuite/SKILL.md",
       "description": "C-suite executive decision support: strategy, technology, growth, competitive intelligence, project evaluation.",
@@ -54,6 +370,58 @@
       "user_invocable": true,
       "pairs_with": []
     },
+    "data-analysis": {
+      "file": "skills/research/data-analysis/SKILL.md",
+      "description": "Decision-first data analysis with statistical rigor gates.",
+      "triggers": [
+        "analyze data",
+        "data analysis",
+        "CSV",
+        "dataset",
+        "metrics",
+        "trend",
+        "cohort",
+        "A/B test",
+        "statistical",
+        "distribution",
+        "correlation",
+        "KPI",
+        "funnel",
+        "experiment results",
+        "data insights",
+        "statistical analysis",
+        "CSV analysis",
+        "explore dataset"
+      ],
+      "category": "analysis",
+      "user_invocable": false,
+      "pairs_with": [
+        "workflow",
+        "codebase-analyzer"
+      ]
+    },
+    "decision-helper": {
+      "file": "skills/research/decision-helper/SKILL.md",
+      "description": "Weighted decision scoring for architectural choices.",
+      "triggers": [
+        "weigh options",
+        "decision matrix",
+        "compare approaches",
+        "help me decide",
+        "pros and cons",
+        "trade-offs",
+        "which is better",
+        "should I use",
+        "evaluate options"
+      ],
+      "category": "process",
+      "user_invocable": false,
+      "pairs_with": [
+        "multi-persona-critique",
+        "adr-consultation",
+        "planning"
+      ]
+    },
     "design": {
       "file": "skills/business/design/SKILL.md",
       "description": "Design workflows \u2014 UX copy, design systems, design critique, accessibility review, design handoff, user research synthesis.",
@@ -76,638 +444,92 @@
       "user_invocable": true,
       "pairs_with": []
     },
-    "finance": {
-      "file": "skills/business/finance/SKILL.md",
-      "description": "Finance and accounting workflows \u2014 journal entries, reconciliation, variance analysis, financial statements, audit support, month-end close, SOX testing.",
+    "distinctive-frontend-design": {
+      "file": "skills/frontend/distinctive-frontend-design/SKILL.md",
+      "description": "Context-driven aesthetic exploration with anti-cliche validation.",
       "triggers": [
-        "finance",
-        "journal entry",
-        "reconciliation",
-        "variance analysis",
-        "financial statements",
-        "audit",
-        "month-end close",
-        "SOX"
+        "frontend design",
+        "typography exploration",
+        "anti-cliche design",
+        "visual identity",
+        "design language"
       ],
-      "category": "business",
-      "user_invocable": true,
-      "pairs_with": []
-    },
-    "hr": {
-      "file": "skills/business/hr/SKILL.md",
-      "description": "People operations workflows \u2014 recruiting pipeline, performance reviews, compensation analysis, offer drafting, interview prep, onboarding, org planning.",
-      "triggers": [
-        "HR",
-        "human resources",
-        "recruiting",
-        "performance review",
-        "compensation",
-        "hiring",
-        "onboarding",
-        "org planning"
-      ],
-      "category": "business",
-      "user_invocable": true,
-      "pairs_with": []
-    },
-    "legal": {
-      "file": "skills/business/legal/SKILL.md",
-      "description": "Legal workflows \u2014 contract review, compliance checks, NDA triage, risk assessment, legal briefs.",
-      "triggers": [
-        "legal",
-        "contract review",
-        "compliance check",
-        "NDA",
-        "legal risk",
-        "legal brief",
-        "vendor check",
-        "german compliance",
-        "DSGVO",
-        "GoBD",
-        "TDDDG",
-        "AI Act compliance",
-        "eIDAS"
-      ],
-      "category": "business",
-      "user_invocable": true,
-      "pairs_with": []
-    },
-    "marketing": {
-      "file": "skills/business/marketing/SKILL.md",
-      "description": "Marketing workflows \u2014 SEO audits, campaign planning, content strategy, email sequences, competitive analysis, brand review, performance reporting.",
-      "triggers": [
-        "marketing",
-        "SEO",
-        "campaign",
-        "content strategy",
-        "email sequence",
-        "brand review",
-        "competitive analysis",
-        "marketing performance"
-      ],
-      "category": "business",
-      "user_invocable": true,
-      "pairs_with": []
-    },
-    "operations": {
-      "file": "skills/business/operations/SKILL.md",
-      "description": "Business operations workflows \u2014 vendor management, runbooks, process documentation, risk assessment, capacity planning, change management, compliance tracking.",
-      "triggers": [
-        "operations",
-        "vendor review",
-        "runbook",
-        "process documentation",
-        "risk assessment",
-        "capacity plan",
-        "change management",
-        "compliance tracking"
-      ],
-      "category": "business",
-      "user_invocable": true,
-      "pairs_with": []
-    },
-    "product-management": {
-      "file": "skills/business/product-management/SKILL.md",
-      "description": "Product management workflows \u2014 feature specs, roadmap planning, stakeholder updates, user research synthesis, competitive analysis, metrics review, sprint planning.",
-      "triggers": [
-        "product management",
-        "feature spec",
-        "PRD",
-        "roadmap",
-        "stakeholder update",
-        "user research",
-        "sprint planning",
-        "product metrics"
-      ],
-      "category": "business",
-      "user_invocable": true,
-      "pairs_with": []
-    },
-    "productivity": {
-      "file": "skills/business/productivity/SKILL.md",
-      "description": "Productivity workflows \u2014 task management, daily planning, weekly reviews, meeting optimization, focus management, goal setting, status updates.",
-      "triggers": [
-        "productivity",
-        "task management",
-        "daily plan",
-        "weekly review",
-        "meeting agenda",
-        "focus time",
-        "goal setting",
-        "status update",
-        "time management",
-        "prioritize tasks",
-        "standup",
-        "retrospective"
-      ],
-      "category": "business",
-      "user_invocable": true,
-      "pairs_with": []
-    },
-    "sales": {
-      "file": "skills/business/sales/SKILL.md",
-      "description": "Sales workflows \u2014 call prep, pipeline analysis, outreach, competitive intelligence, forecasting.",
-      "triggers": [
-        "sales",
-        "call prep",
-        "pipeline review",
-        "forecast",
-        "draft outreach",
-        "prospect research",
-        "competitive intelligence"
-      ],
-      "category": "business",
-      "user_invocable": true,
-      "pairs_with": []
-    },
-    "code-cleanup": {
-      "file": "skills/code-quality/code-cleanup/SKILL.md",
-      "description": "Detect stale TODOs, unused imports, and dead code.",
-      "triggers": [
-        "find dead code",
-        "stale TODOs",
-        "unused imports",
-        "clean up",
-        "tidy code",
-        "remove dead code",
-        "find unused"
-      ],
-      "category": "code-quality",
+      "category": "frontend",
       "user_invocable": false,
       "pairs_with": [
-        "code-linting",
-        "universal-quality-gate",
-        "comment-quality"
+        "threejs-builder",
+        "webgl-card-effects",
+        "frontend-slides"
       ]
     },
-    "code-linting": {
-      "file": "skills/code-quality/code-linting/SKILL.md",
-      "description": "Run Python (ruff) and JavaScript (Biome) linting.",
+    "do": {
+      "file": "skills/meta/do/SKILL.md",
+      "description": "Classify user requests and route to the correct agent + skill.",
       "triggers": [
-        "lint code",
-        "run ruff",
-        "run biome",
-        "format code",
-        "lint errors"
+        "route task",
+        "classify request",
+        "which agent",
+        "delegate to skill",
+        "smart router"
       ],
-      "category": "code-quality",
+      "category": "meta-tooling",
+      "user_invocable": true
+    },
+    "docs-sync-checker": {
+      "file": "skills/meta/docs-sync-checker/SKILL.md",
+      "description": "Detect documentation drift against filesystem state.",
+      "triggers": [
+        "check doc drift",
+        "sync documentation",
+        "stale docs",
+        "documentation drift",
+        "README outdated"
+      ],
+      "category": "documentation",
       "user_invocable": false,
       "pairs_with": [
-        "code-cleanup",
-        "universal-quality-gate",
-        "python-quality-gate"
+        "generate-claudemd",
+        "codebase-overview"
       ]
     },
-    "comment-quality": {
-      "file": "skills/code-quality/comment-quality/SKILL.md",
-      "description": "Review and fix temporal references in code comments.",
+    "e2e-testing": {
+      "file": "skills/testing/e2e-testing/SKILL.md",
+      "description": "Playwright-based end-to-end testing workflow.",
       "triggers": [
-        "review comments",
-        "fix temporal references",
-        "comment quality",
-        "stale comments",
-        "outdated comment"
+        "playwright",
+        "E2E test",
+        "end-to-end",
+        "browser test",
+        "page object model",
+        "POM",
+        "test flakiness"
       ],
-      "category": "code-quality",
+      "category": "testing",
       "user_invocable": false,
       "pairs_with": [
-        "code-cleanup",
-        "systematic-code-review"
-      ]
-    },
-    "condense": {
-      "file": "skills/code-quality/condense/SKILL.md",
-      "description": "Maximize information density: preserve all instructions, remove prose filler.",
-      "triggers": [
-        "condense",
-        "reduce words",
-        "clarity pass",
-        "information density",
-        "remove prose",
-        "tighten",
-        "fewer words"
-      ],
-      "category": "code-quality",
-      "user_invocable": true,
-      "pairs_with": [
-        "skill-creator",
-        "anti-ai-editor"
-      ]
-    },
-    "python-quality-gate": {
-      "file": "skills/code-quality/python-quality-gate/SKILL.md",
-      "description": "Python quality checks: ruff, pytest, mypy, bandit in deterministic order.",
-      "triggers": [
-        "Python quality",
-        "ruff check",
-        "bandit scan",
-        "mypy check",
-        "python lint",
-        "python quality gate",
-        "check python",
-        "pre-commit check"
-      ],
-      "category": "code-quality",
-      "force_route": true,
-      "user_invocable": false,
-      "pairs_with": [
-        "code-linting",
+        "testing-automation-engineer",
+        "typescript-frontend-engineer",
         "test-driven-development"
       ],
-      "agent": "python-general-engineer"
+      "agent": "testing-automation-engineer"
     },
-    "typescript-check": {
-      "file": "skills/code-quality/typescript-check/SKILL.md",
-      "description": "TypeScript type checking via tsc --noEmit with actionable error output.",
+    "endpoint-validator": {
+      "file": "skills/infrastructure/endpoint-validator/SKILL.md",
+      "description": "Deterministic API endpoint validation with pass/fail reporting.",
       "triggers": [
-        "TypeScript check",
-        "tsc noEmit",
-        "type check TypeScript",
-        "tsc errors",
-        "TypeScript type validation"
-      ],
-      "category": "code-quality",
-      "user_invocable": false,
-      "pairs_with": [
-        "vitest-runner",
-        "code-linting"
-      ],
-      "agent": "typescript-frontend-engineer"
-    },
-    "universal-quality-gate": {
-      "file": "skills/code-quality/universal-quality-gate/SKILL.md",
-      "description": "Multi-language code quality gate with auto-detection and linters.",
-      "triggers": [
-        "quality gate",
-        "lint check",
-        "multi-language lint",
-        "code quality check",
-        "language-agnostic lint"
-      ],
-      "category": "code-quality",
-      "user_invocable": false,
-      "pairs_with": [
-        "code-linting",
-        "verification-before-completion"
-      ]
-    },
-    "bluesky-reader": {
-      "file": "skills/content/bluesky-reader/SKILL.md",
-      "description": "Read public Bluesky feeds via AT Protocol API.",
-      "triggers": [
-        "read Bluesky",
-        "fetch Bluesky posts",
-        "AT Protocol",
-        "Bluesky feed",
-        "bsky"
-      ],
-      "category": "research",
-      "user_invocable": false,
-      "pairs_with": [
-        "content-engine"
-      ],
-      "agent": "python-general-engineer"
-    },
-    "content-calendar": {
-      "file": "skills/content/content-calendar/SKILL.md",
-      "description": "Manage editorial content through 6 pipeline stages.",
-      "triggers": [
-        "content pipeline",
-        "editorial calendar",
-        "publishing schedule",
-        "content schedule",
-        "publication plan"
-      ],
-      "category": "content-creation",
-      "user_invocable": false,
-      "pairs_with": [
-        "topic-brainstormer",
-        "series-planner",
-        "publish"
-      ]
-    },
-    "content-engine": {
-      "file": "skills/content/content-engine/SKILL.md",
-      "description": "Repurpose source assets into platform-native social content.",
-      "triggers": [
-        "repurpose this",
-        "adapt for social",
-        "turn this into posts",
-        "content from article",
-        "content from demo",
-        "content from doc",
-        "write variants for",
-        "social content from",
-        "platform variants",
-        "repurpose for"
-      ],
-      "category": "content",
-      "user_invocable": false,
-      "pairs_with": [
-        "x-api"
-      ]
-    },
-    "gemini-image-generator": {
-      "file": "skills/content/gemini-image-generator/SKILL.md",
-      "description": "Generate images from text prompts via Google Gemini.",
-      "triggers": [
-        "generate image",
-        "create image with AI",
-        "gemini image",
-        "text to image",
-        "python image generation",
-        "create sprite",
-        "generate character art"
-      ],
-      "category": "image-generation",
-      "user_invocable": false,
-      "pairs_with": [
-        "python-general-engineer",
-        "workflow"
-      ],
-      "agent": "python-general-engineer"
-    },
-    "image-to-video": {
-      "file": "skills/content/image-to-video/SKILL.md",
-      "description": "FFmpeg-based video creation from image and audio.",
-      "triggers": [
-        "image to video",
-        "audio visualization",
-        "static video",
-        "mp4 from image",
-        "music video",
-        "podcast video",
-        "video from image",
-        "combine image audio",
-        "album art video",
-        "cover art video"
-      ],
-      "category": "video-creation",
-      "user_invocable": false,
-      "pairs_with": [
-        "gemini-image-generator",
-        "workflow"
-      ]
-    },
-    "nano-banana-builder": {
-      "file": "skills/content/nano-banana-builder/SKILL.md",
-      "description": "Image generation and post-processing via Gemini Nano Banana APIs.",
-      "triggers": [
-        "nano banana",
-        "gemini image generation",
-        "AI image generator",
-        "generate image",
-        "gemini-2.5-flash-image",
-        "gemini-3-pro-image-preview",
-        "batch image generation",
-        "image post-processing",
-        "sprite generation",
-        "generate card art"
-      ],
-      "category": "image-generation",
-      "user_invocable": false,
-      "pairs_with": [
-        "python-general-engineer",
-        "universal-quality-gate"
-      ],
-      "agent": "python-general-engineer"
-    },
-    "pptx-generator": {
-      "file": "skills/content/pptx-generator/SKILL.md",
-      "description": "PPTX presentation generation with visual QA: slides, pitch decks.",
-      "triggers": [
-        "presentation",
-        "powerpoint",
-        "pptx",
-        "slide deck",
-        "pitch deck",
-        "slides",
-        "create slides",
-        "generate presentation",
-        "make a deck",
-        "conference talk slides"
-      ],
-      "category": "content-generation",
-      "user_invocable": false,
-      "pairs_with": [
-        "workflow",
-        "gemini-image-generator"
-      ]
-    },
-    "professional-communication": {
-      "file": "skills/content/professional-communication/SKILL.md",
-      "description": "Transform technical communication into structured business formats.",
-      "triggers": [
-        "business communication",
-        "structured format",
-        "clear writing",
-        "write email",
-        "draft memo",
-        "executive summary",
-        "summarize for management",
-        "status update"
-      ],
-      "category": "content-creation",
-      "user_invocable": false,
-      "pairs_with": [
-        "voice-writer",
-        "pptx-generator"
-      ]
-    },
-    "publish": {
-      "file": "skills/content/publish/SKILL.md",
-      "description": "Content-publishing umbrella covering the blog pipeline from blueprint to upload: post outlining, pre-publication validation, SEO optimization, bulk...",
-      "triggers": [
-        "outline post",
-        "blog structure",
-        "article outline",
-        "pre-publish check",
-        "Hugo validation",
-        "front matter check",
-        "frontmatter validation",
-        "check SEO",
-        "optimize SEO",
-        "keyword analysis",
-        "meta description",
-        "batch edit posts",
-        "bulk frontmatter update",
-        "find replace across files",
-        "mass edit",
-        "audit links",
-        "find broken links",
-        "broken links",
-        "dead links",
-        "audit images",
-        "image accessibility",
-        "alt text check",
-        "audit taxonomy",
-        "fix tags",
-        "merge categories",
-        "tag cleanup",
-        "upload to wordpress",
-        "create wordpress draft",
-        "wordpress draft",
-        "upload article",
-        "post to wordpress",
-        "edit wordpress post",
-        "update wordpress post",
-        "wordpress media",
-        "create wp categories",
-        "auto-create categories",
-        "search wp media",
-        "search wordpress media",
-        "find existing wordpress image"
-      ],
-      "not_for": "writing article prose (use voice-writer), live rendering verification (use wordpress-live-validation)",
-      "category": "content-publishing",
-      "user_invocable": false,
-      "pairs_with": [
-        "content-calendar",
-        "wordpress-live-validation",
-        "html-artifact"
-      ],
-      "agent": "general-purpose"
-    },
-    "reddit-moderate": {
-      "file": "skills/content/reddit-moderate/SKILL.md",
-      "description": "Reddit moderation via PRAW: fetch modqueue, classify reports, take actions.",
-      "triggers": [
-        "moderate Reddit",
-        "modqueue",
-        "Reddit reports",
-        "Reddit moderation",
-        "check reports"
-      ],
-      "category": "process",
-      "user_invocable": false,
-      "pairs_with": [
-        "content-engine"
-      ],
-      "agent": "python-general-engineer"
-    },
-    "series-planner": {
-      "file": "skills/content/series-planner/SKILL.md",
-      "description": "Plan multi-part content series: structure, cross-linking, cadence.",
-      "triggers": [
-        "plan series",
-        "multi-part content",
-        "content series",
-        "article series",
-        "content arc"
-      ],
-      "category": "content-creation",
-      "user_invocable": false,
-      "pairs_with": [
-        "content-calendar",
-        "topic-brainstormer",
-        "publish"
-      ]
-    },
-    "topic-brainstormer": {
-      "file": "skills/content/topic-brainstormer/SKILL.md",
-      "description": "Generate blog topic ideas: problem mining, gap analysis, expansion.",
-      "triggers": [
-        "brainstorm topics",
-        "content ideas",
-        "blog topic ideas",
-        "what to write about"
-      ],
-      "category": "content-creation",
-      "user_invocable": false,
-      "pairs_with": [
-        "content-calendar",
-        "series-planner",
-        "research-pipeline"
-      ]
-    },
-    "video-editing": {
-      "file": "skills/content/video-editing/SKILL.md",
-      "description": "Video editing pipeline: cut footage, assemble clips via FFmpeg and Remotion.",
-      "triggers": [
-        "edit video",
-        "cut footage",
-        "make vlog",
-        "screen recording",
-        "video workflow",
-        "ffmpeg",
-        "remotion",
-        "demo video",
-        "make a clip",
-        "assemble clips",
-        "video editing"
-      ],
-      "category": "video-creation",
-      "user_invocable": false,
-      "pairs_with": [
-        "typescript-frontend-engineer"
-      ],
-      "agent": "python-general-engineer"
-    },
-    "wordpress-live-validation": {
-      "file": "skills/content/wordpress-live-validation/SKILL.md",
-      "description": "Validate published WordPress posts in browser via Playwright.",
-      "triggers": [
-        "validate wordpress post",
-        "check live post",
-        "verify published post",
-        "wordpress post looks right",
-        "check og tags live",
-        "responsive check wordpress",
-        "post rendering check",
-        "live site validation"
-      ],
-      "category": "content-publishing",
-      "user_invocable": false,
-      "pairs_with": [
-        "publish",
-        "e2e-testing"
-      ]
-    },
-    "x-api": {
-      "file": "skills/content/x-api/SKILL.md",
-      "description": "Post tweets, build threads, upload media via the X API.",
-      "triggers": [
-        "post to X",
-        "post tweet",
-        "tweet this",
-        "build thread",
-        "post thread",
-        "twitter thread",
-        "x api",
-        "upload media to X",
-        "read timeline",
-        "search X",
-        "search twitter",
-        "publish to X",
-        "publish to twitter"
-      ],
-      "category": "content-publishing",
-      "user_invocable": false,
-      "pairs_with": [
-        "content-engine"
-      ],
-      "agent": "python-general-engineer"
-    },
-    "cobalt-core": {
-      "file": "skills/engineering/cobalt-core/SKILL.md",
-      "description": "Cobalt Core infrastructure knowledge: KVM exporters, hypervisor tooling, OpenStack compute.",
-      "triggers": [
-        "cobalt core",
-        "cobaltcore",
-        "kvm-exporter",
-        "kvm exporter",
-        "hypervisor metrics",
-        "libvirt exporter",
-        "cloud hypervisor"
+        "validate endpoints",
+        "smoke test API",
+        "health check endpoints",
+        "test endpoint",
+        "check API",
+        "smoke test"
       ],
       "category": "infrastructure",
-      "user_invocable": true,
+      "user_invocable": false,
       "pairs_with": [
-        "go-patterns",
-        "prometheus-grafana-engineer",
-        "kubernetes-helm-engineer"
-      ],
-      "agent": "kubernetes-helm-engineer"
+        "service-health-check",
+        "e2e-testing"
+      ]
     },
     "enterprise-search": {
       "file": "skills/engineering/enterprise-search/SKILL.md",
@@ -738,212 +560,132 @@
       "user_invocable": true,
       "pairs_with": []
     },
-    "go-patterns": {
-      "file": "skills/engineering/go-patterns/SKILL.md",
-      "description": "Go development patterns: testing, concurrency, errors, review, and conventions.",
+    "explanation-traces": {
+      "file": "skills/meta/explanation-traces/SKILL.md",
+      "description": "Query and display structured decision traces from routing, agent selection, and skill execution.",
       "triggers": [
-        "go test",
-        "*_test.go",
-        "table-driven",
-        "t.Run",
-        "t.Helper",
-        "goroutine",
-        "channel",
-        "sync.Mutex",
-        "sync.WaitGroup",
-        "worker pool",
-        "fan-in",
-        "context.Context",
-        "goroutine fan-out",
-        "fmt.Errorf",
-        "errors.Is",
-        "errors.As",
-        "%w",
-        "sentinel error",
-        "Go anti-pattern",
-        "Go code smell",
-        "Go code review",
-        "Go PR",
-        "Go quality",
-        "sapcc",
-        "sap-cloud-infrastructure",
-        "go-bits",
-        "keppel",
-        "go-api-declarations",
-        "go-makefile-maker",
-        "make check",
-        "Go lint"
+        "why did you",
+        "explain routing",
+        "show trace",
+        "decision log",
+        "why that agent",
+        "explain decision",
+        "show decisions",
+        "trace log"
       ],
-      "category": "language",
+      "category": "analysis",
+      "force_route": true,
+      "user_invocable": true,
+      "pairs_with": []
+    },
+    "feature-lifecycle": {
+      "file": "skills/process/feature-lifecycle/SKILL.md",
+      "description": "Feature lifecycle: design, plan, implement, validate, release.",
+      "triggers": [
+        "feature design",
+        "design feature",
+        "think through",
+        "explore approaches",
+        "design first",
+        "feature plan",
+        "plan feature",
+        "break down design",
+        "create tasks",
+        "feature implement",
+        "implement feature",
+        "execute plan",
+        "start building",
+        "feature validate",
+        "validate feature",
+        "run feature quality gates",
+        "check feature",
+        "feature release",
+        "release feature",
+        "merge feature",
+        "ship it",
+        "build feature end to end",
+        "full feature lifecycle",
+        "feature from scratch",
+        "design to release",
+        "complete feature pipeline",
+        "feature pipeline"
+      ],
+      "category": "process",
       "force_route": true,
       "user_invocable": false,
       "pairs_with": [
-        "golang-general-engineer",
-        "golang-general-engineer-compact",
-        "systematic-code-review"
-      ],
-      "agent": "golang-general-engineer"
+        "workflow",
+        "subagent-driven-development",
+        "pr-workflow",
+        "verification-before-completion",
+        "universal-quality-gate",
+        "adr-consultation",
+        "planning"
+      ]
     },
-    "kotlin-coroutines": {
-      "file": "skills/engineering/kotlin-coroutines/SKILL.md",
-      "description": "Kotlin structured concurrency, Flow, and Channel patterns.",
+    "finance": {
+      "file": "skills/business/finance/SKILL.md",
+      "description": "Finance and accounting workflows \u2014 journal entries, reconciliation, variance analysis, financial statements, audit support, month-end close, SOX testing.",
       "triggers": [
-        "kotlin coroutines",
-        "kotlin structured concurrency",
-        "kotlin Flow",
-        "kotlin Channel",
-        "suspend function",
-        "structured concurrency kotlin"
+        "finance",
+        "journal entry",
+        "reconciliation",
+        "variance analysis",
+        "financial statements",
+        "audit",
+        "month-end close",
+        "SOX"
       ],
-      "category": "kotlin",
+      "category": "business",
+      "user_invocable": true,
+      "pairs_with": []
+    },
+    "fish-shell-config": {
+      "file": "skills/infrastructure/fish-shell-config/SKILL.md",
+      "description": "Fish shell configuration and PATH management.",
+      "triggers": [
+        "fish",
+        "fish shell",
+        "config.fish",
+        "abbr",
+        "fish function",
+        "fish_config",
+        "fish_variables",
+        "funced",
+        "funcsave",
+        "~/.config/fish",
+        "conf.d",
+        "fish abbreviation",
+        ".fish file",
+        "#!/usr/bin/env fish"
+      ],
+      "category": "process",
+      "force_route": true,
+      "user_invocable": false,
+      "pairs_with": []
+    },
+    "forensics": {
+      "file": "skills/process/forensics/SKILL.md",
+      "description": "Post-mortem diagnostic analysis of failed workflows.",
+      "triggers": [
+        "forensics",
+        "what went wrong",
+        "why did this fail",
+        "stuck loop",
+        "diagnose workflow",
+        "post-mortem",
+        "workflow failure",
+        "session crashed",
+        "why is this stuck",
+        "investigate failure",
+        "why did this break",
+        "incident review"
+      ],
+      "category": "process",
       "user_invocable": false,
       "pairs_with": [
-        "kotlin-testing"
-      ],
-      "agent": "kotlin-general-engineer"
-    },
-    "kotlin-testing": {
-      "file": "skills/engineering/kotlin-testing/SKILL.md",
-      "description": "Kotlin testing with JUnit 5, Kotest, and coroutine dispatchers.",
-      "triggers": [
-        "kotlin testing",
-        "junit kotlin",
-        "kotest",
-        "junit 5 kotlin",
-        "kotlin test dispatcher"
-      ],
-      "category": "kotlin",
-      "user_invocable": false,
-      "pairs_with": [
-        "kotlin-coroutines",
-        "test-driven-development"
-      ],
-      "agent": "kotlin-general-engineer"
-    },
-    "php-quality": {
-      "file": "skills/engineering/php-quality/SKILL.md",
-      "description": "PHP code quality: PSR standards, strict types, framework idioms.",
-      "triggers": [
-        "php quality",
-        "php code review",
-        "PSR standards",
-        "phpstan",
-        "php-cs-fixer"
-      ],
-      "category": "php",
-      "user_invocable": false,
-      "pairs_with": [
-        "php-testing",
-        "code-linting"
-      ],
-      "agent": "php-general-engineer"
-    },
-    "php-testing": {
-      "file": "skills/engineering/php-testing/SKILL.md",
-      "description": "PHP testing patterns: PHPUnit, test doubles, database testing.",
-      "triggers": [
-        "php testing",
-        "phpunit",
-        "pest php",
-        "php mock"
-      ],
-      "category": "php",
-      "user_invocable": false,
-      "pairs_with": [
-        "php-quality",
-        "test-driven-development"
-      ],
-      "agent": "php-general-engineer"
-    },
-    "sapcc-audit": {
-      "file": "skills/engineering/sapcc-audit/SKILL.md",
-      "description": "Full-repo SAP CC Go compliance audit against review standards.",
-      "triggers": [
-        "sapcc audit",
-        "sapcc compliance",
-        "check sapcc rules",
-        "full repo audit",
-        "sapcc secondary review",
-        "sapcc standards check"
-      ],
-      "category": "language",
-      "user_invocable": false,
-      "pairs_with": [
-        "golang-general-engineer",
-        "golang-general-engineer-compact",
-        "go-patterns"
-      ],
-      "agent": "golang-general-engineer"
-    },
-    "sapcc-review": {
-      "file": "skills/engineering/sapcc-review/SKILL.md",
-      "description": "Gold-standard SAP CC Go code review: 10 parallel domain specialists.",
-      "triggers": [
-        "sapcc review",
-        "sapcc lead review",
-        "sapcc compliance review",
-        "comprehensive sapcc audit",
-        "full sapcc check",
-        "review sapcc standards"
-      ],
-      "category": "language",
-      "user_invocable": false,
-      "pairs_with": [
-        "golang-general-engineer",
-        "go-patterns",
-        "sapcc-audit"
-      ],
-      "agent": "golang-general-engineer"
-    },
-    "swift-concurrency": {
-      "file": "skills/engineering/swift-concurrency/SKILL.md",
-      "description": "Swift concurrency: async/await, Actor, Task, Sendable patterns.",
-      "triggers": [
-        "swift concurrency",
-        "swift async await",
-        "Swift Actor",
-        "Swift Task group"
-      ],
-      "category": "swift",
-      "user_invocable": false,
-      "pairs_with": [
-        "swift-testing"
-      ],
-      "agent": "swift-general-engineer"
-    },
-    "swift-testing": {
-      "file": "skills/engineering/swift-testing/SKILL.md",
-      "description": "Swift testing: XCTest, Swift Testing framework, async patterns.",
-      "triggers": [
-        "swift testing",
-        "XCTest",
-        "Swift Testing framework",
-        "async test swift"
-      ],
-      "category": "swift",
-      "user_invocable": false,
-      "pairs_with": [
-        "swift-concurrency",
-        "test-driven-development"
-      ],
-      "agent": "swift-general-engineer"
-    },
-    "distinctive-frontend-design": {
-      "file": "skills/frontend/distinctive-frontend-design/SKILL.md",
-      "description": "Context-driven aesthetic exploration with anti-cliche validation.",
-      "triggers": [
-        "frontend design",
-        "typography exploration",
-        "anti-cliche design",
-        "visual identity",
-        "design language"
-      ],
-      "category": "frontend",
-      "user_invocable": false,
-      "pairs_with": [
-        "threejs-builder",
-        "webgl-card-effects",
-        "frontend-slides"
+        "workflow",
+        "planning"
       ]
     },
     "frontend-slides": {
@@ -970,68 +712,22 @@
       ],
       "agent": "typescript-frontend-engineer"
     },
-    "threejs-builder": {
-      "file": "skills/frontend/threejs-builder/SKILL.md",
-      "description": "Three.js app builder: imperative, React Three Fiber, and WebGPU in 4 phases.",
+    "full-repo-review": {
+      "file": "skills/research/full-repo-review/SKILL.md",
+      "description": "Comprehensive 3-wave review of all repo source files, producing a prioritized issue backlog.",
       "triggers": [
-        "threejs",
-        "three.js",
-        "3D web",
-        "3D scene",
-        "WebGL",
-        "WebGPU",
-        "3D animation",
-        "3D graphics",
-        "react three fiber",
-        "r3f",
-        "drei",
-        "react-three",
-        "@react-three/fiber",
-        "postprocessing 3D",
-        "TSL shader",
-        "three shading language",
-        "compute shader three",
-        "WebGPURenderer",
-        "node material three",
-        "game architecture three",
-        "gltf loading",
-        "glb model",
-        "animation state machine three",
-        "eventbus game",
-        "game state management three",
-        "three.js game"
+        "full repo review",
+        "review entire repo",
+        "codebase health check",
+        "review all files",
+        "full codebase review"
       ],
-      "category": "frontend",
-      "user_invocable": false,
+      "category": "analysis",
+      "user_invocable": true,
       "pairs_with": [
-        "typescript-frontend-engineer",
-        "react-native-engineer",
-        "distinctive-frontend-design"
-      ],
-      "agent": "typescript-frontend-engineer"
-    },
-    "webgl-card-effects": {
-      "file": "skills/frontend/webgl-card-effects/SKILL.md",
-      "description": "Standalone WebGL fragment shaders for card visual effects: holographic foil, shimmer, rarity glow.",
-      "triggers": [
-        "card effects",
-        "holographic",
-        "foil effect",
-        "card shimmer",
-        "card glow",
-        "shader card",
-        "WebGL card",
-        "rarity effects",
-        "Balatro effect",
-        "card visual effects"
-      ],
-      "category": "frontend",
-      "user_invocable": false,
-      "pairs_with": [
-        "typescript-frontend-engineer",
-        "ui-design-engineer"
-      ],
-      "agent": "typescript-frontend-engineer"
+        "systematic-code-review",
+        "parallel-code-review"
+      ]
     },
     "game-asset-generator": {
       "file": "skills/game/game-asset-generator/SKILL.md",
@@ -1140,107 +836,102 @@
       ],
       "agent": "python-general-engineer"
     },
-    "motion-pipeline": {
-      "file": "skills/game/motion-pipeline/SKILL.md",
-      "description": "CPU-only motion data processing pipeline for game animation: BVH import, contact detection, root decomposition, motion blending, FABRIK IK.",
+    "gemini-image-generator": {
+      "file": "skills/content/gemini-image-generator/SKILL.md",
+      "description": "Generate images from text prompts via Google Gemini.",
       "triggers": [
-        "mocap",
-        "motion data",
-        "animation pipeline",
-        "BVH import",
-        "contact detection",
-        "IK solve",
-        "motion blend",
-        "bone trajectory",
-        "root extraction",
-        "FABRIK",
-        "skeletal animation data"
+        "generate image",
+        "create image with AI",
+        "gemini image",
+        "text to image",
+        "python image generation",
+        "create sprite",
+        "generate character art"
       ],
-      "category": "game-animation",
-      "user_invocable": true,
-      "pairs_with": [
-        "game-sprite-pipeline",
-        "phaser-gamedev"
-      ]
-    },
-    "phaser-gamedev": {
-      "file": "skills/game/phaser-gamedev/SKILL.md",
-      "description": "Phaser 3 2D game dev: scenes, physics, tilemaps, sprites, polish.",
-      "triggers": [
-        "phaser",
-        "2d game",
-        "platformer",
-        "arcade physics",
-        "tilemap",
-        "sprite sheet",
-        "side scroller"
-      ],
-      "category": "game-development",
+      "category": "image-generation",
       "user_invocable": false,
       "pairs_with": [
-        "typescript-frontend-engineer",
-        "game-asset-generator"
+        "python-general-engineer",
+        "workflow"
       ],
-      "agent": "typescript-frontend-engineer"
+      "agent": "python-general-engineer"
     },
-    "cron-job-auditor": {
-      "file": "skills/infrastructure/cron-job-auditor/SKILL.md",
-      "description": "Audit cron scripts for reliability and safety.",
+    "generate-claudemd": {
+      "file": "skills/meta/generate-claudemd/SKILL.md",
+      "description": "Generate project-specific CLAUDE.md from repo analysis.",
       "triggers": [
-        "audit cron jobs",
-        "review scheduled scripts",
-        "cron safety",
-        "cron reliability",
-        "scheduled task safety"
+        "generate claude.md",
+        "create claude.md",
+        "init claude.md",
+        "bootstrap claude.md",
+        "make claude.md"
       ],
-      "category": "infrastructure",
+      "category": "documentation",
       "user_invocable": false,
       "pairs_with": [
-        "shell-process-patterns",
-        "headless-cron-creator"
+        "go-patterns",
+        "codebase-overview"
       ]
     },
-    "endpoint-validator": {
-      "file": "skills/infrastructure/endpoint-validator/SKILL.md",
-      "description": "Deterministic API endpoint validation with pass/fail reporting.",
+    "github-notification-triage": {
+      "file": "skills/process/github-notification-triage/SKILL.md",
+      "description": "Triage GitHub notifications and report actions needed.",
       "triggers": [
-        "validate endpoints",
-        "smoke test API",
-        "health check endpoints",
-        "test endpoint",
-        "check API",
-        "smoke test"
+        "github notifications",
+        "triage notifications",
+        "check notifications",
+        "notification cleanup",
+        "github inbox"
       ],
-      "category": "infrastructure",
-      "user_invocable": false,
-      "pairs_with": [
-        "service-health-check",
-        "e2e-testing"
-      ]
-    },
-    "fish-shell-config": {
-      "file": "skills/infrastructure/fish-shell-config/SKILL.md",
-      "description": "Fish shell configuration and PATH management.",
-      "triggers": [
-        "fish",
-        "fish shell",
-        "config.fish",
-        "abbr",
-        "fish function",
-        "fish_config",
-        "fish_variables",
-        "funced",
-        "funcsave",
-        "~/.config/fish",
-        "conf.d",
-        "fish abbreviation",
-        ".fish file",
-        "#!/usr/bin/env fish"
-      ],
-      "category": "process",
-      "force_route": true,
+      "category": "github",
       "user_invocable": false,
       "pairs_with": []
+    },
+    "go-patterns": {
+      "file": "skills/engineering/go-patterns/SKILL.md",
+      "description": "Go development patterns: testing, concurrency, errors, review, and conventions.",
+      "triggers": [
+        "go test",
+        "*_test.go",
+        "table-driven",
+        "t.Run",
+        "t.Helper",
+        "goroutine",
+        "channel",
+        "sync.Mutex",
+        "sync.WaitGroup",
+        "worker pool",
+        "fan-in",
+        "context.Context",
+        "goroutine fan-out",
+        "fmt.Errorf",
+        "errors.Is",
+        "errors.As",
+        "%w",
+        "sentinel error",
+        "Go anti-pattern",
+        "Go code smell",
+        "Go code review",
+        "Go PR",
+        "Go quality",
+        "sapcc",
+        "sap-cloud-infrastructure",
+        "go-bits",
+        "keppel",
+        "go-api-declarations",
+        "go-makefile-maker",
+        "make check",
+        "Go lint"
+      ],
+      "category": "language",
+      "force_route": true,
+      "user_invocable": false,
+      "pairs_with": [
+        "golang-general-engineer",
+        "golang-general-engineer-compact",
+        "systematic-code-review"
+      ],
+      "agent": "golang-general-engineer"
     },
     "headless-cron-creator": {
       "file": "skills/infrastructure/headless-cron-creator/SKILL.md",
@@ -1259,6 +950,157 @@
         "shell-process-patterns"
       ],
       "agent": "python-general-engineer"
+    },
+    "hr": {
+      "file": "skills/business/hr/SKILL.md",
+      "description": "People operations workflows \u2014 recruiting pipeline, performance reviews, compensation analysis, offer drafting, interview prep, onboarding, org planning.",
+      "triggers": [
+        "HR",
+        "human resources",
+        "recruiting",
+        "performance review",
+        "compensation",
+        "hiring",
+        "onboarding",
+        "org planning"
+      ],
+      "category": "business",
+      "user_invocable": true,
+      "pairs_with": []
+    },
+    "html-artifact": {
+      "file": "skills/meta/html-artifact/SKILL.md",
+      "description": "Generate rich self-contained HTML artifacts instead of markdown.",
+      "triggers": [
+        "HTML artifact",
+        "make HTML",
+        "as HTML",
+        "rich visualization",
+        "interactive document",
+        "HTML file",
+        "self-contained HTML",
+        "visual companion"
+      ],
+      "category": "meta",
+      "user_invocable": false,
+      "pairs_with": [
+        "pr-workflow",
+        "research-pipeline",
+        "planning",
+        "publish"
+      ]
+    },
+    "image-to-video": {
+      "file": "skills/content/image-to-video/SKILL.md",
+      "description": "FFmpeg-based video creation from image and audio.",
+      "triggers": [
+        "image to video",
+        "audio visualization",
+        "static video",
+        "mp4 from image",
+        "music video",
+        "podcast video",
+        "video from image",
+        "combine image audio",
+        "album art video",
+        "cover art video"
+      ],
+      "category": "video-creation",
+      "user_invocable": false,
+      "pairs_with": [
+        "gemini-image-generator",
+        "workflow"
+      ]
+    },
+    "install": {
+      "file": "skills/meta/install/SKILL.md",
+      "description": "Verify VexJoy Agent installation, diagnose issues, and guide first-time setup.",
+      "triggers": [
+        "install toolkit",
+        "verify installation",
+        "health check toolkit",
+        "setup toolkit",
+        "diagnose setup",
+        "toolkit health"
+      ],
+      "category": "meta-tooling",
+      "force_route": true,
+      "user_invocable": true
+    },
+    "integration-checker": {
+      "file": "skills/review/integration-checker/SKILL.md",
+      "description": "Verify cross-component wiring and data flow.",
+      "triggers": [
+        "integration check",
+        "check integration",
+        "verify wiring",
+        "are components connected",
+        "check connections",
+        "integration-checker",
+        "wiring check"
+      ],
+      "category": "process",
+      "user_invocable": false,
+      "pairs_with": [
+        "feature-lifecycle",
+        "systematic-code-review"
+      ]
+    },
+    "joy-check": {
+      "file": "skills/code-quality/joy-check/SKILL.md",
+      "description": "Validate content framing on joy-grievance spectrum.",
+      "triggers": [
+        "joy check",
+        "check framing",
+        "positive framing",
+        "negative framing",
+        "instruction framing",
+        "grievance check"
+      ],
+      "category": "code-quality",
+      "user_invocable": true,
+      "force_route": false,
+      "pairs_with": [
+        "anti-ai-editor",
+        "code-cleanup",
+        "comment-quality"
+      ]
+    },
+    "kotlin-coroutines": {
+      "file": "skills/engineering/kotlin-coroutines/SKILL.md",
+      "description": "Kotlin structured concurrency, Flow, and Channel patterns.",
+      "triggers": [
+        "kotlin coroutines",
+        "kotlin structured concurrency",
+        "kotlin Flow",
+        "kotlin Channel",
+        "suspend function",
+        "structured concurrency kotlin"
+      ],
+      "category": "kotlin",
+      "user_invocable": false,
+      "pairs_with": [
+        "kotlin-testing"
+      ],
+      "agent": "kotlin-general-engineer"
+    },
+    "kotlin-testing": {
+      "file": "skills/engineering/kotlin-testing/SKILL.md",
+      "description": "Kotlin testing with JUnit 5, Kotest, and coroutine dispatchers.",
+      "triggers": [
+        "kotlin testing",
+        "junit kotlin",
+        "kotest",
+        "junit 5 kotlin",
+        "kotlin test dispatcher"
+      ],
+      "category": "kotlin",
+      "user_invocable": false,
+      "pairs_with": [
+        "kotlin-coroutines",
+        "test-driven-development"
+      ],
+      "agent": "kotlin-general-engineer"
     },
     "kubernetes-debugging": {
       "file": "skills/infrastructure/kubernetes-debugging/SKILL.md",
@@ -1297,202 +1139,6 @@
       ],
       "agent": "kubernetes-helm-engineer"
     },
-    "service-health-check": {
-      "file": "skills/infrastructure/service-health-check/SKILL.md",
-      "description": "Service health monitoring: Discover, Check, Report in 3 phases.",
-      "triggers": [
-        "service status",
-        "process health",
-        "uptime check",
-        "is service running",
-        "check health"
-      ],
-      "category": "infrastructure",
-      "user_invocable": false,
-      "pairs_with": [
-        "kubernetes-debugging",
-        "endpoint-validator",
-        "condition-based-waiting"
-      ]
-    },
-    "shell-process-patterns": {
-      "file": "skills/infrastructure/shell-process-patterns/SKILL.md",
-      "description": "Safely start, supervise, and terminate shell processes: background jobs, PID capture, signals, traps, cleanup verification.",
-      "triggers": [
-        "background process",
-        "nohup",
-        "kill process",
-        "pid lookup",
-        "shell cleanup",
-        "trap handler",
-        "signal handling",
-        "set -e",
-        "bash process"
-      ],
-      "category": "process",
-      "user_invocable": false,
-      "pairs_with": [
-        "condition-based-waiting",
-        "service-health-check",
-        "cron-job-auditor"
-      ]
-    },
-    "agent-comparison": {
-      "file": "skills/meta/agent-comparison/SKILL.md",
-      "description": "A/B test agent variants for quality and token cost.",
-      "triggers": [
-        "compare agents",
-        "A/B test agents",
-        "benchmark agents",
-        "optimize skill",
-        "optimize description",
-        "run autoresearch"
-      ],
-      "category": "meta-tooling",
-      "user_invocable": false,
-      "pairs_with": [
-        "agent-evaluation",
-        "skill-eval"
-      ]
-    },
-    "agent-evaluation": {
-      "file": "skills/meta/agent-evaluation/SKILL.md",
-      "description": "Evaluate agents and skills for quality and standards compliance.",
-      "triggers": [
-        "evaluate agent",
-        "audit agent",
-        "score skill",
-        "check quality",
-        "grade agent",
-        "agent quality"
-      ],
-      "category": "meta-tooling",
-      "user_invocable": false,
-      "pairs_with": [
-        "agent-comparison",
-        "skill-eval",
-        "skill-creator"
-      ]
-    },
-    "auto-dream": {
-      "file": "skills/meta/auto-dream/SKILL.md",
-      "description": "Background memory consolidation and learning graduation \u2014 overnight knowledge lifecycle.",
-      "triggers": [
-        "dream",
-        "consolidate memories",
-        "clean up memories",
-        "memory maintenance",
-        "memory consolidation",
-        "deduplicate memories",
-        "graduate learnings",
-        "promote learnings"
-      ],
-      "category": "meta-tooling",
-      "user_invocable": true,
-      "pairs_with": []
-    },
-    "do": {
-      "file": "skills/meta/do/SKILL.md",
-      "description": "Classify user requests and route to the correct agent + skill.",
-      "triggers": [
-        "route task",
-        "classify request",
-        "which agent",
-        "delegate to skill",
-        "smart router"
-      ],
-      "category": "meta-tooling",
-      "user_invocable": true
-    },
-    "docs-sync-checker": {
-      "file": "skills/meta/docs-sync-checker/SKILL.md",
-      "description": "Detect documentation drift against filesystem state.",
-      "triggers": [
-        "check doc drift",
-        "sync documentation",
-        "stale docs",
-        "documentation drift",
-        "README outdated"
-      ],
-      "category": "documentation",
-      "user_invocable": false,
-      "pairs_with": [
-        "generate-claudemd",
-        "codebase-overview"
-      ]
-    },
-    "explanation-traces": {
-      "file": "skills/meta/explanation-traces/SKILL.md",
-      "description": "Query and display structured decision traces from routing, agent selection, and skill execution.",
-      "triggers": [
-        "why did you",
-        "explain routing",
-        "show trace",
-        "decision log",
-        "why that agent",
-        "explain decision",
-        "show decisions",
-        "trace log"
-      ],
-      "category": "analysis",
-      "force_route": true,
-      "user_invocable": true,
-      "pairs_with": []
-    },
-    "generate-claudemd": {
-      "file": "skills/meta/generate-claudemd/SKILL.md",
-      "description": "Generate project-specific CLAUDE.md from repo analysis.",
-      "triggers": [
-        "generate claude.md",
-        "create claude.md",
-        "init claude.md",
-        "bootstrap claude.md",
-        "make claude.md"
-      ],
-      "category": "documentation",
-      "user_invocable": false,
-      "pairs_with": [
-        "go-patterns",
-        "codebase-overview"
-      ]
-    },
-    "html-artifact": {
-      "file": "skills/meta/html-artifact/SKILL.md",
-      "description": "Generate rich self-contained HTML artifacts instead of markdown.",
-      "triggers": [
-        "HTML artifact",
-        "make HTML",
-        "as HTML",
-        "rich visualization",
-        "interactive document",
-        "HTML file",
-        "self-contained HTML",
-        "visual companion"
-      ],
-      "category": "meta",
-      "user_invocable": false,
-      "pairs_with": [
-        "pr-workflow",
-        "research-pipeline",
-        "planning",
-        "publish"
-      ]
-    },
-    "install": {
-      "file": "skills/meta/install/SKILL.md",
-      "description": "Verify VexJoy Agent installation, diagnose issues, and guide first-time setup.",
-      "triggers": [
-        "install toolkit",
-        "verify installation",
-        "health check toolkit",
-        "setup toolkit",
-        "diagnose setup",
-        "toolkit health"
-      ],
-      "category": "meta-tooling",
-      "force_route": true,
-      "user_invocable": true
-    },
     "learn": {
       "file": "skills/meta/learn/SKILL.md",
       "description": "Manually teach error pattern and solution to learning database.",
@@ -1510,283 +1156,126 @@
         "auto-dream"
       ]
     },
-    "reference-enrichment": {
-      "file": "skills/meta/reference-enrichment/SKILL.md",
-      "description": "Analyze agent/skill reference depth and generate missing domain-specific reference files.",
+    "legal": {
+      "file": "skills/business/legal/SKILL.md",
+      "description": "Legal workflows \u2014 contract review, compliance checks, NDA triage, risk assessment, legal briefs.",
       "triggers": [
-        "enrich references",
-        "improve reference depth",
-        "generate references",
-        "add reference files",
-        "reference enrichment",
-        "decompose skill",
-        "extract references",
-        "slim down skill",
-        "skill too long",
-        "move content to references"
+        "legal",
+        "contract review",
+        "compliance check",
+        "NDA",
+        "legal risk",
+        "legal brief",
+        "vendor check",
+        "german compliance",
+        "DSGVO",
+        "GoBD",
+        "TDDDG",
+        "AI Act compliance",
+        "eIDAS"
       ],
-      "category": "meta-tooling",
+      "category": "business",
+      "user_invocable": true,
+      "pairs_with": []
+    },
+    "marketing": {
+      "file": "skills/business/marketing/SKILL.md",
+      "description": "Marketing workflows \u2014 SEO audits, campaign planning, content strategy, email sequences, competitive analysis, brand review, performance reporting.",
+      "triggers": [
+        "marketing",
+        "SEO",
+        "campaign",
+        "content strategy",
+        "email sequence",
+        "brand review",
+        "competitive analysis",
+        "marketing performance"
+      ],
+      "category": "business",
+      "user_invocable": true,
+      "pairs_with": []
+    },
+    "motion-pipeline": {
+      "file": "skills/game/motion-pipeline/SKILL.md",
+      "description": "CPU-only motion data processing pipeline for game animation: BVH import, contact detection, root decomposition, motion blending, FABRIK IK.",
+      "triggers": [
+        "mocap",
+        "motion data",
+        "animation pipeline",
+        "BVH import",
+        "contact detection",
+        "IK solve",
+        "motion blend",
+        "bone trajectory",
+        "root extraction",
+        "FABRIK",
+        "skeletal animation data"
+      ],
+      "category": "game-animation",
       "user_invocable": true,
       "pairs_with": [
-        "verification-before-completion"
+        "game-sprite-pipeline",
+        "phaser-gamedev"
       ]
     },
-    "retro": {
-      "file": "skills/meta/retro/SKILL.md",
-      "description": "Learning system interface: stats, search, graduate learnings.",
+    "multi-persona-critique": {
+      "file": "skills/research/multi-persona-critique/SKILL.md",
+      "description": "Parallel critique of proposals via 5 philosophical personas with consensus synthesis.",
       "triggers": [
-        "retro stats",
-        "list learnings",
-        "graduate knowledge",
-        "learning stats",
-        "search learnings"
+        "critique these ideas",
+        "multi-persona review",
+        "philosophical critique",
+        "devil's advocate on ideas",
+        "stress test proposals",
+        "evaluate from multiple perspectives",
+        "get different viewpoints",
+        "critique proposals"
       ],
-      "category": "meta-tooling",
+      "category": "analysis",
       "user_invocable": true,
       "pairs_with": [
-        "learn",
-        "auto-dream"
+        "roast",
+        "decision-helper"
       ]
     },
-    "routing-table-updater": {
-      "file": "skills/meta/routing-table-updater/SKILL.md",
-      "description": "Maintain /do routing tables when skills or agents change.",
+    "nano-banana-builder": {
+      "file": "skills/content/nano-banana-builder/SKILL.md",
+      "description": "Image generation and post-processing via Gemini Nano Banana APIs.",
       "triggers": [
-        "update routing",
-        "sync routing tables",
-        "routing maintenance",
-        "rebuild routing index",
-        "routing drift"
+        "nano banana",
+        "gemini image generation",
+        "AI image generator",
+        "generate image",
+        "gemini-2.5-flash-image",
+        "gemini-3-pro-image-preview",
+        "batch image generation",
+        "image post-processing",
+        "sprite generation",
+        "generate card art"
       ],
-      "category": "meta-tooling",
+      "category": "image-generation",
       "user_invocable": false,
       "pairs_with": [
-        "toolkit-evolution",
-        "generate-claudemd"
-      ]
-    },
-    "skill-composer": {
-      "file": "skills/meta/skill-composer/SKILL.md",
-      "description": "DAG-based multi-skill orchestration with dependency resolution.",
-      "triggers": [
-        "compose skills",
-        "DAG orchestration",
-        "multi-skill chain",
-        "skill pipeline",
-        "combine skills"
+        "python-general-engineer",
+        "universal-quality-gate"
       ],
-      "category": "meta-tooling",
-      "user_invocable": false,
-      "pairs_with": [
-        "workflow",
-        "feature-lifecycle"
-      ]
+      "agent": "python-general-engineer"
     },
-    "skill-creator": {
-      "file": "skills/meta/skill-creator/SKILL.md",
-      "description": "Create and iteratively improve skills through eval-driven validation.",
+    "operations": {
+      "file": "skills/business/operations/SKILL.md",
+      "description": "Business operations workflows \u2014 vendor management, runbooks, process documentation, risk assessment, capacity planning, change management, compliance tracking.",
       "triggers": [
-        "create skill",
-        "new skill",
-        "skill template",
-        "skill design",
-        "test skill",
-        "improve skill",
-        "optimize description",
-        "skill eval"
+        "operations",
+        "vendor review",
+        "runbook",
+        "process documentation",
+        "risk assessment",
+        "capacity plan",
+        "change management",
+        "compliance tracking"
       ],
-      "category": "meta",
-      "user_invocable": false,
-      "pairs_with": [
-        "agent-evaluation",
-        "verification-before-completion"
-      ]
-    },
-    "skill-eval": {
-      "file": "skills/meta/skill-eval/SKILL.md",
-      "description": "Evaluate skills: trigger testing, A/B benchmarks, structure validation, head-to-head bake-offs.",
-      "triggers": [
-        "improve skill",
-        "test skill",
-        "eval skill",
-        "benchmark skill",
-        "skill triggers",
-        "skill quality",
-        "self-improve skill",
-        "skill self-improvement",
-        "improve skill with variants",
-        "bake-off",
-        "bake off",
-        "head-to-head",
-        "head to head",
-        "compare implementations",
-        "grade two versions",
-        "which skill is better"
-      ],
-      "category": "meta",
-      "user_invocable": false,
-      "pairs_with": [
-        "agent-evaluation",
-        "verification-before-completion"
-      ]
-    },
-    "toolkit-evolution": {
-      "file": "skills/meta/toolkit-evolution/SKILL.md",
-      "description": "Closed-loop toolkit self-improvement: discover gaps, diagnose, propose, critique, build, test, evolve.",
-      "triggers": [
-        "evolve toolkit",
-        "improve the system",
-        "self-improve",
-        "toolkit evolution",
-        "what should we improve",
-        "find improvement opportunities",
-        "discover skill gaps",
-        "what skills are missing",
-        "systematic improvement"
-      ],
-      "category": "meta-tooling",
+      "category": "business",
       "user_invocable": true,
-      "pairs_with": [
-        "multi-persona-critique",
-        "skill-eval"
-      ]
-    },
-    "workflow-help": {
-      "file": "skills/meta/workflow-help/SKILL.md",
-      "description": "Interactive guide to workflow system: agents, skills, routing, execution patterns.",
-      "triggers": [
-        "how does routing work",
-        "what skills exist",
-        "system help",
-        "explain workflow",
-        "I am stuck",
-        "toolkit help"
-      ],
-      "category": "meta-tooling",
-      "user_invocable": true,
-      "pairs_with": [
-        "workflow",
-        "do"
-      ]
-    },
-    "adr-consultation": {
-      "file": "skills/process/adr-consultation/SKILL.md",
-      "description": "Multi-agent consultation for architecture decisions.",
-      "triggers": [
-        "consult on ADR",
-        "challenge this design",
-        "review before implementing",
-        "multi-agent consultation",
-        "architecture consultation",
-        "should we proceed",
-        "adr consultation"
-      ],
-      "category": "meta",
-      "user_invocable": false,
-      "pairs_with": [
-        "feature-lifecycle"
-      ]
-    },
-    "condition-based-waiting": {
-      "file": "skills/process/condition-based-waiting/SKILL.md",
-      "description": "Polling, retry, and backoff patterns.",
-      "triggers": [
-        "exponential backoff",
-        "health check polling",
-        "retry pattern",
-        "wait for",
-        "keep trying until",
-        "poll until ready",
-        "retry until success"
-      ],
-      "category": "process",
-      "user_invocable": false,
-      "pairs_with": [
-        "shell-process-patterns",
-        "service-health-check"
-      ]
-    },
-    "feature-lifecycle": {
-      "file": "skills/process/feature-lifecycle/SKILL.md",
-      "description": "Feature lifecycle: design, plan, implement, validate, release.",
-      "triggers": [
-        "feature design",
-        "design feature",
-        "think through",
-        "explore approaches",
-        "design first",
-        "feature plan",
-        "plan feature",
-        "break down design",
-        "create tasks",
-        "feature implement",
-        "implement feature",
-        "execute plan",
-        "start building",
-        "feature validate",
-        "validate feature",
-        "run feature quality gates",
-        "check feature",
-        "feature release",
-        "release feature",
-        "merge feature",
-        "ship it",
-        "build feature end to end",
-        "full feature lifecycle",
-        "feature from scratch",
-        "design to release",
-        "complete feature pipeline",
-        "feature pipeline"
-      ],
-      "category": "process",
-      "force_route": true,
-      "user_invocable": false,
-      "pairs_with": [
-        "workflow",
-        "subagent-driven-development",
-        "pr-workflow",
-        "verification-before-completion",
-        "universal-quality-gate",
-        "adr-consultation",
-        "planning"
-      ]
-    },
-    "forensics": {
-      "file": "skills/process/forensics/SKILL.md",
-      "description": "Post-mortem diagnostic analysis of failed workflows.",
-      "triggers": [
-        "forensics",
-        "what went wrong",
-        "why did this fail",
-        "stuck loop",
-        "diagnose workflow",
-        "post-mortem",
-        "workflow failure",
-        "session crashed",
-        "why is this stuck",
-        "investigate failure",
-        "why did this break",
-        "incident review"
-      ],
-      "category": "process",
-      "user_invocable": false,
-      "pairs_with": [
-        "workflow",
-        "planning"
-      ]
-    },
-    "github-notification-triage": {
-      "file": "skills/process/github-notification-triage/SKILL.md",
-      "description": "Triage GitHub notifications and report actions needed.",
-      "triggers": [
-        "github notifications",
-        "triage notifications",
-        "check notifications",
-        "notification cleanup",
-        "github inbox"
-      ],
-      "category": "github",
-      "user_invocable": false,
       "pairs_with": []
     },
     "pair-programming": {
@@ -1808,6 +1297,78 @@
         "test-driven-development",
         "subagent-driven-development"
       ]
+    },
+    "parallel-code-review": {
+      "file": "skills/review/parallel-code-review/SKILL.md",
+      "description": "Parallel 3-reviewer code review: Security, Business-Logic, Architecture.",
+      "triggers": [
+        "parallel review",
+        "3-reviewer review",
+        "security review",
+        "multi-reviewer",
+        "concurrent review"
+      ],
+      "category": "code-review",
+      "user_invocable": false,
+      "pairs_with": [
+        "systematic-code-review",
+        "verification-before-completion"
+      ]
+    },
+    "phaser-gamedev": {
+      "file": "skills/game/phaser-gamedev/SKILL.md",
+      "description": "Phaser 3 2D game dev: scenes, physics, tilemaps, sprites, polish.",
+      "triggers": [
+        "phaser",
+        "2d game",
+        "platformer",
+        "arcade physics",
+        "tilemap",
+        "sprite sheet",
+        "side scroller"
+      ],
+      "category": "game-development",
+      "user_invocable": false,
+      "pairs_with": [
+        "typescript-frontend-engineer",
+        "game-asset-generator"
+      ],
+      "agent": "typescript-frontend-engineer"
+    },
+    "php-quality": {
+      "file": "skills/engineering/php-quality/SKILL.md",
+      "description": "PHP code quality: PSR standards, strict types, framework idioms.",
+      "triggers": [
+        "php quality",
+        "php code review",
+        "PSR standards",
+        "phpstan",
+        "php-cs-fixer"
+      ],
+      "category": "php",
+      "user_invocable": false,
+      "pairs_with": [
+        "php-testing",
+        "code-linting"
+      ],
+      "agent": "php-general-engineer"
+    },
+    "php-testing": {
+      "file": "skills/engineering/php-testing/SKILL.md",
+      "description": "PHP testing patterns: PHPUnit, test doubles, database testing.",
+      "triggers": [
+        "php testing",
+        "phpunit",
+        "pest php",
+        "php mock"
+      ],
+      "category": "php",
+      "user_invocable": false,
+      "pairs_with": [
+        "php-quality",
+        "test-driven-development"
+      ],
+      "agent": "php-general-engineer"
     },
     "planning": {
       "file": "skills/process/planning/SKILL.md",
@@ -1883,6 +1444,28 @@
         "feature-lifecycle"
       ]
     },
+    "pptx-generator": {
+      "file": "skills/content/pptx-generator/SKILL.md",
+      "description": "PPTX presentation generation with visual QA: slides, pitch decks.",
+      "triggers": [
+        "presentation",
+        "powerpoint",
+        "pptx",
+        "slide deck",
+        "pitch deck",
+        "slides",
+        "create slides",
+        "generate presentation",
+        "make a deck",
+        "conference talk slides"
+      ],
+      "category": "content-generation",
+      "user_invocable": false,
+      "pairs_with": [
+        "workflow",
+        "gemini-image-generator"
+      ]
+    },
     "pr-workflow": {
       "file": "skills/process/pr-workflow/SKILL.md",
       "description": "Pull request lifecycle: commit, codex review, sync, review, fix, status, cleanup, and PR mining.",
@@ -1922,6 +1505,140 @@
         "code-linting",
         "systematic-code-review"
       ]
+    },
+    "product-management": {
+      "file": "skills/business/product-management/SKILL.md",
+      "description": "Product management workflows \u2014 feature specs, roadmap planning, stakeholder updates, user research synthesis, competitive analysis, metrics review, sprint planning.",
+      "triggers": [
+        "product management",
+        "feature spec",
+        "PRD",
+        "roadmap",
+        "stakeholder update",
+        "user research",
+        "sprint planning",
+        "product metrics"
+      ],
+      "category": "business",
+      "user_invocable": true,
+      "pairs_with": []
+    },
+    "productivity": {
+      "file": "skills/business/productivity/SKILL.md",
+      "description": "Productivity workflows \u2014 task management, daily planning, weekly reviews, meeting optimization, focus management, goal setting, status updates.",
+      "triggers": [
+        "productivity",
+        "task management",
+        "daily plan",
+        "weekly review",
+        "meeting agenda",
+        "focus time",
+        "goal setting",
+        "status update",
+        "time management",
+        "prioritize tasks",
+        "standup",
+        "retrospective"
+      ],
+      "category": "business",
+      "user_invocable": true,
+      "pairs_with": []
+    },
+    "professional-communication": {
+      "file": "skills/content/professional-communication/SKILL.md",
+      "description": "Transform technical communication into structured business formats.",
+      "triggers": [
+        "business communication",
+        "structured format",
+        "clear writing",
+        "write email",
+        "draft memo",
+        "executive summary",
+        "summarize for management",
+        "status update"
+      ],
+      "category": "content-creation",
+      "user_invocable": false,
+      "pairs_with": [
+        "voice-writer",
+        "pptx-generator"
+      ]
+    },
+    "publish": {
+      "file": "skills/content/publish/SKILL.md",
+      "description": "Content-publishing umbrella covering the blog pipeline from blueprint to upload: post outlining, pre-publication validation, SEO optimization, bulk...",
+      "triggers": [
+        "outline post",
+        "blog structure",
+        "article outline",
+        "pre-publish check",
+        "Hugo validation",
+        "front matter check",
+        "frontmatter validation",
+        "check SEO",
+        "optimize SEO",
+        "keyword analysis",
+        "meta description",
+        "batch edit posts",
+        "bulk frontmatter update",
+        "find replace across files",
+        "mass edit",
+        "audit links",
+        "find broken links",
+        "broken links",
+        "dead links",
+        "audit images",
+        "image accessibility",
+        "alt text check",
+        "audit taxonomy",
+        "fix tags",
+        "merge categories",
+        "tag cleanup",
+        "upload to wordpress",
+        "create wordpress draft",
+        "wordpress draft",
+        "upload article",
+        "post to wordpress",
+        "edit wordpress post",
+        "update wordpress post",
+        "wordpress media",
+        "create wp categories",
+        "auto-create categories",
+        "search wp media",
+        "search wordpress media",
+        "find existing wordpress image"
+      ],
+      "not_for": "writing article prose (use voice-writer), live rendering verification (use wordpress-live-validation)",
+      "category": "content-publishing",
+      "user_invocable": false,
+      "pairs_with": [
+        "content-calendar",
+        "wordpress-live-validation",
+        "html-artifact"
+      ],
+      "agent": "general-purpose"
+    },
+    "python-quality-gate": {
+      "file": "skills/code-quality/python-quality-gate/SKILL.md",
+      "description": "Python quality checks: ruff, pytest, mypy, bandit in deterministic order.",
+      "triggers": [
+        "Python quality",
+        "ruff check",
+        "bandit scan",
+        "mypy check",
+        "python lint",
+        "python quality gate",
+        "check python",
+        "pre-commit check"
+      ],
+      "category": "code-quality",
+      "force_route": true,
+      "user_invocable": false,
+      "pairs_with": [
+        "code-linting",
+        "test-driven-development"
+      ],
+      "agent": "python-general-engineer"
     },
     "quick": {
       "file": "skills/process/quick/SKILL.md",
@@ -1965,232 +1682,42 @@
         "codebase-overview"
       ]
     },
-    "socratic-debugging": {
-      "file": "skills/process/socratic-debugging/SKILL.md",
-      "description": "Question-only debugging: guide users to find root causes themselves.",
+    "reddit-moderate": {
+      "file": "skills/content/reddit-moderate/SKILL.md",
+      "description": "Reddit moderation via PRAW: fetch modqueue, classify reports, take actions.",
       "triggers": [
-        "guide debugging",
-        "question-based",
-        "teach debugging",
-        "ask me questions",
-        "help me think through",
-        "guide me",
-        "coaching mode",
-        "teach me to find it"
+        "moderate Reddit",
+        "modqueue",
+        "Reddit reports",
+        "Reddit moderation",
+        "check reports"
       ],
       "category": "process",
       "user_invocable": false,
       "pairs_with": [
-        "forensics",
-        "systematic-code-review"
-      ]
-    },
-    "subagent-driven-development": {
-      "file": "skills/process/subagent-driven-development/SKILL.md",
-      "description": "Fresh-subagent-per-task execution with two-stage review gates.",
-      "triggers": [
-        "subagent per task",
-        "fresh context execution",
-        "plan execution",
-        "execute plan with agents",
-        "fresh context per task"
+        "content-engine"
       ],
-      "category": "process",
-      "user_invocable": false,
-      "pairs_with": [
-        "pair-programming",
-        "testing-agents-with-subagents"
-      ]
+      "agent": "python-general-engineer"
     },
-    "verification-before-completion": {
-      "file": "skills/process/verification-before-completion/SKILL.md",
-      "description": "Defense-in-depth verification before declaring any task complete.",
+    "reference-enrichment": {
+      "file": "skills/meta/reference-enrichment/SKILL.md",
+      "description": "Analyze agent/skill reference depth and generate missing domain-specific reference files.",
       "triggers": [
-        "verify completion",
-        "run tests",
-        "check build",
-        "defense in depth",
-        "final verification"
+        "enrich references",
+        "improve reference depth",
+        "generate references",
+        "add reference files",
+        "reference enrichment",
+        "decompose skill",
+        "extract references",
+        "slim down skill",
+        "skill too long",
+        "move content to references"
       ],
-      "category": "process",
-      "user_invocable": false,
-      "pairs_with": [
-        "systematic-code-review",
-        "with-anti-rationalization"
-      ]
-    },
-    "with-anti-rationalization": {
-      "file": "skills/process/with-anti-rationalization/SKILL.md",
-      "description": "Anti-rationalization enforcement for maximum-rigor task execution.",
-      "triggers": [
-        "maximum rigor",
-        "anti-rationalization",
-        "strict verification",
-        "strict mode",
-        "no shortcuts"
-      ],
-      "category": "process",
-      "user_invocable": false,
+      "category": "meta-tooling",
+      "user_invocable": true,
       "pairs_with": [
         "verification-before-completion"
-      ]
-    },
-    "worktree-agent": {
-      "file": "skills/process/worktree-agent/SKILL.md",
-      "description": "Mandatory rules for agents in git worktree isolation.",
-      "triggers": [
-        "worktree agent",
-        "git worktree",
-        "git worktree rules",
-        "isolated agent"
-      ],
-      "category": "git-workflow",
-      "user_invocable": false
-    },
-    "architecture-deepening": {
-      "file": "skills/research/architecture-deepening/SKILL.md",
-      "description": "Proactive architecture improvement: find shallow modules, propose deepening opportunities, design conversation.",
-      "triggers": [
-        "deepen architecture",
-        "find shallow modules",
-        "architecture improvement",
-        "module depth analysis",
-        "deepening opportunities",
-        "improve module interfaces",
-        "reduce complexity",
-        "architecture deepening"
-      ],
-      "category": "analysis",
-      "user_invocable": true,
-      "pairs_with": [
-        "full-repo-review",
-        "adr-consultation",
-        "codebase-overview"
-      ]
-    },
-    "codebase-analyzer": {
-      "file": "skills/research/codebase-analyzer/SKILL.md",
-      "description": "Statistical rule discovery from Go codebase patterns.",
-      "triggers": [
-        "analyze codebase",
-        "discover patterns",
-        "style vector",
-        "code cartographer",
-        "pattern frequency",
-        "structural metrics"
-      ],
-      "category": "analysis",
-      "user_invocable": false,
-      "pairs_with": [
-        "codebase-overview",
-        "go-patterns"
-      ]
-    },
-    "codebase-overview": {
-      "file": "skills/research/codebase-overview/SKILL.md",
-      "description": "Systematic codebase exploration and architecture mapping.",
-      "triggers": [
-        "onboard to codebase",
-        "codebase structure",
-        "what does this project do",
-        "give me an overview",
-        "summarize this repo",
-        "understand this codebase"
-      ],
-      "category": "analysis",
-      "user_invocable": false,
-      "pairs_with": [
-        "codebase-analyzer",
-        "generate-claudemd"
-      ]
-    },
-    "data-analysis": {
-      "file": "skills/research/data-analysis/SKILL.md",
-      "description": "Decision-first data analysis with statistical rigor gates.",
-      "triggers": [
-        "analyze data",
-        "data analysis",
-        "CSV",
-        "dataset",
-        "metrics",
-        "trend",
-        "cohort",
-        "A/B test",
-        "statistical",
-        "distribution",
-        "correlation",
-        "KPI",
-        "funnel",
-        "experiment results",
-        "data insights",
-        "statistical analysis",
-        "CSV analysis",
-        "explore dataset"
-      ],
-      "category": "analysis",
-      "user_invocable": false,
-      "pairs_with": [
-        "workflow",
-        "codebase-analyzer"
-      ]
-    },
-    "decision-helper": {
-      "file": "skills/research/decision-helper/SKILL.md",
-      "description": "Weighted decision scoring for architectural choices.",
-      "triggers": [
-        "weigh options",
-        "decision matrix",
-        "compare approaches",
-        "help me decide",
-        "pros and cons",
-        "trade-offs",
-        "which is better",
-        "should I use",
-        "evaluate options"
-      ],
-      "category": "process",
-      "user_invocable": false,
-      "pairs_with": [
-        "multi-persona-critique",
-        "adr-consultation",
-        "planning"
-      ]
-    },
-    "full-repo-review": {
-      "file": "skills/research/full-repo-review/SKILL.md",
-      "description": "Comprehensive 3-wave review of all repo source files, producing a prioritized issue backlog.",
-      "triggers": [
-        "full repo review",
-        "review entire repo",
-        "codebase health check",
-        "review all files",
-        "full codebase review"
-      ],
-      "category": "analysis",
-      "user_invocable": true,
-      "pairs_with": [
-        "systematic-code-review",
-        "parallel-code-review"
-      ]
-    },
-    "multi-persona-critique": {
-      "file": "skills/research/multi-persona-critique/SKILL.md",
-      "description": "Parallel critique of proposals via 5 philosophical personas with consensus synthesis.",
-      "triggers": [
-        "critique these ideas",
-        "multi-persona review",
-        "philosophical critique",
-        "devil's advocate on ideas",
-        "stress test proposals",
-        "evaluate from multiple perspectives",
-        "get different viewpoints",
-        "critique proposals"
-      ],
-      "category": "analysis",
-      "user_invocable": true,
-      "pairs_with": [
-        "roast",
-        "decision-helper"
       ]
     },
     "repo-value-analysis": {
@@ -2231,6 +1758,23 @@
       ],
       "agent": "research-coordinator-engineer"
     },
+    "retro": {
+      "file": "skills/meta/retro/SKILL.md",
+      "description": "Learning system interface: stats, search, graduate learnings.",
+      "triggers": [
+        "retro stats",
+        "list learnings",
+        "graduate knowledge",
+        "learning stats",
+        "search learnings"
+      ],
+      "category": "meta-tooling",
+      "user_invocable": true,
+      "pairs_with": [
+        "learn",
+        "auto-dream"
+      ]
+    },
     "roast": {
       "file": "skills/research/roast/SKILL.md",
       "description": "Constructive critique via 5 HackerNews personas with claim validation.",
@@ -2248,6 +1792,79 @@
         "multi-persona-critique",
         "systematic-code-review"
       ]
+    },
+    "routing-table-updater": {
+      "file": "skills/meta/routing-table-updater/SKILL.md",
+      "description": "Maintain /do routing tables when skills or agents change.",
+      "triggers": [
+        "update routing",
+        "sync routing tables",
+        "routing maintenance",
+        "rebuild routing index",
+        "routing drift"
+      ],
+      "category": "meta-tooling",
+      "user_invocable": false,
+      "pairs_with": [
+        "toolkit-evolution",
+        "generate-claudemd"
+      ]
+    },
+    "sales": {
+      "file": "skills/business/sales/SKILL.md",
+      "description": "Sales workflows \u2014 call prep, pipeline analysis, outreach, competitive intelligence, forecasting.",
+      "triggers": [
+        "sales",
+        "call prep",
+        "pipeline review",
+        "forecast",
+        "draft outreach",
+        "prospect research",
+        "competitive intelligence"
+      ],
+      "category": "business",
+      "user_invocable": true,
+      "pairs_with": []
+    },
+    "sapcc-audit": {
+      "file": "skills/engineering/sapcc-audit/SKILL.md",
+      "description": "Full-repo SAP CC Go compliance audit against review standards.",
+      "triggers": [
+        "sapcc audit",
+        "sapcc compliance",
+        "check sapcc rules",
+        "full repo audit",
+        "sapcc secondary review",
+        "sapcc standards check"
+      ],
+      "category": "language",
+      "user_invocable": false,
+      "pairs_with": [
+        "golang-general-engineer",
+        "golang-general-engineer-compact",
+        "go-patterns"
+      ],
+      "agent": "golang-general-engineer"
+    },
+    "sapcc-review": {
+      "file": "skills/engineering/sapcc-review/SKILL.md",
+      "description": "Gold-standard SAP CC Go code review: 10 parallel domain specialists.",
+      "triggers": [
+        "sapcc review",
+        "sapcc lead review",
+        "sapcc compliance review",
+        "comprehensive sapcc audit",
+        "full sapcc check",
+        "review sapcc standards"
+      ],
+      "category": "language",
+      "user_invocable": false,
+      "pairs_with": [
+        "golang-general-engineer",
+        "go-patterns",
+        "sapcc-audit"
+      ],
+      "agent": "golang-general-engineer"
     },
     "security-threat-model": {
       "file": "skills/research/security-threat-model/SKILL.md",
@@ -2271,41 +1888,198 @@
       ],
       "agent": "python-general-engineer"
     },
-    "integration-checker": {
-      "file": "skills/review/integration-checker/SKILL.md",
-      "description": "Verify cross-component wiring and data flow.",
+    "series-planner": {
+      "file": "skills/content/series-planner/SKILL.md",
+      "description": "Plan multi-part content series: structure, cross-linking, cadence.",
       "triggers": [
-        "integration check",
-        "check integration",
-        "verify wiring",
-        "are components connected",
-        "check connections",
-        "integration-checker",
-        "wiring check"
+        "plan series",
+        "multi-part content",
+        "content series",
+        "article series",
+        "content arc"
+      ],
+      "category": "content-creation",
+      "user_invocable": false,
+      "pairs_with": [
+        "content-calendar",
+        "topic-brainstormer",
+        "publish"
+      ]
+    },
+    "service-health-check": {
+      "file": "skills/infrastructure/service-health-check/SKILL.md",
+      "description": "Service health monitoring: Discover, Check, Report in 3 phases.",
+      "triggers": [
+        "service status",
+        "process health",
+        "uptime check",
+        "is service running",
+        "check health"
+      ],
+      "category": "infrastructure",
+      "user_invocable": false,
+      "pairs_with": [
+        "kubernetes-debugging",
+        "endpoint-validator",
+        "condition-based-waiting"
+      ]
+    },
+    "shell-process-patterns": {
+      "file": "skills/infrastructure/shell-process-patterns/SKILL.md",
+      "description": "Safely start, supervise, and terminate shell processes: background jobs, PID capture, signals, traps, cleanup verification.",
+      "triggers": [
+        "background process",
+        "nohup",
+        "kill process",
+        "pid lookup",
+        "shell cleanup",
+        "trap handler",
+        "signal handling",
+        "set -e",
+        "bash process"
       ],
       "category": "process",
       "user_invocable": false,
       "pairs_with": [
-        "feature-lifecycle",
+        "condition-based-waiting",
+        "service-health-check",
+        "cron-job-auditor"
+      ]
+    },
+    "skill-composer": {
+      "file": "skills/meta/skill-composer/SKILL.md",
+      "description": "DAG-based multi-skill orchestration with dependency resolution.",
+      "triggers": [
+        "compose skills",
+        "DAG orchestration",
+        "multi-skill chain",
+        "skill pipeline",
+        "combine skills"
+      ],
+      "category": "meta-tooling",
+      "user_invocable": false,
+      "pairs_with": [
+        "workflow",
+        "feature-lifecycle"
+      ]
+    },
+    "skill-creator": {
+      "file": "skills/meta/skill-creator/SKILL.md",
+      "description": "Create and iteratively improve skills through eval-driven validation.",
+      "triggers": [
+        "create skill",
+        "new skill",
+        "skill template",
+        "skill design",
+        "test skill",
+        "improve skill",
+        "optimize description",
+        "skill eval"
+      ],
+      "category": "meta",
+      "user_invocable": false,
+      "pairs_with": [
+        "agent-evaluation",
+        "verification-before-completion"
+      ]
+    },
+    "skill-eval": {
+      "file": "skills/meta/skill-eval/SKILL.md",
+      "description": "Evaluate skills: trigger testing, A/B benchmarks, structure validation, head-to-head bake-offs.",
+      "triggers": [
+        "improve skill",
+        "test skill",
+        "eval skill",
+        "benchmark skill",
+        "skill triggers",
+        "skill quality",
+        "self-improve skill",
+        "skill self-improvement",
+        "improve skill with variants",
+        "bake-off",
+        "bake off",
+        "head-to-head",
+        "head to head",
+        "compare implementations",
+        "grade two versions",
+        "which skill is better"
+      ],
+      "category": "meta",
+      "user_invocable": false,
+      "pairs_with": [
+        "agent-evaluation",
+        "verification-before-completion"
+      ]
+    },
+    "socratic-debugging": {
+      "file": "skills/process/socratic-debugging/SKILL.md",
+      "description": "Question-only debugging: guide users to find root causes themselves.",
+      "triggers": [
+        "guide debugging",
+        "question-based",
+        "teach debugging",
+        "ask me questions",
+        "help me think through",
+        "guide me",
+        "coaching mode",
+        "teach me to find it"
+      ],
+      "category": "process",
+      "user_invocable": false,
+      "pairs_with": [
+        "forensics",
         "systematic-code-review"
       ]
     },
-    "parallel-code-review": {
-      "file": "skills/review/parallel-code-review/SKILL.md",
-      "description": "Parallel 3-reviewer code review: Security, Business-Logic, Architecture.",
+    "subagent-driven-development": {
+      "file": "skills/process/subagent-driven-development/SKILL.md",
+      "description": "Fresh-subagent-per-task execution with two-stage review gates.",
       "triggers": [
-        "parallel review",
-        "3-reviewer review",
-        "security review",
-        "multi-reviewer",
-        "concurrent review"
+        "subagent per task",
+        "fresh context execution",
+        "plan execution",
+        "execute plan with agents",
+        "fresh context per task"
       ],
-      "category": "code-review",
+      "category": "process",
       "user_invocable": false,
       "pairs_with": [
-        "systematic-code-review",
-        "verification-before-completion"
+        "pair-programming",
+        "testing-agents-with-subagents"
       ]
+    },
+    "swift-concurrency": {
+      "file": "skills/engineering/swift-concurrency/SKILL.md",
+      "description": "Swift concurrency: async/await, Actor, Task, Sendable patterns.",
+      "triggers": [
+        "swift concurrency",
+        "swift async await",
+        "Swift Actor",
+        "Swift Task group"
+      ],
+      "category": "swift",
+      "user_invocable": false,
+      "pairs_with": [
+        "swift-testing"
+      ],
+      "agent": "swift-general-engineer"
+    },
+    "swift-testing": {
+      "file": "skills/engineering/swift-testing/SKILL.md",
+      "description": "Swift testing: XCTest, Swift Testing framework, async patterns.",
+      "triggers": [
+        "swift testing",
+        "XCTest",
+        "Swift Testing framework",
+        "async test swift"
+      ],
+      "category": "swift",
+      "user_invocable": false,
+      "pairs_with": [
+        "swift-concurrency",
+        "test-driven-development"
+      ],
+      "agent": "swift-general-engineer"
     },
     "systematic-code-review": {
       "file": "skills/review/systematic-code-review/SKILL.md",
@@ -2325,27 +2099,6 @@
         "verification-before-completion",
         "parallel-code-review"
       ]
-    },
-    "e2e-testing": {
-      "file": "skills/testing/e2e-testing/SKILL.md",
-      "description": "Playwright-based end-to-end testing workflow.",
-      "triggers": [
-        "playwright",
-        "E2E test",
-        "end-to-end",
-        "browser test",
-        "page object model",
-        "POM",
-        "test flakiness"
-      ],
-      "category": "testing",
-      "user_invocable": false,
-      "pairs_with": [
-        "testing-automation-engineer",
-        "typescript-frontend-engineer",
-        "test-driven-development"
-      ],
-      "agent": "testing-automation-engineer"
     },
     "test-driven-development": {
       "file": "skills/testing/test-driven-development/SKILL.md",
@@ -2407,6 +2160,159 @@
         "vitest-runner"
       ]
     },
+    "threejs-builder": {
+      "file": "skills/frontend/threejs-builder/SKILL.md",
+      "description": "Three.js app builder: imperative, React Three Fiber, and WebGPU in 4 phases.",
+      "triggers": [
+        "threejs",
+        "three.js",
+        "3D web",
+        "3D scene",
+        "WebGL",
+        "WebGPU",
+        "3D animation",
+        "3D graphics",
+        "react three fiber",
+        "r3f",
+        "drei",
+        "react-three",
+        "@react-three/fiber",
+        "postprocessing 3D",
+        "TSL shader",
+        "three shading language",
+        "compute shader three",
+        "WebGPURenderer",
+        "node material three",
+        "game architecture three",
+        "gltf loading",
+        "glb model",
+        "animation state machine three",
+        "eventbus game",
+        "game state management three",
+        "three.js game"
+      ],
+      "category": "frontend",
+      "user_invocable": false,
+      "pairs_with": [
+        "typescript-frontend-engineer",
+        "react-native-engineer",
+        "distinctive-frontend-design"
+      ],
+      "agent": "typescript-frontend-engineer"
+    },
+    "toolkit-evolution": {
+      "file": "skills/meta/toolkit-evolution/SKILL.md",
+      "description": "Closed-loop toolkit self-improvement: discover gaps, diagnose, propose, critique, build, test, evolve.",
+      "triggers": [
+        "evolve toolkit",
+        "improve the system",
+        "self-improve",
+        "toolkit evolution",
+        "what should we improve",
+        "find improvement opportunities",
+        "discover skill gaps",
+        "what skills are missing",
+        "systematic improvement"
+      ],
+      "category": "meta-tooling",
+      "user_invocable": true,
+      "pairs_with": [
+        "multi-persona-critique",
+        "skill-eval"
+      ]
+    },
+    "topic-brainstormer": {
+      "file": "skills/content/topic-brainstormer/SKILL.md",
+      "description": "Generate blog topic ideas: problem mining, gap analysis, expansion.",
+      "triggers": [
+        "brainstorm topics",
+        "content ideas",
+        "blog topic ideas",
+        "what to write about"
+      ],
+      "category": "content-creation",
+      "user_invocable": false,
+      "pairs_with": [
+        "content-calendar",
+        "series-planner",
+        "research-pipeline"
+      ]
+    },
+    "typescript-check": {
+      "file": "skills/code-quality/typescript-check/SKILL.md",
+      "description": "TypeScript type checking via tsc --noEmit with actionable error output.",
+      "triggers": [
+        "TypeScript check",
+        "tsc noEmit",
+        "type check TypeScript",
+        "tsc errors",
+        "TypeScript type validation"
+      ],
+      "category": "code-quality",
+      "user_invocable": false,
+      "pairs_with": [
+        "vitest-runner",
+        "code-linting"
+      ],
+      "agent": "typescript-frontend-engineer"
+    },
+    "universal-quality-gate": {
+      "file": "skills/code-quality/universal-quality-gate/SKILL.md",
+      "description": "Multi-language code quality gate with auto-detection and linters.",
+      "triggers": [
+        "quality gate",
+        "lint check",
+        "multi-language lint",
+        "code quality check",
+        "language-agnostic lint"
+      ],
+      "category": "code-quality",
+      "user_invocable": false,
+      "pairs_with": [
+        "code-linting",
+        "verification-before-completion"
+      ]
+    },
+    "verification-before-completion": {
+      "file": "skills/process/verification-before-completion/SKILL.md",
+      "description": "Defense-in-depth verification before declaring any task complete.",
+      "triggers": [
+        "verify completion",
+        "run tests",
+        "check build",
+        "defense in depth",
+        "final verification"
+      ],
+      "category": "process",
+      "user_invocable": false,
+      "pairs_with": [
+        "systematic-code-review",
+        "with-anti-rationalization"
+      ]
+    },
+    "video-editing": {
+      "file": "skills/content/video-editing/SKILL.md",
+      "description": "Video editing pipeline: cut footage, assemble clips via FFmpeg and Remotion.",
+      "triggers": [
+        "edit video",
+        "cut footage",
+        "make vlog",
+        "screen recording",
+        "video workflow",
+        "ffmpeg",
+        "remotion",
+        "demo video",
+        "make a clip",
+        "assemble clips",
+        "video editing"
+      ],
+      "category": "video-creation",
+      "user_invocable": false,
+      "pairs_with": [
+        "typescript-frontend-engineer"
+      ],
+      "agent": "python-general-engineer"
+    },
     "vitest-runner": {
       "file": "skills/testing/vitest-runner/SKILL.md",
       "description": "Run Vitest tests and parse results into actionable output.",
@@ -2422,6 +2328,65 @@
       "pairs_with": [
         "test-driven-development",
         "typescript-check",
+        "e2e-testing"
+      ]
+    },
+    "webgl-card-effects": {
+      "file": "skills/frontend/webgl-card-effects/SKILL.md",
+      "description": "Standalone WebGL fragment shaders for card visual effects: holographic foil, shimmer, rarity glow.",
+      "triggers": [
+        "card effects",
+        "holographic",
+        "foil effect",
+        "card shimmer",
+        "card glow",
+        "shader card",
+        "WebGL card",
+        "rarity effects",
+        "Balatro effect",
+        "card visual effects"
+      ],
+      "category": "frontend",
+      "user_invocable": false,
+      "pairs_with": [
+        "typescript-frontend-engineer",
+        "ui-design-engineer"
+      ],
+      "agent": "typescript-frontend-engineer"
+    },
+    "with-anti-rationalization": {
+      "file": "skills/process/with-anti-rationalization/SKILL.md",
+      "description": "Anti-rationalization enforcement for maximum-rigor task execution.",
+      "triggers": [
+        "maximum rigor",
+        "anti-rationalization",
+        "strict verification",
+        "strict mode",
+        "no shortcuts"
+      ],
+      "category": "process",
+      "user_invocable": false,
+      "pairs_with": [
+        "verification-before-completion"
+      ]
+    },
+    "wordpress-live-validation": {
+      "file": "skills/content/wordpress-live-validation/SKILL.md",
+      "description": "Validate published WordPress posts in browser via Playwright.",
+      "triggers": [
+        "validate wordpress post",
+        "check live post",
+        "verify published post",
+        "wordpress post looks right",
+        "check og tags live",
+        "responsive check wordpress",
+        "post rendering check",
+        "live site validation"
+      ],
+      "category": "content-publishing",
+      "user_invocable": false,
+      "pairs_with": [
+        "publish",
         "e2e-testing"
       ]
     },
@@ -2442,6 +2407,61 @@
         "feature-lifecycle",
         "verification-before-completion"
       ]
+    },
+    "workflow-help": {
+      "file": "skills/meta/workflow-help/SKILL.md",
+      "description": "Interactive guide to workflow system: agents, skills, routing, execution patterns.",
+      "triggers": [
+        "how does routing work",
+        "what skills exist",
+        "system help",
+        "explain workflow",
+        "I am stuck",
+        "toolkit help"
+      ],
+      "category": "meta-tooling",
+      "user_invocable": true,
+      "pairs_with": [
+        "workflow",
+        "do"
+      ]
+    },
+    "worktree-agent": {
+      "file": "skills/process/worktree-agent/SKILL.md",
+      "description": "Mandatory rules for agents in git worktree isolation.",
+      "triggers": [
+        "worktree agent",
+        "git worktree",
+        "git worktree rules",
+        "isolated agent"
+      ],
+      "category": "git-workflow",
+      "user_invocable": false
+    },
+    "x-api": {
+      "file": "skills/content/x-api/SKILL.md",
+      "description": "Post tweets, build threads, upload media via the X API.",
+      "triggers": [
+        "post to X",
+        "post tweet",
+        "tweet this",
+        "build thread",
+        "post thread",
+        "twitter thread",
+        "x api",
+        "upload media to X",
+        "read timeline",
+        "search X",
+        "search twitter",
+        "publish to X",
+        "publish to twitter"
+      ],
+      "category": "content-publishing",
+      "user_invocable": false,
+      "pairs_with": [
+        "content-engine"
+      ],
+      "agent": "python-general-engineer"
     }
   }
 }

--- a/skills/code-quality/joy-check/SKILL.md
+++ b/skills/code-quality/joy-check/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: joy-check
+description: "Validate content framing on joy-grievance spectrum."
+user-invocable: false
+argument-hint: "[--fix] [--strict] [--mode writing|instruction] <file>"
+command: /joy-check
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+routing:
+  triggers:
+    - joy check
+    - check framing
+    - tone check
+    - negative framing
+    - joy validation
+    - too negative
+    - reframe positively
+    - positive framing check
+    - instruction framing
+  pairs_with:
+    - voice-writer
+    - anti-ai-editor
+    - voice-validator
+    - skill-creator
+  complexity: Simple
+  category: content
+---
+
+# Joy Check
+
+Validate content framing using mode-specific rubrics. Two modes:
+
+- **writing** — Joy-grievance spectrum for human-facing content (blog posts, emails, articles). Evaluates whether content frames experiences through curiosity and generosity rather than grievance and accusation.
+- **instruction** — Positive framing validation for LLM-facing content (agents, skills, pipelines). Evaluates whether instructions tell the reader what to do rather than what to avoid (ADR-127).
+
+By default the skill evaluates each paragraph/instruction independently, produces a score (0-100), and suggests reframes without modifying content. Optional flags: `--fix` rewrites flagged items in place and re-verifies; `--strict` fails on any item below 60; `--mode writing|instruction` overrides auto-detection.
+
+This skill checks *framing*, not *topic* and not *voice*. Voice fidelity belongs to voice-validator, AI pattern detection belongs to anti-ai-editor.
+
+## Reference Loading Table
+
+| Signal | Load These Files | Why |
+|---|---|---|
+| tasks related to this reference | `instruction-rubric.md` | Loads detailed guidance from `instruction-rubric.md`. |
+| tasks related to this reference | `writing-rubric.md` | Loads detailed guidance from `writing-rubric.md`. |
+
+## Instructions
+
+### Phase 0: DETECT MODE
+
+**Goal**: Determine which rubric to apply based on file location or explicit flag.
+
+**Auto-detection rules** (in priority order):
+1. Explicit `--mode writing|instruction` flag → use that mode
+2. File in `agents/*.md` → **instruction**
+3. File in `skills/*/SKILL.md` → **instruction**
+4. File in `skills/workflow/references/*.md` → **instruction**
+5. File is `CLAUDE.md` or `README.md` → **instruction**
+6. Everything else → **writing**
+
+**Load the rubric**: Read `references/{mode}-rubric.md` for the scoring criteria, patterns, and examples relevant to this mode.
+
+**GATE**: Mode determined, rubric loaded. Proceed to Phase 1.
+
+### Phase 1: PRE-FILTER
+
+**Goal**: Use regex scanning as a fast gate to catch obvious patterns before spending LLM tokens on semantic analysis.
+
+**For writing mode**: Run the regex-based scanner for grievance patterns:
+```bash
+python3 ~/.claude/scripts/scan-negative-framing.py [file]
+```
+
+**For instruction mode**: Run a grep scan for prohibition patterns:
+```bash
+grep -nE 'NEVER|do NOT|must NOT|FORBIDDEN' [file]
+grep -nE "^-?\s*Don't|^-?\s*Avoid|^#+.*Anti-[Pp]attern|^#+.*Avoid" [file]
+```
+
+**Handle hits**: Report findings with suggested reframes from the loaded rubric. If `--fix` mode is active, apply reframes and re-run to confirm clean.
+
+**GATE**: Regex/grep scan returns zero hits. Resolve obvious patterns before proceeding to Phase 2 — mechanical fixes come first.
+
+### Phase 2: ANALYZE
+
+**Goal**: Read the content and evaluate each item against the loaded rubric using LLM semantic understanding.
+
+**Step 1: Read the content**
+
+Read the full file. Skip frontmatter (YAML between `---` markers) and code blocks.
+
+- **Writing mode**: Identify paragraph boundaries (blank-line separated blocks). Skip blockquotes.
+- **Instruction mode**: Identify each instructional statement — bullet points, table cells, imperative sentences, section headings. Skip examples, code blocks, quoted user dialogue, and file path references.
+
+**Step 2: Evaluate against the rubric**
+
+Apply the scoring dimensions from the loaded rubric (`references/{mode}-rubric.md`). Each rubric defines its own PASS/FAIL dimensions, subtle patterns to detect, and contextual exceptions.
+
+For **writing mode**: Evaluate through the joy-grievance lens. Watch for the subtle patterns described in `references/writing-rubric.md` (defensive disclaimers, accumulative grievance, passive-aggressive factuality, reluctant generosity).
+
+For **instruction mode**: Evaluate through the positive-negative lens. Check each instruction against the patterns table in `references/instruction-rubric.md`. Apply contextual exceptions — subordinate negatives attached to positive instructions are PASS, as are negatives in code examples, writing samples, and technical terms.
+
+**Step 3: Score each item**
+
+Apply the scoring scale from the loaded rubric. For any item scoring in the lower tiers (CAUTION/GRIEVANCE for writing, NEGATIVE-LEANING/PROHIBITION-HEAVY for instruction), draft a specific reframe suggestion that preserves the substance while shifting the framing.
+
+When an item seems subtle enough to question flagging — that is precisely when flagging matters most. Subtle patterns are what the regex/grep pre-filter misses, making them the primary purpose of this LLM analysis phase.
+
+**GATE**: All items analyzed and scored. Reframe suggestions drafted for all flagged items. Proceed to Phase 3.
+
+### Phase 3: REPORT
+
+**Goal**: Produce a structured report with scores, findings, and reframe suggestions.
+
+**Step 1: Calculate overall score**
+
+Average all item scores. Pass criteria come from the loaded rubric:
+- **Writing mode**: Score >= 60 AND no GRIEVANCE paragraphs
+- **Instruction mode**: Score = 100 AND zero primary negative patterns in instructional context
+
+**Step 2: Output the report**
+
+```
+JOY CHECK: [file]
+Mode: [writing|instruction]
+Score: [0-100]
+Status: PASS / FAIL
+
+Items:
+  [writing mode]
+  P1 (L10-12): JOY [85] -- explorer framing, curiosity
+  P3 (L18-22): CAUTION [40] -- "confused" leans defensive
+    -> Reframe: Focus on what you learned from the confusion
+
+  [instruction mode]
+  L33: NEGATIVE [20] -- "NEVER edit code directly"
+    -> Rewrite: "Route all code modifications to domain agents"
+  L45: PASS [90] -- "Create feature branches for all changes"
+  L78: PASS [85] -- "Credentials stay in .env files, never in code" (subordinate negative OK)
+
+Overall: [summary of framing arc]
+```
+
+**Step 3: Handle fix mode**
+
+If `--fix` mode is active:
+1. Rewrite flagged items using the drafted reframe suggestions
+2. Preserve the substance — change only the framing
+3. Re-run Phase 2 analysis on rewritten items to verify fixes landed
+4. If fixes introduce new flagged items, iterate (maximum 3 attempts)
+
+**GATE**: Report produced. If `--fix`, all rewrites applied and re-verified. Joy check complete.
+
+---
+
+### Integration
+
+This skill integrates with content and toolkit pipelines:
+
+**Writing pipeline** (human-facing content):
+```
+CONTENT --> voice-validator --> scan-ai-patterns --> joy-check --mode writing --> anti-ai-editor
+```
+
+**Instruction pipeline** (agent/skill/pipeline creation and modification):
+```
+SKILL.md --> joy-check --mode instruction --> fix flagged patterns --> re-verify
+```
+
+**Auto-invocation points**:
+- `skill-creator` pipeline: Run `joy-check --mode instruction` after generating a new skill
+- `agent-upgrade` pipeline: Run `joy-check --mode instruction` after modifying an agent
+- `voice-writer`: Run `joy-check --mode writing` during validation
+- `doc-pipeline`: Run `joy-check --mode instruction` for toolkit documentation
+
+The joy-check can be invoked standalone via `/joy-check [file]` (auto-detects mode) or with explicit `--mode writing|instruction`.
+
+---
+
+## Error Handling
+
+### Error: "File Not Found"
+**Cause**: Path incorrect or file does not exist
+**Solution**:
+1. Verify path with `ls -la [path]`
+2. Use glob pattern to search: `Glob **/*.md`
+3. Confirm correct working directory
+
+### Error: "Regex Scanner Fails or Not Found"
+**Cause**: `scan-negative-framing.py` script missing or Python error
+**Solution**:
+1. Verify script exists: `ls scripts/scan-negative-framing.py`
+2. Check Python version: `python3 --version` (requires 3.10+)
+3. If script unavailable, skip Phase 1 and proceed directly to Phase 2 LLM analysis -- the regex pre-filter is an optimization, not a requirement
+
+### Error: "All Paragraphs Score GRIEVANCE"
+**Cause**: Content is fundamentally framed through grievance -- not recoverable with paragraph-level reframes
+**Solution**:
+1. Report the scores honestly
+2. Suggest the content needs a full rewrite with a different framing premise, not paragraph-level fixes
+3. Point the user to the Joy Principle section and Examples for guidance on the target framing
+
+### Error: "Fix Mode Fails After 3 Iterations"
+**Cause**: Rewritten paragraphs keep introducing new CAUTION/GRIEVANCE patterns, often because the underlying premise is grievance-based
+**Solution**:
+1. Output the best version achieved with flagged remaining concerns
+2. Explain which specific rubric dimensions resist correction
+3. Suggest the framing premise itself may need rethinking, not just the language
+
+---
+
+## References
+
+### Rubric Files
+- `references/writing-rubric.md` — Joy-grievance spectrum, subtle patterns, scoring, examples (writing mode)
+- `references/instruction-rubric.md` — Positive framing rules, patterns to flag, rewrite strategies, examples (instruction mode)
+
+### Scripts
+- `scan-negative-framing.py` — Regex pre-filter for grievance patterns (writing mode, Phase 1)
+
+### Complementary Skills
+- `voice-validator` — Voice fidelity validation (different concern)
+- `anti-ai-editor` — AI pattern detection and removal (different concern)
+- `voice-writer` — Content pipeline that invokes joy-check as a validation phase
+- `skill-creator` — Skill creation pipeline that invokes joy-check in instruction mode

--- a/skills/code-quality/joy-check/references/instruction-rubric.md
+++ b/skills/code-quality/joy-check/references/instruction-rubric.md
@@ -1,0 +1,136 @@
+# Instruction Rubric — Positive Framing for LLM Instructions
+
+This rubric applies to agent, skill, and pipeline markdown files — instructions read by LLMs, not humans. The principle: state the desired action, not the forbidden one. An LLM needs to know what TO DO, not what to avoid.
+
+## Positive Instruction Framing Rubric
+
+Every instruction should tell the reader what action to take. Prohibitions define a boundary without specifying where to go; positive framing gives a clear action target.
+
+| Dimension | Positive (PASS) | Negative (FAIL) |
+|-----------|----------------|----------------|
+| **Action framing** | "Route all code modifications to domain agents" | "NEVER edit code directly" |
+| **Specific instruction** | "Stage files by name: `git add specific-file.py`" | "do NOT use git add -A" |
+| **Table headings** | "Preferred Patterns", "Hard Gate Patterns" | "Anti-Patterns", "FORBIDDEN Patterns" |
+| **Safety boundaries** | "Create feature branches for all changes" | "Never commit to main" |
+| **Error handling** | "exit 0 on errors to keep tools available" | "must NEVER block tools" |
+| **Double negatives** | "Run validation before marking complete" | "Don't skip validation" |
+| **Section organization** | "What to do" tables showing correct approach | "What NOT to do" tables showing prohibited approach |
+
+## Patterns to Flag
+
+### Primary patterns (always flag when used as instructions)
+
+| Pattern | Regex | Example |
+|---------|-------|---------|
+| NEVER (caps) | `\bNEVER\b` | "NEVER edit code directly" |
+| do NOT / Do NOT | `\b[Dd]o NOT\b` | "Do NOT use git add -A" |
+| must NOT | `\bmust NOT\b` | "must NOT block tools" |
+| FORBIDDEN | `\bFORBIDDEN\b` | "FORBIDDEN Patterns" |
+| Don't (instruction start) | `^-?\s*Don't\b` | "Don't mock the database" |
+| Avoid (as heading/instruction) | `^\s*#{1,6}.*Avoid|^-?\s*Avoid\b` | "### Patterns to Avoid" |
+| Anti-Pattern (in headings) | `^\s*#{1,6}.*[Aa]nti-[Pp]attern` | "### Common Anti-Patterns" |
+
+### Contextual exceptions (allow these)
+
+These are PASS even though they contain negative words:
+
+- **Subordinate negatives attached to positive instructions**: "Credentials stay in .env files, never in code" — the primary instruction is positive ("stay in .env files"), the "never" is a subordinate boundary clarification
+- **Code examples showing bad patterns**: `// NEVER` in a code comment demonstrating what SQL injection looks like — this is illustrative, not instructional
+- **Writing samples and user dialogue**: "Don't do this!" in an example of how users speak — this is quoted content
+- **Technical terms**: "Copula Avoidance" is a proper term for an AI writing pattern — the word "Avoidance" is part of the term, not a prohibition
+- **File path references**: `references/preferred-patterns.md` — this is a filename, not an instruction
+- **Descriptive text about behavior**: "tests do not cover edge cases" — this describes a state, not an instruction
+
+## Rewrite Rules
+
+When flagging a negative pattern, suggest a specific positive rewrite:
+
+| Negative Pattern | Positive Rewrite Strategy |
+|-----------------|--------------------------|
+| Prohibition ("NEVER X") | State the action: "Do Y instead" |
+| Warning ("do NOT use X") | Give the specific alternative: "Use Y: `example`" |
+| Anti-pattern table | Invert to pattern table: show what to do, not what to avoid |
+| Fear-based ("must NEVER block") | State the outcome: "exit 0 to keep available" |
+| Double negative ("Don't skip") | Direct instruction: "Run before marking complete" |
+| "Avoid" heading | Replace with "Preferred" or "Recommended" |
+| "Anti-Pattern" heading | Replace with "Preferred Patterns" or "Patterns to Detect and Fix" |
+
+## Scoring
+
+| Score | Label | Meaning |
+|-------|-------|---------|
+| 80-100 | **POSITIVE** | Instructions frame through desired actions |
+| 50-79 | **MIXED** | Some instructions are positive, some are prohibition-based |
+| 30-49 | **NEGATIVE-LEANING** | Most instructions tell what to avoid rather than what to do |
+| 0-29 | **PROHIBITION-HEAVY** | Instructions are primarily "don't do X" framing |
+
+**Pass criteria**: Score >= 60 AND no primary negative patterns in instructional context.
+
+## Principles
+
+1. **State the desired action, not the forbidden one** — The LLM needs to know what TO DO
+2. **Preserve safety intent** — "Never commit to main" becomes "Create feature branches for all changes" — same protection, positive framing
+3. **Replace anti-pattern tables with pattern tables** — Show "What to do instead", not "What NOT to do"
+4. **Keep the WHY** — "because X" explanations stay unchanged; only the framing changes
+5. **Subordinate negatives are fine** — "Credentials stay in .env files, never in code" is PASS because the positive instruction leads
+
+## Examples
+
+### Example 1: Router Instructions
+
+**NEGATIVE (FAIL):**
+```markdown
+**What the main thread NEVER does:** Read code files, edit files, run tests,
+write docs, handle ANY Simple+ task directly.
+```
+
+**POSITIVE (PASS):**
+```markdown
+**The main thread delegates to agents:** code reading (Explore agent), file
+edits (domain agents), test runs (agent with skill), documentation
+(technical-documentation-engineer), all Simple+ tasks.
+```
+
+**Why the second works:** Tells the LLM exactly where each task type goes instead of listing what's forbidden.
+
+### Example 2: Safety Boundaries
+
+**NEGATIVE (FAIL):**
+```markdown
+Route to agents that create branches; never allow direct main/master commits,
+because main branch commits affect everyone.
+```
+
+**POSITIVE (PASS):**
+```markdown
+Route to agents that create feature branches for all commits, because main
+branch commits affect everyone.
+```
+
+**Why the second works:** Same safety boundary, but the instruction says what to create (feature branches) rather than what to prevent (main commits).
+
+### Example 3: Section Headings
+
+**NEGATIVE (FAIL):**
+```markdown
+## Anti-Patterns
+### FORBIDDEN Patterns (HARD GATE)
+| Pattern | Why FORBIDDEN |
+```
+
+**POSITIVE (PASS):**
+```markdown
+## Preferred Patterns
+### Hard Gate Patterns
+| Pattern | Why Blocked |
+```
+
+**Why the second works:** "Preferred Patterns" tells the reader what to aim for. "Hard Gate Patterns" preserves the enforcement without the fear framing.
+
+### Example 4: Subordinate Negative (PASS)
+
+```markdown
+Credentials stay in .env files, never in code or logs.
+```
+
+This is PASS — the primary instruction is positive ("stay in .env files") and the "never" is a subordinate boundary that clarifies the positive instruction. The reader knows both what to do AND the boundary.

--- a/skills/code-quality/joy-check/references/writing-rubric.md
+++ b/skills/code-quality/joy-check/references/writing-rubric.md
@@ -1,0 +1,197 @@
+# Writing Rubric: Joy-Grievance Spectrum
+
+This rubric applies to human-facing content: blog posts, emails, articles, documentation meant to be read by people.
+
+## Joy Framing Rubric
+
+Every paragraph should frame its subject through curiosity, wonder, generosity, or earned satisfaction. Content that builds a case for grievance alienates readers and undermines the author's credibility, even when the underlying experience is legitimate.
+
+| Dimension | Joy-Centered (PASS) | Grievance-Centered (FAIL) |
+|-----------|-------------------|--------------------------|
+| **Subject position** | Author as explorer, builder, learner | Author as victim, wronged party, unrecognized genius |
+| **Other people** | Fellow travelers, interesting minds, people figuring things out | Opponents, thieves, people who should have done better |
+| **Difficult experiences** | Interesting, surprising, made me think differently | Unfair, hurtful, someone should fix this |
+| **Uncertainty** | Comfortable, curious, "none of us know" | Anxious, defensive, "I need to prove" |
+| **Action framing** | "I decided to", "I realized", "I learned" | "I was forced to", "I had no choice", "they made me" |
+| **Closing energy** | Forward-looking, building, sharing, exploring | Cautionary, warning, demanding, lamenting |
+
+## Subtle Patterns (LLM-only detection)
+
+These patterns are what the regex scanner cannot catch. They are the primary purpose of LLM analysis:
+
+- **Defensive disclaimers** ("I'm not accusing anyone", "This isn't about blame"): If the author has to disclaim, the framing is already grievance-adjacent. The disclaimer signals the content that follows is accusatory enough to need a shield. Flag the paragraph and recommend removing both the disclaimer and the accusatory content it shields.
+- **Accumulative grievance**: Each paragraph is individually mild, but together they build a case for being wronged. A reader who finishes the piece feeling "that person was wronged" has been led through a prosecution. Flag the accumulation pattern and recommend interspersing observations with what the author learned, built, or found interesting.
+- **Passive-aggressive factuality** ("The timeline shows X. The repo was created Y days later. I'll let you draw your own conclusions."): Presenting facts in prosecution order is framing, not neutrality. "I'll let you draw your own conclusions" deputizes the reader as jury. Flag and recommend including facts where relevant to the experience, not as evidence.
+- **Reluctant generosity** ("I'm not saying they did anything wrong, BUT..."): The "but" negates the generosity. This is grievance wearing a generous mask. Flag and recommend being generous without qualification, or acknowledging the complexity directly.
+- **Performative self-flagellation** ("I was wrong", "I shudder to reread it", "my embarrassing error"): The author performs contrition instead of stating the revised position directly. Self-flagellation is grievance directed inward — it centers the drama of being wrong rather than the insight of seeing more clearly. Flag and recommend stating the current understanding without theatrical regret. "I was wrong" can almost always be replaced by simply stating what's right. The correction is implicit. The reader doesn't need the author to bleed.
+- **Mea culpa as structure** (entire pieces organized around "here's how I was wrong"): When an article's primary structure is confession → contrition → redemption, the self-flagellation IS the architecture. Flag and recommend reorganizing around the insight itself, with the earlier position mentioned briefly as context rather than as the dramatic spine.
+
+## Scoring
+
+| Score | Label | Meaning |
+|-------|-------|---------|
+| 80-100 | **JOY** | Frames through curiosity, generosity, or earned satisfaction |
+| 50-79 | **NEUTRAL** | Factual, neither joy nor grievance |
+| 30-49 | **CAUTION** | Leans toward grievance but recoverable with reframing |
+| 0-29 | **GRIEVANCE** | Frames through accusation, victimhood, or bitterness |
+
+**Pass criteria**: Score >= 60 AND no GRIEVANCE paragraphs.
+
+## Active Curiosity Markers (Score Boosters)
+
+Absence of grievance earns 60-75. To score 80+, content must show ACTIVE curiosity — the writer visibly engaged with figuring something out.
+
+| Marker | Example | Score Boost |
+|--------|---------|-------------|
+| **Discovery language** | "I wanted to find out", "what I didn't expect", "that surprised me" | +5 |
+| **Specific hypothesis** | "I expected X, got Y" with concrete X and Y | +5 |
+| **Builder satisfaction** | "I like being able to do that", "this part was satisfying" | +3 |
+| **Genuine question** | A question the author clearly doesn't know the answer to (not rhetorical) | +5 |
+| **Shared exploration** | "we're all figuring this out", "none of us know yet" (collective curiosity, not individual grievance) | +3 |
+| **Surprise admission** | "I was wrong about X" stated flatly, not as self-flagellation | +5 |
+| **Next-step energy** | "I want to try X next", "the next thing I'm going to test" | +3 |
+
+### How to apply:
+1. Score base paragraph for grievance-absence (0-100 scale)
+2. If base score >= 60, scan for active curiosity markers
+3. Add marker bonuses (cap at 100)
+4. A paragraph with zero markers and zero grievance scores 65 (neutral). It PASSES but doesn't excel.
+
+### The distinction:
+- Score 65: "The system uses keyword matching for routing." (neutral fact, no grievance, no curiosity)
+- Score 80: "I wanted to see if keyword matching could beat semantic search. It did, and I still don't fully understand why." (discovery + genuine question)
+- Score 95: "I ran the test expecting semantic search to win. Keywords won by 15%. I'm going to run it again with different prompts because I don't trust the result yet." (surprise + specific number + next-step energy + genuine uncertainty)
+
+## The Joy Principle
+
+**A difficult experience is not a negative topic.** Failure, confusion, being wrong, losing something. These are all worth writing about. The topic can involve surprise, frustration, even grief.
+
+**The framing is what matters.** The same experience can be told as:
+- "The project failed because leadership wouldn't listen" (grievance)
+- "The project failed and it changed how I understand what makes a team actually work" (joy/curiosity)
+
+Both describe the same events. The second frames it through the lens that defines joy-centered content: the specific satisfaction found in understanding something you didn't understand before.
+
+**Joy doesn't mean happiness.** It means engagement, curiosity, the energy of figuring things out. A joy-centered post about a frustrating debugging session isn't happy. It frames the frustration as the puzzle and the understanding as the reward. That's the lens.
+
+## Examples
+
+These examples show the same content reframed from grievance to joy. Each covers a different topic to demonstrate that the pattern applies broadly. The substance stays. Only the framing changes.
+
+### Example 1: A Project That Failed
+
+**GRIEVANCE (FAIL):**
+```
+I spent six months building this and leadership killed it. They never
+gave it a real chance. The team was understaffed, the deadline was
+impossible, and when it didn't ship on time they blamed engineering.
+```
+
+**JOY (PASS):**
+```
+I spent six months on a project that got cancelled. The team was small,
+the deadline was ambitious, and we didn't make it. What I didn't expect
+was how much I'd learn about what makes a technical bet actually land
+versus just being a good idea on paper.
+```
+
+**Why the second works:** The author is a learner extracting insight, not a victim cataloguing injustice. "What I didn't expect" signals curiosity. The failure is acknowledged but framed as the start of understanding.
+
+### Example 2: Finding Someone Solved the Same Problem
+
+**GRIEVANCE (FAIL):**
+```
+I was halfway through the implementation when I found an open-source
+library that does the exact same thing. Six weeks of work, wasted.
+If I'd found it earlier none of this would have happened.
+```
+
+**JOY (PASS):**
+```
+Halfway through, I found an open-source library that solved the same
+problem. My first reaction was frustration, but then I started reading
+their code. They'd made completely different trade-offs than I had,
+and comparing the two taught me more about the problem space than
+either approach alone.
+```
+
+**Why the second works:** "Started reading their code" is an explorer's response. The parallel work becomes a learning opportunity, not wasted effort. Frustration is acknowledged directly, then moved through.
+
+### Example 3: Giving Away Work You Could Have Monetized
+
+**GRIEVANCE (FAIL):**
+```
+I open-sourced the whole thing and nobody even starred the repo. People
+are using it — I can see the clone stats — but nobody bothers to
+contribute back or even say thanks. Open source is a thankless grind.
+```
+
+**JOY (PASS):**
+```
+I open-sourced it and the response was mostly quiet. Some clones, a
+few issues filed, not much else. But every once in a while someone
+emails to say it saved them a week of work, and that's a strange kind
+of satisfaction, knowing something you built is just quietly useful
+somewhere.
+```
+
+**Why the second works:** "Quietly useful" reframes silence as a form of impact. The author finds satisfaction in the work's utility rather than demanding visible reciprocity.
+
+### Example 4: Being Passed Over for Recognition
+
+**GRIEVANCE (FAIL):**
+```
+I've been thinking about why this bothered me, and it's because the
+work speaks for itself. Two years of contributions and they promoted
+someone who joined six months ago. Merit clearly doesn't matter here.
+```
+
+**JOY (PASS):**
+```
+I've been thinking about what I actually want from work, and it turns
+out "being recognized" is too vague to be useful. What I want is to
+work on problems that stretch me, with people who take the craft
+seriously. Once I framed it that way, the promotion question got
+a lot simpler.
+```
+
+**Why the second works:** Locates the feeling in self-knowledge ("what I actually want") not entitlement ("merit should be rewarded"). The author discovers something about themselves rather than building a case against someone else.
+
+### Example 5: Wrapping Up a Career Transition
+
+**GRIEVANCE (FAIL):**
+```
+I left because the industry stopped valuing the kind of deep work I
+do. Everything is about speed now, shipping fast, cutting corners.
+I refuse to compromise on quality, and if that means moving on, fine.
+```
+
+**JOY (PASS):**
+```
+I left because I wanted to find out what I'd build if I got to choose
+the constraints. Turns out the answer is weirder and more interesting
+than what I was building before. I don't know where it leads, but the
+not-knowing is part of what makes it fun.
+```
+
+**Why the second works:** Ends on what the author is moving toward, not what they're escaping from. "The not-knowing is part of what makes it fun" carries experimental energy. No industry-as-villain framing.
+
+### Example 6: Ambiguous Feedback from a Collaborator
+
+**GRIEVANCE (FAIL):**
+```
+They said the design "needed more thought" but wouldn't say what was
+wrong with it. Classic move — vague enough to block progress without
+having to commit to an actual opinion.
+```
+
+**JOY (PASS):**
+```
+They said the design "needed more thought," which is the kind of
+feedback that's frustrating in the moment but sometimes means there's
+something I'm not seeing yet. I went back and sat with it for a day,
+and they were right. There was a whole failure mode I'd been
+hand-waving past.
+```
+
+**Why the second works:** The author sits with discomfort instead of building a case. "They were right" is generous without being self-deprecating. The frustration is honest but leads to discovery.


### PR DESCRIPTION
## Summary

- **Joy-check moved to public repo** at `skills/code-quality/joy-check/` — was in `private-skills/` (gitignored, invisible to GitHub Actions)
- **100% threshold** — zero tolerance for negative framing patterns in skills and agents
- **CI gate** — 179-test fleet scan runs on every PR touching `.md` files
- **PHILOSOPHY.md updated** — new "Positive Framing as CI Gate" section

## Files

| File | What |
|---|---|
| `skills/code-quality/joy-check/SKILL.md` | Skill definition, 100% threshold |
| `skills/code-quality/joy-check/references/instruction-rubric.md` | 7 primary patterns + contextual exceptions |
| `skills/code-quality/joy-check/references/writing-rubric.md` | Joy-grievance spectrum rubric |
| `scripts/validate_positive_instruction_docs.py` | Extended with 2 missing patterns, fixed Avoid regex |
| `scripts/tests/test_joy_check_instruction_mode.py` | 19 golden fixtures + 159-test fleet scan |
| `.github/workflows/test.yml` | New `joy-check` CI job |
| `docs/PHILOSOPHY.md` | Positive framing as CI gate documentation |

## What is NOT in this PR

- No do_b routing scripts
- No do-classify.py, do-enhance.py, do-build-prompt.py
- No experimental routing variants

## Test plan

- [x] 179 tests pass (0.36s)
- [x] ruff clean
- [x] Joy-check SKILL.md passes joy-check at 100%
- [x] All 178 fleet agents/skills pass instruction-mode scan