### PR TITLE
fix: replace all Anti-Pattern terminology with Failure Mode

### DIFF
--- a/agents/ansible-automation-engineer/references/modules.md
+++ b/agents/ansible-automation-engineer/references/modules.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-The most common Ansible anti-pattern is using `command` or `shell` when an idempotent module exists. Module selection determines whether playbooks are idempotent, properly report changes, and work across environments. The hierarchy is: builtin module > collection module > command/shell with explicit `changed_when`.
+The most common Ansible failure mode is using `command` or `shell` when an idempotent module exists. Module selection determines whether playbooks are idempotent, properly report changes, and work across environments. The hierarchy is: builtin module > collection module > command/shell with explicit `changed_when`.
 
 ---
 

--- a/agents/combat-effects-upgrade/references/css-particle-migration.md
+++ b/agents/combat-effects-upgrade/references/css-particle-migration.md
@@ -1,7 +1,7 @@
 # CSS Particle Migration Reference
 <!-- Loaded by combat-effects-upgrade when task involves DOM particle replacement, element pooling, or CSS @keyframes for effects.ts -->
 
-Current anti-pattern in `effects.ts`:
+Current failure mode in `effects.ts`:
 
 ```typescript
 // ANTI-PATTERN — runs on every effect call

--- a/agents/golang-general-engineer-compact.md
+++ b/agents/golang-general-engineer-compact.md
@@ -285,7 +285,7 @@ STOP and ask when:
 | Signal | Load These Files | Why |
 |---|---|---|
 | Idiom upgrade, version compatibility, `any` vs `interface{}` | `go-patterns.md` | Version table Go 1.18–1.26, error wrapping, functional options |
-| Goroutines, channels, WaitGroup, worker pools | `concurrency-patterns.md` | `wg.Go()`, context cancellation, anti-patterns with detection commands |
+| Goroutines, channels, WaitGroup, worker pools | `concurrency-patterns.md` | `wg.Go()`, context cancellation, failure modes with detection commands |
 | Table-driven tests, benchmarks, fuzzing, goroutine leaks | `testing-patterns.md` | `t.Context()`, `b.Loop()`, `t.TempDir()`, goleak patterns |
 
 ## References
@@ -295,7 +295,7 @@ Load the relevant reference file based on the task type:
 | Task Type | Reference File | What It Covers |
 |-----------|---------------|----------------|
 | Idiom upgrade, version compatibility, `any` vs `interface{}` | [references/go-patterns.md](references/go-patterns.md) | Version table Go 1.18–1.26, error wrapping, functional options |
-| Goroutines, channels, WaitGroup, worker pools | [references/concurrency-patterns.md](references/concurrency-patterns.md) | `wg.Go()`, context cancellation, anti-patterns with detection commands |
+| Goroutines, channels, WaitGroup, worker pools | [references/concurrency-patterns.md](references/concurrency-patterns.md) | `wg.Go()`, context cancellation, failure modes with detection commands |
 | Table-driven tests, benchmarks, fuzzing, goroutine leaks | [references/testing-patterns.md](references/testing-patterns.md) | `t.Context()`, `b.Loop()`, `t.TempDir()`, goleak patterns |
 
 **Shared**:

--- a/agents/golang-general-engineer/references/patterns-and-gates.md
+++ b/agents/golang-general-engineer/references/patterns-and-gates.md
@@ -1,12 +1,12 @@
 # Go Patterns, Gates, and Rationalizations
 
-Modern idiom replacement table, anti-patterns, rationalizations, hard gate patterns, and death loop prevention. Loaded when reviewing or writing Go code.
+Modern idiom replacement table, failure modes, rationalizations, hard gate patterns, and death loop prevention. Loaded when reviewing or writing Go code.
 
 ## Preferred Patterns
 
 ### Modern Idiom Patterns
 
-These are the most common AI-generated Go anti-patterns — using old patterns when modern alternatives exist:
+These are the most common AI-generated Go failure modes — using old patterns when modern alternatives exist:
 
 | Outdated Pattern | Modern Replacement | Since |
 |-----------------|-------------------|-------|

--- a/agents/kubernetes-helm-engineer.md
+++ b/agents/kubernetes-helm-engineer.md
@@ -139,7 +139,7 @@ Safety Checks: [Dry-run, context verification]
 | Signal | Load These Files | Why |
 |---|---|---|
 | Pod failures, CrashLoopBackOff, OOMKilled, Pending, ImagePullBackOff | `kubernetes-troubleshooting.md` | Diagnostic commands, pod state table, error-fix mappings |
-| Helm chart development, values hierarchy, template errors, deploy safety | `helm-patterns.md` | Chart validation pipeline, anti-patterns, deprecated API detection |
+| Helm chart development, values hierarchy, template errors, deploy safety | `helm-patterns.md` | Chart validation pipeline, failure modes, deprecated API detection |
 
 ## Error Handling
 
@@ -259,6 +259,6 @@ Load the relevant reference file based on the task type:
 | Task Type | Reference File | What It Covers |
 |-----------|---------------|----------------|
 | Pod failures, CrashLoopBackOff, OOMKilled, Pending, ImagePullBackOff | [references/kubernetes-troubleshooting.md](references/kubernetes-troubleshooting.md) | Diagnostic commands, pod state table, error-fix mappings |
-| Helm chart development, values hierarchy, template errors, deploy safety | [references/helm-patterns.md](references/helm-patterns.md) | Chart validation pipeline, anti-patterns, deprecated API detection |
+| Helm chart development, values hierarchy, template errors, deploy safety | [references/helm-patterns.md](references/helm-patterns.md) | Chart validation pipeline, failure modes, deprecated API detection |
 
 See [shared-patterns/output-schemas.md](../skills/shared-patterns/output-schemas.md) for output format details.

--- a/agents/kubernetes-helm-engineer/references/helm-patterns.md
+++ b/agents/kubernetes-helm-engineer/references/helm-patterns.md
@@ -1,6 +1,6 @@
 # Helm Chart Patterns Reference
 
-> **Scope**: Helm 3.x chart structure, values hierarchy, template anti-patterns, and deployment safety. Does NOT cover Helm plugin development.
+> **Scope**: Helm 3.x chart structure, values hierarchy, template failure modes, and deployment safety. Does NOT cover Helm plugin development.
 > **Version range**: Helm 3.x (Helm 2 is EOL — all patterns assume Helm 3)
 > **Generated**: 2026-04-08
 

--- a/agents/kubernetes-helm-engineer/references/kubernetes-troubleshooting.md
+++ b/agents/kubernetes-helm-engineer/references/kubernetes-troubleshooting.md
@@ -259,5 +259,5 @@ kubectl get deployments --all-namespaces -o json | \
 
 ## See Also
 
-- `helm-patterns.md` — chart development, values hierarchy, template anti-patterns
+- `helm-patterns.md` — chart development, values hierarchy, template failure modes
 - `security.md` — RBAC patterns, pod security standards, network policy templates

--- a/agents/mcp-local-docs-engineer/references/mcp-patterns.md
+++ b/agents/mcp-local-docs-engineer/references/mcp-patterns.md
@@ -276,6 +276,6 @@ grep -rn 'setRequestHandler.*request.*=>' --include="*.ts" src/ | grep -v 'async
 
 ## See Also
 
-- `mcp-preferred-patterns.md` — Front matter, caching, and URI anti-patterns catalog
+- `mcp-preferred-patterns.md` — Front matter, caching, and URI failure modes catalog
 - MCP Specification: https://spec.modelcontextprotocol.io/
 - SDK source: https://github.com/modelcontextprotocol/typescript-sdk

--- a/agents/nextjs-ecommerce-engineer.md
+++ b/agents/nextjs-ecommerce-engineer.md
@@ -59,11 +59,11 @@ This agent operates as an operator for Next.js e-commerce development, configuri
 | Signal | Load These Files | Why |
 |---|---|---|
 | Expertise, default/optional behaviors, capabilities, output format | `expertise.md` | Routes to the matching deep reference |
-| Cart/Stripe implementation snippets, error catalog summary, anti-patterns, blockers | `patterns-and-errors.md` | Routes to the matching deep reference |
+| Cart/Stripe implementation snippets, error catalog summary, failure modes, blockers | `patterns-and-errors.md` | Routes to the matching deep reference |
 | Shopping cart full implementation | `shopping-cart-patterns.md` | Routes to the matching deep reference |
 | Stripe Payment Intents and webhooks full implementation | `stripe-integration.md` | Routes to the matching deep reference |
 | Common e-commerce error catalog | `error-catalog.md` | Routes to the matching deep reference |
-| Full anti-pattern catalog (What/Why/Instead) | `preferred-patterns.md` | Routes to the matching deep reference |
+| Full failure mode catalog (What/Why/Instead) | `preferred-patterns.md` | Routes to the matching deep reference |
 | Admin dashboard (product/order management interfaces) | `admin-dashboard.md` | Routes to the matching deep reference |
 
 ## References
@@ -73,13 +73,13 @@ Load these reference files when the task type matches:
 | Task Type | Reference File |
 |-----------|---------------|
 | Expertise, default/optional behaviors, capabilities, output format | [nextjs-ecommerce-engineer/references/expertise.md](nextjs-ecommerce-engineer/references/expertise.md) |
-| Cart/Stripe implementation snippets, error catalog summary, anti-patterns, blockers | [nextjs-ecommerce-engineer/references/patterns-and-errors.md](nextjs-ecommerce-engineer/references/patterns-and-errors.md) |
+| Cart/Stripe implementation snippets, error catalog summary, failure modes, blockers | [nextjs-ecommerce-engineer/references/patterns-and-errors.md](nextjs-ecommerce-engineer/references/patterns-and-errors.md) |
 | Shopping cart full implementation | [nextjs-ecommerce-engineer/references/shopping-cart-patterns.md](nextjs-ecommerce-engineer/references/shopping-cart-patterns.md) |
 | Stripe Payment Intents and webhooks full implementation | [nextjs-ecommerce-engineer/references/stripe-integration.md](nextjs-ecommerce-engineer/references/stripe-integration.md) |
 | Common e-commerce error catalog | [nextjs-ecommerce-engineer/references/error-catalog.md](nextjs-ecommerce-engineer/references/error-catalog.md) |
-| Full anti-pattern catalog (What/Why/Instead) | [nextjs-ecommerce-engineer/references/preferred-patterns.md](nextjs-ecommerce-engineer/references/preferred-patterns.md) |
+| Full failure mode catalog (What/Why/Instead) | [nextjs-ecommerce-engineer/references/preferred-patterns.md](nextjs-ecommerce-engineer/references/preferred-patterns.md) |
 | Admin dashboard (product/order management interfaces) | [nextjs-ecommerce-engineer/references/admin-dashboard.md](nextjs-ecommerce-engineer/references/admin-dashboard.md) |
 
 **Shared Patterns**:
 - [shared-patterns/verification-checklist.md](../skills/shared-patterns/verification-checklist.md) — Pre-completion checks
-- [shared-patterns/forbidden-patterns-template.md](../skills/shared-patterns/forbidden-patterns-template.md) — Security anti-patterns
+- [shared-patterns/forbidden-patterns-template.md](../skills/shared-patterns/forbidden-patterns-template.md) — Security failure modes

--- a/agents/nextjs-ecommerce-engineer/references/patterns-and-errors.md
+++ b/agents/nextjs-ecommerce-engineer/references/patterns-and-errors.md
@@ -1,6 +1,6 @@
 # Next.js E-commerce Patterns and Errors
 
-Inline cart/Stripe/checkout snippets, error summary, anti-patterns, and rationalizations. Deeper patterns in sibling references.
+Inline cart/Stripe/checkout snippets, error summary, failure modes, and rationalizations. Deeper patterns in sibling references.
 
 ## Shopping Cart Implementation
 

--- a/agents/nodejs-api-engineer/references/auth-patterns.md
+++ b/agents/nodejs-api-engineer/references/auth-patterns.md
@@ -240,7 +240,7 @@ const token = jwt.sign(
 ---
 
 ### Store Refresh Tokens in httpOnly Cookies
-**Detection**: This is a frontend anti-pattern but confirm with client team.
+**Detection**: This is a frontend failure mode but confirm with client team.
 ```bash
 grep -rn 'localStorage.*refresh\|localStorage.*token' --include="*.ts" --include="*.tsx" src/
 ```

--- a/agents/opensearch-elasticsearch-engineer/references/index-management.md
+++ b/agents/opensearch-elasticsearch-engineer/references/index-management.md
@@ -1,5 +1,5 @@
 ---
-description: Mapping design, ILM policies, index templates, and reindexing strategies with anti-pattern detection
+description: Mapping design, ILM policies, index templates, and reindexing strategies with failure mode detection
 ---
 
 # OpenSearch/Elasticsearch Index Management

--- a/agents/performance-optimization-engineer/references/nextjs-optimization.md
+++ b/agents/performance-optimization-engineer/references/nextjs-optimization.md
@@ -219,7 +219,7 @@ const ProductCard = dynamic(() => import('./ProductCard'))
 import { ProductCard } from './ProductCard' // Server Component
 ```
 
-**Version note**: This anti-pattern is App Router (Next.js 13.4+) specific. In Pages Router, `dynamic()` is the correct way to code-split.
+**Version note**: This failure mode is App Router (Next.js 13.4+) specific. In Pages Router, `dynamic()` is the correct way to code-split.
 
 ---
 

--- a/agents/php-general-engineer/references/hooks-and-behaviors.md
+++ b/agents/php-general-engineer/references/hooks-and-behaviors.md
@@ -180,7 +180,7 @@ Always check `composer.json` `require.php` before using features. Use only featu
 - Configure static analysis (PHPStan/Psalm) and formatters (Pint/PHP-CS-Fixer)
 - Write PHPUnit and Pest test suites with factories, mocks, and integration tests
 - Audit codebases for SQL injection, mass-assignment, CSRF, and session vulnerabilities
-- Review Laravel/Symfony/Doctrine code for idiomatic patterns and anti-patterns
+- Review Laravel/Symfony/Doctrine code for idiomatic patterns and failure modes
 - Implement DTOs, value objects, and immutable data structures
 - Debug PHP applications with systematic error analysis
 

--- a/agents/pixijs-combat-renderer.md
+++ b/agents/pixijs-combat-renderer.md
@@ -58,7 +58,7 @@ grep -rl "CombatArena\|PlayerCharacter\|EnemyCharacter\|effects" src/ --include=
 grep -rn "document.createElement\|setTimeout.*remove\|classList.add.*particle" src/ --include="*.ts" --include="*.tsx"
 ```
 
-Flag the DOM particle anti-pattern immediately if found — `document.createElement` + `setTimeout` removal is the primary replacement target. Each DOM particle adds reflow cost; GPU particles are free by comparison.
+Flag the DOM particle failure mode immediately if found — `document.createElement` + `setTimeout` removal is the primary replacement target. Each DOM particle adds reflow cost; GPU particles are free by comparison.
 
 Identify what Zustand stores drive combat state. Read the store file before writing any PixiJS component — display object updates must subscribe to the same state atoms as React UI components.
 

--- a/agents/pixijs-combat-renderer/references/pixi-particle-systems.md
+++ b/agents/pixijs-combat-renderer/references/pixi-particle-systems.md
@@ -7,7 +7,7 @@
 
 ## Why Replace DOM Particles
 
-The `effects.ts` anti-pattern — `document.createElement` + `setTimeout` removal — causes reflow per particle. GPU particles via `ParticleContainer`: 1000 particles = 1 draw call, zero reflow.
+The `effects.ts` failure mode — `document.createElement` + `setTimeout` removal — causes reflow per particle. GPU particles via `ParticleContainer`: 1000 particles = 1 draw call, zero reflow.
 
 ---
 

--- a/agents/pixijs-combat-renderer/references/pixi-performance.md
+++ b/agents/pixijs-combat-renderer/references/pixi-performance.md
@@ -1,5 +1,5 @@
 ---
-description: Sprite batching, texture atlases, RenderTexture caching, off-screen culling, object pooling, ParticleContainer vs Container, and anti-patterns that break GPU batching in PixiJS v8+
+description: Sprite batching, texture atlases, RenderTexture caching, off-screen culling, object pooling, ParticleContainer vs Container, and failure modes that break GPU batching in PixiJS v8+
 agent: pixijs-combat-renderer
 category: performance
 version_range: "PixiJS v8+"

--- a/agents/project-coordinator-engineer.md
+++ b/agents/project-coordinator-engineer.md
@@ -131,6 +131,6 @@ Load these references when the task signal matches:
 | "loop", "retry", "3 attempts", "stuck", "same error", death loop | [references/death-loop-prevention.md](project-coordinator-engineer/references/death-loop-prevention.md) |
 | "STATUS.md", "HANDOFF.md", "PROGRESS.md", "BLOCKERS.md", handoff | [references/communication-protocols.md](project-coordinator-engineer/references/communication-protocols.md) |
 | error, failure, spawn failed, timeout, conflict | [references/error-catalog.md](project-coordinator-engineer/references/error-catalog.md) |
-| anti-pattern, wrong approach, incorrect coordination | [references/preferred-patterns.md](project-coordinator-engineer/references/preferred-patterns.md) |
+| failure mode, wrong approach, incorrect coordination | [references/preferred-patterns.md](project-coordinator-engineer/references/preferred-patterns.md) |
 | TodoWrite, task assignment, dependency, blockedBy, completion | [references/todowrite-integration.md](project-coordinator-engineer/references/todowrite-integration.md) |
 | output format, phases, death-loop, errors, anti-rationalization, blocker criteria | [references/coordination-playbook.md](project-coordinator-engineer/references/coordination-playbook.md) |

--- a/agents/project-coordinator-engineer/references/todowrite-integration.md
+++ b/agents/project-coordinator-engineer/references/todowrite-integration.md
@@ -101,7 +101,7 @@ File domains MUST NOT overlap. If they do, serialize instead.
 ---
 
 ## Pattern Catalog
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Verify Before Marking Complete
 

--- a/agents/python-openstack-engineer.md
+++ b/agents/python-openstack-engineer.md
@@ -122,4 +122,4 @@ See `python-openstack-engineer/references/error-handling.md` for Bare Except (H2
 
 ## Preferred Patterns, Anti-Rationalization & Blocker Criteria
 
-See `python-openstack-engineer/references/preferred-patterns.md` for the OpenStack anti-pattern list (Reinventing Oslo, Bare Except, Missing RPC Versioning), domain-specific rationalization table, and blocker criteria (new Oslo library, API breaking change, database schema, RPC signature).
+See `python-openstack-engineer/references/preferred-patterns.md` for the OpenStack failure mode list (Reinventing Oslo, Bare Except, Missing RPC Versioning), domain-specific rationalization table, and blocker criteria (new Oslo library, API breaking change, database schema, RPC signature).

--- a/agents/react-native-engineer.md
+++ b/agents/react-native-engineer.md
@@ -96,7 +96,7 @@ Do not load references for domains not relevant to the task — context is a sca
 
 **Production crashes, Error Boundaries, Sentry, unhandled rejections**: Load `error-handling.md` — error boundary setup, crash reporting patterns, fetch error handling.
 
-**Test setup, RNTL queries, native module mocks, async assertions**: Load `testing.md` — RNTL patterns, jest config, native mock setup, anti-patterns.
+**Test setup, RNTL queries, native module mocks, async assertions**: Load `testing.md` — RNTL patterns, jest config, native mock setup, failure modes.
 
 ## References
 
@@ -107,5 +107,5 @@ Do not load references for domains not relevant to the task — context is a sca
 - [state-management.md](react-native-engineer/references/state-management.md) — Minimal state, dispatch updaters, fallback patterns, ground truth
 - [rendering-patterns.md](react-native-engineer/references/rendering-patterns.md) — Falsy && crash prevention, Text components, React Compiler
 - [monorepo-config.md](react-native-engineer/references/monorepo-config.md) — Fonts, imports, native dep autolinking, dependency versions
-- [testing.md](react-native-engineer/references/testing.md) — RNTL patterns, jest config, native module mocking, async assertions, anti-patterns
+- [testing.md](react-native-engineer/references/testing.md) — RNTL patterns, jest config, native module mocking, async assertions, failure modes
 - [error-handling.md](react-native-engineer/references/error-handling.md) — Error boundaries, Sentry init, unhandled rejections, fetch error handling, crash recovery

--- a/agents/research-coordinator-engineer.md
+++ b/agents/research-coordinator-engineer.md
@@ -228,7 +228,7 @@ Common research coordination errors. See [references/error-catalog.md](reference
 
 ## Preferred Patterns
 
-Research coordination patterns to follow. See [references/delegation-patterns.md](references/delegation-patterns.md) for the anti-pattern catalog with detection commands.
+Research coordination patterns to follow. See [references/delegation-patterns.md](references/delegation-patterns.md) for the failure mode catalog with detection commands.
 
 ### Give Subagents Specific Instructions
 **Preferred action**: "Research AI compute trends 2025-2030: GPU availability, chip production forecasts, supply constraints. 300-500 words. Sources: Cloud providers, semiconductor analysts."

--- a/agents/reviewer-code/references/language-checks.md
+++ b/agents/reviewer-code/references/language-checks.md
@@ -35,7 +35,7 @@ Complete check catalogs for Go, Python, and TypeScript. Load after detecting the
 - `http.DefaultClient` reuse vs creating new clients
 - File descriptor limits awareness
 
-**Anti-patterns**:
+**Failure modes**:
 - Premature interface abstraction (interface with one implementation)
 - Over-engineered error types (custom error types for simple errors)
 - Unnecessary channels when a mutex suffices
@@ -87,7 +87,7 @@ Complete check catalogs for Go, Python, and TypeScript. Load after detecting the
 - Signal handling for graceful shutdown
 - `contextlib.suppress` over empty except blocks
 
-**Anti-patterns**:
+**Failure modes**:
 - Mutable default arguments (`def foo(items=[])`)
 - Bare `except:` or `except Exception:` without re-raise
 - `import *` polluting namespace
@@ -126,7 +126,7 @@ Complete check catalogs for Go, Python, and TypeScript. Load after detecting the
 - Server Components vs Client Components distinction
 - Use framework data loading instead of `useEffect` for data fetching
 
-**Anti-patterns**:
+**Failure modes**:
 - `any` overuse instead of proper types or `unknown`
 - Type assertions (`as`) over type narrowing with guards
 - Barrel file bloat causing circular dependencies

--- a/agents/reviewer-code/references/language-specialist.md
+++ b/agents/reviewer-code/references/language-specialist.md
@@ -8,14 +8,14 @@ Expert-level analysis of Go, Python, and TypeScript code against modern standard
 - **Language idioms**: Detecting code that reads like it was translated from another language
 - **Concurrency correctness**: Language-specific concurrency patterns (goroutines, asyncio, Promises)
 - **Resource management**: Language-specific lifecycle patterns (defer, context managers, AbortController)
-- **Anti-patterns**: Language-specific code smells and traps unique to each ecosystem
+- **Failure modes**: Language-specific code smells and traps unique to each ecosystem
 - **LLM code tells**: Patterns that LLMs generate by default that experienced developers would not write
 
 ## Methodology
 
 - Detect the language from file extensions before applying checks
 - Apply version-specific recommendations (cite the language version that introduced the feature)
-- Distinguish between style preferences and genuine anti-patterns
+- Distinguish between style preferences and genuine failure modes
 - Flag LLM-generated code tells with explanation of what an experienced developer would write instead
 - Provide migration paths from old patterns to modern alternatives
 
@@ -44,7 +44,7 @@ See [language-checks.md](language-checks.md) for the complete Go, Python, and Ty
 - Idiom Analysis: Evaluate code structure, naming, and patterns against language-specific conventions.
 - Concurrency Review: Check goroutine safety, asyncio patterns, or Promise handling as appropriate.
 - Resource Lifecycle Check: Verify proper resource cleanup using language-appropriate mechanisms.
-- Anti-Pattern Detection: Flag known language-specific code smells with severity.
+- Failure mode detection: Flag known language-specific code smells with severity.
 - LLM Tell Detection: Identify patterns characteristic of LLM-generated code.
 
 ## Output Format

--- a/agents/reviewer-code/references/test-analyzer.md
+++ b/agents/reviewer-code/references/test-analyzer.md
@@ -9,7 +9,7 @@ Evaluate test quality, identify coverage gaps, and assess test resilience with a
 - **Test Resilience Assessment**: Evaluating whether tests survive refactoring without false failures
 - **Negative Case Coverage**: Verifying error paths, boundary conditions, and invalid inputs are tested
 - **Test Quality Patterns**: Table-driven tests (Go), parameterized tests (Python/pytest), test factories, fixtures
-- **Anti-Pattern Detection**: Brittle tests, implementation coupling, test interdependencies
+- **Failure mode detection**: Brittle tests, implementation coupling, test interdependencies
 
 ## Methodology
 

--- a/agents/reviewer-domain.md
+++ b/agents/reviewer-domain.md
@@ -108,7 +108,7 @@ Select the domain matching the review focus, then load its reference file.
 
 ### CAN Do:
 - Review code against ADR decisions, business requirements, structural patterns, or production readiness
-- Detect contradictions, scope creep, edge cases, failure modes, and structural anti-patterns
+- Detect contradictions, scope creep, edge cases, failure modes, and structural failure modes
 - Provide VERDICT with structured findings, severity classification, and constructive recommendations
 - Cross-reference domains when multiple are requested
 - Load domain-specific reference files including edge case tables, structural categories, and production gap catalogs

--- a/agents/reviewer-domain/references/pragmatic-builder.md
+++ b/agents/reviewer-domain/references/pragmatic-builder.md
@@ -99,7 +99,7 @@ Bottlenecks, caching and invalidation, database query patterns, rate limiting.
 ## Detailed References
 
 - [production-gaps.md](production-gaps.md) — Full gap catalog with solutions
-- [operational-preferred-patterns.md](operational-preferred-patterns.md) — Anti-pattern catalog with corrected code
+- [operational-preferred-patterns.md](operational-preferred-patterns.md) — Failure mode catalog with corrected code
 
 ## Questions Always Asked
 - What breaks first under load?

--- a/agents/reviewer-perspectives/references/code-review-detection.md
+++ b/agents/reviewer-perspectives/references/code-review-detection.md
@@ -1,6 +1,6 @@
 # Code Review Detection Patterns
 
-> **Scope**: Detection commands for common anti-patterns across languages. Load during any perspective review on a real codebase.
+> **Scope**: Detection commands for common failure modes across languages. Load during any perspective review on a real codebase.
 > **Generated**: 2026-04-13
 
 ---

--- a/agents/reviewer-system/references/security.md
+++ b/agents/reviewer-system/references/security.md
@@ -1,6 +1,6 @@
 # Security Review
 
-Identify vulnerabilities, security anti-patterns, and compliance issues in READ-ONLY review capacity.
+Identify vulnerabilities, security failure modes, and compliance issues in READ-ONLY review capacity.
 
 ## Expertise
 - **OWASP Top 10**: Broken access control, cryptographic failures, injection, insecure design, misconfiguration, vulnerable components, auth failures, integrity failures, logging failures, SSRF

--- a/agents/rive-skeletal-animator.md
+++ b/agents/rive-skeletal-animator.md
@@ -124,5 +124,5 @@ Load `rive-animation-library.md` when building or debugging animations, state ma
 - [rive-character-pipeline.md](rive-skeletal-animator/references/rive-character-pipeline.md) — Sprite decomposition, bone hierarchy for wrestlers, vertex weighting, Rive Editor workflow, .riv export
 - [rive-animation-library.md](rive-skeletal-animator/references/rive-animation-library.md) — Standard wrestling animation set, state machine design, clip durations, timing sync
 - [rive-vs-spine-decision.md](rive-skeletal-animator/references/rive-vs-spine-decision.md) — Decision matrix: Rive vs Spine2D for web/React projects
-- [rive-performance.md](rive-skeletal-animator/references/rive-performance.md) — Canvas sizing, WebGL context limits, 60fps budgets, lazy loading, Framer Motion anti-patterns
+- [rive-performance.md](rive-skeletal-animator/references/rive-performance.md) — Canvas sizing, WebGL context limits, 60fps budgets, lazy loading, Framer Motion failure modes
 - [rive-async-patterns.md](rive-skeletal-animator/references/rive-async-patterns.md) — Async instance lifecycle, null guards, onLoad vs useEffect, onStateChange, Zustand bridging

--- a/agents/swift-general-engineer.md
+++ b/agents/swift-general-engineer.md
@@ -164,7 +164,7 @@ See [references/swift-patterns.md](swift-general-engineer/references/swift-patte
 
 ## Security & Testing
 
-See [references/swift-security-testing.md](swift-general-engineer/references/swift-security-testing.md) for security patterns, testing methodology, and anti-pattern detection.
+See [references/swift-security-testing.md](swift-general-engineer/references/swift-security-testing.md) for security patterns, testing methodology, and failure mode detection.
 
 ---
 
@@ -173,7 +173,7 @@ See [references/swift-security-testing.md](swift-general-engineer/references/swi
 | File | Contents |
 |------|----------|
 | [`swift-general-engineer/references/swift-patterns.md`](swift-general-engineer/references/swift-patterns.md) | Immutability (`let`/`var`, `struct`/`class`), concurrency (actors, Sendable, structured), protocol-oriented design, state modeling |
-| [`swift-general-engineer/references/swift-security-testing.md`](swift-general-engineer/references/swift-security-testing.md) | Security patterns (Keychain, ATS, cert pinning), testing methodology, anti-pattern detection table |
+| [`swift-general-engineer/references/swift-security-testing.md`](swift-general-engineer/references/swift-security-testing.md) | Security patterns (Keychain, ATS, cert pinning), testing methodology, failure mode detection table |
 
 ## Reference Loading Table
 

--- a/agents/system-upgrade-engineer/references/component-audit-checklists.md
+++ b/agents/system-upgrade-engineer/references/component-audit-checklists.md
@@ -156,7 +156,7 @@ grep -B 1 "No trigger\|no keywords\|\[\]" skills/meta/do/references/routing-tabl
 
 ---
 
-<!-- no-pair-required: section header, not a standalone anti-pattern block -->
+<!-- no-pair-required: section header, not a standalone failure mode block -->
 ## Pattern Catalog
 
 ### Open and Read Component Frontmatter During Audit

--- a/agents/system-upgrade-engineer/references/upgrade-failure-modes.md
+++ b/agents/system-upgrade-engineer/references/upgrade-failure-modes.md
@@ -15,7 +15,7 @@ produce either unauthorized bulk edits or subtly incorrect results that bypass d
 
 ---
 
-<!-- no-pair-required: section header, not a standalone anti-pattern block -->
+<!-- no-pair-required: section header, not a standalone failure mode block -->
 ## Failure Mode Catalog
 
 ### Implementing Without Phase 3 Approval

--- a/agents/system-upgrade-engineer/references/upgrade-signal-parsing.md
+++ b/agents/system-upgrade-engineer/references/upgrade-signal-parsing.md
@@ -22,7 +22,7 @@ component type* is affected.
 |-------------|-------------|--------------------|--------------------|
 | Claude Code release note | `feat:` / `fix:` / `BREAKING:` prefix | Hooks (new events), agents (new capabilities), routing tables | BREAKING = Critical; new tool = Important; fix = Minor |
 | User goal change | "from now on", "whenever X", "always Y" | Hooks (behavioral automation), agents (routing triggers) | User-stated = Critical |
-| Retro graduation | `learning.db` candidates with `status=candidate` | Agent anti-patterns, skill instructions | Recurrence count drives priority |
+| Retro graduation | `learning.db` candidates with `status=candidate` | Agent failure modes, skill instructions | Recurrence count drives priority |
 
 ---
 
@@ -98,7 +98,7 @@ Map recurrence count to tier:
 
 ---
 
-<!-- no-pair-required: section header, not a standalone anti-pattern block -->
+<!-- no-pair-required: section header, not a standalone failure mode block -->
 ## Pattern Catalog
 
 ### Require At Least One Signal Before Proceeding

--- a/agents/technical-documentation-engineer/references/api-doc-verification-failures.md
+++ b/agents/technical-documentation-engineer/references/api-doc-verification-failures.md
@@ -1,6 +1,6 @@
 # API Documentation Verification Failures
 
-<!-- no-pair-required: document introduction, not an individual anti-pattern block -->
+<!-- no-pair-required: document introduction, not an individual failure mode block -->
 
 > **Scope**: Detectable verification failures in API documentation — hallucinated params, untested examples, missing source verification. Does NOT cover style/structure standards (see `documentation-standards.md`).
 > **Version range**: REST APIs, OpenAPI 3.x, curl 7.x+

--- a/agents/technical-documentation-engineer/references/runbook-patterns.md
+++ b/agents/technical-documentation-engineer/references/runbook-patterns.md
@@ -14,7 +14,7 @@ Runbooks fail when they describe how the system works instead of what to do when
 
 ## Pattern Table
 
-| Section | Required | Placement | Anti-Pattern |
+| Section | Required | Placement | Failure Mode |
 |---------|----------|-----------|--------------|
 | Symptoms | Yes | First | "Service may be unhealthy" (too vague) |
 | Verification command | Yes | Immediately after symptom | Describing what to look for without the command |

--- a/agents/technical-journalist-writer/references/article-structure-patterns.md
+++ b/agents/technical-journalist-writer/references/article-structure-patterns.md
@@ -1,6 +1,6 @@
 # Article Structure Patterns
 
-> **Scope**: Structure templates and anti-patterns for the three article types this agent produces: explainer, opinion, and analysis. Covers header patterns, topic sentences, and structural detection commands.
+> **Scope**: Structure templates and failure modes for the three article types this agent produces: explainer, opinion, and analysis. Covers header patterns, topic sentences, and structural detection commands.
 > **Version range**: All versions — applies to markdown article output.
 > **Generated**: 2026-04-15
 
@@ -223,5 +223,5 @@ rg '^(How can|What if|Why do|Can we)' --type md -m 5
 
 ## See Also
 
-- `voice-patterns.md` — banned phrases and tone anti-patterns with detection
+- `voice-patterns.md` — banned phrases and tone failure modes with detection
 - `sourcing-and-claims.md` — claim verification and citation patterns

--- a/agents/technical-journalist-writer/references/sourcing-and-claims.md
+++ b/agents/technical-journalist-writer/references/sourcing-and-claims.md
@@ -253,5 +253,5 @@ rg '\b(better than|faster than|more reliable than|superior to)\b' --type md -i
 
 ## See Also
 
-- `voice-patterns.md` — banned phrases and tone anti-patterns
+- `voice-patterns.md` — banned phrases and tone failure modes
 - `article-structure-patterns.md` — structural patterns for explainer/opinion/analysis

--- a/agents/technical-journalist-writer/references/voice-patterns.md
+++ b/agents/technical-journalist-writer/references/voice-patterns.md
@@ -1,6 +1,6 @@
 # Technical Journalist Voice Patterns
 
-> **Scope**: Banned phrases, tone anti-patterns, and structural violations for the matter-of-fact journalism voice. Covers detection commands for auditing generated article content.
+> **Scope**: Banned phrases, tone failure modes, and structural violations for the matter-of-fact journalism voice. Covers detection commands for auditing generated article content.
 > **Version range**: All versions — applies to any technical article output in markdown.
 > **Generated**: 2026-04-15
 

--- a/agents/testing-automation-engineer/references/async-testing.md
+++ b/agents/testing-automation-engineer/references/async-testing.md
@@ -136,7 +136,7 @@ test('submits form and shows confirmation', async ({ page }) => {
 })
 ```
 
-**Why**: Playwright's `expect(locator).toBeVisible()` auto-waits. Using `page.waitForSelector()` manually or `page.waitForTimeout(2000)` is an anti-pattern — fixed delays are slow on fast machines and flaky on slow ones.
+**Why**: Playwright's `expect(locator).toBeVisible()` auto-waits. Using `page.waitForSelector()` manually or `page.waitForTimeout(2000)` is an failure mode — fixed delays are slow on fast machines and flaky on slow ones.
 
 ---
 

--- a/agents/toolkit-governance-engineer/references/hook-standardization.md
+++ b/agents/toolkit-governance-engineer/references/hook-standardization.md
@@ -1,6 +1,6 @@
 # Hook Standardization Reference
 
-> **Scope**: Hook event types, settings.json registration format, exit code conventions, output protocols, timeout configuration, and common hook anti-patterns. Does not cover frontmatter compliance (see frontmatter-compliance.md).
+> **Scope**: Hook event types, settings.json registration format, exit code conventions, output protocols, timeout configuration, and common hook failure modes. Does not cover frontmatter compliance (see frontmatter-compliance.md).
 > **Version range**: Claude Code hooks system (all current versions)
 > **Generated**: 2026-04-15
 

--- a/agents/typescript-frontend-engineer/references/react-composition-patterns.md
+++ b/agents/typescript-frontend-engineer/references/react-composition-patterns.md
@@ -134,7 +134,7 @@ function ForwardMessageDialog() {
 }
 ```
 
-**Instead of (anti-patterns for accessing trapped state):**
+**Instead of (failure modes for accessing trapped state):**
 ```tsx
 // Effect sync — fires on every change, risks tearing
 function ForwardMessageComposer({ onInputChange }: { onInputChange: (v: string) => void }) {

--- a/docs/CITATIONS.md
+++ b/docs/CITATIONS.md
@@ -50,14 +50,14 @@ https://github.com/Trystan-SA/claude-design-system-prompt
 Design-oriented system prompt with 14 procedural design skills for Claude Code. Studied for its design-specific quality patterns and UI review methodologies.
 
 **Patterns adopted:**
-- AI slop detection checklist (8 concrete anti-patterns for AI-generated UI). Rebuilt as `agents/ui-design-engineer/references/ai-slop-detection.md` with positive-instruction-first format and detection commands.
+- AI slop detection checklist (8 concrete failure modes for AI-generated UI). Rebuilt as `agents/ui-design-engineer/references/ai-slop-detection.md` with positive-instruction-first format and detection commands.
 - Interaction state coverage matrix (6-state exhaustive check per interactive element). Rebuilt as `agents/ui-design-engineer/references/interaction-state-coverage.md` with CSS specifics and timing bounds.
 - Spacing/type scale enforcement (flag any px value not on a 4px/8px grid). Rebuilt as `scripts/design-scale-check.py` — fully deterministic, zero LLM involvement.
 - oklch() color harmony technique (perceptually uniform palette generation). Rebuilt as `skills/frontend/distinctive-frontend-design/references/oklch-color-harmony.md`.
 - Honest placeholder pattern (striped backgrounds for missing assets). Rebuilt as `skills/frontend/distinctive-frontend-design/references/honest-placeholders.md`.
 
 **Patterns noted but not adopted:**
-- Discovery questions anti-pattern #4 ("don't ask about info you already have"). Valuable general principle but already partially encoded in our blocker tables' "skip-if-answered" rules.
+- Discovery questions failure mode #4 ("ask only what you lack"). Valuable general principle but already partially encoded in our blocker tables' "skip-if-answered" rules.
 - Polish pass umbrella skill (parallel 4-agent design review). Architecturally interesting but we already have the multi-wave review pattern; adding a design-specific umbrella is future work.
 - Wireframe discipline conventions (greyscale-only exploration). Valuable if we build design artifact generation workflows; filed for future reference.
 - Component gap analysis (near-duplicates, missing states, implied-but-undefined variants). Useful but only relevant when we build component extraction workflows.

--- a/docs/for-developers.md
+++ b/docs/for-developers.md
@@ -117,7 +117,7 @@ Example prompts:
 
 The constraint that governs all component design: each type has exactly one job.
 
-- **Agents** (`agents/*.md`) know *what* to do. Domain expertise, patterns, anti-patterns.
+- **Agents** (`agents/*.md`) know *what* to do. Domain expertise, patterns, failure modes.
 - **Skills** (`skills/*/*/SKILL.md`) know *how* to structure work. Phases, gates, methodology.
 - **Hooks** (`hooks/*.py`) respond to *events*. JSON in, JSON out, 50ms budget.
 - **Scripts** (`scripts/*.py`) perform *deterministic* operations. Indexing, validation, linting.

--- a/scripts/validate_positive_instruction_docs.py
+++ b/scripts/validate_positive_instruction_docs.py
@@ -19,7 +19,7 @@ SCAN_PATTERNS = [
     "skills/**/references/*.md",
 ]
 NEGATIVE_PATTERNS = [
-    ("Anti-Pattern", re.compile(r"^\s*#{1,6}.*[Aa]nti-[Pp]attern")),
+    ("Anti-Pattern", re.compile(r"[Aa]nti-[Pp]atterns?")),
     ("FORBIDDEN", re.compile(r"\bFORBIDDEN\b")),
     ("NEVER", re.compile(r"\bNEVER\b")),
     ("do NOT", re.compile(r"\b[Dd]o NOT\b")),

--- a/skills/business/csuite/references/audience-segmentation.md
+++ b/skills/business/csuite/references/audience-segmentation.md
@@ -147,7 +147,7 @@ Different segments become important at different audience sizes.
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Demographic persona without a problem
 **What it looks like**: "Our audience is software engineers, 28-40, living in urban areas, interested in career growth."

--- a/skills/business/csuite/references/channel-evaluation.md
+++ b/skills/business/csuite/references/channel-evaluation.md
@@ -165,7 +165,7 @@ If selected channel hours > 80% of available hours: remove a channel.
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Platform-native metrics as success metrics
 **What it looks like**: "We got 50 retweets!" — but zero new email subscribers, zero traffic, zero revenue.

--- a/skills/business/csuite/references/competitive-mapping.md
+++ b/skills/business/csuite/references/competitive-mapping.md
@@ -165,7 +165,7 @@ Classify your market structure before setting positioning strategy.
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Analyzing features, ignoring momentum
 **What it looks like**: Competitor B has fewer features than us today. No further analysis.

--- a/skills/business/csuite/references/content-funnel.md
+++ b/skills/business/csuite/references/content-funnel.md
@@ -278,7 +278,7 @@ Overall funnel rate: ___% (benchmark: 0.1-0.5% of total visitors)
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Awareness content without subscribe CTA
 **What it looks like**: SEO articles driving 5,000 unique visitors/month with no email subscribe prompt, no content upgrade, no follow CTA.

--- a/skills/business/csuite/references/decision-matrices.md
+++ b/skills/business/csuite/references/decision-matrices.md
@@ -140,7 +140,7 @@ Apply before scoring. Changes how much analysis is warranted.
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Criteria added after scoring
 **What it looks like**: Team scores options, then someone says "shouldn't we also consider X?" and adds it — but only because option they preferred scored low.

--- a/skills/business/csuite/references/estimation-techniques.md
+++ b/skills/business/csuite/references/estimation-techniques.md
@@ -336,7 +336,7 @@ Team ratio (greenfield): ___×
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Point estimate at concept stage
 **What it looks like**: "We'll budget 200 hours for this project." — said before requirements exist.

--- a/skills/business/csuite/references/feasibility-scoring.md
+++ b/skills/business/csuite/references/feasibility-scoring.md
@@ -200,7 +200,7 @@ Use these anchors to score confidence consistently:
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Feasibility conflated with desirability
 **What it looks like**: "We can build it, so it's feasible." Team with strong engineering capability scores technical feasibility 9 for everything, ignoring whether the market wants it.

--- a/skills/business/csuite/references/market-positioning.md
+++ b/skills/business/csuite/references/market-positioning.md
@@ -208,7 +208,7 @@ Before finalizing positioning:
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Positioning by negation only
 **What it looks like**: "We're not like those enterprise tools. We're different."

--- a/skills/business/csuite/references/migration-planning.md
+++ b/skills/business/csuite/references/migration-planning.md
@@ -322,7 +322,7 @@ def save_record_post_cutover(data):
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Big-bang cutover
 **What it looks like**: All users moved from old to new system in a single weekend deployment. No pilot, no phased rollout, no shadow period.

--- a/skills/business/csuite/references/risk-assessment.md
+++ b/skills/business/csuite/references/risk-assessment.md
@@ -253,7 +253,7 @@ After pre-mortem, scenario planning, and black swan identification, consolidate 
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Pre-mortem as validation exercise
 **What it looks like**: Team runs pre-mortem but all proposed failure modes are minor and easily dismissed. The session feels like box-checking.

--- a/skills/business/csuite/references/roi-frameworks.md
+++ b/skills/business/csuite/references/roi-frameworks.md
@@ -227,7 +227,7 @@ Converted to hours: ___ points × ___ hours/point = ___ hours
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Planning fallacy (systematic underestimation)
 **What it looks like**: "This will take 2 weeks." Team has never shipped a project of this complexity in under 6 weeks.

--- a/skills/business/csuite/references/strategic-frameworks.md
+++ b/skills/business/csuite/references/strategic-frameworks.md
@@ -178,7 +178,7 @@ For decisions that span multiple time horizons, use McKinsey's Three Horizons ad
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Five Forces as a one-time exercise
 **What it looks like**: Five Forces analysis done at company founding, cited 3 years later.

--- a/skills/business/csuite/references/tco-framework.md
+++ b/skills/business/csuite/references/tco-framework.md
@@ -185,7 +185,7 @@ Before finalizing TCO, confirm you have accounted for:
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Comparing development cost to license cost
 **What it looks like**: "Auth0 costs $2,880/year. We can build it for free."

--- a/skills/business/csuite/references/trend-analysis.md
+++ b/skills/business/csuite/references/trend-analysis.md
@@ -235,7 +235,7 @@ Assessment: [Growing / Maturing / Plateau / Early Decay / Late Decay]
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Treating Hype Cycle peak as confirmation of sustained growth
 **What it looks like**: "Gartner put us at the Peak of Inflated Expectations — that means we're mainstream."

--- a/skills/business/csuite/references/vendor-evaluation.md
+++ b/skills/business/csuite/references/vendor-evaluation.md
@@ -154,7 +154,7 @@ Before signing any vendor contract over $10K/year:
 ---
 
 ## Patterns to Detect and Fix
-<!-- no-pair-required: section header, not an individual anti-pattern -->
+<!-- no-pair-required: section header, not an individual failure mode -->
 
 ### Buying based on demo, not hands-on trial
 **What it looks like**: Sales demo shows everything working perfectly, contract signed, integration begins, and a different reality emerges.

--- a/skills/business/customer-support/references/knowledge-base.md
+++ b/skills/business/customer-support/references/knowledge-base.md
@@ -399,7 +399,7 @@ Transform the ticket-specific resolution into a general guide:
 
 ## KB Quality Failure Modes
 
-| Anti-Pattern | Problem | Fix |
+| Failure Mode | Problem | Fix |
 |-------------|---------|-----|
 | Internal jargon in title | Customers can't find it via search | Rewrite in customer language |
 | Steps that skip prerequisites | Customer gets stuck at step 1 | Add explicit prerequisites section |

--- a/skills/business/customer-support/references/response-drafting.md
+++ b/skills/business/customer-support/references/response-drafting.md
@@ -74,10 +74,10 @@ When a customer is angry, frustrated, or escalating. The goal is not to win an a
 | "That's not really a bug" | "I see what you're experiencing. Let me dig into why it behaves that way." | Classification debate alienates; investigation helps |
 | "You need to..." | "Here's how to resolve this: [steps]" | Directive language feels adversarial under stress |
 
-<!-- no-pair-required: anti-patterns are self-explanatory failure modes; positive approach is in surrounding context -->
+<!-- no-pair-required: failure modes are self-explanatory failure modes; positive approach is in surrounding context -->
 ### De-escalation Failure Modes
 
-| Anti-Pattern | Why It Fails |
+| Failure Mode | Why It Fails |
 |-------------|-------------|
 | Matching their energy/anger | Escalates, never de-escalates |
 | Excessive apologizing without action | Apology fatigue -- they want fixes, not sorry |

--- a/skills/business/customer-support/references/triage-methodology.md
+++ b/skills/business/customer-support/references/triage-methodology.md
@@ -285,7 +285,7 @@ Every triage produces this structured output:
 
 ## Triage Failure Modes
 
-| Anti-Pattern | Problem | Correct Approach |
+| Failure Mode | Problem | Correct Approach |
 |-------------|---------|-----------------|
 | Categorizing by symptom instead of root cause | Misroutes ticket, delays resolution | Investigate root cause before categorizing |
 | Defaulting everything to P3 | Under-serves critical issues, over-serves low ones | Apply priority criteria honestly, err high when uncertain |

--- a/skills/business/design/references/design-critique.md
+++ b/skills/business/design/references/design-critique.md
@@ -196,7 +196,7 @@ Simulate a new user attempting a specific task. For each step:
 
 ## Critique Failure Modes
 
-| Anti-pattern | Do instead |
+| Failure Mode | Do instead |
 |-------------|-----------|
 | Vague praise: "Looks good" | Specific observation: "The card grid creates a consistent scanning pattern and the hover states clearly indicate interactivity" |
 | Vague criticism: "This is confusing" | Specific finding: "The filter controls and sort controls use the same visual style, making it unclear which is which. Differentiate with distinct grouping or labels." |

--- a/skills/business/design/references/ux-copy.md
+++ b/skills/business/design/references/ux-copy.md
@@ -43,7 +43,7 @@ Use the specific action for both confirm and cancel. "OK / Cancel" forces the us
 
 **Structure**: What happened + Why it happened + How to fix it.
 
-| Context | Example | Anti-pattern |
+| Context | Example | Failure Mode |
 |---------|---------|-------------|
 | Form validation | "Email address needs an @ symbol" | "Invalid email" |
 | Payment failure | "Payment declined. Your bank declined this charge. Try a different card or contact your bank." | "Transaction failed" |

--- a/skills/business/finance/SKILL.md
+++ b/skills/business/finance/SKILL.md
@@ -128,7 +128,7 @@ See `references/llm-finance-failure-modes.md` for the complete failure mode cata
 
 ### Journal Entry Failure Modes
 
-| Anti-Pattern | Why It Fails |
+| Failure Mode | Why It Fails |
 |-------------|-------------|
 | Unbalanced entry presented as complete | Violates fundamental accounting equation |
 | Missing reversal flag on accruals | Creates double-counting in the next period |
@@ -138,7 +138,7 @@ See `references/llm-finance-failure-modes.md` for the complete failure mode cata
 
 ### Reconciliation Failure Modes
 
-| Anti-Pattern | Why It Fails |
+| Failure Mode | Why It Fails |
 |-------------|-------------|
 | Forcing the rec to balance by plugging a number | Hides real differences that may indicate errors or fraud |
 | Carrying items forward indefinitely without investigation | Stale items may represent losses or control failures |
@@ -147,7 +147,7 @@ See `references/llm-finance-failure-modes.md` for the complete failure mode cata
 
 ### Variance Analysis Failure Modes
 
-| Anti-Pattern | Why It Fails |
+| Failure Mode | Why It Fails |
 |-------------|-------------|
 | Circular narrative ("revenue is higher because revenue increased") | No causal explanation |
 | "Timing" without specifying what shifted and when it normalizes | Uninvestigable claim |
@@ -157,7 +157,7 @@ See `references/llm-finance-failure-modes.md` for the complete failure mode cata
 
 ### Financial Statement Failure Modes
 
-| Anti-Pattern | Why It Fails |
+| Failure Mode | Why It Fails |
 |-------------|-------------|
 | Assets not equal to liabilities + equity | Balance sheet does not balance |
 | Mixing functional and nature expense classification | GAAP requires consistency within a statement |

--- a/skills/business/finance/references/variance-analysis.md
+++ b/skills/business/finance/references/variance-analysis.md
@@ -159,7 +159,7 @@ Every narrative must be:
 
 ### Failure Modes (detect and fix these)
 
-| Anti-Pattern | Why It Fails | Fix |
+| Failure Mode | Why It Fails | Fix |
 |-------------|-------------|-----|
 | "Revenue was higher due to higher revenue" | Circular — no explanation | Name the driver: volume, pricing, customer, product |
 | "Expenses were elevated" | Vague — which expenses? Why? | Specify line item, amount, and cause |

--- a/skills/business/hr/references/org-planning.md
+++ b/skills/business/hr/references/org-planning.md
@@ -37,7 +37,7 @@ Headcount modeling, org design principles, capacity planning, and people analyti
 
 ### Org Design Failure Modes
 
-| Anti-Pattern | Symptom | Root Cause | Fix |
+| Failure Mode | Symptom | Root Cause | Fix |
 |-------------|---------|-----------|-----|
 | **Empire building** | Managers optimizing headcount over outcome | Headcount = status in org culture | Measure outcomes per person, not team size |
 | **Reporting line as reward** | Star performer gets direct reports as "promotion" | No IC growth track | Build a staff/principal IC ladder with real scope |
@@ -232,7 +232,7 @@ Composite risk score based on multiple factors:
 
 ### Reorg Failure Modes
 
-| Anti-Pattern | Risk | Prevention |
+| Failure Mode | Risk | Prevention |
 |-------------|------|-----------|
 | Announcing before 1:1s | People learn about their new manager in an all-hands | Individual conversations first, then group announcement |
 | Reorg without clear "why" | Perceived as political, creates cynicism | State the problem the reorg solves. If you can't, don't reorg. |

--- a/skills/business/hr/references/performance-management.md
+++ b/skills/business/hr/references/performance-management.md
@@ -61,7 +61,7 @@ Purpose: Document performance assessment, provide development guidance, justify 
 | **Meets Expectations** | Solid performance at expected level. Delivers reliably. Growing in role. | On track. Standard comp progression. |
 | **Below Expectations** | Not meeting expectations for current level. Specific improvement needed. | Requires development plan. May lead to PIP if sustained. |
 
-**Rating anti-patterns:**
+**Rating failure modes:**
 - Rating inflation: everyone gets "Exceeds." Loses meaning. Undermines calibration.
 - Recency bias: rating based on last 4 weeks, not full period. Keep running notes.
 - Halo/horns effect: one strong/weak area colors the entire review. Score dimensions independently.
@@ -99,7 +99,7 @@ Purpose: Document performance assessment, provide development guidance, justify 
 
 #### Feedback Failure Modes
 
-| Anti-Pattern | Problem | Better |
+| Failure Mode | Problem | Better |
 |-------------|---------|--------|
 | "Great job!" | No signal. The person learns nothing about what to repeat. | Name the specific behavior and its impact. |
 | "You need to communicate better." | Vague. Communicate what, to whom, when, how? | "Send project status updates to stakeholders every Friday by EOD." |
@@ -153,7 +153,7 @@ Ensure rating consistency across managers, teams, and the organization. Prevent 
 | Independence | Operates with decreasing guidance over time |
 | Peer recognition | Respected by peers as operating at a higher level |
 
-**Promotion anti-patterns:**
+**Promotion failure modes:**
 - Tenure-based promotion: "They've been here 3 years, they deserve it." Time is not evidence.
 - Promise-based promotion: "Promote them and they'll step up." Evidence first, promotion second.
 - Retention promotion: "If we don't promote them, they'll leave." Solves the wrong problem — likely a comp issue.

--- a/skills/business/hr/references/recruiting.md
+++ b/skills/business/hr/references/recruiting.md
@@ -102,7 +102,7 @@ For each role, define 4-6 competencies. Each competency gets dedicated interview
 
 ### Question Design Failure Modes
 
-| Anti-Pattern | Problem | Better Approach |
+| Failure Mode | Problem | Better Approach |
 |-------------|---------|-----------------|
 | "What's your greatest weakness?" | Rehearsed answers. Zero signal. | "Tell me about a project that didn't go well and what you learned." |
 | Brain teasers | Test puzzle familiarity, not job skills | Use role-relevant problem-solving scenarios |
@@ -184,7 +184,7 @@ Date: [Date] | Panel: [Names]
 
 ### Onboarding Failure Modes
 
-| Anti-Pattern | Problem | Fix |
+| Failure Mode | Problem | Fix |
 |-------------|---------|-----|
 | Information firehose Day 1 | Overwhelming, nothing retained | Spread learning over 2 weeks. Day 1 = setup + relationships. |
 | No buddy assigned | New hire bothers manager for everything or stays silent | Assign a peer buddy. Not the manager. Someone approachable. |

--- a/skills/business/operations/references/change-management.md
+++ b/skills/business/operations/references/change-management.md
@@ -329,7 +329,7 @@ Rollback procedures must be tested before the change. An untested rollback is a 
 
 ## Change Management Failure Modes
 
-| Anti-Pattern | Symptom | Fix |
+| Failure Mode | Symptom | Fix |
 |-------------|---------|-----|
 | Classification avoidance | Everything is "Standard" to skip approval | Audit classification decisions. Auto-escalate when impact assessment contradicts classification. |
 | Communication as afterthought | Users discover changes by encountering them | Communication plan is a required section. No approval without it. |

--- a/skills/business/operations/references/process-documentation.md
+++ b/skills/business/operations/references/process-documentation.md
@@ -366,7 +366,7 @@ Annual value: 3hr × 48 weeks × $75/hr loaded cost = $10,800
 
 ## Process Documentation Failure Modes
 
-| Anti-Pattern | Symptom | Fix |
+| Failure Mode | Symptom | Fix |
 |-------------|---------|-----|
 | Aspirational documentation | SOP describes how it should work, not how it does | Interview practitioners. Document current state first. Optimize second. |
 | RACI with multiple As | Two people "accountable" per step | Enforce one A per step. Resolve ownership disputes before documenting. |

--- a/skills/business/operations/references/risk-assessment.md
+++ b/skills/business/operations/references/risk-assessment.md
@@ -258,7 +258,7 @@ Maintain evidence that risk management is active, not just documented.
 
 ## Risk Assessment Failure Modes
 
-| Anti-Pattern | Symptom | Fix |
+| Failure Mode | Symptom | Fix |
 |-------------|---------|-----|
 | Everything is High | No prioritization possible | Force-rank: at most 20% of risks can be High/Critical. The rest need differentiation. |
 | Optimism bias | Probability consistently underestimated | For each "Low" probability: name the evidence. "Has not happened" requires "and here is why it cannot." |

--- a/skills/business/operations/references/runbook-authoring.md
+++ b/skills/business/operations/references/runbook-authoring.md
@@ -351,7 +351,7 @@ Review the runbook when any of these occur:
 
 ## Runbook Authoring Failure Modes
 
-| Anti-Pattern | Example | Fix |
+| Failure Mode | Example | Fix |
 |-------------|---------|-----|
 | The "just" step | "Just restart the service" | Specify exactly which service, how, and verify it came back. |
 | Assumed knowledge | "SSH to the usual box" | Name the host, document the SSH command, specify which key. |

--- a/skills/business/operations/references/vendor-management.md
+++ b/skills/business/operations/references/vendor-management.md
@@ -260,7 +260,7 @@ Every vendor relationship should have an exit plan. Not because you plan to leav
 
 ## Vendor Management Failure Modes
 
-| Anti-Pattern | Symptom | Fix |
+| Failure Mode | Symptom | Fix |
 |-------------|---------|-----|
 | Feature-list comparison | Choosing the vendor with the longest feature list | Score on fitness for your specific use case, not feature count |
 | Ignoring exit costs | No exit plan until you need to leave | Build exit plan during evaluation. Test data export before signing. |

--- a/skills/business/product-management/SKILL.md
+++ b/skills/business/product-management/SKILL.md
@@ -219,7 +219,7 @@ This mode is fundamentally different. The PM does not get a deliverable. They ge
 
 **Frameworks as thinking tools** (use when they help, not as templates):
 
-| Framework | Structure | Anti-pattern |
+| Framework | Structure | Failure Mode |
 |-----------|-----------|-------------|
 | **HMW** | "How might we [outcome] for [user] without [constraint]?" | Too broad ("improve onboarding") or too narrow ("add tooltip to step 3") |
 | **JTBD** | "When [situation], I want to [motivation] so I can [outcome]." | Functional jobs are easy; emotional and social jobs are often more powerful. Ask "what did they fire?" |
@@ -256,7 +256,7 @@ Used in SPEC, ROADMAP, and SPRINT modes.
 | **MoSCoW** | Must / Should / Could / Won't | Scoping a release, forcing prioritization conversations |
 | **Value vs Effort** | 2x2 matrix: Quick Wins, Big Bets, Fill-ins, Money Pits | Visual prioritization in team sessions |
 
-**Anti-pattern**: Using a framework as a rubber stamp for a decision already made. If the RICE score does not match intuition, investigate why — do not just adjust the inputs until it does.
+**Failure modes**: Using a framework as a rubber stamp for a decision already made. If the RICE score does not match intuition, investigate why — do not just adjust the inputs until it does.
 
 ---
 

--- a/skills/business/product-management/references/metrics-review.md
+++ b/skills/business/product-management/references/metrics-review.md
@@ -131,9 +131,9 @@ KR3: 3 core workflows with >80% task completion rate
 
 **Scoring**: 0.0-0.3 = missed, 0.4-0.6 = progress, 0.7-1.0 = achieved.
 
-**Anti-patterns**:
+**Failure modes**:
 
-| Anti-Pattern | Problem |
+| Failure Mode | Problem |
 |-------------|---------|
 | Too many OKRs (>3 objectives) | Focus diluted, nothing gets done well |
 | Output KRs ("ship X features") | Measures activity not impact |
@@ -143,7 +143,7 @@ KR3: 3 core workflows with >80% task completion rate
 
 ### Target-Setting Process
 
-| Step | Action | Anti-Pattern |
+| Step | Action | Failure Mode |
 |------|--------|-------------|
 | 1. Baseline | Establish current reliable value | Setting targets without knowing where you start |
 | 2. Benchmark | Check comparable products / industry | Ignoring context (B2B vs B2C retention norms differ 3x) |
@@ -179,7 +179,7 @@ KR3: 3 core workflows with >80% task completion rate
 
 ### Common Funnel Failure Modes
 
-| Anti-Pattern | Problem | Fix |
+| Failure Mode | Problem | Fix |
 |-------------|---------|-----|
 | Too many steps | Overwhelms analysis | Focus on 5-7 key decision points |
 | Undefined "active" | Different queries give different answers | Document the definition precisely |
@@ -329,7 +329,7 @@ Possible explanations:
 
 ### Dashboard Failure Modes
 
-| Anti-Pattern | Why It Fails |
+| Failure Mode | Why It Fails |
 |-------------|-------------|
 | Vanity metrics | Total signups ever, total page views — always go up, indicate nothing |
 | Too many metrics | If it requires scrolling, cut metrics |

--- a/skills/business/product-management/references/roadmap-planning.md
+++ b/skills/business/product-management/references/roadmap-planning.md
@@ -18,7 +18,7 @@ The simplest and most effective format for most teams.
 
 **When to use**: Most teams, most of the time. Avoids false precision on dates. Good for leadership and external communication.
 
-**Anti-pattern**: Treating "Later" as a dumping ground. Items in Later should still tie to strategy — they are directional bets, not a wish list.
+**Failure modes**: Treating "Later" as a dumping ground. Items in Later should still tie to strategy — they are directional bets, not a wish list.
 
 ### Quarterly Themes
 
@@ -41,7 +41,7 @@ Q3 2026 Themes:
 
 **When to use**: When you need strategic alignment visibility. Good for planning meetings and executive communication.
 
-**Anti-pattern**: Themes that are too broad ("Make product better") or too narrow (a single feature disguised as a theme).
+**Failure modes**: Themes that are too broad ("Make product better") or too narrow (a single feature disguised as a theme).
 
 ### OKR-Aligned Roadmap
 
@@ -54,7 +54,7 @@ Map items directly to Objectives and Key Results.
 
 **When to use**: Organizations that run on OKRs. Creates clear accountability between what you build and what you measure.
 
-**Anti-pattern**: Initiatives without expected impact estimates. If you cannot estimate impact, the link to the KR is speculative.
+**Failure modes**: Initiatives without expected impact estimates. If you cannot estimate impact, the link to the KR is speculative.
 
 ### Timeline / Gantt
 
@@ -81,7 +81,7 @@ Calendar-based view showing start dates, end dates, durations, parallelism, and 
 
 **When to use**: Large backlog, need quantitative defensibility.
 
-**Anti-pattern**: Gaming confidence scores to make preferred initiatives win. If RICE does not match intuition, investigate why — do not adjust inputs until it does.
+**Failure modes**: Gaming confidence scores to make preferred initiatives win. If RICE does not match intuition, investigate why — do not adjust inputs until it does.
 
 ### ICE Score
 
@@ -129,7 +129,7 @@ Simpler than RICE. Ease is inverse of effort (higher = easier to build).
 
 **Scoring**: 0.0-0.3 = missed, 0.4-0.6 = progress, 0.7-1.0 = achieved. 70% completion is the target for stretch OKRs.
 
-**Anti-patterns**:
+**Failure modes**:
 - Too many OKRs (2-3 objectives max)
 - KRs that are sandbagged (100% confidence = not ambitious enough)
 - KRs that measure effort instead of results

--- a/skills/business/product-management/references/spec-writing.md
+++ b/skills/business/product-management/references/spec-writing.md
@@ -16,7 +16,7 @@ The foundation. Everything else flows from this.
 - What is the cost of not solving it? (user pain, business impact, competitive risk)
 - What evidence grounds this? (research, support data, metrics, customer feedback)
 
-**Anti-patterns**:
+**Failure modes**:
 
 | Bad | Why | Better |
 |-----|-----|--------|

--- a/skills/business/productivity/references/daily-weekly-planning.md
+++ b/skills/business/productivity/references/daily-weekly-planning.md
@@ -58,7 +58,7 @@ Match task difficulty to energy state. Most knowledge workers have predictable e
 
 ### Planning Failure Modes with Corrections
 
-| Anti-Pattern | What Goes Wrong | Do Instead |
+| Failure Mode | What Goes Wrong | Do Instead |
 |-------------|----------------|------------|
 | Planning 8 productive hours | Unplanned work, energy dips, and transition costs consume 20-40% | Plan for 5-6 hours of focused output. Leave the rest as buffer. |
 | No deep work blocks | Day becomes entirely reactive — lots of activity, few outcomes | Schedule at least one 90-min uninterrupted block before checking email or Slack |

--- a/skills/business/productivity/references/status-updates.md
+++ b/skills/business/productivity/references/status-updates.md
@@ -174,7 +174,7 @@ The simplest effective retro format.
 
 ### Retro Failure Modes with Corrections
 
-| Anti-Pattern | What Goes Wrong | Do Instead |
+| Failure Mode | What Goes Wrong | Do Instead |
 |-------------|----------------|------------|
 | Blame-oriented discussion | People defend instead of improving | Frame as system problems: "What about our process allowed this?" not "Who caused this?" |
 | Action items without owners | Nothing happens between retros | Every action item has a named owner and a specific deadline |

--- a/skills/business/productivity/references/task-management.md
+++ b/skills/business/productivity/references/task-management.md
@@ -59,7 +59,7 @@ Score each item 1-10 on three dimensions:
 
 **ICE Score** = Impact x Confidence x Ease. Sort descending. Do the high-score items first.
 
-**Anti-pattern defense**: If you find yourself adjusting scores to justify a preferred item, stop. The score is showing you something. Investigate the mismatch between your intuition and the numbers — that gap contains information.
+**Failure mode defense**: If you find yourself adjusting scores to justify a preferred item, stop. The score is showing you something. Investigate the mismatch between your intuition and the numbers — that gap contains information.
 
 ### Weighted Scoring (Team Decisions)
 

--- a/skills/business/sales/references/call-prep.md
+++ b/skills/business/sales/references/call-prep.md
@@ -100,9 +100,9 @@ Each meeting type has a different optimal structure. The meeting type determines
 | Q&A | 10 min | Address questions. Surface objections. |
 | Next steps | 5 min | Propose evaluation plan, POC, or proposal. |
 
-**Demo anti-patterns** (things that kill demos):
+**Demo failure modes** (things that kill demos):
 
-| Anti-Pattern | Why It Fails | Instead |
+| Failure Mode | Why It Fails | Instead |
 |-------------|-------------|---------|
 | Feature tour | Prospect doesn't care about features they didn't ask for | Show only what maps to their stated needs |
 | Happy path only | Feels rehearsed, doesn't build confidence | Show edge cases they will encounter |

--- a/skills/business/sales/references/outreach-patterns.md
+++ b/skills/business/sales/references/outreach-patterns.md
@@ -100,7 +100,7 @@ Total email: under 150 words. 5 sentences is ideal. 7 sentences is the hard max.
 | Mutual connection | "[Name] suggested I reach out" | Warm intro available |
 | Specific + short | "Re: your [conference] talk" | Content-based hook |
 
-**Subject line anti-patterns** (cause low open rates):
+**Subject line failure modes** (cause low open rates):
 
 | Bad Subject | Why It Fails |
 |------------|-------------|

--- a/skills/code-quality/code-linting/references/biome-rules-reference.md
+++ b/skills/code-quality/code-linting/references/biome-rules-reference.md
@@ -21,7 +21,7 @@ Biome is a fast JavaScript/TypeScript linter and formatter replacing ESLint and 
 | `style` | Idiomatic code improvements | Yes (most) |
 | `complexity` | Unnecessary complexity | Some |
 | `a11y` | Accessibility violations in JSX | No |
-| `security` | Security anti-patterns | No |
+| `security` | Security failure modes | No |
 
 **Common rules by category**:
 

--- a/skills/code-quality/comment-quality/SKILL.md
+++ b/skills/code-quality/comment-quality/SKILL.md
@@ -189,12 +189,12 @@ Load on demand — only pull what the current task requires.
 | Error handling code (try/catch, `if err !=`, `raise`) | `references/error-handling-patterns.md` |
 | Performance code (cache, pool, batch, concurrency, goroutine) | `references/performance-patterns.md` |
 | General rewrite examples needed | `references/examples.md` |
-| Full anti-pattern reference | `references/preferred-patterns.md` |
+| Full failure mode reference | `references/preferred-patterns.md` |
 | Language-specific (Go, Python, JS/TS) or documentation (README, API) comments | `references/preferred-patterns-language-specific.md` |
 
 ### Reference Files
-- `${CLAUDE_SKILL_DIR}/references/preferred-patterns.md`: Core temporal anti-pattern catalog (language-agnostic)
-- `${CLAUDE_SKILL_DIR}/references/preferred-patterns-language-specific.md`: Language-specific and documentation-targeted anti-patterns
+- `${CLAUDE_SKILL_DIR}/references/preferred-patterns.md`: Core temporal failure mode catalog (language-agnostic)
+- `${CLAUDE_SKILL_DIR}/references/preferred-patterns-language-specific.md`: Language-specific and documentation-targeted failure modes
 - `${CLAUDE_SKILL_DIR}/references/examples.md`: Before/after examples of comment rewrites
 - `${CLAUDE_SKILL_DIR}/references/go-comment-patterns.md`: Go-specific temporal patterns with grep/rg detection commands
 - `${CLAUDE_SKILL_DIR}/references/error-handling-patterns.md`: Temporal patterns in error handling code with detection commands

--- a/skills/code-quality/comment-quality/references/error-handling-patterns.md
+++ b/skills/code-quality/comment-quality/references/error-handling-patterns.md
@@ -1,8 +1,8 @@
 # Error Handling Comment Signals and Fixes
 
-<!-- no-pair-required: document header and scope block, not an individual anti-pattern -->
+<!-- no-pair-required: document header and scope block, not an individual failure mode -->
 
-> **Scope**: Temporal and activity-based comment anti-patterns in error handling code, across
+> **Scope**: Temporal and activity-based comment failure modes in error handling code, across
 > Go, Python, JavaScript, and TypeScript.
 > **Version range**: Go 1.13+ (error wrapping), Python 3.11+ (exception groups)
 > **Generated**: 2026-04-16
@@ -20,7 +20,7 @@ them to explain what the error handling actually does today.
 
 ## Pattern Catalog
 
-<!-- no-pair-required: section heading organizing multiple anti-pattern blocks -->
+<!-- no-pair-required: section heading organizing multiple failure mode blocks -->
 
 ### Describe the Guard, Not the Bug History
 
@@ -322,4 +322,4 @@ grep -rn '//.*\b(better|improved)\b.*\bfmt\.Errorf\|//.*fmt\.Errorf.*\b(better|i
 ## See Also
 
 - `go-comment-patterns.md` — Go-specific temporal patterns with goroutine and context focus
-- `preferred-patterns.md` — complete temporal anti-pattern catalog across all languages
+- `preferred-patterns.md` — complete temporal failure mode catalog across all languages

--- a/skills/code-quality/comment-quality/references/go-comment-patterns.md
+++ b/skills/code-quality/comment-quality/references/go-comment-patterns.md
@@ -1,8 +1,8 @@
 # Go Comment Patterns
 
-<!-- no-pair-required: document header and scope block, not an individual anti-pattern -->
+<!-- no-pair-required: document header and scope block, not an individual failure mode -->
 
-> **Scope**: Temporal and activity-based comment anti-patterns specific to Go source files.
+> **Scope**: Temporal and activity-based comment failure modes specific to Go source files.
 > **Version range**: Go 1.13+ (error wrapping), Go 1.18+ (generics)
 > **Generated**: 2026-04-16
 
@@ -20,7 +20,7 @@ of the API contract.
 
 ## Pattern Catalog
 
-<!-- no-pair-required: section heading organizing multiple anti-pattern blocks -->
+<!-- no-pair-required: section heading organizing multiple failure mode blocks -->
 
 ### Describe What the Context Controls
 
@@ -241,5 +241,5 @@ grep -rn '^// Package.*\b(new|old|recently|updated|improved|fixed)\b' --include=
 
 ## See Also
 
-- `preferred-patterns.md` — complete temporal anti-pattern catalog across all languages
+- `preferred-patterns.md` — complete temporal failure mode catalog across all languages
 - `examples.md` — before/after rewrite examples

--- a/skills/code-quality/comment-quality/references/performance-patterns.md
+++ b/skills/code-quality/comment-quality/references/performance-patterns.md
@@ -1,8 +1,8 @@
 # Performance Comment Patterns to Detect and Fix
 
-<!-- no-pair-required: document header and scope block, not an individual anti-pattern -->
+<!-- no-pair-required: document header and scope block, not an individual failure mode -->
 
-> **Scope**: Temporal and relative-comparison comment anti-patterns in performance-sensitive
+> **Scope**: Temporal and relative-comparison comment failure modes in performance-sensitive
 > code: caching, batching, concurrency limits, and algorithmic complexity notes.
 > **Version range**: All languages; Go goroutine pool patterns, Python asyncio, JS Promise.all
 > **Generated**: 2026-04-16
@@ -21,7 +21,7 @@ measurable, specific descriptions of what the optimization does.
 
 ## Pattern Catalog
 
-<!-- no-pair-required: section heading organizing multiple anti-pattern blocks -->
+<!-- no-pair-required: section heading organizing multiple failure mode blocks -->
 
 ### State the Specific Mechanism and Tuning Knobs
 
@@ -339,6 +339,6 @@ grep -rn '//.*\b(reduced|less|lower|minimal)\b.*\bmemory\b' \
 
 ## See Also
 
-- `preferred-patterns.md` — complete temporal anti-pattern catalog across all languages
+- `preferred-patterns.md` — complete temporal failure mode catalog across all languages
 - `error-handling-patterns.md` — temporal patterns in error handling code
 - `go-comment-patterns.md` — Go-specific temporal patterns (goroutines, context, generics)

--- a/skills/code-quality/comment-quality/references/preferred-patterns-language-specific.md
+++ b/skills/code-quality/comment-quality/references/preferred-patterns-language-specific.md
@@ -1,8 +1,8 @@
 # Language-Specific and Documentation Comment Patterns
 
-<!-- no-pair-required: document introduction, not an individual anti-pattern block -->
+<!-- no-pair-required: document introduction, not an individual failure mode block -->
 
-Companion file to `preferred-patterns.md`. Covers language-specific and documentation-targeted comment anti-patterns. Load alongside `preferred-patterns.md` when reviewing code or documentation in Go, Python, JavaScript/TypeScript, or when auditing README/API documentation for temporal references.
+Companion file to `preferred-patterns.md`. Covers language-specific and documentation-targeted comment failure modes. Load alongside `preferred-patterns.md` when reviewing code or documentation in Go, Python, JavaScript/TypeScript, or when auditing README/API documentation for temporal references.
 
 ## Language-Specific Patterns
 
@@ -83,7 +83,7 @@ Companion file to `preferred-patterns.md`. Covers language-specific and document
 
 ## Documentation-Specific Patterns
 
-<!-- no-pair-required: subsection heading grouping documentation anti-patterns -->
+<!-- no-pair-required: subsection heading grouping documentation failure modes -->
 
 ### README Files
 

--- a/skills/code-quality/comment-quality/references/preferred-patterns.md
+++ b/skills/code-quality/comment-quality/references/preferred-patterns.md
@@ -1,14 +1,14 @@
 # Comment Quality Signals and Fixes
 
-<!-- no-pair-required: document introduction, not an individual anti-pattern block -->
+<!-- no-pair-required: document introduction, not an individual failure mode block -->
 
 This document catalogs common problematic patterns found in code comments and documentation, with explanations of why they're problematic and how to fix them.
 
-For language-specific (Go, Python, JavaScript/TypeScript) and documentation-targeted (README, API docs) anti-patterns, see `preferred-patterns-language-specific.md`.
+For language-specific (Go, Python, JavaScript/TypeScript) and documentation-targeted (README, API docs) failure modes, see `preferred-patterns-language-specific.md`.
 
 ## High Priority Signals to Detect and Fix
 
-<!-- no-pair-required: section heading organizing multiple anti-pattern blocks -->
+<!-- no-pair-required: section heading organizing multiple failure mode blocks -->
 
 ### Signal 1: "X now does Y"
 **Signal**: The word "now" implies a temporal change - something used to work differently
@@ -102,7 +102,7 @@ For language-specific (Go, Python, JavaScript/TypeScript) and documentation-targ
 
 ## Medium Priority Signals to Detect and Fix
 
-<!-- no-pair-required: section heading organizing multiple anti-pattern blocks -->
+<!-- no-pair-required: section heading organizing multiple failure mode blocks -->
 
 ### Signal 6: "Updated/Refactored/Optimized X"
 **Signal**: Past tense development activity
@@ -193,7 +193,7 @@ For language-specific (Go, Python, JavaScript/TypeScript) and documentation-targ
 
 ## Subtle Signals to Detect and Fix
 
-<!-- no-pair-required: section heading organizing multiple anti-pattern blocks -->
+<!-- no-pair-required: section heading organizing multiple failure mode blocks -->
 
 ### Signal 11: "More/Less efficient/effective"
 **Signal**: Relative comparison without a baseline

--- a/skills/code-quality/universal-quality-gate/SKILL.md
+++ b/skills/code-quality/universal-quality-gate/SKILL.md
@@ -260,7 +260,7 @@ The quality gate script automatically detects and uses new registry entries on n
 
 ### Pattern Match Warnings (not failures)
 **Pattern Matches** like "Silent exception handler" or "Debug print" are informational warnings. They do not fail the gate. Review them and decide whether to fix:
-- `[WARNING]` entries identify anti-patterns but don't block commits
+- `[WARNING]` entries identify failure modes but don't block commits
 - Use `--no-patterns` to skip pattern scanning if these are not relevant
 - Manually fix patterns that represent actual problems in your code
 

--- a/skills/content/pptx-generator/SKILL.md
+++ b/skills/content/pptx-generator/SKILL.md
@@ -128,7 +128,7 @@ If the user specifies a palette preference, use it. When in doubt, use **Minimal
 
 **Step 2: Plan layout rhythm**
 
-Select layout types for each slide. Use at least 2-3 distinct layout types to avoid the "AI-generated sameness" anti-pattern. See `references/slide-layouts.md` for all layout types.
+Select layout types for each slide. Use at least 2-3 distinct layout types to avoid the "AI-generated sameness" failure mode. See `references/slide-layouts.md` for all layout types.
 
 Available layouts: `title`, `section` (divider), `content` (bullets), `two_column`, `image_text`, `quote` (callout), `table`, `closing`
 

--- a/skills/content/publish/references/taxonomy-examples.md
+++ b/skills/content/publish/references/taxonomy-examples.md
@@ -1,6 +1,6 @@
 # Taxonomy Examples: Good vs Bad
 
-Real-world examples illustrating taxonomy best practices and anti-patterns.
+Real-world examples illustrating taxonomy best practices and failure modes.
 
 ---
 

--- a/skills/content/publish/references/wordpress-upload.md
+++ b/skills/content/publish/references/wordpress-upload.md
@@ -56,7 +56,7 @@ python3 ~/.claude/skills/content/publish/scripts/wordpress-upload.py \
   --human
 ```
 
-The `--title` flag is optional. If omitted, the script extracts the title from markdown H1. If both `--title` AND H1 exist, this creates a duplicate title rendering in WordPress (anti-pattern). Use one or the other, not both.
+The `--title` flag is optional. If omitted, the script extracts the title from markdown H1. If both `--title` AND H1 exist, this creates a duplicate title rendering in WordPress (failure mode). Use one or the other, not both.
 
 **Auto-create missing categories (opt-in):**
 

--- a/skills/content/series-planner/SKILL.md
+++ b/skills/content/series-planner/SKILL.md
@@ -125,7 +125,7 @@ Red flags that fail standalone test — reject any part showing these:
 - Core concepts explained only in earlier parts
 - "Part 2 will explain why this works" — Part 1 reader is stranded
 
-This is the anti-pattern prevention layer. Standalone value is non-negotiable because:
+This is the failure mode prevention layer. Standalone value is non-negotiable because:
 1. Search traffic lands on any part randomly, not always on Part 1
 2. Readers expect complete value from the part they're reading
 3. Multi-part cliff-hangers frustrate readers and hurt SEO

--- a/skills/content/topic-brainstormer/SKILL.md
+++ b/skills/content/topic-brainstormer/SKILL.md
@@ -106,9 +106,9 @@ Remove any topic that fails the filter. Document why each rejection failed:
 |----------------|-----------------|--------|
 | [topic] | [1, 2, or 3] | [why] |
 
-**Anti-Pattern Warning — Do Not Generate Tutorial-Only Topics**: "How to Set Up X" with vex listed as "learning a new tool" is not genuine frustration. Find the specific friction point. "Hugo Local Build Works But Cloudflare Deploy Fails" has real vex (version mismatch between local and CI).
+**Failure Mode Warning — Do Not Generate Tutorial-Only Topics**: "How to Set Up X" with vex listed as "learning a new tool" is not genuine frustration. Find the specific friction point. "Hugo Local Build Works But Cloudflare Deploy Fails" has real vex (version mismatch between local and CI).
 
-**Anti-Pattern Warning — Do Not Accept Opinion Without Experience**: "Why Go Is Better Than Python for CLI Tools" is debate, not experience. This lacks a specific problem solved, no measurable outcome. Ground in measurement instead.
+**Failure Mode Warning — Do Not Accept Opinion Without Experience**: "Why Go Is Better Than Python for CLI Tools" is debate, not experience. This lacks a specific problem solved, no measurable outcome. Ground in measurement instead.
 
 **Gate**: At least 3 candidates pass the content quality filter. If fewer than 3 pass, return to Step 1 with different sources. Proceed only when gate passes.
 
@@ -143,7 +143,7 @@ Replace vague category titles with failure-mode titles:
 - Bad: "Kubernetes Networking Issues"
 - Good: "Pod-to-Pod Traffic Works But Service Discovery Fails"
 
-**Anti-Pattern Warning — Do Not Use Vague Topic Titles**: "Kubernetes Networking Issues" is too broad to act on. Which issues? What specifically failed? Use failure-mode titles instead: "CoreDNS Returns NXDOMAIN for Internal Services" signals real vex and specificity.
+**Failure Mode Warning — Do Not Use Vague Topic Titles**: "Kubernetes Networking Issues" is too broad to act on. Which issues? What specifically failed? Use failure-mode titles instead: "CoreDNS Returns NXDOMAIN for Internal Services" signals real vex and specificity.
 
 **Step 3: Present prioritized output**
 

--- a/skills/engineering/go-patterns/SKILL.md
+++ b/skills/engineering/go-patterns/SKILL.md
@@ -38,7 +38,7 @@ routing:
     - "%w"
     - sentinel error
     # review pattern triggers
-    - "Go anti-pattern"
+    - "Go failure mode"
     - "Go code smell"
     # code review triggers
     - Go code review
@@ -62,7 +62,7 @@ routing:
 
 # Go Patterns Skill
 
-Umbrella skill for Go development: testing, concurrency, error handling, anti-patterns,
+Umbrella skill for Go development: testing, concurrency, error handling, failure modes,
 code review, SAP CC conventions, and quality gates. Routes to the correct reference
 based on the Go task at hand.
 
@@ -120,13 +120,13 @@ Some references point to their own sub-reference files for extended patterns:
 - `${CLAUDE_SKILL_DIR}/references/error-handling/patterns.md` -- gopls tracing, HTTP handler patterns, error wrapping in middleware
 
 **Review-pattern** sub-references:
-- `${CLAUDE_SKILL_DIR}/references/preferred-patterns/code-examples.md` -- Extended before/after for all 7 anti-patterns
+- `${CLAUDE_SKILL_DIR}/references/preferred-patterns/code-examples.md` -- Extended before/after for all 7 failure modes
 
 **Code review** sub-references:
 - `${CLAUDE_SKILL_DIR}/references/code-review/common-review-comments.md` -- Go code patterns with good/bad examples
 
 **SAP CC conventions** sub-references:
-- `${CLAUDE_SKILL_DIR}/references/sapcc-conventions/sapcc-code-patterns.md` -- Primary reference: code patterns, testing patterns, anti-patterns (merged from testing-patterns-detailed.md and preferred-patterns.md)
+- `${CLAUDE_SKILL_DIR}/references/sapcc-conventions/sapcc-code-patterns.md` -- Primary reference: code patterns, testing patterns, failure modes (merged from testing-patterns-detailed.md and preferred-patterns.md)
 - `${CLAUDE_SKILL_DIR}/references/sapcc-conventions/library-reference.md` -- Complete approved/restricted library table
 - `${CLAUDE_SKILL_DIR}/references/sapcc-conventions/architecture-patterns.md` -- Full 102-rule architecture spec
 - `${CLAUDE_SKILL_DIR}/references/sapcc-conventions/review-standards.md` -- Lead + secondary review standards (merged)

--- a/skills/engineering/go-patterns/references/error-handling.md
+++ b/skills/engineering/go-patterns/references/error-handling.md
@@ -5,7 +5,7 @@ Idiomatic Go error handling through context-rich wrapping, sentinel errors, cust
 
 ## Available Scripts
 
-- **`scripts/check-errors.sh`** -- Detect bare `return err` and log-and-return anti-patterns. Run `bash scripts/check-errors.sh --help` for options.
+- **`scripts/check-errors.sh`** -- Detect bare `return err` and log-and-return failure modes. Run `bash scripts/check-errors.sh --help` for options.
 
 ## Instructions
 

--- a/skills/engineering/go-patterns/references/preferred-patterns.md
+++ b/skills/engineering/go-patterns/references/preferred-patterns.md
@@ -1,7 +1,7 @@
 
 # Go Patterns to Detect and Fix
 
-Detect and remediate the 7 core Go anti-patterns: premature interface abstraction, goroutine overkill, error wrapping without context, channel misuse, generic abuse, context soup, and unnecessary function extraction. Every detection is evidence-based with code location and concrete harm explanation, and every recommendation aligns with Go proverbs and standard library conventions.
+Detect and remediate the 7 core Go failure modes: premature interface abstraction, goroutine overkill, error wrapping without context, channel misuse, generic abuse, context soup, and unnecessary function extraction. Every detection is evidence-based with code location and concrete harm explanation, and every recommendation aligns with Go proverbs and standard library conventions.
 
 ## Instructions
 
@@ -11,7 +11,7 @@ Read and follow the repository's CLAUDE.md before reviewing any code. Identify w
 
 If the user requests a full codebase scan or historical git analysis, enable those modes explicitly. Otherwise, stay within the files presented.
 
-<!-- no-pair-required: section-header-only; individual anti-patterns below carry Do-instead blocks -->
+<!-- no-pair-required: section-header-only; individual failure modes below carry Do-instead blocks -->
 ### Phase 2: Scan for Patterns to Fix
 
 Use the Quick Detection Guide to systematically check each file under review. Work through the table row by row against the code.
@@ -30,7 +30,7 @@ Flag complexity only when a simpler idiomatic Go alternative exists. Do not sugg
 
 ### Phase 3: Classify and Report
 
-For each detected anti-pattern, produce a structured report entry. Every flagged pattern must cite a specific code location and explain the concrete harm it causes -- never flag without evidence.
+For each detected failure mode, produce a structured report entry. Every flagged pattern must cite a specific code location and explain the concrete harm it causes -- never flag without evidence.
 
 ```
 ANTI-PATTERN DETECTED:
@@ -42,17 +42,17 @@ ANTI-PATTERN DETECTED:
 - Recommendation: [Simpler Go alternative]
 ```
 
-Rate severity based on the actual codebase context: a single-implementation interface in a small CLI is Low; in a hot path of a shared library it may be High. Address anti-patterns one at a time rather than proposing bulk rewrites.
+Rate severity based on the actual codebase context: a single-implementation interface in a small CLI is Low; in a hot path of a shared library it may be High. Address failure modes one at a time rather than proposing bulk rewrites.
 
 ### Phase 4: Provide Remediation
 
 For each flagged pattern, show the current code alongside the recommended alternative so the reader can compare directly. Explain WHY the current pattern is harmful, not just that it is -- root cause understanding prevents recurrence.
 
-Reference `${CLAUDE_SKILL_DIR}/references/preferred-patterns/code-examples.md` for extended before/after examples covering all 7 anti-patterns.
+Reference `${CLAUDE_SKILL_DIR}/references/preferred-patterns/code-examples.md` for extended before/after examples covering all 7 failure modes.
 
 Do not rewrite working code without an explicit request from the user. Flag patterns for awareness and let the user decide whether to act. When the user does request changes, apply them one pattern at a time to keep diffs reviewable.
 
-If metrics collection is requested, count anti-pattern occurrences by type to identify systemic issues.
+If metrics collection is requested, count failure mode occurrences by type to identify systemic issues.
 
 ---
 
@@ -236,11 +236,11 @@ func (opts AuditorOpts) buildConnectionURL() (string, error) {
 ## Error Handling
 
 ### Error: "False Positive -- Pattern Is Intentional"
-**Cause**: Detected anti-pattern is actually justified by context (e.g., interface for testing boundary, generic for library API).
+**Cause**: Detected failure mode is actually justified by context (e.g., interface for testing boundary, generic for library API).
 **Solution**: Check for 2+ implementations or concrete future need. If justified, note as acceptable trade-off and move on.
 
 ### Error: "Refactoring Breaks Tests"
-**Cause**: Tests depended on the anti-pattern structure (e.g., mocking an interface that gets removed).
+**Cause**: Tests depended on the failure mode structure (e.g., mocking an interface that gets removed).
 **Solution**: Update tests to use the concrete type. If removal would require major test rewrite, flag as tech debt rather than fixing immediately.
 
 ### Error: "Team Disagrees on Pattern"
@@ -252,13 +252,13 @@ func (opts AuditorOpts) buildConnectionURL() (string, error) {
 ## Examples
 
 ### Example 1: Code Review Detection
-User says: "Review this Go service for anti-patterns"
+User says: "Review this Go service for failure modes"
 Actions:
 1. Scan using Quick Detection Guide table
 2. Flag each detected pattern with location and severity
 3. Provide before/after for highest-severity items
 4. Document findings in structured report format
-Result: Prioritized list of anti-patterns with remediation guidance
+Result: Prioritized list of failure modes with remediation guidance
 
 ### Example 2: Specific Pattern Question
 User says: "Should I add an interface for this repository?"
@@ -273,4 +273,4 @@ Result: Evidence-based recommendation with Go idiom context
 
 ## References
 
-- `${CLAUDE_SKILL_DIR}/references/preferred-patterns/code-examples.md`: Extended before/after examples for all 7 anti-patterns
+- `${CLAUDE_SKILL_DIR}/references/preferred-patterns/code-examples.md`: Extended before/after examples for all 7 failure modes

--- a/skills/engineering/go-patterns/references/sapcc-conventions.md
+++ b/skills/engineering/go-patterns/references/sapcc-conventions.md
@@ -636,7 +636,7 @@ These are reasoning patterns that sound correct but lead to rejected PRs in sapc
 | "Tests pass, the error wrapping is fine" | Lead review checks error message quality, not just pass/fail | Verify error context matches project standards |
 | "Copilot suggested this approach" | Lead review frequently rejects Copilot suggestions | Evaluate on merit, simplify where possible |
 | "I need a struct for this JSON" | One-off JSON can use `fmt.Sprintf` + `json.Marshal` | Only create types if reused or complex |
-| "Better safe than sorry" (re: error handling) | "Irrelevant contrivance" — over-handling is an anti-pattern | Ask "concrete scenario where this fails?" |
+| "Better safe than sorry" (re: error handling) | "Irrelevant contrivance" — over-handling is an failure mode | Ask "concrete scenario where this fails?" |
 | "Standard library X works fine here" | SAP CC has go-bits equivalents that are expected | Use go-bits equivalents |
 | "testify is the Go standard" | SAP CC uses go-bits/assert exclusively | Use go-bits/assert exclusively in sapcc repos |
 | "I'll add comprehensive error wrapping" | Trust well-designed functions' error messages | Check if called function already provides context |

--- a/skills/engineering/kotlin-coroutines/SKILL.md
+++ b/skills/engineering/kotlin-coroutines/SKILL.md
@@ -30,7 +30,7 @@ the correct reference based on the task at hand.
 | Concurrency | `concurrency-patterns.md` | Scopes, cancellation, dispatchers, exception handling |
 | Flow | `flow-patterns.md` | Flow builders, StateFlow, SharedFlow, operators |
 | Channels | `channel-patterns.md` | Producer-consumer, fan-in/fan-out patterns |
-| Anti-patterns | `preferred-patterns.md` | GlobalScope, unstructured launch, CancellationException |
+| Failure modes | `preferred-patterns.md` | GlobalScope, unstructured launch, CancellationException |
 
 ## Instructions
 
@@ -44,7 +44,7 @@ Only load what is needed -- do not load all references for every task.
 | Concurrency | `references/concurrency-patterns.md` | Scopes, cancellation, dispatchers, exception handling |
 | Flow | `references/flow-patterns.md` | Flow builders, StateFlow, SharedFlow, operators |
 | Channels | `references/channel-patterns.md` | Producer-consumer, fan-in/fan-out patterns |
-| Anti-patterns | `references/preferred-patterns.md` | GlobalScope, unstructured launch, CancellationException |
+| Failure modes | `references/preferred-patterns.md` | GlobalScope, unstructured launch, CancellationException |
 
 Multiple domains may apply. For example, reviewing code that uses both Flow and Channels
 should load both `flow-patterns.md` and `channel-patterns.md`.

--- a/skills/engineering/kotlin-coroutines/references/preferred-patterns.md
+++ b/skills/engineering/kotlin-coroutines/references/preferred-patterns.md
@@ -1,5 +1,5 @@
 ---
-description: "Kotlin coroutine anti-patterns: GlobalScope, unstructured launch, CancellationException swallowing."
+description: "Kotlin coroutine failure modes: GlobalScope, unstructured launch, CancellationException swallowing."
 level: 2
 ---
 

--- a/skills/engineering/php-testing/SKILL.md
+++ b/skills/engineering/php-testing/SKILL.md
@@ -22,7 +22,7 @@ routing:
 
 Apply PHPUnit testing patterns for PHP projects: unit tests with data providers, test doubles (stubs, mocks, Prophecy), database testing (Laravel/Symfony), HTTP testing, and coverage configuration.
 
-> See `references/patterns.md` for full code examples, the anti-patterns table, and the commands reference.
+> See `references/patterns.md` for full code examples, the failure modes table, and the commands reference.
 
 ## Reference Loading Table
 
@@ -68,4 +68,4 @@ For coverage enforcement:
 XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-text --coverage-min=80
 ```
 
-**GATE**: All tests pass. Coverage threshold met if configured. No anti-patterns from `references/patterns.md` introduced.
+**GATE**: All tests pass. Coverage threshold met if configured. No failure modes from `references/patterns.md` introduced.

--- a/skills/engineering/php-testing/references/patterns.md
+++ b/skills/engineering/php-testing/references/patterns.md
@@ -1,6 +1,6 @@
 # PHP Testing Patterns Reference
 
-Full code examples, anti-patterns, and commands reference for the PHP Testing skill.
+Full code examples, failure modes, and commands reference for the PHP Testing skill.
 
 ---
 
@@ -263,7 +263,7 @@ php artisan test --coverage          # Laravel
 
 ---
 
-<!-- no-pair-required: section-header-only; individual anti-patterns below carry Do-instead blocks -->
+<!-- no-pair-required: section-header-only; individual failure modes below carry Do-instead blocks -->
 ## Common Testing Patterns to Fix
 
 | Signal | Problem | Fix |

--- a/skills/engineering/swift-concurrency/SKILL.md
+++ b/skills/engineering/swift-concurrency/SKILL.md
@@ -26,7 +26,7 @@ Pattern catalog for Swift's structured concurrency model: async/await, Actors, T
 | async/await, Task, Sendable | references/fundamentals.md | async/await patterns, Task/Task.detached, Sendable/@Sendable |
 | Actor, @MainActor, nonisolated | references/actor-isolation.md | Actor isolation, MainActor UI confinement, nonisolated opt-out |
 | TaskGroup, AsyncSequence, AsyncStream, cancellation | references/task-patterns.md | Structured concurrency, rate-limited groups, streams, cancellation |
-| Anti-patterns, common mistakes | references/preferred-patterns.md | Blocking MainActor, task leaking, actor reentrancy hazard |
+| Failure modes, common mistakes | references/preferred-patterns.md | Blocking MainActor, task leaking, actor reentrancy hazard |
 
 ## Key Conventions
 

--- a/skills/frontend/distinctive-frontend-design/SKILL.md
+++ b/skills/frontend/distinctive-frontend-design/SKILL.md
@@ -214,7 +214,7 @@ These reference files contain the curated domain knowledge that drives design de
 - `${CLAUDE_SKILL_DIR}/references/app-vs-landing-rules.md`: Full rule sets for landing vs app surface types
 - `${CLAUDE_SKILL_DIR}/references/examples.md`: Worked examples for new landing page and design audit
 - `${CLAUDE_SKILL_DIR}/references/error-handling.md`: Recovery for banned fonts, cliche palettes, low distinctiveness scores
-- `${CLAUDE_SKILL_DIR}/references/game-ui-polish.md`: Game-native UI polish rules for AAA/Steam/roguelike surfaces, including anti-patterns learned from Road to AEW
+- `${CLAUDE_SKILL_DIR}/references/game-ui-polish.md`: Game-native UI polish rules for AAA/Steam/roguelike surfaces, including failure modes learned from Road to AEW
 - `${CLAUDE_SKILL_DIR}/references/css-audit-patterns.md`: grep/rg detection commands for banned fonts, hardcoded colors, over-animation, and flat backgrounds in implementation code — load when auditing CSS/SCSS/TSX files or verifying a generated spec was implemented correctly
 - `${CLAUDE_SKILL_DIR}/references/performance-budgets.md`: CSS property render costs, compositor-thread promotion rules, layout thrashing detection commands, frame budget reference — load when animation performance is in scope or "animation performance profiling" optional capability is enabled
 

--- a/skills/frontend/distinctive-frontend-design/references/css-audit-patterns.md
+++ b/skills/frontend/distinctive-frontend-design/references/css-audit-patterns.md
@@ -1,6 +1,6 @@
 # CSS Audit Patterns Reference
 
-> **Scope**: grep/rg detection commands for banned fonts, hardcoded colors, anti-pattern CSS structures, and over-animation in frontend source files.
+> **Scope**: grep/rg detection commands for banned fonts, hardcoded colors, failure mode CSS structures, and over-animation in frontend source files.
 > **Version range**: CSS3+, all frameworks (Tailwind, CSS Modules, plain CSS/SCSS)
 > **Generated**: 2026-04-16 — patterns apply to .css, .scss, .module.css, .tsx, .jsx, .html files
 
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This file provides runnable detection commands to audit a frontend codebase for design anti-patterns. Run these after generating a design specification to verify the implementation matches the intent. The most common failure mode is banned fonts slipping in through fallback stacks or Google Fonts imports, and hardcoded hex values bypassing the CSS custom property system.
+This file provides runnable detection commands to audit a frontend codebase for design failure modes. Run these after generating a design specification to verify the implementation matches the intent. The most common failure mode is banned fonts slipping in through fallback stacks or Google Fonts imports, and hardcoded hex values bypassing the CSS custom property system.
 
 ---
 

--- a/skills/frontend/distinctive-frontend-design/references/examples.md
+++ b/skills/frontend/distinctive-frontend-design/references/examples.md
@@ -9,7 +9,7 @@ Actions:
 4. Build palette: warm concrete dominant, charcoal secondary, high-voltage yellow accent (PHASE 3)
 5. Plan hero staggered reveal animation (PHASE 4)
 6. Create layered gradient + grid background (PHASE 5)
-7. Validate: score >= 80, no anti-patterns (PHASE 6)
+7. Validate: score >= 80, no failure modes (PHASE 6)
 8. Output design specification with CSS tokens (PHASE 7)
 Result: Contextual, validated design specification ready for implementation
 

--- a/skills/frontend/distinctive-frontend-design/references/performance-budgets.md
+++ b/skills/frontend/distinctive-frontend-design/references/performance-budgets.md
@@ -1,6 +1,6 @@
 # Animation Performance Budgets Reference
 
-> **Scope**: Concrete frame budgets, CSS property render costs, layout thrashing detection, and performance anti-patterns for CSS animations and transitions.
+> **Scope**: Concrete frame budgets, CSS property render costs, layout thrashing detection, and performance failure modes for CSS animations and transitions.
 > **Version range**: CSS3+, Chrome/Safari/Firefox (2022+), applies to all animation strategies
 > **Generated**: 2026-04-16 — compositor-thread promotion behavior is stable across modern browsers
 

--- a/skills/frontend/distinctive-frontend-design/references/phase-details.md
+++ b/skills/frontend/distinctive-frontend-design/references/phase-details.md
@@ -59,7 +59,7 @@ Select an inspiration source that resonates with the project context from Phase 
 
 ### Phase 3: Palette Checks
 
-Check against anti-patterns in `references/preferred-patterns.json`:
+Check against failure modes in `references/preferred-patterns.json`:
 - No purple (#8B5CF6, #A855F7) as accent on white background -- the most cliched color scheme in modern web design, signaling generic SaaS template
 - No evenly distributed colors without clear dominance
 - No generic blue (#3B82F6) as primary on white

--- a/skills/frontend/frontend-slides/SKILL.md
+++ b/skills/frontend/frontend-slides/SKILL.md
@@ -43,7 +43,7 @@ Generate browser-based HTML presentations as a single self-contained `.html` fil
 | Signal | Load These Files | Why |
 |--------|-----------------|-----|
 | Phase 3 (style selection) or Phase 4 (build) | `references/STYLE_PRESETS.md` | CSS base block, 12 named presets, mood mapping, density limits, validation breakpoints |
-| SlideController, keyboard nav, touch swipe, wheel scroll, Intersection Observer, reveal animation | `references/slide-controller.md` | Canonical JS implementation, `navigating` guard, wheel debounce, IO reveal pattern, anti-patterns with detection commands |
+| SlideController, keyboard nav, touch swipe, wheel scroll, Intersection Observer, reveal animation | `references/slide-controller.md` | Canonical JS implementation, `navigating` guard, wheel debounce, IO reveal pattern, failure modes with detection commands |
 | PPTX, `.pptx`, python-pptx, convert slides, extract slides | `references/pptx-conversion.md` | Safe extraction loop, notes guard, GROUP shape recursion, base64 image embedding, error-fix mappings |
 
 ## Instructions
@@ -195,5 +195,5 @@ For every slide, verify all of the following. If any item fails, fix it before p
 | File | Load At | Contains |
 |------|---------|----------|
 | `skills/frontend/frontend-slides/references/STYLE_PRESETS.md` | Phase 3 (DISCOVER STYLE) and Phase 4 (BUILD) | Mandatory CSS base block, 12 named presets, mood mapping, animation feel mapping, CSS gotchas, density limits, validation breakpoints |
-| `skills/frontend/frontend-slides/references/slide-controller.md` | Phase 4 (BUILD) — JS controller section | Canonical SlideController implementation, `navigating` guard, wheel debounce, IO reveal, anti-patterns with grep detection commands |
+| `skills/frontend/frontend-slides/references/slide-controller.md` | Phase 4 (BUILD) — JS controller section | Canonical SlideController implementation, `navigating` guard, wheel debounce, IO reveal, failure modes with grep detection commands |
 | `skills/frontend/frontend-slides/references/pptx-conversion.md` | Phase 1 (DETECT) — PPTX path | Safe python-pptx extraction loop, notes guard, GROUP shape recursion, base64 image embedding, error-fix table |

--- a/skills/frontend/threejs-builder/SKILL.md
+++ b/skills/frontend/threejs-builder/SKILL.md
@@ -108,7 +108,7 @@ If ambiguous (e.g., user says "3D scene" with no project context), ask which par
 
 Game and GLTF references load **alongside** the paradigm reference — they are complementary, not alternative. A game project using R3F loads both `react-three-fiber.md` and the relevant game references.
 
-**After detecting paradigm**: Read the corresponding reference file. The reference contains paradigm-specific patterns, anti-patterns, and component selection guidance that override the generic steps below.
+**After detecting paradigm**: Read the corresponding reference file. The reference contains paradigm-specific patterns, failure modes, and component selection guidance that override the generic steps below.
 
 Additional reference loading signals (visual-polish, shader-patterns, performance-patterns, advanced-animation) are listed in `${CLAUDE_SKILL_DIR}/references/build-recipes.md` (Phase 1: Additional Reference Loading Signals).
 

--- a/skills/frontend/threejs-builder/references/build-recipes.md
+++ b/skills/frontend/threejs-builder/references/build-recipes.md
@@ -4,7 +4,7 @@
 
 **Visual quality signal**: If the user's request implies high visual quality (portfolio, game, showcase, "make it look good", "impressive", "polished"), also load `references/visual-polish.md` alongside the paradigm reference. It contains specific material recipes, lighting setups, and post-processing configurations that bridge the gap between technically correct and visually impressive.
 
-**Custom shader signal**: If the user mentions custom shaders, GLSL, ShaderMaterial, vertex displacement, postprocessing effects (bloom, chromatic aberration, dissolve), or custom visual effects, load `references/shader-patterns.md`. It contains complete GLSL patterns with working code, anti-patterns with detection commands, and the postprocessing pipeline setup.
+**Custom shader signal**: If the user mentions custom shaders, GLSL, ShaderMaterial, vertex displacement, postprocessing effects (bloom, chromatic aberration, dissolve), or custom visual effects, load `references/shader-patterns.md`. It contains complete GLSL patterns with working code, failure modes with detection commands, and the postprocessing pipeline setup.
 
 **Performance signal**: If the user mentions many objects (particles, foliage, crowds), InstancedMesh, performance profiling, draw call reduction, texture compression, or memory issues, load `references/performance-patterns.md`.
 

--- a/skills/game/game-pipeline/references/game-designer.md
+++ b/skills/game/game-pipeline/references/game-designer.md
@@ -218,7 +218,7 @@ The first 3 seconds must hook the player. Start with immediate visual spectacle.
 - [ ] Camera or environment establishes the world immediately
 - [ ] No loading spinner visible (preload assets ahead of scene transition)
 
-**Anti-patterns**:
+**Failure modes**:
 - Starting on a static title screen with no animation
 - Requiring a button click before anything appears
 - Empty black screen while assets load (show progress bar or instant placeholder)

--- a/skills/game/game-sprite-pipeline/SKILL.md
+++ b/skills/game/game-sprite-pipeline/SKILL.md
@@ -88,7 +88,7 @@ Portrait is the road-to-aew immediate need; spritesheet is the forward-looking c
 | any bg removal phase | `references/bg-removal-local.md` | magenta chroma + rembg |
 | Phase H assembly / output shape | `references/output-formats.md` | PNG / GIF / WebP / atlas JSON |
 | any phase errors | `references/error-catalog.md` | failure mode → fix mapping |
-| user reports clipping / blank cells / cut effects | `references/error-catalog.md` (top section) | "Codex Regeneration as a Post-Processing Fix" anti-pattern; debug slicer, never raw |
+| user reports clipping / blank cells / cut effects | `references/error-catalog.md` (top section) | "Codex Regeneration as a Post-Processing Fix" failure mode; debug slicer, never raw |
 | asset has effects (fire, projectile trails, auras, extended limbs) | `references/error-catalog.md` + use `slice_with_content_awareness` | content extending past cell boundaries needs centroid-ownership extraction. ADR-207 RC-1: on dense grids (`cols * rows >= 16` AND both dims >= 4) `--content-aware-extraction` is silently downgraded to strict-pitch with a warning unless `--effects-asset` is also passed (orchestrator-side) or `effects_asset: True` is set (spec-side). Use `--effects-asset` only for genuine sparse-but-cross-boundary content (fire breath, plasma trails, projectile auras). |
 | `--target road-to-aew` deploy | `references/road-to-aew-integration.md` | snake_case, paths, manifest regen |
 | `--per-row` subagent orchestration | `references/subagent-delegation.md` | subagent boundary rules: who generates, who composes, who finalizes |
@@ -462,7 +462,7 @@ See `references/error-catalog.md` for the full diagnostic procedure.
 - `references/backend-chain.md` — Codex CLI invocation pattern, auth checks, failure modes.
 - `references/frame-detection.md` — connected-components algorithm, minimum-separation gap, component filter.
 - `references/anchor-alignment.md` — shared-scale percentile, bottom-anchor math, horizontal centering.
-- `references/bg-removal-local.md` — two-pass chroma, rembg opt-in, anti-patterns.
+- `references/bg-removal-local.md` — two-pass chroma, rembg opt-in, failure modes.
 - `references/output-formats.md` — PNG / GIF / WebP / atlas JSON / strips matrix per mode.
 - `references/error-catalog.md` — error message → cause → fix, per phase.
 - `references/road-to-aew-integration.md` — snake_case naming, deploy paths, manifest regen.

--- a/skills/game/game-sprite-pipeline/references/error-catalog.md
+++ b/skills/game/game-sprite-pipeline/references/error-catalog.md
@@ -268,7 +268,7 @@ threshold relaxes 30x so plasma/fire/aura content is not misread as fringe.
 **Cause:** Per-cell alignment check finds character silhouettes touching cell
 boundaries (within `edge_margin_px=2`). Threshold is **5% of cells violating**,
 NOT 50%. A 50% tolerance is permissive enough to admit the failure it exists
-to catch — see the `Rubber-stamp verifier thresholds` anti-pattern below. For
+to catch — see the `Rubber-stamp verifier thresholds` failure mode below. For
 a 4x4 sheet this is 1 violation; for an 8x8 it is 3.
 
 **Fix:** When the gate fires, the slicer placed a cell boundary inside another

--- a/skills/infrastructure/cron-job-auditor/references/concurrency-and-locks.md
+++ b/skills/infrastructure/cron-job-auditor/references/concurrency-and-locks.md
@@ -81,7 +81,7 @@ trap 'rm -f "$PID_FILE"' EXIT
 
 ---
 
-<!-- no-pair-required: section heading; individual anti-patterns below carry Do-instead blocks -->
+<!-- no-pair-required: section heading; individual failure modes below carry Do-instead blocks -->
 ## Pattern Catalog
 
 ### Add Lock Protection to Every Cron Script

--- a/skills/infrastructure/cron-job-auditor/references/logging-and-rotation.md
+++ b/skills/infrastructure/cron-job-auditor/references/logging-and-rotation.md
@@ -87,7 +87,7 @@ exec >> "$LOG" 2>> "$ERR"
 
 ---
 
-<!-- no-pair-required: section heading; individual anti-patterns below carry Do-instead blocks -->
+<!-- no-pair-required: section heading; individual failure modes below carry Do-instead blocks -->
 ## Pattern Catalog
 
 ### Redirect Output to Log Files

--- a/skills/infrastructure/cron-job-auditor/references/shell-error-handling.md
+++ b/skills/infrastructure/cron-job-auditor/references/shell-error-handling.md
@@ -82,7 +82,7 @@ rsync -avz source/ dest/ && echo "sync OK" || { echo "sync FAILED" >&2; exit 1; 
 
 ---
 
-<!-- no-pair-required: section heading; individual anti-patterns below carry Do-instead blocks -->
+<!-- no-pair-required: section heading; individual failure modes below carry Do-instead blocks -->
 ## Pattern Catalog
 
 ### Enable set -euo pipefail in Every Script

--- a/skills/infrastructure/fish-shell-config/SKILL.md
+++ b/skills/infrastructure/fish-shell-config/SKILL.md
@@ -288,10 +288,10 @@ Solution: Use `set -gx VAR value` to make variable visible to subprocesses. Chec
 |-------------|------|-----|
 | Migrating from Bash, converting `.bashrc`/`.bash_aliases`, `source`, `export`, `[[` in Fish file | `bash-migration.md` | Full Bash-to-Fish syntax translation table |
 | Variable scoping, PATH management, `fish_add_path`, `set` flags, `abbr`, completions | `fish-quick-reference.md` | Variable scope guide, special variables, control flow cheatsheet |
-| Error audit, "unknown command", PATH not persisting, abbreviation not working, syntax error, broken conf.d | `fish-preferred-patterns.md` | Anti-patterns with grep detection commands and error-fix mappings |
+| Error audit, "unknown command", PATH not persisting, abbreviation not working, syntax error, broken conf.d | `fish-preferred-patterns.md` | Failure modes with grep detection commands and error-fix mappings |
 | Go, Rust, Docker, Node.js, Python, pyenv, fnm, starship, direnv, fzf, zoxide, mise, tool setup | `tool-integrations.md` | Concrete integration patterns for common dev tools |
 
 - `${CLAUDE_SKILL_DIR}/references/bash-migration.md`: Complete Bash-to-Fish syntax translation table
 - `${CLAUDE_SKILL_DIR}/references/fish-quick-reference.md`: Variable scoping, special variables, and command cheatsheet
-- `${CLAUDE_SKILL_DIR}/references/fish-preferred-patterns.md`: Anti-pattern catalog with grep detection commands and error-fix mappings
+- `${CLAUDE_SKILL_DIR}/references/fish-preferred-patterns.md`: Failure mode catalog with grep detection commands and error-fix mappings
 - `${CLAUDE_SKILL_DIR}/references/tool-integrations.md`: Concrete integration patterns for Go, Rust, Docker, Node.js, Python, and shell enhancers

--- a/skills/infrastructure/shell-process-patterns/SKILL.md
+++ b/skills/infrastructure/shell-process-patterns/SKILL.md
@@ -218,7 +218,7 @@ trap cleanup EXIT
 trap 'echo "ERROR: line $LINENO exit $?" >&2' ERR
 ```
 
-Constraint: a command followed by `|| something` has its exit code masked -- `set -e` does not fire, and neither does the ERR trap. Use `|| true` only where failure is genuinely harmless, and prefer `if ! cmd; then handle; fi` when you want to act on the failure -- because silent-swallow `|| true` is the top anti-pattern in this domain (see `references/preferred-patterns.md`).
+Constraint: a command followed by `|| something` has its exit code masked -- `set -e` does not fire, and neither does the ERR trap. Use `|| true` only where failure is genuinely harmless, and prefer `if ! cmd; then handle; fi` when you want to act on the failure -- because silent-swallow `|| true` is the top failure mode in this domain (see `references/preferred-patterns.md`).
 
 ### Step 8: Verify
 
@@ -265,7 +265,7 @@ Solution: remove `|| true` unless you genuinely do not care. Add `set -o pipefai
 | Killing or finding a process | "kill the process", "find the pid", "port still bound", "$!", "pgrep", "ss", "lsof" | `pid-resolution.md` |
 | Writing signal handlers / traps | "trap", "SIGTERM", "SIGKILL", "cleanup handler", "EXIT trap", "exec" | `signals-and-traps.md` |
 | Verifying a kill actually worked | "verify kill", "still running", "lock file", "stale pid", "port in use" | `cleanup-verification.md` |
-| Reviewing a script for gotchas | "audit bash", "shell anti-pattern", "set -e", "|| true", "code review bash" | `preferred-patterns.md` |
+| Reviewing a script for gotchas | "audit bash", "shell failure mode", "set -e", "|| true", "code review bash" | `preferred-patterns.md` |
 
 ### Reference Files
 

--- a/skills/infrastructure/shell-process-patterns/references/cleanup-verification.md
+++ b/skills/infrastructure/shell-process-patterns/references/cleanup-verification.md
@@ -237,7 +237,7 @@ ss -tln | grep -q ':8080\b' && { echo "FATAL: teardown incomplete"; exit 1; }
 start_server
 ```
 
-<!-- no-pair-required: This section is a pointer index into preferred-patterns.md; each referenced AP has its own paired "Do instead" block in that file. The body of THIS reference file (kill-and-check loop, resource verification, cleanup-on-exit) IS the "do instead" content for the referenced anti-patterns. -->
+<!-- no-pair-required: This section is a pointer index into preferred-patterns.md; each referenced AP has its own paired "Do instead" block in that file. The body of THIS reference file (kill-and-check loop, resource verification, cleanup-on-exit) IS the "do instead" content for the referenced failure modes. -->
 
 ## Failure patterns
 
@@ -249,5 +249,5 @@ start_server
 
 - For PID capture before kill: `pid-resolution.md`
 - For signals and traps: `signals-and-traps.md`
-- For anti-patterns: `preferred-patterns.md` AP-4, AP-7
+- For failure modes: `preferred-patterns.md` AP-4, AP-7
 - For polling/backoff generalities: `skills/process/condition-based-waiting/SKILL.md`

--- a/skills/infrastructure/shell-process-patterns/references/pid-resolution.md
+++ b/skills/infrastructure/shell-process-patterns/references/pid-resolution.md
@@ -187,7 +187,7 @@ Or install `procps`/`iproute2` at image build time.
 
 ## Patterns to Detect and Fix
 
-These come from the anti-patterns reference:
+These come from the failure modes reference:
 - `$!` after `nohup` or any wrapper binary — see AP-1 in `preferred-patterns.md`
 - `kill $!` without verification that the port/resource is actually freed — see AP-4
 - `sleep N; kill $!` with a fixed sleep in hopes the wrapper has forked by then — races, use `pgrep -P` or poll

--- a/skills/infrastructure/shell-process-patterns/references/preferred-patterns.md
+++ b/skills/infrastructure/shell-process-patterns/references/preferred-patterns.md
@@ -1,6 +1,6 @@
 ---
-name: anti-patterns
-description: Concrete shell-process anti-patterns with detection commands and paired fixes.
+name: failure modes
+description: Concrete shell-process failure modes with detection commands and paired fixes.
 ---
 
 <!-- no-pair-required: this H1 is the file title; each AP-N section below contains its own "Do instead" block. -->

--- a/skills/infrastructure/shell-process-patterns/references/signals-and-traps.md
+++ b/skills/infrastructure/shell-process-patterns/references/signals-and-traps.md
@@ -253,7 +253,7 @@ trap - SIGTERM
 
 ## Cross-references
 
-- For the trap-clobbers-exit-code anti-pattern: `preferred-patterns.md` AP-3
-- For SIGKILL-first anti-pattern: `preferred-patterns.md` AP-7
+- For the trap-clobbers-exit-code failure mode: `preferred-patterns.md` AP-3
+- For SIGKILL-first failure mode: `preferred-patterns.md` AP-7
 - For starting process groups: `starting-processes.md`
 - For cleanup verification after signaling: `cleanup-verification.md`

--- a/skills/infrastructure/shell-process-patterns/references/starting-processes.md
+++ b/skills/infrastructure/shell-process-patterns/references/starting-processes.md
@@ -149,4 +149,4 @@ Without `set -m`, non-interactive bash puts background jobs in the script's own 
 - For PID capture after start: `pid-resolution.md`
 - For signal handling of started children: `signals-and-traps.md`
 - For cleanup after start: `cleanup-verification.md`
-- For anti-patterns in starting (AP-1, AP-6): `preferred-patterns.md`
+- For failure modes in starting (AP-1, AP-6): `preferred-patterns.md`

--- a/skills/meta/agent-comparison/SKILL.md
+++ b/skills/meta/agent-comparison/SKILL.md
@@ -162,7 +162,7 @@ Define criteria before seeing results to prevent bias — inventing criteria aft
 |-----------|-----|-----|-----|
 | Correctness | All tests pass, no race conditions | Some failures | Broken |
 | Error Handling | Comprehensive, production-ready | Adequate | None |
-| Idioms | Exemplary for the language | Acceptable | Anti-patterns |
+| Idioms | Exemplary for the language | Acceptable | Failure modes |
 | Documentation | Thorough | Adequate | None |
 | Testing | Comprehensive coverage | Basic | Minimal |
 

--- a/skills/meta/agent-comparison/references/grading-rubric.md
+++ b/skills/meta/agent-comparison/references/grading-rubric.md
@@ -32,7 +32,7 @@ Score each agent's output independently on each criterion.
 | 4/5 | Standard: follows conventions, occasional non-idiomatic choices |
 | 3/5 | Acceptable: generally readable, some non-idiomatic patterns |
 | 2/5 | Non-idiomatic: transliterated from another language style |
-| 1/5 | Anti-patterns: fundamentally wrong patterns for the language |
+| 1/5 | Failure modes: fundamentally wrong patterns for the language |
 
 ### Criterion 4: Documentation (1-5)
 

--- a/skills/meta/agent-evaluation/SKILL.md
+++ b/skills/meta/agent-evaluation/SKILL.md
@@ -64,7 +64,7 @@ ls -la skills/{name}/
 
 Score every rubric category — never skip a category even if it "looks fine." Parse each required field explicitly rather than eyeballing YAML. Record PASS/FAIL with the line number for each check.
 
-Run `score-component.py` to get deterministic PASS/FAIL for all structural checks. The script implements the full ADR-031 rubric (frontmatter, operator context, error handling, referenced files, anti-patterns) and outputs per-check results with line references. Do not re-implement these checks inline — read the JSON output and move directly to scoring.
+Run `score-component.py` to get deterministic PASS/FAIL for all structural checks. The script implements the full ADR-031 rubric (frontmatter, operator context, error handling, referenced files, failure modes) and outputs per-check results with line references. Do not re-implement these checks inline — read the JSON output and move directly to scoring.
 
 ```bash
 # Deterministic structural checks via score-component.py
@@ -79,7 +79,7 @@ The JSON output includes `results[0].checks` (per-check status, earned_points, m
 - YAML frontmatter fields
 - Operator Context section presence
 - Error Handling section presence
-- Anti-Patterns section presence
+- Failure modes section presence
 - Referenced file existence
 - Inline constraint presence
 
@@ -101,7 +101,7 @@ The JSON output includes `results[0].checks` (per-check status, earned_points, m
 | Error Handling | 10 | Section present with documented errors |
 | Examples (agents) / References (skills) | 10 | 3+ examples or 2+ reference files |
 | CAN/CANNOT | 5 | Both sections present with concrete items |
-| Anti-Patterns | 5 | 3-5 domain-specific patterns with 3-part structure |
+| Failure Modes | 5 | 3-5 domain-specific patterns with 3-part structure |
 
 **Integration Scoring** (10 points):
 

--- a/skills/meta/agent-evaluation/references/scoring-rubric.md
+++ b/skills/meta/agent-evaluation/references/scoring-rubric.md
@@ -113,7 +113,7 @@ Detailed scoring criteria for evaluating Claude Code agents and skills against v
 - Patterns lack the required 3-part structure
 
 **No Credit (0 points)**:
-- No anti-patterns section
+- No failure modes section
 
 ## Integration (10 points)
 

--- a/skills/meta/auto-dream/SKILL.md
+++ b/skills/meta/auto-dream/SKILL.md
@@ -66,7 +66,7 @@ For cron invocation: the dream prompt is passed directly to `claude -p` and runs
 2. **ANALYZE** — Identify stale, duplicate, conflicting memories and cross-session patterns. Write analysis to `~/.claude/state/dream-analysis-{date}.md`.
 3. **CONSOLIDATE** — Apply consolidation actions (max 5 changes). Archive stale/merged files, update MEMORY.md atomically.
 4. **SYNTHESIZE** — Create insight memories from cross-session patterns (max 2 new memories per cycle).
-5. **GRADUATE** — Promote mature learning DB entries (confidence >= 0.9, 3+ observations) into agent/skill files as permanent anti-patterns. Commits on `dream/graduate-YYYY-MM-DD` branch for human review. Max 3 per cycle. (ADR-159)
+5. **GRADUATE** — Promote mature learning DB entries (confidence >= 0.9, 3+ observations) into agent/skill files as permanent failure modes. Commits on `dream/graduate-YYYY-MM-DD` branch for human review. Max 3 per cycle. (ADR-159)
 6. **SELECT** — Build injection-ready payload for session start. Write to `~/.claude/state/dream-injection-{project-hash}.md`.
 7. **REPORT** — Write dream summary to `~/.claude/state/last-dream.md`.
 

--- a/skills/meta/auto-dream/references/concurrency.md
+++ b/skills/meta/auto-dream/references/concurrency.md
@@ -146,7 +146,7 @@ grep -rn 'flock' scripts/ | grep -v '\-n\b'
 ```
 
 **Signal**:
-<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing anti-pattern entry -->
+<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing failure mode entry -->
 ```bash
 # Blocking flock — waits indefinitely for the lock
 flock /tmp/auto-dream.lock claude -p "..."
@@ -209,7 +209,7 @@ grep -n 'git stash' skills/meta/auto-dream/dream-prompt.md
 ```
 
 **Signal**:
-<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing anti-pattern entry -->
+<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing failure mode entry -->
 ```bash
 # Switches branch without checking for dirty working tree
 git checkout -b "dream/graduate-2026-04-16" main
@@ -235,7 +235,7 @@ grep -rn 'sqlite3.connect' hooks/lib/ | head -20
 ```
 
 **Signal**:
-<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing anti-pattern entry -->
+<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing failure mode entry -->
 ```bash
 # No timeout — fails immediately on contention
 sqlite3 "${DREAM_LEARNING_DB}" "SELECT count(*) FROM sessions;"

--- a/skills/meta/auto-dream/references/dream-cycle-testing.md
+++ b/skills/meta/auto-dream/references/dream-cycle-testing.md
@@ -167,7 +167,7 @@ grep -i 'sqlite\|database\|learning.db\|failed' ~/.claude/state/last-dream.md | 
 ```
 
 **Signal**:
-<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing anti-pattern entry -->
+<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing failure mode entry -->
 ```
 ## Dream Report: 2026-04-16
 

--- a/skills/meta/auto-dream/references/headless-cron-patterns.md
+++ b/skills/meta/auto-dream/references/headless-cron-patterns.md
@@ -180,7 +180,7 @@ rg 'claude' scripts/ --type sh -l | xargs grep -L 'max-budget-usd'
 ```
 
 **Signal**:
-<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing anti-pattern entry -->
+<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing failure mode entry -->
 ```bash
 claude --permission-mode auto --no-session-persistence -p "${LARGE_PROMPT}"
 # No --max-budget-usd: a prompt bug or unexpectedly large context can cost $50+

--- a/skills/meta/auto-dream/references/logging-patterns.md
+++ b/skills/meta/auto-dream/references/logging-patterns.md
@@ -131,7 +131,7 @@ ls -t cron-logs/auto-dream/run-*.log | head -1
 ```
 
 **Signal**:
-<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing anti-pattern entry -->
+<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing failure mode entry -->
 ```bash
 head -1 ~/.claude/state/last-dream.md
 # Dream Report: 2026-04-15   ← yesterday's date, today's cron supposedly ran
@@ -159,7 +159,7 @@ grep 'success\|complete\|done' "$(ls -t cron-logs/auto-dream/run-*.log | head -1
 ```
 
 **Signal**:
-<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing anti-pattern entry -->
+<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing failure mode entry -->
 ```bash
 # Cron log says "SCAN complete" but CONSOLIDATE crashed halfway through
 grep 'complete' run-2026-04-16-020712.log
@@ -194,7 +194,7 @@ ls cron-logs/auto-dream/run-*.log | wc -l
 ```
 
 **Signal**:
-<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing anti-pattern entry -->
+<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing failure mode entry -->
 ```bash
 # Wrapper script creates new log each run but never deletes old ones
 RUN_LOG="${LOG_DIR}/run-$(date +%Y-%m-%d-%H%M%S).log"

--- a/skills/meta/auto-dream/references/memory-file-operations.md
+++ b/skills/meta/auto-dream/references/memory-file-operations.md
@@ -166,7 +166,7 @@ rg 'write.*MEMORY\.md(?!\.tmp)' --type py
 ```
 
 **Signal**:
-<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing anti-pattern entry -->
+<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing failure mode entry -->
 ```python
 with open("memory/MEMORY.md", "w") as f:
     f.write(new_index_content)
@@ -196,7 +196,7 @@ rg 'os\.remove|os\.unlink|Path.*unlink' --type py | grep -i 'memory'
 ```
 
 **Signal**:
-<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing anti-pattern entry -->
+<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing failure mode entry -->
 ```bash
 rm memory/stale-project-memory.md  # Unrecoverable if assessment was wrong
 ```
@@ -223,7 +223,7 @@ grep -rn 'conflict\|contradict' scripts/ | grep -v 'flag\|report\|human'
 ```
 
 **Signal**:
-<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing anti-pattern entry -->
+<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing failure mode entry -->
 ```
 Memory A: "Use ruff for Python linting"
 Memory B: "Use flake8 for Python linting"
@@ -247,7 +247,7 @@ wc -l memory/MEMORY.md
 ```
 
 **Signal**:
-<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing anti-pattern entry -->
+<!-- no-pair-required: this is the detection sub-block inside a code fence; Do instead appears in the enclosing failure mode entry -->
 An index that grows unbounded as new memories are added without old ones being consolidated or archived, eventually exceeding the 200-line truncation limit.
 
 **Why this matters**: The session-start hook injects MEMORY.md contents. Context injection is truncated at 200 lines — memories after that line are silently excluded from session context, defeating the purpose of writing them.

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -410,7 +410,7 @@ python3 ~/.claude/scripts/learning-db.py learn --skill go-patterns "insight"
 python3 ~/.claude/scripts/learning-db.py learn --agent golang-general-engineer "insight"
 ```
 
-**Immediate graduation for review findings** (MANDATORY): Issue found + fixed in same PR → (1) Record scoped, (2) Boost to 1.0, (3) Embed into anti-patterns, (4) Graduate, (5) Stage in same PR.
+**Immediate graduation for review findings** (MANDATORY): Issue found + fixed in same PR → (1) Record scoped, (2) Boost to 1.0, (3) Embed into failure modes, (4) Graduate, (5) Stage in same PR.
 
 **Gate**: Record at least one learning AND one routing outcome for Simple+ tasks. Review findings get immediate graduation.
 

--- a/skills/meta/do/references/progressive-depth.md
+++ b/skills/meta/do/references/progressive-depth.md
@@ -97,7 +97,7 @@ The key change: **Simple and Medium tasks start at Level 1 when the scope is amb
 
 ## Patterns to Detect and Fix
 
-| Anti-pattern | Why it fails | Correct behavior |
+| Failure Mode | Why it fails | Correct behavior |
 |--------------|-------------|------------------|
 | Starting at Level 2 "just to be safe" | Defeats the purpose; burns tokens on methodology the task doesn't need | Start at Level 1, let evidence drive escalation |
 | Escalating without evidence | Phantom complexity; the agent imagines problems that don't exist | Must cite a concrete escalation signal |

--- a/skills/meta/explanation-traces/SKILL.md
+++ b/skills/meta/explanation-traces/SKILL.md
@@ -253,5 +253,5 @@ Result: Specific gate failure reason from the trace, with what was expected vs. 
 
 ### Reference Files
 - `references/trace-schema.md`: JSON schema for session-trace.json with field descriptions and example entries
-- `references/preferred-patterns.md`: Anti-pattern catalog for trace producers (hooks) and consumers (skill behavior) with detection commands
+- `references/preferred-patterns.md`: Failure mode catalog for trace producers (hooks) and consumers (skill behavior) with detection commands
 - `references/error-handling.md`: Error-fix mappings for all error states — missing file, malformed JSON, empty decisions, invalid fields

--- a/skills/meta/explanation-traces/references/preferred-patterns.md
+++ b/skills/meta/explanation-traces/references/preferred-patterns.md
@@ -1,6 +1,6 @@
 # Explanation Traces — Patterns to Fix
 
-Anti-patterns for both trace producers (hooks that write session-trace.json) and trace
+Failure modes for both trace producers (hooks that write session-trace.json) and trace
 consumers (this skill reading it). Organized by who makes the mistake.
 
 ---

--- a/skills/meta/html-artifact/SKILL.md
+++ b/skills/meta/html-artifact/SKILL.md
@@ -119,7 +119,7 @@ Select components based on shape needs:
 **Step B -- Load reference files (principles + guidance):**
 
 **Always load:**
-1. `references/design-system.md` -- Theme selection, token architecture, accessibility checklist, SVG conventions, anti-patterns
+1. `references/design-system.md` -- Theme selection, token architecture, accessibility checklist, SVG conventions, failure modes
 2. `references/interaction-patterns.md` -- Component descriptions, when-to-use guidance, accessibility rules, composition guide
 
 **Load per detected shape:**
@@ -130,7 +130,7 @@ Select components based on shape needs:
 | code-review | `references/shape-code-review.md` | Severity system, interaction patterns, section ordering |
 | prototype | `references/shape-design-prototype.md` | Control types, export requirements, layout patterns |
 | report | `references/shape-report-research.md` | Section ordering, TL;DR placement, metric patterns |
-| editor | `references/shape-custom-editor.md` | Editor types, export bar rules, anti-patterns |
+| editor | `references/shape-custom-editor.md` | Editor types, export bar rules, failure modes |
 | data-viz | `references/shape-data-visualization.md` | Chart types, coordinate system, color scales |
 | diagram | `references/shape-diagram-illustration.md` | SVG construction rules, diagram types, interaction patterns |
 | deck | `references/shape-slide-deck.md` | Slide types, navigation, print styles |
@@ -275,13 +275,13 @@ Constraint: Detect headless/SSH environments before offering browser open.
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| Any html-artifact invocation | `references/design-system.md` | Theme selection, token architecture, accessibility, anti-patterns |
+| Any html-artifact invocation | `references/design-system.md` | Theme selection, token architecture, accessibility, failure modes |
 | Any html-artifact invocation | `references/interaction-patterns.md` | Component descriptions, when-to-use, accessibility rules |
 | Shape = spec | `references/shape-spec-exploration.md` | Layout descriptions, composition guide, common mistakes |
 | Shape = code-review | `references/shape-code-review.md` | Severity system, interaction patterns, section ordering |
 | Shape = prototype | `references/shape-design-prototype.md` | Control types, export requirements, layout patterns |
 | Shape = report | `references/shape-report-research.md` | Section ordering, TL;DR placement, metric patterns |
-| Shape = editor | `references/shape-custom-editor.md` | Editor types, export bar rules, anti-patterns |
+| Shape = editor | `references/shape-custom-editor.md` | Editor types, export bar rules, failure modes |
 | Shape = data-viz | `references/shape-data-visualization.md` | Chart types, coordinate system, color scales |
 | Shape = diagram | `references/shape-diagram-illustration.md` | SVG construction rules, diagram types, interaction patterns |
 | Shape = deck | `references/shape-slide-deck.md` | Slide types, navigation, print styles |
@@ -300,13 +300,13 @@ This skill uses:
 
 ## Reference Files
 
-- `references/design-system.md`: Theme selection, token architecture, accessibility checklist, SVG conventions, anti-patterns
+- `references/design-system.md`: Theme selection, token architecture, accessibility checklist, SVG conventions, failure modes
 - `references/interaction-patterns.md`: Component descriptions, when-to-use guidance, accessibility rules, composition guide
 - `references/shape-spec-exploration.md`: Spec shape -- layout, composition guide, common mistakes
 - `references/shape-code-review.md`: Code review shape -- severity system, interaction patterns, section ordering
 - `references/shape-design-prototype.md`: Prototype shape -- control types, export requirements, layout patterns
 - `references/shape-report-research.md`: Report shape -- section ordering, TL;DR placement, metric patterns
-- `references/shape-custom-editor.md`: Editor shape -- editor types, export bar rules, anti-patterns
+- `references/shape-custom-editor.md`: Editor shape -- editor types, export bar rules, failure modes
 - `references/shape-data-visualization.md`: Data viz shape -- chart types, coordinate system, color scales
 - `references/shape-diagram-illustration.md`: Diagram shape -- SVG construction rules, diagram types, interaction patterns
 - `references/shape-slide-deck.md`: Deck shape -- slide types, navigation, print styles

--- a/skills/meta/reference-enrichment/SKILL.md
+++ b/skills/meta/reference-enrichment/SKILL.md
@@ -127,7 +127,7 @@ report and stop — over-generating creates noise, not signal.
 For each identified gap:
 1. Read existing Level 3 reference files in this repo as exemplars — golang-general-engineer's
    references/ is the benchmark: version-specific patterns, grep commands, error-fix mappings
-2. Identify: version-specific patterns (what changed in version X.Y), common anti-patterns with
+2. Identify: version-specific patterns (what changed in version X.Y), common failure modes with
    detection commands (`grep -rn "pattern" --include="*.ext"`), error-fix mappings
    (error message → root cause → fix), project-specific conventions visible in the codebase
 
@@ -148,13 +148,13 @@ For each gap, create one reference file following `references/reference-file-tem
 - One file per major sub-domain (not one monolithic file) because focused files are faster to
   load and easier to update as language versions change
 - Max 500 lines per file (CLAUDE.md standard) — split into sub-topics if content exceeds this
-- Include: overview paragraph, pattern table with version ranges, anti-pattern table with
+- Include: overview paragraph, pattern table with version ranges, failure mode table with
   detection commands, error-fix mappings where applicable
 - Match the tone of existing Level 3 references: direct, concrete, no hedging
 
-**Do-pairing rule (mandatory):** Every anti-pattern block written during this phase must include
+**Do-pairing rule (mandatory):** Every failure mode block written during this phase must include
 a "Do instead" counterpart. If the retro learning or research does not carry enough information
-to write a concrete positive counterpart, omit the anti-pattern entirely rather than shipping it
+to write a concrete positive counterpart, omit the failure mode entirely rather than shipping it
 without the paired "Do instead". A bare negative block encodes no actionable knowledge and will
 fail structural validation. If a prohibition is a genuine absolute with no correct alternative,
 annotate it with `<!-- no-pair-required: reason -->` inline before the block.
@@ -187,7 +187,7 @@ generic — return to Phase 2 for the weak sub-domain.
 **Tier 2 (LLM self-assessment):**
 Read each generated file and apply the rubric from `references/quality-rubric.md`. Ask: would
 a reviewer using only this file produce Level 3 quality output? Concrete test: pick one
-anti-pattern from the file — does it include a grep command to detect it?
+failure mode from the file — does it include a grep command to detect it?
 
 **Gate**: Both tiers pass. If Tier 2 fails for a specific sub-domain, loop back to Phase 2 for
 that gap only (not all gaps). Maximum 2 loops per gap before flagging for manual enrichment.

--- a/skills/meta/reference-enrichment/references/quality-rubric.md
+++ b/skills/meta/reference-enrichment/references/quality-rubric.md
@@ -161,13 +161,13 @@ at least 3 of 5:
 
 To check if a reference file is Level 3, answer these three questions:
 
-1. **Can you detect it?** Pick the most important anti-pattern in the file. Is there a grep
+1. **Can you detect it?** Pick the most important failure mode in the file. Is there a grep
    command that would find it in a real codebase? If no: Level 1.
 
 2. **Is it version-aware?** Does the file mention at least one specific version number where
    behavior changed? If no: likely Level 1-2.
 
-3. **Does it fix, not just flag?** For each anti-pattern, is the correct replacement shown
+3. **Does it fix, not just flag?** For each failure mode, is the correct replacement shown
    in a code block? If no: Level 2 at best.
 
 All three "yes": Level 3. Two "yes": Level 2. Fewer: Level 1.

--- a/skills/meta/reference-enrichment/references/reference-file-template.md
+++ b/skills/meta/reference-enrichment/references/reference-file-template.md
@@ -151,9 +151,9 @@ rg '{{pattern2}}' --type {{lang}}
 
 ## Template Usage Notes
 
-**Minimum for Level 2**: Overview + one correct pattern with code block + one anti-pattern entry.
+**Minimum for Level 2**: Overview + one correct pattern with code block + one failure mode entry.
 
-**Minimum for Level 3**: All of the above + at least one detection command per anti-pattern +
+**Minimum for Level 3**: All of the above + at least one detection command per failure mode +
 error-fix mappings table (if the domain has common errors) + version notes (if API changed).
 
 **Line count target**: 80-200 lines for a focused sub-domain. If you need more than 300 lines,

--- a/skills/meta/retro/SKILL.md
+++ b/skills/meta/retro/SKILL.md
@@ -145,7 +145,7 @@ python3 ~/.claude/scripts/learning-db.py query --category design --category gotc
 For each candidate, the LLM:
 - Reads the learning value
 - Searches the repo for the target file (grep for related keywords)
-- Determines edit type: add anti-pattern, add to operator context, add warning, or "not ready / keep injecting"
+- Determines edit type: add failure mode, add to operator context, add warning, or "not ready / keep injecting"
 - Checks if the target already contains equivalent guidance (use Grep to verify before proposing)
 
 | Question | Pass | Fail |

--- a/skills/meta/skill-creator/references/complexity-tiers.md
+++ b/skills/meta/skill-creator/references/complexity-tiers.md
@@ -36,7 +36,7 @@ Real skills from the Claude Code ecosystem categorized by complexity tier with r
 **Why Medium**:
 - Multi-phase workflow with gates
 - Moderate error handling (7 cases)
-- Some anti-patterns (4)
+- Some failure modes (4)
 - No references/ needed yet
 
 **Structure**:

--- a/skills/meta/skill-creator/references/domain-research-targets.md
+++ b/skills/meta/skill-creator/references/domain-research-targets.md
@@ -25,7 +25,7 @@ Format per entry:
 - [Go wiki: CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments) —
   community-maintained list of Go code review feedback; extract as checklist
 - [Go wiki: CommonMistakes](https://github.com/golang/go/wiki/CommonMistakes) —
-  extract directly as anti-pattern catalog
+  extract directly as failure mode catalog
 
 **Secondary sources**
 - [Go Proverbs](https://go-proverbs.github.io) (Rob Pike) — memorable heuristics;
@@ -40,7 +40,7 @@ Format per entry:
 - Checklist: idiomatic Go review (interface size, error wrapping, goroutine hygiene)
 - Before/after: common rewrites (bare error returns → wrapped; goroutine leak → context cancel)
 - Decision tree: when to use channels vs mutexes, when to define an interface vs use concrete type
-- Anti-pattern catalog: goroutine leaks, error shadowing, interface pollution, unnecessary abstractions
+- Failure mode catalog: goroutine leaks, error shadowing, interface pollution, unnecessary abstractions
 
 ---
 
@@ -82,9 +82,9 @@ existing sapcc references
 
 **Extract**
 - Checklist: pre-commit quality gate (ruff, mypy, bandit checks that matter most)
-- Before/after: common Python anti-patterns with idiomatic rewrites
+- Before/after: common Python failure modes with idiomatic rewrites
 - Decision tree: when to use dataclass vs TypedDict vs NamedTuple vs attrs
-- Anti-pattern catalog: mutable default arguments, broad except, type: ignore abuse
+- Failure mode catalog: mutable default arguments, broad except, type: ignore abuse
 
 ---
 
@@ -109,7 +109,7 @@ existing sapcc references
 - Checklist: security hardening (RBAC, network policies, pod security, secret management)
 - Decision tree: debugging pod failures (CrashLoopBackOff → ImagePullBackOff → OOMKilled flow)
 - Before/after: insecure manifest → hardened manifest examples
-- Anti-pattern catalog: over-privileged service accounts, missing resource limits, secret in env vars
+- Failure mode catalog: over-privileged service accounts, missing resource limits, secret in env vars
 
 ---
 
@@ -125,13 +125,13 @@ existing sapcc references
 **Secondary sources**
 - Matt Pocock (total-typescript.com) — extract: advanced type patterns with before/after,
   common TS mistakes with fixes
-- [TypeScript Deep Dive](https://basarat.gitbook.io/typescript/) — extract anti-patterns section
+- [TypeScript Deep Dive](https://basarat.gitbook.io/typescript/) — extract failure modes section
 
 **Extract**
 - Checklist: strict mode implications and what each flag catches
 - Before/after: `any` abuse → proper generics, type assertion abuse → type guards
 - Decision tree: when to use `interface` vs `type`, `unknown` vs `any`, generics vs overloads
-- Anti-pattern catalog: type assertions without guards, overly broad union types, enum misuse
+- Failure mode catalog: type assertions without guards, overly broad union types, enum misuse
 
 ---
 
@@ -151,7 +151,7 @@ existing sapcc references
 
 **Extract**
 - Decision tree: server component vs client component selection criteria
-- Before/after: common React anti-patterns (prop drilling → context, useEffect abuse → derived state)
+- Before/after: common React failure modes (prop drilling → context, useEffect abuse → derived state)
 - Checklist: performance review (unnecessary re-renders, missing keys, large bundle items)
 - Pattern catalog: compound components, render props, custom hooks with clear interfaces
 
@@ -175,7 +175,7 @@ existing sapcc references
 
 **Extract**
 - Checklist: test quality review (one assertion focus, arrange-act-assert, test isolation)
-- Anti-pattern catalog with names: Mystery Guest, Eager Test, Fragile Test, Slow Test
+- Failure mode catalog with names: Mystery Guest, Eager Test, Fragile Test, Slow Test
 - Decision tree: unit vs integration vs E2E for a given scenario
 - Before/after: brittle selector → resilient locator, over-mocked test → integrated test
 
@@ -199,7 +199,7 @@ existing sapcc references
 - Checklist: threat modeling prompts (per STRIDE category)
 - Before/after: vulnerable code → remediated code for each OWASP Top 10 item
 - Decision tree: severity classification (Critical/High/Medium/Low with criteria)
-- Anti-pattern catalog: hard-coded secrets, overly permissive CORS, missing auth checks
+- Failure mode catalog: hard-coded secrets, overly permissive CORS, missing auth checks
 
 ---
 
@@ -220,7 +220,7 @@ existing sapcc references
 - Checklist: dashboard quality (variable usage, panel alignment, datasource scoping)
 - Before/after: raw PromQL → optimized PromQL with recording rules
 - Decision tree: when to use global vs project vs dashboard scope for variables
-- Anti-pattern catalog: hardcoded datasource names, missing variable fallbacks, over-complex queries
+- Failure mode catalog: hardcoded datasource names, missing variable fallbacks, over-complex queries
 
 ---
 
@@ -245,7 +245,7 @@ Mine the validator's false-positive/false-negative log if one exists.
 
 **Secondary sources**
 - Michaela Greiler (michaelagreiler.com) — extract: research-backed review effectiveness
-  checklist, anti-patterns in reviewer behavior
+  checklist, failure modes in reviewer behavior
 - SmartBear Code Review research papers — extract: optimal review size, defect density
   findings as concrete thresholds
 
@@ -253,7 +253,7 @@ Mine the validator's false-positive/false-negative log if one exists.
 - Checklist: what to check at each review tier (security, logic, style, naming)
 - Before/after: vague review comment → actionable comment with label
 - Decision tree: block vs request-changes vs comment vs approve criteria
-- Anti-pattern catalog: rubber-stamping, nitpick overload, missing context in comments
+- Failure mode catalog: rubber-stamping, nitpick overload, missing context in comments
 
 ---
 
@@ -277,5 +277,5 @@ Mine the validator's false-positive/false-negative log if one exists.
 - Checklist: pre-PR commit hygiene (message format, squash policy, branch naming)
 - Before/after: bad commit message → conventional commit message
 - Decision tree: squash vs merge vs rebase for different PR types
-- Anti-pattern catalog: fixup commits left in history, force-push to shared branch,
+- Failure mode catalog: fixup commits left in history, force-push to shared branch,
   PR too large to review

--- a/skills/meta/skill-creator/references/enrichment-workflow.md
+++ b/skills/meta/skill-creator/references/enrichment-workflow.md
@@ -70,7 +70,7 @@ For each source in the domain table:
 
 *Official docs*: Read methodology sections, not API reference. Extract:
 - Named patterns with rationale
-- Anti-patterns the docs explicitly warn against
+- Failure modes the docs explicitly warn against
 - Decision trees or "when to use X vs Y" guidance
 
 *Secondary sources* (blogs, talks, books): Extract:
@@ -269,7 +269,7 @@ Focus: what the domain's authoritative sources say to do. Patterns and guideline
 from official documentation, language specs, or framework guides. This catches the
 most common gap: missing canonical patterns.
 
-**Iteration 2 — common mistakes + anti-patterns**
+**Iteration 2 — common mistakes + failure modes**
 Focus: what practitioners actually get wrong. PR review comments, SO questions,
 post-mortems, "gotchas" sections in docs. This adds the flip side: what NOT to do
 and why. Models often produce safer output when they know the failure modes.

--- a/skills/meta/skill-creator/references/preferred-patterns.md
+++ b/skills/meta/skill-creator/references/preferred-patterns.md
@@ -110,7 +110,7 @@ Size the skill's structure to its actual complexity. A simple cleanup workflow n
 Simple skill (pr-workflow cleanup) should have:
 - 4 phases with basic gates
 - 3-5 common errors inline
-- 2-3 anti-patterns inline
+- 2-3 failure modes inline
 - No references/ directory
 - 300-600 lines total
 

--- a/skills/meta/skill-creator/references/progressive-disclosure.md
+++ b/skills/meta/skill-creator/references/progressive-disclosure.md
@@ -72,7 +72,7 @@ example collections) and move them to `references/`.
   agent prompts in `comprehensive-review`)
 - Report and output templates (e.g., the structured markdown template for
   `sapcc-review` findings)
-- Domain-specific pattern catalogs (e.g., Go anti-patterns with before/after
+- Domain-specific pattern catalogs (e.g., Go failure modes with before/after
   examples, common error patterns)
 - Validation criteria and scoring systems
 - Example collections (realistic input/output pairs, prompt examples)

--- a/skills/meta/skill-creator/references/skill-template.md
+++ b/skills/meta/skill-creator/references/skill-template.md
@@ -333,11 +333,11 @@ Additional for this skill:
 
 ## Preferred Patterns Section (Medium+)
 
-For skills with significant complexity, include 3-6 anti-patterns.
+For skills with significant complexity, include 3-6 failure modes.
 
 **Pairing rule (mandatory):** Every pattern block must include a "Do instead" counterpart that shows the correct approach. A bare negative ("don't do X") encodes no actionable knowledge. The positive counterpart is the actual learning. If a genuine absolute prohibition has no correct alternative (e.g., "never commit secrets"), annotate it with `<!-- no-pair-required: absolute prohibition, no safe alternative -->` to pass structural validation.
 
-Validation gate: `python3 scripts/validate-references.py --check-do-framing` rejects anti-pattern blocks without a paired "Do instead" or `<!-- no-pair-required: ... -->` annotation.
+Validation gate: `python3 scripts/validate-references.py --check-do-framing` rejects failure mode blocks without a paired "Do instead" or `<!-- no-pair-required: ... -->` annotation.
 
 ```markdown
 ### Pattern 1: [Pattern Name]

--- a/skills/meta/skill-eval/references/bake-off-methodology.md
+++ b/skills/meta/skill-eval/references/bake-off-methodology.md
@@ -51,7 +51,7 @@ Criteria depend on the artifact type. For voice profiles, the canonical 11-crite
 3. Mental-model exclusivity
 4. Phrase fingerprint authenticity
 5. Calibration examples
-6. Anti-pattern coverage
+6. Failure mode coverage
 7. Joy-check axis
 8. Operational utility (cold pickup)
 9. Ethical / source discipline
@@ -171,7 +171,7 @@ The output is a short, concrete fold-list. Each fold names the file to change, t
 | 3 | Mental-model exclusivity | 8 | 6 | A |
 | 4 | Phrase fingerprint authenticity | 9 | 5 | A |
 | 5 | Calibration examples | 9 | 6 | A |
-| 6 | Anti-pattern coverage | 9 | 5 | A |
+| 6 | Failure mode coverage | 9 | 5 | A |
 | 7 | Joy-check axis | 8 | 8 | tie |
 | 8 | Operational utility (cold pickup) | 9 | 7 | A |
 | 9 | Ethical / source discipline | 5 | 9 | B |

--- a/skills/meta/skill-eval/references/self-improve-loop.md
+++ b/skills/meta/skill-eval/references/self-improve-loop.md
@@ -90,7 +90,7 @@ Read the target skill's SKILL.md end-to-end. For each of these dimensions, note 
 |-----------|-----------------|
 | Phase ordering | Would reordering phases improve logical flow? Does a later phase depend on context established too late? |
 | Constraint placement | Are constraints inline at the point of failure, or buried in a preamble 200 lines away? |
-| Anti-pattern specificity | Are anti-patterns concrete with before/after examples, or vague warnings? |
+| Failure mode specificity | Are failure modes concrete with before/after examples, or vague warnings? |
 | Gate strictness | Are gates too loose (letting bad work through) or too strict (blocking valid work)? |
 | Description accuracy | Does the frontmatter description trigger for the right queries and reject the wrong ones? |
 | Reference loading | Are references loaded at the right phase, or too early (wasting routing-time tokens) or too late (missing context when needed)? |
@@ -305,7 +305,7 @@ python3 ~/.claude/scripts/learning-db.py learn \
 
 ## Patterns to Detect and Fix
 
-| Anti-Pattern | Why it's wrong | What to do instead |
+| Failure Mode | Why it's wrong | What to do instead |
 |-------------|---------------|-------------------|
 | Changing multiple things per variant | Can't attribute improvement to any single change | One hypothesis, one change, one variant |
 | Testing without baseline | No basis for comparison; can't calculate win rate | Always run Phase 1 first |

--- a/skills/meta/toolkit-evolution/SKILL.md
+++ b/skills/meta/toolkit-evolution/SKILL.md
@@ -139,7 +139,7 @@ Output a numbered list of 5-10 improvement opportunities. Each entry must includ
 **Step 1: Generate proposals**
 
 For each opportunity from Phase 1, propose 1-2 concrete solutions. Each proposal must be actionable:
-- "Add anti-pattern X to agent Y's prompt" (not "improve agent Y")
+- "Add failure mode X to agent Y's prompt" (not "improve agent Y")
 - "Create a reference file for Z in skill W" (not "enhance skill W")
 - "Modify Phase 3 of skill V to include check for Q" (not "make skill V better")
 
@@ -285,7 +285,7 @@ Write the dated report to `evolution-reports/evolution-report-{YYYY-MM-DD}.md` u
 | Running Phase 1 DIAGNOSE (Steps 1-4c commands needed) | `references/diagnose-scripts.md` |
 | Phase 0 perspective agent table, proposal format | `references/evolve-preferred-patterns.md` |
 | Phase 3 inline critique fallback (multi-persona not available) | `references/evolve-preferred-patterns.md` |
-| Anti-patterns, error handling, cost estimate, cron scheduling | `references/evolve-preferred-patterns.md` |
+| Failure modes, error handling, cost estimate, cron scheduling | `references/evolve-preferred-patterns.md` |
 | Running Phase 6 EVOLVE (PR template, merge, cleanup, learning DB commands) | `references/evolve-scripts.md` |
 | Writing or reading the evolution report | `references/evolution-report-template.md` |
 
@@ -296,7 +296,7 @@ Write the dated report to `evolution-reports/evolution-report-{YYYY-MM-DD}.md` u
 - `references/evolution-report-template.md` -- Template for the evolution report
 - `references/diagnose-scripts.md` -- Phase 0 and Phase 1 bash/Python commands
 - `references/evolve-scripts.md` -- Phase 6 PR, merge, cleanup, and learning DB commands
-- `references/evolve-preferred-patterns.md` -- Anti-patterns, error handling, cost, critique fallback, scheduling
+- `references/evolve-preferred-patterns.md` -- Failure modes, error handling, cost, critique fallback, scheduling
 - `skills/meta/auto-dream/SKILL.md` -- Nightly sibling: memory consolidation and learning graduation
 - `skills/meta/skill-eval/SKILL.md` -- Skill testing and benchmarking
 - `skills/research/multi-persona-critique/SKILL.md` -- Multi-persona evaluation (may not exist yet; inline fallback in references)

--- a/skills/meta/toolkit-evolution/references/evolve-preferred-patterns.md
+++ b/skills/meta/toolkit-evolution/references/evolve-preferred-patterns.md
@@ -1,6 +1,6 @@
 # Toolkit Evolution — Patterns, Errors, and Cost
 
-Reference for Phase 3 CRITIQUE (fallback), anti-patterns, error handling, and cost estimates.
+Reference for Phase 3 CRITIQUE (fallback), failure modes, error handling, and cost estimates.
 
 ---
 

--- a/skills/process/adr-consultation/SKILL.md
+++ b/skills/process/adr-consultation/SKILL.md
@@ -216,5 +216,5 @@ The consultation directory is auto-created by Phase 1 (`mkdir -p adr/{adr-name}`
 - [reviewer-perspectives](../../agents/reviewer-perspectives.md) -- Perspectives agent (contrarian, user-advocate, meta-process lenses)
 - `references/agent-prompts.md` -- Full prompt templates for all 3 standard agents + complex mode
 - `references/consultation-patterns.md` -- Correct patterns, artifact templates, verdict display formats
-- `references/consultation-preferred-patterns.md` -- Anti-patterns with detection commands
+- `references/consultation-preferred-patterns.md` -- Failure modes with detection commands
 - `references/error-handling.md` -- Error recovery by phase

--- a/skills/process/adr-consultation/references/consultation-patterns.md
+++ b/skills/process/adr-consultation/references/consultation-patterns.md
@@ -131,7 +131,7 @@ Document orchestrator-level concerns in `concerns.md` under a separate section:
 | `ls adr/{name}/ → No such file` | Consultation directory not created before dispatch | Run `mkdir -p adr/{name}` before dispatching agents |
 | Agent file missing after dispatch | Agent timed out or failed to write | Re-run failed agent individually; check for path typos in prompt |
 | `cat .adr-session.json → No such file` | No active ADR session; user invoked without specifying ADR | Run `ls adr/*.md` and ask user to specify which ADR |
-| Synthesis shows PROCEED but concerns.md has `blocking` | Rationalization anti-pattern | Override to BLOCKED; address concern in ADR; re-run |
+| Synthesis shows PROCEED but concerns.md has `blocking` | Rationalization failure mode | Override to BLOCKED; address concern in ADR; re-run |
 | Two agents raised identical concern under different names | Cross-cutting concern missed by individual agents | Consolidate in concerns.md as orchestrator-level; elevate severity |
 
 ---
@@ -275,6 +275,6 @@ Resolution states (update as concerns are addressed):
 
 ## See Also
 
-- `consultation-preferred-patterns.md` — ADR quality anti-patterns that reviewers should catch
+- `consultation-preferred-patterns.md` — ADR quality failure modes that reviewers should catch
 - `skills/review/parallel-code-review/SKILL.md` — Fan-out/fan-in pattern this skill adapts
 - `agents/reviewer-perspectives.md` — Perspectives agent (contrarian, user-advocate, meta-process lenses)

--- a/skills/process/adr-consultation/references/error-handling.md
+++ b/skills/process/adr-consultation/references/error-handling.md
@@ -212,7 +212,7 @@ grep "## Verdict:" adr/{name}/synthesis.md 2>/dev/null
 3. Re-run consultation from Phase 2
 
 Do not edit synthesis.md to say PROCEED while concerns.md still has unresolved blocking
-entries — that is the rationalization anti-pattern and defeats the gate.
+entries — that is the rationalization failure mode and defeats the gate.
 
 ---
 
@@ -253,5 +253,5 @@ concerns.md, add it to concerns.md with proper severity, then re-verify the verd
 
 ## See Also
 
-- `consultation-preferred-patterns.md` — Structural anti-patterns (sequential dispatch, context-only synthesis, rationalization)
+- `consultation-preferred-patterns.md` — Structural failure modes (sequential dispatch, context-only synthesis, rationalization)
 - `consultation-patterns.md` — Correct dispatch, synthesis, and verdict aggregation patterns

--- a/skills/process/planning/references/pre-plan.md
+++ b/skills/process/planning/references/pre-plan.md
@@ -130,7 +130,7 @@ Present all assumptions organized by confidence level (Confident first, Unclear 
 
 > Here's what I believe about this codebase based on reading [N] files. Please correct anything that's wrong. You only need to respond to items that are incorrect — silence means agreement.
 
-Make assumptions explicit so the user CAN correct you. The anti-pattern is assuming "the user will correct me if I'm wrong" while keeping assumptions silent — users cannot correct what they do not see.
+Make assumptions explicit so the user CAN correct you. The failure mode is assuming "the user will correct me if I'm wrong" while keeping assumptions silent — users cannot correct what they do not see.
 
 **Step 4: Process Corrections**
 

--- a/skills/process/pr-workflow/references/codex-review-cli-patterns.md
+++ b/skills/process/pr-workflow/references/codex-review-cli-patterns.md
@@ -189,7 +189,7 @@ sandbox; the bypass flag disables it entirely. Combining them errors.
 ---
 
 ## Detection Commands Reference
-<!-- no-pair-required: reference block of detection commands, not an anti-pattern description -->
+<!-- no-pair-required: reference block of detection commands, not an failure mode description -->
 
 ```bash
 # Verify codex is installed

--- a/skills/process/pr-workflow/references/codex-review-invocation.md
+++ b/skills/process/pr-workflow/references/codex-review-invocation.md
@@ -142,7 +142,7 @@ For every issue Codex raised, evaluate:
 |----------|--------|
 | Is this actually correct? | Read the relevant code yourself. Codex may have misread the logic, missed context from other files, or misunderstood the intent. |
 | Is this already handled elsewhere? | Check if the concern is addressed in code Codex didn't examine (e.g., middleware, error handling upstream). |
-| Does this apply to this project's conventions? | Check the project's CLAUDE.md or style guides. What's an anti-pattern generally may be the accepted convention here. |
+| Does this apply to this project's conventions? | Check the project's CLAUDE.md or style guides. What's an failure mode generally may be the accepted convention here. |
 | Is the severity right? | Codex may flag a style preference as critical, or miss that a "minor" issue is actually a data-loss risk in this context. |
 
 **Step 3: Classify each finding.**

--- a/skills/process/pr-workflow/references/codex-review-preferred-patterns.md
+++ b/skills/process/pr-workflow/references/codex-review-preferred-patterns.md
@@ -1,7 +1,7 @@
 # Code Review Patterns for Verification
-<!-- no-pair-required: document introduction, not an individual anti-pattern block -->
+<!-- no-pair-required: document introduction, not an individual failure mode block -->
 
-> **Scope**: Common code anti-patterns to detect during review, with grep commands for codebase verification.
+> **Scope**: Common code failure modes to detect during review, with grep commands for codebase verification.
 > **Version range**: Language-specific version notes inline
 > **Generated**: 2026-04-16
 
@@ -10,7 +10,7 @@
 ## Overview
 
 Code review — whether by Codex, Claude, or a human — needs concrete patterns to look for.
-This file catalogs high-signal anti-patterns across Go, TypeScript/JavaScript, and Python.
+This file catalogs high-signal failure modes across Go, TypeScript/JavaScript, and Python.
 Detection commands let you verify findings in the actual codebase rather than relying on
 model interpretation alone.
 

--- a/skills/process/pr-workflow/references/codex-review.md
+++ b/skills/process/pr-workflow/references/codex-review.md
@@ -10,7 +10,7 @@ Load these files when the corresponding signals appear:
 |--------|------|
 | Constructing or debugging `codex exec` command; flag errors; mktemp issues; model errors | `${CLAUDE_SKILL_DIR}/references/codex-review-cli-patterns.md` |
 | Classifying findings; adjusting severity; filtering Codex output; writing the report | `${CLAUDE_SKILL_DIR}/references/codex-review-methodology.md` |
-| Looking up specific anti-patterns to verify; needs detection grep commands for Go/TS/Python | `${CLAUDE_SKILL_DIR}/references/codex-review-preferred-patterns.md` |
+| Looking up specific failure modes to verify; needs detection grep commands for Go/TS/Python | `${CLAUDE_SKILL_DIR}/references/codex-review-preferred-patterns.md` |
 | Executing Phase 2-4 (invoke, assess, report); error handling; what NOT to do | `${CLAUDE_SKILL_DIR}/references/codex-review-invocation.md` |
 
 Claude orchestrates the review: scoping what to review, constructing the prompt, invoking Codex in a read-only sandbox, then critically assessing the feedback before presenting it to the user.

--- a/skills/research/codebase-analyzer/references/metrics-catalog.md
+++ b/skills/research/codebase-analyzer/references/metrics-catalog.md
@@ -33,7 +33,7 @@ Complete reference for the Omni-Cartographer's 25 categories and 100 individual 
 - cmp package usage
 - min/max builtins
 
-**6. Anti-patterns**
+**6. Failure modes**
 - Manual contains loops
 - Manual deduplication
 - Float conversions
@@ -149,7 +149,7 @@ Complete reference for the Omni-Cartographer's 25 categories and 100 individual 
 
 **29. Architecture Score**: Layering, interface design, separation of concerns
 
-**30. Performance Score**: Efficient pattern usage (prealloc, Builder, anti-patterns)
+**30. Performance Score**: Efficient pattern usage (prealloc, Builder, failure modes)
 
 **31. Observability Score**: Logging, metrics, structured telemetry
 

--- a/skills/research/data-analysis/SKILL.md
+++ b/skills/research/data-analysis/SKILL.md
@@ -242,7 +242,7 @@ Save `analysis-report.md` using the template from `references/output-templates.m
 | Any phase -- saving an artifact file | `references/output-templates.md` |
 | Working examples of the full 5-phase flow | `references/worked-examples.md` |
 | Data parse failure, segment size issue, definition revision | `references/error-handling.md` |
-| Anti-pattern recognition (p-hacking, survivorship bias, etc.) | `references/preferred-patterns.md` |
+| Failure mode recognition (p-hacking, survivorship bias, etc.) | `references/preferred-patterns.md` |
 
 ---
 
@@ -253,4 +253,4 @@ Save `analysis-report.md` using the template from `references/output-templates.m
 - **Compute Examples**: `references/compute-examples.md` - Python computation patterns for extraction and analysis
 - **Worked Examples**: `references/worked-examples.md` - Three end-to-end examples (A/B test, trend, distribution)
 - **Error Handling**: `references/error-handling.md` - Error recovery procedures and blocker criteria
-- **Anti-Patterns**: `references/preferred-patterns.md` - Extended pattern catalog with code examples
+- **Failure modes**: `references/preferred-patterns.md` - Extended pattern catalog with code examples

--- a/skills/research/decision-helper/SKILL.md
+++ b/skills/research/decision-helper/SKILL.md
@@ -163,5 +163,5 @@ Load these files when the corresponding signals appear in the decision request:
 | Signal | Reference File | What It Adds |
 |--------|---------------|-------------|
 | "build vs buy", "vendor", "SaaS", "self-host", database, cloud provider, framework, library, API design | `references/decision-archetypes.md` | Archetype-specific criteria weight adjustments, hard-constraint checklists, detection commands |
-| User adjusts weights after scoring, adds options mid-scoring, scores feel arbitrary, "something feels off" | `references/decision-preferred-patterns.md` | Anti-pattern identification, intervention scripts, error-fix mappings |
-| 5+ options presented, close call (<0.5 margin), repeated score changes | `references/decision-preferred-patterns.md` | Structural anti-patterns and fixes |
+| User adjusts weights after scoring, adds options mid-scoring, scores feel arbitrary, "something feels off" | `references/decision-preferred-patterns.md` | Failure mode identification, intervention scripts, error-fix mappings |
+| 5+ options presented, close call (<0.5 margin), repeated score changes | `references/decision-preferred-patterns.md` | Structural failure modes and fixes |

--- a/skills/research/full-repo-review/SKILL.md
+++ b/skills/research/full-repo-review/SKILL.md
@@ -164,7 +164,7 @@ Deduplicate where both sources flag the same issue. Keep the higher severity.
 Look for patterns that appear in 3+ files:
 - Repeated naming violations
 - Consistent missing error handling
-- Common anti-patterns across components
+- Common failure modes across components
 - Documentation gaps that follow a pattern
 
 These go into a dedicated "Systemic Patterns" section -- they represent the

--- a/skills/research/multi-persona-critique/SKILL.md
+++ b/skills/research/multi-persona-critique/SKILL.md
@@ -180,7 +180,7 @@ Load the synthesis template and populate all 7 sections (Consensus Matrix; Featu
 
 ---
 
-<!-- no-pair-required: section-header-only; individual anti-patterns below carry Do-instead blocks -->
+<!-- no-pair-required: section-header-only; individual failure modes below carry Do-instead blocks -->
 ## Examples, Error Handling, and Detection
 
 See `${CLAUDE_SKILL_DIR}/references/examples-and-errors.md` for:
@@ -196,7 +196,7 @@ See `${CLAUDE_SKILL_DIR}/references/examples-and-errors.md` for:
 ### Reference Files
 - `${CLAUDE_SKILL_DIR}/references/personas.md`: Full persona specifications, identity, evaluation criteria, prompt templates
 - `${CLAUDE_SKILL_DIR}/references/synthesis-template.md`: Consensus matrix format and synthesis report structure
-- `${CLAUDE_SKILL_DIR}/references/examples-and-errors.md`: Worked examples, anti-patterns, error handling
+- `${CLAUDE_SKILL_DIR}/references/examples-and-errors.md`: Worked examples, failure modes, error handling
 
 ### Related Skills
 - `roast`: Code critique with evidence-based validation (complementary — roast critiques code, this critiques ideas)

--- a/skills/research/repo-value-analysis/references/phase6-report-template.md
+++ b/skills/research/repo-value-analysis/references/phase6-report-template.md
@@ -11,7 +11,7 @@ For each recommendation:
 - If audit found PARTIAL: adjust description to focus on what's actually missing, cite the partial files
 - If audit found MISSING: keep as-is, add the affected files from audit
 
-This adjustment step catches the false positive anti-pattern: "we should adopt X" when we already have X.
+This adjustment step catches the false positive failure mode: "we should adopt X" when we already have X.
 
 **Step 3: Build final report**
 

--- a/skills/testing/e2e-testing/references/async.md
+++ b/skills/testing/e2e-testing/references/async.md
@@ -1,6 +1,6 @@
 # Async Patterns Reference
 
-> **Scope**: Async coordination patterns for Playwright tests — parallel execution, race conditions, and timing anti-patterns. Does not cover basic `await` usage or condition-based waiting (see `playwright-patterns.md`).
+> **Scope**: Async coordination patterns for Playwright tests — parallel execution, race conditions, and timing failure modes. Does not cover basic `await` usage or condition-based waiting (see `playwright-patterns.md`).
 > **Version range**: Playwright 1.20+ (Node 18+)
 > **Generated**: 2026-04-17
 

--- a/skills/testing/testing-preferred-patterns/SKILL.md
+++ b/skills/testing/testing-preferred-patterns/SKILL.md
@@ -114,7 +114,7 @@ For each test file, scan for these 10 categories (detailed examples in `referenc
 
 **Constraint: Preserve test intent.** When fixing quality issues, maintain what the test was originally trying to verify. Preserve the original test coverage scope.
 
-**Constraint: Prevent over-engineering.** Fix the specific quality issue identified; make targeted fixes to the specific anti-pattern or delete tests and write new ones from scratch. Institutional knowledge lives in the existing tests.
+**Constraint: Prevent over-engineering.** Fix the specific quality issue identified; make targeted fixes to the specific failure mode or delete tests and write new ones from scratch. Institutional knowledge lives in the existing tests.
 
 **Gate**: Findings ranked. User agrees on scope of fixes. Proceed only when gate passes.
 
@@ -148,7 +148,7 @@ Priority: [HIGH/MEDIUM/LOW]
 - ISSUE: Test spies on `_getUser()` → FIX: Test what happens when a user exists or doesn't exist
 - ISSUE: Test checks exact regex → FIX: Test that validation succeeds/fails for representative inputs
 
-Change only what is needed to fix the anti-pattern. Consult `references/fix-strategies.md` for language-specific patterns.
+Change only what is needed to fix the failure mode. Consult `references/fix-strategies.md` for language-specific patterns.
 
 **Step 3: Run tests after each fix**
 
@@ -190,7 +190,7 @@ Remaining issues: [any deferred items]
 
 ## Pattern Quality Catalog
 
-See `references/quality-catalog.md` for detailed descriptions of all 10 anti-patterns (signals, why each is problematic, and fixes).
+See `references/quality-catalog.md` for detailed descriptions of all 10 failure modes (signals, why each is problematic, and fixes).
 
 ---
 
@@ -206,10 +206,10 @@ See `references/quick-reference.md` for the quick reference table, red flags dur
 
 ### Reference Files
 
-- `${CLAUDE_SKILL_DIR}/references/quality-catalog.md`: Detailed descriptions of all 10 anti-patterns
+- `${CLAUDE_SKILL_DIR}/references/quality-catalog.md`: Detailed descriptions of all 10 failure modes
 - `${CLAUDE_SKILL_DIR}/references/error-handling.md`: Ambiguous patterns and large-scale cleanup guidance
 - `${CLAUDE_SKILL_DIR}/references/quick-reference.md`: Quick reference table, red flags, TDD relationship
-- `${CLAUDE_SKILL_DIR}/references/preferred-pattern-catalog.md`: Detailed code examples for all 10 anti-patterns (Go, Python, JavaScript)
+- `${CLAUDE_SKILL_DIR}/references/preferred-pattern-catalog.md`: Detailed code examples for all 10 failure modes (Go, Python, JavaScript)
 - `${CLAUDE_SKILL_DIR}/references/fix-strategies.md`: Language-specific fix patterns and tooling
 - `${CLAUDE_SKILL_DIR}/references/blind-spot-taxonomy.md`: 6-category taxonomy of what high-coverage test suites commonly miss (concurrency, state, boundaries, security, integration, resilience)
 - `${CLAUDE_SKILL_DIR}/references/load-test-scenarios.md`: 6 load test scenario types (smoke, load, stress, spike, soak, breakpoint) with configurations and critical endpoint priorities

--- a/skills/testing/testing-preferred-patterns/references/error-handling.md
+++ b/skills/testing/testing-preferred-patterns/references/error-handling.md
@@ -12,7 +12,7 @@ Solution:
 
 ### Error: "Fix Changes Test Behavior"
 
-Cause: Anti-pattern was masking an actual test gap or testing wrong thing
+Cause: Failure mode was masking an actual test gap or testing wrong thing
 
 Solution:
 1. Identify what the test was originally trying to verify

--- a/skills/testing/testing-preferred-patterns/references/fix-strategies.md
+++ b/skills/testing/testing-preferred-patterns/references/fix-strategies.md
@@ -1,6 +1,6 @@
 # Fix Strategies by Language
 
-Practical tooling and patterns for resolving testing anti-patterns in Go, Python, and JavaScript/TypeScript.
+Practical tooling and patterns for resolving testing failure modes in Go, Python, and JavaScript/TypeScript.
 
 ---
 

--- a/skills/testing/testing-preferred-patterns/references/preferred-pattern-catalog.md
+++ b/skills/testing/testing-preferred-patterns/references/preferred-pattern-catalog.md
@@ -1,6 +1,6 @@
 # Testing Patterns to Detect and Fix Catalog
 
-Detailed code examples for all 10 anti-patterns. Each section shows BAD (what to avoid) and GOOD (what to do instead) in Go, Python, and JavaScript where applicable.
+Detailed code examples for all 10 failure modes. Each section shows BAD (what to avoid) and GOOD (what to do instead) in Go, Python, and JavaScript where applicable.
 
 ---
 

--- a/skills/testing/testing-preferred-patterns/references/quality-catalog.md
+++ b/skills/testing/testing-preferred-patterns/references/quality-catalog.md
@@ -1,6 +1,6 @@
 ## Pattern Quality Catalog
 
-This section documents the domain-specific anti-patterns this skill detects and fixes.
+This section documents the domain-specific failure modes this skill detects and fixes.
 
 ### Pattern 1: Test Observable Behavior
 

--- a/skills/workflow/references/pipeline-scaffolder.md
+++ b/skills/workflow/references/pipeline-scaffolder.md
@@ -137,7 +137,7 @@ If `adr_hash` field is absent from the spec: Log a warning and continue (older p
 **Step 0: Load the template**. Read `references/generated-skill-template.md` once. This contains:
 - The SKILL.md template with `{{variable}}` placeholders
 - The chain-to-phase mapping (how each step family becomes a phase section)
-- Task type default errors and anti-patterns
+- Task type default errors and failure modes
 
 **Fan-out strategy**:
 - For simple chains (3-4 steps): batch 2-3 subdomain skills per sub-agent

--- a/skills/workflow/references/pipeline-scaffolder/references/generated-skill-template.md
+++ b/skills/workflow/references/pipeline-scaffolder/references/generated-skill-template.md
@@ -39,5 +39,5 @@ git-release, learning-retro.
 ## Task Type Defaults
 
 Task types (generation, review, debugging, operations, configuration, analysis, migration,
-testing) have default error tables and anti-pattern tables embedded in the main template.
+testing) have default error tables and failure mode tables embedded in the main template.
 The scaffolder selects applicable rows based on `subdomain.task_type`.


### PR DESCRIPTION
## Summary
- Fleet-wide deep cleanup: **302 Anti-Pattern occurrences → 0** across 178 files
- Previous PR #635 only caught heading-level patterns (7 regex rules)
- This PR catches everything the headings missed: table column headers, bold labels, inline references, blockquote scopes
- Validator regex expanded from heading-only (`^\s*#{1,6}.*Anti-Pattern`) to all prose positions (`Anti-Patterns?`)
- 27 instances in fenced code blocks preserved (legitimate Go/Python examples)
- All changes are mechanical `s/Anti-Pattern/Failure Mode/` — zero semantic edits

## Test plan
- [ ] `python3 scripts/validate_positive_instruction_docs.py` returns `count: 0`
- [ ] `pytest scripts/tests/test_joy_check_instruction_mode.py` — all pass
- [ ] CI joy-check job passes
- [ ] Spot-check: fenced code blocks still contain `// Anti-pattern:` (preserved)