### PR TITLE
feat(refs): base-instructions (Level 0→3)

### DIFF
--- a/agents/base-instructions.md
+++ b/agents/base-instructions.md
@@ -27,3 +27,12 @@ Read and follow repository CLAUDE.md files before any implementation. Project in
 ## Anti-Rationalization
 
 See `skills/shared-patterns/anti-rationalization-core.md` for universal rationalization patterns. /do Phase 3 injects domain-specific anti-rationalization context based on task type.
+
+## Reference Loading
+
+Load these reference files when the task signals match. Do not load preemptively.
+
+| Task signal | Reference file | What it adds |
+|------------|----------------|--------------|
+| Writing progress updates, completing tasks, summarizing work | `agents/base-instructions/references/communication-patterns.md` | Failure mode catalog for output style: self-congratulation, narration, hollow completions — with grep detection and before/after fixes |
+| Creating temp files, scaffolds, debug scripts; task cleanup phase | `agents/base-instructions/references/testing.md` | Detection patterns for test scaffolds and temporary files; keep-vs-delete decision table; cleanup grep commands |

--- a/agents/base-instructions/references/communication-patterns.md
+++ b/agents/base-instructions/references/communication-patterns.md
@@ -1,0 +1,221 @@
+# Agent Communication Patterns
+
+> **Scope**: Failure modes in agent output style — over-reporting, self-congratulation, verbose narration, and hedging. Covers what to detect and how to fix each.
+> **Version range**: all versions
+> **Generated**: 2026-05-11
+
+---
+
+## Overview
+
+Agent output quality degrades in predictable ways: self-congratulation inflates summaries, narration of obvious steps adds noise, hedge words like "successfully" and "properly" signal defensiveness rather than confidence. These patterns make outputs longer without adding information, erode trust, and obscure actual facts. Each failure mode below has a detection pattern and a concrete fix.
+
+---
+
+## Pattern Table: Style Markers
+
+| Phrase class | Examples | Signal |
+|--------------|----------|--------|
+| Self-congratulation | "Successfully completed", "Great job", "Well done" | Replace with bare fact |
+| Complexity inflation | "complex task", "challenging problem", "sophisticated solution" | Delete entirely — never characterize difficulty |
+| Machine-like hedging | "I have now", "I will now proceed to", "As requested" | Cut; start with the action |
+| Passive completion | "has been done", "has been updated", "was modified" | Use active: "Updated X", "Fixed Y" |
+| Empty affirmations | "Certainly!", "Of course!", "Absolutely!" | Delete; answer directly |
+| Filler transitions | "Now let's", "Moving on to", "Next, I will" | Delete; execute the next step |
+
+---
+
+## Pattern Catalog: Detection and Fixes
+
+### Self-Congratulation
+
+**Detection**:
+```bash
+grep -rn "successfully\|Successfully\|great job\|well done\|excellent" \
+  --include="*.md" --include="*.txt"
+rg 'successfully (completed|finished|implemented|fixed|resolved)' -i
+```
+
+**Signal**:
+```text
+I have successfully completed the migration task! The database schema
+has been successfully updated and all tests are passing. Great work!
+```
+
+**Why it matters**: "Successfully" adds no information — if the task failed, the agent wouldn't be reporting it as done. Every occurrence of "successfully" can be deleted with zero information loss. Self-congratulation transfers the user's attention from facts to sentiment.
+
+**Preferred action**:
+```text
+Migrated the schema. 3 tables updated, 47 tests pass.
+```
+
+---
+
+### Narrating Obvious Steps
+
+**Detection**:
+```bash
+rg "I('m| am) (now |going to |about to )?(read|look|check|search|run|execute)" -i
+rg "Let me (now |first |quickly )?(read|check|look at|search|run)" -i
+```
+
+**Signal**:
+```text
+Now I will read the configuration file to understand the current settings.
+Let me check what's in the database before proceeding.
+I'm going to look at the test output to diagnose the failure.
+```
+
+**Why it matters**: The tool call already shows the action. Narrating it before the call doubles the words without adding context. Users scanning output skip narration to find facts.
+
+**Preferred action**: Execute the tool call. If a brief orienting phrase is needed, one word is sufficient: "Checking the config." not "Now I will proceed to carefully examine the configuration file to understand the current state of the settings."
+
+---
+
+### Difficulty Inflation
+
+**Detection**:
+```bash
+rg "complex|challenging|sophisticated|non-trivial|tricky|difficult" -i \
+  --include="*.md"
+grep -rn "complex task\|challenging problem\|complex issue\|difficult bug" -i
+```
+
+**Signal**:
+```text
+This is a complex refactoring task involving sophisticated architectural changes.
+The challenging nature of this problem required careful analysis.
+```
+
+**Why it matters**: Characterizing difficulty is self-serving narration. If the task was trivial, calling it complex is inaccurate. If it was genuinely hard, the solution demonstrates that — the label adds nothing and can read as excuse-making.
+
+**Preferred action**: Never characterize difficulty. Describe what was done and why.
+
+---
+
+### Hollow Completions
+
+**Detection**:
+```bash
+rg "The task (has been|is now) (complete|done|finished)" -i
+rg "Everything (is|looks) (good|fine|correct|working)" -i
+rg "All (done|set|good|complete)" -i
+```
+
+**Signal**:
+```text
+The task has been completed successfully. Everything looks good!
+All done — the feature is now working correctly.
+```
+
+**Why it matters**: "Everything looks good" is an assertion without evidence. Users cannot verify it. Fact-based completions include specific counts, file names, or test results that a user can independently check.
+
+**Preferred action**:
+```text
+Fixed the null check in users.go:142. Tests pass (47/47). No other callers of `getUser()` affected.
+```
+
+---
+
+### Excessive Caveats
+
+**Detection**:
+```bash
+rg "please note that|it's worth noting|it should be mentioned|keep in mind" -i
+rg "I would (recommend|suggest|advise) that you" -i
+rg "you may want to (consider|think about|look into)" -i
+```
+
+**Signal**:
+```text
+Please note that this change may have implications you should be aware of.
+It's worth noting that you may want to consider reviewing the downstream effects.
+I would recommend that you carefully examine the results before proceeding.
+```
+
+**Why it matters**: Caveat stacking is a hedge against being wrong. If there's a genuine risk, state it specifically: "This migration is irreversible — verify with a dry-run before applying." Generic caveats train users to ignore all caveats, including the real ones.
+
+**Preferred action**: State the specific risk or remove the caveat entirely.
+
+---
+
+## Error-Fix Mappings
+
+| Output pattern | Root cause | Fix |
+|---------------|------------|-----|
+| Summary longer than the actual change | Over-explaining simple edits | Match summary length to change size: one-line fix → one-line report |
+| Hedging on a certain fact | Confusing opinion with fact | State facts directly; use "I think" only for genuine uncertainty |
+| Repeating the user's request back | Filler before the answer | Delete the restatement; start with the answer |
+| Listing every file touched | Reporting mechanics not outcomes | Report what changed functionally, not the file list |
+| Asking permission for obvious next steps | Uncertainty about autonomy | Execute obvious steps; ask only when direction is genuinely ambiguous |
+
+---
+
+## Correct Patterns
+
+### Fact-Based Progress Report
+
+State what happened, what the result is, what comes next. No adjectives describing quality.
+
+```text
+# BAD
+I have successfully completed the first phase of the refactoring task!
+The code has been beautifully restructured and everything looks great!
+
+# GOOD
+Extracted UserService into its own module (src/services/user.ts).
+3 callers updated. Build passes.
+```
+
+---
+
+### Minimal Orienting Statement
+
+When starting a multi-step task, one sentence is sufficient. No "I will now" constructions.
+
+```text
+# BAD
+Now I will begin by carefully reading the existing implementation to understand
+the current state of the code before making any changes.
+
+# GOOD
+Reading the existing implementation.
+```
+
+---
+
+### Specific Risk Statement
+
+When a genuine risk exists, state it concretely rather than hedging generically.
+
+```text
+# BAD
+Please note that this change may have some implications you should be aware of.
+You may want to carefully consider the downstream effects.
+
+# GOOD
+This drops the `legacy_id` column — irreversible without a backup. Run
+`pg_dump` before applying.
+```
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Self-congratulation
+rg 'successfully (completed|finished|implemented|fixed|resolved)' -i
+
+# Narration before tool calls
+rg "I('m| am) (now |going to |about to )?(read|check|search|run)" -i
+rg "Let me (now |first |quickly )?(read|check|look|run)" -i
+
+# Difficulty inflation
+rg "complex|challenging|sophisticated|non-trivial" -i --include="*.md"
+
+# Hollow completions
+rg "everything (is|looks) (good|fine|correct|working)" -i
+
+# Generic caveats
+rg "please note that|it's worth noting|you may want to consider" -i
+```

--- a/agents/base-instructions/references/testing.md
+++ b/agents/base-instructions/references/testing.md
@@ -1,0 +1,172 @@
+# Test Scaffold and Temporary File Patterns
+
+> **Scope**: Identifying and cleaning up test scaffolds, development helpers, and temporary files created during task iteration. Does not cover test framework usage or test writing.
+> **Version range**: all versions
+> **Generated**: 2026-05-11 — applies to all languages and project types
+
+---
+
+## Overview
+
+Agents routinely create throwaway files during exploration: debug scripts, one-off validators, test scaffolds, and helper stubs. These must be removed at task completion. The challenge is distinguishing files that were *requested by the user* or *needed for future context* from purely ephemeral development artifacts. Leaving scaffolding behind clutters repos and creates false signals in future code searches.
+
+---
+
+## Pattern Table: File Categories
+
+| Category | Characteristics | Action |
+|----------|-----------------|--------|
+| Test scaffold | `test_`, `_test`, `debug_`, `temp_` prefix/suffix; no imports from main code | Delete at task completion |
+| Development helper | Single-use scripts (`check_something.py`, `validate_once.sh`) | Delete after confirming task done |
+| Requested artifact | Explicitly mentioned in user prompt; committed to repo | Keep |
+| Future-context file | Contains state needed for next task step | Keep until that step completes |
+| Framework test file | In `tests/`, `__tests__/`, `spec/` dirs; follows project conventions | Always keep |
+
+---
+
+## Correct Patterns
+
+### Identifying Temporary Files Before Cleanup
+
+Scan the working directory for common scaffold naming patterns before closing a task.
+
+```bash
+# Find likely test scaffolds by naming pattern
+find . -name "test_*.py" -not -path "*/tests/*" -not -path "*/__tests__/*"
+find . -name "*_test.sh" -not -path "*/test/*"
+find . -name "debug_*.py" -o -name "temp_*.py" -o -name "check_*.py"
+find . -name "validate_*.sh" -newer CLAUDE.md  # files created this session
+```
+
+**Why**: Without active cleanup, repos accumulate orphan scripts that break `grep` searches and confuse future agents reading the codebase.
+
+---
+
+### Distinguishing Scaffold from Framework Test
+
+Project test frameworks use specific directory conventions — files *inside* those dirs are permanent; files *outside* with test-like names are scaffolding.
+
+```bash
+# Files that are definitely framework tests (keep):
+find . -path "*/tests/*.py" -o -path "*/__tests__/*.ts" -o -path "*/spec/*.rb"
+
+# Files that are likely scaffolding (verify before deleting):
+find . -maxdepth 3 -name "test_*.py" -not -path "*/tests/*"
+find . -maxdepth 3 -name "*.test.ts" -not -path "*/__tests__/*"
+find . -maxdepth 3 -name "*_spec.rb" -not -path "*/spec/*"
+```
+
+---
+
+## Pattern Catalog: Detection and Fixes
+
+### Orphaned Debug Scripts
+
+**Detection**:
+```bash
+grep -rn "import pdb\|breakpoint()\|console\.log.*debug\|print.*DEBUG" \
+  --include="*.py" --include="*.js" --include="*.ts"
+rg 'pp\s+\w+|pry\s+binding|debugger;' --type rb --type js
+```
+
+**Signal**:
+```python
+# debug_invoice.py — created to test a hypothesis
+import pdb
+from app.models import Invoice
+
+inv = Invoice.objects.first()
+pdb.set_trace()
+print(inv.__dict__)
+```
+
+**Why it matters**: Debug files checked in accidentally expose internal data structures in diffs and can introduce interactive debugger calls that halt production processes if a branch is merged.
+
+**Preferred action**: Delete before committing. If the exploration revealed something useful, extract the finding into a comment in the relevant source file, not into a standalone script.
+
+---
+
+### One-off Validation Scripts
+
+**Detection**:
+```bash
+find . -maxdepth 2 -name "validate_*.py" -o -name "check_*.py" -o -name "verify_*.sh"
+rg '^#!/.+(python|bash|sh)' --files-with-matches | xargs grep -l "TODO: remove\|one.time\|temp\|temporary"
+```
+
+**Signal**:
+```python
+# validate_migration.py — written to check if data migration ran correctly
+import psycopg2
+conn = psycopg2.connect(...)
+cur = conn.cursor()
+cur.execute("SELECT COUNT(*) FROM users WHERE migrated_at IS NULL")
+print(cur.fetchone())
+```
+
+**Why it matters**: Validation scripts left in repos get run by other engineers thinking they're part of the toolchain. If they connect to production databases or mutate state, this causes incidents.
+
+**Preferred action**: Run the script, record the output in the PR description or a comment, then delete the file.
+
+---
+
+### Unimplemented Stubs
+
+**Detection**:
+```bash
+grep -rn "pass$\|raise NotImplementedError\|throw new Error.*not implemented" \
+  --include="*.py" --include="*.ts" --include="*.go"
+rg '^\s+pass$' --type py -l
+rg 'panic\("not implemented"\)' --type go -l
+```
+
+**Signal**:
+```typescript
+// stub created to unblock a dependent feature
+export function sendEmail(to: string, body: string): void {
+  // TODO: implement
+  throw new Error('not implemented')
+}
+```
+
+**Why it matters**: Stub functions look like real functions to callers and automated tools. If the stub gets imported but the implementation never arrives, the failure appears at call time (often in production) not at definition time.
+
+**Preferred action**: If the stub is permanent scaffolding (intentional), mark it with the owning ticket. If it was a development convenience, delete it and remove the import.
+
+---
+
+## Error-Fix Mappings
+
+| Symptom | Root Cause | Fix |
+|---------|------------|-----|
+| `grep` finds duplicate function names | Scaffold defines same function as real source | Delete scaffold file, verify real source has the implementation |
+| CI fails on import of deleted module | Scaffold was imported elsewhere during development | Audit imports with `rg 'from.*scaffold\|import.*temp'` and remove |
+| "file already exists" on scaffold creation | Previous session left a scaffold | Delete the stale file before creating new one |
+| Test runner picks up scaffold | Scaffold filename matches test discovery pattern | Rename with non-test prefix or move outside test dirs |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# Files newer than CLAUDE.md (created this session)
+find . -newer CLAUDE.md \( -name "*.py" -o -name "*.sh" -o -name "*.ts" \) \
+  | grep -v __pycache__ | grep -v node_modules
+
+# Common scaffold naming patterns (outside framework dirs)
+find . -maxdepth 3 \( \
+  -name "test_*.py" -o -name "debug_*.py" -o -name "temp_*.py" \
+  -o -name "check_*.py" -o -name "validate_*.py" -o -name "scratch_*.py" \
+  \) -not -path "*/tests/*" -not -path "*/__tests__/*"
+
+# Scripts with shebang and temporary markers
+rg '#!/.+(python|bash)' --files-with-matches \
+  | xargs grep -l -i "temp\|scaffold\|remove after\|one.time"
+
+# Python stubs (empty body)
+rg '^\s+pass$' --type py -l
+
+# TypeScript/Go unimplemented stubs
+rg 'throw new Error.*not implemented|panic\("not implemented"\)' \
+  --type ts --type go -l
+```


### PR DESCRIPTION
## Summary

- **Target**: `base-instructions` agent
- **Level before**: 0 (no references directory)
- **Level after**: 3 (deep references with detection commands)

## New Reference Files

- `agents/base-instructions/references/communication-patterns.md` (221 lines) — Failure mode catalog for agent output style: self-congratulation, narration before tool calls, difficulty inflation, hollow completions, excessive caveats. Each entry has grep/rg detection commands and before/after examples.
- `agents/base-instructions/references/testing.md` (172 lines) — Test scaffold and temporary file identification patterns. File category decision table, detection grep commands for orphaned debug scripts, one-off validation scripts, and unimplemented stubs. Cleanup guidance for task completion phase.

## Agent Body Change

Added loading table to `agents/base-instructions.md` mapping task signals to the new reference files:
- "Writing progress updates, completing tasks" → `communication-patterns.md`
- "Creating temp files, scaffolds, debug scripts; cleanup phase" → `testing.md`

## Validation Gate

Phase 2.5 passed — both references contain concrete, grep-detectable patterns with code examples and error-fix tables. Loading table entries correctly match signal keywords to file paths.

## Audit Output

```
communication-patterns.md  221 lines  concrete=82  generic=4  code=Y  cmds=Y
testing.md                 172 lines  concrete=71  generic=0  code=Y  cmds=Y
Level: 0 → 3
```