### PR TITLE
refactor(hooks): narrow monitoring hook matchers to their signal domains (#640)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -306,6 +306,12 @@
             "command": "python3 \"$HOME/.claude/hooks/usage-tracker.py\"",
             "description": "Record Skill and Agent invocation analytics",
             "timeout": 3000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/routing-gap-recorder.py\"",
+            "description": "Record /do routing gaps to learning DB for pattern tracking",
+            "timeout": 2000
           }
         ]
       },
@@ -334,13 +340,12 @@
             "command": "python3 \"$HOME/.claude/hooks/error-learner.py\"",
             "description": "Learn from tool errors and suggest solutions",
             "timeout": 3000
-          },
-          {
-            "type": "command",
-            "command": "python3 \"$HOME/.claude/hooks/routing-gap-recorder.py\"",
-            "description": "Record /do routing gaps to learning DB for pattern tracking",
-            "timeout": 2000
-          },
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|Agent",
+        "hooks": [
           {
             "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/record-waste.py\"",


### PR DESCRIPTION
## Summary
- Evolution cycle proposal 2026-05-12: PostToolUse monitoring hook matcher over-breadth
- Consensus score: 3.0/3.0 (Pragmatist: STRONG, Purist: STRONG, User Advocate: STRONG)
- A/B result: 5/5 test cases pass; 100% win rate

## Changes

Three PostToolUse hooks were firing under `Bash|Write|Edit|Agent` but only produce signal on a subset of those events:

| Hook | Old matcher | New matcher | Rationale |
|------|------------|-------------|-----------|
| `routing-gap-recorder.py` | `Bash\|Write\|Edit\|Agent` | `Skill\|Agent` | Scans for `GAP DETECTED:` banners from `/do` skill output — only appears in Skill invocations |
| `record-waste.py` | `Bash\|Write\|Edit\|Agent` | `Bash\|Agent` | Estimates token waste from failures — Write/Edit rarely fail with measurable waste |
| `completion-evidence-check.py` | `Bash\|Write\|Edit\|Agent` | `Bash\|Agent` | Scans for completion language — Write/Edit outputs never contain "I've implemented" patterns |

`error-learner.py` stays at `Bash|Write|Edit|Agent` — file system errors ARE worth learning from.

## Impact

**3 fewer hook fires per Write/Edit operation** — the most frequent operation class in a session. On a typical session with 100 Write/Edit calls, this eliminates 300 unnecessary Python process spawns.

## Test Results
| Test Case | Result |
|-----------|--------|
| `routing-gap-recorder` absent from `Bash\|Write\|Edit\|Agent` | ✓ PASS |
| `routing-gap-recorder` present in `Skill\|Agent` | ✓ PASS |
| `record-waste` + `completion-evidence-check` only in `Bash\|Agent` | ✓ PASS |
| `error-learner` remains at `Bash\|Write\|Edit\|Agent` | ✓ PASS |
| JSON valid, routing drift clean (116/116 skills) | ✓ PASS |

## Evolution Cycle
This PR was generated and validated by the toolkit-evolution skill (2026-05-12 nightly cycle). Critique was unanimous STRONG from Pragmatist, Purist, and User Advocate personas.

## Retro Graduation
20 ungraduated entries graduated before merge: 12 → toolkit-evolution/SKILL.md, 5 → .claude/settings.json, 1 → joy-check/SKILL.md, 1 → posttooluse-joy-check-warn.py, 1 → golang-general-engineer.md.