### PR TITLE
feat(hooks): register 3 advisory hooks and fix stale docs-drift trigger

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,6 +68,13 @@
             "description": "Inject GitHub briefing at session start (opt-in: CLAUDE_KAIROS_ENABLED=true)",
             "timeout": 2000,
             "once": true
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/session-adr-health-check.py\"",
+            "description": "Warn if .adr-session.json is orphaned (referenced ADR file missing); silent when no session exists",
+            "timeout": 2000,
+            "once": true
           }
         ]
       }
@@ -256,6 +263,12 @@
             "command": "python3 \"$HOME/.claude/hooks/posttooluse-sync-skill-index.py\"",
             "description": "Auto-regenerate INDEX.json when SKILL.md is written or edited",
             "timeout": 15000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/posttool-docs-drift-alert.py\"",
+            "description": "Alert when INDEX.json or agents/*.md writes may leave documentation out of sync",
+            "timeout": 3000
           }
         ]
       },
@@ -273,6 +286,12 @@
             "command": "python3 \"$HOME/.claude/hooks/adr-lifecycle-on-merge.py\"",
             "description": "Check ADR implementation status after merge operations",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/posttool-rename-sweep.py\"",
+            "description": "After git mv, scan for stale references to the old filename stem (ADR-129)",
+            "timeout": 3000
           }
         ]
       },

--- a/hooks/posttool-docs-drift-alert.py
+++ b/hooks/posttool-docs-drift-alert.py
@@ -3,12 +3,12 @@
 """
 Claude Code hook: Alert when documentation may be out of sync after file writes.
 
-Fires after Write/Edit operations on INDEX.json, routing-tables.md, or agents/*.md
-files. Runs the docs-sync-checker scanner when available, or falls back to a simple
-file-count comparison between agents/INDEX.json and the agents/ directory on disk.
+Fires after Write/Edit operations on INDEX.json or agents/*.md files. Runs the
+docs-sync-checker scanner when available, or falls back to a simple file-count
+comparison between agents/INDEX.json and the agents/ directory on disk.
 
 Event: PostToolUse (Write, Edit)
-Filters: INDEX.json, routing-tables.md, agents/*.md, skills/INDEX.json, agents/INDEX.json
+Filters: INDEX.json, agents/*.md, skills/INDEX.json, agents/INDEX.json
 """
 
 import json
@@ -21,7 +21,7 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 from stdin_timeout import read_stdin
 
 # Files that trigger a drift check when modified
-_TRIGGER_NAMES = frozenset({"INDEX.json", "routing-tables.md"})
+_TRIGGER_NAMES = frozenset({"INDEX.json"})
 
 # Repo root — derived relative to this hook's location (hooks/ → repo root)
 _REPO_ROOT = Path(__file__).parent.parent

--- a/hooks/posttool-docs-drift-alert.py
+++ b/hooks/posttool-docs-drift-alert.py
@@ -32,7 +32,6 @@ def _is_watched_file(file_path: str) -> bool:
 
     Matches:
     - Any file named INDEX.json
-    - Any file named routing-tables.md
     - Any *.md file inside an agents/ directory segment
     - skills/INDEX.json
     - agents/INDEX.json


### PR DESCRIPTION
## Summary
- Evolution cycle proposal A: Register `session-adr-health-check.py` in SessionStart — consensus 3.0/3.0 (unanimous STRONG)
- Evolution cycle proposal B: Fix stale `routing-tables.md` trigger in `posttool-docs-drift-alert.py` + register — consensus 3.0/3.0 (unanimous STRONG)
- Evolution cycle proposal D: Register `posttool-rename-sweep.py` in PostToolUse:Bash — consensus 2.67/3.0 (STRONG)

## Changes
- `.claude/settings.json`: register `session-adr-health-check.py` (SessionStart, timeout=2000, once=true)
- `.claude/settings.json`: register `posttool-docs-drift-alert.py` (PostToolUse:Write|Edit, timeout=3000)
- `.claude/settings.json`: register `posttool-rename-sweep.py` (PostToolUse:Bash, timeout=3000)
- `hooks/posttool-docs-drift-alert.py`: remove stale `routing-tables.md` from `_TRIGGER_NAMES` (absorbed in PR #626)

## Test Results
| Test | Result |
|------|--------|
| A: session-adr-health-check registered (timeout=2000, once=true) | PASS |
| B: routing-tables.md removed from `_TRIGGER_NAMES` | PASS |
| B: posttool-docs-drift-alert registered (PostToolUse:Write\|Edit, timeout=3000) | PASS |
| B: hook syntax valid | PASS |
| D: posttool-rename-sweep registered (PostToolUse:Bash, timeout=3000) | PASS |
| D: fast exit for non-git-mv command | PASS |
| JSON validity | PASS |
| Routing drift (116/116) | PASS |

## Evolution Cycle
Generated and validated by the 2026-05-13 nightly toolkit-evolution cycle.
Proposals rated STRONG by Pragmatist/Purist/User Advocate personas.
All 3 proposals WIN (100% test pass rate, zero regressions).