### PR TITLE
feat(hooks): register suggest-compact + ruff-format-gate; fix error-learner timeout false positives

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -105,6 +105,16 @@
     ],
     "PreToolUse": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/suggest-compact.py\"",
+            "description": "Advisory: suggests /compact when Edit/Write call count reaches threshold (ADR-103)",
+            "timeout": 2000
+          }
+        ]
+      },
+      {
         "matcher": "Bash|Write|Edit",
         "hooks": [
           {
@@ -129,6 +139,12 @@
             "command": "python3 \"$HOME/.claude/hooks/ci-merge-gate.py\"",
             "description": "Gate: block merge to main/master when CI checks are red",
             "timeout": 3000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/pretool-ruff-format-gate.py\"",
+            "description": "Ruff format gate: blocks git push when ruff format --check finds violations (Python projects with pyproject.toml only)",
+            "timeout": 5000
           }
         ]
       },

--- a/hooks/error-learner.py
+++ b/hooks/error-learner.py
@@ -114,6 +114,13 @@ def detect_error(event: dict) -> tuple[bool, str]:
                     "failed over",
                     "failover",
                     "not found in cache",
+                    # Timeout false positives: "timeout" appears in config output,
+                    # import lines, and success messages — not as an actual error.
+                    "timeout=",  # e.g. timeout=2000 in hook config output
+                    "stdin_timeout",  # e.g. from stdin_timeout import ...
+                    "timeout caps",  # e.g. "PASS: all hooks now have timeout caps"
+                    "timeout/",  # e.g. "Graduated: timeout/abc123 → ..."
+                    "read_stdin(timeout",  # e.g. raw = read_stdin(timeout=2)
                 ]
                 if any(phrase in output_lower for phrase in false_positive_phrases):
                     return False, ""


### PR DESCRIPTION
## Summary
- Evolution cycle 2026-05-14: 3 proposals implemented (2 STRONG + 1 MODERATE)
- Consensus scores: Proposal B=3.0/3.0 STRONG, Proposal D=3.0/3.0 STRONG, Proposal A=2.4/3.0 MODERATE

## Changes

### Proposal B — Register `pretool-ruff-format-gate.py` (PreToolUse:Bash, 5000ms timeout)
- Blocks `git push` when `ruff format --check` finds violations in Python projects
- Only activates when `pyproject.toml` with `[tool.ruff]` exists (zero false activations on non-Python repos)
- Delivers deny via `permissionDecision` JSON (not exit 2); `RUFF_FORMAT_GATE_BYPASS=1` escape hatch
- Consensus: Pragmatist STRONG, Purist STRONG, User Advocate STRONG, Logician STRONG, Philosopher STRONG

### Proposal A — Register `suggest-compact.py` (PreToolUse, no matcher, 2000ms timeout)
- Advisory: counts Edit/Write calls per session; nudges `/compact` at 50-call threshold (ADR-103)
- Never registered despite being complete; ADR-103 backed
- Always exits 0; advisory only; never blocks execution
- Consensus: Builder STRONG, User Advocate STRONG, Logician/Purist/Philosopher MODERATE (proxy calibration question, not a blocking concern)

### Proposal D — Fix `error-learner.py` false-positive timeout detection
- `detect_error()` was flagging tool outputs containing "timeout" in config strings as genuine errors
- Patterns captured as junk: `timeout=2000`, `stdin_timeout`, `PASS: all hooks now have timeout caps`, `Graduated: timeout/abc123`, `read_stdin(timeout=2)`
- Fix: 5 targeted false-positive phrases added to existing exclusion list
- 7/7 test cases pass; real timeout errors ("request timed out", "timed out") still caught correctly
- Consensus: all 5 personas STRONG (3.0/3.0)

## Test Results
| Test Case | Result |
|-----------|--------|
| suggest-compact registered in PreToolUse | PASS |
| suggest-compact syntax valid | PASS |
| pretool-ruff-format-gate registered in PreToolUse:Bash | PASS |
| pretool-ruff-format-gate syntax valid | PASS |
| `timeout=2000` in output → not flagged as error | PASS |
| `stdin_timeout import` → not flagged | PASS |
| `PASS: all hooks now have timeout caps` → not flagged | PASS |
| `Graduated: timeout/abc123` → not flagged | PASS |
| `read_stdin(timeout=2)` → not flagged | PASS |
| `request timed out after 30 seconds` → still flagged | PASS |
| `TimeoutError: connection timed out` → still flagged | PASS |
| settings.json JSON validity | PASS |
| Routing drift (116/116 skills) | PASS |
| ruff format --check passes | PASS |

## Shelved (consensus too low)
- Proposal C: `pretool-main-thread-discipline.py` — WEAK (3/15). Hook source explicitly says "NOT registered"; /tmp marker mechanism rated architecturally fragile by 3/5 personas. Revisit when session-detection uses a typed, bounded-lifetime signal.
- Proposal E: sprite-pipeline ADR session cleanup — MODERATE (11/15). Requires manual verification that ADR work is complete before removal.

## Evolution Cycle
This PR was generated and validated by the toolkit-evolution skill (2026-05-14 cycle).
Critique: 5-persona multi-persona-critique. A/B: 14/14 tests pass.
Prior cycle suggestions addressed: error-learner upstream fix (Proposal D), unregistered hook audit continuation (Proposals A, B).