### PR TITLE
fix(hooks): repair ci-merge-gate + agent-grade silent skip

### DIFF
--- a/hooks/agent-grade-on-change.py
+++ b/hooks/agent-grade-on-change.py
@@ -40,11 +40,18 @@ def grade_agent(agent_path: str) -> tuple[dict | None, str | None]:
 
     Returns:
         Tuple of (result_dict, error_message). If grading succeeds, error is None.
+
+    Dependency: Requires evals/harness.py to be deployed. Without it, grading
+    is skipped silently. Deploy the harness to enable automatic agent grading.
+    See: https://github.com/notque/vexjoy-agent/issues/TBD
     """
     harness_path = Path(__file__).parent.parent / "evals" / "harness.py"
 
     if not harness_path.exists():
-        return None, f"Harness not found at {harness_path}"
+        # Harness not deployed — skip silently. Printing a warning every
+        # invocation creates noise without value. The dependency comment
+        # above documents how to enable grading.
+        return None, None
 
     try:
         result = subprocess.run(

--- a/hooks/ci-merge-gate.py
+++ b/hooks/ci-merge-gate.py
@@ -99,7 +99,7 @@ def main() -> None:
     # Check CI status
     try:
         result = subprocess.run(
-            ["gh", "pr", "checks", pr_number, "--json", "name,state,conclusion"],
+            ["gh", "pr", "checks", pr_number, "--json", "name,state,bucket"],
             capture_output=True,
             text=True,
             timeout=15,
@@ -121,8 +121,9 @@ def main() -> None:
         print("[ci-merge-gate] WARNING: Could not parse CI check results.")
         return
 
-    failing = [c for c in checks if c.get("conclusion") == "failure"]
-    pending = [c for c in checks if c.get("state") in ("pending", "queued", "in_progress")]
+    # bucket field values: pass, fail, pending, skipping, cancel
+    failing = [c for c in checks if c.get("bucket") == "fail"]
+    pending = [c for c in checks if c.get("bucket") == "pending"]
 
     if failing:
         names = ", ".join(c["name"] for c in failing)

--- a/hooks/sql-injection-detector.py
+++ b/hooks/sql-injection-detector.py
@@ -22,6 +22,13 @@ Design:
 - Limits output to first 5 findings to avoid noise
 
 ADR: adr/134-sql-injection-detector-hook.md
+
+TODO: This hook is redundant with posttool-security-scan.py, which merged all
+patterns from this file (see its docstring: "Merged from posttool-security-scan.py
++ sql-injection-detector.py per ADR hook-injection-condensation"). The primary
+scanner is posttool-security-scan.py. This file can be removed once confirmed
+that posttool-security-scan.py covers all patterns here. Do not remove without
+verifying settings.json no longer references this hook.
 """
 
 import json


### PR DESCRIPTION
## Summary
- **ci-merge-gate.py**: Replace invalid `conclusion` field with `bucket` in `gh pr checks --json`. The gate was silently failing open — CI was never actually checked before merges.
- **agent-grade-on-change.py**: Silent early-exit when `evals/harness.py` is missing instead of printing "grading failed" noise on every agent file edit.
- **sql-injection-detector.py**: Added TODO documenting full redundancy with `posttool-security-scan.py` (consolidation candidate).

## Root causes
- `gh` CLI v2.83.1 doesn't support `conclusion` field — valid fields are `bucket`, `state`, `name`, etc.
- `evals/harness.py` was never deployed to production server.

## Test plan
- [x] ci-merge-gate: `echo '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 649 --merge"}}' | python3 hooks/ci-merge-gate.py` → now outputs "CI checks passed" instead of silently failing
- [x] agent-grade: silent exit when harness missing (no more noise output)
- [x] ruff check + ruff format pass