### PR TITLE
feat(html-artifact): dark-by-default + close audit gaps (mirroring contract + 3 validator checks)

### DIFF
--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-05-20T20:35:05Z",
+  "generated": "2026-05-20T23:48:31Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
     "csuite": {

--- a/skills/meta/html-artifact/SKILL.md
+++ b/skills/meta/html-artifact/SKILL.md
@@ -184,6 +184,8 @@ DISCIPLINE GATE: The validator requires the assembler marker comment. Always run
 
 DARK-DEFAULT GATE: Every assembled artifact ships with `<html data-theme="dark">` and a pre-paint init script in `<head>` that honors `localStorage['html-artifact-theme-v2']`. Never hand-author HTML or post-edit the assembler output to flip this to light — the dark default is enforced by the base template. If the user wants light, they click the toggle (preference persists). Past failure (2026-05-20): three artifacts shipped light because the rule lived only in design-system.md prose, not in the assembler. See `references/design-system.md` § Dark-by-default.
 
+MIRRORING GATE: Every load-bearing rule in this skill must live in **at least one** enforcement layer (assembler / validator / test) AND be mirrored as a one-liner in this SKILL.md. Prose alone in `references/` is not enough — past refactors have silently dropped scaffolds and shipped regressions (2026-05-20 dark-default; deck chrome above-vs-below). When adding a rule: (1) write it in the relevant `references/` file with full rationale, (2) mirror a one-line GATE or table row in this file, (3) enforce it in code (assembler default, validator check, or regression test). Three layers: prose (judgment), code (mechanism), test (proof). The taxonomy is in `references/design-system.md` § Reference-file taxonomy.
+
 If you find yourself writing `<!DOCTYPE html>` directly in a Write tool call, STOP. Run assemble-template.py first.
 
 Dispatch the html-builder subagent with the pre-assembled template.
@@ -229,12 +231,15 @@ The script checks:
 | Check | Fails When |
 |---|---|
 | Valid HTML structure | Missing `<html>`, `<head>`, or `<body>` |
-| No external dependencies | Any `src=` or `href=` pointing to external URLs |
+| No external dependencies | Any `src=` or `href=` pointing to external URLs (incl. `<image href>` and `<use href>` in SVG) |
 | Has `<title>` | Missing or empty `<title>` tag |
 | Has charset meta | Missing `<meta charset>` |
 | Has viewport meta | Missing viewport meta tag |
 | File size under 500KB | Excessive inline assets or animation keyframes |
-| No broken internal refs | `href="#id"` pointing to nonexistent `id` attributes |
+| No broken internal refs | `href="#id"` pointing to nonexistent `id` attributes (excluding `#top`) |
+| SVG accessibility | `<svg>` outside `<button>` lacking `role="img"` + `aria-label` (or explicit `role="presentation"` / `aria-hidden="true"`) |
+| Theme toggle present | Required-toggle shape (deck, spec, code-review, prototype, report, diagram) missing `[data-theme-toggle]` or `<button class="theme-toggle">` |
+| Assembler marker present | Hand-authored HTML missing `<!-- assembled by html-artifact v* -->` marker |
 
 Gate: All validation checks pass.
 -- because an HTML file with external dependencies fails offline, missing meta tags render inconsistently across browsers, and missing structure breaks accessibility.

--- a/skills/meta/html-artifact/SKILL.md
+++ b/skills/meta/html-artifact/SKILL.md
@@ -180,7 +180,9 @@ Gate: Template assembled + required references loaded.
 
 ### Phase 3: GENERATE
 
-DISCIPLINE GATE: The validator requires the assembler marker comment. Always run `assemble-template.py` to produce the HTML — past Phase 2, hand-authored HTML lacks the marker and gets rejected. The marker `<!-- assembled by html-artifact v1.1 -->` is your proof the assembler ran. Skipping the assembler means: no theme tokens, no shape CSS, no print stylesheet, no theme-toggle, no data-shape attribute — every downstream step breaks.
+DISCIPLINE GATE: The validator requires the assembler marker comment. Always run `assemble-template.py` to produce the HTML — past Phase 2, hand-authored HTML lacks the marker and gets rejected. The marker `<!-- assembled by html-artifact v1.1 -->` is your proof the assembler ran. Skipping the assembler means: no theme tokens, no shape CSS, no print stylesheet, no theme-toggle, no data-shape attribute, no dark-default — every downstream step breaks.
+
+DARK-DEFAULT GATE: Every assembled artifact ships with `<html data-theme="dark">` and a pre-paint init script in `<head>` that honors `localStorage['html-artifact-theme-v2']`. Never hand-author HTML or post-edit the assembler output to flip this to light — the dark default is enforced by the base template. If the user wants light, they click the toggle (preference persists). Past failure (2026-05-20): three artifacts shipped light because the rule lived only in design-system.md prose, not in the assembler. See `references/design-system.md` § Dark-by-default.
 
 If you find yourself writing `<!DOCTYPE html>` directly in a Write tool call, STOP. Run assemble-template.py first.
 

--- a/skills/meta/html-artifact/assets/base-template.html
+++ b/skills/meta/html-artifact/assets/base-template.html
@@ -1,10 +1,23 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="color-scheme" content="light dark">
+  <meta name="color-scheme" content="dark light">
   <title><!-- TITLE --></title>
+  <script>
+    // Pre-paint theme init. Runs before the body element renders to prevent
+    // flash of incorrect theme. Honors saved preference over the dark default;
+    // storage key is versioned so future default changes can invalidate stale prefs.
+    (function () {
+      try {
+        var saved = localStorage.getItem('html-artifact-theme-v2');
+        if (saved === 'light' || saved === 'dark') {
+          document.documentElement.dataset.theme = saved;
+        }
+      } catch (e) { /* storage blocked: keep hardcoded default */ }
+    })();
+  </script>
   <style>
     /* <!-- STYLES --> */
   </style>

--- a/skills/meta/html-artifact/references/design-system.md
+++ b/skills/meta/html-artifact/references/design-system.md
@@ -163,7 +163,7 @@ These are graduated from real regressions. Read before editing any `templates/pr
 | Rule | Why |
 |---|---|
 | **Never declare runtime-switchable theme tokens on `:root`.** | `:root` rules block lower-specificity `[data-theme]` overrides. The toggle becomes visually dead. Declare tokens on `html[data-theme="dark"]` and `html[data-theme="light"]` at matching specificity to the toggle target. |
-| **Seed `<html data-theme>` from `<body>` on init.** | The toggle flips `<html>`'s attribute, but pages typically declare initial theme on `<body>`. Without the seed, the first toggle click reads `undefined` → no flip. The toggle JS in `templates/components/theme-toggle.js` does this on `DOMContentLoaded`. |
+| **Seed `<html data-theme>` from `localStorage` *before* `<body>` paints.** | The toggle flips `<html>`'s `data-theme` attribute. If the seed runs at `DOMContentLoaded` (end of `<body>`), the page paints once with the wrong theme then re-paints — flash of incorrect content. The pre-paint script in `templates/base-template.html`'s `<head>` sets `data-theme` directly from `localStorage['html-artifact-theme-v2']` before `<body>` renders. `templates/components/theme-toggle.js` only handles click-to-flip and persistence, never init. |
 
 ### Reference-file taxonomy (graduated from a refactor regression)
 

--- a/skills/meta/html-artifact/references/design-system.md
+++ b/skills/meta/html-artifact/references/design-system.md
@@ -23,6 +23,8 @@ Design principles, theme selection, and quality rules for html-builder. CSS impl
 
 **Dark mode toggle (ENFORCED):** Every artifact in shapes {deck, spec, code-review, prototype, report, diagram} MUST include a light/dark toggle. The assembler now adds it automatically — `assemble-template.py` injects `theme-toggle` for these shapes by default. Validator rejects HTML missing `[data-theme-toggle]` or `<button class="theme-toggle">`. Override with `--no-theme-toggle` only when genuinely not needed (rare).
 
+**Dark-by-default (ENFORCED):** Every assembled artifact ships with `<html data-theme="dark">` hardcoded on the root element. A pre-paint script in `<head>` reads `localStorage['html-artifact-theme-v2']` and only overrides when a saved value exists. Rationale: artifacts are technical/working documents that read better dark; setting `data-theme` on `<html>` directly (not via end-of-body JS) prevents flash-of-light-content. The storage key suffix is versioned so a future default change can invalidate stale user prefs by bumping `-v2` → `-v3`. Never hardcode `data-theme="light"` in the base template — the assembler enforcement is the source of truth, prose alone is not enough (see retro 2026-05-20).
+
 ---
 
 ## Theme Files (in templates/themes/)

--- a/skills/meta/html-artifact/scripts/tests/test_assemble_template.py
+++ b/skills/meta/html-artifact/scripts/tests/test_assemble_template.py
@@ -86,6 +86,40 @@ class TestAssembleTemplateDirect:
         assert "<head>" in html
         assert "<body" in html
 
+    def test_dark_default_on_html_root(self) -> None:
+        """REGRESSION GUARD: <html> tag must hardcode data-theme='dark'.
+
+        Captured 2026-05-20: assembler shipped data-theme='light' for months
+        because the dark-default rule lived only in design-system.md prose.
+        This test enforces the rule in the deterministic layer.
+        """
+        for shape in ("spec", "code-review", "prototype", "report", "editor", "data-viz", "diagram", "deck"):
+            html = assemble_template(shape, "Test")
+            assert '<html lang="en" data-theme="dark">' in html, (
+                f"shape={shape}: <html> must hardcode data-theme='dark'"
+            )
+
+    def test_pre_paint_theme_init_script(self) -> None:
+        """Pre-paint <head> script must read versioned localStorage key.
+
+        Bumping the storage-key version (e.g. v2 -> v3) is the migration
+        mechanism for invalidating stale prefs when the default changes.
+        """
+        html = assemble_template("report", "Test")
+        assert "html-artifact-theme-v2" in html, "pre-paint init script missing or storage key not versioned"
+        head_end = html.find("</head>")
+        # Match the real <body data-shape="..."> opening tag, not CSS selectors
+        # like `body { ... }` that also start with `<body` in injected styles.
+        import re
+
+        body_match = re.search(r"<body\s+data-shape=", html)
+        assert body_match, "could not locate <body data-shape> opening tag"
+        body_start = body_match.start()
+        init_pos = html.find("html-artifact-theme-v2")
+        assert init_pos < head_end < body_start, (
+            f"theme init must execute before <body>: init={init_pos} head_end={head_end} body_start={body_start}"
+        )
+
     def test_html_entities_in_title(self) -> None:
         html = assemble_template("spec", "A & B <comparison>")
         assert "<title>A & B <comparison></title>" in html

--- a/skills/meta/html-artifact/scripts/tests/test_validate_artifact.py
+++ b/skills/meta/html-artifact/scripts/tests/test_validate_artifact.py
@@ -336,3 +336,221 @@ class TestCLIInterface:
             assert result["checks"]["has_export_button"] is True
         finally:
             path.unlink()
+
+
+class TestBrokenInternalRefs:
+    """REGRESSION GUARD: validator must catch href='#id' pointing to nonexistent ids.
+
+    SKILL.md:237 has claimed this check exists for months — until 2026-05-20 audit it
+    was prose-only. This test enforces the rule in the deterministic layer.
+    """
+
+    def _wrap(self, body: str) -> str:
+        return f"""<!DOCTYPE html>
+<html><head><!-- assembled by html-artifact v1.1 -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>T</title><style>*{{}}</style></head>
+<body>{body}</body></html>"""
+
+    def test_valid_anchor_passes(self) -> None:
+        path = _write_tmp(self._wrap('<a href="#section-1">Go</a><h2 id="section-1">Section</h2>'))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["no_broken_internal_refs"] is True
+            assert result.valid
+        finally:
+            path.unlink()
+
+    def test_broken_anchor_fails(self) -> None:
+        path = _write_tmp(self._wrap('<a href="#nonexistent">Broken</a>'))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["no_broken_internal_refs"] is False
+            assert any("nonexistent" in e for e in result.errors)
+            assert not result.valid
+        finally:
+            path.unlink()
+
+    def test_top_anchor_exempt(self) -> None:
+        """`href='#top'` is a browser default; should not require explicit id."""
+        path = _write_tmp(self._wrap('<a href="#top">Back to top</a>'))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["no_broken_internal_refs"] is True
+        finally:
+            path.unlink()
+
+    def test_no_anchors_passes(self) -> None:
+        path = _write_tmp(self._wrap("<p>No anchors here.</p>"))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["no_broken_internal_refs"] is True
+        finally:
+            path.unlink()
+
+    def test_id_in_script_string_does_not_satisfy(self) -> None:
+        """A string `'foo'` inside a <script> block must not falsely satisfy `href='#foo'`."""
+        body = '<a href="#foo">Click</a><script>var x = "id=\\"foo\\"";</script>'
+        path = _write_tmp(self._wrap(body))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["no_broken_internal_refs"] is False
+        finally:
+            path.unlink()
+
+    def test_multiple_broken_refs_all_reported(self) -> None:
+        body = '<a href="#a">A</a><a href="#b">B</a><a href="#c">C</a>'
+        path = _write_tmp(self._wrap(body))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["no_broken_internal_refs"] is False
+            err = next(e for e in result.errors if "Broken internal refs" in e)
+            assert "#a" in err
+            assert "#b" in err
+            assert "#c" in err
+        finally:
+            path.unlink()
+
+
+class TestSvgAccessibility:
+    """REGRESSION GUARD: every visible <svg> needs role='img' + aria-label.
+
+    Captured 2026-05-20 audit: design-system.md required this for months but
+    no validator enforced it. Decorative SVGs inside <button> are exempt
+    because the button's aria-label provides the accessibility hook.
+    """
+
+    def _wrap(self, body: str) -> str:
+        return f"""<!DOCTYPE html>
+<html><head><!-- assembled by html-artifact v1.1 -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>T</title><style>*{{}}</style></head>
+<body>{body}</body></html>"""
+
+    def test_svg_with_role_and_aria_label_passes(self) -> None:
+        body = '<svg role="img" aria-label="Architecture diagram" viewBox="0 0 100 100"></svg>'
+        path = _write_tmp(self._wrap(body))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["svg_accessibility"] is True
+            assert result.valid
+        finally:
+            path.unlink()
+
+    def test_svg_missing_role_fails(self) -> None:
+        body = '<svg aria-label="Diagram" viewBox="0 0 100 100"></svg>'
+        path = _write_tmp(self._wrap(body))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["svg_accessibility"] is False
+            assert not result.valid
+        finally:
+            path.unlink()
+
+    def test_svg_missing_aria_label_fails(self) -> None:
+        body = '<svg role="img" viewBox="0 0 100 100"></svg>'
+        path = _write_tmp(self._wrap(body))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["svg_accessibility"] is False
+        finally:
+            path.unlink()
+
+    def test_svg_in_button_exempt(self) -> None:
+        """SVGs nested in <button> are decorative; the button carries accessibility."""
+        body = (
+            '<button class="theme-toggle" aria-label="Toggle theme">'
+            '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="6"/></svg>'
+            "</button>"
+        )
+        path = _write_tmp(self._wrap(body))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["svg_accessibility"] is True
+        finally:
+            path.unlink()
+
+    def test_svg_with_role_presentation_exempt(self) -> None:
+        body = '<svg role="presentation" viewBox="0 0 100 100"></svg>'
+        path = _write_tmp(self._wrap(body))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["svg_accessibility"] is True
+        finally:
+            path.unlink()
+
+    def test_svg_with_aria_hidden_exempt(self) -> None:
+        body = '<svg aria-hidden="true" viewBox="0 0 100 100"></svg>'
+        path = _write_tmp(self._wrap(body))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["svg_accessibility"] is True
+        finally:
+            path.unlink()
+
+    def test_svg_with_aria_labelledby_passes(self) -> None:
+        body = (
+            '<svg role="img" aria-labelledby="caption-1" viewBox="0 0 100 100"></svg>'
+            '<span id="caption-1">Architecture</span>'
+        )
+        path = _write_tmp(self._wrap(body))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["svg_accessibility"] is True
+        finally:
+            path.unlink()
+
+    def test_no_svg_passes_trivially(self) -> None:
+        path = _write_tmp(self._wrap("<p>No SVG here.</p>"))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["svg_accessibility"] is True
+        finally:
+            path.unlink()
+
+
+class TestExternalSvgRefs:
+    """REGRESSION GUARD: <image href='http...'> and <use href='http...'> must fail self-containment.
+
+    SKILL.md:81 says diagrams are inline-SVG-only. Pre-fix, _check_self_contained
+    only looked at <link> stylesheets and <script src>, missing the SVG vectors.
+    """
+
+    def _wrap(self, body: str) -> str:
+        return f"""<!DOCTYPE html>
+<html><head><!-- assembled by html-artifact v1.1 -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>T</title><style>*{{}}</style></head>
+<body>{body}</body></html>"""
+
+    def test_external_image_href_fails(self) -> None:
+        body = '<svg role="img" aria-label="x"><image href="https://example.com/x.png"/></svg>'
+        path = _write_tmp(self._wrap(body))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["self_contained"] is False
+            assert any("<image href>" in e for e in result.errors)
+        finally:
+            path.unlink()
+
+    def test_external_use_href_fails(self) -> None:
+        body = '<svg role="img" aria-label="x"><use href="https://example.com/sprite.svg#icon"/></svg>'
+        path = _write_tmp(self._wrap(body))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["self_contained"] is False
+            assert any("<use href>" in e for e in result.errors)
+        finally:
+            path.unlink()
+
+    def test_local_use_href_passes(self) -> None:
+        """`<use href='#local-id'>` is the canonical inline-SVG sprite pattern; must pass."""
+        body = (
+            '<svg role="img" aria-label="x"><defs><circle id="dot" r="3"/></defs><use href="#dot" x="10" y="10"/></svg>'
+        )
+        path = _write_tmp(self._wrap(body))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["self_contained"] is True
+        finally:
+            path.unlink()

--- a/skills/meta/html-artifact/scripts/validate-artifact.py
+++ b/skills/meta/html-artifact/scripts/validate-artifact.py
@@ -75,12 +75,15 @@ def _check_title(content: str, result: ValidationResult) -> None:
 
 
 def _check_self_contained(content: str, result: ValidationResult) -> None:
-    """No external stylesheet links or script sources via http(s)."""
+    """No external stylesheet links, script sources, or SVG image refs via http(s)."""
     has_external_css = bool(
         re.search(r'<link[^>]+rel=["\']stylesheet["\'][^>]+href=["\']https?://', content, re.IGNORECASE)
     )
     has_external_js = bool(re.search(r'<script[^>]+src=["\']https?://', content, re.IGNORECASE))
-    passed = not has_external_css and not has_external_js
+    # SVG <image href="http..."> and <use href="http..."> bypass the inline-SVG-only contract.
+    has_external_svg_image = bool(re.search(r'<image\b[^>]+href=["\']https?://', content, re.IGNORECASE))
+    has_external_svg_use = bool(re.search(r'<use\b[^>]+href=["\']https?://', content, re.IGNORECASE))
+    passed = not (has_external_css or has_external_js or has_external_svg_image or has_external_svg_use)
     result.checks["self_contained"] = passed
     if not passed:
         externals = []
@@ -88,6 +91,10 @@ def _check_self_contained(content: str, result: ValidationResult) -> None:
             externals.append("external CSS")
         if has_external_js:
             externals.append("external JS")
+        if has_external_svg_image:
+            externals.append("external <image href>")
+        if has_external_svg_use:
+            externals.append("external <use href>")
         result.errors.append(f"Not self-contained: found {', '.join(externals)}.")
 
 
@@ -222,6 +229,80 @@ def _check_export_button(content: str, shape: str, result: ValidationResult) -> 
         )
 
 
+_INTERNAL_REF_RE = re.compile(r'href=["\']#([^"\']+)["\']', re.IGNORECASE)
+_ID_ATTR_RE = re.compile(r'\bid=["\']([^"\']+)["\']', re.IGNORECASE)
+
+
+def _check_no_broken_internal_refs(content: str, result: ValidationResult) -> None:
+    """Every `href="#id"` must point to an element with matching `id`.
+
+    Mirrors the SKILL.md "No broken internal refs" claim. Skips empty `href="#"`
+    (deliberate placeholder) and `href="#top"` (browser default for top-of-page).
+    """
+    # Strip <script> and <style> blocks before scanning ids — JS string literals and
+    # CSS selectors can produce false ids that don't actually exist as DOM ids.
+    scrubbed = re.sub(r"<script\b[^>]*>.*?</script>", "", content, flags=re.IGNORECASE | re.DOTALL)
+    scrubbed = re.sub(r"<style\b[^>]*>.*?</style>", "", scrubbed, flags=re.IGNORECASE | re.DOTALL)
+
+    refs = {m.group(1) for m in _INTERNAL_REF_RE.finditer(scrubbed)}
+    refs.discard("top")  # browser default
+    ids = {m.group(1) for m in _ID_ATTR_RE.finditer(scrubbed)}
+
+    broken = sorted(refs - ids)
+    passed = not broken
+    result.checks["no_broken_internal_refs"] = passed
+    if not passed:
+        # Cap the message length so a runaway template doesn't blow up output.
+        shown = ", ".join(f"#{r}" for r in broken[:5])
+        suffix = f" (+{len(broken) - 5} more)" if len(broken) > 5 else ""
+        result.errors.append(f"Broken internal refs: {shown}{suffix}.")
+
+
+_SVG_OPEN_RE = re.compile(r"<svg\b([^>]*)>", re.IGNORECASE)
+_BUTTON_BLOCK_RE = re.compile(r"<button\b[^>]*>.*?</button>", re.IGNORECASE | re.DOTALL)
+
+
+def _check_svg_accessibility(content: str, result: ValidationResult) -> None:
+    """Every visible <svg> needs role="img" + aria-label OR explicit role="presentation".
+
+    Mirrors design-system.md accessibility checklist. SVGs nested inside <button>
+    are exempt because the button's aria-label provides the accessibility hook.
+    Empty/no-svg artifacts pass trivially.
+    """
+    # Strip <button>...</button> blocks first — their inner <svg>s are decorative.
+    scrubbed = _BUTTON_BLOCK_RE.sub("", content)
+    matches = list(_SVG_OPEN_RE.finditer(scrubbed))
+    if not matches:
+        result.checks["svg_accessibility"] = True
+        return
+
+    bad = []
+    for m in matches:
+        attrs = m.group(1)
+        has_role_img = bool(re.search(r'\brole=["\']img["\']', attrs, re.IGNORECASE))
+        has_aria_label = bool(re.search(r'\baria-label=["\'][^"\']+["\']', attrs, re.IGNORECASE))
+        has_aria_labelledby = bool(re.search(r"\baria-labelledby=", attrs, re.IGNORECASE))
+        has_role_presentation = bool(re.search(r'\brole=["\'](presentation|none)["\']', attrs, re.IGNORECASE))
+        has_aria_hidden = bool(re.search(r'\baria-hidden=["\']true["\']', attrs, re.IGNORECASE))
+        if has_role_presentation or has_aria_hidden:
+            continue
+        if has_role_img and (has_aria_label or has_aria_labelledby):
+            continue
+        # Snip the offending tag opening for the error message.
+        snippet = (m.group(0)[:80] + "…") if len(m.group(0)) > 80 else m.group(0)
+        bad.append(snippet)
+
+    passed = not bad
+    result.checks["svg_accessibility"] = passed
+    if not passed:
+        shown = "; ".join(bad[:3])
+        suffix = f" (+{len(bad) - 3} more)" if len(bad) > 3 else ""
+        result.errors.append(
+            f"SVG accessibility: {len(bad)} <svg> missing role='img'+aria-label "
+            f"(or role='presentation'/aria-hidden='true'): {shown}{suffix}."
+        )
+
+
 def validate_artifact(file_path: Path, shape: str | None = None) -> ValidationResult:
     """Run all validation checks on an HTML artifact file.
 
@@ -245,6 +326,8 @@ def validate_artifact(file_path: Path, shape: str | None = None) -> ValidationRe
     _check_valid_structure(content, result)
     _check_assembler_marker(content, result)
     _check_theme_toggle(content, shape, result)
+    _check_no_broken_internal_refs(content, result)
+    _check_svg_accessibility(content, result)
 
     if shape is not None:
         _check_export_button(content, shape, result)

--- a/skills/meta/html-artifact/templates/components/theme-toggle.js
+++ b/skills/meta/html-artifact/templates/components/theme-toggle.js
@@ -1,20 +1,13 @@
 /* === Theme Toggle Component ===
- * Initialize <html data-theme> based on body's loaded theme name on first run,
- * then toggle between "light" and "dark" on click. The CSS in
- * theme-toggle.css overrides :root tokens at higher specificity so the
- * toggle works regardless of which named theme is loaded on body.
+ * Pre-paint init in <head> already set <html data-theme> from localStorage
+ * (or to the "dark" default). This file only handles click-to-flip and
+ * persistence. Storage key 'html-artifact-theme-v2' is versioned: bumping
+ * the suffix invalidates stale prefs when the default theme changes.
  */
-(function initThemeToggle() {
-  var html = document.documentElement;
-  var body = document.body;
-  if (!html.dataset.theme || html.dataset.theme === '' || html.dataset.theme === 'light' || html.dataset.theme === 'dark') {
-    var bodyTheme = body && body.dataset ? body.dataset.theme || '' : '';
-    var darkThemes = ['dark-focus'];
-    var startsDark = darkThemes.indexOf(bodyTheme) !== -1;
-    html.dataset.theme = startsDark ? 'dark' : 'light';
-  }
-})();
+var THEME_STORAGE_KEY = 'html-artifact-theme-v2';
 function toggleTheme() {
   var html = document.documentElement;
-  html.dataset.theme = html.dataset.theme === 'dark' ? 'light' : 'dark';
+  var next = html.dataset.theme === 'dark' ? 'light' : 'dark';
+  html.dataset.theme = next;
+  try { localStorage.setItem(THEME_STORAGE_KEY, next); } catch (e) { /* storage blocked: in-memory only */ }
 }


### PR DESCRIPTION
## Summary

Two threads, one branch — both prevent classes of silent regression in `skills/meta/html-artifact/`:

1. **Dark-by-default** (commit 74b41323) — every assembled artifact ships with `<html data-theme="dark">` hardcoded, plus a pre-paint `<head>` script that honors `localStorage['html-artifact-theme-v2']` before `<body>` paints. No flash of light content. Versioned storage key lets future default changes invalidate stale prefs.

2. **Close audit gaps** (commit a38d0a82) — the 2026-05-20 dark-default failure exposed a meta-failure: the rule that prevents that class of regression (the reference-file taxonomy at `design-system.md:167-178`) was itself unmirrored to SKILL.md. Plus three "checks" SKILL.md claimed existed didn't.

## What changed

**Dark-default (commit 1):**
- `templates/base-template.html`: `<html data-theme="dark">` + pre-paint init script in `<head>`.
- `templates/components/theme-toggle.js`: simplified to click-to-flip + persistence (init moved to `<head>`).
- `references/design-system.md`: documents the dark-by-default contract and the versioned storage-key migration mechanism.
- `SKILL.md`: adds DARK-DEFAULT GATE.
- Tests: 2 new regression guards (hardcoded-dark, pre-paint-init-runs-before-body).

**Audit gaps (commit 2):**
- `SKILL.md`: adds MIRRORING GATE — every load-bearing rule lives in (a) prose for judgment, (b) code for mechanism, (c) test for proof. The rule-that-prevents-this is now itself self-enforcing.
- `validate-artifact.py`: three new deterministic checks
  - `no_broken_internal_refs`: `href="#id"` must point to an existing `id` (excluding `#top`). Strips `<script>`/`<style>` blocks before scanning so JS string literals can't falsely satisfy a ref.
  - `svg_accessibility`: every visible `<svg>` needs `role="img"` + `aria-label` (or `aria-labelledby`). Decorative SVGs inside `<button>` are exempt. `role="presentation"` and `aria-hidden="true"` are explicit opt-outs.
  - External SVG refs: `<image href="http...">` and `<use href="http...">` now fail self-containment.
- `references/design-system.md`: corrects obsolete prose. Was documenting the old DOMContentLoaded init pattern; now reflects the pre-paint architecture.
- `SKILL.md` validation table: aligned with code reality (added missing rows, removed false claim).

## Test plan
- [x] `pytest skills/meta/html-artifact/scripts/tests/` — 174 passed (+18 new regression guards), 1 skipped (pre-existing slow marker).
- [x] All 8 shapes (spec, code-review, prototype, report, editor, data-viz, diagram, deck) assemble + validate clean against new checks.
- [x] `ruff check . --config pyproject.toml` — All checks passed.
- [x] `ruff format --check . --config pyproject.toml` — 396 files already formatted.
- [x] Hardcoded `<html data-theme="dark">` enforced for all 8 shapes (regression test).
- [x] Pre-paint init script runs before `<body>` opens (regression test).