### PR TITLE
feat: add agent-creator skill + agents-best-practices submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "skills/meta/agents-best-practices"]
-	path = skills/meta/agents-best-practices
-	url = git@github.com:DenisSergeevitch/agents-best-practices.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "skills/meta/agents-best-practices"]
+	path = skills/meta/agents-best-practices
+	url = git@github.com:DenisSergeevitch/agents-best-practices.git

--- a/scripts/migrate-skills-to-folders.py
+++ b/scripts/migrate-skills-to-folders.py
@@ -98,6 +98,7 @@ SKILL_MAPPING: dict[str, str] = {
     "skill-creator": "meta",
     "skill-eval": "meta",
     "agent-comparison": "meta",
+    "agent-creator": "meta",
     "agent-evaluation": "meta",
     "toolkit-evolution": "meta",
     "workflow-help": "meta",

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-05-21T03:25:47Z",
+  "generated": "2026-05-21T11:19:49Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
     "csuite": {
@@ -1622,7 +1622,8 @@
       "user_invocable": false,
       "pairs_with": [
         "agent-evaluation",
-        "verification-before-completion"
+        "verification-before-completion",
+        "agent-creator"
       ]
     },
     "skill-eval": {
@@ -2508,6 +2509,25 @@
         "planning",
         "feature-lifecycle",
         "verification-before-completion"
+      ]
+    },
+    "agent-creator": {
+      "file": "skills/meta/agent-creator/SKILL.md",
+      "description": "Scaffold vexjoy-agent operator .md files: frontmatter, routing block, operator context, reference loading table, phase/gate workflow.",
+      "triggers": [
+        "create agent",
+        "new agent",
+        "scaffold agent",
+        "agent template",
+        "build agent",
+        "agent design",
+        "make agent"
+      ],
+      "category": "meta",
+      "user_invocable": false,
+      "pairs_with": [
+        "skill-creator",
+        "agent-evaluation"
       ]
     }
   }

--- a/skills/meta/agent-creator/SKILL.md
+++ b/skills/meta/agent-creator/SKILL.md
@@ -101,7 +101,7 @@ agents/
 **Positive framing (CI gate):** Every instruction tells the reader what to do. Run the check after writing:
 
 ```bash
-python3 scripts/validate_positive_instruction_docs.py agents/{agent-name}.md
+python3 scripts/validate_positive_instruction_docs.py
 ```
 
 Exit code 1 means violations. Rewrite flagged instructions in action form before proceeding.
@@ -146,8 +146,8 @@ Run all validation checks before declaring the agent shippable.
 # Structural checks: filenames, frontmatter, line counts, loading tables
 python3 scripts/validate-references.py --agent {agent-name}
 
-# Positive framing gate
-python3 scripts/validate_positive_instruction_docs.py agents/{agent-name}.md
+# Positive framing gate (scans all tracked .md files)
+python3 scripts/validate_positive_instruction_docs.py
 
 # YAML parse
 python3 -c "import yaml; yaml.safe_load(open('agents/{agent-name}.md').read().split('---')[1]); print('YAML OK')"

--- a/skills/meta/agent-creator/SKILL.md
+++ b/skills/meta/agent-creator/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: agent-creator
+description: "Scaffold vexjoy-agent operator .md files: frontmatter, routing block, operator context, reference loading table, phase/gate workflow."
+routing:
+  triggers:
+    - create agent
+    - new agent
+    - scaffold agent
+    - agent template
+    - build agent
+    - agent design
+    - make agent
+  pairs_with:
+    - skill-creator
+    - agent-evaluation
+  complexity: Medium
+  category: meta
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash
+  - Glob
+  - Grep
+user_invocable: false
+---
+
+# Agent Creator
+
+Scaffold correctly-formed vexjoy-agent operator `.md` files. An agent file is a system-prompt contract: it sets identity, constraints, expertise, and routing — not application code.
+
+Phases: **DISCOVER → DESIGN → SCAFFOLD → REGISTER → VALIDATE**
+
+---
+
+## Phase 1 — DISCOVER
+
+Check for domain overlap before creating anything.
+
+```bash
+grep -i "<domain-keyword>" agents/*.md | grep "^agents/" | cut -d: -f1 | sort -u
+ls agents/ | grep "<domain-prefix>"
+```
+
+Gate 1: If an existing agent covers the domain, add a `references/` file to that agent instead of creating a new one. Proceed only when no existing agent covers the domain, or the user confirms after seeing the overlap.
+
+Read `docs/PHILOSOPHY.md` before proceeding — the philosophy governs operator context structure, progressive disclosure, positive framing, and tool restrictions. Components that violate it will fail CI.
+
+---
+
+## Phase 2 — DESIGN
+
+Decide the agent's identity and routing contract before writing a single line.
+
+| Decision | Question to answer |
+|----------|--------------------|
+| Role type | Reviewer/auditor, code modifier/engineer, or orchestrator? |
+| Allowed tools | Matches role: reviewers→Read/Glob/Grep; engineers→+Edit/Write/Bash; orchestrators→Read/Agent/Bash |
+| Complexity | Low (single-file, read-only), Medium (multi-file, routing), High (full sweeps, orchestration) |
+| Triggers | 3–6 specific phrases a user would naturally say — not generic verbs |
+| pairs_with | 2–3 agents commonly co-dispatched; verify each exists on disk before listing |
+| Reference files | Domains needing depth — each goes in `agents/{name}/references/` loaded on demand |
+
+Load `references/agent-design-patterns.md` for operator context structure, hook design, and routing design guidance.
+
+Gate 2: All six decisions answered before writing agent file content.
+
+---
+
+## Phase 3 — SCAFFOLD
+
+Write the agent file using the annotated template.
+
+Load `references/agent-frontmatter-template.md` for the complete template with all required fields and valid values.
+
+**File layout:**
+
+```
+agents/
+├── {agent-name}.md          # operator file — the system prompt contract
+└── {agent-name}/
+    ├── references/
+    │   └── *.md             # deep context, loaded on demand
+    ├── SPEC.md              # optional: contract for complex/high-impact agents
+    └── EVAL.md              # optional: repeatable eval cases
+```
+
+**Writing the operator context** (body after frontmatter):
+
+1. Role statement: what the agent does, what domain it owns
+2. Expertise list: concrete capabilities with specific sub-skills
+3. Mandatory pre-action protocol: what to read before acting and why
+4. Operator context block: hardcoded behaviors, default behaviors (ON), optional behaviors (OFF)
+5. Capabilities and limitations table: CAN / CANNOT with agent suggestions for out-of-scope requests
+6. Reference loading table: `| Signal | Load These Files | Why |` — required when a `references/` directory exists
+7. Workflow section: phase-by-phase with gates
+8. Error handling: cause/solution pairs for common failures
+9. Preferred patterns: what good looks like (positive framing)
+10. Anti-rationalization table: common rationalizations with required action
+
+**Positive framing (CI gate):** Every instruction tells the reader what to do. Run the check after writing:
+
+```bash
+python3 scripts/validate_positive_instruction_docs.py agents/{agent-name}.md
+```
+
+Exit code 1 means violations. Rewrite flagged instructions in action form before proceeding.
+
+**Progressive disclosure:** Main agent file stays navigable. Deep reference material goes in `{agent-name}/references/` loaded on demand. If the file exceeds 600 lines, extract content to `references/` first.
+
+Gate 3: Agent file written, YAML frontmatter parses cleanly:
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('agents/{agent-name}.md').read().split('---')[1]); print('OK')"
+```
+
+---
+
+## Phase 4 — REGISTER
+
+Add the agent to the routing index.
+
+```bash
+python3 scripts/generate-agent-index.py
+```
+
+Verify the count increased by exactly one:
+
+```bash
+python3 -c "
+import json
+d = json.load(open('agents/INDEX.json'))
+agents = d.get('agents', [])
+print(f'Registered agents: {len(agents)}')"
+```
+
+Gate 4: `agents/INDEX.json` contains the new agent entry. The router cannot discover unregistered agents.
+
+---
+
+## Phase 5 — VALIDATE
+
+Run all validation checks before declaring the agent shippable.
+
+```bash
+# Structural checks: filenames, frontmatter, line counts, loading tables
+python3 scripts/validate-references.py --agent {agent-name}
+
+# Positive framing gate
+python3 scripts/validate_positive_instruction_docs.py agents/{agent-name}.md
+
+# YAML parse
+python3 -c "import yaml; yaml.safe_load(open('agents/{agent-name}.md').read().split('---')[1]); print('YAML OK')"
+
+# Verify pairs_with entries exist on disk
+python3 -c "
+import yaml, os
+txt = open('agents/{agent-name}.md').read()
+fm = yaml.safe_load(txt.split('---')[1])
+for p in fm.get('routing', {}).get('pairs_with', []):
+    exists = os.path.exists(f'agents/{p}.md') or os.path.exists(f'skills/{p}/SKILL.md')
+    print(f'  {p}: {\"OK\" if exists else \"MISSING\"}')"
+```
+
+Gate 5: All scripts exit 0. No phantom `pairs_with` entries. No positive-framing violations.
+
+---
+
+## Error Handling
+
+### YAML parse error on frontmatter
+Cause: Unquoted colon in description, or bad indentation in routing block.
+Solution: Wrap description in double quotes. Run the YAML parse command above — the traceback pinpoints the line.
+
+### Trigger conflict with existing agent
+Cause: Two agents claim the same trigger phrase.
+Solution: Run the duplicate detection script in `agents/toolkit-governance-engineer/references/routing-table-patterns.md`. Make this agent's trigger more specific.
+
+### Agent not appearing in routing after INDEX regeneration
+Cause: Agent file path not matching the expected pattern, or frontmatter missing `routing.triggers`.
+Solution: Confirm file is at `agents/{name}.md`. Confirm `routing.triggers` is a non-empty list.
+
+### Reference loading table missing from validation
+Cause: Agent body has no `| Signal | Load These Files | Why |` table.
+Solution: Add a reference loading table with at least one row. See `references/agent-design-patterns.md` for the required format.
+
+---
+
+## Preferred Patterns
+
+### Role-matched allowed-tools
+Set `allowed-tools` to match what the agent actually does — reviewers read only, engineers write, orchestrators dispatch. This ensures agents stay within their domain and cannot make out-of-scope changes.
+
+### Triggers that match natural speech
+Write triggers as phrases a first-time user would naturally say, not internal system identifiers. "fix a bug in Go" routes better than "golang-debugging-invocation".
+
+### Reference loading table as required section
+Every agent that has a `references/` directory includes a loading table mapping signals to files. Agents without this table load references eagerly, violating the progressive disclosure principle from `docs/PHILOSOPHY.md`.
+
+### Expertise list over motivational framing
+List concrete capabilities the agent has: version-specific idiom tables, failure mode catalogs, concrete commands. Skip "you are an expert in X" — it adds no information the model will act on.
+
+---
+
+## Reference Loading Table
+
+| Signal | Load These Files | Why |
+|--------|-----------------|-----|
+| operator context structure, reference loading table format, phase/gate pattern, hook design, routing design | `references/agent-design-patterns.md` | Vexjoy-specific architecture patterns distilled from harness architecture literature |
+| frontmatter fields, YAML template, complexity tiers, INDEX.json registration | `references/agent-frontmatter-template.md` | Complete annotated template with all required fields and valid values |

--- a/skills/meta/agent-creator/references/agent-design-patterns.md
+++ b/skills/meta/agent-creator/references/agent-design-patterns.md
@@ -1,0 +1,219 @@
+# Agent Design Patterns
+
+> **Scope**: Vexjoy-specific operator context structure, reference loading table format, phase/gate patterns, hook design, routing design, and allowed-tools role mapping.
+> **Load when**: designing operator context, writing reference loading tables, planning routing triggers, or understanding hook event types.
+
+---
+
+## Operator Context Structure
+
+An agent `.md` file is a system-prompt contract. The body after frontmatter must contain these sections in order:
+
+```
+1. Role statement (1 paragraph)
+2. Expertise list (bullet list: concrete capabilities, not "you are an expert in X")
+3. Mandatory pre-action protocol (what to read first and why)
+4. Operator context block (hardcoded / default / optional behaviors)
+5. Capabilities and limitations table (CAN / CANNOT)
+6. Reference loading table (required when references/ exists)
+7. Workflow (phase-by-phase with gates)
+8. Error handling (cause/solution pairs)
+9. Preferred patterns (positive framing)
+10. Anti-rationalization table
+```
+
+### Operator Context Block
+
+The three-tier behavior model maps directly to how the agent is configured:
+
+| Tier | Label | Behavior |
+|------|-------|----------|
+| Always enforced | **Hardcoded** | Cannot be disabled. Include with WHY clause. |
+| On by default | **Default (ON unless disabled)** | Active unless the user turns them off. |
+| Off by default | **Optional (OFF unless enabled)** | Inactive unless the user explicitly enables. |
+
+Example entry with WHY clause:
+
+```markdown
+### Hardcoded Behaviors (Always Apply)
+
+- **Philosophy-First Editing**: Every modification must be defensible against
+  `docs/PHILOSOPHY.md`. If an edit violates a principle, reject or restructure.
+  WHY: Edits that drift from the philosophy create technical debt that compounds.
+```
+
+WHY clauses are mandatory for hardcoded behaviors — they enable the agent to apply the constraint to novel situations not covered by the literal text.
+
+---
+
+## Reference Loading Table Format
+
+Required in every agent that has a `references/` directory. Format:
+
+```markdown
+## Reference Loading Table
+
+| Signal | Load These Files | Why |
+|--------|-----------------|-----|
+| signal phrase matching task context | `references/file-name.md` | One sentence: what the file adds |
+```
+
+**Signal design rules:**
+
+- Signals are phrases or keywords that appear in the user's request or the task context
+- Each signal must map to exactly one or two reference files (progressive disclosure)
+- Signals overlap is acceptable — load greedily when multiple match
+- The Why column states what the file adds, not what it contains
+
+**Example:**
+
+```markdown
+| Signal | Load These Files | Why |
+|--------|-----------------|-----|
+| frontmatter, YAML, allowed-tools, field compliance | `references/frontmatter-compliance.md` | Required fields, ADR-063 tool restrictions, detection commands |
+| routing, triggers, pairs_with, INDEX.json | `references/routing-table-patterns.md` | Phantom route detection, trigger conflict checks |
+```
+
+---
+
+## Phase/Gate Pattern
+
+Phases advance sequentially. Each phase ends with a deterministic gate that must pass before the next phase begins.
+
+```markdown
+## Phase N — NAME
+
+[Instructions for this phase]
+
+Gate N: [Deterministic check the LLM or a script runs. Expressed as a command or a boolean condition.]
+```
+
+**Gate design rules:**
+
+- Gates must be checkable — not advisory opinions
+- Script-based gates (commands with exit codes) are stronger than prose conditions
+- Gates reference artifacts produced in the current phase, not future phases
+- A failing gate names the exact repair action
+
+**Example gate:**
+
+```markdown
+Gate 2: YAML frontmatter parses cleanly:
+```bash
+python3 -c "import yaml; yaml.safe_load(open('agents/{name}.md').read().split('---')[1]); print('OK')"
+```
+```
+
+---
+
+## Routing Design
+
+### Trigger Phrase Rules
+
+| Rule | Correct | Wrong |
+|------|---------|-------|
+| Natural speech | `create agent`, `scaffold agent` | `agent-creation-invocation` |
+| Specific enough | `edit skill frontmatter` | `edit`, `update`, `fix` |
+| Not generic verbs | `audit hook configuration` | `check`, `manage`, `run` |
+| 3–6 triggers per agent | 4 triggers | 1 trigger (under-routing) or 10 (over-claiming) |
+
+### Trigger Conflict Prevention
+
+Before adding triggers, detect conflicts:
+
+```bash
+python3 -c "
+import yaml, glob
+from collections import defaultdict
+triggers = defaultdict(list)
+for f in glob.glob('agents/*.md'):
+    txt = open(f).read()
+    if '---' not in txt: continue
+    try:
+        fm = yaml.safe_load(txt.split('---')[1])
+        for t in fm.get('routing', {}).get('triggers', []):
+            triggers[t.lower()].append(f)
+    except: pass
+for t, files in triggers.items():
+    if len(files) > 1:
+        print(f'CONFLICT: \"{t}\" in {files}')
+"
+```
+
+### pairs_with Design
+
+`pairs_with` lists agents commonly co-dispatched — not all possible collaborators. Rules:
+
+1. List 2–4 agents maximum
+2. Each entry must exist on disk before committing
+3. An agent cannot list itself
+4. Verify existence before adding:
+
+```bash
+for name in agent1 agent2; do
+  ls agents/${name}.md 2>/dev/null || ls skills/${name}/SKILL.md 2>/dev/null || echo "MISSING: ${name}"
+done
+```
+
+---
+
+## Allowed-Tools Role Mapping (ADR-063)
+
+| Role | Permitted Tools | Rationale |
+|------|-----------------|-----------|
+| Reviewer / auditor | `Read`, `Glob`, `Grep` | Read-only: prevents unauthorized changes during review |
+| Code modifier / engineer | `Read`, `Edit`, `Write`, `Bash`, `Glob`, `Grep` | Full access for implementation |
+| Orchestrator / coordinator | `Read`, `Agent`, `Bash` | Dispatches agents; no direct file edits |
+| Skill-invoker | `Read`, `Bash`, `Glob`, `Grep` | Executes skills but does not write files |
+
+**The rule**: `allowed-tools` must match the agent's actual role. Granting `Edit` to a reviewer lets it make unauthorized changes. Granting `Agent` to a non-orchestrator creates an uncontrolled dispatch path.
+
+Detection — find reviewers with write tools:
+
+```bash
+grep -l "reviewer" agents/*.md | xargs grep -l "Edit\|Write"
+```
+
+---
+
+## Hook Design
+
+Hooks fire on harness events and enforce gates the model cannot rationalize past. They use exit codes:
+
+| Exit code | Meaning | Use for |
+|-----------|---------|---------|
+| `0` | Pass / advisory | Warnings, informational output, non-blocking nudges |
+| `2` | Block | Hard gates: prerequisite missing, policy violation |
+
+**Event types and their purpose:**
+
+| Event | Fires when | Typical gates |
+|-------|------------|---------------|
+| `SessionStart` | Session opens | Inject learned context, detect operator mode |
+| `UserPromptSubmit` | User sends a message | Detect pipeline requests, capture corrections |
+| `PreToolUse` | Before any tool call | Safety gates, ADR checks, branch safety |
+| `PostToolUse` | After any tool call | Quality checks, INDEX sync, framing validation |
+| `PreCompact` | Before context compaction | Archive session learnings |
+| `Stop` | Session ends | Record metrics, graduate learnings |
+
+**Hook safety rule**: Hooks that enforce advisory policies exit 0. Hooks that enforce hard gates exit 2. A hook that exits non-zero on every call will deadlock the agent loop.
+
+Hook timeout: set `timeout` to the minimum needed. Advisory hooks: 2000–3000ms. Hooks with subprocess calls: 5000ms max.
+
+---
+
+## Progressive Disclosure Economics
+
+The three-file budget for a well-designed agent:
+
+| File | Role | Size target |
+|------|------|-------------|
+| `agents/{name}.md` | System prompt — loaded on every dispatch | < 600 lines |
+| `{name}/references/*.md` | Deep context — loaded on demand per phase | ≤ 500 lines each |
+| `{name}/SPEC.md` | Contract — loaded when designing or modifying | No limit |
+
+**What belongs in the main file**: role statement, frontmatter, phase structure, gate commands, error handling, reference loading table.
+
+**What belongs in references/**: checklists, pattern catalogs, example collections, detection command sets, template prose, anything only needed at execution time.
+
+**Test**: Remove the reference file. Does the agent still work for simple requests? (Yes.) Remove the reference loading table. Can the agent find deep content? (No.) The table is load-bearing; the reference body is not loaded until it's needed.

--- a/skills/meta/agent-creator/references/agent-frontmatter-template.md
+++ b/skills/meta/agent-creator/references/agent-frontmatter-template.md
@@ -164,7 +164,7 @@ python3 scripts/generate-skill-index.py
 After writing an agent `.md` file, run these in order:
 
 1. YAML parse: `python3 -c "import yaml; yaml.safe_load(open('agents/{name}.md').read().split('---')[1])"`
-2. Positive framing: `python3 scripts/validate_positive_instruction_docs.py agents/{name}.md`
+2. Positive framing: `python3 scripts/validate_positive_instruction_docs.py` (scans all tracked .md files)
 3. Reference structure: `python3 scripts/validate-references.py --agent {name}` (if references/ exists)
 4. pairs_with existence: verify each listed agent/skill exists on disk
 5. INDEX registration: `python3 scripts/generate-agent-index.py`

--- a/skills/meta/agent-creator/references/agent-frontmatter-template.md
+++ b/skills/meta/agent-creator/references/agent-frontmatter-template.md
@@ -1,0 +1,173 @@
+# Agent Frontmatter Template
+
+> **Scope**: Complete annotated YAML frontmatter template for vexjoy-agent operator `.md` files. Covers all required fields, valid values, complexity tier definitions, and INDEX.json registration.
+> **Load when**: writing agent frontmatter, auditing field compliance, or diagnosing routing failures.
+
+---
+
+## Complete Annotated Template
+
+```yaml
+---
+# Required: lowercase letters, numbers, hyphens only. Must match the directory
+# name under agents/ if a references/ directory exists.
+name: my-agent-name
+
+# Required: quoted string. Answers: what does this agent do, when should it
+# be selected, and what is it NOT for. Colons and commas require double quotes.
+# Length: 60–120 chars. No "Use when:" or "Use for:" prefix.
+description: "Domain-specific work: concrete capability A, capability B. Not for X or Y."
+
+# Optional: color shown in routing UI. Standard values: blue, green, yellow,
+# red, purple, orange. Omit if the agent has no visual grouping.
+color: blue
+
+# Optional: model override. Omit to use the session default.
+# Values: haiku (classification/scanning), sonnet (implementation/review).
+# Do not set opus — inspect task decomposition if opus seems required.
+model: sonnet
+
+routing:
+  # Required: list of 3–6 intent phrases matching natural speech.
+  # Each phrase should uniquely identify this agent's domain.
+  triggers:
+    - specific phrase users would say
+    - another natural phrase
+    - domain-specific action phrase
+
+  # Optional: 2–4 agents commonly co-dispatched with this one.
+  # Each entry must exist on disk before committing (verify with ls).
+  pairs_with:
+    - other-agent-name
+    - another-agent-name
+
+  # Required. Case-sensitive. Exactly one of: Low, Medium, High.
+  # Low: single-file edits, read-only audits, fast lookups
+  # Medium: multi-file edits, routing table updates, moderate orchestration
+  # High: full compliance sweeps, ADR consultations, heavy orchestration
+  complexity: Medium
+
+  # Required. String. Use these standard values:
+  # meta, engineering, review, operations, content
+  category: meta
+
+# Required for agents. List must match the agent's actual role (ADR-063).
+# Reviewers: [Read, Glob, Grep]
+# Engineers: [Read, Edit, Write, Bash, Glob, Grep]
+# Orchestrators: [Read, Agent, Bash]
+# Skill-invokers: [Read, Bash, Glob, Grep]
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash
+  - Glob
+  - Grep
+
+# Required for skills, optional for agents. Default: false.
+# false = router-dispatched (user never types the name)
+# true = user types it directly as a slash-command entry point
+user_invocable: false
+---
+```
+
+---
+
+## Field Reference Table
+
+| Field | Required | Type | Valid values |
+|-------|----------|------|-------------|
+| `name` | yes | string | lowercase, hyphens, numbers |
+| `description` | yes | quoted string | 60–120 chars; no "Use when:" prefix |
+| `color` | no | string | blue, green, yellow, red, purple, orange |
+| `model` | no | string | haiku, sonnet |
+| `routing.triggers` | yes | list | 3–6 natural-speech phrases |
+| `routing.pairs_with` | no | list | agent names that exist on disk |
+| `routing.complexity` | yes | enum | Low, Medium, High (case-sensitive) |
+| `routing.category` | yes | string | meta, engineering, review, operations, content |
+| `allowed-tools` | yes (agents) | list | tool names from the ADR-063 role table |
+| `user_invocable` | no | boolean | true, false (default: false) |
+
+---
+
+## Complexity Tier Definitions
+
+| Tier | Load strategy | Example agents |
+|------|---------------|----------------|
+| `Low` | Single dispatch, minimal context | Reviewer reading one file, simple lookup |
+| `Medium` | Multi-step dispatch, moderate context loading | Routing table update, 2–3 file edits |
+| `High` | Full orchestration, large reference sets | Compliance sweep, ADR consultation, cross-repo analysis |
+
+---
+
+## Validation Commands
+
+```bash
+# YAML parse — pinpoints broken field
+python3 -c "import yaml; yaml.safe_load(open('agents/{name}.md').read().split('---')[1]); print('OK')"
+
+# Find agents missing allowed-tools
+grep -rL "allowed-tools" agents/*.md
+
+# Find descriptions with unquoted colons
+grep -n "^description: [^\"'].*:" agents/*.md
+
+# Find wrong complexity casing
+grep -rn "complexity:" agents/*.md | grep -vE "complexity: (Low|Medium|High)"
+
+# Find phantom pairs_with entries
+python3 -c "
+import yaml, glob, os
+for f in glob.glob('agents/*.md'):
+    txt = open(f).read()
+    if '---' not in txt: continue
+    try:
+        fm = yaml.safe_load(txt.split('---')[1])
+        for p in fm.get('routing', {}).get('pairs_with', []):
+            if not os.path.exists(f'agents/{p}.md') and not os.path.exists(f'skills/{p}/SKILL.md'):
+                print(f'PHANTOM: {f} -> {p}')
+    except: pass
+"
+```
+
+---
+
+## INDEX.json Registration
+
+After writing the agent file, register it in the routing index. The router cannot discover unregistered agents.
+
+```bash
+# Regenerate agents index
+python3 scripts/generate-agent-index.py
+
+# Verify the new agent appears
+python3 -c "
+import json
+d = json.load(open('agents/INDEX.json'))
+agents = d.get('agents', [])
+print(f'Registered: {len(agents)}')
+names = [a.get('name') for a in agents] if isinstance(agents, list) else list(agents.keys())
+print('my-agent-name' in names and 'FOUND' or 'MISSING')
+"
+```
+
+Skills also need registration in `skills/INDEX.json`:
+
+```bash
+python3 scripts/generate-skill-index.py
+```
+
+---
+
+## Post-Write Checklist
+
+After writing an agent `.md` file, run these in order:
+
+1. YAML parse: `python3 -c "import yaml; yaml.safe_load(open('agents/{name}.md').read().split('---')[1])"`
+2. Positive framing: `python3 scripts/validate_positive_instruction_docs.py agents/{name}.md`
+3. Reference structure: `python3 scripts/validate-references.py --agent {name}` (if references/ exists)
+4. pairs_with existence: verify each listed agent/skill exists on disk
+5. INDEX registration: `python3 scripts/generate-agent-index.py`
+6. Trigger conflicts: run duplicate trigger detection from `agents/toolkit-governance-engineer/references/routing-table-patterns.md`
+
+All six steps must pass before the agent is committed.


### PR DESCRIPTION
## Summary

- Adds `skills/meta/agent-creator/` — a new meta skill that guides creation of correctly-formed vexjoy operator `.md` files, filling the gap between `skill-creator` (creates skills) and no prior tooling for agent scaffolding
- Adds `agents-best-practices` as a git submodule at `skills/meta/agents-best-practices/` pointing to `git@github.com:DenisSergeevitch/agents-best-practices.git` — used as source material for harness-architecture concepts, not imported directly (per PHILOSOPHY.md: "External Components Are Research Inputs, Not Imports")
- Updates `skills/INDEX.json`: registers `agent-creator` (117 skills total), adds `agent-creator` to `skill-creator.pairs_with`

## What agent-creator provides

5-phase workflow: **DISCOVER → DESIGN → SCAFFOLD → REGISTER → VALIDATE**

Two reference files loaded on demand:
- `references/agent-design-patterns.md` — operator context structure, routing trigger design, allowed-tools role mapping, hook event types, phase/gate format (adapted to vexjoy idiom)
- `references/agent-frontmatter-template.md` — complete annotated YAML template, complexity tier definitions, INDEX.json registration commands

Addresses gaps identified in capability assessment (`new-input.md`): no vexjoy `.md` format template, no INDEX.json registration step, no routing trigger design guidance, no `pairs_with` concept, no reference loading table pattern, no hook design guidance, no allowed-tools guidance.

## Keeping agents-best-practices current

```bash
git submodule update --remote skills/meta/agents-best-practices
```

## Test plan

- [ ] `python3 scripts/validate-skill-frontmatter.py skills/meta/agent-creator/SKILL.md` passes
- [ ] `python3 scripts/validate-references.py` passes
- [ ] `agent-creator` present in `skills/INDEX.json` with correct triggers
- [ ] `skill-creator.pairs_with` contains `agent-creator`
- [ ] Submodule resolves: `git submodule update --init skills/meta/agents-best-practices`