### PR TITLE
fix(agent-creator): add force_route: true so single-trigger matches route correctly

### DIFF
--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-05-22T01:06:50Z",
+  "generated": "2026-05-22T04:08:58Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
     "csuite": {
@@ -1391,6 +1391,7 @@
         "make agent"
       ],
       "category": "meta",
+      "force_route": true,
       "user_invocable": false,
       "pairs_with": [
         "skill-creator",

--- a/skills/meta/agent-creator/SKILL.md
+++ b/skills/meta/agent-creator/SKILL.md
@@ -10,6 +10,7 @@ routing:
     - build agent
     - agent design
     - make agent
+  force_route: true
   pairs_with:
     - skill-creator
     - agent-evaluation


### PR DESCRIPTION
## Summary

- `agent-creator` skill was missing `force_route: true`, causing single-trigger matches to score "low" confidence and return `matched: false` from the pre-router — requests like "create agent that is an urban gardener" fell through to the Haiku LLM router unnecessarily
- Adding `force_route: true` promotes any trigger hit to "medium" confidence, so agent-creation requests route deterministically without LLM disambiguation
- `skills/INDEX.json` regenerated: `force_route: true` added to `agent-creator` entry

## Changes

| File | Change |
|------|--------|
| `skills/meta/agent-creator/SKILL.md` | Added `force_route: true` to routing frontmatter |
| `skills/INDEX.json` | Regenerated — `force_route: true` added to agent-creator entry |

## Test plan

- [ ] `ruff check . --config pyproject.toml` passes
- [ ] `ruff format --check . --config pyproject.toml` passes
- [ ] Route "create agent that is an urban gardener" — confirm pre-router returns `matched: true` with skill `agent-creator`
- [ ] Route "create an agent" — same confirmation
- [ ] Route unrelated request — confirm agent-creator does not intercept