### PR TITLE
fix(routing): expand fish-shell-config semantic guards; extend benchmark

### DIFF
--- a/scripts/index-router.py
+++ b/scripts/index-router.py
@@ -65,7 +65,7 @@ MIN_SCORE_THRESHOLD = 0.1
 # When any guard word appears in the request, the match is discarded.
 SEMANTIC_GUARDS: dict[str, set[str]] = {
     "pr-workflow": {"back", "pressure", "pushback", "pushed", "pushing"},
-    "fish-shell-config": {"for", "bugs", "compliments", "information", "ideas", "answers"},
+    "fish-shell-config": {"for", "bug", "bugs", "compliments", "information", "ideas", "answers", "out", "feedback"},
     "voice-writer": {"remove", "strip", "clean", "detect", "identify", "fix", "scan", "audit"},
 }
 

--- a/scripts/index-router.py
+++ b/scripts/index-router.py
@@ -65,8 +65,16 @@ MIN_SCORE_THRESHOLD = 0.1
 # When any guard word appears in the request, the match is discarded.
 SEMANTIC_GUARDS: dict[str, set[str]] = {
     "pr-workflow": {"back", "pressure", "pushback", "pushed", "pushing"},
-    "fish-shell-config": {"for", "bug", "bugs", "compliments", "information", "ideas", "answers", "out", "feedback"},
+    "fish-shell-config": {"for", "bugs", "compliments", "information", "ideas", "answers"},
     "voice-writer": {"remove", "strip", "clean", "detect", "identify", "fix", "scan", "audit"},
+}
+
+# Multi-word disqualifying phrases (substring match in lowered request).
+# Use this when a unigram guard would over-suppress legitimate requests
+# (e.g. 'out' alone collides with "log out", "check out"; but "fish out"
+# reliably means search/extract, not the Fish shell).
+SEMANTIC_GUARD_PHRASES: dict[str, set[str]] = {
+    "fish-shell-config": {"fish out", "fish for"},
 }
 
 
@@ -252,7 +260,13 @@ def check_force_routes(request: str, entries: list[IndexEntry]) -> IndexEntry | 
     for entry in entries:
         if not entry.force_route:
             continue
-        # Semantic guard: skip if request contains disqualifying context words
+        # Phrase-level guard: skip if request contains a disqualifying phrase
+        # (e.g. "fish out" suppresses fish-shell-config without over-blocking
+        # legitimate "log out" or "check out").
+        phrase_guards = SEMANTIC_GUARD_PHRASES.get(entry.name)
+        if phrase_guards and any(phrase in lowered for phrase in phrase_guards):
+            continue
+        # Unigram guard: skip if request contains disqualifying context words
         guards = SEMANTIC_GUARDS.get(entry.name)
         if guards and (request_words & guards):
             continue

--- a/scripts/index-router.py
+++ b/scripts/index-router.py
@@ -260,11 +260,11 @@ def check_force_routes(request: str, entries: list[IndexEntry]) -> IndexEntry | 
     for entry in entries:
         if not entry.force_route:
             continue
-        # Phrase-level guard: skip if request contains a disqualifying phrase
-        # (e.g. "fish out" suppresses fish-shell-config without over-blocking
-        # legitimate "log out" or "check out").
+        # Phrase-level guard: skip if a disqualifying phrase appears as a
+        # whole-word match (e.g. "fish out" suppresses fish-shell-config
+        # without blocking "log out" or substring-matching "selfish forum").
         phrase_guards = SEMANTIC_GUARD_PHRASES.get(entry.name)
-        if phrase_guards and any(phrase in lowered for phrase in phrase_guards):
+        if phrase_guards and any(re.search(rf"\b{re.escape(phrase)}\b", lowered) for phrase in phrase_guards):
             continue
         # Unigram guard: skip if request contains disqualifying context words
         guards = SEMANTIC_GUARDS.get(entry.name)

--- a/scripts/pre-route.py
+++ b/scripts/pre-route.py
@@ -40,7 +40,7 @@ INDEX_PATHS = {
 # unrelated to the skill. Keyed by skill name -> set of disqualifying context words.
 SEMANTIC_GUARDS: dict[str, set[str]] = {
     "pr-workflow": {"back", "pressure", "pushback", "pushed", "pushing"},
-    "fish-shell-config": {"for", "bugs", "compliments", "information", "ideas", "answers"},
+    "fish-shell-config": {"for", "bug", "bugs", "compliments", "information", "ideas", "answers", "out", "feedback"},
     "voice-writer": {"remove", "strip", "clean", "detect", "identify", "fix", "scan", "audit"},
 }
 

--- a/scripts/pre-route.py
+++ b/scripts/pre-route.py
@@ -188,12 +188,13 @@ def _is_semantically_guarded(
 
     Returns True if the match should be discarded.
     """
-    # Phrase-level guard: if any disqualifying phrase appears anywhere in the
-    # request, this is not a domain match.
+    # Phrase-level guard: if any disqualifying phrase appears as a whole-word
+    # match anywhere in the request, this is not a domain match. Word-boundary
+    # match prevents "fish for" suppressing "selfish forum" etc.
     phrase_guards = SEMANTIC_GUARD_PHRASES.get(skill_name)
     if phrase_guards:
         for phrase in phrase_guards:
-            if phrase in request_lower:
+            if re.search(rf"\b{re.escape(phrase)}\b", request_lower):
                 return True
 
     guards = SEMANTIC_GUARDS.get(skill_name)

--- a/scripts/pre-route.py
+++ b/scripts/pre-route.py
@@ -40,8 +40,16 @@ INDEX_PATHS = {
 # unrelated to the skill. Keyed by skill name -> set of disqualifying context words.
 SEMANTIC_GUARDS: dict[str, set[str]] = {
     "pr-workflow": {"back", "pressure", "pushback", "pushed", "pushing"},
-    "fish-shell-config": {"for", "bug", "bugs", "compliments", "information", "ideas", "answers", "out", "feedback"},
+    "fish-shell-config": {"for", "bugs", "compliments", "information", "ideas", "answers"},
     "voice-writer": {"remove", "strip", "clean", "detect", "identify", "fix", "scan", "audit"},
+}
+
+# Multi-word disqualifying phrases (substring match in lowered request).
+# Use this when a unigram guard would over-suppress legitimate requests
+# (e.g. 'out' alone collides with "log out", "check out"; but "fish out"
+# reliably means search/extract, not the Fish shell).
+SEMANTIC_GUARD_PHRASES: dict[str, set[str]] = {
+    "fish-shell-config": {"fish out", "fish for"},
 }
 
 
@@ -168,12 +176,26 @@ def _is_semantically_guarded(
 ) -> bool:
     """Check if the match is a false positive due to common English idioms.
 
+    Two layers of suppression:
+    1. SEMANTIC_GUARD_PHRASES (multi-word substring match anywhere in request) —
+       used when a single guard word would over-suppress (e.g. "fish out").
+    2. SEMANTIC_GUARDS (unigram word match in 60-char context window around
+       the trigger) — used for words that are unambiguous in context.
+
     Uses the trigger's compiled regex pattern to locate the match position,
     which correctly handles multi-word triggers with intervening words
     (e.g. "create a PR" matching trigger "create pr").
 
     Returns True if the match should be discarded.
     """
+    # Phrase-level guard: if any disqualifying phrase appears anywhere in the
+    # request, this is not a domain match.
+    phrase_guards = SEMANTIC_GUARD_PHRASES.get(skill_name)
+    if phrase_guards:
+        for phrase in phrase_guards:
+            if phrase in request_lower:
+                return True
+
     guards = SEMANTIC_GUARDS.get(skill_name)
     if not guards:
         return False

--- a/scripts/routing-benchmark.json
+++ b/scripts/routing-benchmark.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "description": "Canonical routing benchmark for /do router regression testing. Each test case pairs a natural-language request with its expected agent and/or skill. Used to detect silent routing regressions when models or routing tables change. routing_tier classifies how strictly the router is expected to match: force_route (script must fire correct force_route), candidate (correct answer in top-3), llm_only (no false-positive force-route expected).",
   "test_cases": [
     {
@@ -365,6 +365,172 @@
       "category": "pairs-with-agent-resolution",
       "routing_tier": "candidate",
       "notes": "Security threat model \u2014 agent resolved via pairs_with=['python-general-engineer']. Single agent in pairs_with, no agent field on skill."
+    },
+    {
+      "request": "commit to this design and move forward",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "llm_only",
+      "notes": "Decision/dedication, not git commit \u2014 must NOT route to pr-workflow"
+    },
+    {
+      "request": "fish out the root cause of this bug",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "llm_only",
+      "notes": "Search/investigate, not Fish shell \u2014 must NOT route to fish-shell-config"
+    },
+    {
+      "request": "give me a quick read on the architecture",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "llm_only",
+      "notes": "Brief overview, not a quick edit \u2014 must NOT route to quick"
+    },
+    {
+      "request": "go ahead and merge the branches in your head",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "llm_only",
+      "notes": "Cognitive merge, not git merge \u2014 must NOT route to pr-workflow"
+    },
+    {
+      "request": "review the planning meeting notes",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "llm_only",
+      "notes": "Reading notes, not code review or planning skill \u2014 must NOT force-route"
+    },
+    {
+      "request": "install the new ergonomic keyboard",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "llm_only",
+      "notes": "Hardware install, not toolkit install skill \u2014 must NOT route to install"
+    },
+    {
+      "request": "we need to scan and remove voice samples from the corpus",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "llm_only",
+      "notes": "Data cleaning, not voice-writer generation \u2014 must NOT force-route to voice-writer (semantic guard exists)"
+    },
+    {
+      "request": "audit our explanation traces for accuracy",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "llm_only",
+      "notes": "Audit/review intent, not generating new explanation \u2014 must NOT auto-force to explanation-traces"
+    },
+    {
+      "request": "what's my current branch?",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "trivial-operations",
+      "routing_tier": "llm_only",
+      "notes": "Trivial git status check \u2014 router handles directly, no force-route"
+    },
+    {
+      "request": "compare this approach to the alternative",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "trivial-operations",
+      "routing_tier": "llm_only",
+      "notes": "Opinion/comparison \u2014 NOT trivial, but should not force-route either; LLM judgment needed"
+    },
+    {
+      "request": "evaluate https://example.com/some-blog-post",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "trivial-operations",
+      "routing_tier": "llm_only",
+      "notes": "URL evaluation \u2014 NOT trivial despite looking like a single read; needs Simple+ routing"
+    },
+    {
+      "request": "give me your opinion on this design",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "trivial-operations",
+      "routing_tier": "llm_only",
+      "notes": "Opinion/recommendation \u2014 NOT trivial, must not force-route"
+    },
+    {
+      "request": "create a new hook for the SessionStart event",
+      "expected_agent": "hook-development-engineer",
+      "expected_skill": null,
+      "category": "meta-tooling",
+      "routing_tier": "candidate",
+      "candidate_depth": 5,
+      "notes": "Hook creation \u2014 specialist agent should appear in top-5 candidates (lesson #7 preferred-routes)"
+    },
+    {
+      "request": "scaffold a new agent for Rust development",
+      "expected_agent": null,
+      "expected_skill": "agent-creator",
+      "category": "meta-tooling",
+      "routing_tier": "force_route",
+      "notes": "Agent creation \u2014 force-route to agent-creator skill"
+    },
+    {
+      "request": "I need a new pipeline for video processing",
+      "expected_agent": "pipeline-orchestrator-engineer",
+      "expected_skill": null,
+      "category": "meta-tooling",
+      "routing_tier": "candidate",
+      "candidate_depth": 5,
+      "notes": "Pipeline creation \u2014 pipeline-orchestrator-engineer must be in top-5 (currently top-1, so pass)"
+    },
+    {
+      "request": "go test ./internal/... to check the changes",
+      "expected_agent": "golang-general-engineer",
+      "expected_skill": "go-patterns",
+      "category": "pre-route-confidence",
+      "routing_tier": "force_route",
+      "notes": "Multiple go-patterns triggers (go test, ./...) \u2014 high confidence force-route, lesson #7 hard-gate target"
+    },
+    {
+      "request": "run the goroutine leak check",
+      "expected_agent": "golang-general-engineer",
+      "expected_skill": "go-patterns",
+      "category": "pre-route-confidence",
+      "routing_tier": "force_route",
+      "candidate_depth": 5,
+      "notes": "'goroutine' is a go-patterns trigger \u2014 force-route fires correctly, this exercises Go domain force-routing"
+    },
+    {
+      "request": "create a PR",
+      "expected_agent": null,
+      "expected_skill": "pr-workflow",
+      "category": "pre-route-confidence",
+      "routing_tier": "pre_route_only",
+      "notes": "PR creation \u2014 pre-route.py force-routes via 'create PR' trigger (multi-word). index-router.py candidate scoring normalization makes this hard there.",
+      "candidate_depth": 5
+    },
+    {
+      "request": "push the work to GitHub for review",
+      "expected_agent": null,
+      "expected_skill": "pr-workflow",
+      "category": "pre-route-confidence",
+      "routing_tier": "pre_route_only",
+      "notes": "PR push intent \u2014 pre-route.py multi-word trigger 'push changes' or 'push to' should fire. index-router.py candidate normalization disadvantages high-trigger skills.",
+      "candidate_depth": 5
+    },
+    {
+      "request": "do a structured code review on the diff",
+      "expected_agent": null,
+      "expected_skill": "systematic-code-review",
+      "category": "pre-route-confidence",
+      "routing_tier": "candidate",
+      "candidate_depth": 5,
+      "notes": "Code review intent \u2014 systematic-code-review should be in top-5 candidates"
     }
   ]
 }

--- a/scripts/tests/test_routing_accuracy.py
+++ b/scripts/tests/test_routing_accuracy.py
@@ -218,3 +218,73 @@ class TestLLMOnly:
                     f"Script force-routed to {routed!r} but expected {expected_skill!r} "
                     f"(or None) for LLM-only case: {case['request']!r}"
                 )
+
+
+# ---------------------------------------------------------------------------
+# pre-route.py tier — exercises the FAST pre-router used by /do Phase 2 Step 0
+# ---------------------------------------------------------------------------
+
+PRE_ROUTE_SCRIPT = REPO_ROOT / "scripts" / "pre-route.py"
+
+
+def run_pre_route(request: str) -> dict:
+    """Invoke pre-route.py for a request and return parsed JSON output.
+
+    pre-route.py is the FAST pre-router that /do Phase 2 Step 0 calls before
+    dispatching the Haiku routing agent. It returns matched/agent/skill/confidence,
+    not scored candidates.
+
+    Args:
+        request: The user request string to route.
+
+    Returns:
+        Parsed JSON dict from pre-route.py stdout.
+    """
+    result = subprocess.run(
+        ["python3", str(PRE_ROUTE_SCRIPT), "--request", request, "--json-compact"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"pre-route.py exited with {result.returncode}: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+class TestPreRoute:
+    """Tests for the pre-route.py fast pre-router (used by /do Phase 2 Step 0).
+
+    pre-route.py is invoked first by /do; if it returns matched=True with high
+    confidence, /do skips the Haiku routing agent. These tests verify the
+    pre-route layer routes correctly for cases where it's the authoritative
+    decision-maker.
+    """
+
+    @pytest.mark.parametrize(
+        "case",
+        _tier_cases("pre_route_only"),
+        ids=_case_id,
+    )
+    def test_pre_route_matches(self, case: dict) -> None:
+        """Assert pre-route.py returns the expected skill or agent for the request.
+
+        Args:
+            case: Test case dict from routing-benchmark.json.
+        """
+        result = run_pre_route(case["request"])
+        expected_skill = case.get("expected_skill")
+        expected_agent = case.get("expected_agent")
+
+        assert result.get("matched") is True, (
+            f"Expected pre-route.py to match {case['request']!r} but got matched=False. "
+            f"Reasoning: {result.get('reasoning')}"
+        )
+
+        if expected_skill is not None:
+            assert result.get("skill") == expected_skill, (
+                f"Expected skill={expected_skill!r}, got {result.get('skill')!r}. Reasoning: {result.get('reasoning')}"
+            )
+
+        if expected_agent is not None:
+            assert result.get("agent") == expected_agent, (
+                f"Expected agent={expected_agent!r}, got {result.get('agent')!r}. Reasoning: {result.get('reasoning')}"
+            )

--- a/scripts/tests/test_routing_accuracy.py
+++ b/scripts/tests/test_routing_accuracy.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -241,7 +242,7 @@ def run_pre_route(request: str) -> dict:
         Parsed JSON dict from pre-route.py stdout.
     """
     result = subprocess.run(
-        ["python3", str(PRE_ROUTE_SCRIPT), "--request", request, "--json-compact"],
+        [sys.executable, str(PRE_ROUTE_SCRIPT), "--request", request, "--json-compact"],
         capture_output=True,
         text=True,
         timeout=10,
@@ -273,6 +274,14 @@ class TestPreRoute:
         result = run_pre_route(case["request"])
         expected_skill = case.get("expected_skill")
         expected_agent = case.get("expected_agent")
+
+        # Every pre_route_only case must declare at least one expectation.
+        # Without this assertion, a fixture with neither expected_skill nor
+        # expected_agent would silently pass on the matched-only check below.
+        assert expected_skill is not None or expected_agent is not None, (
+            f"pre_route_only case {case['request']!r} has neither expected_skill nor expected_agent. "
+            f"Add an expectation or move the case to llm_only tier."
+        )
 
         assert result.get("matched") is True, (
             f"Expected pre-route.py to match {case['request']!r} but got matched=False. "


### PR DESCRIPTION
## Summary

- Resolved a deterministic false-positive force-route: "fish out the root cause of this bug" was matching `fish-shell-config`. Originally fixed by adding `bug`, `out`, `feedback` to SEMANTIC_GUARDS — code review (iteration 1) caught that this over-suppressed legitimate requests like "config.fish has a bug" and "log out and back into fish_config". Refactored to introduce `SEMANTIC_GUARD_PHRASES` (multi-word substring guards) keyed off `"fish out"` and `"fish for"`. Reverted SEMANTIC_GUARDS to its original idiom set.
- Extended the routing benchmark from 45 → 65 fixture cases across `false-positive-guard`, `trivial-operations`, `meta-tooling`, and a new `pre-route-confidence` boundary tier.
- Added `TestPreRoute` class to exercise `pre-route.py` (the fast pre-router used by /do Phase 2 Step 0) — `test_routing_accuracy.py` only covered `index-router.py` before.

## Why

`/do` Phase 2 Step 0 calls `pre-route.py` first; if it force-routes with high confidence, /do skips the Haiku LLM. A false-positive force-route here is more harmful than at the LLM layer because it bypasses semantic judgment entirely. The `bug` singular gap was real and hit a plausible debugging request.

## Test results

```
95/95 pass    (was 64/65 — the missing 1 was the bug this PR fixes)
ruff check    All checks passed!
ruff format   172 files already formatted
```

## Reviewer regression cases (iteration 1 verification)

After the phrase-guard refactor, all five cases route correctly:
- `"fish out the root cause of this bug"` → falls through (phrase guard "fish out" fires)
- `"config.fish has a bug"` → matches fish-shell-config (no over-suppression)
- `"log out and back into fish_config"` → matches fish-shell-config (no over-suppression)
- `"config.fish needs feedback"` → matches fish-shell-config (no over-suppression)
- `"fish for bugs"` → falls through (phrase guard "fish for" fires)

## Things to scrutinize

- **The 65-case fixture set includes 20 new entries** appended to the original 45. The PR description in an earlier draft of this body misstated this as "5 fixture corrections to existing cases" — that was wrong. There are no edits to pre-existing fixtures; the 5 corrections I made mid-development were applied in-place to fixtures I had already added in the same session, so they don't appear as a diff. Correcting the description here for accuracy.
- A genuine separate router defect was discovered but **NOT fixed here**: `index-router.py` candidate scoring is normalized by total trigger count, which disadvantages skills with many triggers (e.g. `pr-workflow` has 47, never wins candidate top-5). Pre-route.py force-routes those cases correctly, so user-visible /do behavior is fine. Flagged for a separate PR.
- The benchmark expansion is the lasting value here. The single-bug fix is small.

## Test plan

- [x] `pytest scripts/tests/test_routing_accuracy.py scripts/tests/test_pre_route.py -q` → 95/95 pass
- [x] `ruff check . --config pyproject.toml` → All checks passed
- [x] `ruff format --check . --config pyproject.toml` → no reformat needed
- [x] All 5 reviewer regression cases verified
- [ ] CI green