### PR TITLE
feat(routing): backfill not_for on all force-route skills

### DIFF
--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-05-22T04:41:35Z",
+  "generated": "2026-05-23T15:29:49Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
     "csuite": {
@@ -330,6 +330,7 @@
         "check python",
         "pre-commit check"
       ],
+      "not_for": "general Python coding (use python-general-engineer), data analysis scripts, or tutorials \u2014 fires when the user wants ruff/mypy/pytest/bandit quality checks run on existing code",
       "category": "code-quality",
       "force_route": true,
       "user_invocable": false,
@@ -797,6 +798,7 @@
         "make check",
         "Go lint"
       ],
+      "not_for": "'go' as a verb (go ahead, here we go, go-live, let's go), Go (the board game), pidgin/cargo english 'go do X' \u2014 only fires for the Go programming language",
       "category": "language",
       "force_route": true,
       "user_invocable": false,
@@ -1282,6 +1284,7 @@
         ".fish file",
         "#!/usr/bin/env fish"
       ],
+      "not_for": "fishing for bugs (debugging), fishing for feedback (asking for input), 'fish out' as 'extract/find', fish (the animal) \u2014 only fires for the Fish shell config",
       "category": "process",
       "force_route": true,
       "user_invocable": false,
@@ -1412,6 +1415,7 @@
         "agent design",
         "make agent"
       ],
+      "not_for": "creating real estate agents, ML agents, OS agents (e.g. SNMP), travel agents, customer service agents \u2014 only for vexjoy-agent .md operator files",
       "category": "meta",
       "force_route": true,
       "user_invocable": false,
@@ -1499,6 +1503,7 @@
         "show decisions",
         "trace log"
       ],
+      "not_for": "general 'why did the test fail' debugging, explaining concepts to a user, code documentation, stack traces \u2014 only for querying recorded routing/agent decisions",
       "category": "analysis",
       "force_route": true,
       "user_invocable": true,
@@ -1554,6 +1559,7 @@
         "diagnose setup",
         "toolkit health"
       ],
+      "not_for": "installing npm packages, pip packages, OS packages, hardware, third-party tools \u2014 only for VexJoy Agent toolkit setup verification",
       "category": "meta-tooling",
       "force_route": true,
       "user_invocable": true
@@ -1803,6 +1809,7 @@
         "complete feature pipeline",
         "feature pipeline"
       ],
+      "not_for": "small bug fixes (use quick), code reviews, refactoring single files, content writing \u2014 only for new feature work spanning design \u2192 plan \u2192 implement \u2192 validate \u2192 release",
       "category": "process",
       "force_route": true,
       "user_invocable": false,
@@ -1944,6 +1951,7 @@
         "where did I leave off",
         "what's next"
       ],
+      "not_for": "city planning, financial planning, meeting planning, travel itineraries, casual 'planning meeting notes' \u2014 only for software task planning, specs, and plan-lifecycle management",
       "category": "process",
       "force_route": true,
       "user_invocable": true,
@@ -2023,6 +2031,7 @@
         "gpt review",
         "cross-model review"
       ],
+      "not_for": "general disagreement ('push back on a design'), committing to an idea ('commit to this approach'), pushing out the door, push notifications, social media reviews \u2014 only for git push/commit/PR operations",
       "category": "git-workflow",
       "force_route": true,
       "user_invocable": true,

--- a/skills/code-quality/python-quality-gate/SKILL.md
+++ b/skills/code-quality/python-quality-gate/SKILL.md
@@ -14,6 +14,7 @@ allowed-tools:
 agent: python-general-engineer
 routing:
   force_route: true
+  not_for: "general Python coding (use python-general-engineer), data analysis scripts, or tutorials — fires when the user wants ruff/mypy/pytest/bandit quality checks run on existing code"
   triggers:
     - "Python quality"
     - "ruff check"

--- a/skills/engineering/go-patterns/SKILL.md
+++ b/skills/engineering/go-patterns/SKILL.md
@@ -15,6 +15,7 @@ agent: golang-general-engineer
 routing:
   category: language
   force_route: true
+  not_for: "'go' as a verb (go ahead, here we go, go-live, let's go), Go (the board game), pidgin/cargo english 'go do X' — only fires for the Go programming language"
   triggers:
     # testing triggers
     - go test

--- a/skills/infrastructure/fish-shell-config/SKILL.md
+++ b/skills/infrastructure/fish-shell-config/SKILL.md
@@ -11,6 +11,7 @@ allowed-tools:
   - Edit
 routing:
   category: process
+  not_for: "fishing for bugs (debugging), fishing for feedback (asking for input), 'fish out' as 'extract/find', fish (the animal) — only fires for the Fish shell config"
   triggers:
     - fish
     - fish shell

--- a/skills/meta/agent-creator/SKILL.md
+++ b/skills/meta/agent-creator/SKILL.md
@@ -11,6 +11,7 @@ routing:
     - agent design
     - make agent
   force_route: true
+  not_for: "creating real estate agents, ML agents, OS agents (e.g. SNMP), travel agents, customer service agents — only for vexjoy-agent .md operator files"
   pairs_with:
     - skill-creator
     - agent-evaluation

--- a/skills/meta/explanation-traces/SKILL.md
+++ b/skills/meta/explanation-traces/SKILL.md
@@ -19,6 +19,7 @@ routing:
     - "show decisions"
     - "trace log"
   force_route: true
+  not_for: "general 'why did the test fail' debugging, explaining concepts to a user, code documentation, stack traces — only for querying recorded routing/agent decisions"
   pairs_with: []
   complexity: Simple
   category: analysis

--- a/skills/meta/install/SKILL.md
+++ b/skills/meta/install/SKILL.md
@@ -12,6 +12,7 @@ allowed-tools:
   - Agent
 routing:
   force_route: true
+  not_for: "installing npm packages, pip packages, OS packages, hardware, third-party tools — only for VexJoy Agent toolkit setup verification"
   triggers:
     - "install toolkit"
     - "verify installation"

--- a/skills/process/feature-lifecycle/SKILL.md
+++ b/skills/process/feature-lifecycle/SKILL.md
@@ -15,6 +15,7 @@ allowed-tools:
   - Task
 routing:
   force_route: true
+  not_for: "small bug fixes (use quick), code reviews, refactoring single files, content writing — only for new feature work spanning design → plan → implement → validate → release"
   triggers:
     - feature design
     - design feature

--- a/skills/process/planning/SKILL.md
+++ b/skills/process/planning/SKILL.md
@@ -20,6 +20,7 @@ allowed-tools:
   - Skill
 routing:
   force_route: true
+  not_for: "city planning, financial planning, meeting planning, travel itineraries, casual 'planning meeting notes' — only for software task planning, specs, and plan-lifecycle management"
   triggers:
     - "write spec"
     - "user stories"

--- a/skills/process/pr-workflow/SKILL.md
+++ b/skills/process/pr-workflow/SKILL.md
@@ -21,6 +21,7 @@ allowed-tools:
   - AskUserQuestion
 routing:
   force_route: true
+  not_for: "general disagreement ('push back on a design'), committing to an idea ('commit to this approach'), pushing out the door, push notifications, social media reviews — only for git push/commit/PR operations"
   triggers:
     - "push changes"
     - "push my changes"


### PR DESCRIPTION
## Summary

Brings `not_for` coverage on force-route skills from **1/10 → 10/10**. The `routing-manifest.py` output already emits `not_for` per skill — it just had nothing useful to emit for 9 of the 10 force-routes. This change populates the missing fields so the Haiku routing agent has explicit negative examples for every force-route candidate.

## What's NOT in this PR

- No changes to `pre-route.py` or `index-router.py` — those use the `SEMANTIC_GUARDS` Python word sets, not `not_for` text. PR #666 covered the deterministic-router fix.
- No changes to /do skill files or quality-loop.md. The doc edits I tested in a prior branch were deferred per accuracy-over-bloat directive.
- This is a metadata-only PR. Rendered output below.

## Honest framing

There is **no automated test** that exercises the Haiku layer. The effect of these `not_for` descriptions on real routing decisions can only be observed live via `learning-db.py route-stats`. I believe the additions will reduce force-route misrouting on ambiguous phrasings, but I cannot prove it from a test rig.

The change is low-risk because:
- It only adds documentation strings; no code paths change
- The deterministic routers (pre-route.py, index-router.py) ignore `not_for` entirely
- INDEX.json is auto-generated from frontmatter — verified by re-running the generator

## Coverage delta

```
Before: 1/10 force-route skills with not_for (only `quick`)
After:  10/10 force-route skills with not_for
```

Skills updated:
- python-quality-gate, go-patterns, fish-shell-config, agent-creator, explanation-traces, install, feature-lifecycle, planning, pr-workflow

## Test results

```
pytest scripts/tests/test_routing_*  -> 166/166 pass
validate_positive_instruction_docs.py -> count: 0
check-routing-drift.py -> exit 0
ruff check . -> All checks passed
ruff format --check . -> 396 files already formatted
```

## Things to scrutinize

- The `not_for` text per skill — is it accurate to the skill's actual scope? Spot check by reading the SKILL.md description vs the new not_for line.
- INDEX.json diff should match exactly the frontmatter additions (10 entries, one line each, plus a regenerated `generated` timestamp). No unexpected drift.
- Lesson #1 from the prior research session called for "negative examples in force-route tables." This PR delivers that via the `not_for` field consumed by the manifest.

## Test plan

- [x] `pytest scripts/tests/test_routing_accuracy.py scripts/tests/test_pre_route.py scripts/tests/test_index_router.py -q` → 166/166 pass
- [x] `python3 scripts/validate_positive_instruction_docs.py` → exit 0
- [x] `python3 scripts/check-routing-drift.py` → exit 0
- [x] `ruff check . --config pyproject.toml` → All checks passed
- [x] `ruff format --check . --config pyproject.toml` → no reformat needed
- [x] `python3 scripts/generate-skill-index.py` → reproduces INDEX.json from updated frontmatter
- [ ] CI green