### PR TITLE
feat(skills): add cve-source-check skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-This toolkit prevents that. 44 domain agents, 121 workflow skills, 77 hooks, 101 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+This toolkit prevents that. 44 domain agents, 122 workflow skills, 77 hooks, 101 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Factory (`/do`).
 

--- a/docs/for-knowledge-workers.md
+++ b/docs/for-knowledge-workers.md
@@ -2,7 +2,7 @@
 
 ## What This Gives You
 
-Writing, research, community moderation, data analysis, content publishing. 121 skills behind a single command. You describe work. The system routes it.
+Writing, research, community moderation, data analysis, content publishing. 122 skills behind a single command. You describe work. The system routes it.
 
 ## Interface
 

--- a/docs/for-linkedin.md
+++ b/docs/for-linkedin.md
@@ -69,7 +69,7 @@ A year of daily use on real work. Finding gaps, filling them, watching the syste
 The result:
 
 - 44 domain specialist agents across languages, infrastructure, review, research, content
-- 121 workflow skills covering everything from TDD to article writing to Reddit moderation
+- 122 workflow skills covering everything from TDD to article writing to Reddit moderation
 - 77 lifecycle hooks that fire at session boundaries to inject context, capture learnings, enforce gates
 - A learning database that tracks patterns and graduates them into agent behavior
 - Parallel review pipelines that catch issues before they reach production

--- a/scripts/migrate-skills-to-folders.py
+++ b/scripts/migrate-skills-to-folders.py
@@ -91,6 +91,7 @@ SKILL_MAPPING: dict[str, str] = {
     "cron-job-auditor": "infrastructure",
     "endpoint-validator": "infrastructure",
     "service-health-check": "infrastructure",
+    "cve-source-check": "infrastructure",
     # meta/ — toolkit self-management
     "do": "meta",
     "install": "meta",

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-05-23T21:14:24Z",
+  "generated": "2026-05-26T14:30:07Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
     "csuite": {
@@ -1327,6 +1327,23 @@
       "pairs_with": [
         "shell-process-patterns",
         "headless-cron-creator"
+      ]
+    },
+    "cve-source-check": {
+      "file": "skills/infrastructure/cve-source-check/SKILL.md",
+      "description": "Audit CVE/vulnerability source coverage for a technology stack.",
+      "triggers": [
+        "check cve sources",
+        "cve source coverage",
+        "audit cve feeds",
+        "vulnerability source audit",
+        "verify cve sources",
+        "security feed audit"
+      ],
+      "category": "infrastructure",
+      "user_invocable": true,
+      "pairs_with": [
+        "service-health-check"
       ]
     },
     "endpoint-validator": {

--- a/skills/infrastructure/cve-source-check/SKILL.md
+++ b/skills/infrastructure/cve-source-check/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: cve-source-check
+description: "Audit CVE/vulnerability source coverage for a technology stack. Maps each component (container, library, base image, runtime) to authoritative CVE feeds, flags gaps, and produces audit-ready reports. Generic: works for any service or stack."
+user-invocable: true
+argument-hint: "[--inventory <file>] [--inline <tech-list>] [--current-sources <file>] [--service <name>] [--check-urls]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+routing:
+  triggers:
+    - "check cve sources"
+    - "cve source coverage"
+    - "audit cve feeds"
+    - "vulnerability source audit"
+    - "verify cve sources"
+    - "security feed audit"
+  category: infrastructure
+  complexity: Simple
+  pairs_with:
+    - service-health-check
+---
+
+# CVE Source Check
+
+Audits CVE/vulnerability source coverage for a technology stack. Given an inventory
+of components and (optionally) the feeds you currently monitor, it maps each
+component to authoritative CVE sources, flags gaps, and emits audit-ready reports.
+
+## Scope
+
+| In scope | Out of scope |
+|---|---|
+| Mapping components → authoritative feeds via a versioned registry | Running vulnerability scanners (Trivy/Snyk/etc.) |
+| Reporting coverage and gaps in JSON + Markdown | Fetching CVE content or ranking by severity |
+| Optional HEAD-check for source URL reachability | Integrating with private/commercial vuln databases |
+| Audit-ready output (deterministic, reproducible) | Live LLM research per run |
+
+## Inputs
+
+| Flag | Purpose |
+|---|---|
+| `--inventory <file>` | JSON inventory: `[{name, version?, type?}, ...]` or `{components: [...]}`. |
+| `--inline "name@ver,name,..."` | Quick comma-separated list. Mutually exclusive with `--inventory`. |
+| `--current-sources <file>` | Optional. One URL per line. Blank lines and `#` comments skipped. |
+| `--service <name>` | Free-form name used in report header and filenames. |
+| `--check-urls` | HEAD-check every source URL (5s timeout, graceful degradation). |
+| `--registry <path>` | Override default `tech-source-registry.json`. |
+| `--out-dir <path>` | Output directory (default: cwd). |
+
+JSON inventory format only. YAML is not supported — stdlib does not ship a YAML parser.
+
+## Outputs
+
+| File | Format |
+|---|---|
+| `cve-source-report-{service}-{YYYYMMDD}.md` | Human-readable audit report. |
+| `cve-source-report-{service}-{YYYYMMDD}.json` | Machine-readable per `references/output-formats.md`. |
+
+| Exit code | Meaning |
+|---|---|
+| 0 | Full coverage. |
+| 1 | Gaps exist (unmapped components or unmonitored sources). |
+| 2 | At least one source URL is unreachable (only with `--check-urls`). |
+| 3 | Input error (missing/malformed registry or inventory). |
+
+## Workflow
+
+### Phase 1: LOAD
+
+1. Locate the registry: `tech-source-registry.json` next to this SKILL.md by default.
+2. Build an inventory:
+   - From `--inventory`: parse JSON; accept either a list or `{components: [...]}`.
+   - From `--inline`: split on commas, parse `name@version` pairs.
+3. If `--current-sources` is provided, read URLs (one per line); normalize for
+   case-insensitive comparison.
+
+**Gate**: at least one inventory component is present. Empty inventory → exit 3.
+
+### Phase 2: MAP & VERIFY
+
+1. For each component, look up `name` (and aliases) in the registry.
+   - Found → status `mapped`, attach the registry's source list.
+   - Missing → status `unmapped`, sources `[]`.
+2. If current sources were loaded, mark each source `monitored: true` when its
+   normalized URL appears in the set.
+3. If `--check-urls` is set, HEAD-check every unique source URL. Treat
+   200/301/302/403/405 as reachable; record definite failures and network errors
+   distinctly. See `references/source-verification.md`.
+
+**Gate**: every component has a status; every source has `monitored` and
+`reachable` fields populated (`reachable: null` when checks are skipped).
+
+### Phase 3: REPORT
+
+1. Compute the summary: components, mapped/unmapped, monitored, coverage %,
+   gaps, unreachable.
+2. Write the JSON report.
+3. Write the Markdown report:
+   - Summary table.
+   - Components table with ✅ / ⚠️ / ❌ markers.
+   - **Gaps** section listing primary then secondary sources to add (only when
+     gaps exist).
+   - **Unmapped** section listing registry-extension TODOs (only when unmapped
+     components exist).
+4. Print a one-screen summary to stdout including report paths.
+5. Set the exit code per the table above.
+
+**Gate**: both files exist on disk and the summary printed; exit code reflects
+the audit result.
+
+## Quick start
+
+```bash
+# Inline, offline, no monitoring data
+python3 scripts/check-cve-sources.py \
+  --inline "go@1.22,alpine@3.19,postgres@16,redis@7,nginx@1.25" \
+  --service my-service
+
+# Inventory file + current monitored feeds
+python3 scripts/check-cve-sources.py \
+  --inventory examples/inventory.example.json \
+  --current-sources examples/current-sources.example.txt \
+  --service my-service
+
+# Same, with link verification
+python3 scripts/check-cve-sources.py \
+  --inventory examples/inventory.example.json \
+  --current-sources examples/current-sources.example.txt \
+  --service my-service \
+  --check-urls
+```
+
+## Extending the registry
+
+To add a technology, edit `tech-source-registry.json`. Each entry needs `name`,
+`aliases`, `type`, and 1–3 `sources`. Schema lives at
+`references/registry-schema.md`.
+
+## Reference files
+
+- `references/registry-schema.md` — registry shape, allowed `kind`/`priority`,
+  and how to add entries.
+- `references/source-verification.md` — HEAD-check semantics and graceful
+  degradation rules.
+- `references/output-formats.md` — JSON schema, Markdown sections, and exit-code
+  table.
+
+## Error handling
+
+### "ERROR: failed to load registry"
+Cause: registry file missing or malformed JSON.
+Solution: confirm `tech-source-registry.json` is at `--registry` (or default
+location) and parses with `python3 -m json.tool`.
+
+### "ERROR: failed to load inventory"
+Cause: inventory file missing, malformed JSON, or unexpected shape.
+Solution: validate with `python3 -m json.tool`. Inventory must be a list or an
+object with a `components` key.
+
+### "ERROR: inventory is empty"
+Cause: no usable components after parsing.
+Solution: confirm each entry has a `name`. Inline form requires non-empty tokens.
+
+### Coverage stuck at 0%
+Cause: `--current-sources` URLs do not match registry URLs exactly (e.g., extra
+path segments, trailing slashes).
+Solution: copy URLs directly from the registry. The script normalizes scheme/host
+case and trailing slash; everything else must match.
+
+### `--check-urls` flags many `[—]` entries
+Cause: network issues (proxy, DNS, offline) — recorded as `reachable: null`.
+Solution: re-run without `--check-urls` for the audit; investigate network
+separately. Network errors do not affect the gap exit code.

--- a/skills/infrastructure/cve-source-check/examples/current-sources.example.txt
+++ b/skills/infrastructure/cve-source-check/examples/current-sources.example.txt
@@ -1,0 +1,5 @@
+# Example: feeds my-service currently monitors.
+# One URL per line; blank lines and `#` comments are skipped.
+https://pkg.go.dev/vuln/list
+https://security.alpinelinux.org/
+https://www.postgresql.org/support/security/

--- a/skills/infrastructure/cve-source-check/examples/inventory.example.json
+++ b/skills/infrastructure/cve-source-check/examples/inventory.example.json
@@ -1,0 +1,10 @@
+{
+  "service": "my-service",
+  "components": [
+    {"name": "go", "version": "1.22.3", "type": "runtime"},
+    {"name": "alpine", "version": "3.19", "type": "base-image"},
+    {"name": "postgres", "version": "16.2", "type": "container"},
+    {"name": "redis", "version": "7.2", "type": "container"},
+    {"name": "nginx", "version": "1.25", "type": "container"}
+  ]
+}

--- a/skills/infrastructure/cve-source-check/references/output-formats.md
+++ b/skills/infrastructure/cve-source-check/references/output-formats.md
@@ -1,0 +1,90 @@
+# Output Formats
+
+The script writes two reports per run:
+
+- `cve-source-report-{service}-{YYYYMMDD}.json` — machine-readable.
+- `cve-source-report-{service}-{YYYYMMDD}.md` — human-readable / audit-ready.
+
+Both live in `--out-dir` (defaults to cwd). The service name is sanitized to `[A-Za-z0-9_.-]`.
+
+## JSON schema
+
+```json
+{
+  "service": "my-service",
+  "generated_at": "2026-05-26T14:32:11Z",
+  "summary": {
+    "components": 5,
+    "mapped": 5,
+    "unmapped": 0,
+    "monitored": 3,
+    "coverage_pct": 60.0,
+    "gaps": 2,
+    "unreachable": 0
+  },
+  "components": [
+    {
+      "name": "postgres",
+      "version": "16.2",
+      "type": "container",
+      "status": "mapped",
+      "sources": [
+        {
+          "url": "https://www.postgresql.org/support/security/",
+          "kind": "advisory-list",
+          "priority": "primary",
+          "monitored": true,
+          "reachable": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `summary.coverage_pct` | `monitored / components × 100`, one decimal. |
+| `summary.gaps` | Count of components either unmapped, or mapped but with zero monitored sources. |
+| `summary.unreachable` | Count of source URLs that returned a definitive HTTP failure (only with `--check-urls`). |
+| `components[].status` | `"mapped"` (in registry) or `"unmapped"` (registry has no entry). |
+| `components[].sources[].monitored` | `true` if `--current-sources` listed this URL. |
+| `components[].sources[].reachable` | `true` / `false` / `null`; see `source-verification.md`. |
+
+## Markdown report
+
+Sections in order:
+
+1. **H1 header** with the service name.
+2. **Generated timestamp** (UTC, ISO-8601).
+3. **Summary table** — component / mapped / unmapped / monitored / coverage / gaps / unreachable.
+4. **Legend** — ✅ mapped+monitored, ⚠️ mapped not monitored, ❌ unmapped.
+5. **Components table** — one row per component with status marker, name, version, type, and sources.
+6. **Gaps section** — per-component primary/secondary sources to add. Only present when gaps exist.
+7. **Unmapped section** — registry-extension TODO list. Only present when unmapped components exist.
+
+## Source-cell format
+
+Each source in the components table renders as:
+
+```
+{flag} {priority}/{kind}{reach}
+```
+
+| Token | Meaning |
+|---|---|
+| `flag` | `✓` if monitored, `·` if not. |
+| `priority` | `primary` / `secondary`. |
+| `kind` | One of the registry's allowed kinds. |
+| `reach` | `[ok]`, `[DOWN]`, or `[—]`; only present when `--check-urls` was set. |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Full coverage: every mapped component has at least one monitored source, and there are no unmapped components. |
+| 1 | Gaps exist (unmapped components and/or mapped components with no monitored sources). |
+| 2 | At least one source URL returned a definitive HTTP failure. Only emitted when `--check-urls` is set. Implies 1 too — gaps are still reported. |
+| 3 | Input error (registry/inventory missing or malformed, or empty inventory). |
+
+CI consumers should treat 1 and 2 as actionable and 3 as a configuration bug.

--- a/skills/infrastructure/cve-source-check/references/registry-schema.md
+++ b/skills/infrastructure/cve-source-check/references/registry-schema.md
@@ -1,0 +1,71 @@
+# Registry Schema
+
+`tech-source-registry.json` is the canonical mapping from technology to authoritative
+CVE/security feeds. Edits are additive: new entries grow coverage without breaking
+existing ones.
+
+## Top-level shape
+
+```json
+{
+  "$schema_version": "1.0",
+  "description": "...",
+  "kinds": [...],
+  "priorities": [...],
+  "technologies": [ ... ]
+}
+```
+
+| Field | Type | Purpose |
+|---|---|---|
+| `$schema_version` | string | Bump on breaking shape change. |
+| `kinds` | string[] | Allowed values for each source's `kind`. |
+| `priorities` | string[] | Allowed values for each source's `priority`. |
+| `technologies` | object[] | One entry per technology. |
+
+## Technology entry
+
+```json
+{
+  "name": "postgres",
+  "aliases": ["postgresql", "pg"],
+  "type": "container",
+  "sources": [
+    {"url": "https://www.postgresql.org/support/security/", "kind": "advisory-list", "priority": "primary"}
+  ]
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | yes | Canonical name. Lowercase, no spaces. Used as primary lookup key. |
+| `aliases` | yes (may be empty) | Alternate names users put in inventories. Lowercased on load. |
+| `type` | yes | One of `runtime`, `base-image`, `container`, `library`. Free-form additions allowed. |
+| `sources` | yes | One or more authoritative feeds. |
+
+## Source entry
+
+| Field | Allowed values | Notes |
+|---|---|---|
+| `url` | full https URL | Stable feed URL. Avoid links that 30x to login pages. |
+| `kind` | `advisory-list`, `github-security`, `mailing-list`, `distro-tracker`, `vendor-page`, `mitre` | Drives reader expectations. |
+| `priority` | `primary`, `secondary` | At least one `primary` per technology. Secondary feeds add depth. |
+
+## Adding a new technology
+
+1. Pick a canonical `name` (lowercase). Search the registry first to avoid duplicates.
+2. List likely user-typed aliases.
+3. Pick `type` from the existing set when possible.
+4. Add 1–3 sources. Lead with the vendor's own advisory page or GHSA when present.
+5. Re-run the script against a sample inventory to confirm the entry resolves.
+
+## Adding a new `kind`
+
+Edit the top-level `kinds` array first, then use it in source entries. Keep the set
+small; `kind` is for filtering and explanation, not categorization theatre.
+
+## Versioning
+
+The registry is additive. Breaking changes (renaming `kinds`, removing entries with
+existing usage) bump `$schema_version`. The script reads the registry permissively;
+unknown fields are ignored.

--- a/skills/infrastructure/cve-source-check/references/source-verification.md
+++ b/skills/infrastructure/cve-source-check/references/source-verification.md
@@ -1,0 +1,54 @@
+# Source Verification
+
+`--check-urls` enables HTTP HEAD verification of registry source URLs. The verification
+step is best-effort and degrades gracefully — it never blocks the audit.
+
+## Behavior
+
+| Outcome | HTTP signal | Recorded as | Affects exit code? |
+|---|---|---|---|
+| Reachable | 200 / 301 / 302 / 403 / 405 | `reachable: true` | No |
+| Definitively unreachable | 4xx (except 403/405), 5xx | `reachable: false` | Yes (exit 2 if any) |
+| Network error | timeout, DNS failure, TLS failure | `reachable: null` (WARN) | No |
+
+403 and 405 are treated as reachable: many security feed pages reject HEAD with
+"Method Not Allowed" or block bots, but the URL still resolves and serves content
+to a browser.
+
+## Why HEAD instead of GET
+
+- HEAD avoids downloading large advisory archives.
+- Most servers honor HEAD with the same routing as GET.
+- Failures are still informative: a 404 from HEAD is a 404 from GET.
+
+## Timeout
+
+5 seconds per URL. Each URL is checked at most once per run (results cached on the
+URL string). For a registry of ~22 entries with 2–3 sources each, the worst case is
+under 4 minutes; the typical case is under 30 seconds.
+
+## When `--check-urls` is appropriate
+
+| Situation | Run with `--check-urls`? |
+|---|---|
+| CI / scheduled audit | Yes — catches link rot early. |
+| Offline laptop / no network | No. The audit works fully offline without the flag. |
+| Restricted egress (corporate proxy) | Set `HTTPS_PROXY` env var; or omit the flag. |
+| One-shot audit during PR review | Optional. Skip if network is flaky. |
+
+## Reading the report
+
+In Markdown, each source cell shows `[ok]`, `[DOWN]`, or `[—]`:
+
+- `[ok]` — server responded with a reachable status.
+- `[DOWN]` — server responded with a clear error status. Investigate.
+- `[—]` — network error or check skipped. No conclusion drawn.
+
+In JSON, the same information is in each source's `reachable` field as
+`true` / `false` / `null`.
+
+## Failure handling
+
+A single unreachable URL does not abort the run. The script continues, records the
+state, and surfaces the count in the summary. Exit code 2 is set only when at least
+one source returned a definitive failure AND `--check-urls` was passed.

--- a/skills/infrastructure/cve-source-check/scripts/check-cve-sources.py
+++ b/skills/infrastructure/cve-source-check/scripts/check-cve-sources.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""check-cve-sources.py — audit CVE/vulnerability source coverage for a tech stack.
+
+Three-phase methodology:
+  1. LOAD          inventory + registry + (optional) currently-monitored sources
+  2. MAP & VERIFY  resolve each component to authoritative feeds; mark monitored;
+                   optionally HEAD-check URL reachability
+  3. REPORT        emit JSON + Markdown audit reports
+
+stdlib only. Generic. Vendor-neutral.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+DEFAULT_REGISTRY = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..",
+    "tech-source-registry.json",
+)
+HEAD_TIMEOUT = 5
+REACHABLE_CODES = {200, 301, 302, 403, 405}
+
+
+# ----------------------------- LOAD -----------------------------------------
+
+
+def load_registry(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def build_lookup(registry: dict) -> dict[str, dict]:
+    """Map name + aliases (lowercased) -> tech entry."""
+    lookup: dict[str, dict] = {}
+    for entry in registry.get("technologies", []):
+        keys = [entry["name"]] + list(entry.get("aliases", []))
+        for k in keys:
+            lookup[k.lower()] = entry
+    return lookup
+
+
+def parse_inventory(path: str) -> list[dict]:
+    """JSON inventory: [{name, version?, type?}, ...] or {components: [...]}."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        components = data.get("components", [])
+    elif isinstance(data, list):
+        components = data
+    else:
+        raise ValueError("Inventory JSON must be a list or {components: [...]}")
+    out = []
+    for c in components:
+        if isinstance(c, str):
+            name, ver = _split_pin(c)
+            out.append({"name": name, "version": ver, "type": ""})
+        elif isinstance(c, dict):
+            out.append(
+                {
+                    "name": c.get("name", "").strip(),
+                    "version": str(c.get("version", "")).strip(),
+                    "type": c.get("type", "").strip(),
+                }
+            )
+    return [c for c in out if c["name"]]
+
+
+def parse_inline(spec: str) -> list[dict]:
+    """Parse 'name@ver,name,name@ver' into component list."""
+    out = []
+    for token in spec.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        name, ver = _split_pin(token)
+        out.append({"name": name, "version": ver, "type": ""})
+    return out
+
+
+def _split_pin(token: str) -> tuple[str, str]:
+    if "@" in token:
+        n, v = token.split("@", 1)
+        return n.strip(), v.strip()
+    return token.strip(), ""
+
+
+def load_current_sources(path: str) -> set[str]:
+    """One URL per line; blank and # comments skipped."""
+    urls: set[str] = set()
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            urls.add(_normalize_url(line))
+    return urls
+
+
+def _normalize_url(url: str) -> str:
+    # Drop trailing slash, lowercase scheme+host for comparison.
+    m = re.match(r"^(https?://)([^/]+)(/.*)?$", url, re.IGNORECASE)
+    if not m:
+        return url.rstrip("/")
+    scheme, host, path = m.group(1).lower(), m.group(2).lower(), (m.group(3) or "")
+    return f"{scheme}{host}{path}".rstrip("/")
+
+
+# ----------------------------- MAP & VERIFY ---------------------------------
+
+
+def map_component(component: dict, lookup: dict[str, dict]) -> dict:
+    key = component["name"].lower()
+    entry = lookup.get(key)
+    if entry is None:
+        return {
+            **component,
+            "status": "unmapped",
+            "type": component.get("type") or "unknown",
+            "sources": [],
+        }
+    sources = [{**s, "monitored": False, "reachable": None} for s in entry.get("sources", [])]
+    return {
+        **component,
+        "status": "mapped",
+        "type": component.get("type") or entry.get("type", "unknown"),
+        "sources": sources,
+    }
+
+
+def mark_monitored(mapped: list[dict], current: set[str]) -> None:
+    for comp in mapped:
+        for s in comp["sources"]:
+            if _normalize_url(s["url"]) in current:
+                s["monitored"] = True
+
+
+def head_check(url: str) -> bool | None:
+    """Return True (reachable), False (definitely unreachable), None (network error)."""
+    try:
+        req = urllib.request.Request(url, method="HEAD")
+        with urllib.request.urlopen(req, timeout=HEAD_TIMEOUT) as resp:
+            return resp.status in REACHABLE_CODES
+    except urllib.error.HTTPError as e:
+        return e.code in REACHABLE_CODES
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return None
+    except Exception:
+        return None
+
+
+def verify_urls(mapped: list[dict]) -> int:
+    """HEAD-check every URL; return count of definitively unreachable URLs."""
+    unreachable = 0
+    seen: dict[str, bool | None] = {}
+    for comp in mapped:
+        for s in comp["sources"]:
+            url = s["url"]
+            if url not in seen:
+                seen[url] = head_check(url)
+            s["reachable"] = seen[url]
+            if seen[url] is False:
+                unreachable += 1
+    return unreachable
+
+
+# ----------------------------- REPORT ---------------------------------------
+
+
+def summarize(mapped: list[dict]) -> dict:
+    n = len(mapped)
+    n_mapped = sum(1 for c in mapped if c["status"] == "mapped")
+    n_unmapped = n - n_mapped
+    n_monitored = sum(1 for c in mapped if c["status"] == "mapped" and any(s["monitored"] for s in c["sources"]))
+    n_gaps = (
+        sum(1 for c in mapped if c["status"] == "mapped" and not any(s["monitored"] for s in c["sources"])) + n_unmapped
+    )
+    n_unreachable = sum(1 for c in mapped for s in c["sources"] if s.get("reachable") is False)
+    coverage = round(100.0 * n_monitored / n, 1) if n else 0.0
+    return {
+        "components": n,
+        "mapped": n_mapped,
+        "unmapped": n_unmapped,
+        "monitored": n_monitored,
+        "coverage_pct": coverage,
+        "gaps": n_gaps,
+        "unreachable": n_unreachable,
+    }
+
+
+def render_json(service: str, mapped: list[dict], summary: dict) -> dict:
+    return {
+        "service": service,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "summary": summary,
+        "components": mapped,
+    }
+
+
+def _marker(comp: dict) -> str:
+    if comp["status"] == "unmapped":
+        return "❌"
+    if any(s["monitored"] for s in comp["sources"]):
+        return "✅"
+    return "⚠️"
+
+
+def _reach_str(reachable) -> str:
+    if reachable is True:
+        return "ok"
+    if reachable is False:
+        return "DOWN"
+    return "—"
+
+
+def render_markdown(service: str, mapped: list[dict], summary: dict, checked: bool) -> str:
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    out: list[str] = []
+    out.append(f"# CVE Source Coverage Report: {service}")
+    out.append("")
+    out.append(f"_Generated: {ts}_")
+    out.append("")
+    out.append("## Summary")
+    out.append("")
+    out.append("| Metric | Value |")
+    out.append("|--------|-------|")
+    out.append(f"| Components | {summary['components']} |")
+    out.append(f"| Mapped to registry | {summary['mapped']} |")
+    out.append(f"| Unmapped | {summary['unmapped']} |")
+    out.append(f"| Monitored (≥1 source) | {summary['monitored']} |")
+    out.append(f"| Coverage | {summary['coverage_pct']}% |")
+    out.append(f"| Gaps | {summary['gaps']} |")
+    if checked:
+        out.append(f"| Unreachable URLs | {summary['unreachable']} |")
+    out.append("")
+    out.append("Legend: ✅ mapped + monitored • ⚠️ mapped, not monitored • ❌ unmapped")
+    out.append("")
+    out.append("## Components")
+    out.append("")
+    header = "| Status | Component | Version | Type | Sources |"
+    sep = "|--------|-----------|---------|------|---------|"
+    out.append(header)
+    out.append(sep)
+    for c in mapped:
+        sources_cell = _format_sources(c["sources"], checked)
+        out.append(
+            f"| {_marker(c)} | `{c['name']}` | {c.get('version') or '—'} | {c.get('type') or '—'} | {sources_cell} |"
+        )
+    out.append("")
+
+    # Gaps
+    gap_rows = [c for c in mapped if c["status"] == "mapped" and not any(s["monitored"] for s in c["sources"])]
+    if gap_rows:
+        out.append("## Gaps — Sources to add")
+        out.append("")
+        out.append("Components mapped to authoritative sources you do not currently monitor:")
+        out.append("")
+        for c in gap_rows:
+            out.append(f"### {c['name']}")
+            for s in c["sources"]:
+                if s["priority"] == "primary":
+                    out.append(f"- **primary** ({s['kind']}): {s['url']}")
+            for s in c["sources"]:
+                if s["priority"] != "primary":
+                    out.append(f"- secondary ({s['kind']}): {s['url']}")
+            out.append("")
+
+    # Unmapped
+    unmapped = [c for c in mapped if c["status"] == "unmapped"]
+    if unmapped:
+        out.append("## Unmapped — Registry Extension TODO")
+        out.append("")
+        out.append("These components are not in the registry. Add entries (see `references/registry-schema.md`):")
+        out.append("")
+        for c in unmapped:
+            out.append(f"- [ ] `{c['name']}` (version `{c.get('version') or '?'}`, type `{c.get('type') or '?'}`)")
+        out.append("")
+
+    return "\n".join(out) + "\n"
+
+
+def _format_sources(sources: list[dict], checked: bool) -> str:
+    if not sources:
+        return "—"
+    cells = []
+    for s in sources:
+        flag = "✓" if s["monitored"] else "·"
+        reach = f" [{_reach_str(s.get('reachable'))}]" if checked else ""
+        cells.append(f"{flag} {s['priority']}/{s['kind']}{reach}")
+    return "<br>".join(cells)
+
+
+# ----------------------------- CLI ------------------------------------------
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Audit CVE/vulnerability source coverage for a technology stack.",
+    )
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--inventory", help="Path to JSON inventory file.")
+    src.add_argument("--inline", help='Inline list: "name@ver,name,name@ver"')
+    p.add_argument("--current-sources", help="Optional path; one URL per line.")
+    p.add_argument("--service", default="service", help="Service name for report header.")
+    p.add_argument("--check-urls", action="store_true", help="HEAD-check source URLs (5s timeout).")
+    p.add_argument("--registry", default=DEFAULT_REGISTRY, help="Path to tech-source-registry.json.")
+    p.add_argument("--out-dir", default=".", help="Output directory (default: cwd).")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    # PHASE 1: LOAD
+    try:
+        registry = load_registry(args.registry)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"ERROR: failed to load registry: {e}", file=sys.stderr)
+        return 3
+    lookup = build_lookup(registry)
+
+    if args.inventory:
+        try:
+            components = parse_inventory(args.inventory)
+        except (OSError, json.JSONDecodeError, ValueError) as e:
+            print(f"ERROR: failed to load inventory: {e}", file=sys.stderr)
+            return 3
+    else:
+        components = parse_inline(args.inline)
+
+    if not components:
+        print("ERROR: inventory is empty", file=sys.stderr)
+        return 3
+
+    current = set()
+    if args.current_sources:
+        try:
+            current = load_current_sources(args.current_sources)
+        except OSError as e:
+            print(f"WARN: failed to load current sources ({e}); proceeding without.", file=sys.stderr)
+
+    # PHASE 2: MAP & VERIFY
+    mapped = [map_component(c, lookup) for c in components]
+    if current:
+        mark_monitored(mapped, current)
+
+    unreachable_count = 0
+    if args.check_urls:
+        unreachable_count = verify_urls(mapped)
+
+    # PHASE 3: REPORT
+    summary = summarize(mapped)
+    payload = render_json(args.service, mapped, summary)
+    md = render_markdown(args.service, mapped, summary, checked=args.check_urls)
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    date_tag = datetime.now(timezone.utc).strftime("%Y%m%d")
+    safe_service = re.sub(r"[^A-Za-z0-9_.-]+", "-", args.service)
+    json_path = os.path.join(args.out_dir, f"cve-source-report-{safe_service}-{date_tag}.json")
+    md_path = os.path.join(args.out_dir, f"cve-source-report-{safe_service}-{date_tag}.md")
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    with open(md_path, "w", encoding="utf-8") as f:
+        f.write(md)
+
+    print(f"Service:       {args.service}")
+    print(f"Components:    {summary['components']}")
+    print(f"Mapped:        {summary['mapped']}  (unmapped: {summary['unmapped']})")
+    print(f"Monitored:     {summary['monitored']}  (coverage: {summary['coverage_pct']}%)")
+    print(f"Gaps:          {summary['gaps']}")
+    if args.check_urls:
+        print(f"Unreachable:   {summary['unreachable']}")
+    print(f"JSON report:   {json_path}")
+    print(f"MD report:     {md_path}")
+
+    if args.check_urls and unreachable_count > 0:
+        return 2
+    if summary["gaps"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/infrastructure/cve-source-check/tech-source-registry.json
+++ b/skills/infrastructure/cve-source-check/tech-source-registry.json
@@ -1,0 +1,211 @@
+{
+  "$schema_version": "1.0",
+  "description": "Maps technologies to authoritative CVE/security feeds. See references/registry-schema.md to extend.",
+  "kinds": ["advisory-list", "github-security", "mailing-list", "distro-tracker", "vendor-page", "mitre"],
+  "priorities": ["primary", "secondary"],
+  "technologies": [
+    {
+      "name": "go",
+      "aliases": ["golang", "go-lang"],
+      "type": "runtime",
+      "sources": [
+        {"url": "https://pkg.go.dev/vuln/list", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://groups.google.com/g/golang-announce", "kind": "mailing-list", "priority": "primary"},
+        {"url": "https://github.com/golang/go/security/advisories", "kind": "github-security", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "python",
+      "aliases": ["python3", "cpython"],
+      "type": "runtime",
+      "sources": [
+        {"url": "https://discuss.python.org/c/announcements/security-announcements/47", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://github.com/python/cpython/security/advisories", "kind": "github-security", "priority": "primary"},
+        {"url": "https://osv.dev/list?q=&ecosystem=PyPI", "kind": "advisory-list", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "node",
+      "aliases": ["nodejs", "node.js"],
+      "type": "runtime",
+      "sources": [
+        {"url": "https://nodejs.org/en/blog/vulnerability/", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://github.com/nodejs/node/security/advisories", "kind": "github-security", "priority": "primary"},
+        {"url": "https://github.com/advisories?query=ecosystem%3Anpm", "kind": "github-security", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "java",
+      "aliases": ["openjdk", "jdk", "jre"],
+      "type": "runtime",
+      "sources": [
+        {"url": "https://www.oracle.com/security-alerts/", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://openjdk.org/groups/vulnerability.html", "kind": "vendor-page", "priority": "primary"},
+        {"url": "https://github.com/advisories?query=ecosystem%3Amaven", "kind": "github-security", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "alpine",
+      "aliases": ["alpine-linux"],
+      "type": "base-image",
+      "sources": [
+        {"url": "https://security.alpinelinux.org/", "kind": "distro-tracker", "priority": "primary"},
+        {"url": "https://lists.alpinelinux.org/~alpine/security-announce/", "kind": "mailing-list", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "debian",
+      "aliases": ["debian-linux"],
+      "type": "base-image",
+      "sources": [
+        {"url": "https://security-tracker.debian.org/tracker/", "kind": "distro-tracker", "priority": "primary"},
+        {"url": "https://lists.debian.org/debian-security-announce/", "kind": "mailing-list", "priority": "primary"}
+      ]
+    },
+    {
+      "name": "ubuntu",
+      "aliases": ["ubuntu-linux"],
+      "type": "base-image",
+      "sources": [
+        {"url": "https://ubuntu.com/security/notices", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://ubuntu.com/security/cves", "kind": "distro-tracker", "priority": "primary"},
+        {"url": "https://lists.ubuntu.com/archives/ubuntu-security-announce/", "kind": "mailing-list", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "postgres",
+      "aliases": ["postgresql", "pg"],
+      "type": "container",
+      "sources": [
+        {"url": "https://www.postgresql.org/support/security/", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://www.postgresql.org/list/pgsql-announce/", "kind": "mailing-list", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "redis",
+      "aliases": ["redis-server"],
+      "type": "container",
+      "sources": [
+        {"url": "https://github.com/redis/redis/security/advisories", "kind": "github-security", "priority": "primary"},
+        {"url": "https://redis.io/blog/", "kind": "vendor-page", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "mysql",
+      "aliases": ["mariadb"],
+      "type": "container",
+      "sources": [
+        {"url": "https://www.oracle.com/security-alerts/", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://mariadb.org/about/security-policy/", "kind": "vendor-page", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "opensearch",
+      "aliases": ["opensearch-project"],
+      "type": "container",
+      "sources": [
+        {"url": "https://github.com/opensearch-project/OpenSearch/security/advisories", "kind": "github-security", "priority": "primary"},
+        {"url": "https://opensearch.org/blog/", "kind": "vendor-page", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "elasticsearch",
+      "aliases": ["elastic", "es"],
+      "type": "container",
+      "sources": [
+        {"url": "https://www.elastic.co/community/security", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://discuss.elastic.co/c/announcements/security-announcements/31", "kind": "mailing-list", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "rabbitmq",
+      "aliases": ["rabbit", "amqp"],
+      "type": "container",
+      "sources": [
+        {"url": "https://github.com/rabbitmq/rabbitmq-server/security/advisories", "kind": "github-security", "priority": "primary"},
+        {"url": "https://www.rabbitmq.com/release-information.html", "kind": "vendor-page", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "kafka",
+      "aliases": ["apache-kafka"],
+      "type": "container",
+      "sources": [
+        {"url": "https://kafka.apache.org/cve-list", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://lists.apache.org/list.html?announce@apache.org", "kind": "mailing-list", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "nginx",
+      "aliases": ["nginx-server"],
+      "type": "container",
+      "sources": [
+        {"url": "https://nginx.org/en/security_advisories.html", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://mailman.nginx.org/mailman3/lists/nginx-announce.nginx.org/", "kind": "mailing-list", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "apache",
+      "aliases": ["httpd", "apache-httpd"],
+      "type": "container",
+      "sources": [
+        {"url": "https://httpd.apache.org/security/vulnerabilities_24.html", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://lists.apache.org/list.html?announce@httpd.apache.org", "kind": "mailing-list", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "logstash",
+      "aliases": [],
+      "type": "container",
+      "sources": [
+        {"url": "https://www.elastic.co/community/security", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://github.com/elastic/logstash/security/advisories", "kind": "github-security", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "prometheus",
+      "aliases": ["prom"],
+      "type": "container",
+      "sources": [
+        {"url": "https://github.com/prometheus/prometheus/security/advisories", "kind": "github-security", "priority": "primary"},
+        {"url": "https://prometheus.io/docs/operating/security/", "kind": "vendor-page", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "grafana",
+      "aliases": [],
+      "type": "container",
+      "sources": [
+        {"url": "https://grafana.com/security/security-advisories/", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://github.com/grafana/grafana/security/advisories", "kind": "github-security", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "memcached",
+      "aliases": [],
+      "type": "container",
+      "sources": [
+        {"url": "https://github.com/memcached/memcached/wiki/ReleaseNotes", "kind": "vendor-page", "priority": "primary"},
+        {"url": "https://github.com/memcached/memcached/security/advisories", "kind": "github-security", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "haproxy",
+      "aliases": [],
+      "type": "container",
+      "sources": [
+        {"url": "https://www.haproxy.org/#vuln", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://github.com/haproxy/haproxy/security/advisories", "kind": "github-security", "priority": "secondary"}
+      ]
+    },
+    {
+      "name": "openssl",
+      "aliases": ["libssl"],
+      "type": "library",
+      "sources": [
+        {"url": "https://www.openssl.org/news/vulnerabilities.html", "kind": "advisory-list", "priority": "primary"},
+        {"url": "https://mta.openssl.org/pipermail/openssl-announce/", "kind": "mailing-list", "priority": "secondary"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds generic, vendor-neutral `cve-source-check` skill that takes a technology inventory and verifies authoritative CVE feeds are monitored for each component.
- Ships a 22-entry `tech-source-registry.json` covering widely-used components (containers, libraries, base images, runtimes) with their authoritative feeds.
- Three-phase methodology (LOAD inventory -> MAP & VERIFY against registry -> REPORT gaps); deterministic stdlib-only Python script for the audit logic.

## Changes
- `skills/infrastructure/cve-source-check/SKILL.md` -- skill entry point with frontmatter, phases, gates.
- `skills/infrastructure/cve-source-check/scripts/check-cve-sources.py` -- stdlib-only audit script.
- `skills/infrastructure/cve-source-check/tech-source-registry.json` -- registry of 22 technologies and their CVE feeds.
- `skills/infrastructure/cve-source-check/references/{output-formats,registry-schema,source-verification}.md` -- progressive-disclosure reference files.
- `skills/infrastructure/cve-source-check/examples/{inventory.example.json,current-sources.example.txt}` -- usage examples.
- `skills/INDEX.json` -- regenerated to include the new skill (entry only; no other skills changed).

## Test Plan
- [x] `ruff check . --config pyproject.toml` clean
- [x] `ruff format --check . --config pyproject.toml` clean
- [x] `python3 scripts/validate-skill-frontmatter.py skills/infrastructure/cve-source-check/SKILL.md` PASS
- [x] `python3 scripts/validate-index-integrity.py` PASS (0 errors; only pre-existing trigger-overlap warnings unrelated to this skill)
- [ ] CI green on remote

## Notes
- ADR for this skill is local-only at `adr/cve-source-check-skill.md` (per repo convention; `adr/` is gitignored).
- This is PR 1 of 2 from a multi-skill session; the skill-creator routing fix ships separately to keep diffs focused.