### PR TITLE
fix(routing): map skill-creation to toolkit-governance-engineer

### DIFF
--- a/agents/INDEX.json
+++ b/agents/INDEX.json
@@ -867,12 +867,18 @@
         "check coverage",
         "skill compliance",
         "hook standardization",
-        "cross-component consistency"
+        "cross-component consistency",
+        "create skill",
+        "new skill",
+        "scaffold skill",
+        "build a skill",
+        "create a skill"
       ],
       "pairs_with": [
         "adr-consultation",
         "routing-table-updater",
-        "docs-sync-checker"
+        "docs-sync-checker",
+        "skill-creator"
       ],
       "complexity": "Medium",
       "category": "meta"

--- a/agents/toolkit-governance-engineer.md
+++ b/agents/toolkit-governance-engineer.md
@@ -13,10 +13,16 @@ routing:
     - skill compliance
     - hook standardization
     - cross-component consistency
+    - create skill
+    - new skill
+    - scaffold skill
+    - build a skill
+    - create a skill
   pairs_with:
     - adr-consultation
     - routing-table-updater
     - docs-sync-checker
+    - skill-creator
   complexity: Medium
   category: meta
 allowed-tools:

--- a/scripts/routing-benchmark.json
+++ b/scripts/routing-benchmark.json
@@ -531,6 +531,30 @@
       "routing_tier": "candidate",
       "candidate_depth": 5,
       "notes": "Code review intent \u2014 systematic-code-review should be in top-5 candidates"
+    },
+    {
+      "request": "create a skill that does X",
+      "expected_agent": "toolkit-governance-engineer",
+      "expected_skill": "skill-creator",
+      "category": "meta-tooling",
+      "routing_tier": "force_route",
+      "notes": "Skill creation intent \u2014 force-route to skill-creator with toolkit-governance-engineer as executor agent (declared via skill-creator's top-level `agent` field)"
+    },
+    {
+      "request": "scaffold a new skill",
+      "expected_agent": "toolkit-governance-engineer",
+      "expected_skill": "skill-creator",
+      "category": "meta-tooling",
+      "routing_tier": "force_route",
+      "notes": "Scaffold intent \u2014 multiple triggers ('new skill', 'scaffold skill', 'scaffold a skill') yield high-confidence force-route"
+    },
+    {
+      "request": "build a skill for Y",
+      "expected_agent": "toolkit-governance-engineer",
+      "expected_skill": "skill-creator",
+      "category": "meta-tooling",
+      "routing_tier": "force_route",
+      "notes": "Build-a-skill intent \u2014 force-route fires on single trigger 'build a skill' (medium confidence)"
     }
   ]
 }

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-05-26T14:30:07Z",
+  "generated": "2026-05-26T14:40:23Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
     "csuite": {
@@ -1757,7 +1757,12 @@
       "description": "Create and iteratively improve skills through eval-driven validation.",
       "triggers": [
         "create skill",
+        "create a skill",
+        "create new skill",
         "new skill",
+        "scaffold skill",
+        "scaffold a skill",
+        "build a skill",
         "skill template",
         "skill design",
         "test skill",
@@ -1766,11 +1771,13 @@
         "skill eval"
       ],
       "category": "meta",
+      "force_route": true,
       "user_invocable": false,
       "pairs_with": [
         "agent-evaluation",
         "verification-before-completion"
-      ]
+      ],
+      "agent": "toolkit-governance-engineer"
     },
     "skill-eval": {
       "file": "skills/meta/skill-eval/SKILL.md",

--- a/skills/meta/skill-creator/SKILL.md
+++ b/skills/meta/skill-creator/SKILL.md
@@ -1,10 +1,17 @@
 ---
 name: skill-creator
 description: "Create and iteratively improve skills through eval-driven validation."
+agent: toolkit-governance-engineer
 routing:
+  force_route: true
   triggers:
     - create skill
+    - create a skill
+    - create new skill
     - new skill
+    - scaffold skill
+    - scaffold a skill
+    - build a skill
     - skill template
     - skill design
     - test skill


### PR DESCRIPTION
## Summary
- Skill-creation requests previously routed to `skill-creator` (a skill, not a dispatchable agent), leaving the executor ambiguous.
- This PR makes the mapping deterministic: `skill-creator` declares `agent: toolkit-governance-engineer` and `force_route: true`; `toolkit-governance-engineer` triggers expand to cover skill-creation phrases.
- Routing benchmark gains 3 cases; full benchmark stays green (68/68).

## Test plan
- [x] `pre-route.py --request "create a skill that does X"` -> matched=true, agent=toolkit-governance-engineer, skill=skill-creator, confidence=high
- [x] `pre-route.py --request "scaffold a new skill"` -> matched=true, confidence=high
- [x] `pre-route.py --request "build a skill for Y"` -> matched=true, confidence=medium
- [x] `routing-benchmark.py` -> 68/68 pass
- [x] `ruff check` and `ruff format --check` clean
- [x] `validate-index-integrity.py` -> 0 errors
- [x] `cve-source-check` entry preserved in `skills/INDEX.json` after rebase