### PR TITLE
feat(shells): add first-class zsh support matching fish parity

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,7 @@
           {
             "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/zsh-shell-detector.py\"",
+            "description": "Auto-detect Zsh shell users and inject zsh-shell-config skill",
             "timeout": 1000,
             "once": true
           },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,6 +50,12 @@
           },
           {
             "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/zsh-shell-detector.py\"",
+            "timeout": 1000,
+            "once": true
+          },
+          {
+            "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/sapcc-go-detector.py\"",
             "description": "Auto-detect SAP CC Go projects and inject go-patterns skill",
             "timeout": 1000,

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-This toolkit prevents that. 44 domain agents, 122 workflow skills, 77 hooks, 101 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+This toolkit prevents that. 44 domain agents, 123 workflow skills, 78 hooks, 101 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Factory (`/do`).
 

--- a/docs/for-knowledge-workers.md
+++ b/docs/for-knowledge-workers.md
@@ -2,7 +2,7 @@
 
 ## What This Gives You
 
-Writing, research, community moderation, data analysis, content publishing. 122 skills behind a single command. You describe work. The system routes it.
+Writing, research, community moderation, data analysis, content publishing. 123 skills behind a single command. You describe work. The system routes it.
 
 ## Interface
 

--- a/docs/for-linkedin.md
+++ b/docs/for-linkedin.md
@@ -69,7 +69,7 @@ A year of daily use on real work. Finding gaps, filling them, watching the syste
 The result:
 
 - 44 domain specialist agents across languages, infrastructure, review, research, content
-- 122 workflow skills covering everything from TDD to article writing to Reddit moderation
+- 123 workflow skills covering everything from TDD to article writing to Reddit moderation
 - 77 lifecycle hooks that fire at session boundaries to inject context, capture learnings, enforce gates
 - A learning database that tracks patterns and graduates them into agent behavior
 - Parallel review pipelines that catch issues before they reach production

--- a/hooks/afk-mode/README.md
+++ b/hooks/afk-mode/README.md
@@ -15,7 +15,9 @@ Set the `CLAUDE_AFK_MODE` environment variable:
 CLAUDE_AFK_MODE=never claude
 
 # Disable permanently (add to your shell profile)
-echo 'export CLAUDE_AFK_MODE=never' >> ~/.bashrc
+echo 'export CLAUDE_AFK_MODE=never' >> ~/.zshrc  # zsh
+# Note: zsh users should use ~/.zshrc or ~/.zshenv, not ~/.bashrc
+# bash users: echo 'export CLAUDE_AFK_MODE=never' >> ~/.bashrc
 
 # Auto-detect mode: active on SSH/tmux, inactive on local terminal
 CLAUDE_AFK_MODE=auto claude

--- a/hooks/fish-shell-detector.py
+++ b/hooks/fish-shell-detector.py
@@ -39,14 +39,28 @@ def is_fish_shell() -> bool:
 
     Returns:
         True if Fish shell is detected, False otherwise
+
+    Detection logic:
+    - Primary: $SHELL contains "fish" → True
+    - Primary: $SHELL explicitly names a different shell (zsh, bash, etc.) → False
+      (config-dir fallback must NOT fire when $SHELL points elsewhere)
+    - Fallback: ~/.config/fish/ exists AND $SHELL does not name a known non-fish shell
     """
-    # Check $SHELL environment variable
-    shell = os.environ.get("SHELL", "")
-    if "fish" in shell.lower():
+    shell = os.environ.get("SHELL", "").lower()
+
+    # Primary signal: $SHELL names fish explicitly
+    if "fish" in shell:
         return True
 
-    # Fallback: check if Fish config directory exists
-    # Handle environments without HOME (containers, CI) gracefully
+    # If $SHELL explicitly names a different shell, do not fall through.
+    # This prevents false positives for users who once tried Fish and left
+    # ~/.config/fish/ on disk but have since switched to zsh/bash/etc.
+    non_fish_shells = ("zsh", "bash", "dash", "ksh", "tcsh", "csh", "sh")
+    if any(s in shell for s in non_fish_shells):
+        return False
+
+    # Fallback: $SHELL is unset or unrecognised — check config directory.
+    # Handle environments without HOME (containers, CI) gracefully.
     try:
         fish_config_dir = Path.home() / ".config" / "fish"
         if fish_config_dir.is_dir():

--- a/hooks/fish-shell-detector.py
+++ b/hooks/fish-shell-detector.py
@@ -7,8 +7,8 @@ Detects Fish shell users and injects the fish-shell-config skill.
 Runs once at session start to provide Fish-specific guidance.
 
 Detection Logic:
-- Check $SHELL environment variable for "fish"
-- Check if ~/.config/fish/ directory exists
+- $SHELL short-circuits: names "fish" -> detected; names another shell -> skip
+- Fallback (only when $SHELL is unset/unrecognised): ~/.config/fish/ directory exists
 
 Output Format:
 - [fish-shell] Detected Fish shell user

--- a/hooks/tests/test_zsh_shell_detector.py
+++ b/hooks/tests/test_zsh_shell_detector.py
@@ -1,0 +1,208 @@
+"""Tests for zsh-shell-detector.py."""
+
+import importlib.util
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the modules under test
+# ---------------------------------------------------------------------------
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+
+_zsh_spec = importlib.util.spec_from_file_location(
+    "zsh_shell_detector",
+    HOOKS_DIR / "zsh-shell-detector.py",
+)
+zsh_mod = importlib.util.module_from_spec(_zsh_spec)
+_zsh_spec.loader.exec_module(zsh_mod)
+
+_fish_spec = importlib.util.spec_from_file_location(
+    "fish_shell_detector",
+    HOOKS_DIR / "fish-shell-detector.py",
+)
+fish_mod = importlib.util.module_from_spec(_fish_spec)
+_fish_spec.loader.exec_module(fish_mod)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_zsh_main(shell: str = "", debug: str = "") -> tuple[int, dict | None]:
+    """Invoke zsh_mod.main() with $SHELL set to the given value.
+
+    Returns (exit_code, parsed_stdout_json).
+    """
+    env = {k: v for k, v in os.environ.items()}
+    env["SHELL"] = shell
+    if debug:
+        env["CLAUDE_HOOKS_DEBUG"] = debug
+    else:
+        env.pop("CLAUDE_HOOKS_DEBUG", None)
+
+    stdout_capture = io.StringIO()
+    with (
+        patch.dict(os.environ, env, clear=True),
+        patch("sys.stdout", stdout_capture),
+    ):
+        try:
+            zsh_mod.main()
+        except SystemExit:
+            pass
+
+    output = stdout_capture.getvalue().strip()
+    parsed = None
+    if output:
+        try:
+            parsed = json.loads(output)
+        except json.JSONDecodeError:
+            pass
+    return 0, parsed
+
+
+# ---------------------------------------------------------------------------
+# is_zsh_shell unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsZshShell:
+    def test_zsh_in_shell_returns_true(self):
+        with patch.dict(os.environ, {"SHELL": "/bin/zsh"}, clear=False):
+            assert zsh_mod.is_zsh_shell() is True
+
+    def test_zsh_usr_bin_returns_true(self):
+        with patch.dict(os.environ, {"SHELL": "/usr/bin/zsh"}, clear=False):
+            assert zsh_mod.is_zsh_shell() is True
+
+    def test_fish_shell_returns_false(self):
+        with patch.dict(os.environ, {"SHELL": "/usr/bin/fish"}, clear=False):
+            assert zsh_mod.is_zsh_shell() is False
+
+    def test_bash_shell_returns_false(self):
+        with patch.dict(os.environ, {"SHELL": "/bin/bash"}, clear=False):
+            assert zsh_mod.is_zsh_shell() is False
+
+    def test_empty_shell_returns_false(self):
+        env = {k: v for k, v in os.environ.items()}
+        env.pop("SHELL", None)
+        with patch.dict(os.environ, env, clear=True):
+            assert zsh_mod.is_zsh_shell() is False
+
+    def test_shell_unset_returns_false(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert zsh_mod.is_zsh_shell() is False
+
+
+# ---------------------------------------------------------------------------
+# Fish false-positive regression tests
+# ---------------------------------------------------------------------------
+
+
+class TestFishFalsePositiveRegression:
+    """Regression: fish config dir present but $SHELL=/bin/zsh must not trigger fish detection."""
+
+    def test_zsh_shell_with_fish_config_dir_is_not_fish(self, tmp_path: Path):
+        """Core regression: SHELL=zsh + ~/.config/fish/ present → fish detector returns False."""
+        fish_config = tmp_path / ".config" / "fish"
+        fish_config.mkdir(parents=True)
+
+        with (
+            patch.dict(os.environ, {"SHELL": "/bin/zsh"}, clear=False),
+            patch("pathlib.Path.home", return_value=tmp_path),
+        ):
+            assert fish_mod.is_fish_shell() is False
+
+    def test_zsh_shell_with_fish_config_dir_is_zsh(self, tmp_path: Path):
+        """Core regression: SHELL=zsh + ~/.config/fish/ present → zsh detector returns True."""
+        fish_config = tmp_path / ".config" / "fish"
+        fish_config.mkdir(parents=True)
+
+        with (
+            patch.dict(os.environ, {"SHELL": "/bin/zsh"}, clear=False),
+            patch("pathlib.Path.home", return_value=tmp_path),
+        ):
+            assert zsh_mod.is_zsh_shell() is True
+
+    def test_bash_shell_with_fish_config_dir_is_not_fish(self, tmp_path: Path):
+        """SHELL=bash + ~/.config/fish/ → fish detector returns False."""
+        fish_config = tmp_path / ".config" / "fish"
+        fish_config.mkdir(parents=True)
+
+        with (
+            patch.dict(os.environ, {"SHELL": "/bin/bash"}, clear=False),
+            patch("pathlib.Path.home", return_value=tmp_path),
+        ):
+            assert fish_mod.is_fish_shell() is False
+
+    def test_no_shell_with_fish_config_dir_is_fish(self, tmp_path: Path):
+        """SHELL unset + ~/.config/fish/ exists → fish fallback fires (no known non-fish shell)."""
+        fish_config = tmp_path / ".config" / "fish"
+        fish_config.mkdir(parents=True)
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("pathlib.Path.home", return_value=tmp_path),
+        ):
+            assert fish_mod.is_fish_shell() is True
+
+    def test_fish_shell_explicit_returns_true(self):
+        """SHELL=/usr/bin/fish → fish detector still returns True."""
+        with patch.dict(os.environ, {"SHELL": "/usr/bin/fish"}, clear=False):
+            assert fish_mod.is_fish_shell() is True
+
+
+# ---------------------------------------------------------------------------
+# main() integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestZshMain:
+    def test_zsh_detected_emits_context(self):
+        """SHELL=/bin/zsh → main() emits additionalContext with zsh tags."""
+        _, parsed = _run_zsh_main(shell="/bin/zsh")
+        assert parsed is not None
+        inner = parsed.get("hookSpecificOutput", {})
+        ctx = inner.get("additionalContext", "")
+        assert "[zsh-shell] Detected Zsh shell user" in ctx
+        assert "[auto-skill] zsh-shell-config" in ctx
+
+    def test_non_zsh_emits_empty(self):
+        """SHELL=/bin/bash → main() emits empty output (no additionalContext)."""
+        _, parsed = _run_zsh_main(shell="/bin/bash")
+        assert parsed is not None
+        inner = parsed.get("hookSpecificOutput", {})
+        assert "additionalContext" not in inner
+
+    def test_fish_shell_emits_empty(self):
+        """SHELL=/usr/bin/fish → main() emits empty output (no additionalContext)."""
+        _, parsed = _run_zsh_main(shell="/usr/bin/fish")
+        assert parsed is not None
+        inner = parsed.get("hookSpecificOutput", {})
+        assert "additionalContext" not in inner
+
+    def test_empty_shell_emits_empty(self):
+        """SHELL='' → main() emits empty output."""
+        _, parsed = _run_zsh_main(shell="")
+        assert parsed is not None
+        inner = parsed.get("hookSpecificOutput", {})
+        assert "additionalContext" not in inner
+
+    def test_exit_code_always_0(self):
+        """main() always exits 0 regardless of detection result."""
+        code, _ = _run_zsh_main(shell="/bin/zsh")
+        assert code == 0
+
+        code, _ = _run_zsh_main(shell="/bin/bash")
+        assert code == 0
+
+    def test_injection_format_correct(self):
+        """Injected context matches exact expected format."""
+        assert zsh_mod.get_zsh_injection() == "[zsh-shell] Detected Zsh shell user\n[auto-skill] zsh-shell-config"

--- a/hooks/zsh-shell-detector.py
+++ b/hooks/zsh-shell-detector.py
@@ -7,10 +7,10 @@ Detects Zsh shell users and injects the zsh-shell-config skill.
 Runs once at session start to provide Zsh-specific guidance.
 
 Detection Logic:
-- Primary: $SHELL contains "zsh"
-- Optional confirmation: ~/.zshrc or ~/.config/zsh/ exists
-  (presence of these files is supporting evidence, not required)
-- $SHELL is the authoritative signal — directory presence alone is insufficient
+- $SHELL contains "zsh" is the sole, authoritative signal.
+- Config directories (~/.zshrc, ~/.config/zsh/) are intentionally not
+  inspected — $SHELL alone determines detection, which avoids false
+  positives from leftover config after a user switches shells.
 
 Output Format:
 - [zsh-shell] Detected Zsh shell user

--- a/hooks/zsh-shell-detector.py
+++ b/hooks/zsh-shell-detector.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+SessionStart Hook: Zsh Shell Detection
+
+Detects Zsh shell users and injects the zsh-shell-config skill.
+Runs once at session start to provide Zsh-specific guidance.
+
+Detection Logic:
+- Primary: $SHELL contains "zsh"
+- Optional confirmation: ~/.zshrc or ~/.config/zsh/ exists
+  (presence of these files is supporting evidence, not required)
+- $SHELL is the authoritative signal — directory presence alone is insufficient
+
+Output Format:
+- [zsh-shell] Detected Zsh shell user
+- [auto-skill] zsh-shell-config
+
+Design Principles:
+- Lightweight detection (no complex processing)
+- Non-blocking (always exits 0)
+- Fast execution (<50ms target, depends on filesystem responsiveness)
+"""
+
+import os
+import sys
+import traceback
+from pathlib import Path
+
+# Add lib directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+
+from hook_utils import context_output, empty_output
+
+EVENT_NAME = "SessionStart"
+
+
+def is_zsh_shell() -> bool:
+    """
+    Detect if the user is using Zsh shell.
+
+    Returns:
+        True if Zsh shell is detected, False otherwise
+
+    Detection logic:
+    - Primary: $SHELL contains "zsh" → True
+    - Directory presence (~/.zshrc, ~/.config/zsh/) alone is NOT sufficient;
+      $SHELL must be the confirming signal to avoid false positives from
+      leftover config directories.
+    """
+    shell = os.environ.get("SHELL", "").lower()
+
+    # Primary signal: $SHELL must name zsh explicitly
+    if "zsh" not in shell:
+        return False
+
+    # $SHELL contains "zsh" — confirmed Zsh user.
+    # Optionally verify config artifacts exist (supporting evidence only).
+    # We do not require them; $SHELL alone is sufficient.
+    return True
+
+
+def get_zsh_injection() -> str:
+    """Get the context injection for Zsh shell users.
+
+    Emits only tags. The zsh-shell-config skill carries its own knowledge.
+    """
+    return "[zsh-shell] Detected Zsh shell user\n[auto-skill] zsh-shell-config"
+
+
+def main():
+    """Main entry point for the hook."""
+    debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
+
+    try:
+        if not is_zsh_shell():
+            # Silent for non-Zsh users
+            empty_output(EVENT_NAME).print_and_exit()
+
+        # Log detection for debugging visibility
+        if debug:
+            shell = os.environ.get("SHELL", "")
+            print(f"[zsh-shell] Detected Zsh shell: SHELL={shell}", file=sys.stderr)
+
+        # Inject Zsh shell context
+        injection = get_zsh_injection()
+        context_output(EVENT_NAME, injection).print_and_exit()
+
+    except Exception as e:
+        # Always log error to stderr for observability
+        if debug:
+            print(f"[zsh-shell] Error: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+        else:
+            print(f"[zsh-shell] Error: {type(e).__name__}: {e}", file=sys.stderr)
+        empty_output(EVENT_NAME).print_and_exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/count-components.sh
+++ b/scripts/count-components.sh
@@ -7,7 +7,7 @@
 # Used by install.sh and can be used to update documentation.
 #
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
 
 # Count each component type
 AGENT_COUNT=$(ls -1 "${SCRIPT_DIR}/agents/"*.md 2>/dev/null | grep -v README | wc -l)

--- a/scripts/fix-skill-paths.py
+++ b/scripts/fix-skill-paths.py
@@ -74,6 +74,7 @@ SKILL_MAPPING: dict[str, str] = {
     "kubernetes-debugging": "infrastructure",
     "kubernetes-security": "infrastructure",
     "fish-shell-config": "infrastructure",
+    "zsh-shell-config": "infrastructure",
     "shell-process-patterns": "infrastructure",
     "headless-cron-creator": "infrastructure",
     "cron-job-auditor": "infrastructure",

--- a/scripts/index-router.py
+++ b/scripts/index-router.py
@@ -66,6 +66,7 @@ MIN_SCORE_THRESHOLD = 0.1
 SEMANTIC_GUARDS: dict[str, set[str]] = {
     "pr-workflow": {"back", "pressure", "pushback", "pushed", "pushing"},
     "fish-shell-config": {"for", "bugs", "compliments", "information", "ideas", "answers"},
+    "zsh-shell-config": {"for", "bugs", "compliments", "information", "ideas", "answers"},
     "voice-writer": {"remove", "strip", "clean", "detect", "identify", "fix", "scan", "audit"},
 }
 
@@ -75,6 +76,7 @@ SEMANTIC_GUARDS: dict[str, set[str]] = {
 # reliably means search/extract, not the Fish shell).
 SEMANTIC_GUARD_PHRASES: dict[str, set[str]] = {
     "fish-shell-config": {"fish out", "fish for"},
+    "zsh-shell-config": {"zsh out", "zsh for"},
 }
 
 

--- a/scripts/migrate-skills-to-folders.py
+++ b/scripts/migrate-skills-to-folders.py
@@ -86,6 +86,7 @@ SKILL_MAPPING: dict[str, str] = {
     "kubernetes-debugging": "infrastructure",
     "kubernetes-security": "infrastructure",
     "fish-shell-config": "infrastructure",
+    "zsh-shell-config": "infrastructure",
     "shell-process-patterns": "infrastructure",
     "headless-cron-creator": "infrastructure",
     "cron-job-auditor": "infrastructure",

--- a/scripts/pre-route.py
+++ b/scripts/pre-route.py
@@ -41,6 +41,7 @@ INDEX_PATHS = {
 SEMANTIC_GUARDS: dict[str, set[str]] = {
     "pr-workflow": {"back", "pressure", "pushback", "pushed", "pushing"},
     "fish-shell-config": {"for", "bugs", "compliments", "information", "ideas", "answers"},
+    "zsh-shell-config": {"for", "bugs", "compliments", "information", "ideas", "answers"},
     "voice-writer": {"remove", "strip", "clean", "detect", "identify", "fix", "scan", "audit"},
 }
 
@@ -50,6 +51,7 @@ SEMANTIC_GUARDS: dict[str, set[str]] = {
 # reliably means search/extract, not the Fish shell).
 SEMANTIC_GUARD_PHRASES: dict[str, set[str]] = {
     "fish-shell-config": {"fish out", "fish for"},
+    "zsh-shell-config": {"zsh out", "zsh for"},
 }
 
 

--- a/scripts/reference-enrichment-cron.sh
+++ b/scripts/reference-enrichment-cron.sh
@@ -19,7 +19,7 @@
 # Ensure claude CLI is in PATH (cron doesn't inherit user PATH)
 export PATH="$HOME/.local/bin:$HOME/.nvm/versions/node/$(ls $HOME/.nvm/versions/node/ 2>/dev/null | tail -1)/bin:$PATH"
 
-# Ensure GitHub CLI auth for PR creation (cron doesn't source .bashrc)
+# Ensure GitHub CLI auth for PR creation (cron doesn't source .bashrc/.zshrc)
 if [ -z "${GH_TOKEN:-}" ]; then
     export GH_TOKEN=$(python3 -c "
 import subprocess

--- a/scripts/toolkit-evolution-cron.sh
+++ b/scripts/toolkit-evolution-cron.sh
@@ -16,7 +16,7 @@
 # Ensure claude CLI is in PATH (cron doesn't inherit user PATH)
 export PATH="$HOME/.local/bin:$HOME/.nvm/versions/node/$(ls $HOME/.nvm/versions/node/ 2>/dev/null | tail -1)/bin:$PATH"
 
-# Ensure GitHub CLI auth for PR creation (cron doesn't source .bashrc)
+# Ensure GitHub CLI auth for PR creation (cron doesn't source .bashrc/.zshrc)
 if [ -z "${GH_TOKEN:-}" ]; then
     export GH_TOKEN=$(python3 -c "
 import subprocess

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "generated": "2026-05-26T14:40:23Z",
+  "generated": "2026-05-26T19:59:45Z",
   "generated_by": "scripts/generate-skill-index.py",
   "skills": {
     "csuite": {
@@ -1483,6 +1483,42 @@
         "service-health-check",
         "cron-job-auditor"
       ]
+    },
+    "zsh-shell-config": {
+      "file": "skills/infrastructure/zsh-shell-config/SKILL.md",
+      "description": "Zsh shell configuration, PATH management, completions, and framework setup.",
+      "triggers": [
+        "zsh",
+        "zsh shell",
+        ".zshrc",
+        "zshrc",
+        ".zshenv",
+        "zshenv",
+        ".zprofile",
+        "zprofile",
+        "compinit",
+        "fpath",
+        "autoload",
+        "oh-my-zsh",
+        "prezto",
+        "zinit",
+        "antigen",
+        "p10k",
+        "powerlevel10k",
+        "setopt",
+        "zsh completion",
+        "zsh function",
+        "zsh plugin",
+        "typeset -U",
+        "zplug",
+        "configure zsh",
+        "zsh config"
+      ],
+      "not_for": "not for non-zsh shells \u2014 only fires for Zsh configuration",
+      "category": "process",
+      "force_route": true,
+      "user_invocable": false,
+      "pairs_with": []
     },
     "agent-comparison": {
       "file": "skills/meta/agent-comparison/SKILL.md",

--- a/skills/INDEX.json
+++ b/skills/INDEX.json
@@ -1498,7 +1498,7 @@
         "zprofile",
         "compinit",
         "fpath",
-        "autoload",
+        "autoload -Uz",
         "oh-my-zsh",
         "prezto",
         "zinit",

--- a/skills/infrastructure/zsh-shell-config/SKILL.md
+++ b/skills/infrastructure/zsh-shell-config/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: zsh-shell-config
+description: "Zsh shell configuration, PATH management, completions, and framework setup."
+user-invocable: false
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Grep
+  - Glob
+  - Edit
+routing:
+  category: process
+  not_for: "not for non-zsh shells — only fires for Zsh configuration"
+  triggers:
+    - zsh
+    - zsh shell
+    - .zshrc
+    - zshrc
+    - .zshenv
+    - zshenv
+    - .zprofile
+    - zprofile
+    - compinit
+    - fpath
+    - autoload
+    - oh-my-zsh
+    - prezto
+    - zinit
+    - antigen
+    - p10k
+    - powerlevel10k
+    - setopt
+    - zsh completion
+    - zsh function
+    - zsh plugin
+    - typeset -U
+    - zplug
+    - configure zsh
+    - zsh config
+  pairs_with: []
+  force_route: true
+---
+
+# Zsh Shell Configuration Skill
+
+Zsh is POSIX-compatible with powerful extensions. Every pattern here targets Zsh 5.8+ (ships with macOS 14+, Ubuntu 22.04+). All generated code must use Zsh-native syntax — `typeset`/`local` for scoping, `path` array for PATH, `compinit` for completions.
+
+## Reference Loading Table
+
+| Signal | Load These Files | Why |
+|---|---|---|
+| migrations, bash syntax, POSIX shell | `bash-migration.md` | Bash→Zsh syntax translation table with code blocks for each pattern |
+| parameter expansion, scoping, special vars, fpath | `zsh-quick-reference.md` | Variable flags, expansion flags `${(f)}` `${(s)}` `${(j)}`, special variables |
+| implementation patterns, failure modes, detection commands | `zsh-preferred-patterns.md` | Pattern catalog with grep detection and error-fix mappings |
+| Go, Rust, Node, Python, starship, direnv, fzf, zoxide, mise | `tool-integrations.md` | Concrete zsh integration patterns for common dev tools |
+
+## Step 1: Confirm Zsh Context
+
+Before writing any shell code, confirm the target is Zsh:
+
+- `$SHELL` contains `zsh`, or
+- Target file has `.zsh` extension, or
+- Target file is one of: `.zshrc`, `.zshenv`, `.zprofile`, `.zlogin`, `.zlogout`
+
+If none hold, this skill does not apply — route to fish-shell-config or bash.
+
+## Step 2: Choose the Correct RC File
+
+Zsh sources startup files in a defined order depending on shell type (login vs. interactive).
+
+**Load order**:
+
+| File | Sourced when | Use for |
+|------|-------------|---------|
+| `~/.zshenv` | Every zsh invocation (login, interactive, script) | `$PATH`, `$EDITOR`, `$LANG` — variables needed by all processes |
+| `~/.zprofile` | Login shells only (before `.zshrc`) | Login-time setup (e.g., `eval "$(brew shellenv)"`) |
+| `~/.zshrc` | Interactive shells only | Aliases, functions, completions, prompt, key bindings |
+| `~/.zlogin` | Login shells (after `.zshrc`) | Rarely used; message-of-the-day type hooks |
+| `~/.zlogout` | Login shell exit | Cleanup on logout |
+
+**Decision tree**:
+
+| What you're writing | Where it goes |
+|---------------------|---------------|
+| `PATH`, `EDITOR`, `LANG`, `GOPATH` | `~/.zshenv` |
+| Homebrew / nix / login-time init | `~/.zprofile` |
+| Aliases, functions, `compinit`, prompt | `~/.zshrc` |
+| Key bindings (`bindkey`) | `~/.zshrc` |
+| `setopt` / `unsetopt` | `~/.zshrc` |
+| Framework (oh-my-zsh, prezto) | `~/.zshrc` |
+
+Place env vars in `~/.zshenv` not `~/.zshrc` — scripts and non-interactive shells source `.zshenv` only, so exported variables must live there to reach child processes started from scripts.
+
+## Step 3: Manage PATH
+
+Zsh uses `path` as an array tied to `$PATH`. Use `typeset -U path` to deduplicate automatically.
+
+```zsh
+# ~/.zshenv — PATH management
+typeset -U path           # Enforce unique entries; run once at top of file
+
+path=(
+  ~/bin
+  ~/.local/bin
+  $path                   # Preserve existing entries
+)
+export PATH               # Re-export after array modification
+```
+
+**fpath and autoload**:
+
+```zsh
+# Add completion directories to fpath before compinit
+typeset -U fpath
+fpath=(~/.zsh/completions $fpath)
+
+# Autoload functions from fpath
+autoload -Uz compinit     # -U: no alias expansion; -z: zsh-style autoload
+autoload -Uz add-zsh-hook
+autoload -Uz vcs_info
+
+# Completion cache: only re-init once per day
+if [[ -n ~/.zcompdump(#qN.mh+24) ]]; then
+  compinit
+else
+  compinit -C             # -C: skip security check, use cached dump
+fi
+```
+
+`~/.zcompdump` caches completion definitions. Without the age guard, `compinit` rescans all fpath entries on every shell start — adds 100–300ms of startup time.
+
+## Step 4: Write Variables and Functions
+
+**Variable scoping**:
+
+```zsh
+local var="value"          # Local to current function
+typeset -i count=0         # Integer
+typeset -l lower="VALUE"   # Auto-lowercased
+typeset -u upper="value"   # Auto-uppercased
+typeset -r CONST="fixed"   # Read-only
+typeset -x EXPORTED="val"  # Export (same as export)
+typeset -a arr             # Indexed array
+typeset -A assoc           # Associative array
+```
+
+**Functions**:
+
+```zsh
+# Regular function
+mkcd() {
+  mkdir -p "$1" && cd "$1"
+}
+
+# Alternative (preferred in zsh): function keyword
+function mkcd {
+  mkdir -p "$1" && cd "$1"
+}
+
+# Autoloaded function (place in a fpath directory as a standalone file)
+# ~/.zsh/functions/mkcd — file contains only the function body:
+# mkdir -p "$1" && cd "$1"
+# Then in .zshrc: autoload -Uz mkcd
+```
+
+For autoloaded functions, the file must be named exactly after the function and live in a `fpath` directory.
+
+## Step 5: Completions
+
+```zsh
+# ~/.zshrc — completions setup
+
+# 1. Extend fpath before compinit
+fpath=(~/.zsh/completions $fpath)
+
+# 2. Initialize (with cache guard)
+autoload -Uz compinit
+compinit
+
+# 3. Key completion options
+setopt COMPLETE_IN_WORD     # Complete from both ends of word
+setopt ALWAYS_TO_END        # Move cursor to end after completion
+setopt AUTO_MENU            # Show menu on second Tab
+setopt MENU_COMPLETE        # Auto-select first match
+zstyle ':completion:*' menu select
+
+# 4. Styling completions
+zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'   # Case-insensitive
+zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
+zstyle ':completion:*:descriptions' format '%B%d%b'
+zstyle ':completion:*:warnings' format 'No matches for: %d'
+
+# 5. Add a completion function for a custom command
+# ~/.zsh/completions/_mycommand
+# #compdef mycommand
+# _mycommand() {
+#   local -a commands
+#   commands=('start:Start the service' 'stop:Stop the service')
+#   _describe 'commands' commands
+# }
+```
+
+## Step 6: Framework Awareness
+
+Detect active framework before adding configuration — frameworks own the prompt, completion init, and plugin loading.
+
+**Detection patterns**:
+
+```zsh
+# oh-my-zsh
+[[ -n "$ZSH" ]] && echo "oh-my-zsh active (ZSH=$ZSH)"
+[[ -f ~/.oh-my-zsh/oh-my-zsh.sh ]] && echo "oh-my-zsh installed"
+
+# prezto
+[[ -d ~/.zprezto ]] && echo "prezto installed"
+
+# zinit
+[[ -d ~/.zinit ]] || [[ -d ~/.local/share/zinit ]] && echo "zinit installed"
+
+# antigen
+command -v antigen &>/dev/null && echo "antigen active"
+
+# powerlevel10k / p10k
+[[ -f ~/.p10k.zsh ]] && echo "p10k config present"
+```
+
+**Framework coexistence rules**:
+
+| Situation | Action |
+|-----------|--------|
+| oh-my-zsh active | Place custom config in `~/.oh-my-zsh/custom/` — not directly in `.zshrc` |
+| prezto active | Use `~/.zpreztorc` modules; add extra config after `source ~/.zprezto/init.zsh` |
+| zinit active | Add plugins with `zinit light`; place after zinit bootstrap block |
+| p10k active | Call `[[ -f ~/.p10k.zsh ]] && source ~/.p10k.zsh` after framework init |
+| No framework | Full control — structure `.zshrc` with `compinit`, prompt, plugins manually |
+
+When a framework manages `compinit`, do not call `compinit` again — double-init causes duplicate completion definitions and slows startup.
+
+## Step 7: Hooks
+
+Zsh hooks fire at defined shell events. Use `add-zsh-hook` to attach — it preserves existing handlers for the same event.
+
+```zsh
+autoload -Uz add-zsh-hook
+
+# precmd: runs before each prompt (use for vcs_info, title updates)
+_my_precmd() {
+  print -Pn "\e]0;%~\a"   # Set terminal title to current dir
+}
+add-zsh-hook precmd _my_precmd
+
+# preexec: runs before each command (receives command string as $1)
+_my_preexec() {
+  print -Pn "\e]0;$1\a"   # Set terminal title to running command
+}
+add-zsh-hook preexec _my_preexec
+
+# chpwd: runs when directory changes
+_my_chpwd() {
+  ls --color=auto           # Auto-list on cd
+}
+add-zsh-hook chpwd _my_chpwd
+
+# zshaddhistory: runs before adding command to history; return 1 to suppress
+_no_history() {
+  [[ "$1" == " "* ]] && return 1   # Leading space = skip history
+  return 0
+}
+add-zsh-hook zshaddhistory _no_history
+```
+
+Writing `precmd() { ... }` directly overwrites any previously defined `precmd` — `add-zsh-hook` appends to the hook array instead.
+
+## Step 8: Zsh Options
+
+```zsh
+# History
+setopt HIST_IGNORE_DUPS       # Ignore consecutive duplicates
+setopt HIST_IGNORE_SPACE      # Ignore commands starting with space
+setopt HIST_EXPIRE_DUPS_FIRST # Expire duplicates first when trimming
+setopt HIST_FIND_NO_DUPS      # No dups in history search
+setopt SHARE_HISTORY          # Share history across sessions
+setopt APPEND_HISTORY         # Append rather than overwrite
+setopt INC_APPEND_HISTORY     # Write immediately, not on exit
+HISTFILE=~/.zsh_history
+HISTSIZE=50000
+SAVEHIST=50000
+
+# Globbing
+setopt EXTENDED_GLOB          # Enable (#q...) glob qualifiers and ^ ~
+setopt NULL_GLOB              # No-match globs expand to empty (no error)
+setopt GLOB_DOTS              # Dot files matched by * patterns
+
+# Behavior
+setopt PIPE_FAIL              # Pipeline exit code = first failed command
+setopt NO_CLOBBER             # Prevent > from overwriting files
+setopt AUTO_CD                # cd by typing directory name alone
+setopt CORRECT                # Suggest corrections for mistyped commands
+setopt NO_BEEP                # Silence
+
+# Key options to unset
+unsetopt BG_NICE              # Background jobs run at normal priority
+unsetopt FLOW_CONTROL         # Disable Ctrl+S/Ctrl+Q flow control
+```
+
+**Critical options**:
+
+| Option | Effect | Recommend |
+|--------|--------|-----------|
+| `PIPE_FAIL` | Pipeline returns exit code of first failed command | Always set |
+| `NULL_GLOB` | Unmatched globs expand to empty list | Set to avoid "no matches" errors |
+| `EXTENDED_GLOB` | Enables `^`, `~`, `(#q...)` qualifiers | Set when using glob qualifiers |
+| `HIST_IGNORE_SPACE` | Commands prefixed with space skip history | Set for sensitive commands |
+| `SHARE_HISTORY` | Multiple sessions share history in real time | Set for multi-terminal workflows |
+
+## Step 9: Verify
+
+```zsh
+# 1. Syntax check without sourcing
+zsh -n ~/.zshrc
+
+# 2. Run in isolated environment (no user config)
+zsh --no-rcs -c 'source ~/.zshrc; echo ok'
+
+# 3. Profile startup time
+time zsh -i -c exit
+
+# 4. Trace file loading order
+zsh --sourcetrace -i -c exit 2>&1 | head
+
+# 5. Profile compinit specifically
+zsh -i -c 'zmodload zsh/zprof; compinit; zprof' 2>&1 | head -20
+```
+
+**Glob quoting pitfalls**: With `EXTENDED_GLOB` set, `^`, `~`, and `#` are active in unquoted contexts. Quote them in strings: `echo "it's ~fine"` passes literally; `echo it's ~fine` expands `~fine` as a path.
+
+**NULL_GLOB vs no-match error**: Without `NULL_GLOB`, `rm *.tmp` fails with "no matches" when no `.tmp` files exist. With `NULL_GLOB`, `rm *.tmp` expands to `rm` with no arguments (also an error). Use glob qualifier `(N)` for conditional expansion: `rm -- *.tmp(N)` silently does nothing when there are no matches.
+
+---
+
+## Error Handling
+
+### Error: `compinit: insecure directories`
+
+Cause: Files in `fpath` are group- or world-writable.
+Solution: `compaudit` lists the offending paths. Fix with `chmod go-w /path` or pass `-u` flag: `compinit -u` (unsafe — skips ownership check).
+
+### Error: Completions not found after adding to fpath
+
+Cause: `compinit` was called before the `fpath` extension, or `~/.zcompdump` is stale.
+Solution: Move `fpath=(~/.zsh/completions $fpath)` above `compinit`. Delete `~/.zcompdump` and restart shell to regenerate.
+
+### Error: `add-zsh-hook: function not found`
+
+Cause: `autoload -Uz add-zsh-hook` was not called before using the hook.
+Solution: Add `autoload -Uz add-zsh-hook` before any `add-zsh-hook` call — typically at the top of `.zshrc`.
+
+### Error: PATH additions not visible to scripts
+
+Cause: Variables set in `~/.zshrc` are not sourced by non-interactive shells.
+Solution: Move `PATH` exports to `~/.zshenv` — it is sourced by every Zsh invocation including scripts.
+
+### Error: Slow shell startup (>300ms)
+
+Cause: `compinit` rescanning all fpath entries on every start; heavy plugin loading.
+Solution: Add the `~/.zcompdump` age guard (see Step 3). Profile with `zmodload zsh/zprof; compinit; zprof`. Use `zinit` or lazy-loading for plugins.
+
+### Error: `zsh -n` reports syntax error in valid-looking code
+
+Cause: `EXTENDED_GLOB` patterns like `^` or `#` in unquoted strings parsed as glob operators.
+Solution: Quote strings containing these characters. Check with `setopt NO_EXTENDED_GLOB` temporarily to isolate.
+
+---
+
+## References
+
+| Task Signal | Load | Why |
+|-------------|------|-----|
+| Migrating from Bash, converting `.bashrc`, `export VAR=`, `[[ ]]`, arrays, heredocs | `bash-migration.md` | Full Bash→Zsh syntax translation table |
+| Variable scoping, `typeset` flags, `${(f)}` `${(s:,:)}` expansion, `$REPLY`, `$MATCH` | `zsh-quick-reference.md` | Parameter expansion flags, special variables, control flow cheatsheet |
+| Error audit, PATH not persisting, completions slow, glob errors, hook not firing | `zsh-preferred-patterns.md` | Failure modes with grep detection commands and error-fix mappings |
+| Go, Rust, Docker, Node.js, Python, pyenv, fnm, starship, direnv, fzf, zoxide, mise | `tool-integrations.md` | Concrete integration patterns for common dev tools |
+
+- `${CLAUDE_SKILL_DIR}/references/bash-migration.md`: Complete Bash-to-Zsh syntax translation table
+- `${CLAUDE_SKILL_DIR}/references/zsh-quick-reference.md`: Variable scoping, parameter expansion flags, and special variables
+- `${CLAUDE_SKILL_DIR}/references/zsh-preferred-patterns.md`: Failure mode catalog with grep detection commands and error-fix mappings
+- `${CLAUDE_SKILL_DIR}/references/tool-integrations.md`: Concrete integration patterns for Go, Rust, Docker, Node.js, Python, and shell enhancers

--- a/skills/infrastructure/zsh-shell-config/SKILL.md
+++ b/skills/infrastructure/zsh-shell-config/SKILL.md
@@ -23,7 +23,7 @@ routing:
     - zprofile
     - compinit
     - fpath
-    - autoload
+    - autoload -Uz
     - oh-my-zsh
     - prezto
     - zinit

--- a/skills/infrastructure/zsh-shell-config/references/bash-migration.md
+++ b/skills/infrastructure/zsh-shell-config/references/bash-migration.md
@@ -1,0 +1,248 @@
+# Bash to Zsh Migration Reference
+
+> **Scope**: Bash→Zsh syntax translation for shell config migration. Covers variables, arrays, conditionals, loops, functions, traps, process substitution, heredocs, and parameter expansion.
+> **Version range**: Zsh 5.8+
+> **Generated**: 2026-05-26
+
+---
+
+## Syntax Translation Table
+
+| Bash | Zsh | Notes |
+|------|-----|-------|
+| `VAR=value` | `VAR=value` | Both work — Zsh is POSIX-compatible |
+| `export VAR=value` | `export VAR=value` or `typeset -x VAR=value` | Both work; `typeset -x` is Zsh-native |
+| `unset VAR` | `unset VAR` | Same syntax |
+| `$?` | `$?` | Exit status — identical |
+| `$@` or `$*` | `$@` or `$*` | Function arguments — identical |
+| `$#` | `$#` | Argument count — identical |
+| `${var:-default}` | `${var:-default}` | Default value — identical |
+| `$(command)` | `$(command)` | Command substitution — identical |
+| `[[ condition ]]` | `[[ condition ]]` | Both work — `[[ ]]` is native in Zsh |
+| `[ condition ]` | `[ condition ]` or `[[ ]]` | Both work; prefer `[[ ]]` in Zsh |
+| `&&` / `\|\|` | `&&` / `\|\|` | Identical |
+| `function name() { }` | `function name { }` or `name() { }` | Both work in Zsh |
+| `source file` | `source file` or `. file` | Identical |
+| `declare -a arr` | `typeset -a arr` | `declare` works but `typeset` is canonical |
+| `declare -A assoc` | `typeset -A assoc` | Associative arrays — same semantics |
+| `declare -i int` | `typeset -i int` | Integer — same semantics |
+| `declare -r CONST` | `typeset -r CONST` | Read-only — same semantics |
+| `local var` | `local var` | Both work inside functions |
+| `array=(one two three)` | `array=(one two three)` | Same syntax |
+| `${array[0]}` | `${array[1]}` | **Zsh arrays are 1-indexed** |
+| `${#array[@]}` | `${#array[@]}` or `$#array` | Count — `$#array` is Zsh shorthand |
+| `export PATH="$PATH:/new"` | `path+=/new` or `path=(/new $path)` | Use `path` array — Zsh-native |
+| `trap 'cmd' SIGTERM` | `trap 'cmd' TERM` | Zsh omits `SIG` prefix |
+| `diff <(sort f1) <(sort f2)` | `diff <(sort f1) <(sort f2)` | Process substitution — identical |
+| `heredoc <<EOF` | `heredoc <<EOF` | Identical |
+| `=()` temp file | `=()` temp file | Zsh-only: `=(cmd)` creates temp file |
+
+---
+
+## Common Migration Patterns
+
+### Variable Assignment
+
+```bash
+# Bash
+VAR=value command        # Inline env for command
+```
+
+```zsh
+# Zsh — inline env works the same
+VAR=value command
+
+# Or with typeset for function-scoped
+typeset -x VAR=value; command
+```
+
+### PATH Manipulation
+
+```bash
+# Bash
+export PATH="$PATH:/new/path"
+```
+
+```zsh
+# Zsh — preferred: use path array
+path+=(/new/path)           # Append
+path=(/new/path $path)      # Prepend
+typeset -U path             # Deduplicate
+
+# Compatible: still works in zsh
+export PATH="$PATH:/new/path"
+```
+
+### Conditionals
+
+```bash
+# Bash
+if [[ -z "$var" ]]; then
+    echo "empty"
+fi
+```
+
+```zsh
+# Zsh — identical syntax (both [[ ]] and [ ] work)
+if [[ -z "$var" ]]; then
+    echo "empty"
+fi
+
+# Zsh also accepts: if [[ -z $var ]]; (no quotes needed for single words)
+```
+
+### Arrays
+
+```bash
+# Bash — 0-indexed
+array=(one two three)
+echo "${array[0]}"    # one
+echo "${#array[@]}"   # 3
+for item in "${array[@]}"; do echo "$item"; done
+```
+
+```zsh
+# Zsh — 1-indexed
+array=(one two three)
+echo "$array[1]"      # one  (note: no braces needed for simple index)
+echo "$array[-1]"     # three (negative indexing)
+echo "$array[2,3]"    # two three (range slice)
+echo "${#array}"      # 3  (or $#array)
+for item in $array; do echo "$item"; done
+```
+
+### Associative Arrays
+
+```bash
+# Bash
+declare -A map
+map[key]="value"
+echo "${map[key]}"
+for k in "${!map[@]}"; do echo "$k=${map[$k]}"; done
+```
+
+```zsh
+# Zsh
+typeset -A map
+map[key]="value"
+echo "$map[key]"
+for k in "${(k)map}"; do echo "$k=$map[$k]"; done
+# Keys: ${(k)map}  Values: ${(v)map}  Key+value pairs: ${(kv)map}
+```
+
+### Heredocs
+
+```bash
+# Bash
+cat <<EOF
+line 1
+line 2
+EOF
+```
+
+```zsh
+# Zsh — identical syntax
+cat <<EOF
+line 1
+line 2
+EOF
+
+# Zsh-only: strip leading tabs with <<-EOF
+cat <<-EOF
+    line 1
+    line 2
+EOF
+```
+
+### Process Substitution
+
+```bash
+# Bash
+diff <(sort file1) <(sort file2)
+```
+
+```zsh
+# Zsh — identical syntax
+diff <(sort file1) <(sort file2)
+
+# Zsh-only: =(cmd) creates a named temp file (not a pipe)
+# Useful for commands that require seekable input
+diff =(sort file1) =(sort file2)
+```
+
+### Traps
+
+```bash
+# Bash
+trap 'cleanup' SIGTERM SIGINT EXIT
+```
+
+```zsh
+# Zsh — omit SIG prefix; EXIT uses zshexit
+trap 'cleanup' TERM INT EXIT
+# Or use zsh hooks:
+zshexit() { cleanup; }
+```
+
+### Parameter Expansion
+
+```bash
+# Bash
+${var#prefix}       # Remove shortest prefix
+${var##prefix}      # Remove longest prefix
+${var%suffix}       # Remove shortest suffix
+${var%%suffix}      # Remove longest suffix
+${var/old/new}      # Replace first
+${var//old/new}     # Replace all
+${var^}             # Uppercase first char (Bash 4+)
+${var^^}            # Uppercase all (Bash 4+)
+${var,}             # Lowercase first (Bash 4+)
+${var,,}            # Lowercase all (Bash 4+)
+```
+
+```zsh
+# Zsh — all Bash forms work, plus expansion flags
+${var#prefix}       # Same
+${var##prefix}      # Same
+${var%suffix}       # Same
+${var%%suffix}      # Same
+${var/old/new}      # Same
+${var//old/new}     # Same
+
+# Zsh-native (via parameter expansion flags — load zsh-quick-reference.md for full list)
+${(U)var}           # Uppercase all (replaces ${var^^})
+${(L)var}           # Lowercase all (replaces ${var,,})
+${(C)var}           # Capitalize first letter of each word
+${(f)var}           # Split on newlines → array
+${(s:,:)var}        # Split on comma → array
+${(j: :)array}      # Join array with spaces → string
+${(u)array}         # Unique elements
+```
+
+---
+
+## Key Differences to Remember
+
+1. **Arrays are 1-indexed**: `$array[1]` is the first element. `$array[0]` is empty in Zsh, not the first element.
+
+2. **`[[ ]]` works in Zsh**: Unlike fish, `[[ ]]` is native Zsh syntax. Bash scripts using `[[ ]]` run in Zsh without modification.
+
+3. **`typeset` vs `declare`**: `declare` is a Bash synonym that works in Zsh for compatibility. `typeset` is the Zsh-canonical form. Use `typeset` in new Zsh code.
+
+4. **`=()` temp files**: Zsh-only feature. `diff =(sort f1) =(sort f2)` creates actual temp files (not pipes), enabling random access. Bash has no equivalent.
+
+5. **`path` array**: Zsh maintains `$path` (array) and `$PATH` (colon string) in sync. Manipulating `$path` directly is cleaner than string concatenation.
+
+6. **`typeset -U`**: Zsh-only. `typeset -U path` automatically deduplicates the `path` array on every assignment. No Bash equivalent.
+
+7. **Glob qualifiers**: `*.txt(N)` (null glob), `**/*.go(.)` (regular files only), `*(m-7)` (modified in last 7 days). Bash has no equivalent — requires `find`.
+
+8. **`autoload`**: Zsh lazy-loads functions from `fpath`. A function file is not sourced until the function is first called. Bash has no equivalent mechanism.
+
+---
+
+## See Also
+
+- `zsh-quick-reference.md` — Parameter expansion flags, special variables, control flow
+- `zsh-preferred-patterns.md` — Failure modes and detection commands
+- `tool-integrations.md` — Tool integration patterns (Go, Rust, Node, Python, shell enhancers)

--- a/skills/infrastructure/zsh-shell-config/references/tool-integrations.md
+++ b/skills/infrastructure/zsh-shell-config/references/tool-integrations.md
@@ -1,0 +1,368 @@
+# Zsh Tool Integrations
+
+> **Scope**: Concrete zsh integration patterns for common dev tools (Go, Rust, Docker, Node.js, Python, and shell enhancers). Covers PATH setup, eval hooks, and alias patterns. Does not cover tool installation.
+> **Version range**: Zsh 5.8+; tool-version notes inline where behavior differs
+> **Generated**: 2026-05-26
+
+---
+
+## Overview
+
+Each tool integration follows the same structure: (1) PATH and env setup in `~/.zshenv`, (2) eval hook with availability guard in `~/.zshrc`, (3) aliases in `~/.zshrc` inside an interactive guard. Use `(( $+commands[tool] ))` (hash lookup, no subprocess) or `command -v tool &>/dev/null` (POSIX, spawns subprocess) for availability checks.
+
+---
+
+## Pattern Table
+
+| Tool | Init Pattern | PATH Location | Version Notes |
+|------|-------------|---------------|---------------|
+| Go | `export GOPATH` | `path+=(~/go/bin)` | Go 1.16+: `GOPATH` defaults to `~/go` |
+| Rust/Cargo | source `~/.cargo/env` | `path+=(~/.cargo/bin)` | rustup writes `~/.cargo/env` for sh/bash/zsh |
+| Node/fnm | `eval "$(fnm env --use-on-cd)"` | handled by fnm | fnm 1.32+: native zsh support |
+| Python/pyenv | `eval "$(pyenv init -)"` | `path+=(~/.pyenv/bin ~/.pyenv/shims)` | pyenv 2.0+: use `pyenv init -` |
+| Docker | none (PATH handled by installer) | none | aliases only |
+| starship | `eval "$(starship init zsh)"` | none | requires starship 0.46+ |
+| direnv | `eval "$(direnv hook zsh)"` | none | requires direnv 2.21+ |
+| fzf | `source <(fzf --zsh)` | none | `--zsh` flag: fzf 0.48+; older: source `~/.fzf.zsh` |
+| zoxide | `eval "$(zoxide init zsh)"` | none | all versions |
+| mise | `eval "$(mise activate zsh)"` | none | replaces asdf |
+| Homebrew (macOS) | `eval "$(brew shellenv)"` | handled by shellenv | place in `~/.zprofile` for login shells |
+
+---
+
+## Availability Check Patterns
+
+```zsh
+# Preferred: hash lookup (fastest, no subprocess)
+if (( $+commands[starship] )); then
+  eval "$(starship init zsh)"
+fi
+
+# Alternative: command -v (POSIX, spawns subprocess)
+if command -v direnv &>/dev/null; then
+  eval "$(direnv hook zsh)"
+fi
+
+# For checking files/directories (not commands)
+if [[ -f ~/.cargo/env ]]; then
+  source ~/.cargo/env
+fi
+
+if [[ -d ~/.pyenv ]]; then
+  path=(~/.pyenv/bin ~/.pyenv/shims $path)
+fi
+```
+
+---
+
+## Go
+
+```zsh
+# ~/.zshenv
+export GOPATH=~/go
+# GOROOT only needed for non-standard Go installations:
+# export GOROOT=/usr/local/go
+
+typeset -U path
+path=(~/go/bin $path)       # Compiled binaries (go install output)
+# path=(/usr/local/go/bin $path)  # Go toolchain — only if not already in PATH
+export PATH
+```
+
+```zsh
+# ~/.zshrc — aliases (inside interactive check or at top level, zsh always checks)
+if (( $+commands[go] )); then
+  alias gob="go build ./..."
+  alias got="go test ./..."
+  alias gotr="go test -race ./..."
+  alias gom="go mod tidy"
+  alias gor="go run ."
+  alias goi="go install ./..."
+fi
+```
+
+**Version note**: Go 1.16+ sets `GOPATH` to `~/go` automatically if unset. Explicitly setting it is harmless but documents the intent. `GOROOT` is only needed for non-standard installations (e.g., Go installed via tarball to a custom path).
+
+---
+
+## Rust / Cargo
+
+```zsh
+# ~/.zshenv
+# Option A: source rustup's env script (sets PATH, CARGO_HOME, RUSTUP_HOME)
+[[ -f ~/.cargo/env ]] && source ~/.cargo/env
+
+# Option B: direct path addition (simpler, equivalent for most setups)
+typeset -U path
+path=(~/.cargo/bin $path)
+export PATH
+```
+
+```zsh
+# ~/.zshrc — aliases
+if (( $+commands[cargo] )); then
+  alias cb="cargo build"
+  alias cbr="cargo build --release"
+  alias ct="cargo test"
+  alias cr="cargo run"
+  alias cc="cargo check"
+  alias ccl="cargo clippy"
+  alias cf="cargo fmt"
+  alias cfd="cargo fmt --check"
+fi
+```
+
+**Note**: `rustup` writes `~/.cargo/env` — a sh/bash/zsh-compatible script that sets `PATH`, `CARGO_HOME`, and `RUSTUP_HOME`. Sourcing it is equivalent to manually adding `~/.cargo/bin` to PATH. Both approaches work; sourcing `~/.cargo/env` is more robust when `CARGO_HOME` is customized.
+
+---
+
+## Node.js — fnm (Recommended)
+
+```zsh
+# ~/.zshrc
+if (( $+commands[fnm] )); then
+  eval "$(fnm env --use-on-cd)"    # Auto-switches Node version on cd
+fi
+```
+
+```zsh
+# ~/.zshrc — aliases
+if (( $+commands[fnm] )); then
+  alias ni="npm install"
+  alias nid="npm install --save-dev"
+  alias nr="npm run"
+  alias nx="npx"
+  alias nls="fnm list"
+  alias nuse="fnm use"
+fi
+```
+
+**Version note**: `fnm env --use-on-cd` requires fnm 1.32+. For older fnm, use `eval "$(fnm env)"` without `--use-on-cd` and run `fnm use` manually when changing projects.
+
+## Node.js — nvm (Alternative)
+
+```zsh
+# ~/.zshrc — nvm is bash-native; source directly in zsh (zsh is sh-compatible)
+if [[ -s ~/.nvm/nvm.sh ]]; then
+  source ~/.nvm/nvm.sh              # Load nvm
+  source ~/.nvm/bash_completion     # Optional: nvm tab completion
+fi
+```
+
+**Note**: nvm works in Zsh despite being written for Bash — Zsh's POSIX compatibility handles it. For a native experience, prefer fnm (faster, has native Zsh hooks) or install the `zsh-nvm` plugin.
+
+---
+
+## Python — pyenv
+
+```zsh
+# ~/.zshenv
+if [[ -d ~/.pyenv ]]; then
+  typeset -U path
+  path=(~/.pyenv/bin ~/.pyenv/shims $path)
+  export PATH
+  export PYENV_ROOT=~/.pyenv
+fi
+```
+
+```zsh
+# ~/.zshrc
+if (( $+commands[pyenv] )); then
+  eval "$(pyenv init -)"
+fi
+```
+
+```zsh
+# ~/.zshrc — aliases
+if (( $+commands[pyenv] )); then
+  alias py="python"
+  alias pip="python -m pip"
+fi
+```
+
+**Version note**: pyenv 2.0+ uses `pyenv init -` (no language argument). Older pyenv (< 2.0) used the same syntax but without the `--path` / `--no-path` flags added later. Both work; the newer form is preferred.
+
+## Python — venv Helper
+
+```zsh
+# ~/.zshrc — venv activation function
+venv() {
+  local venv_dir="${1:-.venv}"
+  if [[ -d "$venv_dir" ]]; then
+    source "$venv_dir/bin/activate"
+  else
+    python -m venv "$venv_dir" && source "$venv_dir/bin/activate"
+  fi
+}
+```
+
+---
+
+## Docker / Docker Compose
+
+```zsh
+# ~/.zshrc — aliases (no init hook needed; Docker modifies PATH at install)
+if (( $+commands[docker] )); then
+  alias d="docker"
+  alias dc="docker compose"
+  alias dcu="docker compose up"
+  alias dcud="docker compose up -d"
+  alias dcd="docker compose down"
+  alias dcl="docker compose logs -f"
+  alias dps="docker ps"
+  alias dpsa="docker ps -a"
+  alias dex="docker exec -it"
+  alias drm="docker rm"
+  alias drmi="docker rmi"
+  alias dprune="docker system prune -af"
+fi
+```
+
+**Note**: `docker compose` (V2, no hyphen) is the current syntax. `docker-compose` (V1, with hyphen) is deprecated since Docker Desktop 4.20 / Docker Engine 23.0.
+
+---
+
+## Shell Enhancers
+
+### starship (Cross-Shell Prompt)
+
+```zsh
+# ~/.zshrc
+if (( $+commands[starship] )); then
+  eval "$(starship init zsh)"
+fi
+```
+
+**Version note**: starship 0.46+ has native Zsh support. Place this after any framework loading (oh-my-zsh, prezto) so starship overrides their prompt.
+
+### direnv (Per-Directory Env)
+
+```zsh
+# ~/.zshrc
+if (( $+commands[direnv] )); then
+  eval "$(direnv hook zsh)"
+fi
+```
+
+**Note**: direnv 2.21+ has native Zsh hook support. The hook wraps `cd` to load/unload `.envrc` files automatically. Does not slow down non-cd operations.
+
+### fzf (Fuzzy Finder)
+
+```zsh
+# ~/.zshrc — fzf 0.48+ (native --zsh flag)
+if (( $+commands[fzf] )); then
+  source <(fzf --zsh)
+fi
+
+# Fallback for fzf < 0.48 (installed via package manager)
+# if [[ -f ~/.fzf.zsh ]]; then
+#   source ~/.fzf.zsh
+# fi
+```
+
+**Version note**: `fzf --zsh` (outputting Zsh-native key bindings) was introduced in fzf 0.48.0 (2024-01). For older fzf, the `~/.fzf.zsh` file (written by `fzf --install`) provides equivalent Ctrl+R, Ctrl+T, Alt+C bindings.
+
+### zoxide (Smart cd Replacement)
+
+```zsh
+# ~/.zshrc
+if (( $+commands[zoxide] )); then
+  eval "$(zoxide init zsh)"
+  # After init: 'z dirname' jumps to frecent match; 'zi' opens fzf selector
+fi
+```
+
+### mise / rtx (Version Manager, asdf Replacement)
+
+```zsh
+# ~/.zshrc
+if (( $+commands[mise] )); then
+  eval "$(mise activate zsh)"
+fi
+```
+
+**Note**: mise (formerly rtx) replaces asdf for managing language versions (Node, Python, Go, Ruby, etc.). The Zsh activation hook manages shims automatically. Remove asdf integration if switching to mise — they conflict.
+
+### Homebrew (macOS)
+
+```zsh
+# ~/.zprofile — login shells only (brew shellenv is slow; run once per login)
+if [[ -x /opt/homebrew/bin/brew ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
+# Intel Mac
+if [[ -x /usr/local/bin/brew ]]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+```
+
+**Note**: Place in `~/.zprofile` (login shells), not `~/.zshrc` (interactive only). `brew shellenv` sets `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR`, `HOMEBREW_REPOSITORY`, and adds Homebrew bin/sbin to PATH.
+
+---
+
+## Full ~/.zshrc Tool Block Example
+
+```zsh
+# ~/.zshrc — tool integrations block (place near end of file)
+
+# Version managers (mise replaces asdf)
+if (( $+commands[mise] )); then
+  eval "$(mise activate zsh)"
+fi
+
+# Python
+if (( $+commands[pyenv] )); then
+  eval "$(pyenv init -)"
+fi
+
+# Node
+if (( $+commands[fnm] )); then
+  eval "$(fnm env --use-on-cd)"
+fi
+
+# Prompt
+if (( $+commands[starship] )); then
+  eval "$(starship init zsh)"
+fi
+
+# Directory env
+if (( $+commands[direnv] )); then
+  eval "$(direnv hook zsh)"
+fi
+
+# Smart cd
+if (( $+commands[zoxide] )); then
+  eval "$(zoxide init zsh)"
+fi
+
+# Fuzzy finder
+if (( $+commands[fzf] )); then
+  source <(fzf --zsh)
+fi
+```
+
+---
+
+## Error-Fix Mappings
+
+| Error / Symptom | Root Cause | Fix |
+|-----------------|------------|-----|
+| `command not found: go` after install | `~/go/bin` not in PATH | Add `path=(~/go/bin $path)` to `~/.zshenv` |
+| `cargo: command not found` | `~/.cargo/bin` not in PATH | Add `source ~/.cargo/env` or `path+=(~/.cargo/bin)` to `~/.zshenv` |
+| `fnm: Unknown version` on new shell | `--use-on-cd` not in init | Change to `eval "$(fnm env --use-on-cd)"` |
+| direnv not loading `.envrc` | direnv hook not sourced | Add `eval "$(direnv hook zsh)"` to `~/.zshrc` |
+| `fzf --zsh` flag unknown | fzf version < 0.48 | Use `source ~/.fzf.zsh` instead |
+| `pyenv: command not found` | pyenv shims not in PATH | Add `path=(~/.pyenv/bin ~/.pyenv/shims $path)` to `~/.zshenv` |
+| Tool init error on every shell | Init without availability guard | Wrap in `(( $+commands[tool] ))` check |
+| `GOPATH` not set for scripts | `GOPATH` in `~/.zshrc` not `~/.zshenv` | Move `export GOPATH` to `~/.zshenv` |
+| Homebrew tools not found in scripts | `brew shellenv` in `~/.zshrc` | Move `eval "$(brew shellenv)"` to `~/.zprofile` |
+| starship prompt missing on non-login shells | `starship init` in `~/.zprofile` | Move to `~/.zshrc` |
+
+---
+
+## See Also
+
+- `zsh-preferred-patterns.md` — Detection commands for common Zsh config mistakes
+- `bash-migration.md` — Bash→Zsh syntax translation
+- `zsh-quick-reference.md` — Variable scoping and PATH management cheatsheet

--- a/skills/infrastructure/zsh-shell-config/references/zsh-preferred-patterns.md
+++ b/skills/infrastructure/zsh-shell-config/references/zsh-preferred-patterns.md
@@ -1,0 +1,289 @@
+# Zsh Configuration Patterns
+
+> **Scope**: Zsh-native patterns for PATH management, variable scoping, completions, and tool integration. Covers correct configuration for Zsh 5.8+ with detection commands for common violations.
+> **Version range**: Zsh 5.8+
+> **Generated**: 2026-05-26
+
+---
+
+## Overview
+
+Zsh configuration errors rarely produce loud failures — they produce silent wrong behavior: PATH entries that vanish after restart, completions that work once then break, hooks that overwrite each other, or variables invisible to scripts. The patterns below show the Zsh-native approach for each common task, with detection commands to find violations in existing configs.
+
+---
+
+## Pattern Catalog
+
+### Use `typeset -U path` for PATH Deduplication
+
+Declare `path` as a unique array at the top of `~/.zshenv`. Every subsequent assignment deduplicates automatically.
+
+```zsh
+# ~/.zshenv — top of file
+typeset -U path
+path=(~/bin ~/.local/bin $path)
+export PATH
+```
+
+**Why this matters**: Without `typeset -U`, repeated shell starts (tmux panes, subshells) cause PATH to grow with duplicate entries. Commands may unexpectedly resolve to earlier (possibly stale) versions of the same binary.
+
+**Detection**:
+```bash
+grep -n 'export PATH' ~/.zshenv ~/.zshrc 2>/dev/null | grep -v 'typeset -U'
+grep -n 'PATH.*:.*PATH' ~/.zshenv ~/.zshrc 2>/dev/null
+```
+
+**Preferred action**: Add `typeset -U path` as the first line in `~/.zshenv`. Replace string-concatenation PATH assignments (`export PATH="$PATH:/new"`) with array-style: `path+=(/new/path)`.
+
+---
+
+### Use `.zshenv` for Environment Variables (Not `.zshrc`)
+
+Place `PATH`, `EDITOR`, `LANG`, `GOPATH`, and other exported variables in `~/.zshenv`.
+
+```zsh
+# ~/.zshenv — correct
+export EDITOR=nvim
+export LANG=en_US.UTF-8
+export GOPATH=~/go
+typeset -U path
+path=(~/go/bin $path)
+export PATH
+```
+
+**Why this matters**: `~/.zshrc` is sourced only for interactive shells. Scripts, cron jobs, and processes spawned by editors (e.g., neovim terminal) source `~/.zshenv` only. Variables in `~/.zshrc` are invisible to those processes.
+
+**Detection**:
+```bash
+grep -n '^export\s\+\(EDITOR\|LANG\|GOPATH\|CARGO_HOME\|PATH\)' ~/.zshrc 2>/dev/null
+```
+
+**Preferred action**: Move exported environment variables from `~/.zshrc` to `~/.zshenv`. Keep aliases, functions, completions, and prompt in `~/.zshrc`.
+
+---
+
+### Use `compinit` Guards to Avoid Slow Startup
+
+Guard `compinit` with a `~/.zcompdump` age check so it only rescans fpath once per day.
+
+```zsh
+# ~/.zshrc — fast compinit
+autoload -Uz compinit
+if [[ -n ~/.zcompdump(#qN.mh+24) ]]; then
+  compinit
+else
+  compinit -C    # -C: use cached dump, skip security check
+fi
+```
+
+**Why this matters**: Without the guard, `compinit` scans every file in every fpath directory on every shell start. With 20+ fpath directories (common with oh-my-zsh or homebrew), this adds 200–500ms per shell open.
+
+**Detection**:
+```bash
+# Measure startup time
+time zsh -i -c exit
+
+# Profile compinit
+zsh -i -c 'zmodload zsh/zprof; compinit; zprof' 2>&1 | head -20
+```
+
+**Preferred action**: Add the age guard around `compinit`. Regenerate `~/.zcompdump` manually when adding new completion scripts: `rm ~/.zcompdump && compinit`.
+
+---
+
+### Use `add-zsh-hook` Instead of Overwriting `precmd`/`preexec`
+
+Attach hooks with `add-zsh-hook` — this preserves existing handlers.
+
+```zsh
+autoload -Uz add-zsh-hook
+
+_my_precmd() { print -Pn "\e]0;%~\a"; }
+add-zsh-hook precmd _my_precmd
+
+_my_preexec() { print -Pn "\e]0;$1\a"; }
+add-zsh-hook preexec _my_preexec
+```
+
+**Why this matters**: Writing `precmd() { ... }` directly replaces the entire `precmd` function. If a prompt theme or another plugin already defined `precmd`, that definition is lost — causing silent breakage of the overwritten handler (typically the prompt's vcs_info update).
+
+**Detection**:
+```bash
+grep -n '^precmd()\|^preexec()\|^chpwd()' ~/.zshrc ~/.zsh/*.zsh 2>/dev/null
+```
+
+**Preferred action**: Replace bare `precmd() { ... }` function definitions with `add-zsh-hook precmd my_function_name`. Verify `autoload -Uz add-zsh-hook` is called first.
+
+---
+
+### Use Glob Qualifier `(N)` to Prevent "No Matches" Errors
+
+Append `(N)` to globs that may match nothing when `NULL_GLOB` is not set, or when passing to commands that error on empty args.
+
+```zsh
+# Without (N): error if no .log files exist
+rm -- *.log           # zsh: no matches found: *.log
+
+# With (N): silently expands to nothing
+rm -- *.log(N)        # no error if no matches
+
+# Practical uses
+for f in /var/log/*.log(N); do
+  gzip "$f"
+done
+
+# Check existence before glob
+local files=(~/.zsh/completions/*(N))
+(( ${#files} > 0 )) && echo "Found ${#files} completions"
+```
+
+**Why this matters**: With `EXTENDED_GLOB` set (common default), unmatched globs throw an error and abort the current script or function. `(N)` is per-glob; `NULL_GLOB` is global (changes behavior for all globs in the session).
+
+**Detection**:
+```bash
+grep -n '\*\.' ~/.zshrc ~/.zshenv 2>/dev/null | grep -v '(N)'
+```
+
+**Preferred action**: Add `(N)` to any glob used in conditional or cleanup contexts (`rm`, `for`, test). Use `setopt NULL_GLOB` only when you want this behavior session-wide.
+
+---
+
+### Guard Tool Integrations With `(( $+commands[tool] ))`
+
+Check tool availability before running init hooks. Use `(( $+commands[tool] ))` (hash lookup) or `command -v tool &>/dev/null`.
+
+```zsh
+# ~/.zshrc — guarded tool inits
+if (( $+commands[starship] )); then
+  eval "$(starship init zsh)"
+fi
+
+if (( $+commands[direnv] )); then
+  eval "$(direnv hook zsh)"
+fi
+
+if (( $+commands[zoxide] )); then
+  eval "$(zoxide init zsh)"
+fi
+
+# Alternative: command -v (POSIX-compatible)
+if command -v fnm &>/dev/null; then
+  eval "$(fnm env --use-on-cd)"
+fi
+```
+
+**Why this matters**: If a tool is not installed, the bare init command fails with "command not found" — producing an error on every new shell. This is especially visible in CI environments, Docker containers, or machines with minimal tool installations.
+
+**Detection**:
+```bash
+grep -n 'eval.*init zsh\|eval.*hook zsh\|eval.*activate zsh' ~/.zshrc 2>/dev/null | grep -v 'command\|+commands'
+```
+
+**Preferred action**: Wrap every `eval "$(tool init zsh)"` in `(( $+commands[tool] )) &&` or an `if` block. The `$+commands` hash is faster than `command -v` (no subprocess).
+
+---
+
+### Place `fpath` Extensions Before `compinit`
+
+Always extend `fpath` before calling `compinit`. Completions added after `compinit` are not registered until the next shell start.
+
+```zsh
+# Correct order in ~/.zshrc
+typeset -U fpath
+fpath=(~/.zsh/completions /opt/homebrew/share/zsh/site-functions $fpath)
+autoload -Uz compinit
+compinit
+```
+
+**Why this matters**: `compinit` builds the completion index from the current `fpath` snapshot. Extensions added after `compinit` are in `fpath` but not in the index — `_mycommand` completion is never found even though the file is present.
+
+**Detection**:
+```bash
+awk '/fpath=|fpath\+=/,/compinit/' ~/.zshrc 2>/dev/null | grep -c 'compinit'
+# If fpath lines appear after compinit, output will be > 0
+```
+
+**Preferred action**: Move all `fpath` assignments above the `autoload -Uz compinit && compinit` block. When adding Homebrew completions, use the setup block at the top of `.zshrc` before any plugin loading.
+
+---
+
+### Use `autoload -Uz` Consistently
+
+Always pass `-Uz` flags to `autoload`: `-U` disables alias expansion (prevents accidental override), `-z` forces Zsh-style autoload.
+
+```zsh
+autoload -Uz compinit
+autoload -Uz add-zsh-hook
+autoload -Uz vcs_info
+autoload -Uz my_custom_function
+```
+
+**Why this matters**: `autoload` without `-U` expands aliases during function definition, which can silently change behavior if you have an alias that shadows a builtin. `-z` forces Zsh-native loading semantics (as opposed to ksh-compatibility mode).
+
+**Detection**:
+```bash
+grep -n '^autoload ' ~/.zshrc 2>/dev/null | grep -v '\-U'
+```
+
+**Preferred action**: Replace all bare `autoload func` with `autoload -Uz func`.
+
+---
+
+## Error-Fix Mappings
+
+| Error / Symptom | Root Cause | Fix |
+|-----------------|------------|-----|
+| PATH grows on each new shell/tmux pane | No `typeset -U path` | Add `typeset -U path` at top of `~/.zshenv` |
+| Env var not visible in scripts | Set in `~/.zshrc` | Move to `~/.zshenv` |
+| Shell startup > 300ms | `compinit` running without cache guard | Add `~/.zcompdump` age check around `compinit -C` |
+| Prompt stops updating after adding `precmd` | Overwrote existing `precmd` | Use `add-zsh-hook precmd my_func` |
+| `no matches found: *.ext` error | Glob with no matches, no `(N)` qualifier | Append `(N)`: `*.ext(N)` |
+| Tool init error on every shell open | `eval "$(tool init zsh)"` without availability guard | Wrap in `(( $+commands[tool] ))` check |
+| Completions not found after adding `_mycommand` | `fpath` extended after `compinit` | Move `fpath` extension above `compinit` |
+| `autoload` function uses wrong alias | Missing `-U` flag | Use `autoload -Uz func` |
+| `compinit: insecure directories` | World/group-writable fpath entries | `compaudit`; `chmod go-w /path`; or `compinit -u` |
+| `add-zsh-hook: command not found` | `autoload -Uz add-zsh-hook` not called | Add `autoload -Uz add-zsh-hook` before hook calls |
+| `~/.zcompdump` outdated | Stale cache after adding new completions | `rm ~/.zcompdump && compinit` |
+
+---
+
+## Detection Commands Reference
+
+```bash
+# PATH growing (no typeset -U)
+grep -n 'export PATH\|PATH.*:.*PATH' ~/.zshenv ~/.zshrc 2>/dev/null
+
+# Env vars in wrong file (should be in .zshenv)
+grep -n '^export\s\+\(EDITOR\|LANG\|GOPATH\|PATH\)' ~/.zshrc 2>/dev/null
+
+# Missing compinit cache guard
+grep -n 'compinit' ~/.zshrc 2>/dev/null | grep -v '\-C\|zcompdump'
+
+# Direct precmd/preexec overwrite (should use add-zsh-hook)
+grep -n '^precmd()\|^preexec()\|^chpwd()' ~/.zshrc 2>/dev/null
+
+# Globs without (N) qualifier in loops/cleanup
+grep -n 'rm.*\*\.' ~/.zshrc 2>/dev/null | grep -v '(N)'
+
+# Tool inits without availability guard
+grep -n 'eval.*init zsh\|eval.*hook zsh' ~/.zshrc 2>/dev/null | grep -v 'commands\|command -v'
+
+# fpath after compinit
+grep -n 'fpath\|compinit' ~/.zshrc 2>/dev/null
+
+# autoload without -U flag
+grep -n '^autoload ' ~/.zshrc 2>/dev/null | grep -v '\-U'
+
+# Syntax check all rc files
+for f in ~/.zshenv ~/.zprofile ~/.zshrc; do
+  [[ -f "$f" ]] && zsh -n "$f" || echo "SYNTAX ERROR: $f"
+done
+```
+
+---
+
+## See Also
+
+- `bash-migration.md` — Bash→Zsh syntax translation table
+- `zsh-quick-reference.md` — Variable scoping, parameter expansion flags, special variables
+- `tool-integrations.md` — Complete tool integration patterns (Go, Rust, Docker, Node.js, pyenv)

--- a/skills/infrastructure/zsh-shell-config/references/zsh-quick-reference.md
+++ b/skills/infrastructure/zsh-shell-config/references/zsh-quick-reference.md
@@ -1,0 +1,332 @@
+# Zsh Quick Reference
+
+> **Scope**: Variable scoping, parameter expansion flags, special variables, fpath management, and control flow. Covers Zsh-specific features not in POSIX sh or Bash.
+> **Version range**: Zsh 5.8+
+> **Generated**: 2026-05-26
+
+---
+
+## Variable Scoping
+
+### Scope Modifiers
+
+```zsh
+local var="value"          # Local to current function (preferred for readability)
+typeset var="value"        # Same as local inside functions; global at top level
+typeset -g var="value"     # Force global even inside function
+typeset -x var="value"     # Export (same as export)
+typeset -r var="value"     # Read-only
+typeset -i var=0           # Integer (arithmetic auto-applied)
+typeset -l var="VALUE"     # Always stored lowercase
+typeset -u var="value"     # Always stored uppercase
+typeset -a arr             # Indexed array
+typeset -A assoc           # Associative array
+typeset -U arr             # Unique elements (dedup on assignment)
+```
+
+### Scope Guidelines
+
+| Scope | Modifier | Use For |
+|-------|----------|---------|
+| Function-local | `local` / `typeset` | Loop variables, temporary values in functions |
+| Global | `typeset -g` or top-level | Session-wide settings |
+| Exported | `typeset -x` / `export` | Variables visible to child processes |
+| Read-only | `typeset -r` | Constants |
+| Unique array | `typeset -U` | PATH, fpath — auto-deduplicates |
+
+### Scope Examples
+
+```zsh
+# Function-local variable
+my_function() {
+  local result=""
+  typeset -i count=0
+  # $result and $count are destroyed on function return
+}
+
+# Global exported variable
+export EDITOR=nvim
+# or equivalently:
+typeset -x EDITOR=nvim
+
+# PATH deduplication (set once at top of .zshenv)
+typeset -U path
+path=(~/bin ~/.local/bin $path)
+
+# Integer arithmetic
+typeset -i total=0
+total+=5    # total is now 5 (not "05")
+```
+
+---
+
+## Parameter Expansion Flags
+
+Zsh parameter expansion flags go inside `${(flags)var}` — load them lazily; full list in `man zshexpn`.
+
+### String Operations
+
+```zsh
+${(U)var}           # Uppercase all characters
+${(L)var}           # Lowercase all characters
+${(C)var}           # Capitalize first letter of each word
+${(q)var}           # Shell-quote the value (safe for eval)
+${(Q)var}           # Remove one level of quoting
+${(l:N::c:)var}     # Left-pad to width N with char c
+${(r:N::c:)var}     # Right-pad to width N with char c
+${#var}             # Length of string (or array element count)
+```
+
+### Splitting and Joining
+
+```zsh
+${(f)var}           # Split on newlines → array
+${(s:,:)var}        # Split on comma → array  (any delimiter in :delim:)
+${(z)var}           # Split as shell words (respecting quotes)
+${(j: :)array}      # Join array with space separator
+${(j:\n:)array}     # Join array with newlines
+${(F)array}         # Join array with newlines (shorthand for ${(j:\n:)})
+```
+
+### Array Operations
+
+```zsh
+${(u)array}         # Unique elements (deduplicated)
+${(o)array}         # Sort ascending
+${(O)array}         # Sort descending
+${(i)array}         # Sort case-insensitively
+${(n)array}         # Sort numerically
+${(r)array}         # Reverse order
+${(k)assoc}         # Keys of associative array
+${(v)assoc}         # Values of associative array
+${(kv)assoc}        # Interleaved key-value pairs
+```
+
+### Practical Examples
+
+```zsh
+# Split a colon-separated PATH into array
+path_parts=("${(s.:.)PATH}")
+
+# Split command output into lines array
+lines=("${(f)$(cat file.txt)}")
+
+# Join array back to string
+joined="${(j:,:)myarray}"
+
+# Get unique items from array
+typeset -U myarray
+# or without typeset:
+unique=("${(u)myarray[@]}")
+
+# Lowercase a string
+lower="${(L)MY_UPPER_VAR}"
+
+# Shell-safe quoting for dynamic eval
+safe="${(q)user_input}"
+
+# Split on newlines and iterate
+while IFS= read -r line; do
+  # ...
+done <<< "${(F)myarray}"
+```
+
+---
+
+## fpath Management
+
+`fpath` is to functions what `PATH` is to executables. Zsh searches `fpath` for autoloaded functions and completion scripts.
+
+```zsh
+# ~/.zshrc — extend fpath before compinit
+
+# Dedup fpath (same as path)
+typeset -U fpath
+
+# Add custom completion directory
+fpath=(~/.zsh/completions $fpath)
+
+# Add custom functions directory
+fpath=(~/.zsh/functions $fpath)
+
+# Homebrew completions (macOS)
+if [[ -d /opt/homebrew/share/zsh/site-functions ]]; then
+  fpath=(/opt/homebrew/share/zsh/site-functions $fpath)
+fi
+
+# Autoload a function from fpath (lazy — loads on first call)
+autoload -Uz my_function
+
+# Autoload all functions in a directory
+for f in ~/.zsh/functions/*; do
+  autoload -Uz "${f:t}"    # :t = tail (basename)
+done
+```
+
+**Completion script naming**: Completion functions must be named `_command` (underscore prefix). Place `_mycommand` in a `fpath` directory, then `compinit` finds it automatically — no explicit `autoload` needed.
+
+---
+
+## Special Variables
+
+```zsh
+$?          # Exit status of last command
+$!          # PID of last background process
+$$          # PID of current shell
+$0          # Name of current script or shell
+$SHELL      # Path to current shell binary
+$ZSH_VERSION # Zsh version string (e.g., "5.9")
+$SHLVL      # Shell nesting level (increments per subshell)
+
+# History
+$HISTFILE   # Path to history file (default: ~/.zsh_history)
+$HISTSIZE   # Max commands in memory
+$SAVEHIST   # Max commands saved to HISTFILE
+
+# Prompt
+$PROMPT     # Primary prompt (same as $PS1)
+$PS1        # Primary prompt (POSIX compatible)
+$RPROMPT    # Right-side prompt (Zsh-only)
+$PS2        # Continuation prompt (default: "> ")
+$PS3        # Select menu prompt
+$PS4        # Xtrace prefix (default: "+ ")
+
+# Completion/match state
+$REPLY      # Default variable for read builtin; also set by some builtins
+$reply      # Array version of $REPLY (lowercase)
+$MATCH      # String matched by last regex (with =~ or pcre_match)
+$match      # Array of capture groups from last regex match
+$MBEGIN     # Start position of last regex match
+$MEND       # End position of last regex match
+$compstate  # Associative array of completion state (in completion functions)
+
+# Directory
+$PWD        # Current directory
+$OLDPWD     # Previous directory (used by cd -)
+$CDPATH     # Colon-separated list of dirs to search for cd targets
+
+# Zsh-specific
+$ZSH_ARGZERO    # $0 equivalent but not modified by function calls
+$LINENO         # Current line number in script
+$COLUMNS        # Terminal width
+$LINES          # Terminal height
+```
+
+---
+
+## Control Flow Cheatsheet
+
+```zsh
+# If/elif/else
+if [[ condition ]]; then
+    action
+elif [[ other ]]; then
+    other_action
+else
+    fallback
+fi
+
+# Common conditions
+[[ -f file ]]       # File exists and is regular file
+[[ -d dir ]]        # Directory exists
+[[ -e path ]]       # Path exists (any type)
+[[ -r file ]]       # Readable
+[[ -w file ]]       # Writable
+[[ -x file ]]       # Executable
+[[ -s file ]]       # Non-empty file
+[[ -L link ]]       # Symbolic link
+[[ -z "$var" ]]     # String is empty
+[[ -n "$var" ]]     # String is not empty
+[[ "$a" == "$b" ]]  # String equality (glob patterns on right side)
+[[ "$a" =~ regex ]] # Regex match (POSIX ERE; match in $MATCH)
+[[ $n -eq 5 ]]      # Numeric equal
+[[ $n -lt 5 ]]      # Numeric less than
+[[ $n -gt 5 ]]      # Numeric greater than
+
+# Case
+case "$var" in
+  start|begin) action ;;
+  stop|end)    other_action ;;
+  *)           default_action ;;
+esac
+
+# For loop
+for item in one two three; do
+    echo "$item"
+done
+
+# For loop over array
+for item in "${array[@]}"; do
+    echo "$item"
+done
+
+# C-style for loop
+for (( i=0; i<10; i++ )); do
+    echo "$i"
+done
+
+# While loop
+while [[ condition ]]; do
+    action
+done
+
+# Read lines from file
+while IFS= read -r line; do
+    echo "$line"
+done < file.txt
+
+# Until loop
+until [[ condition ]]; do
+    action
+done
+
+# Select menu
+select choice in option1 option2 quit; do
+    case "$choice" in
+        option1) handle1 ;;
+        option2) handle2 ;;
+        quit)    break ;;
+    esac
+done
+
+# Arithmetic
+(( total = a + b ))
+(( i++ ))
+result=$(( 2 ** 8 ))    # 256
+```
+
+---
+
+## Debugging and Inspection
+
+```zsh
+# Syntax check without executing
+zsh -n script.zsh
+
+# Trace execution
+set -x          # Enable xtrace (echoes each command)
+set +x          # Disable xtrace
+
+# Check variable value and type
+typeset -p var         # Print variable with flags and value
+print -l "${path[@]}"  # Print array one per line
+
+# Check if variable is set
+[[ -v var ]]           # True if var is set (any value including empty)
+[[ -n "${var+x}" ]]    # POSIX-compatible set check
+
+# Profile startup
+zsh -i -c 'zmodload zsh/zprof; source ~/.zshrc; zprof'
+
+# Check which file defines a function
+which function_name     # or: whence -v function_name
+type function_name      # Full type info
+```
+
+---
+
+## See Also
+
+- `bash-migration.md` — Bash→Zsh syntax translation table
+- `zsh-preferred-patterns.md` — Failure modes with detection commands
+- `tool-integrations.md` — Tool integration patterns


### PR DESCRIPTION
## Summary

- **New `zsh-shell-config` skill** — 383-line SKILL.md + 4 reference files (1237 lines) covering rcfile load order, PATH/fpath/compinit, completions, framework detection (oh-my-zsh, prezto, zinit, p10k), hooks (`precmd`/`preexec`), `setopt`, and tool integrations (Go, Rust, Node/fnm, Python/pyenv, Docker, starship, direnv, fzf, zoxide, mise)
- **New `zsh-shell-detector.py` SessionStart hook** — detects `$SHELL=…zsh`, emits `[zsh-shell] Detected Zsh shell user` + `[auto-skill] zsh-shell-config`; wired into `.claude/settings.json` after fish detector
- **Bug fix: fish-shell-detector false-positive** (Defect #1) — zsh users with a leftover `~/.config/fish/` directory were misidentified as fish users; `$SHELL` now takes priority and short-circuits before the config-dir fallback
- **Bug fix: `count-components.sh` BASH_SOURCE fragility** (Defect #2) — `${BASH_SOURCE[0]:-$0}` prevents silent 0-counts when sourced from zsh
- **Bug fix: afk-mode README** (Defect #3) — instructs zsh users to use `~/.zshrc`, not `~/.bashrc`
- **Bug fix: cron script comments** (Defect #4) — mention `.zshrc`/`.zshenv` alongside `.bashrc`
- **Router triggers** — 25 zsh triggers in `skills/INDEX.json` with `force_route: true`; `SEMANTIC_GUARDS` + `SEMANTIC_GUARD_PHRASES` in `pre-route.py`

## Parity scorecard (before → after)

| Dimension | Before | After |
|---|---|---|
| SessionStart detector | ❌ none | ✅ `zsh-shell-detector.py` |
| Dedicated skill | ❌ none | ✅ `zsh-shell-config` (383 lines + 4 refs) |
| Auto-skill injection | ❌ none | ✅ `[auto-skill] zsh-shell-config` |
| Router force-route triggers | ❌ none | ✅ 25 triggers in INDEX.json |
| Rcfile-aware advice | ❌ none | ✅ .zshenv/.zprofile/.zshrc decision tree |
| Fish detector false-positive | ❌ fires for zsh users with fish config dir | ✅ fixed |

## Test plan

- [x] `python3 -m pytest hooks/tests/test_zsh_shell_detector.py -v` — 17/17 pass
- [x] `python3 -m pytest hooks/tests/ -v` — 706 pass, 4 fail (pre-existing failures on `main`, unrelated to this PR)
- [x] `python3 -m ruff check . --config pyproject.toml` — All checks passed
- [x] `python3 -m ruff format --check . --config pyproject.toml` — 399 files already formatted
- [x] `python3 scripts/pre-route.py --request "configure my zsh shell"` → `matched: true, skill: zsh-shell-config, confidence: high`
- [x] `python3 scripts/pre-route.py --request "fish for bugs"` → `matched: false` (guard working)
- [x] Both detectors exit in <50ms under current `SHELL=/bin/zsh`

## Based on evaluation

Findings from 5-agent parallel evaluation in `/tmp/zsh-eval/` (SYNTHESIS.md, agent1–5 reports). All 5 Defects and all P0/P1 gaps addressed.