### PR TITLE
fix(security-review): skip Stop rewake for mode-only diffs

### DIFF
--- a/hooks/security-review-hook.py
+++ b/hooks/security-review-hook.py
@@ -282,6 +282,14 @@ def _working_tree_diff(cwd: str | None) -> str:
     return result.stdout
 
 
+def _has_reviewable_content(diff: str) -> bool:
+    """Return True if diff has actual added/removed lines (not just mode changes)."""
+    for line in diff.splitlines():
+        if line.startswith(('+', '-')) and not line.startswith(('+++', '---')):
+            return True
+    return False
+
+
 def handle_stop(event: dict) -> None:
     """Stop: asyncRewake the session agent to run the security-review pipeline.
 
@@ -297,8 +305,8 @@ def handle_stop(event: dict) -> None:
 
     cwd = event.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR")
     diff = _working_tree_diff(cwd)
-    if not diff.strip():
-        # Nothing changed this session — no review needed.
+    if not diff.strip() or not _has_reviewable_content(diff):
+        # Nothing reviewable (empty or mode-only changes) — skip.
         sys.exit(0)
 
     # Cap the injected diff so the rewake context stays bounded.

--- a/hooks/security-review-hook.py
+++ b/hooks/security-review-hook.py
@@ -285,7 +285,7 @@ def _working_tree_diff(cwd: str | None) -> str:
 def _has_reviewable_content(diff: str) -> bool:
     """Return True if diff has actual added/removed lines (not just mode changes)."""
     for line in diff.splitlines():
-        if line.startswith(('+', '-')) and not line.startswith(('+++', '---')):
+        if line.startswith(("+", "-")) and not line.startswith(("+++", "---")):
             return True
     return False
 

--- a/hooks/tests/test_security_review_hook.py
+++ b/hooks/tests/test_security_review_hook.py
@@ -271,6 +271,13 @@ class TestStopAsyncRewake:
         assert code == 0
         assert "rewakeSummary" not in out
 
+    def test_stop_mode_only_diff_no_rewake(self):
+        """A diff with only mode changes (no +/- content lines) must not trigger a rewake."""
+        mode_only = "diff --git a/foo.py b/foo.py\nold mode 100644\nnew mode 100755\n"
+        code, out, err = _run(_stop_event(cwd="/repo"), diff=mode_only)
+        assert code == 0
+        assert "rewakeSummary" not in out
+
     def test_stop_hook_active_skips(self):
         """The asyncRewake recursion guard prevents re-firing while a rewake is in flight."""
         code, out, err = _run(


### PR DESCRIPTION
## Summary

- The Stop hook was firing security-review on every session that had a `chmod +x` change (e.g. making hook scripts executable), even though no code content changed
- Root cause: `git diff HEAD` emits `old mode 100644 / new mode 100755` header lines for permission changes — non-empty output, but zero `+`/`-` content lines. The existing `if not diff.strip()` guard passed, triggering the rewake unnecessarily
- Fix: added `_has_reviewable_content(diff)` helper that returns `True` only when at least one line starts with `+`/`-` (excluding `+++`/`---` file headers); guard now exits 0 on mode-only diffs

## Test plan

- [x] `test_stop_mode_only_diff_no_rewake` added — passes a mode-only diff and asserts `exit 0`, no rewakeSummary
- [x] All 32 existing tests pass: `python3 -m pytest hooks/tests/test_security_review_hook.py -q`