### PR TITLE
fix(security-review): dedup Stop rewake on identical diffs

### DIFF
--- a/hooks/security-review-hook.py
+++ b/hooks/security-review-hook.py
@@ -41,18 +41,27 @@ Contracts:
 Bypass / kill switches:
 - VEXJOY_SECURITY_REVIEW_SKIP=1     disables the commit BLOCK (deliberate override).
 - VEXJOY_SECURITY_REVIEW_DISABLE=1  disables the hook entirely (both events).
+- VEXJOY_SECURITY_REVIEW_DEDUP_TTL_SECONDS=N  Stop dedup window (default 300s; <=0 disables).
+
+Stop dedup: byte-identical working-tree diffs (under the same cwd) re-firing within
+the TTL window short-circuit instead of triggering another rewake. State persists
+to ~/.claude/state/security-review-hook/last-diff-hash.json via atomic write.
 
 Fail-open: any internal error allows the commit / skips the rewake and prints a
 warning to stderr. A crashed hook never blocks a tool and never stalls a session.
 """
 
+import hashlib
 import importlib.util
 import json
 import os
 import re
 import subprocess
 import sys
+import tempfile
+import time
 import traceback
+from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
@@ -61,6 +70,12 @@ from stdin_timeout import read_stdin
 
 _SKIP_ENV = "VEXJOY_SECURITY_REVIEW_SKIP"
 _DISABLE_ENV = "VEXJOY_SECURITY_REVIEW_DISABLE"
+_DEDUP_TTL_ENV = "VEXJOY_SECURITY_REVIEW_DEDUP_TTL_SECONDS"
+_DEDUP_TTL_DEFAULT = 300  # 5 minutes
+
+# Stop-event dedup state. Absolute path so it works from any cwd the harness fires in.
+_STATE_DIR = Path.home() / ".claude" / "state" / "security-review-hook"
+_STATE_FILE = _STATE_DIR / "last-diff-hash.json"
 
 # Matches a `git commit` invocation anywhere in the Bash command string.
 _GIT_COMMIT_RE = re.compile(r"\bgit\s+commit(?:\s|$)")
@@ -290,6 +305,89 @@ def _has_reviewable_content(diff: str) -> bool:
     return False
 
 
+def _dedup_ttl_seconds() -> int:
+    """Read TTL from env, fall back to default. Non-positive disables dedup."""
+    raw = os.environ.get(_DEDUP_TTL_ENV)
+    if not raw:
+        return _DEDUP_TTL_DEFAULT
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return _DEDUP_TTL_DEFAULT
+
+
+def _diff_signature(cwd: str | None, diff: str) -> str:
+    """Hash (cwd, diff) so different repos with identical diffs don't collide."""
+    h = hashlib.sha256()
+    h.update((cwd or "").encode("utf-8", errors="replace"))
+    h.update(b"\x00")
+    h.update(diff.encode("utf-8", errors="replace"))
+    return h.hexdigest()
+
+
+def _load_dedup_state() -> dict:
+    """Load last-diff-hash state. Empty dict on any failure."""
+    try:
+        if _STATE_FILE.exists():
+            return json.loads(_STATE_FILE.read_text())
+    except (json.JSONDecodeError, OSError, ValueError):
+        pass
+    return {}
+
+
+def _save_dedup_state(state: dict) -> None:
+    """Atomic write: tempfile in same dir + os.replace. Silent on failure (advisory path)."""
+    try:
+        _STATE_DIR.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(_STATE_DIR), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(state, f)
+            os.replace(tmp, str(_STATE_FILE))
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except Exception:
+        # Failing to persist dedup state must never block a Stop hook — at worst we
+        # double-review on the next event, which is the existing behavior.
+        pass
+
+
+def _is_duplicate_diff(cwd: str | None, diff: str) -> tuple[bool, str | None]:
+    """Return (is_duplicate, last_seen_iso). Compares hash + freshness against state file."""
+    ttl = _dedup_ttl_seconds()
+    if ttl <= 0:
+        return False, None
+    state = _load_dedup_state()
+    sig = _diff_signature(cwd, diff)
+    if state.get("hash") != sig:
+        return False, None
+    try:
+        last_ts = float(state.get("ts", 0))
+    except (TypeError, ValueError):
+        return False, None
+    if (time.time() - last_ts) > ttl:
+        return False, None
+    last_iso = state.get("ts_iso")
+    return True, last_iso
+
+
+def _record_diff_seen(cwd: str | None, diff: str) -> None:
+    """Persist the current diff signature so a byte-identical re-fire short-circuits."""
+    now = time.time()
+    _save_dedup_state(
+        {
+            "hash": _diff_signature(cwd, diff),
+            "ts": now,
+            "ts_iso": datetime.fromtimestamp(now, tz=timezone.utc).isoformat(),
+            "cwd": cwd or "",
+        }
+    )
+
+
 def handle_stop(event: dict) -> None:
     """Stop: asyncRewake the session agent to run the security-review pipeline.
 
@@ -307,6 +405,18 @@ def handle_stop(event: dict) -> None:
     diff = _working_tree_diff(cwd)
     if not diff.strip() or not _has_reviewable_content(diff):
         # Nothing reviewable (empty or mode-only changes) — skip.
+        sys.exit(0)
+
+    # Dedup: short-circuit if this exact diff (under this cwd) was already reviewed
+    # within the TTL window. Prevents the rewake from re-firing on Stop events that
+    # carry an unchanged working tree.
+    is_dup, last_iso = _is_duplicate_diff(cwd, diff)
+    if is_dup:
+        ts_msg = f" since {last_iso}" if last_iso else ""
+        print(
+            f"[security-review] diff unchanged{ts_msg} — skipping",
+            file=sys.stderr,
+        )
         sys.exit(0)
 
     # Cap the injected diff so the rewake context stays bounded.
@@ -329,6 +439,10 @@ def handle_stop(event: dict) -> None:
     # Per-run rewakeSummary (one-liner shown to the user). Mirrors the official
     # plugin's emit_metrics rewake_summary on a stdout JSON line.
     print(json.dumps({"rewakeSummary": "Local security review of session changes"}), flush=True)
+
+    # Record the diff signature so a byte-identical re-fire within the TTL window
+    # short-circuits cleanly. Recorded BEFORE exit 2 so the rewake itself won't loop.
+    _record_diff_seen(cwd, diff)
 
     # The rewake context goes to stderr; exit 2 is the asyncRewake signal.
     sys.stderr.write(

--- a/hooks/tests/test_security_review_hook.py
+++ b/hooks/tests/test_security_review_hook.py
@@ -278,6 +278,73 @@ class TestStopAsyncRewake:
         assert code == 0
         assert "rewakeSummary" not in out
 
+    def test_stop_dedup_short_circuits_identical_diff(self, tmp_path):
+        """A byte-identical diff re-fired within the TTL window must short-circuit (exit 0)."""
+        state_file = tmp_path / "last-diff-hash.json"
+        diff = "diff --git a/x b/x\n+payload\n"
+        with patch.object(mod, "_STATE_DIR", tmp_path), patch.object(mod, "_STATE_FILE", state_file):
+            code1, _, _ = _run(_stop_event(cwd="/repo"), diff=diff)
+            assert code1 == 2
+            assert state_file.exists()
+            code2, out2, err2 = _run(_stop_event(cwd="/repo"), diff=diff)
+            assert code2 == 0
+            assert "rewakeSummary" not in out2
+            assert "diff unchanged" in err2
+
+    def test_stop_dedup_does_not_block_changed_diff(self, tmp_path):
+        """A different diff after a recorded one must still trigger a rewake."""
+        state_file = tmp_path / "last-diff-hash.json"
+        with patch.object(mod, "_STATE_DIR", tmp_path), patch.object(mod, "_STATE_FILE", state_file):
+            code1, _, _ = _run(_stop_event(cwd="/repo"), diff="diff --git a/x b/x\n+a\n")
+            assert code1 == 2
+            code2, out2, _ = _run(_stop_event(cwd="/repo"), diff="diff --git a/x b/x\n+b\n")
+            assert code2 == 2
+            assert "rewakeSummary" in out2
+
+    def test_stop_dedup_disabled_when_ttl_zero(self, tmp_path):
+        """VEXJOY_SECURITY_REVIEW_DEDUP_TTL_SECONDS=0 disables dedup; identical diffs both rewake."""
+        state_file = tmp_path / "last-diff-hash.json"
+        diff = "diff --git a/x b/x\n+payload\n"
+        with patch.object(mod, "_STATE_DIR", tmp_path), patch.object(mod, "_STATE_FILE", state_file):
+            env = {"VEXJOY_SECURITY_REVIEW_DEDUP_TTL_SECONDS": "0"}
+            code1, _, _ = _run(_stop_event(cwd="/repo"), env=env, diff=diff)
+            code2, out2, _ = _run(_stop_event(cwd="/repo"), env=env, diff=diff)
+            assert code1 == 2
+            assert code2 == 2
+            assert "rewakeSummary" in out2
+
+    def test_stop_dedup_expires_after_ttl(self, tmp_path):
+        """A stale state record (older than TTL) must NOT short-circuit; rewake fires again."""
+        state_file = tmp_path / "last-diff-hash.json"
+        diff = "diff --git a/x b/x\n+payload\n"
+        with patch.object(mod, "_STATE_DIR", tmp_path), patch.object(mod, "_STATE_FILE", state_file):
+            # Pre-seed state with a record older than the default TTL window.
+            stale_ts = __import__("time").time() - 10_000
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "hash": mod._diff_signature("/repo", diff),
+                        "ts": stale_ts,
+                        "ts_iso": "2020-01-01T00:00:00+00:00",
+                        "cwd": "/repo",
+                    }
+                )
+            )
+            code, out, _ = _run(_stop_event(cwd="/repo"), diff=diff)
+            assert code == 2
+            assert "rewakeSummary" in out
+
+    def test_stop_dedup_distinguishes_by_cwd(self, tmp_path):
+        """Same diff under different cwds must not collide — each cwd dedups independently."""
+        state_file = tmp_path / "last-diff-hash.json"
+        diff = "diff --git a/x b/x\n+payload\n"
+        with patch.object(mod, "_STATE_DIR", tmp_path), patch.object(mod, "_STATE_FILE", state_file):
+            code1, _, _ = _run(_stop_event(cwd="/repo-a"), diff=diff)
+            code2, out2, _ = _run(_stop_event(cwd="/repo-b"), diff=diff)
+            assert code1 == 2
+            assert code2 == 2
+            assert "rewakeSummary" in out2
+
     def test_stop_hook_active_skips(self):
         """The asyncRewake recursion guard prevents re-firing while a rewake is in flight."""
         code, out, err = _run(


### PR DESCRIPTION
## Summary
Adds 5-minute diff-hash deduplication to the security-review hook's Stop branch. Identical, unchanged working-tree diffs no longer re-trigger reviews on every idle Stop event.

## Why
The Stop hook fires on every idle moment with `asyncRewake: true`. With no diff-stability check, the same unchanged working tree was being re-reviewed multiple times per session. PR #677 fixed mode-only-diff false positives; this PR fixes identical-diff repeat firings — the same noise from a different cause.

## What changed
- `hooks/security-review-hook.py`: `handle_stop` now hashes `(cwd, diff)` and short-circuits if the hash matches the last-seen value within a TTL window. State at `~/.claude/state/security-review-hook/last-diff-hash.json`.
- TTL: 300s default; `VEXJOY_SECURITY_REVIEW_DEDUP_TTL_SECONDS` overrides; `<=0` disables.
- Atomic write via tempfile + `os.replace`. Concurrent Stop races are accepted (worst case: one extra review).
- PreToolUse Bash (commit gate) and PostToolUse Edit/Write (advisory) branches untouched.
- 5 new tests under `TestStopAsyncRewake` covering: short-circuit on identical diff, TTL expiry, env override, cwd-distinguishing hash, no-block on changed diff.

## Test plan
- [x] `python3 -m pytest hooks/tests/test_security_review_hook.py -v` — 37/37 pass
- [x] `ruff check . --config pyproject.toml` clean
- [x] `ruff format --check . --config pyproject.toml` clean
- [x] Live smoke (clean repo): run1 → rewake; run2 → "diff unchanged since {ts} — skipping"; run3 (after edit) → rewake
- [x] PR #677 mode-only-skip semantics preserved (dedup runs *after* `_has_reviewable_content`)