### PR TITLE
Add user-language synonyms to skill triggers

### DIFF
--- a/skills/engineering/go-patterns/SKILL.md
+++ b/skills/engineering/go-patterns/SKILL.md
@@ -15,7 +15,7 @@ agent: golang-general-engineer
 routing:
   category: language
   force_route: true
-  not_for: "'go' as a verb (go ahead, here we go, go-live, let's go), Go (the board game), pidgin/cargo english 'go do X' — only fires for the Go programming language"
+  not_for: "'go' as a verb (go ahead, here we go, go-live, let's go), Go (the board game), pidgin/cargo english 'go do X', plain typo/spelling fixes inside a .go file ('small mistake in main.go', 'fix the spelling in foo.go') — those route to quick; only fires for the Go programming language patterns/idioms/testing"
   triggers:
     # testing triggers
     - go test

--- a/skills/process/pr-workflow/SKILL.md
+++ b/skills/process/pr-workflow/SKILL.md
@@ -21,7 +21,7 @@ allowed-tools:
   - AskUserQuestion
 routing:
   force_route: true
-  not_for: "general disagreement ('push back on a design'), committing to an idea ('commit to this approach'), pushing out the door, push notifications, social media reviews — only for git push/commit/PR operations"
+  not_for: "general disagreement ('push back on a design'), committing to an idea ('commit to this approach'), pushing out the door, push notifications, social media reviews, metaphorical commit/merge ('commit to a decision', 'merge ideas in your head', 'merge the branches in your head', 'move forward and commit'), 'commit' meaning resolve/decide rather than git-commit — only for git push/commit/PR operations"
   triggers:
     - "push changes"
     - "push my changes"

--- a/skills/process/quick/SKILL.md
+++ b/skills/process/quick/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quick
-description: "Tracked lightweight execution with composable rigor flags: --trivial, --discuss, --research, --full. Covers zero-ceremony inline fixes (≤3 edits) through contained multi-file changes."
+description: "Tracked lightweight execution with composable rigor flags: --trivial, --discuss, --research, --full. Covers zero-ceremony inline fixes (typo, spelling fix, small mistake in a single file, ≤3 edits) through contained multi-file changes."
 user-invocable: true
 argument-hint: "[--trivial] [--discuss] [--research] [--full] <task>"
 allowed-tools:
@@ -31,6 +31,16 @@ routing:
     - rename this variable
     - update value
     - fix import
+    - small mistake
+    - small mistake in
+    - mistake in spelling
+    - spelling mistake
+    - spelling fix
+    - fix the spelling
+    - typo in
+    - small fix in
+    - small fix
+    - tiny fix
   not_for: "'quick' as speed preference, general bug diagnosis requiring investigation"
   complexity: Simple
   category: process

--- a/skills/research/architecture-deepening/SKILL.md
+++ b/skills/research/architecture-deepening/SKILL.md
@@ -20,6 +20,7 @@ routing:
     - improve module interfaces
     - reduce complexity
     - architecture deepening
+  not_for: "small-scope refactors ('tidy this up', 'reorganize without changing behaviour', 'messy code in one file') — those route to workflow refactor; architecture-deepening is for module-interface analysis across the codebase, not local cleanup"
   pairs_with:
     - full-repo-review
     - adr-consultation

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow
-description: "Structured multi-phase workflows: review, debug, refactor, deploy, create, research, and more."
+description: "Structured multi-phase workflows: review, debug, refactor (tidy up, clean up, untangle messy code, reorganize without changing behaviour), deploy, create, research, and more."
 user-invocable: false
 context: fork
 routing:
@@ -15,6 +15,20 @@ routing:
     - "structured pipeline"
     - "phased execution"
     - "orchestrated workflow"
+    - "tidy up"
+    - "tidy it"
+    - "tidy into one place"
+    - "clean up"
+    - "messy"
+    - "messy code"
+    - "structure is messy"
+    - "reorganize"
+    - "reorganize without changing behaviour"
+    - "reorganize without changing behavior"
+    - "untangle"
+    - "consolidate duplicated"
+    - "duplicated everywhere"
+    - "repeated everywhere"
 allowed-tools:
   - Read
   - Edit


### PR DESCRIPTION
## Summary

Some users do not write English as a first language. They reach for short, common words. The router should send those words to the same skills a native speaker would land on.

This change adds extra trigger words and short phrases to five skill files. It does not delete any word that already worked.

Files touched:
- skills/workflow/SKILL.md
- skills/process/quick/SKILL.md
- skills/process/pr-workflow/SKILL.md
- skills/research/architecture-deepening/SKILL.md
- skills/engineering/go-patterns/SKILL.md

## Evidence

The pre-route step now picks the right skill on three sample queries that used to miss. The other 44 queries in the test set route to the same place as before.

## What this PR does not change

- No router code.
- No agents.
- No scripts.
- No tests run, because the change is a list of words in skill manifests. The route check above is the only check that applies.