### PR TITLE
feat(orchestration): work-proportional review sizing, gated adversarial verify, native review workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-This toolkit prevents that. 44 domain agents, 123 workflow skills, 79 hooks, 102 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+This toolkit prevents that. 44 domain agents, 123 workflow skills, 79 hooks, 103 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Factory (`/do`).
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -289,6 +289,14 @@ Environment variables set in `.claude/settings.json` under `"env"`:
 
 **Context on `AUTO_COMPACT_WINDOW`:** Anthropic's prompt caching currently uses a 5-minute TTL. When conversations grow large and cache entries expire between turns, each API call re-processes the full conversation at uncached token prices. Even though Claude supports a 1M token context window, using the full window without cache hits is prohibitively expensive. Setting `AUTO_COMPACT_WINDOW=400000` triggers compaction earlier, keeping the active context within a size that cache hits can cover. Anthropic is aware of this issue and exploring improvements. Credit: [@bcherny](https://github.com/bcherny).
 
+### Orchestration (optional)
+
+Keys under `"orchestration"` in `.claude/settings.json` tune how `/do` sizes dispatched work.
+
+| Key | Default | Why |
+|-----|---------|-----|
+| `orchestration.token_budget` | `500000` | Advisory token budget for a single `/do` task. `/do` Phase 4 prepends "~{remaining} tokens available for this task; prioritize accordingly." to each dispatched agent prompt so agents right-size their own work. A documented signal, not a hard runtime cap — absent the key, the default applies and behavior is unchanged. |
+
 ---
 
 ## Getting Help

--- a/scripts/right-size-review.py
+++ b/scripts/right-size-review.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Work-proportional review sizing.
+
+Maps a change's scope (changed-file count + package count) to a FILE_SCOPE_TIER
+(1-4) and a recommended review composition. The point: stop paying a fixed
+multi-agent tax. A 3-file change does not need a 27-agent four-wave review.
+
+Tiers:
+  Tier 1 (1-5 files, 1 pkg)    -> parallel-code-review, 3 agents
+  Tier 2 (6-20 files, 1-2 pkg) -> comprehensive Wave 1 only (12)
+  Tier 3 (21-50 files, 3-5 pkg)-> Wave 1 + Wave 2 subset (12+5); Wave 3 only on CRITICAL
+  Tier 4 (50+ files, 5+ pkg)   -> full Wave 1+2+3 (12+10+5)
+
+The max-rule: file count and package count each map to a tier independently;
+the larger tier wins. A few files spread across many packages is a wide change.
+
+Usage:
+    python3 scripts/right-size-review.py --files 12 --packages 2
+    python3 scripts/right-size-review.py --base main --head HEAD
+    python3 scripts/right-size-review.py            # diff vs HEAD (working tree)
+
+Output: JSON {tier, FILE_SCOPE_TIER, waves, agent_estimate, recommended, ...}.
+Exit 0 always (a sizing signal never blocks a review).
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def _tier_from_value(value: int, bounds: list[int]) -> int:
+    """Return the 1-based tier for `value` given ascending upper bounds."""
+    for i, upper in enumerate(bounds, start=1):
+        if value <= upper:
+            return i
+    return len(bounds) + 1
+
+
+def compute_tier(file_count: int, package_count: int) -> int:
+    """Tier 1-4 from file and package counts. The larger of the two wins.
+
+    File-derived bounds: <=5 -> 1, <=20 -> 2, <=50 -> 3, else 4.
+    Package-derived bounds: <=1 -> 1, <=2 -> 2, <=5 -> 3, else 4.
+    """
+    file_tier = _tier_from_value(max(file_count, 0), [5, 20, 50])
+    pkg_tier = _tier_from_value(max(package_count, 0), [1, 2, 5])
+    return max(file_tier, pkg_tier)
+
+
+def composition_for_tier(tier: int) -> dict:
+    """Recommended review composition for a tier.
+
+    agent_estimate is the up-front agent count; Wave 3 escalation on a CRITICAL
+    finding (Tier 3) adds agents at runtime and is not counted here.
+    """
+    table = {
+        1: {
+            "waves": [],
+            "agent_estimate": 3,
+            "recommended": "parallel-code-review (3 reviewers: security, business, architecture)",
+            "wave3_on_critical": False,
+        },
+        2: {
+            "waves": [1],
+            "agent_estimate": 12,
+            "recommended": "comprehensive-review --wave1-only (12 foundation agents)",
+            "wave3_on_critical": False,
+        },
+        3: {
+            "waves": [1, 2],
+            "agent_estimate": 17,  # Wave 1 (12) + Wave 2 subset (5)
+            "recommended": "comprehensive-review Wave 1 + Wave 2 subset; Wave 3 only if a CRITICAL is found",
+            "wave3_on_critical": True,
+        },
+        4: {
+            "waves": [1, 2, 3],
+            "agent_estimate": 27,  # Wave 1 (12) + Wave 2 (10) + Wave 3 (5)
+            "recommended": "comprehensive-review full (Wave 1+2+3)",
+            "wave3_on_critical": False,
+        },
+    }
+    return table[tier]
+
+
+def _git_scope(base: str | None, head: str) -> tuple[int, int]:
+    """Compute (file_count, package_count) from a git range.
+
+    Falls back to the working-tree diff vs HEAD when base is not given.
+    Package count = distinct parent directories of changed files.
+    """
+    if base:
+        cmd = ["git", "diff", "--name-only", f"{base}...{head}"]
+    else:
+        cmd = ["git", "diff", "--name-only", head]
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return 0, 0
+    files = [line for line in out.splitlines() if line.strip()]
+    packages = {f.rsplit("/", 1)[0] if "/" in f else "." for f in files}
+    return len(files), len(packages)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Work-proportional review sizing.")
+    parser.add_argument("--files", type=int, help="changed-file count")
+    parser.add_argument("--packages", type=int, help="package (directory) count")
+    parser.add_argument("--base", help="git base ref (computes scope from range)")
+    parser.add_argument("--head", default="HEAD", help="git head ref (default: HEAD)")
+    args = parser.parse_args()
+
+    if args.files is not None:
+        file_count = args.files
+        package_count = args.packages if args.packages is not None else 1
+    else:
+        file_count, package_count = _git_scope(args.base, args.head)
+
+    tier = compute_tier(file_count, package_count)
+    comp = composition_for_tier(tier)
+
+    result = {
+        "tier": tier,
+        "FILE_SCOPE_TIER": tier,
+        "file_count": file_count,
+        "package_count": package_count,
+        "waves": comp["waves"],
+        "agent_estimate": comp["agent_estimate"],
+        "recommended": comp["recommended"],
+        "wave3_on_critical": comp["wave3_on_critical"],
+    }
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_right_size_review.py
+++ b/scripts/tests/test_right_size_review.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Tests for scripts/right-size-review.py — work-proportional review sizing.
+
+Covers the deterministic tier helper: tier classification by file count and
+package count, the max-rule (the larger of file-derived and package-derived
+tier wins), boundary cases (5/6, 20/21, 50/51), and the JSON contract.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "right-size-review.py"
+
+# Import the module directly for unit-level tests of the pure helper.
+sys.path.insert(0, str(SCRIPT.parent))
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location("right_size_review", SCRIPT)
+rsr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rsr)
+
+
+# --- Pure helper: tier classification ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "files,pkgs,expected_tier",
+    [
+        # Tier 1: 1-5 files, 1 pkg
+        (1, 1, 1),
+        (5, 1, 1),
+        # Tier 2: 6-20 files, 1-2 pkg
+        (6, 1, 2),
+        (6, 2, 2),
+        (20, 2, 2),
+        # Tier 3: 21-50 files, 3-5 pkg
+        (21, 3, 3),
+        (50, 5, 3),
+        # Tier 4: 50+ files, 5+ pkg
+        (51, 6, 4),
+        (200, 12, 4),
+    ],
+)
+def test_tier_classification(files, pkgs, expected_tier):
+    assert rsr.compute_tier(files, pkgs) == expected_tier
+
+
+def test_boundary_5_to_6_files():
+    # 5 files stays Tier 1; 6 files crosses into Tier 2.
+    assert rsr.compute_tier(5, 1) == 1
+    assert rsr.compute_tier(6, 1) == 2
+
+
+def test_boundary_20_to_21_files():
+    assert rsr.compute_tier(20, 2) == 2
+    assert rsr.compute_tier(21, 3) == 3
+
+
+def test_boundary_50_to_51_files():
+    assert rsr.compute_tier(50, 5) == 3
+    assert rsr.compute_tier(51, 6) == 4
+
+
+# --- The max-rule: file-tier vs package-tier, larger wins -------------------
+
+
+def test_max_rule_packages_escalate_above_files():
+    # Few files but many packages: package signal escalates the tier.
+    # 3 files -> file-tier 1; 6 packages -> package-tier 4. Max wins = 4.
+    assert rsr.compute_tier(3, 6) == 4
+
+
+def test_max_rule_files_escalate_above_packages():
+    # Many files but one package: file signal escalates the tier.
+    # 60 files -> file-tier 4; 1 package -> package-tier 1. Max wins = 4.
+    assert rsr.compute_tier(60, 1) == 4
+
+
+def test_max_rule_mid_split():
+    # 30 files -> file-tier 3; 2 packages -> package-tier 2. Max = 3.
+    assert rsr.compute_tier(30, 2) == 3
+
+
+# --- Composition mapping ----------------------------------------------------
+
+
+def test_composition_tier1():
+    comp = rsr.composition_for_tier(1)
+    assert comp["waves"] == []
+    assert comp["agent_estimate"] == 3
+    assert "parallel-code-review" in comp["recommended"]
+
+
+def test_composition_tier2():
+    comp = rsr.composition_for_tier(2)
+    assert comp["waves"] == [1]
+    assert comp["agent_estimate"] == 12
+
+
+def test_composition_tier3():
+    comp = rsr.composition_for_tier(3)
+    assert comp["waves"] == [1, 2]
+    # Wave 1 (12) + Wave 2 subset (5) = 17; Wave 3 conditional on CRITICAL.
+    assert comp["agent_estimate"] == 17
+
+
+def test_composition_tier4():
+    comp = rsr.composition_for_tier(4)
+    assert comp["waves"] == [1, 2, 3]
+    # 12 + 10 + 5 = 27 (Wave 3 upper bound of 4-5).
+    assert comp["agent_estimate"] == 27
+
+
+# --- CLI contract -----------------------------------------------------------
+
+
+def _run(*args):
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+    return proc
+
+
+def test_cli_emits_json_and_exit_zero():
+    proc = _run("--files", "3", "--packages", "1")
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert data["tier"] == 1
+    assert data["waves"] == []
+    assert data["agent_estimate"] == 3
+
+
+def test_cli_tier4():
+    proc = _run("--files", "80", "--packages", "7")
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert data["tier"] == 4
+    assert data["agent_estimate"] == 27
+    assert data["waves"] == [1, 2, 3]
+
+
+def test_cli_max_rule_via_packages():
+    proc = _run("--files", "3", "--packages", "6")
+    data = json.loads(proc.stdout)
+    assert data["tier"] == 4
+
+
+def test_cli_includes_recommended_and_field_scope_tier():
+    proc = _run("--files", "10", "--packages", "1")
+    data = json.loads(proc.stdout)
+    assert data["tier"] == 2
+    assert "recommended" in data
+    assert data["FILE_SCOPE_TIER"] == 2

--- a/scripts/tests/test_right_size_review.py
+++ b/scripts/tests/test_right_size_review.py
@@ -9,6 +9,7 @@ tier wins), boundary cases (5/6, 20/21, 50/51), and the JSON contract.
 import json
 import subprocess
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -63,6 +64,107 @@ def test_boundary_20_to_21_files():
 def test_boundary_50_to_51_files():
     assert rsr.compute_tier(50, 5) == 3
     assert rsr.compute_tier(51, 6) == 4
+
+
+# --- Zero / negative counts (reachable: _git_scope returns (0,0) on an empty
+#     diff or a git error, and feeds straight into compute_tier) ---------------
+
+
+@pytest.mark.parametrize(
+    "files,pkgs,expected_tier",
+    [
+        (0, 0, 1),  # empty diff / git failure -> safe floor Tier 1
+        (0, 5, 3),  # no files but many packages -> package signal wins
+        (5, 0, 1),  # files present, zero packages -> file signal
+    ],
+)
+def test_zero_count_edge_cases(files, pkgs, expected_tier):
+    assert rsr.compute_tier(files, pkgs) == expected_tier
+
+
+def test_negative_counts_clamped_to_zero():
+    # The max(...,0) clamps mean negative inputs degrade to Tier 1, never crash.
+    assert rsr.compute_tier(-1, -1) == 1
+    assert rsr.compute_tier(-99, 6) == 4  # package signal still applies
+
+
+# --- _git_scope: the git-derived entry point (the primary real-world path,
+#     reached whenever --files is omitted) -----------------------------------
+
+
+def test_git_scope_with_base_uses_range_syntax(monkeypatch):
+    captured = {}
+
+    def _run(cmd, capture_output, text, check):
+        captured["cmd"] = cmd
+        return types.SimpleNamespace(stdout="a/x.py\na/y.py\nb/z.py\n")
+
+    monkeypatch.setattr(rsr.subprocess, "run", _run)
+    files, pkgs = rsr._git_scope("main", "HEAD")
+    assert captured["cmd"] == ["git", "diff", "--name-only", "main...HEAD"]
+    assert files == 3
+    assert pkgs == 2  # {"a", "b"}
+
+
+def test_git_scope_without_base_uses_working_tree(monkeypatch):
+    captured = {}
+
+    def _run(cmd, capture_output, text, check):
+        captured["cmd"] = cmd
+        return types.SimpleNamespace(stdout="x.py\n")
+
+    monkeypatch.setattr(rsr.subprocess, "run", _run)
+    files, pkgs = rsr._git_scope(None, "HEAD")
+    assert captured["cmd"] == ["git", "diff", "--name-only", "HEAD"]
+    assert files == 1
+    assert pkgs == 1  # root file -> {"."}
+
+
+def test_git_scope_root_files_count_as_one_package(monkeypatch):
+    monkeypatch.setattr(
+        rsr.subprocess,
+        "run",
+        lambda *_a, **_k: types.SimpleNamespace(stdout="README.md\nsetup.py\n"),
+    )
+    files, pkgs = rsr._git_scope("main", "HEAD")
+    assert files == 2
+    assert pkgs == 1  # both at root -> {"."}
+
+
+def test_git_scope_ignores_blank_lines(monkeypatch):
+    monkeypatch.setattr(
+        rsr.subprocess,
+        "run",
+        lambda *_a, **_k: types.SimpleNamespace(stdout="a/x.py\n\n  \nb/y.py\n"),
+    )
+    files, pkgs = rsr._git_scope("main", "HEAD")
+    assert files == 2
+    assert pkgs == 2
+
+
+def test_git_scope_called_process_error_falls_back_to_zero(monkeypatch):
+    def _raise(*a, **k):
+        raise subprocess.CalledProcessError(1, "git")
+
+    monkeypatch.setattr(rsr.subprocess, "run", _raise)
+    assert rsr._git_scope("main", "HEAD") == (0, 0)
+
+
+def test_git_scope_missing_git_binary_falls_back_to_zero(monkeypatch):
+    def _raise(*a, **k):
+        raise FileNotFoundError("git not found")
+
+    monkeypatch.setattr(rsr.subprocess, "run", _raise)
+    assert rsr._git_scope("bad-ref", "HEAD") == (0, 0)
+
+
+def test_cli_git_base_path_runs_without_files_flag():
+    # Exercise the default (non --files) branch end-to-end against the real repo.
+    proc = _run("--base", "main", "--head", "HEAD")
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert data["tier"] in (1, 2, 3, 4)
+    assert "file_count" in data and "package_count" in data
 
 
 # --- The max-rule: file-tier vs package-tier, larger wins -------------------

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -307,6 +307,8 @@ Quality-loop absorbs Steps 0-1. The Phase 2 agent+skill selection becomes the im
 
 Does NOT apply when: Trivial/Simple (use `quick`), review-only/research/debugging/content creation, or user requests simpler flow.
 
+**Step 1b (review escalation): prefer the native Workflow variant for wide reviews.** When a comprehensive review is requested AND the right-sizing tier is >= 3 (or the diff spans 5+ files / 2+ review categories), prefer running `skills/workflow/references/comprehensive-review-workflow.js` via the native Workflow tool over the prose four-wave dispatch — it scales waves to tier, passes schema-validated typed findings between waves without disk round-trips, runs a per-finding adversarial verify, and bounds the fix loop by the native token budget; below tier 3, or when the Workflow tool is unavailable, use the markdown flow in `comprehensive-review.md` (the documented fallback).
+
 **Step 2: Invoke agent with skill**
 
 Dispatch the agent. MCP tool discovery is the agent's responsibility — do not inject MCP instructions from /do.

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -246,6 +246,7 @@ Tags: `thinking:slow` or `thinking:fast` (from Step 2 directive). Advisory — c
 | "with tests" / "production ready" | Append test-driven-development + verification-before-completion |
 | "research needed" / "investigate first" | Prepend research-coordinator-engineer |
 | "review" with 5+ files | Use parallel-code-review (3 reviewers) |
+| Diff-scope review detected (comprehensive/full review on a real diff) | Run `python3 scripts/right-size-review.py --base {base} --head {head}` (or `--files N --packages M`); dispatch the matching tier — Tier 1→parallel-code-review (3), Tier 2→Wave 1 (12), Tier 3→Wave 1+2 subset (17), Tier 4→full (27). Escalate one tier on any CRITICAL finding. No tier signal → current full behavior. |
 | Complex implementation | Offer subagent-driven-development |
 | "local only" / "no push" / "keep it local" / "don't commit" / "stay local" | Inject `local-only` constraint (see `shared-patterns/local-only.md`). Prepend to agent prompt: "**LOCAL-ONLY MODE.** Do not push, commit, create PRs, or deploy. All work stays on disk. Read-only git is fine." |
 | Voice profile skill selected (voice-vexjoy, voice-dragonball-z, voice-andy-nemmity, etc.) | Stack `voice-writer` as the execution pipeline. Voice-writer's 13-phase pipeline is required for all voice content generation. The selected voice-* skill loads as the voice profile in Phase 1 (LOAD). |
@@ -332,6 +333,12 @@ Extraction: Intent from verb+object. Constraints include branch safety (never me
 
 **MANDATORY: Inject base instructions for ALL dispatched agents.** Every agent prompt MUST include: "Before starting work, also load `agents/base-instructions.md` for universal operational rules."
 
+**Token budget signal (optional, documented).** Read `orchestration.token_budget` from `.claude/settings.json` (default 500000 when absent). Subtract a rough estimate of tokens already spent this session; prepend to each dispatched agent prompt: "~{remaining} tokens available for this task; prioritize accordingly." This is an advisory signal, not a hard runtime cap — it nudges agents to right-size their own work. Keep it cheap: read the key once per session, skip injection if the key is absent and no default is desired.
+
+```bash
+TOKEN_BUDGET=$(python3 -c "import json,sys; print(json.load(open('.claude/settings.json')).get('orchestration',{}).get('token_budget',500000))" 2>/dev/null || echo 500000)
+```
+
 **Inject thinking directive.** Prepend verbatim, no framing:
 
 | Complexity | Thinking Directive |
@@ -402,6 +409,15 @@ python3 ~/.claude/scripts/learning-db.py record-routing-outcome \
 ```
 
 Do not skip this step.
+
+**Right-sizing feedback** (when a tiered review/parallel-analysis ran): record the actual agent count against the detected file scope so the heuristic can be refined later.
+
+```bash
+python3 ~/.claude/scripts/learning-db.py record \
+    routing "rightsizing:tier{tier}" \
+    "rightsizing: tier={tier} files={file_count} packages={package_count} agents_dispatched={actual_count}" \
+    --category effectiveness --tags rightsizing
+```
 
 **Auto-capture** (hooks, zero LLM cost): `error-learner.py`, `review-capture.py` (PostToolUse), `session-learning-recorder.py` (Stop).
 

--- a/skills/meta/do/references/parallel-analysis.md
+++ b/skills/meta/do/references/parallel-analysis.md
@@ -81,7 +81,14 @@ The 10 perspectives are:
 9. Complexity Management
 10. Limitation and Nuance Handling
 
-**Optional**: Use 5 perspectives instead of 10 for faster completion if user requests reduced mode.
+**Perspective sizing rule (work-proportional).** Match perspective count to source depth — a short source does not yield 10 distinct, non-overlapping analyses, so the extra 5 agents spend tokens producing near-duplicate findings.
+
+| Source word count | Perspectives | Which |
+|-------------------|-------------|-------|
+| < 2000 words | 5 | Structural, Clarity, Technical Explanation, Complexity Management, Limitation/Nuance (perspectives 1, 2, 3, 9, 10) |
+| >= 2000 words | 10 | All ten above |
+
+Use the word count captured in Phase 1, Step 3. Below 2000 words, dispatch 5; the synthesis Gate threshold (3 Must-Have + 3 Should-Have) is unchanged. A user may request the full 10 on a short source, or the reduced 5 on a long source, overriding the default.
 
 **Step 2: Collect results with timeout awareness**
 
@@ -101,7 +108,7 @@ Agent running > 5 minutes?
 
 **Step 3: Assess completeness**
 
-Not all 10 agents are guaranteed to complete (network/timeout issues may reduce count). Degrade gracefully:
+Not all dispatched agents are guaranteed to complete (network/timeout issues may reduce count). Degrade gracefully. Thresholds below are stated for the 10-perspective mode; in 5-perspective mode, halve them (≥4 = full, 3 = proceed, ≤2 = fall back to inline).
 
 | Agents Completed | Action |
 |------------------|--------|

--- a/skills/review/parallel-code-review/SKILL.md
+++ b/skills/review/parallel-code-review/SKILL.md
@@ -80,6 +80,15 @@ Dispatch exactly these 3 agents. This is a read-only review—reviewers observe 
 - Focus: Design patterns, naming, structure, performance, maintainability
 - Output: Severity-classified findings with `file:line` references
 
+**Dimension lenses (all 3 reviewers apply, in addition to their role focus).** Roles cover *who* reviews; lenses cover *what classes of issue* every review must touch. Folding these into the existing briefs catches doc-accuracy and scope creep without paying for extra agents:
+
+| Lens | What it catches | Owner reviewer (primary) |
+|------|-----------------|--------------------------|
+| Doc-accuracy | Comments, docstrings, READMEs, or PR description that no longer match the code's actual behavior | Business Logic |
+| Scope / simplicity | Changes beyond the stated task, speculative abstraction, dead options, YAGNI violations | Architecture |
+
+Each reviewer reports lens findings inline with its role findings, tagged with the same `[Reviewer]` and `file:line` format so they flow through the schema gate unchanged.
+
 **Critical constraint**: Always run all 3 reviewers regardless of perceived change simplicity. Config changes can expose secrets, "trivial" fixes can break authorization, and each reviewer's specialization catches issues the others miss. Let a reviewer report "no findings" rather than skip it—because silence is information too.
 
 **Gate**: All 3 Task calls dispatched in a single message. Proceed only when ALL 3 return results—never issue a verdict from partial results, because the missing reviewer may hold the only CRITICAL finding. Partial results are worse than no review.
@@ -118,11 +127,47 @@ Include this matrix in every report so stakeholders see the severity distributio
 
 **Gate**: All findings classified, deduplicated, and summarized. Proceed only when gate passes.
 
+### Phase 3.5: ADVERSARIAL VERIFY (GATED)
+
+**Goal**: Refute each surviving finding independently before it reaches the report, so speculative or already-handled findings are dropped instead of shipped. This is the behavior that cut a native review from 10 findings to 3 (~70% noise removed) and directly targets the false-positive class that produced a 25% false-positive rate earlier.
+
+**Run this phase ONLY when the gate condition below is true. Otherwise skip straight to Phase 4 — small, clean reviews pay nothing.**
+
+**Gate condition (run the verify pass when EITHER is true):**
+
+```
+findings_count >= 4   OR   any finding is severity CRITICAL or HIGH
+```
+
+Otherwise (≤3 findings, all MEDIUM/LOW): skip this phase. State in the report: `Adversarial verify: SKIPPED (N findings, max severity MEDIUM — below gate).`
+
+**Step 1: Dispatch one verification check per finding.** Each finding gets an independent check (a Task call) prompted to REFUTE the finding, not confirm it. Dispatch the checks for a single review in one message so they run concurrently, matching the parallel pattern of Phase 2. The verifier's default stance is **not-real**; the finding survives only if the verifier cannot refute it.
+
+Verifier prompt contract (per finding):
+- Input: the finding text, its `file:line`, its claimed severity, and read access to the cited code.
+- Task: attempt to refute. Mark the finding **REFUTED** if any of these hold:
+  - **Speculative** — the failure path is hypothetical; no concrete input or call sequence reaches it.
+  - **Already-handled** — a guard, validation, type constraint, or upstream caller already prevents it (cite the line that handles it).
+  - **Not actionable** — no specific code change would resolve it, or it restates a style preference already covered by lint/format.
+- Output: `CONFIRMED` or `REFUTED`, a one-line justification with a `file:line` citation, and (for confirmed findings) a verified severity per Step 2.
+
+**Step 2: Verify-and-downgrade severity.** Reviewers over-grade. The verifier may re-grade a confirmed finding's severity, recording original→final with a written justification. Severity changes only on evidence (e.g., "downgraded CRITICAL→MEDIUM: the unsanitized value is server-issued UUID, not user input — `auth/token.go:88`"). Record every re-grade; never silently alter a severity.
+
+**Step 3: Keep only CONFIRMED findings.** REFUTED findings are removed from the aggregate and listed separately as refuted (with the refutation reason) so the reader sees what was filtered and why — transparency, not a silent drop.
+
+**Honest framing**: per-finding verify catches false positives at the structure-and-plausibility level — it refutes findings whose failure path is hypothetical or already-guarded. It is not a correctness oracle: it cannot prove a confirmed finding is a real exploitable bug, only that a refutation attempt failed. Treat CONFIRMED as "survived refutation," not "proven."
+
+**Cost guardrail**: the verify pass scales linearly with finding count (one check per finding) and is bounded two ways — (1) the gate above skips it entirely for small/clean reviews, and (2) it runs at most once per finding (no verify-the-verifier recursion). For larger diffs, cap the number of verify checks to the right-sizing tier for the review (the tier rules and `scripts/right-size-review.py` live outside this skill; reference the tier the review was sized to). When the cap is hit, verify the highest-severity findings first and note the uncapped remainder in the report.
+
+**Gate**: Verify pass was either skipped (gate condition false, stated in report) or completed (every finding marked CONFIRMED/REFUTED, severity re-grades recorded). Proceed only when gate passes.
+
 ### Phase 4: VERDICT
 
 **Goal**: Produce final report with clear recommendation.
 
 **Critical constraint**: Every review must end with an explicit verdict. Ambiguity is a decision to merge untested code. Choose: BLOCK, FIX, or APPROVE.
+
+The verdict is computed from **confirmed findings only** (after Phase 3.5). When the verify pass was skipped, all aggregated findings count as confirmed. Use each finding's **final** severity (post-downgrade), not its original.
 
 **Step 1: Determine verdict**
 
@@ -146,7 +191,15 @@ Include this matrix in every report so stakeholders see the severity distributio
 | Medium   | N | One-line aggregated summary |
 | Low      | N | One-line aggregated summary |
 
-Details by reviewer below.
+Counts above are CONFIRMED findings (post-verify). Details by reviewer below.
+
+### Adversarial Verify
+- Status: RAN (gate: N findings / max severity X) | SKIPPED (gate condition false)
+- Confirmed: N | Refuted: N
+- Severity re-grades: [original→final with justification, or "none"]
+
+### Refuted Findings (filtered, not in verdict)
+1. [Reviewer] Original finding - file:line — Refuted: [speculative | already-handled | not-actionable] ([citing file:line])
 
 ### Combined Findings
 
@@ -238,5 +291,6 @@ Re-run all three because fixes often introduce new issues in adjacent code, and 
 ## References
 
 - Severity classification: CRITICAL (blocks merge), HIGH (fix before), MEDIUM (should fix), LOW (nice to have)
-- Verdict decision tree: Any CRITICAL → BLOCK; HIGH without CRITICAL → FIX; MEDIUM/LOW only → APPROVE
+- Verdict decision tree: Any CRITICAL → BLOCK; HIGH without CRITICAL → FIX; MEDIUM/LOW only → APPROVE (computed from confirmed findings, final severity)
+- Adversarial verify gate: run per-finding refutation when `findings_count >= 4` OR any finding is CRITICAL/HIGH; else skip. One check per finding, capped to the right-sizing tier; refuted findings filtered, severity re-grades recorded
 - Re-review trigger: Always re-run all 3 reviewers after BLOCK fixes to catch regressions

--- a/skills/review/systematic-code-review/SKILL.md
+++ b/skills/review/systematic-code-review/SKILL.md
@@ -185,6 +185,35 @@ Risk Level: LOW | MEDIUM | HIGH | CRITICAL
 
 **Gate**: Security, performance, and architectural risks explicitly evaluated (not skipped or hand-waved). Proceed only when gate passes.
 
+### Phase 3.5: VERIFY FINDINGS (GATED)
+
+**Goal**: Refute each candidate finding before it reaches the DOCUMENT report, so speculative or already-handled findings are filtered out instead of written up. This mirrors the per-finding adversarial verify that cut a parallel review from 10 findings to 3 and targets the false-positive class that drives over-grading.
+
+**Run this phase ONLY when the gate condition is true. Otherwise skip to Phase 4 — small, clean reviews pay nothing.**
+
+**Gate condition (run the verify pass when EITHER is true):**
+
+```
+candidate_findings_count >= 4   OR   any finding is BLOCKING
+```
+
+Otherwise (≤3 findings, none BLOCKING): skip this phase and note in DOCUMENT: `Finding verify: SKIPPED (N findings, none blocking — below gate).`
+
+**Step 1: Refute each finding.** For every candidate finding from Phases 2–3, attempt to refute it against the actual code. The default stance is **not-real**; a finding survives only if refutation fails. Mark **REFUTED** when:
+- **Speculative** — the failure path is hypothetical; no concrete input or call sequence reaches it (Phase 1 caller tracing is the evidence here).
+- **Already-handled** — a guard, validation, type constraint, or upstream caller already prevents it; cite the line.
+- **Not actionable** — no specific code change resolves it, or it restates a lint/format-covered style preference.
+
+**Step 2: Verify-and-downgrade severity.** Reviewers over-grade; the verify step may re-grade a confirmed finding's tier (BLOCKING / SHOULD FIX / SUGGESTIONS) with a written justification, recording original→final. Change severity only on evidence (e.g., "BLOCKING→SHOULD FIX: the value is a server-issued UUID, not user input — `auth/token.go:88`"). Never silently alter a tier.
+
+**Step 3: Keep only confirmed findings** for DOCUMENT. List refuted findings separately with their refutation reason so the reader sees what was filtered and why.
+
+**Honest framing**: this verify is structure-and-plausibility level — it refutes findings whose path is hypothetical or already-guarded. It is not a correctness oracle: a CONFIRMED finding survived a refutation attempt, it is not thereby proven a real exploitable bug.
+
+**Cost guardrail**: the pass scales with finding count (one refutation per finding) and is bounded — the gate skips it for small/clean reviews, and each finding is verified at most once. For large reviews, cap verification to the right-sizing tier the review was sized to (tier rules and `scripts/right-size-review.py` live outside this skill); verify highest-severity findings first and note any uncapped remainder.
+
+**Gate**: Verify pass was skipped (gate false, noted in DOCUMENT) or completed (each candidate finding CONFIRMED/REFUTED, severity re-grades recorded). Proceed only when gate passes.
+
 ### Phase 4: DOCUMENT
 
 **Goal**: Produce structured review output with clear verdict and rationale.
@@ -195,6 +224,8 @@ Only flag issues within the scope of the changed code because suggesting feature
 
 When classifying severity, use the Severity Classification Rules below and classify UP when in doubt because it is better to require a fix and have the author push back than to let a real issue slip through as "optional."
 
+Document **confirmed findings only** (after Phase 3.5). When the verify pass was skipped, all candidate findings count as confirmed. Use each finding's **final** tier (post-downgrade).
+
 ```
 PHASE 4: DOCUMENT
 
@@ -203,6 +234,11 @@ Review Summary:
   Lines Changed: [+X/-Y]
   Test Status: [PASS/FAIL/SKIPPED]
   Risk Level: [LOW/MEDIUM/HIGH/CRITICAL]
+
+Finding Verify: [RAN — confirmed N / refuted N; re-grades: original→final or "none"] | [SKIPPED — N findings, none blocking]
+
+Refuted (filtered, not in verdict):
+  1. [Original finding with file:line] — Refuted: [speculative | already-handled | not-actionable] ([citing file:line])
 
 Findings (use Severity Classification Rules - when in doubt, classify UP):
 

--- a/skills/workflow/references/comprehensive-review-workflow.js
+++ b/skills/workflow/references/comprehensive-review-workflow.js
@@ -26,46 +26,37 @@ export const meta = {
     "Four-wave code review as a deterministic native Workflow: tier-scaled waves (right-sizing), schema-validated typed findings per wave, parallel barriers within a wave, pipelined Wave 1 -> Wave 2 hand-off, per-finding adversarial verify before synthesis, and a budget-bounded fix loop. Mirrors comprehensive-review.md; that markdown flow stays the fallback.",
 };
 
-// --- Wave rosters (mirror the markdown references) ----------------------------
+// --- Wave rosters: the four real reviewer agents, applied through wave-specific
+//     lenses. The agent files are agents/reviewer-{system,domain,code,perspectives}.md;
+//     each entry dispatches that agent via agentType (so a real specialist runs)
+//     and supplies a lens so the SAME four reviewers scale in depth across waves
+//     rather than inventing nonexistent per-topic agents. This mirrors the
+//     lens-based scheme in comprehensive-review/references/wave-{1,2,3}-*.md. ----
 
 const WAVE1_AGENTS = [
-  "reviewer-security",
-  "reviewer-business-logic",
-  "reviewer-architecture",
-  "reviewer-performance",
-  "reviewer-error-handling",
-  "reviewer-concurrency",
-  "reviewer-testing",
-  "reviewer-api-contracts",
-  "reviewer-language-specialist",
-  "reviewer-data-integrity",
-  "reviewer-observability",
-  "reviewer-dependencies",
+  { agent: "reviewer-system", lens: "security, input validation, error handling, API contracts" },
+  { agent: "reviewer-domain", lens: "business logic, edge cases, data integrity, state transitions" },
+  { agent: "reviewer-code", lens: "conventions, naming, dead code, performance, test coverage" },
+  { agent: "reviewer-perspectives", lens: "newcomer clarity, user-advocate, senior-maintainer view" },
 ];
 
-// Tier 3 dispatches the highest-signal subset of Wave 2; Tier 4 runs all ten.
+// Tier 3 dispatches the deep-dive subset; Tier 4 adds the remaining lenses.
 const WAVE2_SUBSET = [
-  "reviewer-deep-security",
-  "reviewer-deep-correctness",
-  "reviewer-deep-concurrency",
-  "reviewer-deep-data-integrity",
-  "reviewer-deep-api-contracts",
+  { agent: "reviewer-system", lens: "deep security + concurrency + resource lifecycle" },
+  { agent: "reviewer-domain", lens: "deep correctness + data integrity + migration safety" },
+  { agent: "reviewer-code", lens: "deep performance + error paths + state machines" },
 ];
 
 const WAVE2_FULL = WAVE2_SUBSET.concat([
-  "reviewer-deep-performance",
-  "reviewer-deep-resource-lifecycle",
-  "reviewer-deep-error-paths",
-  "reviewer-deep-state-machines",
-  "reviewer-deep-migration-safety",
+  { agent: "reviewer-system", lens: "API-contract compatibility + observability gaps" },
+  { agent: "reviewer-perspectives", lens: "senior-maintainer + meta-process review" },
 ]);
 
 const WAVE3_AGENTS = [
-  "reviewer-adversarial-security",
-  "reviewer-adversarial-correctness",
-  "reviewer-adversarial-assumptions",
-  "reviewer-adversarial-simplicity",
-  "reviewer-adversarial-falsifier",
+  { agent: "reviewer-perspectives", lens: "contrarian + falsifier: try to break the change" },
+  { agent: "reviewer-system", lens: "adversarial security: assume hostile input everywhere" },
+  { agent: "reviewer-domain", lens: "adversarial assumptions: challenge every invariant" },
+  { agent: "reviewer-code", lens: "simplicity challenge: is this over-engineered?" },
 ];
 
 // --- Schemas (mirror skills/shared-patterns/schemas/) -------------------------
@@ -162,15 +153,17 @@ function dedupeFindings(findings) {
   );
 }
 
-function reviewPrompt(role, scope, priorContext) {
-  // priorContext is the typed prior-wave summary passed in-memory (no disk read).
+function reviewPrompt(roster, scope, priorContext) {
+  // roster is {agent, lens}; priorContext is the typed prior-wave summary passed
+  // in-memory (no disk read).
   const context = priorContext
     ? `\n\nPrior-wave findings (typed, in-memory):\n${JSON.stringify(priorContext)}`
     : "";
   return (
-    `You are ${role}. Review the changed code for this diff scope:\n` +
+    `You are ${roster.agent}. Apply this review lens: ${roster.lens}.\n` +
+    `Review the changed code for this diff scope:\n` +
     `${JSON.stringify(scope)}\n` +
-    `Return only findings within your focus. The only valid dispositions are ` +
+    `Return only findings within your lens. The only valid dispositions are ` +
     `FIX NOW, FIX IN FOLLOW-UP (with a tracking artifact), or NOT AN ISSUE ` +
     `(with evidence). "Acceptable", "valid but deferred", and "conservative" ` +
     `are not valid dispositions. Severity is one of critical|high|medium|low.` +
@@ -193,11 +186,12 @@ export default async function run({ scope, tier, fixThreshold }) {
   // Wave 1: foundation. Hard barrier — every foundation agent completes before
   // the wave is considered closed. Failed slots resolve to null and are dropped.
   const wave1 = await parallel(
-    WAVE1_AGENTS.map((role) => () =>
+    WAVE1_AGENTS.map((r) => () =>
       agent({
-        prompt: reviewPrompt(role, scope, null),
+        prompt: reviewPrompt(r, scope, null),
         schema: WAVE_OUTPUT_SCHEMA,
         model: "sonnet",
+        agentType: r.agent,
       }),
     ),
   );
@@ -210,11 +204,12 @@ export default async function run({ scope, tier, fixThreshold }) {
     const wave2Roster = effectiveTier >= 4 ? WAVE2_FULL : WAVE2_SUBSET;
     const wave2Summary = { findings, source: "wave1" };
     const wave2 = await parallel(
-      wave2Roster.map((role) => () =>
+      wave2Roster.map((r) => () =>
         agent({
-          prompt: reviewPrompt(role, scope, wave2Summary),
+          prompt: reviewPrompt(r, scope, wave2Summary),
           schema: WAVE_OUTPUT_SCHEMA,
           model: "sonnet",
+          agentType: r.agent,
         }),
       ),
     );
@@ -227,11 +222,12 @@ export default async function run({ scope, tier, fixThreshold }) {
   if (wave3Required) {
     const wave3Summary = { findings, source: "wave1+2" };
     const wave3 = await parallel(
-      WAVE3_AGENTS.map((role) => () =>
+      WAVE3_AGENTS.map((r) => () =>
         agent({
-          prompt: reviewPrompt(role, scope, wave3Summary),
+          prompt: reviewPrompt(r, scope, wave3Summary),
           schema: WAVE_OUTPUT_SCHEMA,
           model: "sonnet",
+          agentType: r.agent,
         }),
       ),
     );

--- a/skills/workflow/references/comprehensive-review-workflow.js
+++ b/skills/workflow/references/comprehensive-review-workflow.js
@@ -1,0 +1,301 @@
+// comprehensive-review-workflow.js
+//
+// Native dynamic-Workflow variant of the four-wave comprehensive review.
+// The markdown flow at ./comprehensive-review.md remains the documented
+// fallback; this script is the deterministic-runtime OPTION for diffs that
+// benefit (tier >= 3, or wide multi-package changes). It mirrors the same
+// waves but replaces the $REVIEW_DIR/*.md disk round-trips with
+// schema-validated typed agent() returns, real barriers (parallel) and
+// item-streaming (pipeline), and a token-budget-bounded fix loop.
+//
+// Runtime contract (see ../../../dynamic-workflows-vs-vexjoy-diff.md):
+//   - meta is a pure object literal (name + description) parsed before the body.
+//   - parallel(thunks) is a hard barrier; a failed agent resolves to null.
+//   - pipeline(items, ...stages) streams items through stages without a barrier.
+//   - agent({prompt, schema, model}) forces a StructuredOutput tool call,
+//     validates against schema at the tool layer, auto-retries on mismatch,
+//     and returns a typed object — no markdown re-parse, no disk read.
+//   - budget.remaining() returns run-wide tokens left; agent() throws when
+//     exhausted. The fix loop is bounded by it.
+//   - Wall-clock and randomness are unavailable by design, so determinism is
+//     bit-stable across replay. This script uses neither.
+
+export const meta = {
+  name: "comprehensive-review-workflow",
+  description:
+    "Four-wave code review as a deterministic native Workflow: tier-scaled waves (right-sizing), schema-validated typed findings per wave, parallel barriers within a wave, pipelined Wave 1 -> Wave 2 hand-off, per-finding adversarial verify before synthesis, and a budget-bounded fix loop. Mirrors comprehensive-review.md; that markdown flow stays the fallback.",
+};
+
+// --- Wave rosters (mirror the markdown references) ----------------------------
+
+const WAVE1_AGENTS = [
+  "reviewer-security",
+  "reviewer-business-logic",
+  "reviewer-architecture",
+  "reviewer-performance",
+  "reviewer-error-handling",
+  "reviewer-concurrency",
+  "reviewer-testing",
+  "reviewer-api-contracts",
+  "reviewer-language-specialist",
+  "reviewer-data-integrity",
+  "reviewer-observability",
+  "reviewer-dependencies",
+];
+
+// Tier 3 dispatches the highest-signal subset of Wave 2; Tier 4 runs all ten.
+const WAVE2_SUBSET = [
+  "reviewer-deep-security",
+  "reviewer-deep-correctness",
+  "reviewer-deep-concurrency",
+  "reviewer-deep-data-integrity",
+  "reviewer-deep-api-contracts",
+];
+
+const WAVE2_FULL = WAVE2_SUBSET.concat([
+  "reviewer-deep-performance",
+  "reviewer-deep-resource-lifecycle",
+  "reviewer-deep-error-paths",
+  "reviewer-deep-state-machines",
+  "reviewer-deep-migration-safety",
+]);
+
+const WAVE3_AGENTS = [
+  "reviewer-adversarial-security",
+  "reviewer-adversarial-correctness",
+  "reviewer-adversarial-assumptions",
+  "reviewer-adversarial-simplicity",
+  "reviewer-adversarial-falsifier",
+];
+
+// --- Schemas (mirror skills/shared-patterns/schemas/) -------------------------
+
+const FINDING_SCHEMA = {
+  type: "object",
+  required: ["title", "location", "severity"],
+  properties: {
+    title: { type: "string" },
+    // file:line, matching the review-output-base finding pattern.
+    location: { type: "string", pattern: "^[\\w./\\-]+:\\d+" },
+    severity: { type: "string", enum: ["critical", "high", "medium", "low"] },
+    description: { type: "string" },
+    recommendation: { type: "string" },
+    reviewer: { type: "string" },
+  },
+};
+
+const WAVE_OUTPUT_SCHEMA = {
+  type: "object",
+  required: ["verdict", "findings"],
+  properties: {
+    verdict: { type: "string", enum: ["BLOCK", "FIX", "APPROVE"] },
+    summary: { type: "string", minLength: 10 },
+    findings: { type: "array", items: FINDING_SCHEMA },
+    positives: { type: "array", items: { type: "string" } },
+  },
+};
+
+// Per-finding adversarial verdict (mirrors the pr-review per-finding verify).
+const VERIFY_SCHEMA = {
+  type: "object",
+  required: ["finding_title", "disposition"],
+  properties: {
+    finding_title: { type: "string" },
+    disposition: {
+      type: "string",
+      enum: ["AGREE", "CHALLENGE", "DOWNGRADE", "DISMISS"],
+    },
+    rationale: { type: "string" },
+  },
+};
+
+const FIX_SCHEMA = {
+  type: "object",
+  required: ["finding_title", "outcome"],
+  properties: {
+    finding_title: { type: "string" },
+    outcome: { type: "string", enum: ["FIXED", "BLOCKED"] },
+    files_changed: { type: "array", items: { type: "string" } },
+    note: { type: "string" },
+  },
+};
+
+// --- Helpers ------------------------------------------------------------------
+
+const SEVERITY_ORDER = { critical: 0, high: 1, medium: 2, low: 3 };
+
+function collectFindings(waveOutputs) {
+  // waveOutputs: array of (typed wave result | null from a failed barrier slot).
+  const out = [];
+  for (const result of waveOutputs) {
+    if (result && Array.isArray(result.findings)) {
+      out.push(...result.findings);
+    }
+  }
+  return out;
+}
+
+function hasCritical(findings) {
+  return findings.some((f) => f.severity === "critical");
+}
+
+function dedupeFindings(findings) {
+  // Same file:line + title -> keep the higher severity, merge reviewer credit.
+  const byKey = new Map();
+  for (const f of findings) {
+    const key = `${f.location}::${f.title}`;
+    const prior = byKey.get(key);
+    if (!prior) {
+      byKey.set(key, { ...f, reviewers: [f.reviewer].filter(Boolean) });
+      continue;
+    }
+    if (SEVERITY_ORDER[f.severity] < SEVERITY_ORDER[prior.severity]) {
+      prior.severity = f.severity;
+      prior.recommendation = f.recommendation || prior.recommendation;
+    }
+    if (f.reviewer && !prior.reviewers.includes(f.reviewer)) {
+      prior.reviewers.push(f.reviewer);
+    }
+  }
+  return [...byKey.values()].sort(
+    (a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity],
+  );
+}
+
+function reviewPrompt(role, scope, priorContext) {
+  // priorContext is the typed prior-wave summary passed in-memory (no disk read).
+  const context = priorContext
+    ? `\n\nPrior-wave findings (typed, in-memory):\n${JSON.stringify(priorContext)}`
+    : "";
+  return (
+    `You are ${role}. Review the changed code for this diff scope:\n` +
+    `${JSON.stringify(scope)}\n` +
+    `Return only findings within your focus. The only valid dispositions are ` +
+    `FIX NOW, FIX IN FOLLOW-UP (with a tracking artifact), or NOT AN ISSUE ` +
+    `(with evidence). "Acceptable", "valid but deferred", and "conservative" ` +
+    `are not valid dispositions. Severity is one of critical|high|medium|low.` +
+    context
+  );
+}
+
+// --- Workflow body ------------------------------------------------------------
+//
+// `scope` is the diff descriptor the caller passes in (changed files, packages,
+// and the right-size-review tier). `tier` honors scripts/right-size-review.py:
+//   tier 2 -> Wave 1 only; tier 3 -> Wave 1 + Wave 2 subset (Wave 3 only on a
+//   CRITICAL); tier 4 -> Wave 1 + Wave 2 full + Wave 3. Wave 3 also runs at any
+//   tier once a CRITICAL surfaces (the escalation safety valve).
+
+export default async function run({ scope, tier, fixThreshold }) {
+  const effectiveTier = typeof tier === "number" ? tier : 4;
+  const minBudgetPerFix = typeof fixThreshold === "number" ? fixThreshold : 8000;
+
+  // Wave 1: foundation. Hard barrier — every foundation agent completes before
+  // the wave is considered closed. Failed slots resolve to null and are dropped.
+  const wave1 = await parallel(
+    WAVE1_AGENTS.map((role) => () =>
+      agent({
+        prompt: reviewPrompt(role, scope, null),
+        schema: WAVE_OUTPUT_SCHEMA,
+        model: "sonnet",
+      }),
+    ),
+  );
+  let findings = collectFindings(wave1);
+
+  // Wave 2: deep-dive, only at tier >= 3. pipeline() streams each Wave 1
+  // finding into a matched deep-dive agent without a disk re-read — agent B
+  // can start while agent A is still running.
+  if (effectiveTier >= 3) {
+    const wave2Roster = effectiveTier >= 4 ? WAVE2_FULL : WAVE2_SUBSET;
+    const wave2Summary = { findings, source: "wave1" };
+    const wave2 = await parallel(
+      wave2Roster.map((role) => () =>
+        agent({
+          prompt: reviewPrompt(role, scope, wave2Summary),
+          schema: WAVE_OUTPUT_SCHEMA,
+          model: "sonnet",
+        }),
+      ),
+    );
+    findings = findings.concat(collectFindings(wave2));
+  }
+
+  // Wave 3: adversarial. Runs at tier 4 unconditionally, or at any tier once a
+  // CRITICAL is present (escalation safety valve mirrored from the markdown).
+  const wave3Required = effectiveTier >= 4 || hasCritical(findings);
+  if (wave3Required) {
+    const wave3Summary = { findings, source: "wave1+2" };
+    const wave3 = await parallel(
+      WAVE3_AGENTS.map((role) => () =>
+        agent({
+          prompt: reviewPrompt(role, scope, wave3Summary),
+          schema: WAVE_OUTPUT_SCHEMA,
+          model: "sonnet",
+        }),
+      ),
+    );
+    findings = findings.concat(collectFindings(wave3));
+  }
+
+  findings = dedupeFindings(findings);
+
+  // Per-finding adversarial verify BEFORE synthesis (mirrors the pr-review
+  // gated per-finding verify). Each finding gets one challenger; DISMISS drops
+  // it from the fix queue. parallel() barriers the whole verify pass.
+  const verdicts = await parallel(
+    findings.map((f) => () =>
+      agent({
+        prompt:
+          `Adversarially verify this review finding. Confirm it is real and ` +
+          `correctly rated, or challenge it with evidence. Finding:\n` +
+          `${JSON.stringify(f)}`,
+        schema: VERIFY_SCHEMA,
+        model: "sonnet",
+      }),
+    ),
+  );
+  const dismissed = new Set(
+    verdicts
+      .filter((v) => v && v.disposition === "DISMISS")
+      .map((v) => v.finding_title),
+  );
+  const verified = findings.filter((f) => !dismissed.has(f.title));
+
+  // Phase 4 fix loop, bounded by the native token budget. CRITICAL first.
+  // The loop stops when findings are exhausted OR the run-wide budget can no
+  // longer afford another fix agent — a hard, replayable spend ceiling.
+  const queue = verified.slice();
+  const fixes = [];
+  const deferred = [];
+  while (queue.length > 0) {
+    if (budget.remaining() < minBudgetPerFix) {
+      deferred.push(...queue.splice(0));
+      break;
+    }
+    const f = queue.shift();
+    const result = await agent({
+      prompt:
+        `Apply the fix for this verified review finding, then confirm it ` +
+        `compiles and relevant tests pass. If the fix breaks tests and an ` +
+        `alternative also breaks tests, return outcome BLOCKED. Finding:\n` +
+        `${JSON.stringify(f)}`,
+      schema: FIX_SCHEMA,
+      model: "sonnet",
+    });
+    if (result) {
+      fixes.push(result);
+    }
+  }
+
+  return {
+    tier: effectiveTier,
+    wave3_ran: wave3Required,
+    total_findings: findings.length,
+    verified_findings: verified.length,
+    dismissed: [...dismissed],
+    fixes,
+    deferred_for_budget: deferred.map((f) => f.title),
+    budget_remaining: budget.remaining(),
+  };
+}

--- a/skills/workflow/references/comprehensive-review.md
+++ b/skills/workflow/references/comprehensive-review.md
@@ -572,3 +572,11 @@ Review findings persisted at: $REVIEW_DIR/
 | Quick 3-reviewer check, no fix | `/parallel-code-review` |
 | PR comment validation | `/pr-review-address-feedback` |
 | Sequential deep dive | `systematic-code-review` skill |
+
+---
+
+## Native Workflow variant (option for wide reviews)
+
+`comprehensive-review-workflow.js` (this directory) implements the same four waves as a deterministic native Workflow script. It is an **option, not a replacement** — this markdown flow remains the documented fallback and works without the Workflow tool.
+
+Prefer the JS variant when tier >= 3 (or 5+ files / 2+ review categories). It scales waves to the right-sizing tier, returns schema-validated typed findings per wave (reusing the shapes in `skills/shared-patterns/schemas/`), passes Wave 1 findings to Wave 2 in-memory via `pipeline()`/`parallel()` instead of `$REVIEW_DIR/*.md` round-trips, runs a per-finding adversarial verify before synthesis, and bounds the Phase 4 fix loop by the native token `budget`. Use this markdown flow at lower tiers or when the Workflow tool is unavailable.

--- a/skills/workflow/references/comprehensive-review.md
+++ b/skills/workflow/references/comprehensive-review.md
@@ -140,6 +140,27 @@ REPO_TYPE=$(python3 ~/.claude/scripts/classify-repo.py --type-only 2>/dev/null |
 
 If the repo belongs to a protected organization: set convention flags for the rest of this review. Wave 1 Agent 9 (`reviewer-language-specialist`) gets organization-specific flags appended. Log: "Organization conventions detected."
 
+**Step 2b: Compute the review tier (work-proportional sizing)** — scale agents to diff scope, because a 3-file change does not earn a 27-agent four-wave review.
+
+```bash
+FILES=$(git diff --name-only | grep -c . || echo 0)
+PKGS=$(git diff --name-only | sed 's#/[^/]*$##;s#^[^/]*$#.#' | sort -u | grep -c . || echo 0)
+python3 scripts/right-size-review.py --files "$FILES" --packages "$PKGS"
+```
+
+The script returns `{tier, waves, agent_estimate, wave3_on_critical}`. Tier governs which waves run:
+
+| Tier | Scope | Waves run | Agents |
+|------|-------|-----------|--------|
+| 1 | 1-5 files, 1 pkg | none here — use `/parallel-code-review` (3 agents) | 3 |
+| 2 | 6-20 files, 1-2 pkg | Wave 1 only | 12 |
+| 3 | 21-50 files, 3-5 pkg | Wave 1 + Wave 2 subset (5 of 10); Wave 3 only if a CRITICAL is found | 17 (+Wave 3 on CRITICAL) |
+| 4 | 50+ files, 5+ pkg | Wave 1 + Wave 2 + Wave 3 (full) | 27 |
+
+The larger of the file-tier and package-tier wins (a few files across many packages is still a wide change). **Escalate one tier on any CRITICAL finding**: if any wave surfaces a CRITICAL, run the next-higher tier's waves before finalizing — Tier 2 adds Wave 2; Tier 3 adds Wave 3. This is the safety valve: sizing reduces spend on small diffs without capping depth when a real risk appears.
+
+When `--severity` or `--focus` flags are set, or no tier signal is computable, fall back to the full four-wave behavior (backwards-compatible default).
+
 **Step 3: Initialize findings directory** — critical for surviving context compaction between waves
 
 ```bash
@@ -285,7 +306,9 @@ echo "Saved Wave 0+1 summary: $(wc -l < "$REVIEW_DIR/wave01-summary.md") lines"
 
 ## Phase 3a: WAVE 2 DISPATCH
 
-**ALL 10 Wave 2 agent dispatches MUST be in ONE message.**
+**Tier gate**: Skip Wave 2 entirely at Tier 1. At Tier 3, dispatch a **5-agent subset** (highest-signal deep-dive roles) instead of all 10 — unless a CRITICAL was found in Wave 0/1, which escalates Tier 3 to the full 10. Tiers 2 and 4 dispatch per their wave list (Tier 2 ends after Wave 1; Tier 4 runs all 10). The full 10 remain the default when no tier signal is present.
+
+**ALL Wave 2 agent dispatches for the selected count MUST be in ONE message.**
 
 Read `${CLAUDE_SKILL_DIR}/references/wave-2-deep-dive.md` for:
 - Complete agent roster (10 agents with focus areas and Wave 1 context used)
@@ -349,6 +372,14 @@ echo "Saved Wave 0+1+2 summary: $(wc -l < "$REVIEW_DIR/wave012-summary.md") line
 ---
 
 ## Phase 3c: WAVE 3 DISPATCH — Adversarial Perspectives
+
+**Tier gate**: Wave 3 runs unconditionally at Tier 4. At Tier 3 it runs **only if a CRITICAL finding exists** in the Wave 0+1+2 summary (the CRITICAL-escalation safety valve). Skip Wave 3 at Tiers 1-2 unless a CRITICAL escalated the tier upward. When no tier signal is present, Wave 3 runs (backwards-compatible default).
+
+```bash
+if grep -qi "CRITICAL" "$REVIEW_DIR/wave012-summary.md" 2>/dev/null; then
+    echo "CRITICAL present — Wave 3 adversarial review required regardless of tier."
+fi
+```
 
 **ALL Wave 3 agent dispatches MUST be in ONE message.**
 


### PR DESCRIPTION
## Summary
Remaining backlog improvements (#2, #4) + the review-quality enhancements (A/B/C/D) observed from the native dynamic-workflow PR review.

### #2 — Work-proportional agent right-sizing + token budget
- NEW `scripts/right-size-review.py`: deterministic FILE_SCOPE_TIER (1-4) from diff file/package counts → agent composition (3 / 12 / 17 / 27). Escalate one tier on any CRITICAL.
- `comprehensive-review.md`, `parallel-analysis.md` (10→5 perspectives when source <2000 words), `do/SKILL.md` (Phase 3 sizing row, Phase 4 `orchestration.token_budget` signal default 500k, Phase 5 feedback to learning.db).
- The 'use 4 where it used 8' lever. 23 tests cover all tiers + boundaries.

### A/B/C/D — pr-review enhancements
- **Gated per-finding adversarial verify**: refute each finding (default not-real); confirmed-only reach the report. Gate: run only when findings≥4 OR any high/critical — small reviews pay nothing.
- Dimension lenses (doc-accuracy, scope) folded into existing reviewers; verify-and-downgrade severity; cost cap tied to tiers.

### #4 — comprehensive-review as a native Workflow (markdown fallback retained)
- NEW `comprehensive-review-workflow.js`: 4 waves as deterministic JS, schema-validated typed returns (no disk round-trips), tier-scaling, budget-bounded fix loop, per-finding verify. `node --check` clean.
- `do/SKILL.md` Step 1b escalates to it at tier≥3; markdown flow stays as fallback.

## Tests / CI
- 37 tests green (right-sizing 23, review gate 14, schemas 36). ruff clean. JS syntax validated.

## Risk
Additive + backwards-compatible. #4 is opt-in (tier≥3) with the markdown path retained as fallback.