### PR TITLE
fix(review-gate): flag findings under invalid systematic severity headings

### DIFF
--- a/scripts/tests/bench_review_gate_ab.py
+++ b/scripts/tests/bench_review_gate_ab.py
@@ -283,19 +283,18 @@ Rationale: low-risk mechanical change, safe to merge.
 
     # Invalid severity bucket: uses parallel's "Critical" heading in a
     # systematic review (systematic buckets are blocking/should_fix/suggestions).
-    # The blocking finding therefore lands in no recognized bucket -> the real
-    # should-fix content is lost; combined with removing the legit should-fix
-    # this yields a structurally thin review. Here we additionally strip the
-    # location to guarantee a schema violation on the surviving finding.
+    # The "Unbounded cache growth" finding therefore lands under an unrecognized
+    # heading and is silently dropped into no bucket. Because the systematic
+    # schema has no minItems on findings, the surviving Suggestions finding keeps
+    # the review schema-valid — so a naive gate accepts it (a true false-negative).
+    # The validator must detect the invalid severity heading itself and flag it.
     items.append(
         Item(
             "S04",
             "systematic",
             "malformed",
-            "invalid severity bucket heading + finding missing file:line",
-            SYSTEMATIC_VALID.replace("### Should Fix", "### Critical").replace(
-                "`internal/cache/store.go:53`", "the store file"
-            ),
+            "invalid severity bucket heading (finding silently dropped)",
+            SYSTEMATIC_VALID.replace("### Should Fix", "### Critical"),
         )
     )
 

--- a/scripts/tests/test_review_output_gate.py
+++ b/scripts/tests/test_review_output_gate.py
@@ -152,6 +152,36 @@ MALFORMED_SYSTEMATIC_MD = textwrap.dedent("""\
 """)
 
 
+# systematic review whose Findings section uses an INVALID severity heading
+# (`### Critical` is a parallel bucket, not systematic). The finding under it
+# would otherwise be silently dropped into no bucket, and — because the
+# systematic schema has no minItems on findings — the review would pass with the
+# real finding lost. This is the false-negative the gate must catch (exit 1).
+MALFORMED_SYSTEMATIC_BAD_BUCKET_MD = textwrap.dedent("""\
+    # Code Review
+
+    ## Summary
+    Reviewed the cache layer; one eviction concern. Otherwise acceptable.
+
+    ## Risk Level: MEDIUM
+
+    ## Findings
+
+    ### Critical
+    1. **Unbounded cache growth** - `internal/cache/store.go:53`
+       - Issue: entries are never evicted under memory pressure
+       - Recommendation: add an LRU bound
+
+    ### Suggestions
+    1. **Extract magic number** - `internal/cache/store.go:17`
+       - Recommendation: name the 3600 TTL constant
+
+    ## Verdict: REQUEST-CHANGES
+
+    Rationale: eviction gap should be addressed before merge.
+""")
+
+
 # parallel with the CANONICAL hyphenated reviewer name [Business-Logic]
 # (per skills/review/parallel-code-review/SKILL.md). The reviewer-extraction
 # regex must accept the hyphen, or this structurally valid review is rejected
@@ -240,6 +270,35 @@ def test_malformed_systematic_flags_verdict_risk_and_location() -> None:
     # Bare "handler.go" never reaches the file:line pattern; it surfaces as a
     # missing location on the finding.
     assert "MISSING: location" in joined
+
+
+def test_systematic_invalid_severity_heading_is_rejected() -> None:
+    """A systematic finding under an invalid bucket heading must NOT be silently dropped.
+
+    Regression for the false-negative: `### Critical` is a valid parallel bucket
+    but not a systematic one. Previously the parser treated it as a non-severity
+    heading that ended the section, discarding the finding into no bucket, and the
+    review passed (exit 0). It must now surface a structural error.
+    """
+    parsed = parse_markdown(MALFORMED_SYSTEMATIC_BAD_BUCKET_MD, "systematic")
+    errors = validate_structure(parsed, "systematic")
+    joined = "\n".join(errors)
+    assert errors, "expected a structural error for the invalid severity heading, got none"
+    assert "INVALID SEVERITY HEADING" in joined
+    assert "Critical" in joined
+
+
+def test_cli_rejects_systematic_invalid_severity_heading_via_stdin() -> None:
+    """The invalid-bucket systematic review exits 1 via the CLI (the gate fires)."""
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR_PATH), "--type", "systematic", "-"],
+        input=MALFORMED_SYSTEMATIC_BAD_BUCKET_MD,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "VALIDATION FAILED" in result.stdout
+    assert "INVALID SEVERITY HEADING" in result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/validate-review-output.py
+++ b/scripts/validate-review-output.py
@@ -411,6 +411,66 @@ def _extract_findings_section(
     return findings
 
 
+def _normalize_heading(text: str) -> str:
+    """Normalize a heading to its severity key form (lowercased, no count/suffix).
+
+    Mirrors the normalization in `_extract_findings_section` so heading-to-bucket
+    comparison is consistent: "CRITICAL (0)" and "Critical (Block Merge)" both
+    normalize to "critical".
+    """
+    text_lower = text.lower().strip()
+    text_clean = re.sub(r"\s*\(.*?\)\s*$", "", text_lower)
+    text_clean = re.sub(r"\s*\(.*$", "", text_clean)
+    return text_clean.strip()
+
+
+def _find_invalid_severity_headings(lines: list[str], severity_map: dict[str, str]) -> list[str]:
+    """Find severity-typed subheadings in the Findings section not valid for this type.
+
+    A finding written under a heading that is NOT a recognized severity bucket for
+    the review type is silently dropped by `_extract_findings_section` (the heading
+    ends the prior bucket and starts no new one). That is a structural defect, not
+    a clean review: it must be surfaced, never dropped.
+
+    We scope detection to the ``## Findings`` section and flag any ``###`` (or
+    deeper) subheading whose normalized text is not in this type's ``severity_map``.
+    A genuinely empty Findings section (no stray subheadings) yields no findings,
+    so a clean zero-findings APPROVE still passes.
+
+    Returns the raw (un-normalized) heading texts that are invalid, in document
+    order, deduplicated.
+    """
+    if not severity_map:
+        return []
+
+    invalid: list[str] = []
+    in_findings = False
+    findings_level = 0
+
+    for line in lines:
+        heading = _heading_level(line)
+        if heading is None:
+            continue
+        level, text = heading
+
+        if not in_findings:
+            if level <= 2 and _normalize_heading(text).startswith("findings"):
+                in_findings = True
+                findings_level = level
+            continue
+
+        # Inside the Findings section.
+        # A heading at or above the Findings heading level closes the section.
+        if level <= findings_level:
+            break
+
+        normalized = _normalize_heading(text)
+        if normalized and normalized not in severity_map and text not in invalid:
+            invalid.append(text)
+
+    return invalid
+
+
 def _extract_scorecard(lines: list[str]) -> list[dict[str, Any]]:
     """Extract SAPCC review scorecard from markdown table."""
     scorecard: list[dict[str, Any]] = []
@@ -672,6 +732,14 @@ def parse_markdown(content: str, review_type: str) -> dict[str, Any]:
     findings = _extract_findings_section(lines, sev_map)
     result["findings"] = findings
 
+    # Structural guard: a finding under an unrecognized severity heading is
+    # silently dropped by the bucket parser. Record those headings so the
+    # validator can flag them instead of letting the review pass with lost
+    # findings. Stored under a private key stripped before schema validation.
+    invalid_headings = _find_invalid_severity_headings(lines, sev_map)
+    if invalid_headings:
+        result["_invalid_severity_headings"] = invalid_headings
+
     # Positives
     positives = _extract_positives(lines)
     if positives:
@@ -735,6 +803,20 @@ def load_schema(review_type: str) -> dict[str, Any]:
     return json.loads(schema_file.read_text())
 
 
+def _valid_bucket_names(review_type: str) -> str:
+    """Return a human-readable, ordered list of valid severity buckets for a type.
+
+    Derived from the unique normalized values in ``SEVERITY_MAP`` so the message
+    stays in sync with the parser (e.g. systematic -> "Blocking, Should Fix,
+    Suggestions"). Order follows first appearance in the alias map.
+    """
+    seen: list[str] = []
+    for value in SEVERITY_MAP.get(review_type, {}).values():
+        if value not in seen:
+            seen.append(value)
+    return ", ".join(v.replace("_", " ").title() for v in seen)
+
+
 def validate_structure(data: dict[str, Any], review_type: str) -> list[str]:
     """Validate parsed review data against its JSON Schema.
 
@@ -745,9 +827,19 @@ def validate_structure(data: dict[str, Any], review_type: str) -> list[str]:
     Returns:
         List of human-readable error messages. Empty list means valid.
     """
+    errors: list[str] = []
+
+    # Structural pre-check: findings written under a severity heading that is not
+    # valid for this review type are silently dropped by the bucket parser. Flag
+    # them explicitly so a malformed review can never pass with lost findings.
+    invalid_headings = data.pop("_invalid_severity_headings", None)
+    if invalid_headings:
+        valid_buckets = _valid_bucket_names(review_type)
+        for heading in invalid_headings:
+            errors.append(f"INVALID SEVERITY HEADING: '{heading}' ({review_type} reviews use: {valid_buckets})")
+
     schema = load_schema(review_type)
     validator = jsonschema.Draft202012Validator(schema)
-    errors: list[str] = []
 
     for error in sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path)):
         path = ".".join(str(p) for p in error.absolute_path) if error.absolute_path else "(root)"


### PR DESCRIPTION
## Defect (false negative)

\`validate-review-output.py\` silently **dropped** any systematic finding written under a severity heading not valid for that type (e.g. \`### Critical\`, a *parallel* bucket). In \`_extract_findings_section\`, an unrecognized heading ended the current bucket and started no new one, so the finding fell into no bucket. The systematic schema has no \`minItems\` on findings, so the resulting near-empty review still validated → **exit 0**. A malformed systematic review passed the gate undetected.

Reproduce (before): rename \`### Should Fix\` → \`### Critical\` in a valid systematic review, leave \`file:line\` intact, pipe to \`--type systematic -\` → exit 0 (should be 1).

## Fix

| Area | Change |
|------|--------|
| validator | New \`_find_invalid_severity_headings\`: scopes to the \`## Findings\` section, flags any \`###\`+ subheading whose normalized text is not in the type's \`SEVERITY_MAP\`. Surfaced as a structural error: \`INVALID SEVERITY HEADING: 'Critical' (systematic reviews use: Blocking, Should Fix, Suggestions)\`. Stored under a private parser key, consumed + stripped before jsonschema validation. |
| guards | Clean zero-findings APPROVE still passes (no stray headings). Legit parallel \`### Critical\` unaffected (it's in parallel's map). Exit-code contract unchanged (0/1/2/3). |
| bench S04 | Removed the misleading location-strip — it landed on the *dropped* finding, so S04 never tested its intent. Renaming the bucket alone now exercises the FN. Comment corrected. |
| test | Regression lock: invalid-bucket systematic review rejected (exit 1 / schema error) via parser and CLI. |

## Verification

- \`scripts/tests/test_review_output_gate.py\`: 16 passed (2 new).
- Full \`scripts/tests/\`: 2478 passed, 1 skipped, 75 xfailed.
- \`ruff check\` / \`ruff format --check\` (excl. venv.312.bak): clean.

## Before / after false-negative rate (bench Arm B)

| | TP | FN | FP | TN | FN rate |
|--|----|----|----|----|---------|
| Before | 8 | 1 | 0 | 4 | **0.111** |
| After  | 9 | 0 | 0 | 4 | **0.000** |

S04: ACCEPT/exit-0 → FLAG/exit-1. False-positive rate unchanged at 0.0.