### PR TITLE
feat(do): harness-conditional Workflow dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-This toolkit prevents that. 44 domain agents, 123 workflow skills, 79 hooks, 103 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+This toolkit prevents that. 44 domain agents, 123 workflow skills, 79 hooks, 105 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Factory (`/do`).
 

--- a/scripts/detect-workflow-capability.py
+++ b/scripts/detect-workflow-capability.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Detect the running harness from environment variables (env proxy).
+
+Emits JSON: {"harness": "claude-code|codex|gemini|factory|unknown",
+             "workflow_capable": bool}
+
+Anthropic's native ``Workflow`` tool (deterministic JS orchestration) is
+Claude Code-only. Codex, Gemini, and Factory do not have it; the toolkit's
+prose pipelines run everywhere. ``workflow_capable`` is the env-derived proxy
+``harness == "claude-code"``.
+
+PROXY, NOT AUTHORITY. A subprocess cannot introspect the session's tool list,
+only the environment. So this script answers "which harness am I in?" and the
+orchestrator LLM adds the authoritative gate: "is the `Workflow` tool actually
+in my tool list?". Both must be true to take the native path. See
+adr/harness-conditional-workflow-dispatch.md (R1).
+
+Detection markers (distinctive entrypoint/session/home vars — never generic
+API-key vars like GEMINI_API_KEY, which are commonly set under any harness):
+  claude-code : CLAUDECODE, CLAUDE_CODE_ENTRYPOINT, CLAUDE_CODE_SESSION_ID
+  codex       : CODEX_HOME, CODEX_HOOKS_DIR
+  gemini      : GEMINI_CLI
+  factory     : FACTORY_SESSION_ID, FACTORY_HOME, DROID_SESSION_ID, DROID_HOME
+Mirrors hooks/lib/hook_utils.py:detect_cli(), extended with factory + the
+Claude Code session markers.
+
+Pure stdlib. Exit 0 always. Never raises.
+
+Usage:
+    python3 scripts/detect-workflow-capability.py            # JSON to stdout
+    python3 scripts/detect-workflow-capability.py --harness  # bare harness id
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+HARNESSES = ("claude-code", "codex", "gemini", "factory", "unknown")
+
+# Marker var -> harness. Claude Code is checked first so it wins when env from
+# a Claude Code session leaks other harnesses' vars (config copied around).
+_MARKERS: list[tuple[str, tuple[str, ...]]] = [
+    ("claude-code", ("CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "CLAUDE_CODE_SESSION_ID")),
+    ("codex", ("CODEX_HOME", "CODEX_HOOKS_DIR")),
+    ("gemini", ("GEMINI_CLI",)),
+    ("factory", ("FACTORY_SESSION_ID", "FACTORY_HOME", "DROID_SESSION_ID", "DROID_HOME")),
+]
+
+
+def detect_harness(env: dict | None) -> str:
+    """Return the harness id implied by ``env``. Never raises.
+
+    A marker counts as present when its value is truthy (set and non-empty).
+    Returns "unknown" when no distinctive marker is present.
+    """
+    try:
+        if not env:
+            return "unknown"
+        for harness, keys in _MARKERS:
+            for key in keys:
+                if env.get(key):
+                    return harness
+    except Exception:
+        return "unknown"
+    return "unknown"
+
+
+def workflow_capable(harness: str) -> bool:
+    """Env-derived proxy for native Workflow availability."""
+    return harness == "claude-code"
+
+
+def main(argv: list[str]) -> int:
+    harness = detect_harness(dict(os.environ))
+    if "--harness" in argv:
+        print(harness)
+        return 0
+    print(json.dumps({"harness": harness, "workflow_capable": workflow_capable(harness)}))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except Exception:
+        # Exit-0 contract: a detection signal never blocks the orchestrator.
+        print(json.dumps({"harness": "unknown", "workflow_capable": False}))
+        sys.exit(0)

--- a/scripts/tests/fixtures/workflow_js/inline-meta.js
+++ b/scripts/tests/fixtures/workflow_js/inline-meta.js
@@ -1,0 +1,3 @@
+// inline-meta.js — fixture: single-line meta with single quotes.
+export const meta = { name: 'inline-pipeline', description: 'one liner' };
+export async function run() {}

--- a/scripts/tests/fixtures/workflow_js/multiline-meta.js
+++ b/scripts/tests/fixtures/workflow_js/multiline-meta.js
@@ -1,0 +1,10 @@
+// multiline-meta.js — fixture: meta block spread across lines, description
+// before name, extra whitespace, and a trailing comma.
+export const meta = {
+  description:
+    "A pipeline whose description appears before the name key to exercise " +
+    "key-order independence in the parser.",
+  name: "multiline-pipeline",
+};
+
+export async function run() {}

--- a/scripts/tests/fixtures/workflow_js/no-meta.js
+++ b/scripts/tests/fixtures/workflow_js/no-meta.js
@@ -1,0 +1,4 @@
+// no-meta.js — fixture: a .js file with no exported meta.name. Such a file
+// does not register; its pipeline (if any) stays prose-only.
+export async function run() {}
+const meta = 42; // not an exported object, no name key

--- a/scripts/tests/test_detect_workflow_capability.py
+++ b/scripts/tests/test_detect_workflow_capability.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Tests for scripts/detect-workflow-capability.py — harness identity from env.
+
+Covers the env-matrix harness classifier (claude-code / codex / gemini /
+factory / unknown), the workflow_capable proxy (true only for claude-code),
+the never-raises / exit-0 contract, and the JSON output shape. The env signal
+is a PROXY: the orchestrator LLM adds the authoritative tool-list gate.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "detect-workflow-capability.py"
+
+# Import the module directly for unit-level tests of the pure classifier.
+sys.path.insert(0, str(SCRIPT.parent))
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location("detect_workflow_capability", SCRIPT)
+dwc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dwc)
+
+
+# --- Pure classifier: harness identity from an env dict ----------------------
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    [
+        # claude-code: any of the distinctive markers
+        ({"CLAUDECODE": "1"}, "claude-code"),
+        ({"CLAUDE_CODE_ENTRYPOINT": "cli"}, "claude-code"),
+        ({"CLAUDE_CODE_SESSION_ID": "abc123"}, "claude-code"),
+        # codex: home / hooks dir markers
+        ({"CODEX_HOME": "/home/u/.codex"}, "codex"),
+        ({"CODEX_HOOKS_DIR": "/x"}, "codex"),
+        # gemini: explicit CLI identifier
+        ({"GEMINI_CLI": "1"}, "gemini"),
+        # factory / droid
+        ({"FACTORY_SESSION_ID": "f1"}, "factory"),
+        ({"DROID_SESSION_ID": "d1"}, "factory"),
+        # nothing distinctive
+        ({}, "unknown"),
+    ],
+)
+def test_detect_harness(env, expected):
+    assert dwc.detect_harness(env) == expected
+
+
+def test_generic_api_keys_do_not_classify():
+    """A bare GEMINI_API_KEY/GOOGLE_API_KEY must NOT be read as the gemini
+    harness — those vars are commonly set even under Claude Code."""
+    assert dwc.detect_harness({"GEMINI_API_KEY": "x"}) == "unknown"
+    assert dwc.detect_harness({"GOOGLE_API_KEY": "x"}) == "unknown"
+
+
+def test_claude_code_wins_over_other_markers():
+    """If both Claude Code and another marker are present, Claude Code wins:
+    the toolkit ships from Claude Code and copies env-laden config around."""
+    env = {"CLAUDECODE": "1", "CODEX_HOME": "/x", "GEMINI_CLI": "1"}
+    assert dwc.detect_harness(env) == "claude-code"
+
+
+# --- workflow_capable proxy --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "harness,expected",
+    [
+        ("claude-code", True),
+        ("codex", False),
+        ("gemini", False),
+        ("factory", False),
+        ("unknown", False),
+    ],
+)
+def test_workflow_capable(harness, expected):
+    assert dwc.workflow_capable(harness) is expected
+
+
+# --- never raises ------------------------------------------------------------
+
+
+def test_classify_never_raises_on_garbage():
+    # Non-string values must not crash the classifier.
+    assert dwc.detect_harness({"CLAUDECODE": None}) in dwc.HARNESSES
+    assert dwc.detect_harness(None) == "unknown"
+
+
+# --- CLI / JSON contract -----------------------------------------------------
+
+
+def _run(env):
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return proc
+
+
+def test_cli_exit_zero_and_json_shape():
+    proc = _run({"CLAUDECODE": "1", "PATH": "/usr/bin"})
+    assert proc.returncode == 0
+    out = json.loads(proc.stdout)
+    assert out == {"harness": "claude-code", "workflow_capable": True}
+
+
+def test_cli_unknown_harness():
+    # Empty-ish env (PATH only) → unknown, not capable.
+    proc = _run({"PATH": "/usr/bin"})
+    assert proc.returncode == 0
+    out = json.loads(proc.stdout)
+    assert out["harness"] == "unknown"
+    assert out["workflow_capable"] is False

--- a/scripts/tests/test_workflow_registry.py
+++ b/scripts/tests/test_workflow_registry.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Tests for scripts/workflow-registry.py — auto-derived native-variant map.
+
+Scans skills/workflow/references/*.js for the exported `meta.name` and maps
+name -> script path. Absence of a meta.name means the file does not register
+(its pipeline, if any, stays prose-only). The registry is derived, never
+hand-maintained, so adding a *.js with a meta.name auto-registers it (R3).
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "workflow-registry.py"
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "workflow_js"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+sys.path.insert(0, str(SCRIPT.parent))
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location("workflow_registry", SCRIPT)
+wr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(wr)
+
+
+# --- meta.name parsing (the tolerant regex) ----------------------------------
+
+
+def test_parse_inline_single_quotes():
+    name = wr.parse_meta_name((FIXTURES / "inline-meta.js").read_text())
+    assert name == "inline-pipeline"
+
+
+def test_parse_multiline_key_order_independent():
+    """name appearing after description, across lines, still parses."""
+    name = wr.parse_meta_name((FIXTURES / "multiline-meta.js").read_text())
+    assert name == "multiline-pipeline"
+
+
+def test_parse_no_meta_returns_none():
+    name = wr.parse_meta_name((FIXTURES / "no-meta.js").read_text())
+    assert name is None
+
+
+def test_parse_real_comprehensive_review_variant():
+    """The shipped variant must register under its real meta.name."""
+    js = (REPO_ROOT / "skills" / "workflow" / "references" / "comprehensive-review-workflow.js").read_text()
+    assert wr.parse_meta_name(js) == "comprehensive-review-workflow"
+
+
+# --- build_registry over a directory -----------------------------------------
+
+
+def test_build_registry_skips_no_meta(tmp_path):
+    reg = wr.build_registry(FIXTURES)
+    assert reg["inline-pipeline"].endswith("inline-meta.js")
+    assert reg["multiline-pipeline"].endswith("multiline-meta.js")
+    # no-meta.js contributes no entry
+    assert all(not p.endswith("no-meta.js") for p in reg.values())
+
+
+def test_build_registry_empty_dir(tmp_path):
+    assert wr.build_registry(tmp_path) == {}
+
+
+def test_build_registry_missing_dir(tmp_path):
+    assert wr.build_registry(tmp_path / "does-not-exist") == {}
+
+
+# --- default scan registers the real variant ---------------------------------
+
+
+def test_default_registry_includes_comprehensive_review():
+    reg = wr.build_registry()
+    assert "comprehensive-review-workflow" in reg
+    assert reg["comprehensive-review-workflow"].endswith("comprehensive-review-workflow.js")
+
+
+# --- CLI / JSON contract -----------------------------------------------------
+
+
+def test_cli_exit_zero_and_json_map():
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    out = json.loads(proc.stdout)
+    assert isinstance(out, dict)
+    assert "comprehensive-review-workflow" in out

--- a/scripts/workflow-registry.py
+++ b/scripts/workflow-registry.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Auto-derived native-variant registry for /do workflow dispatch.
+
+Scans ``skills/workflow/references/*.js`` for each file's exported
+``meta.name`` and emits a JSON map ``{meta.name: script_path}``. A pipeline
+name with a registry entry has a deterministic native Workflow variant;
+absence means the pipeline is prose-only.
+
+DERIVED, NOT HAND-MAINTAINED. Adding a ``*.js`` with a ``meta.name`` block
+auto-registers it — there is no dict to keep in sync (mitigates drift, R3).
+See adr/harness-conditional-workflow-dispatch.md.
+
+Parsing: the runtime contract pins ``meta`` to a pure object literal
+(``export const meta = { ... name: "..." ... }``). A tolerant regex finds the
+``name`` key anywhere inside the first ``meta = { ... }`` block, independent of
+key order, quote style, or line breaks. Files without a ``meta.name`` register
+nothing.
+
+Pure stdlib. Exit 0 always. Never raises.
+
+Usage:
+    python3 scripts/workflow-registry.py            # JSON map to stdout
+    python3 scripts/workflow-registry.py --names    # one meta.name per line
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DIR = REPO_ROOT / "skills" / "workflow" / "references"
+
+# Capture the body of the first `meta = { ... }` block (non-greedy to the
+# first closing brace at depth 0 — meta is a flat literal by contract).
+_META_BLOCK = re.compile(r"meta\s*=\s*\{(.*?)\}", re.DOTALL)
+# Within that body, find `name: "value"` (single or double quotes).
+_NAME_KEY = re.compile(r"""\bname\s*:\s*(['"])(.*?)\1""", re.DOTALL)
+
+
+def parse_meta_name(source: str) -> str | None:
+    """Extract the exported ``meta.name`` from JS source, or None. Never raises."""
+    try:
+        block = _META_BLOCK.search(source)
+        if not block:
+            return None
+        m = _NAME_KEY.search(block.group(1))
+        return m.group(2) if m else None
+    except Exception:
+        return None
+
+
+def build_registry(directory: Path | str | None = None) -> dict[str, str]:
+    """Map ``meta.name`` -> absolute ``.js`` path for every variant in *directory*.
+
+    Missing or empty directories yield an empty map. Never raises.
+    """
+    try:
+        root = Path(directory) if directory is not None else DEFAULT_DIR
+        if not root.is_dir():
+            return {}
+        registry: dict[str, str] = {}
+        for js in sorted(root.glob("*.js")):
+            name = parse_meta_name(js.read_text(encoding="utf-8", errors="replace"))
+            if name:
+                registry[name] = str(js.resolve())
+        return registry
+    except Exception:
+        return {}
+
+
+def main(argv: list[str]) -> int:
+    registry = build_registry()
+    if "--names" in argv:
+        for name in registry:
+            print(name)
+        return 0
+    print(json.dumps(registry, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except Exception:
+        print("{}")
+        sys.exit(0)

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -319,7 +319,24 @@ Quality-loop absorbs Steps 0-1. The Phase 2 agent+skill selection becomes the im
 
 Does NOT apply when: Trivial/Simple (use `quick`), review-only/research/debugging/content creation, or user requests simpler flow.
 
-**Step 1b (review escalation): prefer the native Workflow variant for wide reviews.** When a comprehensive review is requested AND the right-sizing tier is >= 3 (or the diff spans 5+ files / 2+ review categories), prefer running `skills/workflow/references/comprehensive-review-workflow.js` via the native Workflow tool over the prose four-wave dispatch — it scales waves to tier, passes schema-validated typed findings between waves without disk round-trips, runs a per-finding adversarial verify, and bounds the fix loop by the native token budget; below tier 3, or when the Workflow tool is unavailable, use the markdown flow in `comprehensive-review.md` (the documented fallback).
+**Step 1b (native Workflow dispatch): run the deterministic variant when the harness supports it, else the prose pipeline.** When the Haiku router emitted a pipeline `pick` (#686), decide the executor with the ADR decision table (`harness-conditional-workflow-dispatch`):
+
+```
+pick = haiku_route.pipeline                         # #686, may be null
+cap  = scripts/detect-workflow-capability.py        # env proxy: {harness, workflow_capable}
+reg  = scripts/workflow-registry.py                 # auto-derived {meta.name: path}
+{scope, tier} = scripts/right-size-review.py        # #688 right-sizing (review picks)
+
+if pick is None:                                            -> agent + skill direct (no pipeline)
+elif reg.get(pick) and cap.workflow_capable and (Workflow tool in MY tool list):
+        # env proxy AND LLM tool-list self-check (the authoritative gate)
+                                                            -> Workflow tool: run(reg[pick], {scope, tier})
+else:                                                       -> run the prose pipeline markdown (unchanged)
+```
+
+The native path (e.g. `comprehensive-review-workflow.js`) scales waves to tier, passes schema-validated typed findings between waves without disk round-trips, runs a per-finding adversarial verify, and bounds the fix loop by the native token budget. The prose markdown flow is the always-safe fallback and runs identically on Codex/Gemini/Factory or when the `Workflow` tool is absent. `cap.workflow_capable` is an env-derived PROXY; the orchestrator's own tool-list check is the authoritative gate — both must hold. A `pick` with no registry entry is prose-only.
+
+**Banner parity (R4):** expand the pipeline name → phase list for the routing banner on BOTH paths, so the banner reads identically regardless of executor.
 
 **Step 2: Invoke agent with skill**
 


### PR DESCRIPTION
## What

Generalize `/do` Phase 4 **Step 1b** from the comprehensive-review-only special case to a harness-conditional decision table: run the native Claude Code `Workflow` tool when the harness supports it and a JS variant exists, otherwise fall back to the existing prose pipeline / Task dispatch.

ADR: `harness-conditional-workflow-dispatch` (consultation verdict: PROCEED, 3/3 reviewers).

## New components (TDD, RED→GREEN)

| File | Role |
|------|------|
| `scripts/detect-workflow-capability.py` | Env proxy → JSON `{harness, workflow_capable}`. Pure stdlib, exit 0 always, never raises. |
| `scripts/workflow-registry.py` | Auto-derived `{meta.name: path}` by scanning `skills/workflow/references/*.js`. No hand-maintained dict. |
| `scripts/tests/test_detect_workflow_capability.py` | Env-matrix + JSON contract (12 cases). |
| `scripts/tests/test_workflow_registry.py` | `meta.name` parsing + registry build (3 JS fixtures). |

## Detection matrix

| Harness | Distinctive markers | `workflow_capable` |
|---------|--------------------|--------------------|
| claude-code | `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_SESSION_ID` | true |
| codex | `CODEX_HOME`, `CODEX_HOOKS_DIR` | false |
| gemini | `GEMINI_CLI` | false |
| factory | `FACTORY_SESSION_ID/HOME`, `DROID_SESSION_ID/HOME` | false |
| unknown | (none) | false |

Mirrors `hooks/lib/hook_utils.py:detect_cli()`, extended with factory + Claude Code session markers. Generic API-key vars (`GEMINI_API_KEY`) are deliberately ignored — they leak across harnesses. claude-code wins ties.

**Env is a PROXY.** A subprocess cannot read the session tool list. The orchestrator LLM adds the authoritative gate ("is the `Workflow` tool in my tool list?"). Both must hold to take the native path. Documented in the script and SKILL.md.

## Step 1b: before → after

- **Before:** hard-coded "prefer `comprehensive-review-workflow.js` at tier ≥ 3 if available."
- **After:** decision table keyed on `pick` (#686) × registry × `workflow_capable` × tool-list self-check; `{scope, tier}` from right-sizing (#688). Banner name→phase expansion on **both** paths (R4). Prose markdown is the documented always-safe fallback.

```
if pick is None:                                  -> agent + skill direct
elif reg.get(pick) and cap.workflow_capable and (Workflow tool in MY tools):
                                                  -> Workflow tool: run(reg[pick], {scope, tier})
else:                                             -> prose pipeline markdown (unchanged)
```

## Fallback behavior

Every failure mode lands on prose: unknown harness, detector/registry error (both exit 0), `pick` with no registry entry, or `Workflow` tool absent. Worst case = no regression. Codex/Gemini/Factory keep today's flow unchanged.

## Validation

- `scripts/tests/` full suite: 2506 passed, 1 skipped, 75 xfailed (new: 28 pass).
- `ruff check . --config pyproject.toml --exclude venv.312.bak`: clean.
- `ruff format --check . --exclude venv.312.bak`: clean.
- `python3 scripts/validate-doc-counts.py`: clean (README 103 → 105 scripts).