### PR TITLE
fix(security-review): gate Stop rewake on security-relevant diffs

### DIFF
--- a/hooks/security-review-hook.py
+++ b/hooks/security-review-hook.py
@@ -301,10 +301,80 @@ def _working_tree_diff(cwd: str | None) -> str:
     return result.stdout
 
 
+def _scannable_extensions() -> frozenset[str]:
+    """Return the scanner's *source* extensions (its supported set minus doc types).
+
+    Derived from the scanner's own constants so the Stop gate and the scanner can't
+    drift: SUPPORTED_EXTENSIONS is the superset the scanner opens, and _DOC_EXTS is
+    the doc/data subset (.md/.txt/.rst/.json/.mdx) where only anchored secret rules
+    fire. The Stop rewake is the heavy LLM-depth pass, so it gates on real code
+    files; doc-only changes are non-triggering here (their secret leaks are still
+    caught by the edit-time advisory and the commit-block gate, which scan docs).
+
+    Falls back to common source extensions if the scanner can't load. The
+    over-broad fallback is safe because the added-line gate still applies.
+    """
+    scanner = _load_scanner_module()
+    if scanner is not None:
+        supported = getattr(scanner, "SUPPORTED_EXTENSIONS", None)
+        if supported:
+            doc_exts = frozenset(getattr(scanner, "_DOC_EXTS", ()))
+            return frozenset(supported) - doc_exts
+    return frozenset({".py", ".go", ".js", ".ts", ".rb", ".java", ".php", ".kt", ".swift"})
+
+
+def _diff_post_image_ext(header_line: str) -> str | None:
+    """Extract the lowercased extension of a diff's post-image path.
+
+    `header_line` is a `+++ ` line. Returns None for `/dev/null` (deletions) or
+    when no extension is present.
+    """
+    path = header_line[4:].strip()
+    if not path or path == "/dev/null":
+        return None
+    # Strip git's `b/` prefix (and the rare `i/`/`w/`/`c/`/`o/` prefixes).
+    if len(path) > 2 and path[1] == "/" and path[0] in "abciwo":
+        path = path[2:]
+    dot = path.rfind(".")
+    slash = path.rfind("/")
+    if dot == -1 or dot < slash:
+        return None
+    return path[dot:].lower()
+
+
 def _has_reviewable_content(diff: str) -> bool:
-    """Return True if diff has actual added/removed lines (not just mode changes)."""
+    """Return True only if the diff is security-relevant for the Stop rewake.
+
+    Security-relevant means: at least one scannable source file (an extension in
+    _scannable_extensions() — the scanner's SUPPORTED_EXTENSIONS minus doc types)
+    has at least one ADDED or MODIFIED line.
+
+    Why this gate:
+    - Pure deletions (only `-` lines) cannot introduce a vulnerability, so a diff
+      whose only changes are removals is skipped.
+    - Doc/config-only diffs (.md, .txt, .json, etc. — not in the source set)
+      aren't worth the heavy LLM-depth Stop pass, so they're skipped.
+    - Mode-only diffs (no content lines) were already skipped; they still are,
+      since they contain no added lines.
+
+    An added line in a real source file (e.g. a new `eval(...)` in a `.py`) MUST
+    still pass this gate — true positives are preserved.
+    """
+    scannable_exts = _scannable_extensions()
+    current_scannable = False  # is the file in the current diff block scannable?
     for line in diff.splitlines():
-        if line.startswith(("+", "-")) and not line.startswith(("+++", "---")):
+        if line.startswith("+++ "):
+            # New per-file post-image header: decide if this file is scannable.
+            ext = _diff_post_image_ext(line)
+            current_scannable = ext in scannable_exts if ext is not None else False
+            continue
+        if line.startswith("diff --git "):
+            # Start of a new file block; reset until its +++ header is seen.
+            current_scannable = False
+            continue
+        # An added content line (not the `+++` header) in a scannable file is the
+        # only thing that makes a diff security-relevant.
+        if current_scannable and line.startswith("+") and not line.startswith("+++"):
             return True
     return False
 

--- a/hooks/tests/test_security_review_hook.py
+++ b/hooks/tests/test_security_review_hook.py
@@ -51,6 +51,20 @@ def _stop_event(cwd: str | None = None, stop_hook_active: bool = False) -> str:
     return json.dumps(event)
 
 
+def _src_diff(added: str, path: str = "app.py") -> str:
+    """Build a realistic single-file unified diff that ADDS `added` to a scannable
+    source file. Used wherever a test just needs "a security-relevant diff"."""
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"index 1111111..2222222 100644\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        f"@@ -1,1 +1,2 @@\n"
+        f" existing\n"
+        f"+{added}\n"
+    )
+
+
 def _post_event(tool_name: str, file_path: str, cwd: str | None = None) -> str:
     event = {
         "hook_event_name": "PostToolUse",
@@ -239,10 +253,11 @@ class TestBypass:
         assert not _is_deny(out)
 
     def test_disable_env_disables_stop(self):
+        # A security-relevant diff that WOULD rewake — DISABLE must win anyway.
         code, out, err = _run(
             _stop_event(cwd="/repo"),
             env={"VEXJOY_SECURITY_REVIEW_DISABLE": "1"},
-            diff="diff --git a/x b/x\n+secret",
+            diff=_src_diff("secret = 'x'"),
         )
         assert code == 0
         assert "rewakeSummary" not in out
@@ -255,7 +270,7 @@ class TestBypass:
 
 class TestStopAsyncRewake:
     def test_stop_emits_rewake_on_diff(self):
-        code, out, err = _run(_stop_event(cwd="/repo"), diff="diff --git a/x b/x\n+os.system(cmd)\n")
+        code, out, err = _run(_stop_event(cwd="/repo"), diff=_src_diff("os.system(cmd)"))
         # exit 2 is the asyncRewake signal
         assert code == 2
         # stdout carries a valid JSON line with rewakeSummary
@@ -267,7 +282,7 @@ class TestStopAsyncRewake:
         assert "os.system(cmd)" in err
 
     def test_stop_instruction_states_no_sdk_no_api_key(self):
-        code, out, err = _run(_stop_event(cwd="/repo"), diff="diff --git a/x b/x\n+x\n")
+        code, out, err = _run(_stop_event(cwd="/repo"), diff=_src_diff("payload"))
         assert "no API key" in err
         assert "no SDK" in err
 
@@ -283,10 +298,129 @@ class TestStopAsyncRewake:
         assert code == 0
         assert "rewakeSummary" not in out
 
+    def test_stop_pure_deletion_source_no_rewake(self):
+        """A pure-deletion diff of a source file (only `-` lines) cannot add a
+        vulnerability, so it must NOT trigger a rewake."""
+        pure_delete = (
+            "diff --git a/app.py b/app.py\n"
+            "index 83db48f..8129d30 100644\n"
+            "--- a/app.py\n"
+            "+++ b/app.py\n"
+            "@@ -1,3 +1,2 @@\n"
+            " keepline\n"
+            "-os.system(removed)\n"
+            " another\n"
+        )
+        code, out, err = _run(_stop_event(cwd="/repo"), diff=pure_delete)
+        assert code == 0
+        assert "rewakeSummary" not in out
+
+    def test_stop_deleted_file_no_rewake(self):
+        """A whole-file deletion (`deleted file mode` + `+++ /dev/null`) cannot add
+        a vulnerability, so it must NOT trigger a rewake."""
+        deleted = (
+            "diff --git a/app.py b/app.py\n"
+            "deleted file mode 100644\n"
+            "index de98044..0000000\n"
+            "--- a/app.py\n"
+            "+++ /dev/null\n"
+            "@@ -1,3 +0,0 @@\n"
+            "-import os\n"
+            "-os.system(x)\n"
+            "-eval(y)\n"
+        )
+        code, out, err = _run(_stop_event(cwd="/repo"), diff=deleted)
+        assert code == 0
+        assert "rewakeSummary" not in out
+
+    def test_stop_doc_only_diff_no_rewake(self):
+        """A doc-only diff (only non-scannable file types like .md, even with
+        added lines) is not scannable, so it must NOT trigger a rewake."""
+        doc_only = (
+            "diff --git a/README.md b/README.md\n"
+            "index 1111111..2222222 100644\n"
+            "--- a/README.md\n"
+            "+++ b/README.md\n"
+            "@@ -1,2 +1,3 @@\n"
+            " intro\n"
+            "+Call eval(x) to run things and use os.system(cmd).\n"
+        )
+        code, out, err = _run(_stop_event(cwd="/repo"), diff=doc_only)
+        assert code == 0
+        assert "rewakeSummary" not in out
+
+    def test_stop_doc_deletion_no_rewake(self):
+        """Deleting markdown files (the reported false-fire) must NOT rewake."""
+        doc_deletes = (
+            "diff --git a/a.md b/a.md\ndeleted file mode 100644\n"
+            "index de98044..0000000\n--- a/a.md\n+++ /dev/null\n@@ -1,2 +0,0 @@\n-line\n-line2\n"
+            "diff --git a/b.md b/b.md\ndeleted file mode 100644\n"
+            "index de98044..0000000\n--- a/b.md\n+++ /dev/null\n@@ -1,1 +0,0 @@\n-x\n"
+            "diff --git a/c.txt b/c.txt\ndeleted file mode 100644\n"
+            "index de98044..0000000\n--- a/c.txt\n+++ /dev/null\n@@ -1,1 +0,0 @@\n-y\n"
+        )
+        code, out, err = _run(_stop_event(cwd="/repo"), diff=doc_deletes)
+        assert code == 0
+        assert "rewakeSummary" not in out
+
+    def test_stop_added_source_line_still_rewakes(self):
+        """TRUE POSITIVE PRESERVED: a diff that ADDS a line in a scannable source
+        file must still trigger a rewake."""
+        added_src = (
+            "diff --git a/app.py b/app.py\n"
+            "index 83db48f..06b56c3 100644\n"
+            "--- a/app.py\n"
+            "+++ b/app.py\n"
+            "@@ -1,1 +1,2 @@\n"
+            " line1\n"
+            "+subprocess.run(x, shell=True)\n"
+        )
+        code, out, err = _run(_stop_event(cwd="/repo"), diff=added_src)
+        assert code == 2
+        assert "rewakeSummary" in out
+
+    def test_stop_new_source_file_rewakes(self):
+        """A brand-new scannable source file (`new file mode` + only `+` lines)
+        adds content, so it MUST trigger a rewake."""
+        new_src = (
+            "diff --git a/new.py b/new.py\n"
+            "new file mode 100644\n"
+            "index 0000000..1234567\n"
+            "--- /dev/null\n"
+            "+++ b/new.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            "+import os\n"
+            "+eval(payload)\n"
+        )
+        code, out, err = _run(_stop_event(cwd="/repo"), diff=new_src)
+        assert code == 2
+        assert "rewakeSummary" in out
+
+    def test_stop_mixed_doc_and_source_add_rewakes(self):
+        """A diff that mixes a doc edit with an added source line must rewake
+        (the source add is security-relevant)."""
+        mixed = (
+            "diff --git a/README.md b/README.md\n"
+            "index 1..2 100644\n--- a/README.md\n+++ b/README.md\n@@ -1 +1,2 @@\n intro\n+docs\n"
+            "diff --git a/app.py b/app.py\n"
+            "index 3..4 100644\n--- a/app.py\n+++ b/app.py\n@@ -1 +1,2 @@\n x\n+yaml.load(data)\n"
+        )
+        code, out, err = _run(_stop_event(cwd="/repo"), diff=mixed)
+        assert code == 2
+        assert "rewakeSummary" in out
+
+    def test_stop_renamed_source_no_added_content_no_rewake(self):
+        """A pure rename (no content hunk, just a similarity header) adds nothing
+        and must NOT rewake."""
+        rename = "diff --git a/old.py b/new.py\nsimilarity index 100%\nrename from old.py\nrename to new.py\n"
+        code, out, err = _run(_stop_event(cwd="/repo"), diff=rename)
+        assert code == 0
+        assert "rewakeSummary" not in out
+
     def test_stop_dedup_short_circuits_identical_diff(self, tmp_path):
         """A byte-identical diff re-fired must short-circuit (exit 0). Permanent by default."""
         state_file = tmp_path / "last-diff-hash.json"
-        diff = "diff --git a/x b/x\n+payload\n"
+        diff = _src_diff("payload")
         with patch.object(mod, "_STATE_DIR", tmp_path), patch.object(mod, "_STATE_FILE", state_file):
             code1, _, _ = _run(_stop_event(cwd="/repo"), diff=diff)
             assert code1 == 2
@@ -300,16 +434,16 @@ class TestStopAsyncRewake:
         """A different diff after a recorded one must still trigger a rewake."""
         state_file = tmp_path / "last-diff-hash.json"
         with patch.object(mod, "_STATE_DIR", tmp_path), patch.object(mod, "_STATE_FILE", state_file):
-            code1, _, _ = _run(_stop_event(cwd="/repo"), diff="diff --git a/x b/x\n+a\n")
+            code1, _, _ = _run(_stop_event(cwd="/repo"), diff=_src_diff("a = 1"))
             assert code1 == 2
-            code2, out2, _ = _run(_stop_event(cwd="/repo"), diff="diff --git a/x b/x\n+b\n")
+            code2, out2, _ = _run(_stop_event(cwd="/repo"), diff=_src_diff("b = 2"))
             assert code2 == 2
             assert "rewakeSummary" in out2
 
     def test_no_ttl_means_forever(self, tmp_path):
         """Default behavior: no TTL. An ancient ts (e.g. ts=0) still suppresses if hash matches."""
         state_file = tmp_path / "last-diff-hash.json"
-        diff = "diff --git a/x b/x\n+payload\n"
+        diff = _src_diff("payload")
         with patch.object(mod, "_STATE_DIR", tmp_path), patch.object(mod, "_STATE_FILE", state_file):
             state_file.write_text(
                 json.dumps(
@@ -329,7 +463,7 @@ class TestStopAsyncRewake:
     def test_explicit_ttl_env_still_works(self, tmp_path):
         """Setting VEXJOY_SECURITY_REVIEW_DEDUP_TTL_SECONDS to a positive int re-enables TTL expiry."""
         state_file = tmp_path / "last-diff-hash.json"
-        diff = "diff --git a/x b/x\n+payload\n"
+        diff = _src_diff("payload")
         with patch.object(mod, "_STATE_DIR", tmp_path), patch.object(mod, "_STATE_FILE", state_file):
             # Pre-seed state with a record older than the explicit TTL.
             stale_ts = __import__("time").time() - 10_000
@@ -351,7 +485,7 @@ class TestStopAsyncRewake:
     def test_stop_dedup_distinguishes_by_cwd(self, tmp_path):
         """Same diff under different cwds must not collide — each cwd dedups independently."""
         state_file = tmp_path / "last-diff-hash.json"
-        diff = "diff --git a/x b/x\n+payload\n"
+        diff = _src_diff("payload")
         with patch.object(mod, "_STATE_DIR", tmp_path), patch.object(mod, "_STATE_FILE", state_file):
             code1, _, _ = _run(_stop_event(cwd="/repo-a"), diff=diff)
             code2, out2, _ = _run(_stop_event(cwd="/repo-b"), diff=diff)
@@ -363,7 +497,7 @@ class TestStopAsyncRewake:
         """The asyncRewake recursion guard prevents re-firing while a rewake is in flight."""
         code, out, err = _run(
             _stop_event(cwd="/repo", stop_hook_active=True),
-            diff="diff --git a/x b/x\n+x\n",
+            diff=_src_diff("payload"),
         )
         assert code == 0
         assert "rewakeSummary" not in out


### PR DESCRIPTION
## Root cause

`handle_stop` gated the Stop-rewake on `_has_reviewable_content(diff)`, which returned `True` for **any** `+`/`-` content line. So the heavy LLM-depth session security review fired on changes that cannot surface a vulnerability and that the scanner cannot even scan:

- **Pure deletions** (only `-` lines) — removing code/docs adds no vuln.
- **Doc-only / non-source diffs** (`.md`, `.txt`, `.json`, …) — not scannable by `scripts/security-review-scan.py`.

Reported symptom: **deleting 3 markdown files triggered a full security review.** Commit #677 already skipped *mode-only* diffs; this extends that gate to the deletion/doc-only class.

## Fix (`hooks/security-review-hook.py`)

`_has_reviewable_content` now returns `True` only when **at least one scannable source file has an ADDED/MODIFIED line**:

- Parse the diff per file (`diff --git` reset; post-image path from the `+++ ` header).
- A file is *scannable* iff its post-image extension is in `_scannable_extensions()`.
- A diff is security-relevant iff a scannable file has ≥1 added line (`+`, not `+++`).

**No drift by construction:** `_scannable_extensions()` is derived from the scanner's own constants — `SUPPORTED_EXTENSIONS − _DOC_EXTS` — so the Stop gate and the scanner agree on "scannable source." `.py/.go/.js/.ts/.yml/.yaml/.html/…` trigger; `.md/.txt/.json/.rst/.mdx` don't. Mode-only skip and dedup/TTL behavior unchanged; still fail-open (errors skip the rewake, never crash the session).

## Audit of the other two paths (no over-fire — left unchanged)

| Path | Why it's safe |
|------|---------------|
| **PostToolUse** edit-time | Scans the just-edited file's *content* through the real scanner (which doc-skips non-secret rules). Can't "edit" a deletion. Fires only on real findings. |
| **PreToolUse** commit-block | `_staged_files()` already filters to `SUPPORTED_EXTENSIONS` and `--diff-filter=ACM` (excludes Deleted). Blocks only real staged HIGH/CRITICAL. Verified: a deletion+doc-only staged set → allow (exit 0); a staged `os.system(...)` `.py` → deny. |

## Dog-food (live `git diff` runs, real hook invocation)

| # | Working-tree state | Expected | Actual |
|---|--------------------|----------|--------|
| 1 | Delete 3 `.md` files (reported false-fire) | no rewake | exit 0, no stderr ✅ |
| 2 | Pure-deletion of a `.py` (only `-` lines) | no rewake | exit 0, no stderr ✅ |
| 3 | Add `subprocess.run(cmd, shell=True)` to a `.py` | **rewake + scanner flags** | exit 2, `rewakeSummary`, scanner HIGH shell-injection ✅ |
| 4 | Doc-only `.md` add (text mentions `eval`/`os.system`) | no rewake | exit 0, no stderr ✅ |
| 5 | Re-run byte-identical `.py`-add diff | dedup short-circuit | exit 2 → exit 0 "diff unchanged" ✅ |

**True positives preserved** (#3, #5 first fire, plus tests): an ADDED line in a real source file still rewakes; the deterministic scanner flags `subprocess shell=True` / `yaml.load` / `eval` / `os.system` as before.

## Tests (TDD: RED → GREEN)

`hooks/tests/test_security_review_hook.py`: 8 new Stop-gate cases — pure-deletion source, deleted-file, doc-only, doc-deletion (the 3-`.md` repro), added-source (true positive), new-source-file, mixed doc+source, pure-rename. Existing dedup/rewake fixtures rebuilt as realistic unified diffs via a `_src_diff` helper (synthetic `a/x b/x` payloads no longer pass the type gate). **45 pass.**

## Anthropic parity

Anthropic's official `security-guidance` reviewer does **not** share this flaw, and our fix converges on its two gates:
- It reviews **touched source paths** filtered to `SOURCE_CODE_EXTENSIONS` (file-type gate) — our `_scannable_extensions()` mirrors this.
- It treats a deleted file as *fixed* (`security_reminder_hook.py`: "A file that's been deleted counts as fixed — the dangerous code is gone") — our pure-deletion skip mirrors this.
Our hook diverged only because it parsed raw `git diff` for any `±` line with no type/added-vs-deleted distinction.

## Notes
- This PR's own staged-set scan flags docstring prose (`eval(...)` example) and intentional vulnerable-looking **test fixtures** as findings — all false positives in a security test file. Committed with `VEXJOY_SECURITY_REVIEW_SKIP=1` (the documented deliberate override).
- Scope: only `hooks/security-review-hook.py` + its test file are staged. Pre-existing dirty files (mode-only `scripts/*`, `skills/voice-shared-references/*` deletions) are intentionally untouched.

CI: ruff check + format clean (changed files); `validate-doc-counts.py` passes; full `hooks/tests` + `scripts/tests` pass (the 2 unrelated `test_ci_merge_gate` failures pre-exist and don't touch these files).
