### PR TITLE
fix(routing): disambiguate overlapping agents in /do router

### DIFF
--- a/agents/data-engineer.md
+++ b/agents/data-engineer.md
@@ -35,6 +35,7 @@ routing:
     - data-pipeline-patterns
     - data-quality
     - debugging
+  not_for: "OLTP schema/query tuning (use database-engineer)"
   pairs_with:
     - database-engineer
     - data-analysis

--- a/agents/golang-general-engineer-compact.md
+++ b/agents/golang-general-engineer-compact.md
@@ -5,17 +5,15 @@ color: blue
 memory: project
 routing:
   triggers:
-    - go
-    - golang
     - tight context
     - compact
     - focused go
+  not_for: "general Go feature/debug work via /do (use golang-general-engineer) — only tight-context budgets and per-package review fan-out"
   retro-topics:
     - go-patterns
     - concurrency
     - debugging
   pairs_with:
-    - go-patterns
     - go-patterns
   complexity: Medium-Complex
   category: language

--- a/agents/mcp-local-docs-engineer.md
+++ b/agents/mcp-local-docs-engineer.md
@@ -8,6 +8,7 @@ routing:
     - docs server
     - documentation server
     - hugo
+  not_for: "using existing MCP tools/servers (only building local-docs MCP servers)"
   pairs_with:
     - verification-before-completion
   complexity: Medium

--- a/agents/performance-optimization-engineer.md
+++ b/agents/performance-optimization-engineer.md
@@ -4,10 +4,13 @@ description: "Web performance optimization: Core Web Vitals, rendering, bundle a
 color: yellow
 routing:
   triggers:
-    - performance
-    - optimization
-    - speed
-    - profiling
+    - core web vitals
+    - LCP
+    - bundle size
+    - render performance
+    - web performance
+    - lighthouse
+  not_for: "backend/algorithmic performance in a specific language (use that language engineer) — only web/frontend runtime and load performance"
   pairs_with:
     - verification-before-completion
   complexity: Medium-Complex

--- a/agents/research-coordinator-engineer.md
+++ b/agents/research-coordinator-engineer.md
@@ -5,13 +5,14 @@ color: purple
 background: true
 routing:
   triggers:
-    - research
-    - investigate
-    - explore
-    - analyze
+    - research topic
+    - multi-source analysis
+    - investigate question
+    - synthesize sources
     - comprehensive analysis
     - study
     - examine
+  not_for: "reading/exploring local code (use codebase-overview/read-only-ops) or a single delegated subtask (use research-subagent-executor)"
   pairs_with:
     - workflow
     - subagent-driven-development

--- a/agents/sqlite-peewee-engineer.md
+++ b/agents/sqlite-peewee-engineer.md
@@ -9,6 +9,7 @@ routing:
     - ORM
     - python database
     - playhouse
+  not_for: "server databases like Postgres/MySQL (use database-engineer)"
   retro-topics:
     - database-patterns
     - debugging

--- a/agents/typescript-frontend-engineer.md
+++ b/agents/typescript-frontend-engineer.md
@@ -18,7 +18,7 @@ routing:
     - debugging
   pairs_with:
     - universal-quality-gate
-    - go-patterns
+    - typescript-check
   complexity: Medium-Complex
   category: language
 allowed-tools:
@@ -77,7 +77,7 @@ This agent operates as an operator for TypeScript frontend development, configur
 | Skill | When to Invoke |
 |-------|---------------|
 | `universal-quality-gate` | Multi-language code quality gate with auto-detection and language-specific linters. Use when user asks to "run qualit... |
-| `go-patterns` | Go testing patterns and methodology: table-driven tests, t.Run subtests, t.Helper helpers, mocking interfaces, benchm... |
+| `typescript-check` | TypeScript type checking via tsc --noEmit with actionable error output. Use after edits to verify the project still type-checks. |
 
 **Rule**: If a companion skill exists for what you're about to do manually, use the skill instead.
 


### PR DESCRIPTION
## Intent
Disambiguate overlapping agents in the `/do` router so intent-bearing requests select the right specialist instead of tie-breaking on bare keywords. Edits are scoped to the `routing:` frontmatter block (triggers / pairs_with / not_for) of 7 agent files.

`agents/INDEX.json` is gitignored — regenerated locally to validate (`python3 scripts/generate-agent-index.py`); not committed.

## Changes: before → after

| Agent | Field | Before | After |
|---|---|---|---|
| golang-general-engineer-compact | triggers | `go`, `golang`, `tight context`, `compact`, `focused go` | `tight context`, `compact`, `focused go` |
| golang-general-engineer-compact | pairs_with | `go-patterns`, `go-patterns` (dup) | `go-patterns` |
| golang-general-engineer-compact | not_for | (none) | general Go feature/debug via /do (use golang-general-engineer) — only tight-context budgets and per-package review fan-out |
| performance-optimization-engineer | triggers | `performance`, `optimization`, `speed`, `profiling` | `core web vitals`, `LCP`, `bundle size`, `render performance`, `web performance`, `lighthouse` |
| performance-optimization-engineer | not_for | (none) | backend/algorithmic perf in a specific language (use that language engineer) — only web/frontend runtime and load perf |
| typescript-frontend-engineer | pairs_with | `universal-quality-gate`, `go-patterns` | `universal-quality-gate`, `typescript-check` |
| research-coordinator-engineer | triggers | `research`, `investigate`, `explore`, `analyze`, `comprehensive analysis`, `study`, `examine` | `research topic`, `multi-source analysis`, `investigate question`, `synthesize sources`, `comprehensive analysis`, `study`, `examine` |
| research-coordinator-engineer | not_for | (none) | reading/exploring local code (use codebase-overview/read-only-ops) or a single delegated subtask (use research-subagent-executor) |
| sqlite-peewee-engineer | not_for | (none) | server databases like Postgres/MySQL (use database-engineer) |
| data-engineer | not_for | (none) | OLTP schema/query tuning (use database-engineer) |
| mcp-local-docs-engineer | not_for | (none) | using existing MCP tools/servers (only building local-docs MCP servers) |

(typescript-frontend-engineer companion-skills body table updated to match the new `typescript-check` pairing, keeping the file internally consistent.)

## Manifest evidence (regenerated `scripts/routing-manifest.py`)

```
golang-general-engineer-compact [go-patterns] — ... NOT: general Go feature/debug work via /do (use golang-general-engineer) — only tight-context budgets and per-package review fan-out
performance-optimization-engineer [verification-before-completion] — ... NOT: backend/algorithmic performance in a specific language (use that language engineer) — only web/frontend runtime and load performance
typescript-frontend-engineer [universal-quality-gate, typescript-check] — ... NOT: React Native mobile apps (use react-native-engineer)
research-coordinator-engineer [workflow, subagent-driven-development] — ... NOT: reading/exploring local code (use codebase-overview/read-only-ops) or a single delegated subtask (use research-subagent-executor)
sqlite-peewee-engineer [python-general-engineer, database-engineer] — ... NOT: server databases like Postgres/MySQL (use database-engineer)
data-engineer [database-engineer, data-analysis] — ... NOT: OLTP schema/query tuning (use database-engineer)
mcp-local-docs-engineer [verification-before-completion] — ... NOT: using existing MCP tools/servers (only building local-docs MCP servers)
```

Triggers (regenerated `agents/INDEX.json`):
```
golang-general-engineer-compact -> ['tight context', 'compact', 'focused go']
performance-optimization-engineer -> ['core web vitals', 'LCP', 'bundle size', 'render performance', 'web performance', 'lighthouse']
research-coordinator-engineer -> ['research topic', 'multi-source analysis', 'investigate question', 'synthesize sources', 'comprehensive analysis', 'study', 'examine']
```

## Validation
- `python3 scripts/generate-agent-index.py` — 43 agents, 0 without routing metadata
- `python3 scripts/validate-doc-counts.py` — all count claims agree
- `ruff check` + `ruff format --check` — clean (415 files formatted)
- joy-check CI gate `test_joy_check_instruction_mode.py` — 186 passed
- routing tests — `test_routing_accuracy.py` 68, `test_routing_outcome.py` 13, `test_manifest.py` 24 — all pass
- phantom `pairs_with` scan — none (`typescript-check`, `go-patterns` resolve to real skills)
