### PR TITLE
refactor(security): consolidate inline scanner on canonical engine + share diff/dedup/rewake helpers

### DIFF
--- a/hooks/lib/hook_utils.py
+++ b/hooks/lib/hook_utils.py
@@ -10,10 +10,15 @@ Provides common functionality used across multiple hooks:
 Inspired by shared/lib patterns.
 """
 
+import hashlib
 import json
 import os
+import subprocess
 import sys
+import tempfile
+import time
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Optional, TypeVar
 
@@ -583,3 +588,173 @@ def record_activations_safe(
     except Exception as e:
         if debug:
             print(f"[activation] Recording failed: {e}", file=sys.stderr)
+
+
+# =============================================================================
+# Working-tree diff / reviewable-content gating / async rewake
+#
+# Promoted from hooks/security-review-hook.py so any hook that needs to reason
+# about the git working-tree diff (Stop rewake, security review, etc.) shares a
+# single implementation. These are import-and-call utilities — not auto-applied.
+# =============================================================================
+
+
+def working_tree_diff(cwd: Optional[str], timeout: int = 15) -> str:
+    """Return the working-tree diff (tracked changes vs HEAD) for `cwd`.
+
+    Fails closed to an empty string on any error (non-repo, git missing,
+    timeout) so callers can treat "no diff" and "couldn't diff" the same way.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--no-color", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=cwd or None,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def diff_post_image_ext(header_line: str) -> Optional[str]:
+    """Extract the lowercased extension of a unified-diff post-image path.
+
+    `header_line` is a ``+++ `` line. Returns None for ``/dev/null``
+    (deletions) or when the post-image path has no extension.
+    """
+    path = header_line[4:].strip()
+    if not path or path == "/dev/null":
+        return None
+    # Strip git's `b/` prefix (and the rare `i/`/`w/`/`c/`/`o/` prefixes).
+    if len(path) > 2 and path[1] == "/" and path[0] in "abciwo":
+        path = path[2:]
+    dot = path.rfind(".")
+    slash = path.rfind("/")
+    if dot == -1 or dot < slash:
+        return None
+    return path[dot:].lower()
+
+
+def has_reviewable_content(diff: str, scannable_exts: frozenset[str]) -> bool:
+    """Return True only if `diff` is security-relevant.
+
+    Security-relevant means: at least one file whose extension is in
+    `scannable_exts` has at least one ADDED content line. The caller supplies
+    `scannable_exts` (e.g. the scanner's SUPPORTED_EXTENSIONS minus doc types)
+    so this helper stays decoupled from any particular rule engine.
+
+    - Pure deletions (only ``-`` lines) cannot introduce a vulnerability → False.
+    - Files whose extension is not in `scannable_exts` (docs/config) → ignored.
+    - Mode-only / pure-rename diffs (no added content lines) → False.
+
+    An added line in a scannable file (e.g. a new ``eval(...)`` in a ``.py``)
+    MUST pass this gate — true positives are preserved.
+    """
+    current_scannable = False  # is the file in the current diff block scannable?
+    for line in diff.splitlines():
+        if line.startswith("+++ "):
+            ext = diff_post_image_ext(line)
+            current_scannable = ext in scannable_exts if ext is not None else False
+            continue
+        if line.startswith("diff --git "):
+            current_scannable = False
+            continue
+        if current_scannable and line.startswith("+") and not line.startswith("+++"):
+            return True
+    return False
+
+
+class DiffDedup:
+    """Byte-identical working-tree-diff dedup with atomic state + opt-in TTL.
+
+    Hashes ``sha256(cwd, diff)`` so different repos with identical diffs do not
+    collide. State persists to a JSON file via atomic write (tempfile in the
+    same dir + ``os.replace``). By default dedup is permanent — the same
+    ``(cwd, diff)`` hash means the same review until the diff actually changes;
+    a non-matching hash overwrites the old record (self-healing).
+
+    A positive ``ttl_seconds`` re-enables a time window: a hash match older than
+    the TTL is treated as a miss.
+    """
+
+    def __init__(self, state_dir: Path, state_file: Path, ttl_seconds: int = 0):
+        self.state_dir = Path(state_dir)
+        self.state_file = Path(state_file)
+        self.ttl_seconds = ttl_seconds if ttl_seconds and ttl_seconds > 0 else 0
+
+    def signature(self, cwd: Optional[str], diff: str) -> str:
+        """Hash (cwd, diff) so different repos with identical diffs don't collide."""
+        h = hashlib.sha256()
+        h.update((cwd or "").encode("utf-8", errors="replace"))
+        h.update(b"\x00")
+        h.update(diff.encode("utf-8", errors="replace"))
+        return h.hexdigest()
+
+    def _load(self) -> dict:
+        try:
+            if self.state_file.exists():
+                return json.loads(self.state_file.read_text())
+        except (json.JSONDecodeError, OSError, ValueError):
+            pass
+        return {}
+
+    def is_duplicate(self, cwd: Optional[str], diff: str) -> tuple[bool, Optional[str]]:
+        """Return (is_duplicate, last_seen_iso).
+
+        A hash match is permanent unless ``ttl_seconds`` is positive, in which
+        case a match older than the TTL is treated as a miss.
+        """
+        state = self._load()
+        if state.get("hash") != self.signature(cwd, diff):
+            return False, None
+        if self.ttl_seconds > 0:
+            try:
+                last_ts = float(state.get("ts", 0))
+            except (TypeError, ValueError):
+                return False, None
+            if (time.time() - last_ts) > self.ttl_seconds:
+                return False, None
+        return True, state.get("ts_iso")
+
+    def record(self, cwd: Optional[str], diff: str) -> None:
+        """Persist the current (cwd, diff) signature. Silent on failure —
+        dedup persistence is best-effort and must never block a hook."""
+        now = time.time()
+        state = {
+            "hash": self.signature(cwd, diff),
+            "ts": now,
+            "ts_iso": datetime.fromtimestamp(now, tz=timezone.utc).isoformat(),
+            "cwd": cwd or "",
+        }
+        try:
+            self.state_dir.mkdir(parents=True, exist_ok=True)
+            fd, tmp = tempfile.mkstemp(dir=str(self.state_dir), suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w") as f:
+                    json.dump(state, f)
+                os.replace(tmp, str(self.state_file))
+            except Exception:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+        except Exception:
+            # At worst we double-review on the next event — the existing behavior.
+            pass
+
+
+def async_rewake(message: str, summary: str) -> None:
+    """Emit an asyncRewake signal: rewakeSummary on stdout, context on stderr,
+    then exit 2 (the asyncRewake signal that mirrors the official plugin).
+
+    Does not return — always raises SystemExit(2). `summary` is the one-liner
+    shown to the user; `message` is the full rewake context for the agent.
+    """
+    print(json.dumps({"rewakeSummary": summary}), flush=True)
+    sys.stderr.write(message)
+    sys.exit(2)

--- a/hooks/posttool-security-scan.py
+++ b/hooks/posttool-security-scan.py
@@ -1,233 +1,81 @@
 #!/usr/bin/env python3
-# hook-version: 1.0.0
+# hook-version: 2.0.0
 """
 PostToolUse:Write,Edit Hook: Unified Security Pattern Scanner
 
 Scans edited/written code files for common security vulnerability patterns
 after each modification. Outputs informational warnings — never blocks.
 
-Categories scanned:
-1. Hardcoded credentials (credential-named variables with string literals)
-2. SQL injection (f-strings, format(), concatenation, sprintf in SQL context)
-3. Command injection (shell=True, os.system)
-4. Path traversal (unvalidated relative path components)
-5. Unsafe deserialization (loading without safe loaders)
+Detection is delegated to the CANONICAL rule engine,
+``scripts/security-review-scan.py`` (the single source of detection rules,
+shared with hooks/security-review-hook.py). This hook used to hand-maintain
+its own ``_build_patterns`` regex list; that fork has been retired. Importing
+the canonical engine means this hook automatically inherits:
 
-Merged from posttool-security-scan.py + sql-injection-detector.py per
-ADR hook-injection-condensation.
+  - the engine's full rule set (a strict superset of the old inline list —
+    parity proven by scripts/tests/test_security_review_scan.py),
+  - the 13 test-skip guards (``skip_test`` rules + ``_is_test_file``) so
+    project test-fixture files no longer false-positive, and
+  - doc-aware filtering (``_DOC_EXTS`` / ``_rule_applies_to_file``) so prose in
+    markdown/JSON does not trip code-pattern rules, while anchored secret
+    signatures (AKIA/PEM) still fire in docs,
+  - custom rules from ``.claude/security-patterns.{yaml,json}``.
 
 Design:
-- PostToolUse (informational only, never blocks)
-- Only scans code files (skips markdown, config, images)
-- Compiled regex patterns for <50ms execution
+- PostToolUse (informational only, never blocks — always exit 0)
+- Only scans files the engine supports (SUPPORTED_EXTENSIONS)
 - Reads file content from disk (tool_result may be truncated)
-- Skips files >10,000 lines
+- Fail-open: any error is swallowed and the hook exits 0
 
-ADR: adr/018-post-edit-security-scan.md, adr/134-sql-injection-detector-hook.md
+ADR: adr/018-post-edit-security-scan.md
 """
 
+import importlib.util
 import json
 import os
-import re
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 from stdin_timeout import read_stdin
 
-# Code file extensions worth scanning
-_CODE_EXTENSIONS = frozenset(
-    {
-        ".py",
-        ".go",
-        ".js",
-        ".ts",
-        ".tsx",
-        ".jsx",
-        ".rb",
-        ".java",
-        ".php",
-        ".rs",
-        ".c",
-        ".cpp",
-        ".cs",
-        ".swift",
-        ".kt",
-    }
-)
-
-# Max lines to scan (skip generated/vendored files)
-_MAX_LINES = 10_000
+# Max findings to print before collapsing to a count (avoid noise).
+_MAX_FINDINGS = 5
 
 
-def _build_patterns() -> list[tuple[re.Pattern[str], str, str]]:
-    """Build security patterns at import time.
+def _scanner_path() -> Path | None:
+    """Locate scripts/security-review-scan.py from known deploy layouts.
 
-    Patterns are constructed programmatically to avoid triggering
-    security-reminder hooks that scan for literal pattern strings.
+    Mirrors hooks/security-review-hook.py so this hook works from any cwd
+    (deployed copies live under ~/.claude/hooks/ alongside ~/.claude/scripts/).
     """
-    # Credential variable names to detect
-    cred_names = "|".join(
-        [
-            "password",
-            "passwd",
-            "api_key",
-            "apikey",
-            "secret_key",
-            "secretkey",
-            "auth_token",
-        ]
-    )
-
-    # Extended SQL keywords for broader coverage (merged from sql-injection-detector.py)
-    sql_kw = "|".join(
-        [
-            "SELECT",
-            "INSERT",
-            "UPDATE",
-            "DELETE",
-            "DROP",
-            "WHERE",
-            "FROM",
-            "JOIN",
-            "SET",
-            "VALUES",
-        ]
-    )
-
-    return [
-        # Hardcoded credentials — variable assignment with string literal
-        (
-            re.compile(
-                rf"""(?:{cred_names})\s*[=:]\s*['"][^'"]{"{8,}"}['"]""",
-                re.IGNORECASE,
-            ),
-            "hardcoded-credential",
-            "Use environment variables or a secrets manager instead of hardcoded values",
-        ),
-        # SQL injection — f-string or format() in SQL-like strings
-        (
-            re.compile(
-                r"""f['"]{1,3}(?:SELECT|INSERT|UPDATE|DELETE|DROP)\s.*\{""",
-                re.IGNORECASE,
-            ),
-            "sql-injection",
-            "Use parameterized queries instead of string interpolation in SQL",
-        ),
-        (
-            re.compile(
-                r"""['"](?:SELECT|INSERT|UPDATE|DELETE)\s.*['"].*%\s""",
-                re.IGNORECASE,
-            ),
-            "sql-injection",
-            "Use parameterized queries instead of % formatting in SQL",
-        ),
-        # SQL injection — string concatenation: "...SQL..." + variable
-        (
-            re.compile(
-                rf"""['"](?:[^'"]*\b(?:{sql_kw})\b[^'"]*)['"]\s*\+""",
-                re.IGNORECASE,
-            ),
-            "sql-injection",
-            "Use parameterized queries (e.g., cursor.execute(sql, params))",
-        ),
-        # SQL injection — variable + "...SQL..."
-        (
-            re.compile(
-                rf"""\+\s*['"](?:[^'"]*\b(?:{sql_kw})\b[^'"]*)['"]\s*(?:\+|$|;|\)|,)""",
-                re.IGNORECASE,
-            ),
-            "sql-injection",
-            "Use parameterized queries (e.g., cursor.execute(sql, params))",
-        ),
-        # SQL injection — .format() call on a SQL string
-        (
-            re.compile(
-                rf"""['"](?:[^'"]*\b(?:{sql_kw})\b[^'"]*\{{[^'"]*)['"]\s*\.format\s*\(""",
-                re.IGNORECASE,
-            ),
-            "sql-injection",
-            "Use parameterized queries instead of .format() in SQL strings",
-        ),
-        # SQL injection — Go fmt.Sprintf with SQL percent placeholders
-        (
-            re.compile(
-                rf"""fmt\.Sprintf\s*\(\s*['"`](?:[^'"`]*\b(?:{sql_kw})\b[^'"`]*%[sdvfq][^'"`]*)[`'"]\s*,""",
-                re.IGNORECASE,
-            ),
-            "sql-injection",
-            "Use db.Query with ? or $N placeholders and pass values as arguments",
-        ),
-        # SQL injection — Java String.format with SQL percent placeholders
-        (
-            re.compile(
-                rf"""String\.format\s*\(\s*["'](?:[^"']*\b(?:{sql_kw})\b[^"']*%[sdnf][^"']*)['"]\s*,""",
-                re.IGNORECASE,
-            ),
-            "sql-injection",
-            "Use PreparedStatement with ? placeholders instead of String.format",
-        ),
-        # SQL injection — PHP sprintf with SQL percent placeholders
-        (
-            re.compile(
-                rf"""(?<!\w)sprintf\s*\(\s*["'](?:[^"']*\b(?:{sql_kw})\b[^"']*%[sduf][^"']*)['"]\s*,""",
-                re.IGNORECASE,
-            ),
-            "sql-injection",
-            "Use PDO prepared statements with ? placeholders instead of sprintf",
-        ),
-        # SQL injection — f-string with extended SQL keywords (WHERE, FROM, JOIN, SET, VALUES)
-        (
-            re.compile(
-                r"""f['"]{1,3}(?:[^'"]*\b(?:WHERE|FROM|JOIN|SET|VALUES)\b[^'"]*)\{""",
-                re.IGNORECASE,
-            ),
-            "sql-injection",
-            "Use parameterized queries instead of f-string interpolation in SQL",
-        ),
-        # SQL injection — multi-line SQL building via += concatenation
-        (
-            re.compile(
-                rf"""\b\w+\s*\+=\s*(?:f?['"][^'"]*\b(?:{sql_kw})\b)""",
-                re.IGNORECASE,
-            ),
-            "sql-injection",
-            "Build SQL with parameterized placeholders; collect params in a list",
-        ),
-        # Command injection — shell=True with variable input
-        (
-            re.compile(r"""subprocess\.(?:call|run|Popen)\(.*shell\s*=\s*True"""),
-            "command-injection",
-            "Use subprocess with shell=False and pass args as a list",
-        ),
-        (
-            re.compile(r"""os\.system\s*\("""),
-            "command-injection",
-            "Use subprocess.run() with shell=False instead of os.system()",
-        ),
-        # Path traversal — joining user input with paths without sanitization
-        (
-            re.compile(r"""os\.path\.join\(.*\.\./"""),
-            "path-traversal",
-            "Validate path components and use Path.resolve() to prevent traversal",
-        ),
-        # Unsafe YAML loading
-        (
-            re.compile(r"""yaml\.load\s*\([^)]*\)(?!.*Loader)"""),
-            "unsafe-deserialization",
-            "Use yaml.safe_load() or specify Loader=yaml.SafeLoader",
-        ),
-        # Unsafe serialization loading from untrusted sources
-        (
-            re.compile(re.escape("pickle") + r"""\.loads?\s*\("""),
-            "unsafe-deserialization",
-            "Unsafe with untrusted data; consider json or msgpack",
-        ),
+    here = Path(__file__).resolve()
+    candidates = [
+        here.parent.parent / "scripts" / "security-review-scan.py",  # repo: hooks/ -> scripts/
+        here.parent / "scripts" / "security-review-scan.py",
+        Path(os.path.expanduser("~/.claude/scripts/security-review-scan.py")),
     ]
+    for c in candidates:
+        if c.is_file():
+            return c
+    return None
 
 
-# Compile once at module load
-_PATTERNS = _build_patterns()
+def _load_scanner_module():
+    """Load scripts/security-review-scan.py as a module (single source of rules).
+
+    Returns the module or None on any failure (callers fail open / silent).
+    """
+    scanner = _scanner_path()
+    if scanner is None:
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("security_review_scan", scanner)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:
+        return None
 
 
 def main() -> None:
@@ -235,60 +83,53 @@ def main() -> None:
         raw = read_stdin(timeout=2)
         event = json.loads(raw)
 
-        # tool_name/event_type filters removed — matcher "Write|Edit" in settings.json
-        # prevents this hook from spawning for non-matching tools.
-
+        # tool_name/event_type filters are unnecessary — the matcher "Write|Edit"
+        # in settings.json prevents this hook from spawning for other tools.
         tool_input = event.get("tool_input", {})
-        file_path = tool_input.get("file_path", "")
+        file_path = tool_input.get("file_path") or tool_input.get("path") or ""
         if not file_path:
             return
 
-        # Only scan code files
-        ext = Path(file_path).suffix.lower()
-        if ext not in _CODE_EXTENSIONS:
+        scanner = _load_scanner_module()
+        if scanner is None:
             return
 
-        # Read file content from disk
-        p = Path(file_path)
-        if not p.is_file():
+        # Only scan files the engine supports; everything else is skipped.
+        if scanner._ext(file_path) not in scanner.SUPPORTED_EXTENSIONS:
             return
 
-        try:
-            content = p.read_text(errors="replace")
-        except OSError:
+        # Resolve relative tool paths against the session cwd.
+        cwd = event.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR")
+        abs_path = file_path if os.path.isabs(file_path) else os.path.join(cwd or os.getcwd(), file_path)
+        if not os.path.isfile(abs_path):
             return
 
-        lines = content.splitlines()
-        if len(lines) > _MAX_LINES:
+        # Build the canonical rule set (+ any project custom rules) and scan.
+        # _scan_file applies the engine's test-skip + doc-aware filtering.
+        rules = scanner._build_rules()
+        rules.extend(scanner._load_custom_rules(cwd or os.getcwd()))
+        findings = scanner._scan_file(abs_path, rules)
+        if not findings:
             return
 
-        # Scan each line against patterns
-        findings: list[str] = []
-        for line_num, line in enumerate(lines, 1):
-            for pattern, category, suggestion in _PATTERNS:
-                if pattern.search(line):
-                    findings.append(
-                        f"[SECURITY-HINT] Potential {category} at "
-                        f"{Path(file_path).name}:{line_num}\n"
-                        f"  Suggestion: {suggestion}"
-                    )
-                    break  # One finding per line max
+        name = Path(file_path).name
+        for f in findings[:_MAX_FINDINGS]:
+            print(
+                f"[SECURITY-HINT] Potential {f.get('rule', '?')} "
+                f"({f.get('severity', '?')}) at {name}:{f.get('line', '?')}\n"
+                f"  Match: {f.get('match', '')}"
+            )
+        if len(findings) > _MAX_FINDINGS:
+            print(f"  ... and {len(findings) - _MAX_FINDINGS} more security hints")
 
-        if findings:
-            # Limit output to first 5 findings to avoid noise
-            for finding in findings[:5]:
-                print(finding)
-            if len(findings) > 5:
-                print(f"  ... and {len(findings) - 5} more security hints")
-
-    except (json.JSONDecodeError, Exception) as e:
+    except Exception as e:
         if os.environ.get("CLAUDE_HOOKS_DEBUG"):
             import traceback
 
             print(f"[security-scan] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
             traceback.print_exc(file=sys.stderr)
     finally:
-        # CRITICAL: Always exit 0 to prevent blocking Claude Code
+        # CRITICAL: Always exit 0 to prevent blocking Claude Code.
         sys.exit(0)
 
 

--- a/hooks/security-review-hook.py
+++ b/hooks/security-review-hook.py
@@ -56,21 +56,24 @@ Fail-open: any internal error allows the commit / skips the rewake and prints a
 warning to stderr. A crashed hook never blocks a tool and never stalls a session.
 """
 
-import hashlib
 import importlib.util
 import json
 import os
 import re
 import subprocess
 import sys
-import tempfile
-import time
 import traceback
-from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
-from hook_utils import context_output, empty_output
+from hook_utils import (
+    DiffDedup,
+    async_rewake,
+    context_output,
+    empty_output,
+    has_reviewable_content,
+    working_tree_diff,
+)
 from stdin_timeout import read_stdin
 
 _SKIP_ENV = "VEXJOY_SECURITY_REVIEW_SKIP"
@@ -285,20 +288,12 @@ def handle_post_tool_use(event: dict) -> None:
 
 
 def _working_tree_diff(cwd: str | None) -> str:
-    """Return the working-tree diff (tracked changes) for the Stop rewake context."""
-    try:
-        result = subprocess.run(
-            ["git", "diff", "--no-color", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-            cwd=cwd or None,
-        )
-    except (subprocess.TimeoutExpired, OSError):
-        return ""
-    if result.returncode != 0:
-        return ""
-    return result.stdout
+    """Return the working-tree diff (tracked changes) for the Stop rewake context.
+
+    Thin wrapper over hook_utils.working_tree_diff (the shared implementation).
+    Kept as a module-level name so the test-suite can patch it.
+    """
+    return working_tree_diff(cwd)
 
 
 def _scannable_extensions() -> frozenset[str]:
@@ -323,60 +318,19 @@ def _scannable_extensions() -> frozenset[str]:
     return frozenset({".py", ".go", ".js", ".ts", ".rb", ".java", ".php", ".kt", ".swift"})
 
 
-def _diff_post_image_ext(header_line: str) -> str | None:
-    """Extract the lowercased extension of a diff's post-image path.
-
-    `header_line` is a `+++ ` line. Returns None for `/dev/null` (deletions) or
-    when no extension is present.
-    """
-    path = header_line[4:].strip()
-    if not path or path == "/dev/null":
-        return None
-    # Strip git's `b/` prefix (and the rare `i/`/`w/`/`c/`/`o/` prefixes).
-    if len(path) > 2 and path[1] == "/" and path[0] in "abciwo":
-        path = path[2:]
-    dot = path.rfind(".")
-    slash = path.rfind("/")
-    if dot == -1 or dot < slash:
-        return None
-    return path[dot:].lower()
-
-
 def _has_reviewable_content(diff: str) -> bool:
     """Return True only if the diff is security-relevant for the Stop rewake.
 
-    Security-relevant means: at least one scannable source file (an extension in
-    _scannable_extensions() — the scanner's SUPPORTED_EXTENSIONS minus doc types)
-    has at least one ADDED or MODIFIED line.
+    Thin wrapper over hook_utils.has_reviewable_content with this hook's scanner-
+    derived scannable extension set (SUPPORTED_EXTENSIONS minus doc types). Kept
+    as a module-level name so the test-suite can reason about it directly.
 
-    Why this gate:
-    - Pure deletions (only `-` lines) cannot introduce a vulnerability, so a diff
-      whose only changes are removals is skipped.
-    - Doc/config-only diffs (.md, .txt, .json, etc. — not in the source set)
-      aren't worth the heavy LLM-depth Stop pass, so they're skipped.
-    - Mode-only diffs (no content lines) were already skipped; they still are,
-      since they contain no added lines.
-
-    An added line in a real source file (e.g. a new `eval(...)` in a `.py`) MUST
-    still pass this gate — true positives are preserved.
+    Security-relevant means: at least one scannable source file has at least one
+    ADDED line. Pure deletions, doc/config-only diffs, mode-only and pure-rename
+    diffs are all non-triggering. An added line in a real source file (a new
+    `eval(...)` in a `.py`) MUST still pass — true positives are preserved.
     """
-    scannable_exts = _scannable_extensions()
-    current_scannable = False  # is the file in the current diff block scannable?
-    for line in diff.splitlines():
-        if line.startswith("+++ "):
-            # New per-file post-image header: decide if this file is scannable.
-            ext = _diff_post_image_ext(line)
-            current_scannable = ext in scannable_exts if ext is not None else False
-            continue
-        if line.startswith("diff --git "):
-            # Start of a new file block; reset until its +++ header is seen.
-            current_scannable = False
-            continue
-        # An added content line (not the `+++` header) in a scannable file is the
-        # only thing that makes a diff security-relevant.
-        if current_scannable and line.startswith("+") and not line.startswith("+++"):
-            return True
-    return False
+    return has_reviewable_content(diff, _scannable_extensions())
 
 
 def _dedup_ttl_seconds() -> int:
@@ -395,81 +349,32 @@ def _dedup_ttl_seconds() -> int:
     return ttl if ttl > 0 else 0
 
 
+def _dedup() -> DiffDedup:
+    """Build a DiffDedup bound to the current state paths + TTL.
+
+    Reads _STATE_DIR / _STATE_FILE / _dedup_ttl_seconds() at call time so the
+    test-suite's patching of those module-level names keeps working.
+    """
+    return DiffDedup(_STATE_DIR, _STATE_FILE, ttl_seconds=_dedup_ttl_seconds())
+
+
 def _diff_signature(cwd: str | None, diff: str) -> str:
     """Hash (cwd, diff) so different repos with identical diffs don't collide."""
-    h = hashlib.sha256()
-    h.update((cwd or "").encode("utf-8", errors="replace"))
-    h.update(b"\x00")
-    h.update(diff.encode("utf-8", errors="replace"))
-    return h.hexdigest()
-
-
-def _load_dedup_state() -> dict:
-    """Load last-diff-hash state. Empty dict on any failure."""
-    try:
-        if _STATE_FILE.exists():
-            return json.loads(_STATE_FILE.read_text())
-    except (json.JSONDecodeError, OSError, ValueError):
-        pass
-    return {}
-
-
-def _save_dedup_state(state: dict) -> None:
-    """Atomic write: tempfile in same dir + os.replace. Silent on failure (advisory path)."""
-    try:
-        _STATE_DIR.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=str(_STATE_DIR), suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w") as f:
-                json.dump(state, f)
-            os.replace(tmp, str(_STATE_FILE))
-        except Exception:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
-    except Exception:
-        # Failing to persist dedup state must never block a Stop hook — at worst we
-        # double-review on the next event, which is the existing behavior.
-        pass
+    return _dedup().signature(cwd, diff)
 
 
 def _is_duplicate_diff(cwd: str | None, diff: str) -> tuple[bool, str | None]:
     """Return (is_duplicate, last_seen_iso). Hash match is permanent by default.
 
-    Same (cwd, diff) hash means same review — no time window. The state file
-    self-heals: a non-matching hash overwrites the old one on the next call.
-
-    If VEXJOY_SECURITY_REVIEW_DEDUP_TTL_SECONDS is set to a positive int, the
-    old TTL window applies and stale matches are treated as misses.
+    Delegates to the shared DiffDedup state machine. Same (cwd, diff) hash means
+    same review unless VEXJOY_SECURITY_REVIEW_DEDUP_TTL_SECONDS is a positive int.
     """
-    state = _load_dedup_state()
-    sig = _diff_signature(cwd, diff)
-    if state.get("hash") != sig:
-        return False, None
-    ttl = _dedup_ttl_seconds()
-    if ttl > 0:
-        try:
-            last_ts = float(state.get("ts", 0))
-        except (TypeError, ValueError):
-            return False, None
-        if (time.time() - last_ts) > ttl:
-            return False, None
-    return True, state.get("ts_iso")
+    return _dedup().is_duplicate(cwd, diff)
 
 
 def _record_diff_seen(cwd: str | None, diff: str) -> None:
     """Persist the current diff signature so a byte-identical re-fire short-circuits."""
-    now = time.time()
-    _save_dedup_state(
-        {
-            "hash": _diff_signature(cwd, diff),
-            "ts": now,
-            "ts_iso": datetime.fromtimestamp(now, tz=timezone.utc).isoformat(),
-            "cwd": cwd or "",
-        }
-    )
+    _dedup().record(cwd, diff)
 
 
 def handle_stop(event: dict) -> None:
@@ -520,23 +425,21 @@ def handle_stop(event: dict) -> None:
     if truncated:
         instruction += f"\n\n(diff truncated to {max_chars} chars)"
 
-    # Per-run rewakeSummary (one-liner shown to the user). Mirrors the official
-    # plugin's emit_metrics rewake_summary on a stdout JSON line.
-    print(json.dumps({"rewakeSummary": "Local security review of session changes"}), flush=True)
-
     # Record the diff signature so a byte-identical re-fire short-circuits cleanly.
-    # Recorded BEFORE exit 2 so the rewake itself won't loop.
+    # Recorded BEFORE the rewake (exit 2) so the rewake itself won't loop.
     _record_diff_seen(cwd, diff)
 
-    # The rewake context goes to stderr; exit 2 is the asyncRewake signal.
-    sys.stderr.write(
+    # async_rewake (shared helper) emits the per-run rewakeSummary one-liner on
+    # stdout, writes the rewake context to stderr, and exits 2 (the asyncRewake
+    # signal). Mirrors the official plugin; advisory — never blocks.
+    message = (
         "[security-review] Session security review\n\n"
         + instruction
         + "\n\n=== working-tree diff ===\n"
         + diff_excerpt
         + "\n"
     )
-    sys.exit(2)
+    async_rewake(message, "Local security review of session changes")
 
 
 def main() -> None:

--- a/hooks/tests/test_hook_utils_security.py
+++ b/hooks/tests/test_hook_utils_security.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Tests for the security/diff helpers lifted into hook_utils.
+
+Run with: python3 -m pytest hooks/tests/test_hook_utils_security.py -v
+
+Covers the helpers promoted out of hooks/security-review-hook.py so multiple
+hooks can share one implementation:
+- working_tree_diff(cwd)        — git working-tree diff (subprocess wrapper)
+- diff_post_image_ext(line)     — extract a +++ header's post-image extension
+- has_reviewable_content(diff, scannable_exts) — added-source-line gate
+- DiffDedup                     — sha256(cwd,diff) signature + atomic state +
+                                  opt-in TTL state machine
+- async_rewake(message, summary) — stdout rewakeSummary + stderr context + exit 2
+"""
+
+import io
+import json
+import sys
+import time
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
+
+from hook_utils import (
+    DiffDedup,
+    async_rewake,
+    diff_post_image_ext,
+    has_reviewable_content,
+    working_tree_diff,
+)
+
+_SRC_EXTS = frozenset({".py", ".go", ".js", ".ts", ".rb", ".java", ".php", ".kt", ".swift"})
+
+
+def _src_diff(added: str, path: str = "app.py") -> str:
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"index 1111111..2222222 100644\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        f"@@ -1,1 +1,2 @@\n"
+        f" existing\n"
+        f"+{added}\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# diff_post_image_ext
+# ---------------------------------------------------------------------------
+
+
+class TestDiffPostImageExt:
+    def test_basic_b_prefix(self):
+        assert diff_post_image_ext("+++ b/src/app.py") == ".py"
+
+    def test_dev_null_returns_none(self):
+        assert diff_post_image_ext("+++ /dev/null") is None
+
+    def test_no_extension_returns_none(self):
+        assert diff_post_image_ext("+++ b/Makefile") is None
+
+    def test_lowercased(self):
+        assert diff_post_image_ext("+++ b/A.PY") == ".py"
+
+    def test_dotfile_treated_as_extension(self):
+        # Behavior preserved byte-identically from security-review-hook.py: a
+        # leading-dot dotfile like `.gitignore` is reported as ext ".gitignore".
+        # Harmless — such extensions are never in any scannable set, so the
+        # has_reviewable_content gate ignores them anyway.
+        assert diff_post_image_ext("+++ b/.gitignore") == ".gitignore"
+
+
+# ---------------------------------------------------------------------------
+# has_reviewable_content
+# ---------------------------------------------------------------------------
+
+
+class TestHasReviewableContent:
+    def test_added_source_line_is_reviewable(self):
+        assert has_reviewable_content(_src_diff("os.system(x)"), _SRC_EXTS) is True
+
+    def test_pure_deletion_not_reviewable(self):
+        diff = (
+            "diff --git a/app.py b/app.py\n"
+            "index 83db48f..8129d30 100644\n--- a/app.py\n+++ b/app.py\n"
+            "@@ -1,2 +1,1 @@\n keep\n-os.system(removed)\n"
+        )
+        assert has_reviewable_content(diff, _SRC_EXTS) is False
+
+    def test_doc_only_added_line_not_reviewable(self):
+        diff = (
+            "diff --git a/README.md b/README.md\n"
+            "index 1..2 100644\n--- a/README.md\n+++ b/README.md\n"
+            "@@ -1 +1,2 @@\n intro\n+Call eval(x).\n"
+        )
+        assert has_reviewable_content(diff, _SRC_EXTS) is False
+
+    def test_mixed_doc_and_source_add_is_reviewable(self):
+        diff = (
+            "diff --git a/README.md b/README.md\n"
+            "index 1..2 100644\n--- a/README.md\n+++ b/README.md\n@@ -1 +1,2 @@\n x\n+docs\n"
+            "diff --git a/app.py b/app.py\n"
+            "index 3..4 100644\n--- a/app.py\n+++ b/app.py\n@@ -1 +1,2 @@\n y\n+yaml.load(d)\n"
+        )
+        assert has_reviewable_content(diff, _SRC_EXTS) is True
+
+    def test_pure_rename_not_reviewable(self):
+        diff = "diff --git a/old.py b/new.py\nsimilarity index 100%\nrename from old.py\nrename to new.py\n"
+        assert has_reviewable_content(diff, _SRC_EXTS) is False
+
+    def test_empty_diff_not_reviewable(self):
+        assert has_reviewable_content("", _SRC_EXTS) is False
+
+
+# ---------------------------------------------------------------------------
+# working_tree_diff
+# ---------------------------------------------------------------------------
+
+
+class TestWorkingTreeDiff:
+    def test_returns_stdout_on_success(self):
+        class _R:
+            returncode = 0
+            stdout = "diff --git a/x b/x\n"
+
+        with patch("hook_utils.subprocess.run", return_value=_R()):
+            assert working_tree_diff("/repo") == "diff --git a/x b/x\n"
+
+    def test_nonzero_returncode_yields_empty(self):
+        class _R:
+            returncode = 128
+            stdout = "fatal: not a repo\n"
+
+        with patch("hook_utils.subprocess.run", return_value=_R()):
+            assert working_tree_diff("/repo") == ""
+
+    def test_subprocess_error_yields_empty(self):
+        with patch("hook_utils.subprocess.run", side_effect=OSError("boom")):
+            assert working_tree_diff("/repo") == ""
+
+
+# ---------------------------------------------------------------------------
+# DiffDedup
+# ---------------------------------------------------------------------------
+
+
+class TestDiffDedup:
+    def test_signature_distinguishes_cwd(self):
+        d = DiffDedup(Path("/tmp/x"), Path("/tmp/x/s.json"))
+        assert d.signature("/a", "diff") != d.signature("/b", "diff")
+
+    def test_signature_distinguishes_diff(self):
+        d = DiffDedup(Path("/tmp/x"), Path("/tmp/x/s.json"))
+        assert d.signature("/a", "diff1") != d.signature("/a", "diff2")
+
+    def test_first_seen_is_not_duplicate(self, tmp_path):
+        d = DiffDedup(tmp_path, tmp_path / "s.json")
+        is_dup, _ = d.is_duplicate("/repo", "diffA")
+        assert is_dup is False
+
+    def test_record_then_identical_is_duplicate(self, tmp_path):
+        d = DiffDedup(tmp_path, tmp_path / "s.json")
+        d.record("/repo", "diffA")
+        is_dup, _ = d.is_duplicate("/repo", "diffA")
+        assert is_dup is True
+
+    def test_record_writes_atomically(self, tmp_path):
+        state = tmp_path / "s.json"
+        d = DiffDedup(tmp_path, state)
+        d.record("/repo", "diffA")
+        assert state.exists()
+        data = json.loads(state.read_text())
+        assert "hash" in data and "ts" in data
+
+    def test_changed_diff_is_not_duplicate(self, tmp_path):
+        d = DiffDedup(tmp_path, tmp_path / "s.json")
+        d.record("/repo", "diffA")
+        is_dup, _ = d.is_duplicate("/repo", "diffB")
+        assert is_dup is False
+
+    def test_different_cwd_not_duplicate(self, tmp_path):
+        d = DiffDedup(tmp_path, tmp_path / "s.json")
+        d.record("/repo-a", "diffA")
+        is_dup, _ = d.is_duplicate("/repo-b", "diffA")
+        assert is_dup is False
+
+    def test_no_ttl_is_permanent(self, tmp_path):
+        """Default TTL=0 → an ancient ts still dedups when the hash matches."""
+        state = tmp_path / "s.json"
+        d = DiffDedup(tmp_path, state, ttl_seconds=0)
+        state.write_text(json.dumps({"hash": d.signature("/repo", "diffA"), "ts": 0, "ts_iso": "x", "cwd": "/repo"}))
+        is_dup, _ = d.is_duplicate("/repo", "diffA")
+        assert is_dup is True
+
+    def test_positive_ttl_expires_old_record(self, tmp_path):
+        state = tmp_path / "s.json"
+        d = DiffDedup(tmp_path, state, ttl_seconds=300)
+        old_ts = time.time() - 10_000
+        state.write_text(
+            json.dumps({"hash": d.signature("/repo", "diffA"), "ts": old_ts, "ts_iso": "x", "cwd": "/repo"})
+        )
+        is_dup, _ = d.is_duplicate("/repo", "diffA")
+        assert is_dup is False
+
+    def test_corrupt_state_is_not_duplicate(self, tmp_path):
+        state = tmp_path / "s.json"
+        state.write_text("not json {{{")
+        d = DiffDedup(tmp_path, state)
+        is_dup, _ = d.is_duplicate("/repo", "diffA")
+        assert is_dup is False
+
+    def test_record_failure_is_silent(self, tmp_path):
+        # An unwritable state dir must not raise — dedup persistence is best-effort.
+        d = DiffDedup(tmp_path / "nope", tmp_path / "nope" / "deep" / "s.json")
+        with patch("hook_utils.os.replace", side_effect=OSError("ro")):
+            d.record("/repo", "diffA")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# async_rewake
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncRewake:
+    def test_exits_2_with_summary_and_context(self):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            try:
+                async_rewake("CONTEXT-BODY", "ONE-LINE-SUMMARY")
+            except SystemExit as e:
+                code = int(e.code) if e.code is not None else 0
+        assert code == 2
+        data = json.loads(out.getvalue().strip().splitlines()[0])
+        assert data["rewakeSummary"] == "ONE-LINE-SUMMARY"
+        assert "CONTEXT-BODY" in err.getvalue()

--- a/hooks/tests/test_posttool_security_scan.py
+++ b/hooks/tests/test_posttool_security_scan.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+Tests for hooks/posttool-security-scan.py — advisory PostToolUse security scan.
+
+Run with: python3 -m pytest hooks/tests/test_posttool_security_scan.py -v
+
+This hook was refactored to delegate ALL detection to the canonical engine
+(scripts/security-review-scan.py). These tests prove the consolidation:
+
+- Real insecure code (shell=True, yaml.load, hardcoded secret, SQLi) is still
+  flagged — no true positive lost when the inline _build_patterns fork retired.
+- The engine's test-skip guard now applies: a test-fixture file (test_*.py)
+  with eval()/exec() is SKIPPED (the inline scanner false-positived on these).
+- Doc-aware filtering applies: prose in .md is not flagged.
+- Non-source files are skipped; missing files / malformed stdin fail open.
+- ALWAYS exits 0 (non-blocking — advisory PostToolUse hook).
+"""
+
+import importlib.util
+import io
+import json
+import os
+from contextlib import ExitStack, redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+HOOK_PATH = Path(__file__).parent.parent / "posttool-security-scan.py"
+
+spec = importlib.util.spec_from_file_location("posttool_security_scan", HOOK_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+def _event(file_path: str, cwd: str | None = None, tool_name: str = "Write") -> str:
+    event = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": tool_name,
+        "tool_input": {"file_path": file_path},
+    }
+    if cwd:
+        event["cwd"] = cwd
+    return json.dumps(event)
+
+
+def _run(stdin_payload: str, env: dict | None = None) -> tuple[int, str, str]:
+    """Invoke mod.main() in-process. Returns (exit_code, stdout, stderr)."""
+    out, err = io.StringIO(), io.StringIO()
+    base_env = dict(os.environ)
+    if env:
+        base_env.update(env)
+    code = 0
+    with ExitStack() as stack:
+        stack.enter_context(patch.dict(os.environ, base_env, clear=True))
+        stack.enter_context(patch.object(mod, "read_stdin", return_value=stdin_payload))
+        stack.enter_context(redirect_stdout(out))
+        stack.enter_context(redirect_stderr(err))
+        try:
+            mod.main()
+        except SystemExit as e:
+            code = int(e.code) if e.code is not None else 0
+    return code, out.getvalue(), err.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# True positives preserved (parity with the retired inline scanner)
+# ---------------------------------------------------------------------------
+
+
+class TestTruePositivesPreserved:
+    def test_shell_true_flagged(self, tmp_path):
+        f = tmp_path / "app.py"
+        f.write_text("import subprocess\nsubprocess.run(cmd, shell=True)\n")
+        code, out, _ = _run(_event(str(f), cwd=str(tmp_path)))
+        assert code == 0
+        assert "[SECURITY-HINT]" in out
+        assert "shell-injection" in out
+
+    def test_yaml_load_flagged(self, tmp_path):
+        f = tmp_path / "loader.py"
+        f.write_text("import yaml\ndata = yaml.load(stream)\n")
+        code, out, _ = _run(_event(str(f), cwd=str(tmp_path)))
+        assert code == 0
+        assert "unsafe-yaml" in out
+
+    def test_hardcoded_secret_flagged(self, tmp_path):
+        f = tmp_path / "conf.py"
+        f.write_text('password = "hunter2hunter2"\n')
+        code, out, _ = _run(_event(str(f), cwd=str(tmp_path)))
+        assert code == 0
+        assert "hardcoded-secret" in out
+
+    def test_sql_injection_flagged(self, tmp_path):
+        f = tmp_path / "db.py"
+        f.write_text('q = f"SELECT * FROM t WHERE id={uid}"\n')
+        code, out, _ = _run(_event(str(f), cwd=str(tmp_path)))
+        assert code == 0
+        assert "sql-injection" in out
+
+    def test_os_system_flagged(self, tmp_path):
+        f = tmp_path / "run.py"
+        f.write_text('os.system("rm -rf /tmp/x")\n')
+        code, out, _ = _run(_event(str(f), cwd=str(tmp_path)))
+        assert code == 0
+        assert "shell-injection" in out
+
+
+# ---------------------------------------------------------------------------
+# NEW behavior inherited from the canonical engine: test-skip + doc-aware
+# ---------------------------------------------------------------------------
+
+
+class TestTestFixtureSkip:
+    def test_test_fixture_eval_skipped(self, tmp_path):
+        """A test-fixture file (test_*.py) with eval()/exec() is SKIPPED — the
+        engine's skip_test guard suppresses these in test files. The retired
+        inline scanner would have false-positived here."""
+        f = tmp_path / "test_thing.py"
+        f.write_text("def test_x():\n    eval(payload)\n    exec(code)\n")
+        code, out, _ = _run(_event(str(f), cwd=str(tmp_path)))
+        assert code == 0
+        assert "[SECURITY-HINT]" not in out
+
+    def test_test_fixture_public_ip_skipped(self, tmp_path):
+        """hardcoded-ip has skip_test=True; a public IP literal in a test file
+        is not flagged."""
+        f = tmp_path / "conn_test.py"
+        f.write_text("HOST = 8.8.8.8\n")
+        code, out, _ = _run(_event(str(f), cwd=str(tmp_path)))
+        assert code == 0
+        assert "hardcoded-ip" not in out
+
+    def test_nontest_eval_still_flagged(self, tmp_path):
+        """Control: the SAME eval() in a non-test file IS flagged — proving the
+        skip is scoped to test files, not a blanket disable."""
+        f = tmp_path / "prod.py"
+        f.write_text("eval(payload)\n")
+        code, out, _ = _run(_event(str(f), cwd=str(tmp_path)))
+        assert code == 0
+        assert "dangerous-eval" in out
+
+
+class TestDocAware:
+    def test_markdown_prose_not_flagged(self, tmp_path):
+        """Prose in markdown mentioning eval()/os.system() is not code — skipped."""
+        f = tmp_path / "notes.md"
+        f.write_text("Use eval(x) carefully and avoid os.system(cmd).\n")
+        code, out, _ = _run(_event(str(f), cwd=str(tmp_path)))
+        assert code == 0
+        assert "[SECURITY-HINT]" not in out
+
+    def test_aws_key_in_markdown_still_flagged(self, tmp_path):
+        """Anchored secret signatures (AKIA) still fire in docs (scan_docs)."""
+        f = tmp_path / "README.md"
+        f.write_text("key: AKIAIOSFODNN7EXAMPLE\n")
+        code, out, _ = _run(_event(str(f), cwd=str(tmp_path)))
+        assert code == 0
+        assert "hardcoded-secret" in out
+
+
+# ---------------------------------------------------------------------------
+# Skips and fail-open paths — always exit 0, never block
+# ---------------------------------------------------------------------------
+
+
+class TestSkipsAndFailOpen:
+    def test_clean_file_no_hint(self, tmp_path):
+        f = tmp_path / "ok.py"
+        f.write_text("x = 1 + 1\n")
+        code, out, _ = _run(_event(str(f), cwd=str(tmp_path)))
+        assert code == 0
+        assert out.strip() == ""
+
+    def test_unsupported_extension_skipped(self, tmp_path):
+        f = tmp_path / "image.png"
+        f.write_text("not really an image\n")
+        code, out, _ = _run(_event(str(f), cwd=str(tmp_path)))
+        assert code == 0
+        assert out.strip() == ""
+
+    def test_missing_file_fails_open(self, tmp_path):
+        code, out, _ = _run(_event(str(tmp_path / "gone.py"), cwd=str(tmp_path)))
+        assert code == 0
+        assert out.strip() == ""
+
+    def test_no_file_path_exits_0(self):
+        code, out, _ = _run(json.dumps({"hook_event_name": "PostToolUse", "tool_input": {}}))
+        assert code == 0
+        assert out.strip() == ""
+
+    def test_malformed_stdin_exits_0(self):
+        code, out, _ = _run("not valid json {{{")
+        assert code == 0
+
+    def test_empty_stdin_exits_0(self):
+        code, out, _ = _run("")
+        assert code == 0
+
+    def test_findings_capped_at_five(self, tmp_path):
+        f = tmp_path / "many.py"
+        # 8 distinct os.system calls -> 8 findings, output collapses after 5.
+        f.write_text("\n".join(f'os.system("cmd{i}")' for i in range(8)) + "\n")
+        code, out, _ = _run(_event(str(f), cwd=str(tmp_path)))
+        assert code == 0
+        assert out.count("[SECURITY-HINT]") == 5
+        assert "and 3 more" in out
+
+    def test_path_field_alias_supported(self, tmp_path):
+        """Some events use tool_input.path instead of file_path."""
+        f = tmp_path / "app.py"
+        f.write_text("os.system(cmd)\n")
+        event = json.dumps(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Edit",
+                "tool_input": {"path": str(f)},
+                "cwd": str(tmp_path),
+            }
+        )
+        code, out, _ = _run(event)
+        assert code == 0
+        assert "shell-injection" in out

--- a/scripts/security-review-scan.py
+++ b/scripts/security-review-scan.py
@@ -280,6 +280,70 @@ def _build_rules() -> list[dict]:
     )
     add("sql-injection", "HIGH", r"""["'].*\b(?:SELECT|INSERT|UPDATE|DELETE)\b.*%s.*["']\s*%""", flags=re.IGNORECASE)
 
+    # The following SQL-injection forms are consolidated from the retired inline
+    # PostToolUse scanner (hooks/posttool-security-scan._build_patterns). They
+    # extend the three rules above so the canonical engine is a strict superset
+    # of the inline scanner's SQL coverage — no true positive is lost on retire.
+    # `_SQL_KW` is the broader keyword set the inline scanner used for the
+    # concat / sprintf-family / `+=` forms.
+    _SQL_KW = "SELECT|INSERT|UPDATE|DELETE|DROP|WHERE|FROM|JOIN|SET|VALUES"
+    # String concatenation: "...SQL..." + variable
+    add("sql-injection", "HIGH", rf"""["'](?:[^"']*\b(?:{_SQL_KW})\b[^"']*)["']\s*\+""", flags=re.IGNORECASE)
+    # variable + "...SQL..."
+    add(
+        "sql-injection",
+        "HIGH",
+        rf"""\+\s*["'](?:[^"']*\b(?:{_SQL_KW})\b[^"']*)["']\s*(?:\+|$|;|\)|,)""",
+        flags=re.IGNORECASE,
+    )
+    # Go fmt.Sprintf with SQL percent placeholders
+    add(
+        "sql-injection",
+        "HIGH",
+        rf"""fmt\.Sprintf\s*\(\s*['"`](?:[^'"`]*\b(?:{_SQL_KW})\b[^'"`]*%[sdvfq][^'"`]*)[`'"]\s*,""",
+        flags=re.IGNORECASE,
+    )
+    # Java String.format with SQL percent placeholders
+    add(
+        "sql-injection",
+        "HIGH",
+        rf"""String\.format\s*\(\s*["'](?:[^"']*\b(?:{_SQL_KW})\b[^"']*%[sdnf][^"']*)['"]\s*,""",
+        flags=re.IGNORECASE,
+    )
+    # PHP sprintf with SQL percent placeholders (lookbehind skips fmt.Sprintf above)
+    add(
+        "sql-injection",
+        "HIGH",
+        rf"""(?<!\w)sprintf\s*\(\s*["'](?:[^"']*\b(?:{_SQL_KW})\b[^"']*%[sduf][^"']*)['"]\s*,""",
+        flags=re.IGNORECASE,
+    )
+    # f-string with the extended keywords (WHERE/FROM/JOIN/SET/VALUES) the
+    # SELECT/INSERT/... f-string rule above doesn't cover.
+    add(
+        "sql-injection",
+        "HIGH",
+        r"""f["'](?:[^"']*\b(?:WHERE|FROM|JOIN|SET|VALUES)\b[^"']*)\{""",
+        flags=re.IGNORECASE,
+    )
+    # Multi-line SQL building via += concatenation
+    add("sql-injection", "HIGH", rf"""\b\w+\s*\+=\s*(?:f?["'][^"']*\b(?:{_SQL_KW})\b)""", flags=re.IGNORECASE)
+
+    # ==================================================================
+    # MEDIUM — path traversal (consolidated from the retired inline scanner)
+    # ==================================================================
+
+    # os.path.join(...) with a literal `../` component. Heuristic and
+    # Python-specific; MEDIUM so it never blocks a commit (the inline scanner
+    # was advisory-only). filter_fn keeps it quiet when a clear sanitizer
+    # (Path.resolve / os.path.realpath) is already on the same line.
+    add(
+        "path-traversal",
+        "MEDIUM",
+        r"""os\.path\.join\([^)\n]*\.\./""",
+        path_filter=py_only,
+        filter_fn=_filter_sanitized_path,
+    )
+
     # ==================================================================
     # HIGH — unsafe deserialization (Anthropic; ADR bumps deser to HIGH)
     # ==================================================================
@@ -431,6 +495,15 @@ def _filter_safe_yaml_load(match: re.Match, line: str, filepath: str) -> bool:
     """Return True to keep finding (unsafe yaml.load). Suppress when the line
     pins a safe loader (Loader=SafeLoader / Loader=Safe...)."""
     if "Loader=" in line and "Safe" in line:
+        return False
+    return True
+
+
+def _filter_sanitized_path(match: re.Match, line: str, filepath: str) -> bool:
+    """Return True to keep finding (potential path traversal). Suppress when the
+    same line already pins a resolver (Path.resolve / os.path.realpath /
+    os.path.abspath) — those normalize away `../` before use."""
+    if any(s in line for s in (".resolve(", "os.path.realpath", "os.path.abspath")):
         return False
     return True
 

--- a/scripts/tests/test_security_review_scan.py
+++ b/scripts/tests/test_security_review_scan.py
@@ -526,6 +526,82 @@ class TestRedosHeuristic:
 
 
 # ---------------------------------------------------------------------------
+# Consolidation parity: patterns lifted from the old inline
+# posttool-security-scan._build_patterns must all fire here, so the inline
+# scanner can be retired without losing any true positive.
+# ---------------------------------------------------------------------------
+
+
+class TestSqlInjectionConsolidation:
+    """SQL-injection forms the retired inline scanner caught. The canonical
+    engine already had f-string / .format() / `%s % ` — these add the
+    string-concat, var+string, cross-language sprintf-family, extended-keyword
+    f-string, and `+=` building forms so coverage is a strict superset."""
+
+    def test_sql_concat_string_then_plus(self):
+        # "SELECT ... WHERE id=" + uid
+        assert "sql-injection" in _rules_hit('q = "SELECT * FROM users WHERE id=" + uid', "a.py")
+
+    def test_sql_concat_plus_then_string(self):
+        # base + "SELECT name FROM t"
+        assert "sql-injection" in _rules_hit('q = base + "SELECT name FROM t"', "a.py")
+
+    def test_sql_go_sprintf(self):
+        assert "sql-injection" in _rules_hit('q := fmt.Sprintf("SELECT * FROM t WHERE id=%d", uid)', "a.go")
+
+    def test_sql_java_string_format(self):
+        assert "sql-injection" in _rules_hit('String q = String.format("SELECT id FROM t WHERE x=%s", v);', "a.java")
+
+    def test_sql_php_sprintf(self):
+        assert "sql-injection" in _rules_hit('$q = sprintf("DELETE FROM t WHERE id=%d", $uid);', "a.php")
+
+    def test_sql_fstring_extended_keyword_where(self):
+        # f-string with WHERE/FROM/JOIN/SET/VALUES (no SELECT/INSERT/...).
+        assert "sql-injection" in _rules_hit('q = f"col WHERE id={uid}"', "a.py")
+
+    def test_sql_fstring_extended_keyword_from_join(self):
+        assert "sql-injection" in _rules_hit('q = f"x FROM t JOIN y ON {cond}"', "a.py")
+
+    def test_sql_plus_equals_build(self):
+        assert "sql-injection" in _rules_hit('q += "SELECT col FROM t"', "a.py")
+
+    def test_sql_concat_is_high_severity(self):
+        # SQL injection is HIGH in the canonical engine — keep the commit gate
+        # blocking it (the inline scanner was advisory; the engine is the SoT).
+        f = _findings('q = "SELECT * FROM t WHERE id=" + uid', "a.py")
+        assert any(x["rule"] == "sql-injection" and x["severity"] == "HIGH" for x in f)
+
+    # Documented exclusions — parameterized SQL and non-SQL concat must NOT fire.
+    def test_parameterized_query_not_flagged(self):
+        assert "sql-injection" not in _rules_hit("cursor.execute(sql, (uid,))", "a.py")
+
+    def test_plain_string_concat_not_flagged(self):
+        assert "sql-injection" not in _rules_hit('msg = "hello " + name', "a.py")
+
+    def test_sql_rules_skip_docs(self):
+        # SQL rules are code rules — prose in markdown must stay quiet.
+        assert "sql-injection" not in _rules_hit('q = "SELECT * FROM t" + uid', "a.md")
+
+
+class TestPathTraversalConsolidation:
+    """Path traversal via os.path.join with a literal `../` component — lifted
+    from the retired inline scanner. MEDIUM: heuristic, must not block commits."""
+
+    def test_os_path_join_dotdot(self):
+        assert "path-traversal" in _rules_hit('p = os.path.join(base, "../etc/passwd")', "a.py")
+
+    def test_path_traversal_is_medium(self):
+        f = _findings('p = os.path.join(base, "../x")', "a.py")
+        assert any(x["rule"] == "path-traversal" and x["severity"] == "MEDIUM" for x in f)
+
+    def test_safe_join_not_flagged(self):
+        assert "path-traversal" not in _rules_hit('p = os.path.join(base, "sub", name)', "a.py")
+
+    def test_path_traversal_skips_docs(self):
+        assert "path-traversal" not in _rules_hit('os.path.join(base, "../x")', "a.md")
+
+
+# ---------------------------------------------------------------------------
 # Parity count guard (ADR criterion 8 — all 25 Anthropic patterns covered)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Consolidates the inline PostToolUse `Write|Edit` security scanner onto the **canonical** `scripts/security-review-scan.py` rule engine (removing a hand-maintained regex fork) and promotes the security hook's reusable diff/dedup/rewake helpers into shared `hooks/lib/hook_utils.py`.

Two findings addressed:
1. **Consolidate (HIGH):** `hooks/posttool-security-scan.py` hand-maintained its own `_build_patterns` regex list. It now imports the canonical engine via the same `importlib` pattern `security-review-hook.py` uses and calls `_build_rules()` / `_load_custom_rules()` / `_scan_file()`. This inherits the engine's 13 test-skip guards + doc-aware filtering + `SUPPORTED_EXTENSIONS` and retires the fork.
2. **Shared helpers (LOW):** lifted `working_tree_diff`, `diff_post_image_ext`, `has_reviewable_content`, a `DiffDedup` class, and `async_rewake` into `hook_utils.py`. `security-review-hook.py` imports them instead of its private copies — behavior byte-identical.

## Parity matrix (old `_build_patterns` → canonical engine)

Built a fixture matrix of representative insecure snippets per rule class. The canonical engine was a near-superset but **missed 8 pattern classes** the inline scanner caught — all 8 were ADDED to `_build_rules()` (do not lose coverage). Final: **0 lost patterns**.

| Rule class / snippet | Old caught | Canonical (after) | Status |
|---|---|---|---|
| hardcoded-credential (password/api_key/secret_key/auth_token) | yes | hardcoded-secret | OK (pre-existing) |
| SQL f-string `SELECT…{` | yes | sql-injection | OK (pre-existing) |
| SQL `%` format | yes | sql-injection | OK (pre-existing) |
| SQL `.format()` | yes | sql-injection | OK (pre-existing) |
| SQL concat `"SELECT…" +` | yes | sql-injection | **ADDED** |
| SQL `+ "SELECT…"` | yes | sql-injection | **ADDED** |
| SQL Go `fmt.Sprintf` | yes | sql-injection | **ADDED** |
| SQL Java `String.format` | yes | sql-injection | **ADDED** |
| SQL PHP `sprintf` | yes | sql-injection | **ADDED** |
| SQL f-string extended kw (WHERE/FROM/JOIN/SET/VALUES) | yes | sql-injection | **ADDED** |
| SQL `+=` building | yes | sql-injection | **ADDED** |
| `os.path.join(…,"../")` path traversal | yes | path-traversal | **ADDED** |
| command-injection `shell=True` / `os.system` | yes | shell-injection | OK (pre-existing) |
| unsafe-deser `yaml.load` / `pickle.loads` | yes | unsafe-yaml / unsafe-deserialization | OK (pre-existing) |

**Severity choices:** added SQL rules are `HIGH` (matches the engine's existing SQL severity — keeps the commit gate blocking them). Path-traversal is `MEDIUM` (heuristic regex; never blocks a commit — the inline scanner was advisory-only). A `filter_fn` suppresses path-traversal when `Path.resolve`/`os.path.realpath`/`os.path.abspath` is on the same line.

## Dog-food evidence

### `posttool-security-scan.py` (reads edited file path from a PostToolUse event on stdin)

| Case | Input | Result | Exit |
|---|---|---|---|
| (a) real insecure `.py` | `subprocess.run(x, shell=True)` + `yaml.load(s)` | FLAGGED: shell-injection ×2, unsafe-yaml | 0 |
| (b) project test fixture | `test_fixture.py` with `eval()`/`exec()`/public IP | **SKIPPED** (no false positive — test-skip guard) | 0 |
| (b2) control | same `eval()` in non-test `prod.py` | FLAGGED: dangerous-eval (proves skip is scoped) | 0 |
| (c) doc-aware | markdown prose `eval(x)` / `os.system(cmd)` | **SKIPPED** (doc filtering) | 0 |

### `security-review-hook.py` Stop path (#691 gate, now via shared helpers)

| Case | Diff | Result | Exit |
|---|---|---|---|
| added source line | `+subprocess.run(c, shell=True)` in `.py` | rewake (rewakeSummary + stderr context) | 2 |
| doc-only edit | `+` lines in `README.md` only | NO rewake (#691) | 0 |
| pure deletion | `-os.system(x)` in `.py` | NO rewake (#691) | 0 |
| PostToolUse advisory | edit `svc.py` with `os.system` | additionalContext injected | 0 |

## What moved to `hook_utils.py`

- `working_tree_diff(cwd, timeout=15)` — git working-tree diff wrapper (fail-closed to "").
- `diff_post_image_ext(header_line)` — extract a `+++` header's post-image extension.
- `has_reviewable_content(diff, scannable_exts)` — added-source-line gate; `scannable_exts` is caller-supplied so the helper stays decoupled from any rule engine.
- `DiffDedup(state_dir, state_file, ttl_seconds=0)` — `sha256(cwd, diff)` signature + atomic write (tempfile + `os.replace`) + opt-in TTL state machine (`signature` / `is_duplicate` / `record`).
- `async_rewake(message, summary)` — stdout `rewakeSummary` + stderr context + `exit 2`.

`security-review-hook.py` keeps thin module-level wrappers (`_working_tree_diff`, `_has_reviewable_content`, `_diff_signature`, `_is_duplicate_diff`, `_record_diff_seen`) that delegate to the shared helpers, preserving the existing test surface (`_STATE_DIR`/`_STATE_FILE` patchability, TTL env).

## Tests

- `scripts/tests/test_security_review_scan.py`: +16 (8 SQL consolidation + 4 path-traversal + exclusions/severity guards). 132 pass.
- `hooks/tests/test_posttool_security_scan.py`: **new**, 18 (true-positive parity, test-fixture skip + control, doc-aware, fail-open, cap, path alias).
- `hooks/tests/test_hook_utils_security.py`: **new**, 26 (diff ext, reviewable gate, working_tree_diff, DiffDedup TTL/atomic/corruption, async_rewake).
- `hooks/tests/test_security_review_hook.py`: 45 pass unchanged (byte-identical behavior).

Full `hooks/` + `scripts/` suites: 3308 passed (2 pre-existing `test_ci_merge_gate.py` failures unrelated — env `ALLOW_*_MERGE` set; verified they fail identically with these changes stashed). Ruff check + format clean. `validate-doc-counts.py` passes.

## Notes

- The PreToolUse commit gate false-positives on the pattern literals inside these scanner/test source files (20 critical / 65 high are all regex strings + test fixtures, not real vulns). The commit used the documented `VEXJOY_SECURITY_REVIEW_SKIP=1` override.
- Non-blocking verified: `posttool-security-scan.py` exits 0 on all paths (empty stdin, missing file, malformed JSON). In-process steady-state ~0.8ms.
