### PR TITLE
feat(hooks): add Stop-event toolkit drift guard

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -539,6 +539,15 @@
             "asyncRewake": true,
             "rewakeMessage": "Local security review of this session's changes \u2014 address or acknowledge the findings below, then continue with the user's original request or continue waiting for their reply. This is supplementary, not a replacement for your previous response:",
             "rewakeSummary": "Local security review found changes to review"
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/stop-drift-guard.py\"",
+            "description": "Advisory: re-wake the session when this session's changes introduce toolkit drift (hook smoke-test, doc-count, or routing-manifest drift) so it can be fixed before CI",
+            "timeout": 20000,
+            "asyncRewake": true,
+            "rewakeMessage": "Toolkit drift guard found drift in this session's changes \u2014 fix the drift below (or acknowledge it), then continue with the user's original request or continue waiting for their reply. This is supplementary, not a replacement for your previous response:",
+            "rewakeSummary": "Toolkit drift guard found drift to review"
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-This toolkit prevents that. 44 domain agents, 123 workflow skills, 78 hooks, 104 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+This toolkit prevents that. 44 domain agents, 123 workflow skills, 79 hooks, 104 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Factory (`/do`).
 

--- a/hooks/stop-drift-guard.py
+++ b/hooks/stop-drift-guard.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+Stop-event drift guard (ADR: adr/stop-event-drift-guards.md)
+
+Advisory Stop hook that catches three classes of self-inflicted toolkit
+regression the moment they're introduced — at Stop, not at CI. It computes the
+session's working-tree diff, decides which component classes changed, runs ONLY
+the relevant existing check script, and re-wakes the session ADVISORY- only (it
+never blocks) when a check actually REPORTS drift.
+
+Relevance gate (diff file paths -> which check to run):
+  - hooks/** changed                          -> smoke-test-hooks.py --ci
+  - a component file ADDED/REMOVED under
+    hooks/|skills/|agents/|scripts/, OR a
+    count-claim doc touched (README.md,
+    CLAUDE.md, docs/**)                        -> validate-doc-counts.py --json
+  - skills/** or agents/** frontmatter changed -> check-routing-drift.py
+
+Only checks whose component class actually changed run, and a check surfaces
+output ONLY when it REPORTS drift — a clean session stays silent.
+
+Correctness properties (this is security-adjacent self-improvement infra):
+  - NEVER blocks. Drift surfaces via hook_utils.async_rewake (exit 2 +
+    rewakeSummary on stdout, context on stderr). There is no
+    permissionDecision:deny path anywhere in this hook.
+  - Fail-open. ANY internal error -> exit 0, skip. A crashed guard never stalls
+    a session.
+  - Dedup. A byte-identical working-tree diff short-circuits via
+    hook_utils.DiffDedup with its own state dir, so an unchanged diff doesn't
+    re-nag across consecutive Stop events.
+  - Recursion guard. stop_hook_active (CC sets it while a rewake is in flight)
+    short-circuits so the rewake itself can't loop.
+
+Kill switch:
+  - VEXJOY_DRIFT_GUARD_DISABLE=1  disables the hook entirely (and ONLY "1";
+    "0" / anything else does not disable).
+
+The hook owns no detection logic of its own — it delegates to the three existing
+scripts (scripts/smoke-test-hooks.py, scripts/validate-doc-counts.py,
+scripts/check-routing-drift.py). A script that errors or can't run is treated as
+"no drift" (fail-open), never as drift.
+
+Module seams (patched by hooks/tests/test_stop_drift_guard.py):
+  - read_stdin(timeout=...)         (imported from stdin_timeout)
+  - _working_tree_diff(cwd) -> str  (thin wrapper over hook_utils.working_tree_diff)
+  - _has_reviewable_content(diff)   (front gate; True if the diff has any signal)
+  - _run_check(name, cwd) -> {"drift": bool, "detail": str, "fix": str}
+                                     | {"drift": False} | None
+  - _STATE_DIR, _STATE_FILE         (Path constants for DiffDedup)
+  - main()                          (stdin -> dispatch on hook_event_name == "Stop")
+"""
+
+import json
+import os
+import subprocess
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from hook_utils import (
+    DiffDedup,
+    async_rewake,
+    working_tree_diff,
+)
+from stdin_timeout import read_stdin
+
+_DISABLE_ENV = "VEXJOY_DRIFT_GUARD_DISABLE"
+
+# Stop-event dedup state. Absolute path so it works from any cwd the harness
+# fires in. Own state dir so this guard's dedup never collides with another hook.
+_STATE_DIR = Path.home() / ".claude" / "state" / "stop-drift-guard"
+_STATE_FILE = _STATE_DIR / "last-diff-hash.json"
+
+# Canonical check names — these are the keys _run_check dispatches on and the
+# keys the test-suite patches against.
+SMOKE = "smoke-test-hooks"
+DOC_COUNTS = "validate-doc-counts"
+ROUTING = "check-routing-drift"
+
+# Component class roots. A file ADDED or REMOVED under any of these flips a
+# count claim -> doc-counts. (Modifying an existing file does not change counts.)
+_COMPONENT_ROOTS = ("hooks/", "skills/", "agents/", "scripts/")
+
+# Count-claim docs: touching any of these can stale a "N agents/skills/..." claim.
+_COUNT_CLAIM_DOCS = ("README.md", "CLAUDE.md")
+_COUNT_CLAIM_DIRS = ("docs/",)
+
+
+# =============================================================================
+# Diff parsing
+# =============================================================================
+
+
+def _strip_git_prefix(path: str) -> str:
+    """Strip git's a/ b/ (and rare i/w/c/o/) one-char path prefix."""
+    if len(path) > 2 and path[1] == "/" and path[0] in "abciwo":
+        return path[2:]
+    return path
+
+
+def _parse_diff(diff: str) -> list[dict]:
+    """Parse a unified working-tree diff into per-file change records.
+
+    Returns a list of {"path": str, "added": bool, "removed": bool,
+    "modified": bool, "has_added_lines": bool}. `path` is the post-image path
+    for adds/modifies and the pre-image path for deletions. Best-effort and
+    forgiving: any header it can't classify is simply skipped.
+    """
+    files: list[dict] = []
+    cur: dict | None = None
+
+    def _flush() -> None:
+        if cur is not None:
+            files.append(cur)
+
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            _flush()
+            # `diff --git a/<p> b/<p>` — take the b/ path as the working name.
+            parts = line.split(" ")
+            path = _strip_git_prefix(parts[-1]) if len(parts) >= 4 else ""
+            cur = {
+                "path": path,
+                "added": False,
+                "removed": False,
+                "modified": True,
+                "has_added_lines": False,
+            }
+            continue
+        if cur is None:
+            continue
+        if line.startswith("new file mode"):
+            cur["added"] = True
+            cur["modified"] = False
+        elif line.startswith("deleted file mode"):
+            cur["removed"] = True
+            cur["modified"] = False
+        elif line.startswith("+++ "):
+            post = line[4:].strip()
+            if post and post != "/dev/null":
+                cur["path"] = _strip_git_prefix(post)
+        elif line.startswith("--- "):
+            pre = line[4:].strip()
+            # For deletions the +++ is /dev/null, so anchor on the pre-image path.
+            if cur["removed"] and pre and pre != "/dev/null":
+                cur["path"] = _strip_git_prefix(pre)
+        elif line.startswith("+") and not line.startswith("+++"):
+            cur["has_added_lines"] = True
+
+    _flush()
+    return [f for f in files if f["path"]]
+
+
+def _is_count_claim_doc(path: str) -> bool:
+    """Is `path` a doc whose count claims this guard cares about?"""
+    if path in _COUNT_CLAIM_DOCS:
+        return True
+    return any(path.startswith(d) for d in _COUNT_CLAIM_DIRS)
+
+
+def _is_frontmatter_relevant(path: str) -> bool:
+    """skills/** or agents/** markdown — routing keys off their frontmatter."""
+    return (path.startswith("skills/") or path.startswith("agents/")) and path.endswith(".md")
+
+
+def _has_reviewable_content(diff: str) -> bool:
+    """Front gate: True if the diff carries ANY signal this guard acts on.
+
+    Reviewable means at least one changed file is something this guard would
+    inspect: a component file (added/removed/modified under a component root),
+    a count-claim doc, or a skills/agents frontmatter file. A diff with no such
+    file (or an empty diff) short-circuits before any check runs.
+
+    Note: pure deletions ARE reviewable here (a removed component changes counts),
+    so this gate is broader than hook_utils.has_reviewable_content's added-line-
+    only contract — it keys on file class, not on added lines.
+    """
+    for f in _parse_diff(diff):
+        path = f["path"]
+        if any(path.startswith(root) for root in _COMPONENT_ROOTS):
+            return True
+        if _is_count_claim_doc(path):
+            return True
+        if _is_frontmatter_relevant(path):
+            return True
+    return False
+
+
+def _relevant_checks(diff: str) -> list[str]:
+    """Map a diff to the set of checks to run, in a stable order.
+
+    Relevance gate (exclusive — only classes that actually changed run):
+      - any file under hooks/                        -> smoke-test-hooks
+      - any component add/remove under a root, OR a
+        count-claim doc touched                       -> validate-doc-counts
+      - any skills/** or agents/** frontmatter file   -> check-routing-drift
+    """
+    checks: list[str] = []
+    run_smoke = False
+    run_doc_counts = False
+    run_routing = False
+
+    for f in _parse_diff(diff):
+        path = f["path"]
+        if path.startswith("hooks/"):
+            run_smoke = True
+        if (f["added"] or f["removed"]) and any(path.startswith(root) for root in _COMPONENT_ROOTS):
+            run_doc_counts = True
+        if _is_count_claim_doc(path):
+            run_doc_counts = True
+        if _is_frontmatter_relevant(path):
+            run_routing = True
+
+    # Stable order: smoke, doc-counts, routing.
+    if run_smoke:
+        checks.append(SMOKE)
+    if run_doc_counts:
+        checks.append(DOC_COUNTS)
+    if run_routing:
+        checks.append(ROUTING)
+    return checks
+
+
+# =============================================================================
+# Check execution — map each existing script to a {drift, detail, fix} result
+# =============================================================================
+
+
+def _script_path(name: str) -> Path | None:
+    """Locate scripts/<name>.py across the repo and deployed layouts."""
+    here = Path(__file__).resolve()
+    candidates = [
+        here.parent.parent / "scripts" / name,  # repo: hooks/ -> scripts/
+        here.parent / "scripts" / name,
+        Path(os.path.expanduser(f"~/.claude/scripts/{name}")),
+    ]
+    for c in candidates:
+        if c.is_file():
+            return c
+    return None
+
+
+def _run_script(script: str, args: list[str], cwd: str | None, timeout: int = 30):
+    """Run scripts/<script> with args; return CompletedProcess or None on failure."""
+    path = _script_path(script)
+    if path is None:
+        return None
+    try:
+        return subprocess.run(
+            [sys.executable, str(path), *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=cwd or None,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def _check_smoke(cwd: str | None) -> dict | None:
+    """smoke-test-hooks.py --ci: exit 0 = clean, exit 1 = FAIL/MISSING."""
+    proc = _run_script("smoke-test-hooks.py", ["--ci"], cwd)
+    if proc is None:
+        return None
+    if proc.returncode == 0:
+        return {"drift": False}
+    detail = (proc.stdout or proc.stderr or "").strip().splitlines()
+    summary = detail[-1] if detail else "one or more hooks FAIL/MISSING"
+    return {
+        "drift": True,
+        "detail": f"hook smoke test failed: {summary}",
+        "fix": "python3 scripts/smoke-test-hooks.py --ci",
+    }
+
+
+def _check_doc_counts(cwd: str | None) -> dict | None:
+    """validate-doc-counts.py --json: drift when the `drifts` array is non-empty."""
+    proc = _run_script("validate-doc-counts.py", ["--json"], cwd)
+    if proc is None:
+        return None
+    try:
+        report = json.loads(proc.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    drifts = report.get("drifts") or []
+    if not drifts:
+        return {"drift": False}
+    lines = ["doc count claims no longer match the filesystem:"]
+    for d in drifts[:10]:
+        lines.append(
+            f"  {d.get('source', '?')}:{d.get('line', '?')} "
+            f"claims {d.get('claim', '?')!r} (actual {d.get('actual', '?')})"
+        )
+    if len(drifts) > 10:
+        lines.append(f"  ... and {len(drifts) - 10} more")
+    return {
+        "drift": True,
+        "detail": "\n".join(lines),
+        "fix": "python3 scripts/validate-doc-counts.py --json",
+    }
+
+
+def _check_routing(cwd: str | None) -> dict | None:
+    """check-routing-drift.py: exit 0 = clean, exit 1 = a skill missing from manifest."""
+    proc = _run_script("check-routing-drift.py", [], cwd)
+    if proc is None:
+        return None
+    if proc.returncode == 0:
+        return {"drift": False}
+    detail = (proc.stdout or proc.stderr or "").strip()
+    summary = detail or "one or more skills are absent from the routing manifest"
+    return {
+        "drift": True,
+        "detail": f"routing manifest drift: {summary}",
+        "fix": "python3 scripts/check-routing-drift.py --verbose",
+    }
+
+
+_CHECK_RUNNERS = {
+    SMOKE: _check_smoke,
+    DOC_COUNTS: _check_doc_counts,
+    ROUTING: _check_routing,
+}
+
+
+def _run_check(name: str, cwd: str | None) -> dict | None:
+    """Run ONE check by canonical name; return a structured result.
+
+    Returns {"drift": True, "detail": str, "fix": str} when the underlying
+    script reports drift, {"drift": False} when it's clean, or None when the
+    script is missing / errored / unparseable (fail-open: callers treat None
+    as "no drift").
+    """
+    runner = _CHECK_RUNNERS.get(name)
+    if runner is None:
+        return None
+    return runner(cwd)
+
+
+# =============================================================================
+# Dedup
+# =============================================================================
+
+
+def _dedup() -> DiffDedup:
+    """Build a DiffDedup bound to the current state paths.
+
+    Reads _STATE_DIR / _STATE_FILE at call time so the test-suite's patching of
+    those module-level names keeps working.
+    """
+    return DiffDedup(_STATE_DIR, _STATE_FILE)
+
+
+# =============================================================================
+# Stop handler
+# =============================================================================
+
+
+def _working_tree_diff(cwd: str | None) -> str:
+    """Working-tree diff for the relevance gate / dedup.
+
+    Thin wrapper over hook_utils.working_tree_diff (the shared implementation),
+    kept as a module-level name so the test-suite can patch it.
+    """
+    return working_tree_diff(cwd)
+
+
+def handle_stop(event: dict) -> None:
+    """Stop: run the relevant drift checks and ADVISORY re-wake on real drift."""
+    # asyncRewake recursion guard: CC sets stop_hook_active while a rewake is in
+    # flight — don't re-fire.
+    if event.get("stop_hook_active"):
+        sys.exit(0)
+
+    cwd = event.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR")
+    diff = _working_tree_diff(cwd)
+
+    # Front gate: nothing reviewable -> short-circuit before any check runs.
+    if not diff.strip() or not _has_reviewable_content(diff):
+        sys.exit(0)
+
+    checks = _relevant_checks(diff)
+    if not checks:
+        sys.exit(0)
+
+    # Run only the relevant checks; collect those that REPORT drift.
+    drifting: list[dict] = []
+    for name in checks:
+        result = _run_check(name, cwd)
+        # None (couldn't run) and {"drift": False} both mean "no drift" (fail-open).
+        if result and result.get("drift"):
+            drifting.append(result)
+
+    if not drifting:
+        # Files changed but every relevant check is clean -> stay silent.
+        sys.exit(0)
+
+    # Dedup: a byte-identical diff already surfaced -> don't re-nag.
+    dedup = _dedup()
+    is_dup, last_iso = dedup.is_duplicate(cwd, diff)
+    if is_dup:
+        ts_msg = f" since {last_iso}" if last_iso else ""
+        print(f"[stop-drift-guard] diff unchanged{ts_msg} — skipping", file=sys.stderr)
+        sys.exit(0)
+
+    # Record BEFORE the rewake (exit 2) so the rewake itself won't loop.
+    dedup.record(cwd, diff)
+
+    # Compose the advisory. List each drifting check's detail + one-line fix.
+    lines = ["[stop-drift-guard] Toolkit drift detected in this session's changes:\n"]
+    for d in drifting:
+        lines.append(f"- {d.get('detail', 'drift detected')}")
+        lines.append(f"    fix: {d.get('fix', '(see the relevant check script)')}")
+    lines.append(
+        "\nThis is advisory — fix the drift above (or acknowledge it), then continue with the user's original request."
+    )
+    message = "\n".join(lines) + "\n"
+
+    # async_rewake: rewakeSummary on stdout, context on stderr, exit 2. Advisory —
+    # never a permissionDecision:deny, never blocks.
+    async_rewake(message, "Toolkit drift guard found drift to review")
+
+
+def main() -> None:
+    # Full kill switch — disables the hook entirely. ONLY exact "1" disables.
+    if os.environ.get(_DISABLE_ENV) == "1":
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            print(f"[stop-drift-guard] Disabled via {_DISABLE_ENV}=1", file=sys.stderr)
+        sys.exit(0)
+
+    raw = read_stdin(timeout=2)
+    try:
+        event = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+    if not isinstance(event, dict):
+        sys.exit(0)
+
+    if event.get("hook_event_name") == "Stop":
+        # Fail-open at the dispatch boundary too: tests drive main() directly
+        # (bypassing the __main__ guard), and a crashed check / diff helper must
+        # never escape as a non-zero, non-asyncRewake exit. async_rewake raises
+        # SystemExit(2) — that is the intended signal and must propagate.
+        try:
+            handle_stop(event)
+        except SystemExit:
+            raise
+        except Exception as e:
+            if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+                traceback.print_exc(file=sys.stderr)
+            else:
+                print(f"[stop-drift-guard] Error: {type(e).__name__}: {e}", file=sys.stderr)
+            sys.exit(0)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise  # Let sys.exit(0/2) propagate normally.
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            traceback.print_exc(file=sys.stderr)
+        else:
+            print(f"[stop-drift-guard] Error: {type(e).__name__}: {e}", file=sys.stderr)
+        # A crashed hook fails OPEN — never block, never stall a session.
+        sys.exit(0)

--- a/hooks/tests/conftest.py
+++ b/hooks/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Shared pytest fixtures for hook tests.
+
+Isolates per-hook on-disk dedup state so that tests which reuse an identical
+working-tree diff (and therefore an identical DiffDedup signature) don't
+contaminate one another through the real ~/.claude/state/ directory.
+
+The fixture is autouse but inert for any test module that does not expose a hook
+`mod` with `_STATE_DIR` / `_STATE_FILE`: it reaches the hook module via the
+requesting test module's `mod` attribute (the importlib-loaded module under
+test) and redirects its state to a fresh tmp dir per test. Other hook test files
+that don't bind a `mod` with those attributes are unaffected.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hook_dedup_state(request, tmp_path, monkeypatch):
+    """Point a hook's dedup state at a fresh tmp dir for each test.
+
+    No-op unless the requesting test module exposes `mod._STATE_DIR`. Tests that
+    patch `_STATE_DIR` / `_STATE_FILE` themselves (e.g. TestDedup) take
+    precedence — their `with patch.object(...)` block is entered later and
+    restored on exit.
+    """
+    mod = getattr(request.module, "mod", None)
+    if mod is not None and hasattr(mod, "_STATE_DIR"):
+        state_dir = tmp_path / "hook-dedup-state"
+        monkeypatch.setattr(mod, "_STATE_DIR", state_dir, raising=False)
+        monkeypatch.setattr(mod, "_STATE_FILE", state_dir / "last-diff-hash.json", raising=False)
+    yield

--- a/hooks/tests/test_stop_drift_guard.py
+++ b/hooks/tests/test_stop_drift_guard.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""
+RED tests for the (not-yet-written) Stop-event drift guard.
+
+Spec: adr/stop-event-drift-guards.md
+Pattern: mirrors hooks/tests/test_security_review_hook.py (the established Stop-hook
+test harness) — importlib-load the module under test, drive mod.main() in-process
+with patched stdin/diff/check seams, assert on (exit_code, stdout, stderr).
+
+These tests are written BEFORE hooks/stop-drift-guard.py exists (TDD RED phase).
+They MUST fail at import/collection time with FileNotFoundError because the hook
+file is absent — a clean "missing implementation" RED, not a syntax/assertion
+slip. Once the GREEN implementation lands, the module import resolves and the
+behavioral assertions take over.
+
+Behaviors under test (ADR acceptance criteria 1-7):
+  1. Relevance gate: only run a check when the diff touches that component class.
+  2. Run ONLY the relevant existing check:
+       - hooks/**                         -> smoke-test-hooks.py --ci
+       - component add/remove OR a
+         count-claim doc touched          -> validate-doc-counts.py --json
+       - skills/** or agents/** frontmatter -> check-routing-drift.py
+  3. Surface output ONLY on REAL drift; a clean session (checks pass) stays SILENT.
+  4. Dedup via hook_utils.DiffDedup (module-level _STATE_DIR / _STATE_FILE).
+  5. Fail-open on ANY internal error -> exit 0, never crash the session.
+  6. Never blocks (advisory): drift surfaces via async_rewake (exit 2 + rewakeSummary),
+     never a permissionDecision:deny.
+  7. Honor VEXJOY_DRIFT_GUARD_DISABLE=1.
+
+Run with: python3 -m pytest hooks/tests/test_stop_drift_guard.py -v
+
+Expected module-level contract the GREEN implementation must expose (the seams
+these tests patch):
+  - read_stdin(timeout=...)            (imported from stdin_timeout; patched)
+  - _working_tree_diff(cwd) -> str     (thin wrapper over hook_utils.working_tree_diff)
+  - _run_check(name, cwd) -> dict      (runs ONE check script; returns a structured
+                                        result {"drift": bool, "detail": str, "fix": str}
+                                        or {"drift": False} / None on failure — patched)
+  - _STATE_DIR, _STATE_FILE            (Path constants for DiffDedup; patched in dedup tests)
+  - main()                             (stdin -> dispatch on hook_event_name == "Stop")
+"""
+
+import importlib.util
+import io
+import json
+import os
+from contextlib import ExitStack, redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Import the module under test.
+#
+# RED: hooks/stop-drift-guard.py does not exist yet. spec_from_file_location +
+# exec_module raises FileNotFoundError here, so the whole module fails to collect
+# and every test in it errors for the right reason: the implementation is missing.
+# ---------------------------------------------------------------------------
+
+HOOK_PATH = Path(__file__).parent.parent / "stop-drift-guard.py"
+
+spec = importlib.util.spec_from_file_location("stop_drift_guard", HOOK_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _stop_event(cwd: str | None = "/repo", stop_hook_active: bool = False) -> str:
+    event = {"hook_event_name": "Stop", "stop_hook_active": stop_hook_active}
+    if cwd:
+        event["cwd"] = cwd
+    return json.dumps(event)
+
+
+def _diff_for(path: str, *, added: str = "x = 1", new_file: bool = False) -> str:
+    """Build a unified diff that ADDS a line under `path`.
+
+    `path` drives the relevance gate (the +++ b/<path> line). `new_file` emits a
+    `new file mode` header so component-add detection has something to key on.
+    """
+    header = f"diff --git a/{path} b/{path}\n"
+    if new_file:
+        header += "new file mode 100644\nindex 0000000..1234567\n--- /dev/null\n"
+    else:
+        header += "index 1111111..2222222 100644\n--- a/" + path + "\n"
+    return header + f"+++ b/{path}\n" + "@@ -0,0 +1,1 @@\n" + f"+{added}\n"
+
+
+def _deletion_diff_for(path: str) -> str:
+    """Whole-file deletion diff for `path` (drives component-remove detection)."""
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        "deleted file mode 100644\n"
+        "index de98044..0000000\n"
+        f"--- a/{path}\n"
+        "+++ /dev/null\n"
+        "@@ -1,1 +0,0 @@\n"
+        "-gone = True\n"
+    )
+
+
+# Structured check results the seam (_run_check) is expected to return.
+def _drift(detail: str = "drift detected", fix: str = "run the fix") -> dict:
+    return {"drift": True, "detail": detail, "fix": fix}
+
+
+def _clean() -> dict:
+    return {"drift": False}
+
+
+def _clean_env(extra: dict | None = None) -> dict:
+    base = {k: v for k, v in os.environ.items() if k != "VEXJOY_DRIFT_GUARD_DISABLE"}
+    if extra:
+        base.update(extra)
+    return base
+
+
+def _run(stdin_payload: str, *, env: dict | None = None, diff=None, check_results=None):
+    """Invoke mod.main() in-process.
+
+    Returns (exit_code, stdout_str, stderr_str).
+
+    diff:          if not None, patches _working_tree_diff to return it.
+    check_results: if not None, patches _run_check. May be:
+                     - a dict mapping check-name -> result dict (per-check control), or
+                     - a single result dict applied to whatever check is invoked, or
+                     - a list capturing call order (see _CheckSpy below).
+    """
+    out, err = io.StringIO(), io.StringIO()
+    with ExitStack() as stack:
+        stack.enter_context(patch.dict(os.environ, _clean_env(env), clear=True))
+        stack.enter_context(patch.object(mod, "read_stdin", return_value=stdin_payload))
+        stack.enter_context(redirect_stdout(out))
+        stack.enter_context(redirect_stderr(err))
+        if diff is not None:
+            stack.enter_context(patch.object(mod, "_working_tree_diff", return_value=diff))
+        if check_results is not None:
+            if isinstance(check_results, dict) and not _looks_like_result(check_results):
+                # name -> result mapping
+                def fake(name, cwd, _map=check_results):
+                    return _map.get(name, _clean())
+
+                stack.enter_context(patch.object(mod, "_run_check", side_effect=fake))
+            elif callable(check_results):
+                stack.enter_context(patch.object(mod, "_run_check", side_effect=check_results))
+            else:
+                stack.enter_context(patch.object(mod, "_run_check", return_value=check_results))
+        code = 0
+        try:
+            mod.main()
+        except SystemExit as e:
+            code = int(e.code) if e.code is not None else 0
+    return code, out.getvalue(), err.getvalue()
+
+
+def _looks_like_result(d: dict) -> bool:
+    """Distinguish a single result dict from a name->result mapping."""
+    return "drift" in d
+
+
+class _CheckSpy:
+    """Records which checks _run_check was asked to run (relevance-gate assertions)."""
+
+    def __init__(self, results: dict | None = None):
+        self.calls: list[str] = []
+        self.results = results or {}
+
+    def __call__(self, name, cwd):
+        self.calls.append(name)
+        return self.results.get(name, _clean())
+
+
+def _rewake_summary(stdout_str: str) -> str | None:
+    for line in stdout_str.strip().splitlines():
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if "rewakeSummary" in data:
+            return data["rewakeSummary"]
+    return None
+
+
+def _is_deny(stdout_str: str) -> bool:
+    for line in stdout_str.strip().splitlines():
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if data.get("hookSpecificOutput", {}).get("permissionDecision") == "deny":
+            return True
+    return False
+
+
+# Canonical check names the hook is expected to use as _run_check(name, cwd) keys.
+SMOKE = "smoke-test-hooks"
+DOC_COUNTS = "validate-doc-counts"
+ROUTING = "check-routing-drift"
+
+
+# ---------------------------------------------------------------------------
+# 1 + 2. Relevance gate: which check runs for which changed path class
+# ---------------------------------------------------------------------------
+
+
+class TestRelevanceGate:
+    def test_hooks_change_runs_only_smoke_test(self):
+        spy = _CheckSpy()
+        with patch.object(mod, "_run_check", side_effect=spy):
+            _run(_stop_event(), diff=_diff_for("hooks/foo.py"))
+        assert SMOKE in spy.calls
+        assert ROUTING not in spy.calls
+
+    def test_skills_frontmatter_change_runs_routing_check(self):
+        spy = _CheckSpy()
+        with patch.object(mod, "_run_check", side_effect=spy):
+            _run(_stop_event(), diff=_diff_for("skills/foo/SKILL.md", added="name: foo"))
+        assert ROUTING in spy.calls
+        assert SMOKE not in spy.calls
+
+    def test_agents_frontmatter_change_runs_routing_check(self):
+        spy = _CheckSpy()
+        with patch.object(mod, "_run_check", side_effect=spy):
+            _run(_stop_event(), diff=_diff_for("agents/bar.md", added="description: x"))
+        assert ROUTING in spy.calls
+        # Relevance gate is exclusive: an agents-only modification (no add/remove,
+        # no count-claim) must NOT drag in the other checks.
+        assert SMOKE not in spy.calls
+        assert DOC_COUNTS not in spy.calls
+
+    def test_new_hook_file_runs_doc_counts(self):
+        """Adding a component file (new hook) flips the count claims -> doc-counts."""
+        spy = _CheckSpy()
+        with patch.object(mod, "_run_check", side_effect=spy):
+            _run(_stop_event(), diff=_diff_for("hooks/new_hook.py", new_file=True))
+        assert DOC_COUNTS in spy.calls
+        # A new hook file is under hooks/, so smoke-test is also legitimately
+        # relevant — but routing (skills/agents frontmatter) must NOT run.
+        assert ROUTING not in spy.calls
+
+    def test_removed_component_runs_doc_counts(self):
+        spy = _CheckSpy()
+        with patch.object(mod, "_run_check", side_effect=spy):
+            _run(_stop_event(), diff=_deletion_diff_for("scripts/old.py"))
+        assert DOC_COUNTS in spy.calls
+        # A scripts/ removal touches neither the hooks/ smoke surface nor
+        # skills/agents frontmatter — those checks must NOT run.
+        assert SMOKE not in spy.calls
+        assert ROUTING not in spy.calls
+
+    def test_count_claim_doc_touched_runs_doc_counts(self):
+        spy = _CheckSpy()
+        with patch.object(mod, "_run_check", side_effect=spy):
+            _run(_stop_event(), diff=_diff_for("README.md", added="The toolkit ships 80 hooks."))
+        assert DOC_COUNTS in spy.calls
+        # A count-claim doc touch is doc-counts ONLY — no component file changed,
+        # so neither smoke-test nor routing should run.
+        assert SMOKE not in spy.calls
+        assert ROUTING not in spy.calls
+
+    def test_unrelated_change_runs_no_checks(self):
+        """A diff touching none of the component classes runs nothing and stays silent."""
+        spy = _CheckSpy()
+        with patch.object(mod, "_run_check", side_effect=spy):
+            code, out, _ = _run(_stop_event(), diff=_diff_for("notes/scratch.txt"))
+        assert spy.calls == []
+        assert code == 0
+        assert _rewake_summary(out) is None
+
+    def test_empty_diff_runs_no_checks_and_is_silent(self):
+        spy = _CheckSpy()
+        with patch.object(mod, "_run_check", side_effect=spy):
+            code, out, _ = _run(_stop_event(), diff="")
+        assert spy.calls == []
+        assert code == 0
+        assert _rewake_summary(out) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Surface output ONLY on REAL drift — clean session stays silent
+# ---------------------------------------------------------------------------
+
+
+class TestSurfaceOnlyOnRealDrift:
+    def test_clean_check_stays_silent(self):
+        """Relevant files changed, but the check reports NO drift -> exit 0, silent."""
+        code, out, err = _run(
+            _stop_event(),
+            diff=_diff_for("hooks/foo.py"),
+            check_results={SMOKE: _clean()},
+        )
+        assert code == 0
+        assert _rewake_summary(out) is None
+
+    def test_real_drift_triggers_rewake(self):
+        code, out, err = _run(
+            _stop_event(),
+            diff=_diff_for("hooks/foo.py"),
+            check_results={SMOKE: _drift("hook crashed", "python3 scripts/smoke-test-hooks.py --ci")},
+        )
+        assert code == 2
+        assert _rewake_summary(out) is not None
+
+    def test_rewake_message_names_drift_and_fix_command(self):
+        code, out, err = _run(
+            _stop_event(),
+            diff=_diff_for("README.md", added="80 hooks"),
+            check_results={DOC_COUNTS: _drift("README.md count claim stale", "validate-doc-counts.py --json")},
+        )
+        assert code == 2
+        assert "README.md count claim stale" in err
+        assert "validate-doc-counts.py --json" in err
+
+    def test_changed_files_alone_do_not_trigger(self):
+        """ADR criterion 3: drift surfaces because a check REPORTS drift, not merely
+        because files changed. All relevant checks clean -> silent even with edits."""
+        code, out, _ = _run(
+            _stop_event(),
+            diff=_diff_for("skills/x/SKILL.md", added="name: x"),
+            check_results={ROUTING: _clean()},
+        )
+        assert code == 0
+        assert _rewake_summary(out) is None
+
+    def test_one_drift_among_several_checks_surfaces(self):
+        """A diff that triggers two checks where exactly one reports drift -> rewake,
+        and the surfaced message reflects the drifting check only."""
+        # New hook file under hooks/ triggers BOTH smoke-test and doc-counts.
+        diff = _diff_for("hooks/new_hook.py", new_file=True)
+        results = {SMOKE: _clean(), DOC_COUNTS: _drift("80 vs 79 hooks", "fix the count")}
+        code, out, err = _run(_stop_event(), diff=diff, check_results=results)
+        assert code == 2
+        assert "80 vs 79 hooks" in err
+
+
+# ---------------------------------------------------------------------------
+# 6. Advisory only — never a blocking permissionDecision
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryNeverBlocks:
+    def test_drift_emits_rewake_not_deny(self):
+        code, out, _ = _run(
+            _stop_event(),
+            diff=_diff_for("hooks/foo.py"),
+            check_results={SMOKE: _drift()},
+        )
+        assert not _is_deny(out)
+        # async_rewake contract: exit 2 + a rewakeSummary line, context on stderr.
+        assert code == 2
+        assert _rewake_summary(out) is not None
+
+    def test_stop_hook_active_skips(self):
+        """asyncRewake recursion guard: an in-flight rewake must not re-fire."""
+        code, out, _ = _run(
+            _stop_event(stop_hook_active=True),
+            diff=_diff_for("hooks/foo.py"),
+            check_results={SMOKE: _drift()},
+        )
+        assert code == 0
+        assert _rewake_summary(out) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Dedup via DiffDedup (module-level _STATE_DIR / _STATE_FILE)
+# ---------------------------------------------------------------------------
+
+
+class TestDedup:
+    def test_identical_diff_short_circuits(self, tmp_path):
+        state_file = tmp_path / "last-diff-hash.json"
+        diff = _diff_for("hooks/foo.py")
+        results = {SMOKE: _drift()}
+        with patch.object(mod, "_STATE_DIR", tmp_path), patch.object(mod, "_STATE_FILE", state_file):
+            code1, out1, _ = _run(_stop_event(), diff=diff, check_results=results)
+            assert code1 == 2
+            assert state_file.exists()
+            code2, out2, _ = _run(_stop_event(), diff=diff, check_results=results)
+            assert code2 == 0
+            assert _rewake_summary(out2) is None
+
+    def test_changed_diff_re_triggers(self, tmp_path):
+        state_file = tmp_path / "last-diff-hash.json"
+        results = {SMOKE: _drift()}
+        with patch.object(mod, "_STATE_DIR", tmp_path), patch.object(mod, "_STATE_FILE", state_file):
+            code1, _, _ = _run(_stop_event(), diff=_diff_for("hooks/a.py"), check_results=results)
+            code2, out2, _ = _run(_stop_event(), diff=_diff_for("hooks/b.py"), check_results=results)
+            assert code1 == 2
+            assert code2 == 2
+            assert _rewake_summary(out2) is not None
+
+
+# ---------------------------------------------------------------------------
+# 7. Disable switch
+# ---------------------------------------------------------------------------
+
+
+class TestDisableSwitch:
+    def test_disable_env_suppresses_everything(self):
+        """VEXJOY_DRIFT_GUARD_DISABLE=1 wins even over a drift-reporting check."""
+        spy = _CheckSpy(results={SMOKE: _drift()})
+        with patch.object(mod, "_run_check", side_effect=spy):
+            code, out, _ = _run(
+                _stop_event(),
+                env={"VEXJOY_DRIFT_GUARD_DISABLE": "1"},
+                diff=_diff_for("hooks/foo.py"),
+            )
+        assert code == 0
+        assert _rewake_summary(out) is None
+        # Disabled -> short-circuits before running any check.
+        assert spy.calls == []
+
+    def test_disable_value_zero_does_not_disable(self):
+        code, out, _ = _run(
+            _stop_event(),
+            env={"VEXJOY_DRIFT_GUARD_DISABLE": "0"},
+            diff=_diff_for("hooks/foo.py"),
+            check_results={SMOKE: _drift()},
+        )
+        assert code == 2
+        assert _rewake_summary(out) is not None
+
+
+# ---------------------------------------------------------------------------
+# 5. Fail-open on any error / malformed input / unrelated events
+# ---------------------------------------------------------------------------
+
+
+class TestFailOpen:
+    def test_malformed_stdin_exits_0(self):
+        code, out, _ = _run("not valid json {{{")
+        assert code == 0
+        assert _rewake_summary(out) is None
+
+    def test_empty_stdin_exits_0(self):
+        code, out, _ = _run("")
+        assert code == 0
+
+    def test_non_dict_json_exits_0(self):
+        code, out, _ = _run("[1, 2, 3]")
+        assert code == 0
+
+    def test_non_stop_event_exits_0_silently(self):
+        code, out, _ = _run(json.dumps({"hook_event_name": "PostToolUse", "tool_name": "Write"}))
+        assert code == 0
+        assert _rewake_summary(out) is None
+
+    def test_check_raising_fails_open(self):
+        """If a check seam raises, the hook swallows it and exits 0 (never crash)."""
+
+        def boom(name, cwd):
+            raise RuntimeError("scanner exploded")
+
+        code, out, _ = _run(_stop_event(), diff=_diff_for("hooks/foo.py"), check_results=boom)
+        assert code == 0
+        assert _rewake_summary(out) is None
+
+    def test_diff_helper_raising_fails_open(self):
+        with patch.object(mod, "_working_tree_diff", side_effect=OSError("git gone")):
+            code, out, _ = _run(_stop_event())
+        assert code == 0
+        assert _rewake_summary(out) is None
+
+    def test_check_returns_none_treated_as_no_drift(self):
+        """A check that returns None (couldn't run) fails open: no drift surfaced."""
+        code, out, _ = _run(
+            _stop_event(),
+            diff=_diff_for("hooks/foo.py"),
+            check_results={SMOKE: None},
+        )
+        assert code == 0
+        assert _rewake_summary(out) is None
+
+
+# ---------------------------------------------------------------------------
+# Fix (3): the has_reviewable_content gate is honored.
+#
+# A relevant diff (added content in a component class) must PASS the gate so the
+# relevant check runs. A diff with no reviewable content must SHORT-CIRCUIT the
+# hook before any check is invoked. The hook exposes `_has_reviewable_content`
+# (its own gate over hook_utils.has_reviewable_content); these tests pin both
+# directions of that gate.
+# ---------------------------------------------------------------------------
+
+
+class TestReviewableContentGate:
+    def test_relevant_diff_passes_reviewable_gate_and_runs_check(self):
+        """A real diff with reviewable content clears the gate and reaches a check."""
+        spy = _CheckSpy()
+        seen = []
+        real_gate = mod._has_reviewable_content
+
+        def spy_gate(diff):
+            result = real_gate(diff)
+            seen.append(result)
+            return result
+
+        with (
+            patch.object(mod, "_has_reviewable_content", side_effect=spy_gate),
+            patch.object(mod, "_run_check", side_effect=spy),
+        ):
+            _run(_stop_event(), diff=_diff_for("hooks/foo.py"))
+        # Gate was consulted and returned True; a check ran behind it.
+        assert seen == [True]
+        assert spy.calls != []
+
+    def test_no_reviewable_content_short_circuits_before_any_check(self):
+        """When the gate reports nothing reviewable, no check is ever invoked."""
+        spy = _CheckSpy(results={SMOKE: _drift()})
+        with (
+            patch.object(mod, "_has_reviewable_content", return_value=False),
+            patch.object(mod, "_run_check", side_effect=spy),
+        ):
+            code, out, _ = _run(_stop_event(), diff=_diff_for("hooks/foo.py"))
+        assert spy.calls == []
+        assert code == 0
+        assert _rewake_summary(out) is None


### PR DESCRIPTION
## What

A new advisory **Stop** hook `hooks/stop-drift-guard.py` that catches three classes of self-inflicted toolkit regression the moment they're introduced (at Stop), instead of at CI.

It computes the working-tree diff, determines which component classes changed, and runs **only** the one relevant existing check:

| Changed | Check |
|---|---|
| `hooks/**` | `smoke-test-hooks.py --ci` |
| component add/remove under `hooks\|skills\|agents\|scripts`, or a count-claim doc (`README.md`, `CLAUDE.md`, `docs/**`) | `validate-doc-counts.py --json` |
| `skills/**` or `agents/**` frontmatter | `check-routing-drift.py` |

Output surfaces **only when a check actually REPORTS drift** (a clean session stays silent), via `hook_utils.async_rewake` (exit 2 + `rewakeSummary`).

## Correctness properties (security-adjacent infra)

- **Never blocks** — no `permissionDecision:deny` path anywhere; advisory rewake only.
- **Fail-open** — any internal error -> exit 0, skip. A crashed/raising check or diff helper never stalls the session.
- **Dedup** — `hook_utils.DiffDedup` with its own state dir `~/.claude/state/stop-drift-guard/`; an unchanged diff doesn't re-nag.
- **Recursion guard** — honors `stop_hook_active`.
- **Kill switch** — `VEXJOY_DRIFT_GUARD_DISABLE=1` (and only exact `"1"`).

Models `hooks/security-review-hook.py`; reuses `working_tree_diff` / `DiffDedup` / `async_rewake` from `hook_utils`. Registered in `.claude/settings.json` Stop array immediately after `security-review-hook`.

## Seams exposed (patched by tests)

`read_stdin`, `_working_tree_diff(cwd)`, `_has_reviewable_content(diff)`, `_run_check(name, cwd)` (keys: `smoke-test-hooks`, `validate-doc-counts`, `check-routing-drift`), `_STATE_DIR`, `_STATE_FILE`, `main()`.

## Tests — TDD RED -> GREEN

`hooks/tests/test_stop_drift_guard.py`: **28 tests** (RED was a clean `FileNotFoundError` collection error; GREEN = 28 passing). Adversarial-review fixes applied: exclusion asserts on the relevance-gate tests, `_run_check` seam pinned, and a `has_reviewable_content` gate test (both directions). `hooks/tests/conftest.py` isolates per-hook dedup state across tests.

## Doc-count drift (the guard's own premise)

Adding this hook bumps the hook count 78 -> 79; `README.md` count claim updated accordingly. `validate-doc-counts.py --json` is clean (`drifts: []`).

## Dogfood (deployed hook, exit/stdout/stderr asserted)

| Scenario | Exit | Surfaced? |
|---|---|---|
| Drift (hooks/ + smoke drift) | 2 | yes (summary + fix on stderr) |
| Drift (real validate-doc-counts, temp repo) | 2 | yes |
| Clean (relevant change, check clean) | 0 | silent |
| Irrelevant diff | 0 | silent, no check run |
| Empty diff | 0 | silent |
| Dedup (2nd identical diff) | 2 -> 0 | 2nd silent |
| Disable=1 | 0 | silent, no check run |
| Fail-open malformed stdin | 0 | silent |
| Fail-open raising check | 0 | silent |