### PR TITLE
feat(workflow): skill-attach + meta.contract conformance gate (Stages 0-1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,11 @@ jobs:
       - run: python scripts/validate-doc-counts.py
       - run: python scripts/validate-doc-commands.py
       - run: python scripts/validate_component_models.py
+      # Conformance gate for native .js workflows: declared meta.contract vs actual
+      # dispatch. node is not installed in CI, so the STATIC validator is the gate
+      # and the dynamic .mjs harness pass auto-skips (local/dev tool). See
+      # adr/native-fast-path-portable-floor.md Stages 0-1.
+      - run: python scripts/validate-workflow-conformance.py
 
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-This toolkit prevents that. 44 domain agents, 123 workflow skills, 79 hooks, 104 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+This toolkit prevents that. 44 domain agents, 123 workflow skills, 79 hooks, 105 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Factory (`/do`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dev = [
 [tool.ruff]
 line-length = 120
 target-version = "py310"
+# Local-only backup virtualenv (untracked; absent in CI). Exclude its vendored
+# third-party scripts from lint/format so local gate runs stay clean.
+extend-exclude = ["venv.312.bak"]
 
 [tool.ruff.lint]
 select = [

--- a/scripts/conformance-harness.mjs
+++ b/scripts/conformance-harness.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// conformance-harness.mjs — dynamic dispatch recorder for native .js workflows.
+//
+// LOCAL/DEV TOOL (not a CI gate). CI does not provide node (see
+// .github/workflows/test.yml — setup-python only). The CI conformance gate is
+// scripts/validate-workflow-conformance.py (STATIC). This harness is the DYNAMIC
+// half: it runs a target workflow's default() with RECORDING mocks so the
+// data-driven branches (tier-gated waves, per-finding verify, budget-bounded fix
+// loop) actually execute, and records the real dispatch trace — WITHOUT spending
+// tokens, hitting the network, or needing an API key. validate-workflow-
+// conformance.py shells to this harness when node is available and asserts the
+// recorded trace against meta.contract. See adr/native-fast-path-portable-floor.md
+// Stages 0-1.
+//
+// Contract with the runtime it mocks (matches dynamic-workflows-vs-vexjoy-diff.md):
+//   - agent({prompt, schema, model, agentType}) -> records {agentType, skills, phase}
+//     and returns a minimal schema-shaped stub so the workflow body can proceed.
+//   - parallel(thunks) -> Promise.all(thunks.map(t => t()))  (hard barrier)
+//   - pipeline(items, ...stages) -> sequential stage application per item
+//   - phase(title) -> records the entered phase (and tags subsequent agent records)
+//   - budget -> {remaining: () => 1e9, spent: () => 0, total: null}  (never exhausts)
+//   - log(...) -> no-op recorder
+//
+// Usage:
+//   node scripts/conformance-harness.mjs <path-to-workflow.js> [--tiers 2,3,4]
+// Emits to stdout: JSON { workflow, traces: { "<tier>": <trace> }, errors: [...] }
+// where each trace = { phases_entered, agent_count, rosters: [{agentType, skills}] }.
+// Exit 0 on success, 2 on a harness/import error (so the caller can distinguish a
+// recording failure from a conformance mismatch).
+
+import { pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+
+// --- Skill("...") extraction --------------------------------------------------
+// The workflow embeds skill directives in the agent prompt as Skill("name").
+// Extract every such name from a prompt string, preserving order, de-duped.
+const SKILL_RE = /Skill\(\s*["'`]([^"'`]+)["'`]\s*\)/g;
+function extractSkills(prompt) {
+  if (typeof prompt !== "string") return [];
+  const out = [];
+  let m;
+  while ((m = SKILL_RE.exec(prompt)) !== null) {
+    if (!out.includes(m[1])) out.push(m[1]);
+  }
+  return out;
+}
+
+// --- Minimal schema-shaped stub -----------------------------------------------
+// agent() returns a typed object in the real runtime. The workflow body reads
+// fields like .findings / .disposition / .severity. Produce the smallest object
+// that lets every branch proceed deterministically without inventing findings
+// (so the verify/fix loops are entered but terminate — recording the dispatch
+// shape, not simulating a full review).
+function stubForSchema(schema) {
+  const out = {};
+  const props = (schema && schema.properties) || {};
+  const required = (schema && schema.required) || [];
+  for (const key of required) {
+    const spec = props[key] || {};
+    if (spec.type === "array") out[key] = [];
+    else if (spec.type === "object") out[key] = {};
+    else if (spec.enum && spec.enum.length) out[key] = spec.enum[0];
+    else if (spec.type === "number") out[key] = 0;
+    else out[key] = "";
+  }
+  return out;
+}
+
+// --- Recording runtime --------------------------------------------------------
+function makeRuntime() {
+  const records = []; // [{agentType, skills, phase}]
+  const phasesEntered = []; // ordered, de-duped
+  let currentPhase = null;
+
+  globalThis.phase = (title) => {
+    currentPhase = title;
+    if (!phasesEntered.includes(title)) phasesEntered.push(title);
+  };
+  globalThis.log = () => {};
+  globalThis.budget = {
+    remaining: () => 1e9,
+    spent: () => 0,
+    total: null,
+  };
+  globalThis.agent = async ({ prompt, schema, agentType } = {}) => {
+    records.push({
+      agentType: agentType || null,
+      skills: extractSkills(prompt),
+      phase: currentPhase,
+    });
+    return stubForSchema(schema);
+  };
+  globalThis.parallel = (thunks) => Promise.all(thunks.map((t) => t()));
+  globalThis.pipeline = async (items, ...stages) => {
+    const results = [];
+    for (const item of items) {
+      let acc = item;
+      for (const stage of stages) acc = await stage(acc);
+      results.push(acc);
+    }
+    return results;
+  };
+
+  return { records, phasesEntered };
+}
+
+// --- Trace builder ------------------------------------------------------------
+// Roster = the Wave-1 static barrier dispatches, identified as the agent records
+// whose phase is the FIRST entered phase. (Wave-1 is the fixed barrier the
+// contract pins; later phases are dynamic.) Falls back to all agentType-tagged
+// records when no phase was entered.
+function buildTrace(records, phasesEntered) {
+  const firstPhase = phasesEntered[0] || null;
+  const rosterRecords = firstPhase
+    ? records.filter((r) => r.phase === firstPhase && r.agentType)
+    : records.filter((r) => r.agentType);
+  const rosters = rosterRecords.map((r) => ({
+    agentType: r.agentType,
+    skills: r.skills,
+  }));
+  return {
+    phases_entered: phasesEntered,
+    agent_count: records.length,
+    rosters,
+  };
+}
+
+async function recordTier(modUrl, tier) {
+  const { records, phasesEntered } = makeRuntime();
+  const mod = await import(modUrl);
+  const run = mod.default;
+  if (typeof run !== "function") {
+    throw new Error("workflow has no default export function");
+  }
+  // Minimal mock args that exercise the data-driven branches at this tier.
+  await run({
+    scope: { files: ["src/a.py", "src/b.py"], packages: ["pkg"], tier },
+    tier,
+    fixThreshold: 8000,
+  });
+  return buildTrace(records, phasesEntered);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const target = args.find((a) => !a.startsWith("--"));
+  if (!target) {
+    process.stderr.write("usage: conformance-harness.mjs <workflow.js> [--tiers 2,3,4]\n");
+    process.exit(2);
+  }
+  const tiersArg = args.find((a) => a.startsWith("--tiers"));
+  let tiers = [2, 3, 4];
+  if (tiersArg) {
+    const val = tiersArg.includes("=") ? tiersArg.split("=")[1] : args[args.indexOf(tiersArg) + 1];
+    if (val) tiers = val.split(",").map((s) => parseInt(s.trim(), 10)).filter((n) => !Number.isNaN(n));
+  }
+
+  const modUrl = pathToFileURL(resolve(target)).href;
+  const traces = {};
+  const errors = [];
+  for (const tier of tiers) {
+    try {
+      // Fresh module URL per tier so each run re-imports with clean globals.
+      traces[String(tier)] = await recordTier(`${modUrl}?tier=${tier}`, tier);
+    } catch (e) {
+      errors.push({ tier, error: String(e && e.message ? e.message : e) });
+    }
+  }
+
+  process.stdout.write(
+    JSON.stringify({ workflow: resolve(target), traces, errors }, null, 2) + "\n",
+  );
+  process.exit(errors.length > 0 && Object.keys(traces).length === 0 ? 2 : 0);
+}
+
+main().catch((e) => {
+  process.stderr.write(`conformance-harness fatal: ${e && e.stack ? e.stack : e}\n`);
+  process.exit(2);
+});

--- a/scripts/tests/fixtures/conformance/matching.js
+++ b/scripts/tests/fixtures/conformance/matching.js
@@ -1,0 +1,46 @@
+// matching.js — fixture: a minimal native workflow whose meta.contract MATCHES
+// its actual phases / static Wave-1 roster / agentType+Skill tokens. The
+// conformance validator must PASS this file.
+export const meta = {
+  name: "fixture-matching-workflow",
+  description: "minimal conformant fixture",
+  contract: {
+    phases: ["wave-1", "verify"],
+    roster: [
+      { agentType: "reviewer-system", skill: "systematic-code-review" },
+      { agentType: "reviewer-perspectives", skill: "roast" },
+    ],
+    agents: { static: 2, dynamic: false },
+    dynamic: true,
+  },
+};
+
+function enterPhase(title) {
+  if (typeof phase === "function") phase(title);
+}
+
+const WAVE1 = [
+  { agent: "reviewer-system", skill: "systematic-code-review" },
+  { agent: "reviewer-perspectives", skill: "roast" },
+];
+
+export default async function run({ scope, tier } = {}) {
+  enterPhase("wave-1");
+  const wave1 = await parallel(
+    WAVE1.map((r) => () =>
+      agent({
+        prompt:
+          `You are ${r.agent}. Invoke your review methodology by name first: ` +
+          `Skill("${r.skill}"). Scope: ${JSON.stringify(scope)}`,
+        schema: { type: "object", required: ["verdict", "findings"], properties: { verdict: { type: "string", enum: ["APPROVE"] }, findings: { type: "array" } } },
+        agentType: r.agent,
+      }),
+    ),
+  );
+  enterPhase("verify");
+  await agent({
+    prompt: `Adversarially verify. tier=${tier}`,
+    schema: { type: "object", required: ["disposition"], properties: { disposition: { type: "string", enum: ["AGREE"] } } },
+  });
+  return { wave1_count: wave1.length };
+}

--- a/scripts/tests/fixtures/conformance/mismatch-agentcount.js
+++ b/scripts/tests/fixtures/conformance/mismatch-agentcount.js
@@ -1,0 +1,34 @@
+// mismatch-agentcount.js — fixture: meta.contract.agents.static declares 3 static
+// Wave-1 agents and the roster lists 3, but the source's static Wave-1 barrier
+// only dispatches 1 distinct agentType. The conformance validator must FAIL on
+// the STATIC agent-count / roster-coverage check (declared static count does not
+// match the roster length / source agentTypes).
+export const meta = {
+  name: "fixture-mismatch-agentcount",
+  description: "declared static agent count exceeds the actual static roster",
+  contract: {
+    phases: ["wave-1"],
+    roster: [
+      { agentType: "reviewer-system", skill: "systematic-code-review" },
+      { agentType: "reviewer-domain", skill: "systematic-code-review" },
+      { agentType: "reviewer-code", skill: "systematic-code-review" },
+    ],
+    // Declares 3 static agents but the body only dispatches reviewer-system.
+    agents: { static: 3, dynamic: false },
+    dynamic: false,
+  },
+};
+
+function enterPhase(title) {
+  if (typeof phase === "function") phase(title);
+}
+
+export default async function run({ scope } = {}) {
+  enterPhase("wave-1");
+  await agent({
+    prompt: `You are reviewer-system. Skill("systematic-code-review"). ${JSON.stringify(scope)}`,
+    schema: { type: "object", required: ["verdict"], properties: { verdict: { type: "string", enum: ["APPROVE"] } } },
+    agentType: "reviewer-system",
+  });
+  return {};
+}

--- a/scripts/tests/fixtures/conformance/mismatch-phase.js
+++ b/scripts/tests/fixtures/conformance/mismatch-phase.js
@@ -1,0 +1,28 @@
+// mismatch-phase.js — fixture: meta.contract declares a phase ("synthesis") the
+// source never enters, and the source enters a phase ("verify") the contract
+// omits. The conformance validator must FAIL this file on the STATIC phase check.
+export const meta = {
+  name: "fixture-mismatch-phase",
+  description: "phases declared do not match phases entered",
+  contract: {
+    phases: ["wave-1", "synthesis"],
+    roster: [{ agentType: "reviewer-system", skill: "systematic-code-review" }],
+    agents: { static: 1, dynamic: false },
+    dynamic: false,
+  },
+};
+
+function enterPhase(title) {
+  if (typeof phase === "function") phase(title);
+}
+
+export default async function run({ scope } = {}) {
+  enterPhase("wave-1");
+  await agent({
+    prompt: `You are reviewer-system. Skill("systematic-code-review"). ${JSON.stringify(scope)}`,
+    schema: { type: "object", required: ["verdict"], properties: { verdict: { type: "string", enum: ["APPROVE"] } } },
+    agentType: "reviewer-system",
+  });
+  enterPhase("verify"); // entered but NOT in contract.phases -> mismatch
+  return {};
+}

--- a/scripts/tests/fixtures/conformance/mismatch-skill.js
+++ b/scripts/tests/fixtures/conformance/mismatch-skill.js
@@ -1,0 +1,29 @@
+// mismatch-skill.js — fixture: meta.contract.roster declares reviewer-system uses
+// Skill("systematic-code-review"), but the source never emits that Skill token for
+// it (the Skill directive is missing). The conformance validator must FAIL on the
+// STATIC roster/skill check (declared skill absent from source tokens).
+export const meta = {
+  name: "fixture-mismatch-skill",
+  description: "contract roster skill is not present in source",
+  contract: {
+    phases: ["wave-1"],
+    roster: [{ agentType: "reviewer-system", skill: "systematic-code-review" }],
+    agents: { static: 1, dynamic: false },
+    dynamic: false,
+  },
+};
+
+function enterPhase(title) {
+  if (typeof phase === "function") phase(title);
+}
+
+export default async function run({ scope } = {}) {
+  enterPhase("wave-1");
+  await agent({
+    // No Skill("...") token at all — the declared skill is unbacked.
+    prompt: `You are reviewer-system. Review scope: ${JSON.stringify(scope)}`,
+    schema: { type: "object", required: ["verdict"], properties: { verdict: { type: "string", enum: ["APPROVE"] } } },
+    agentType: "reviewer-system",
+  });
+  return {};
+}

--- a/scripts/tests/fixtures/conformance/no-contract.js
+++ b/scripts/tests/fixtures/conformance/no-contract.js
@@ -1,0 +1,11 @@
+// no-contract.js — fixture: a native workflow with meta.name but NO meta.contract.
+// Such a file is prose-only / legacy and is EXEMPT: the conformance validator must
+// SKIP it (not fail it).
+export const meta = {
+  name: "fixture-no-contract",
+  description: "no conformance contract declared — exempt from the gate",
+};
+
+export default async function run() {
+  return {};
+}

--- a/scripts/tests/test_validate_workflow_conformance.py
+++ b/scripts/tests/test_validate_workflow_conformance.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Tests for scripts/validate-workflow-conformance.py — the conformance gate.
+
+A native .js workflow declares a pure-literal ``meta.contract`` (phases, the
+static Wave-1 roster of ``{agentType, skill}``, ``agents:{static,dynamic}``, and a
+top-level ``dynamic`` flag for data-driven passes). The validator asserts the
+actual script against that contract:
+
+- STATIC: ``meta.phases`` titles == ``contract.phases``; the static roster's
+  agentType+skill pairs are present in source ``agentType:``/``Skill("..")``
+  tokens; the declared static agent count matches the roster.
+- DYNAMIC (only when node is available): shells to conformance-harness.mjs and
+  asserts the recorded trace (phases entered subset of contract.phases; static
+  Wave-1 roster agentType+skills) against the contract. For ``dynamic:true``
+  rosters it asserts SHAPE + SKILLS, not COUNT (honest limits).
+
+Files WITHOUT a ``meta.contract`` are EXEMPT (skipped), not failed.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "validate-workflow-conformance.py"
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "conformance"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REAL_WORKFLOW_DIR = REPO_ROOT / "skills" / "workflow" / "references"
+
+# Import the module for unit-level tests of the static checker.
+sys.path.insert(0, str(SCRIPT.parent))
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location("validate_workflow_conformance", SCRIPT)
+vwc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(vwc)
+
+NODE = shutil.which("node")
+
+
+def _run_json(*paths_or_flags):
+    """Run the validator CLI with --json over given dir/flags; return (rc, data)."""
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", *paths_or_flags],
+        capture_output=True,
+        text=True,
+    )
+    data = json.loads(proc.stdout) if proc.stdout.strip() else {}
+    return proc.returncode, data
+
+
+def _result_for(data, name_substr):
+    """Find the per-file result whose path contains name_substr."""
+    for r in data["files"]:
+        if name_substr in r["file"]:
+            return r
+    raise AssertionError(f"no result for {name_substr} in {[r['file'] for r in data['files']]}")
+
+
+# --- STATIC: pure parser unit tests ------------------------------------------
+
+
+def test_extract_contract_present():
+    src = (FIXTURES / "matching.js").read_text()
+    contract = vwc.extract_contract(src)
+    assert contract is not None
+    assert contract["phases"] == ["wave-1", "verify"]
+    assert contract["agents"]["static"] == 2
+
+
+def test_extract_contract_absent_is_none():
+    src = (FIXTURES / "no-contract.js").read_text()
+    assert vwc.extract_contract(src) is None
+
+
+def test_extract_phase_titles_from_source():
+    src = (FIXTURES / "matching.js").read_text()
+    assert vwc.extract_phase_titles(src) == {"wave-1", "verify"}
+
+
+def test_extract_skill_tokens_from_source():
+    src = (FIXTURES / "matching.js").read_text()
+    skills = vwc.extract_skill_tokens(src)
+    assert "systematic-code-review" in skills
+    assert "roast" in skills
+
+
+def test_count_agent_callsites():
+    src = (FIXTURES / "matching.js").read_text()
+    # matching.js dispatches agent() twice (wave-1 map + verify).
+    assert vwc.count_agent_callsites(src) == 2
+
+
+# --- STATIC: pass / fail matrix via the CLI ----------------------------------
+
+
+def test_matching_fixture_passes():
+    rc, data = _run_json("--dir", str(FIXTURES), "--static-only")
+    res = _result_for(data, "matching.js")
+    assert res["status"] == "pass", res
+    # matching.js itself passes; rc reflects whole-dir (which includes mismatches).
+
+
+def test_mismatch_phase_fails():
+    rc, data = _run_json("--dir", str(FIXTURES), "--static-only")
+    res = _result_for(data, "mismatch-phase.js")
+    assert res["status"] == "fail"
+    assert any("phase" in e.lower() for e in res["static_errors"]), res["static_errors"]
+    assert rc != 0
+
+
+def test_mismatch_skill_fails():
+    rc, data = _run_json("--dir", str(FIXTURES), "--static-only")
+    res = _result_for(data, "mismatch-skill.js")
+    assert res["status"] == "fail"
+    assert any("skill" in e.lower() for e in res["static_errors"]), res["static_errors"]
+
+
+def test_mismatch_agentcount_fails():
+    rc, data = _run_json("--dir", str(FIXTURES), "--static-only")
+    res = _result_for(data, "mismatch-agentcount.js")
+    assert res["status"] == "fail"
+    assert any("count" in e.lower() or "roster" in e.lower() or "static" in e.lower() for e in res["static_errors"]), (
+        res["static_errors"]
+    )
+
+
+def test_no_contract_is_exempt():
+    rc, data = _run_json("--dir", str(FIXTURES), "--static-only")
+    res = _result_for(data, "no-contract.js")
+    assert res["status"] == "exempt"
+
+
+def test_dir_with_any_failure_exits_nonzero():
+    rc, _ = _run_json("--dir", str(FIXTURES), "--static-only")
+    assert rc != 0  # fixtures dir contains deliberate mismatches
+
+
+# --- The real hardened workflow MUST conform (static) ------------------------
+
+
+def test_real_comprehensive_review_workflow_passes_static():
+    rc, data = _run_json("--dir", str(REAL_WORKFLOW_DIR), "--static-only")
+    res = _result_for(data, "comprehensive-review-workflow.js")
+    assert res["status"] == "pass", res
+    assert rc == 0, data
+
+
+# --- DYNAMIC: only when node is available ------------------------------------
+
+
+@pytest.mark.skipif(NODE is None, reason="node not available; dynamic harness is a local/dev tool")
+def test_matching_fixture_passes_dynamic():
+    rc, data = _run_json("--dir", str(FIXTURES))
+    res = _result_for(data, "matching.js")
+    assert res["status"] == "pass", res
+    assert res.get("dynamic_ran") is True
+
+
+@pytest.mark.skipif(NODE is None, reason="node not available; dynamic harness is a local/dev tool")
+def test_real_workflow_dynamic_trace_matches_contract():
+    rc, data = _run_json("--dir", str(REAL_WORKFLOW_DIR))
+    res = _result_for(data, "comprehensive-review-workflow.js")
+    assert res["status"] == "pass", res
+    assert res.get("dynamic_ran") is True
+    assert not res["dynamic_errors"], res["dynamic_errors"]
+
+
+def test_node_absent_skips_dynamic_gracefully(monkeypatch):
+    """When node is unavailable the dynamic pass is skipped, not failed."""
+    # Force the 'node missing' path regardless of host.
+    monkeypatch.setattr(vwc, "node_available", lambda: False)
+    results = vwc.validate_dir(FIXTURES / "matching.js", static_only=False)
+    res = results[0]
+    assert res["status"] == "pass"
+    assert res["dynamic_ran"] is False
+    assert any("node" in n.lower() for n in res["notes"]), res["notes"]
+
+
+# --- Honest-limits surface ---------------------------------------------------
+
+
+def test_output_labels_count_vs_shape_checks():
+    """The validator must say which checks are COUNT vs SHAPE+SKILLS."""
+    rc, data = _run_json("--dir", str(FIXTURES), "--static-only")
+    res = _result_for(data, "matching.js")
+    blob = json.dumps(res).lower()
+    assert "count" in blob and ("shape" in blob or "skills" in blob), res

--- a/scripts/validate-workflow-conformance.py
+++ b/scripts/validate-workflow-conformance.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Conformance gate for native .js workflows: declared contract vs actual dispatch.
+
+A native Workflow ``.js`` may declare a pure-literal ``meta.contract`` describing
+the dispatch shape it promises:
+
+    contract: {
+      phases: ["wave-1", ...],                 // phase() titles entered
+      roster: [{agentType, skill}, ...],       // the FIXED (static) Wave-1 barrier
+      agents: { static: <N>, dynamic: <bool> },// fixed barrier size
+      dynamic: <bool>,                          // data-driven passes present?
+    }
+
+This script asserts the actual script against that contract, in two layers:
+
+* STATIC (pure stdlib, always runs, the CI gate):
+  - ``meta.phases`` (the phase()/enterPhase() titles in source) == ``contract.phases``
+  - every ``contract.roster`` agentType is dispatched in source (``agentType:`` token)
+  - every ``contract.roster`` skill appears as a ``Skill("..")`` token in source
+  - ``contract.agents.static`` == ``len(contract.roster)`` (the fixed barrier size),
+    and there are at least that many ``agent(`` call-sites
+* DYNAMIC (shells to scripts/conformance-harness.mjs IF node is available):
+  - every recorded ``phases_entered`` (per tier) is a subset of ``contract.phases``
+  - the recorded static Wave-1 roster (agentType + skills) matches ``contract.roster``
+  - for ``dynamic:true`` it asserts SHAPE + SKILLS, NOT COUNT (honest limit) and
+    says so in the output.
+
+Honest limits, no silent caps: the STATIC pass COUNT-checks only the fixed Wave-1
+barrier (``contract.agents.static``). For ``dynamic:true`` workflows the per-finding
+verify pass and the budget-bounded fix loop fan out over RUNTIME data and are NOT
+count-checked — only their SHAPE and SKILLS are asserted. Each result records which
+checks were COUNT vs SHAPE+SKILLS.
+
+node availability: CI does not provide node (.github/workflows/test.yml uses
+setup-python only). When node is absent the DYNAMIC pass is SKIPPED (recorded as a
+note), NOT failed — the STATIC pass is the CI gate. The .mjs harness is a documented
+local/dev tool. See adr/native-fast-path-portable-floor.md Stages 0-1.
+
+Files WITHOUT a ``meta.contract`` are EXEMPT (prose-only / legacy) — skipped, not
+failed.
+
+Pure stdlib. Exit 0 when every contracted file passes (and exempt files are
+skipped); exit 1 on any conformance mismatch; exit 2 on a usage error.
+
+Usage:
+    python3 scripts/validate-workflow-conformance.py            # default dir
+    python3 scripts/validate-workflow-conformance.py --json
+    python3 scripts/validate-workflow-conformance.py --static-only
+    python3 scripts/validate-workflow-conformance.py --dir <dir-or-file>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DIR = REPO_ROOT / "skills" / "workflow" / "references"
+HARNESS = REPO_ROOT / "scripts" / "conformance-harness.mjs"
+
+# --- meta / contract parsing --------------------------------------------------
+# meta.name is parsed by workflow-registry.py with a non-greedy first-`}` match;
+# the contract is a NESTED literal, so we brace-match the `contract: { ... }`
+# sub-block explicitly instead of relying on a non-greedy regex.
+
+_CONTRACT_KEY = re.compile(r"\bcontract\s*:\s*\{")
+# phase("..") OR enterPhase("..") with a STRING-LITERAL title (the defensive
+# wrapper enterPhase(title) calls phase(title) with a variable — skip those).
+_PHASE_CALL = re.compile(r"""(?:enterPhase|phase)\(\s*["'`]([^"'`$]+)["'`]""")
+_AGENT_TYPE = re.compile(r"""\bagentType\s*:\s*["'`]([^"'`$]+)["'`]""")
+# Literal `agent: "name"` roster-declaration fields (agentType reaches dispatch
+# via a variable r.agent; the literal names live in the roster array).
+_AGENT_FIELD = re.compile(r"""\bagent\s*:\s*["'`]([^"'`$]+)["'`]""")
+# A literal Skill("name") token (name must not be an interpolation placeholder).
+_SKILL_LITERAL = re.compile(r"""\bSkill\(\s*["'`]([^"'`$]+)["'`]\s*\)""")
+# Any Skill( directive at all — proves the skill-attach wiring is emitted, even
+# when the name is template-interpolated (Skill("${roster.skill}")).
+_SKILL_DIRECTIVE = re.compile(r"\bSkill\(")
+# Literal `skill: "name"` values declared on roster entries / maps in source.
+_SKILL_FIELD = re.compile(r"""\bskill\s*:\s*["'`]([^"'`$]+)["'`]""")
+# Quoted string values inside an AGENT_SKILL-style map (key: "value").
+_MAP_VALUE = re.compile(r"""["'`][\w.\-/]+["'`]\s*:\s*["'`]([^"'`$]+)["'`]""")
+_AGENT_CALL = re.compile(r"\bagent\(")
+
+
+def _match_braced_block(source: str, open_brace_idx: int) -> str | None:
+    """Return the text between the matched braces starting at *open_brace_idx*.
+
+    *open_brace_idx* points at the ``{``. Returns the inner text (excluding the
+    outer braces), brace-matched, ignoring braces inside strings. Never raises.
+    """
+    try:
+        depth = 0
+        i = open_brace_idx
+        n = len(source)
+        in_str = None
+        start_inner = open_brace_idx + 1
+        while i < n:
+            ch = source[i]
+            if in_str:
+                if ch == "\\":
+                    i += 2
+                    continue
+                if ch == in_str:
+                    in_str = None
+            elif ch in "\"'`":
+                in_str = ch
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return source[start_inner:i]
+            i += 1
+        return None
+    except Exception:
+        return None
+
+
+def _js_object_to_json(text: str) -> str:
+    """Best-effort convert a JS object-literal body to JSON-parseable text.
+
+    Handles: unquoted keys, single quotes, trailing commas, line comments. The
+    contract is a pure literal by contract (no calls/variables), so this is
+    sufficient. Never raises (returns text unchanged on trouble).
+    """
+    try:
+        # Strip // line comments (not inside strings — contract has none).
+        no_comments = re.sub(r"//[^\n]*", "", text)
+        # Single -> double quotes for string literals.
+        s = re.sub(r"'([^'\\]*(?:\\.[^'\\]*)*)'", lambda m: json.dumps(m.group(1)), no_comments)
+        # Quote unquoted object keys:  key:  ->  "key":
+        s = re.sub(r"([{,]\s*)([A-Za-z_$][\w$]*)\s*:", r'\1"\2":', s)
+        # Remove trailing commas before } or ].
+        s = re.sub(r",(\s*[}\]])", r"\1", s)
+        return s
+    except Exception:
+        return text
+
+
+def extract_contract(source: str) -> dict | None:
+    """Extract and parse ``meta.contract`` from JS source, or None if absent.
+
+    Never raises. Returns the parsed contract dict, or None when no contract key
+    is present (the file is exempt).
+    """
+    try:
+        km = _CONTRACT_KEY.search(source)
+        if not km:
+            return None
+        open_idx = km.end() - 1  # index of the `{`
+        inner = _match_braced_block(source, open_idx)
+        if inner is None:
+            return None
+        body = "{" + inner + "}"
+        return json.loads(_js_object_to_json(body))
+    except Exception:
+        return None
+
+
+def strip_contract(source: str) -> str:
+    """Return source with the meta.contract block removed.
+
+    The contract is the SPEC being validated; its own literals (roster
+    ``agentType:``/``skill:``, ``phases``) must not count as evidence that the
+    body dispatches them. Never raises — returns source unchanged on trouble.
+    """
+    try:
+        km = _CONTRACT_KEY.search(source)
+        if not km:
+            return source
+        open_idx = km.end() - 1
+        inner = _match_braced_block(source, open_idx)
+        if inner is None:
+            return source
+        # Remove from the `contract` keyword to the matching closing brace.
+        end_idx = open_idx + 1 + len(inner) + 1
+        return source[: km.start()] + source[end_idx:]
+    except Exception:
+        return source
+
+
+_LINE_COMMENT = re.compile(r"//[^\n]*")
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def strip_comments(source: str) -> str:
+    """Remove // line and /* */ block comments. Comments are never evidence that
+    the body dispatches an agent/skill (a comment mentioning Skill("x") proves
+    nothing). Never raises."""
+    try:
+        return _LINE_COMMENT.sub("", _BLOCK_COMMENT.sub("", source))
+    except Exception:
+        return source
+
+
+def evidence_body(source: str) -> str:
+    """Return source stripped of BOTH the contract block and comments — the only
+    text that counts as proof the body actually dispatches what it declares."""
+    return strip_comments(strip_contract(source))
+
+
+def extract_phase_titles(source: str) -> set[str]:
+    """Return the set of phase() titles entered in source (via phase()/enterPhase)."""
+    return set(_PHASE_CALL.findall(source))
+
+
+def extract_agent_types(source: str) -> set[str]:
+    """Return the set of agent names declared/dispatched in source.
+
+    agentType reaches dispatch via a variable (``agentType: r.agent``), so the
+    literal names live in the roster declarations (``agent: "name"``). Collect
+    from both literal ``agentType:`` tokens and ``agent:`` roster fields.
+    """
+    names: set[str] = set()
+    names.update(_AGENT_TYPE.findall(source))
+    names.update(_AGENT_FIELD.findall(source))
+    return names
+
+
+def extract_skill_tokens(source: str) -> set[str]:
+    """Return the set of skill names statically resolvable from source.
+
+    Skill names reach the prompt via a template (``Skill("${roster.skill}")``), so
+    the literal names live in the roster/map declarations, not the prompt string.
+    Collect from: literal ``Skill("name")`` tokens, ``skill: "name"`` fields, and
+    ``"agentType": "name"`` map values (the AGENT_SKILL map). Interpolation
+    placeholders (``${...}``) are excluded by the patterns.
+    """
+    names: set[str] = set()
+    names.update(_SKILL_LITERAL.findall(source))
+    names.update(_SKILL_FIELD.findall(source))
+    names.update(_MAP_VALUE.findall(source))
+    return names
+
+
+def has_skill_directive(source: str) -> bool:
+    """True if source emits a Skill( directive at all (skill-attach wiring present)."""
+    return _SKILL_DIRECTIVE.search(source) is not None
+
+
+def count_agent_callsites(source: str) -> int:
+    """Count agent( call-sites in source."""
+    return len(_AGENT_CALL.findall(source))
+
+
+# --- static validation --------------------------------------------------------
+
+
+def _static_checks(source: str, contract: dict) -> tuple[list[str], list[str]]:
+    """Return (errors, check_labels) for the static layer.
+
+    check_labels names which checks are COUNT vs SHAPE+SKILLS (honest limits).
+    """
+    errors: list[str] = []
+    labels: list[str] = []
+
+    # Evidence comes from the body, NOT the contract block or comments (the
+    # contract is the spec being validated; comments prove nothing).
+    body = evidence_body(source)
+
+    # 1. phases (SHAPE): declared set == entered set.
+    declared_phases = set(contract.get("phases", []))
+    entered_phases = extract_phase_titles(body)
+    labels.append("phases: SHAPE (declared set == phase() titles in source)")
+    if declared_phases != entered_phases:
+        missing = declared_phases - entered_phases
+        extra = entered_phases - declared_phases
+        parts = []
+        if missing:
+            parts.append(f"declared-but-not-entered={sorted(missing)}")
+        if extra:
+            parts.append(f"entered-but-not-declared={sorted(extra)}")
+        errors.append("phase mismatch: " + "; ".join(parts))
+
+    roster = contract.get("roster", [])
+    src_agent_types = extract_agent_types(body)
+    src_skills = extract_skill_tokens(body)
+
+    # 2. roster agentType present in source (SHAPE).
+    labels.append("roster.agentType: SHAPE (each present as agentType: in source)")
+    for entry in roster:
+        at = entry.get("agentType")
+        if at and at not in src_agent_types:
+            errors.append(f"roster agentType '{at}' not dispatched in source (no agentType: token)")
+
+    # 3. roster skill present in source (SKILLS). The skill-attach directive must
+    #    be emitted (Skill( present), and each declared skill must be resolvable
+    #    from source roster/map literals (names reach the prompt via a template).
+    labels.append(
+        "roster.skill: SKILLS (Skill( directive emitted; each skill resolvable from source roster/map literals)"
+    )
+    wiring = has_skill_directive(body)
+    if roster and not wiring:
+        errors.append(
+            "no Skill( directive emitted in source, but contract.roster declares "
+            f"skills {[e.get('skill') for e in roster if e.get('skill')]}"
+        )
+    for entry in roster:
+        sk = entry.get("skill")
+        if sk and sk not in src_skills:
+            errors.append(
+                f"roster skill '{sk}' not resolvable from source "
+                '(no Skill("{sk}") literal, skill: field, or AGENT_SKILL map value)'.replace("{sk}", sk)
+            )
+
+    # 4. fixed Wave-1 barrier size (COUNT — the ONLY count check; static barrier).
+    labels.append("agents.static: COUNT (== len(roster); fixed Wave-1 barrier only)")
+    agents = contract.get("agents", {})
+    static_n = agents.get("static")
+    if static_n is not None and static_n != len(roster):
+        errors.append(
+            f"agents.static={static_n} does not match roster length {len(roster)} "
+            f"(the static Wave-1 barrier must list every fixed agent)"
+        )
+    callsites = count_agent_callsites(body)
+    if static_n is not None and callsites < static_n:
+        errors.append(f"only {callsites} agent( call-sites in source but contract declares {static_n} static agents")
+
+    # 5. Honest-limit note for dynamic passes (SHAPE+SKILLS, NOT COUNT).
+    if contract.get("dynamic"):
+        labels.append(
+            "dynamic passes (Wave-2/3, verify, fix): SHAPE+SKILLS only, NOT COUNT "
+            "(data-driven fan-out is not statically countable)"
+        )
+
+    return errors, labels
+
+
+# --- dynamic validation -------------------------------------------------------
+
+
+def node_available() -> bool:
+    """Return True if a `node` executable is on PATH."""
+    return shutil.which("node") is not None
+
+
+def _run_harness(js_path: Path) -> dict | None:
+    """Shell to conformance-harness.mjs for *js_path*; return parsed JSON or None."""
+    try:
+        proc = subprocess.run(
+            ["node", str(HARNESS), str(js_path), "--tiers", "2,3,4"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if not proc.stdout.strip():
+            return None
+        return json.loads(proc.stdout)
+    except Exception:
+        return None
+
+
+def _dynamic_checks(js_path: Path, contract: dict) -> tuple[list[str], list[str]]:
+    """Return (errors, notes) for the dynamic layer (assumes node available)."""
+    errors: list[str] = []
+    notes: list[str] = []
+
+    harness_out = _run_harness(js_path)
+    if harness_out is None:
+        notes.append("dynamic: harness produced no parseable trace; skipped")
+        return errors, notes
+    if harness_out.get("errors"):
+        for e in harness_out["errors"]:
+            errors.append(f"harness error at tier {e.get('tier')}: {e.get('error')}")
+
+    declared_phases = set(contract.get("phases", []))
+    roster = contract.get("roster", [])
+    expected_roster = [(e.get("agentType"), tuple(sorted([e.get("skill")] if e.get("skill") else []))) for e in roster]
+
+    traces = harness_out.get("traces", {})
+    notes.append(f"dynamic: recorded {len(traces)} tier trace(s): {sorted(traces.keys())}")
+    for tier, trace in traces.items():
+        # phases entered must be a SUBSET of declared (tier-gated phases skip some).
+        entered = set(trace.get("phases_entered", []))
+        if not entered.issubset(declared_phases):
+            errors.append(
+                f"tier {tier}: entered phases {sorted(entered)} not a subset of "
+                f"contract.phases {sorted(declared_phases)}"
+            )
+        # static Wave-1 roster: SHAPE + SKILLS (agentType + its skills), NOT COUNT.
+        recorded_roster = [(r.get("agentType"), tuple(sorted(r.get("skills", [])))) for r in trace.get("rosters", [])]
+        if recorded_roster != expected_roster:
+            errors.append(
+                f"tier {tier}: recorded Wave-1 roster {recorded_roster} != "
+                f"contract.roster (agentType+skills) {expected_roster}"
+            )
+    if contract.get("dynamic"):
+        notes.append(
+            "dynamic: agent_count is data-driven and NOT asserted (honest limit); "
+            "only phase-subset + static Wave-1 roster SHAPE+SKILLS are checked"
+        )
+    return errors, notes
+
+
+# --- per-file + directory orchestration --------------------------------------
+
+
+def validate_file(js_path: Path, static_only: bool = False) -> dict:
+    """Validate a single .js file against its meta.contract. Never raises."""
+    result: dict = {
+        "file": str(js_path),
+        "status": "exempt",
+        "static_errors": [],
+        "dynamic_errors": [],
+        "checks": [],
+        "notes": [],
+        "dynamic_ran": False,
+    }
+    try:
+        source = js_path.read_text(encoding="utf-8", errors="replace")
+    except Exception as exc:
+        result["status"] = "fail"
+        result["static_errors"].append(f"unreadable file: {exc}")
+        return result
+
+    contract = extract_contract(source)
+    if contract is None:
+        result["notes"].append("exempt: no meta.contract (prose-only/legacy)")
+        return result
+
+    static_errors, labels = _static_checks(source, contract)
+    result["static_errors"] = static_errors
+    result["checks"] = labels
+
+    if not static_only:
+        if node_available():
+            dyn_errors, dyn_notes = _dynamic_checks(js_path, contract)
+            result["dynamic_errors"] = dyn_errors
+            result["notes"].extend(dyn_notes)
+            result["dynamic_ran"] = True
+        else:
+            result["notes"].append(
+                "dynamic: node unavailable — DYNAMIC pass skipped (not failed); "
+                "STATIC is the CI gate. The .mjs harness is a local/dev tool."
+            )
+
+    result["status"] = "fail" if (result["static_errors"] or result["dynamic_errors"]) else "pass"
+    return result
+
+
+def validate_dir(path: Path, static_only: bool = False) -> list[dict]:
+    """Validate every .js under *path* (or *path* itself if it is a file)."""
+    if path.is_file():
+        return [validate_file(path, static_only=static_only)]
+    if not path.is_dir():
+        return []
+    return [validate_file(js, static_only=static_only) for js in sorted(path.glob("*.js"))]
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Validate native .js workflows against their meta.contract.")
+    parser.add_argument("--dir", default=str(DEFAULT_DIR), help="directory (or single .js file) to validate")
+    parser.add_argument("--json", action="store_true", help="emit JSON report")
+    parser.add_argument("--static-only", action="store_true", help="skip the dynamic harness pass")
+    args = parser.parse_args(argv)
+
+    target = Path(args.dir)
+    results = validate_dir(target, static_only=args.static_only)
+
+    contracted = [r for r in results if r["status"] != "exempt"]
+    exempt = [r for r in results if r["status"] == "exempt"]
+    failures = [r for r in results if r["status"] == "fail"]
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "target": str(target),
+                    "summary": {
+                        "total": len(results),
+                        "contracted": len(contracted),
+                        "exempt": len(exempt),
+                        "passed": len([r for r in contracted if r["status"] == "pass"]),
+                        "failed": len(failures),
+                    },
+                    "files": results,
+                },
+                indent=2,
+            )
+        )
+    else:
+        for r in results:
+            tag = {"pass": "PASS", "fail": "FAIL", "exempt": "EXEMPT"}[r["status"]]
+            print(f"[{tag}] {r['file']}")
+            for note in r["notes"]:
+                print(f"    note: {note}")
+            for label in r["checks"]:
+                print(f"    check: {label}")
+            for e in r["static_errors"]:
+                print(f"    STATIC ERROR: {e}")
+            for e in r["dynamic_errors"]:
+                print(f"    DYNAMIC ERROR: {e}")
+        s = f"\n{len(contracted)} contracted, {len(exempt)} exempt, {len(failures)} failed."
+        print(s)
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except SystemExit:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"validate-workflow-conformance: {type(exc).__name__}: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/skills/workflow/references/comprehensive-review-workflow.js
+++ b/skills/workflow/references/comprehensive-review-workflow.js
@@ -24,6 +24,43 @@ export const meta = {
   name: "comprehensive-review-workflow",
   description:
     "Four-wave code review as a deterministic native Workflow: tier-scaled waves (right-sizing), schema-validated typed findings per wave, parallel barriers within a wave, pipelined Wave 1 -> Wave 2 hand-off, per-finding adversarial verify before synthesis, and a budget-bounded fix loop. Mirrors comprehensive-review.md; that markdown flow stays the fallback.",
+  // --- Conformance contract (pure literal — no calls/variables; see
+  //     scripts/validate-workflow-conformance.py + adr/native-fast-path-portable-floor.md
+  //     Stages 0-1). This is the declared dispatch shape the conformance gate
+  //     asserts the actual script against. STATIC validation pins phases + the
+  //     fixed Wave-1 barrier (countable). DYNAMIC validation records the real
+  //     dispatch trace and asserts SHAPE + SKILLS, NOT count, where dynamic:true.
+  //     name + description stay BEFORE this nested object so the non-greedy
+  //     meta-name parser in workflow-registry.py still resolves meta.name.
+  contract: {
+    // Phase titles this script enters at runtime via phase(). Order matters.
+    phases: ["wave-1", "wave-2", "wave-3", "verify", "fix"],
+    // Wave-1 is a FIXED barrier: a literal 4-agent roster, every run. Countable.
+    roster: [
+      { agentType: "reviewer-system", skill: "systematic-code-review" },
+      { agentType: "reviewer-domain", skill: "systematic-code-review" },
+      { agentType: "reviewer-code", skill: "systematic-code-review" },
+      { agentType: "reviewer-perspectives", skill: "roast" },
+    ],
+    // The Wave-1 barrier dispatches exactly 4 agents on every run (static).
+    agents: { static: 4, dynamic: false },
+    // Wave-2/3 rosters are literal arrays (countable) but tier-gated, and the
+    // per-finding verify pass + the budget-bounded fix loop fan out over
+    // RUNTIME data (findings.length, budget) — NOT statically countable.
+    // Honest limit: the gate asserts SHAPE + SKILLS for these, not COUNT.
+    dynamic: true,
+  },
+};
+
+// Map each reviewer agent to the methodology skill it invokes by name. Skill-
+// attach inside a native Workflow agent() dispatch resolves by name (path-
+// independent), proven this session. reviewer-{system,domain,code} run the
+// 4-phase systematic review; reviewer-perspectives runs the roast lens.
+const AGENT_SKILL = {
+  "reviewer-system": "systematic-code-review",
+  "reviewer-domain": "systematic-code-review",
+  "reviewer-code": "systematic-code-review",
+  "reviewer-perspectives": "roast",
 };
 
 // --- Wave rosters: the four real reviewer agents, applied through wave-specific
@@ -33,30 +70,33 @@ export const meta = {
 //     rather than inventing nonexistent per-topic agents. This mirrors the
 //     lens-based scheme in comprehensive-review/references/wave-{1,2,3}-*.md. ----
 
+// Each entry now carries BOTH `agent` (-> agentType, dispatches the real
+// specialist) AND `skill` (the methodology that agent invokes by name via
+// Skill("...")). `lens` still scales review depth across waves.
 const WAVE1_AGENTS = [
-  { agent: "reviewer-system", lens: "security, input validation, error handling, API contracts" },
-  { agent: "reviewer-domain", lens: "business logic, edge cases, data integrity, state transitions" },
-  { agent: "reviewer-code", lens: "conventions, naming, dead code, performance, test coverage" },
-  { agent: "reviewer-perspectives", lens: "newcomer clarity, user-advocate, senior-maintainer view" },
+  { agent: "reviewer-system", skill: AGENT_SKILL["reviewer-system"], lens: "security, input validation, error handling, API contracts" },
+  { agent: "reviewer-domain", skill: AGENT_SKILL["reviewer-domain"], lens: "business logic, edge cases, data integrity, state transitions" },
+  { agent: "reviewer-code", skill: AGENT_SKILL["reviewer-code"], lens: "conventions, naming, dead code, performance, test coverage" },
+  { agent: "reviewer-perspectives", skill: AGENT_SKILL["reviewer-perspectives"], lens: "newcomer clarity, user-advocate, senior-maintainer view" },
 ];
 
 // Tier 3 dispatches the deep-dive subset; Tier 4 adds the remaining lenses.
 const WAVE2_SUBSET = [
-  { agent: "reviewer-system", lens: "deep security + concurrency + resource lifecycle" },
-  { agent: "reviewer-domain", lens: "deep correctness + data integrity + migration safety" },
-  { agent: "reviewer-code", lens: "deep performance + error paths + state machines" },
+  { agent: "reviewer-system", skill: AGENT_SKILL["reviewer-system"], lens: "deep security + concurrency + resource lifecycle" },
+  { agent: "reviewer-domain", skill: AGENT_SKILL["reviewer-domain"], lens: "deep correctness + data integrity + migration safety" },
+  { agent: "reviewer-code", skill: AGENT_SKILL["reviewer-code"], lens: "deep performance + error paths + state machines" },
 ];
 
 const WAVE2_FULL = WAVE2_SUBSET.concat([
-  { agent: "reviewer-system", lens: "API-contract compatibility + observability gaps" },
-  { agent: "reviewer-perspectives", lens: "senior-maintainer + meta-process review" },
+  { agent: "reviewer-system", skill: AGENT_SKILL["reviewer-system"], lens: "API-contract compatibility + observability gaps" },
+  { agent: "reviewer-perspectives", skill: AGENT_SKILL["reviewer-perspectives"], lens: "senior-maintainer + meta-process review" },
 ]);
 
 const WAVE3_AGENTS = [
-  { agent: "reviewer-perspectives", lens: "contrarian + falsifier: try to break the change" },
-  { agent: "reviewer-system", lens: "adversarial security: assume hostile input everywhere" },
-  { agent: "reviewer-domain", lens: "adversarial assumptions: challenge every invariant" },
-  { agent: "reviewer-code", lens: "simplicity challenge: is this over-engineered?" },
+  { agent: "reviewer-perspectives", skill: AGENT_SKILL["reviewer-perspectives"], lens: "contrarian + falsifier: try to break the change" },
+  { agent: "reviewer-system", skill: AGENT_SKILL["reviewer-system"], lens: "adversarial security: assume hostile input everywhere" },
+  { agent: "reviewer-domain", skill: AGENT_SKILL["reviewer-domain"], lens: "adversarial assumptions: challenge every invariant" },
+  { agent: "reviewer-code", skill: AGENT_SKILL["reviewer-code"], lens: "simplicity challenge: is this over-engineered?" },
 ];
 
 // --- Schemas (mirror skills/shared-patterns/schemas/) -------------------------
@@ -154,14 +194,21 @@ function dedupeFindings(findings) {
 }
 
 function reviewPrompt(roster, scope, priorContext) {
-  // roster is {agent, lens}; priorContext is the typed prior-wave summary passed
-  // in-memory (no disk read).
+  // roster is {agent, skill, lens}; priorContext is the typed prior-wave summary
+  // passed in-memory (no disk read). The skill directive instructs the dispatched
+  // agent to load its methodology by name — Skill("...") resolves path-independent
+  // inside a native Workflow agent() dispatch (proven this session).
   const context = priorContext
     ? `\n\nPrior-wave findings (typed, in-memory):\n${JSON.stringify(priorContext)}`
     : "";
+  const skillDirective = roster.skill
+    ? `\nInvoke your review methodology by name first: Skill("${roster.skill}"). ` +
+      `Run it, then report findings through its structure.`
+    : "";
   return (
-    `You are ${roster.agent}. Apply this review lens: ${roster.lens}.\n` +
-    `Review the changed code for this diff scope:\n` +
+    `You are ${roster.agent}. Apply this review lens: ${roster.lens}.` +
+    skillDirective +
+    `\nReview the changed code for this diff scope:\n` +
     `${JSON.stringify(scope)}\n` +
     `Return only findings within your lens. The only valid dispositions are ` +
     `FIX NOW, FIX IN FOLLOW-UP (with a tracking artifact), or NOT AN ISSUE ` +
@@ -169,6 +216,16 @@ function reviewPrompt(roster, scope, priorContext) {
     `are not valid dispositions. Severity is one of critical|high|medium|low.` +
     context
   );
+}
+
+// Defensive phase marker: the native runtime guarantees agent/parallel/pipeline/
+// budget, but does NOT document a phase() global. Guard the call so the real
+// runtime never throws if phase is absent, while the conformance harness's mock
+// records the entered phase. Phase titles match meta.contract.phases.
+function enterPhase(title) {
+  if (typeof phase === "function") {
+    phase(title);
+  }
 }
 
 // --- Workflow body ------------------------------------------------------------
@@ -185,6 +242,7 @@ export default async function run({ scope, tier, fixThreshold }) {
 
   // Wave 1: foundation. Hard barrier — every foundation agent completes before
   // the wave is considered closed. Failed slots resolve to null and are dropped.
+  enterPhase("wave-1");
   const wave1 = await parallel(
     WAVE1_AGENTS.map((r) => () =>
       agent({
@@ -201,6 +259,7 @@ export default async function run({ scope, tier, fixThreshold }) {
   // finding into a matched deep-dive agent without a disk re-read — agent B
   // can start while agent A is still running.
   if (effectiveTier >= 3) {
+    enterPhase("wave-2");
     const wave2Roster = effectiveTier >= 4 ? WAVE2_FULL : WAVE2_SUBSET;
     const wave2Summary = { findings, source: "wave1" };
     const wave2 = await parallel(
@@ -220,6 +279,7 @@ export default async function run({ scope, tier, fixThreshold }) {
   // CRITICAL is present (escalation safety valve mirrored from the markdown).
   const wave3Required = effectiveTier >= 4 || hasCritical(findings);
   if (wave3Required) {
+    enterPhase("wave-3");
     const wave3Summary = { findings, source: "wave1+2" };
     const wave3 = await parallel(
       WAVE3_AGENTS.map((r) => () =>
@@ -239,6 +299,7 @@ export default async function run({ scope, tier, fixThreshold }) {
   // Per-finding adversarial verify BEFORE synthesis (mirrors the pr-review
   // gated per-finding verify). Each finding gets one challenger; DISMISS drops
   // it from the fix queue. parallel() barriers the whole verify pass.
+  enterPhase("verify");
   const verdicts = await parallel(
     findings.map((f) => () =>
       agent({
@@ -261,6 +322,7 @@ export default async function run({ scope, tier, fixThreshold }) {
   // Phase 4 fix loop, bounded by the native token budget. CRITICAL first.
   // The loop stops when findings are exhausted OR the run-wide budget can no
   // longer afford another fix agent — a hard, replayable spend ceiling.
+  enterPhase("fix");
   const queue = verified.slice();
   const fixes = [];
   const deferred = [];


### PR DESCRIPTION
## What

Proves the "a `.js` workflow runs exactly the agents/phases/skills it declares" loop end-to-end. Implements the **execution limb** (Stages 0–1) of ADR `native-fast-path-portable-floor`. The routing-fork half (Designs A/B/C, `UserPromptSubmit` pre-flight, dropping the Haiku hop) is **NOT** touched — it remains the owner's OPEN DECISIONS.

ADR consultation: PROCEED (all 3 perspectives), recorded locally at `adr/native-fast-path-portable-floor/synthesis.md` (gitignored).

## Stage 0 — harden `comprehensive-review-workflow.js`
- Each roster entry now carries BOTH `agent` (→ agentType) AND `skill`. The dispatched agent is instructed to invoke its methodology by name: `reviewer-{system,domain,code}` → `Skill("systematic-code-review")`, `reviewer-perspectives` → `Skill("roast")`. The `lens` string is kept (it scales depth across waves).
- Phases entered via a **defensive** `enterPhase()` (`typeof phase === "function"` guard — `phase`/`log` are not documented runtime globals, so the real runtime never throws while the harness mock records).
- Declares a pure-literal `meta.contract`: `phases`, Wave-1 `roster:[{agentType,skill}]`, `agents:{static:4,dynamic:false}` (the fixed barrier), and top-level `dynamic:true` (the data-driven passes). `name`/`description` stay BEFORE the nested `contract` so `workflow-registry.py`'s non-greedy meta-name parser still resolves `meta.name` (verified by running it).

## Stage 1 — the conformance gate
- **`scripts/conformance-harness.mjs`** (Node, no deps/network/tokens): sets RECORDING mocks for `agent/parallel/pipeline/phase/log` + a non-exhausting `budget`, `await import()`s the target, runs `default()` for a tier 2/3/4 matrix so data-driven branches execute, and emits a JSON dispatch trace per tier.
- **`scripts/validate-workflow-conformance.py`** (pure stdlib): STATIC (phases == declared; roster agentType+skill present in source evidence; `agents.static` == roster length / call-sites) + optional DYNAMIC (shells to the harness when `node` is available; asserts recorded phases ⊆ contract.phases and the static Wave-1 roster agentType+skills). **Honest limits, no silent caps:** count-checks ONLY the fixed Wave-1 barrier; `dynamic:true` passes assert SHAPE+SKILLS, NOT COUNT — and the output says which check is which. No-contract `.js` files are EXEMPT.
- **Tests:** `scripts/tests/test_validate_workflow_conformance.py` — 16 tests (matching passes; mismatched phase/skill/agent-count fixtures fail with actionable diffs; no-contract exempt; real workflow passes static+dynamic; node-absent skips gracefully).

## node in CI?
**No.** `.github/workflows/test.yml` installs Python only (no `setup-node`). So the **Python STATIC validator is the CI gate** and the `.mjs` DYNAMIC harness is a documented local/dev tool. The validator self-adapts: DYNAMIC when `node` is on PATH, gracefully **skipped (note, not failure)** when absent. CI is never blocked on a missing runtime. Wired into the `lint` job.

## Dogfood (recorded trace vs contract)
Running the validator against the hardened workflow: **PASS, exit 0** — static + dynamic. Recorded trace MATCHES `meta.contract`:
- tier 2 → phases `[wave-1, verify, fix]`; tier 3 adds `wave-2`; tier 4 adds `wave-3` (all ⊆ declared phases)
- Wave-1 roster = the declared 4 `{agentType,skill}` pairs at every tier
- `agent_count` 4/7/13 is data-driven (why count is `dynamic:true`)

Deliberately-mismatched fixtures FAIL (exit 1) with specific diffs.

## Misc
- Doc counts: `scripts/*.py` 104 → 105 (README updated; `validate-doc-counts.py` clean).
- ruff: excluded the local-only `venv.312.bak` backup dir (untracked, absent in CI).

## Verification
- `node --check` both `.js`/`.mjs`: OK
- `python3 scripts/workflow-registry.py --names` still lists `comprehensive-review-workflow`
- `ruff check . --config pyproject.toml` + `ruff format --check`: clean
- `python3 -m pytest scripts/tests/ -q`: 2534 passed, 1 skipped, 75 xfailed