### PR TITLE
feat(workflow): generic fan-out workflow + /do complexity-trigger dispatch (Stage 2)

### DIFF
--- a/scripts/conformance-harness.mjs
+++ b/scripts/conformance-harness.mjs
@@ -21,6 +21,11 @@
 //   - budget -> {remaining: () => 1e9, spent: () => 0, total: null}  (never exhausts)
 //   - log(...) -> no-op recorder
 //
+// The harness calls run({scope, tier, fixThreshold, roster, synthAgentType}). The
+// roster + synthAgentType keys let a FULLY-DYNAMIC workflow (caller-supplied
+// roster, e.g. fan-out-workflow) execute its fan-out; static-roster workflows
+// (e.g. comprehensive-review) ignore the extra keys.
+//
 // Usage:
 //   node scripts/conformance-harness.mjs <path-to-workflow.js> [--tiers 2,3,4]
 // Emits to stdout: JSON { workflow, traces: { "<tier>": <trace> }, errors: [...] }
@@ -133,10 +138,18 @@ async function recordTier(modUrl, tier) {
     throw new Error("workflow has no default export function");
   }
   // Minimal mock args that exercise the data-driven branches at this tier.
+  // A sample roster + synthAgentType lets a FULLY-DYNAMIC workflow (caller-supplied
+  // roster, e.g. fan-out-workflow) run its fan-out; static-roster workflows ignore
+  // these extra keys. fixThreshold bounds any budget loop.
   await run({
     scope: { files: ["src/a.py", "src/b.py"], packages: ["pkg"], tier },
     tier,
     fixThreshold: 8000,
+    roster: [
+      { agentType: "reviewer-system", skill: "systematic-code-review", lens: "security" },
+      { agentType: "reviewer-code", skill: "systematic-code-review", lens: "quality" },
+    ],
+    synthAgentType: "research-coordinator-engineer",
   });
   return buildTrace(records, phasesEntered);
 }

--- a/scripts/tests/fixtures/conformance/dynamic-roster-missing-skill.js
+++ b/scripts/tests/fixtures/conformance/dynamic-roster-missing-skill.js
@@ -1,0 +1,42 @@
+// dynamic-roster-missing-skill.js — fixture: a FULLY-DYNAMIC-roster workflow that
+// dispatches agentType from a roster variable but NEVER emits a Skill( directive.
+// The contract declares roster:{dynamic:true}, so the validator asserts the
+// STRUCTURAL invariant — and must FAIL here because the per-roster Skill(-from-
+// variable directive (the proven per-agent methodology attach) is missing.
+export const meta = {
+  name: "fixture-dynamic-roster-missing-skill",
+  description: "fully-dynamic roster missing the Skill(-from-roster invariant",
+  contract: {
+    phases: ["fan-out", "synthesize"],
+    roster: { dynamic: true },
+    agents: { dynamic: true },
+    dynamic: true,
+  },
+};
+
+function enterPhase(title) {
+  if (typeof phase === "function") phase(title);
+}
+
+export default async function run({ scope, roster, synthAgentType } = {}) {
+  enterPhase("fan-out");
+  const workers = await parallel(
+    roster.map((r) => () =>
+      agent({
+        // No Skill( directive — the per-agent methodology attach is missing.
+        prompt: `You are a ${r.lens} specialist. Scope: ${JSON.stringify(scope)}`,
+        schema: { type: "object", required: ["summary"], properties: { summary: { type: "string" } } },
+        agentType: r.agentType,
+        phase: "fan-out",
+      }),
+    ),
+  );
+  enterPhase("synthesize");
+  const synthesis = await agent({
+    prompt: `Synthesize ${workers.length} worker outputs.`,
+    schema: { type: "object", required: ["summary"], properties: { summary: { type: "string" } } },
+    agentType: synthAgentType,
+    phase: "synthesize",
+  });
+  return { workers_ran: workers.length, synthesis };
+}

--- a/scripts/tests/fixtures/conformance/dynamic-roster.js
+++ b/scripts/tests/fixtures/conformance/dynamic-roster.js
@@ -1,0 +1,44 @@
+// dynamic-roster.js — fixture: a FULLY-DYNAMIC-roster workflow. The roster is
+// supplied entirely by the caller, so there are NO static agentType:/Skill("..")
+// literals to pin. The contract declares roster:{dynamic:true} and agents:{dynamic
+// :true}. The conformance validator must assert the STRUCTURAL invariant — the
+// source emits a Skill( directive derived from a roster variable AND dispatches
+// agentType from a roster variable — and PASS this file (not vacuously).
+export const meta = {
+  name: "fixture-dynamic-roster",
+  description: "fully-dynamic roster; structural invariant present",
+  contract: {
+    phases: ["fan-out", "synthesize"],
+    roster: { dynamic: true },
+    agents: { dynamic: true },
+    dynamic: true,
+  },
+};
+
+function enterPhase(title) {
+  if (typeof phase === "function") phase(title);
+}
+
+export default async function run({ scope, roster, synthAgentType } = {}) {
+  enterPhase("fan-out");
+  const workers = await parallel(
+    roster.map((r) => () =>
+      agent({
+        prompt:
+          `You are a ${r.lens} specialist. Invoke your methodology by name ` +
+          `first: Skill("${r.skill}"). Scope: ${JSON.stringify(scope)}`,
+        schema: { type: "object", required: ["summary"], properties: { summary: { type: "string" } } },
+        agentType: r.agentType,
+        phase: "fan-out",
+      }),
+    ),
+  );
+  enterPhase("synthesize");
+  const synthesis = await agent({
+    prompt: `Synthesize ${workers.length} worker outputs.`,
+    schema: { type: "object", required: ["summary"], properties: { summary: { type: "string" } } },
+    agentType: synthAgentType,
+    phase: "synthesize",
+  });
+  return { workers_ran: workers.length, synthesis };
+}

--- a/scripts/tests/test_validate_workflow_conformance.py
+++ b/scripts/tests/test_validate_workflow_conformance.py
@@ -189,3 +189,91 @@ def test_output_labels_count_vs_shape_checks():
     res = _result_for(data, "matching.js")
     blob = json.dumps(res).lower()
     assert "count" in blob and ("shape" in blob or "skills" in blob), res
+
+
+# --- FULLY-DYNAMIC ROSTER: the fan-out contract shape ------------------------
+# A fully-dynamic-roster workflow has NO static agentType:/Skill("..") literals
+# (the roster is caller-supplied). The contract declares roster:{dynamic:true}.
+# The validator must assert the STRUCTURAL invariant — source emits a Skill(
+# directive derived from a roster variable AND dispatches agentType from a roster
+# variable — NOT specific names, and LABEL the check as structural.
+
+
+def test_roster_is_fully_dynamic_helper():
+    """roster_is_fully_dynamic() is True for {dynamic:true}, False for a list."""
+    assert vwc.roster_is_fully_dynamic({"roster": {"dynamic": True}}) is True
+    assert vwc.roster_is_fully_dynamic({"roster": [{"agentType": "x", "skill": "y"}]}) is False
+    assert vwc.roster_is_fully_dynamic({"roster": []}) is False
+
+
+def test_has_dynamic_skill_directive_detects_interpolated_skill():
+    """Skill("${r.skill}") (template-derived) counts as a per-roster Skill directive."""
+    yes = 'agent({ prompt: `Skill("${r.skill}")`, agentType: r.agentType })'
+    no = "agent({ prompt: `review the diff`, agentType: r.agentType })"
+    assert vwc.has_dynamic_skill_directive(yes) is True
+    assert vwc.has_dynamic_skill_directive(no) is False
+
+
+def test_has_dynamic_agent_dispatch_detects_variable_agenttype():
+    """agentType: <variable> (not a string literal) counts as dynamic dispatch."""
+    yes = "agent({ agentType: r.agentType })"
+    literal_only = 'agent({ agentType: "reviewer-system" })'
+    assert vwc.has_dynamic_agent_dispatch(yes) is True
+    assert vwc.has_dynamic_agent_dispatch(literal_only) is False
+
+
+def test_dynamic_roster_fixture_passes_static():
+    """Fully-dynamic roster WITH the structural invariant present PASSES."""
+    rc, data = _run_json("--dir", str(FIXTURES), "--static-only")
+    res = _result_for(data, "dynamic-roster.js")
+    assert res["status"] == "pass", res
+
+
+def test_dynamic_roster_missing_skill_fails_static():
+    """Fully-dynamic roster MISSING the Skill(-from-roster invariant FAILS."""
+    rc, data = _run_json("--dir", str(FIXTURES), "--static-only")
+    res = _result_for(data, "dynamic-roster-missing-skill.js")
+    assert res["status"] == "fail", res
+    assert any("skill" in e.lower() for e in res["static_errors"]), res["static_errors"]
+
+
+def test_dynamic_roster_labels_structural():
+    """The validator must LABEL the dynamic-roster check as STRUCTURAL (honest limits)."""
+    rc, data = _run_json("--dir", str(FIXTURES), "--static-only")
+    res = _result_for(data, "dynamic-roster.js")
+    blob = json.dumps(res["checks"]).lower()
+    assert "structural" in blob, res["checks"]
+
+
+def test_dynamic_roster_not_vacuous_pass():
+    """A fully-dynamic contract must NOT pass merely because there are no names to
+    check. Stripping the structural invariant from a {dynamic:true} contract source
+    must produce a failure (proves the check is doing real work)."""
+    src = (FIXTURES / "dynamic-roster.js").read_text()
+    contract = vwc.extract_contract(src)
+    assert vwc.roster_is_fully_dynamic(contract) is True
+    errors, _ = vwc._static_checks(src, contract)
+    assert errors == [], errors  # the real fixture passes
+    # Remove the Skill( directive -> structural invariant violated -> must error.
+    stripped = src.replace('Skill("${r.skill}")', "your usual methodology")
+    errs2, _ = vwc._static_checks(stripped, contract)
+    assert any("skill" in e.lower() for e in errs2), errs2
+
+
+@pytest.mark.skipif(NODE is None, reason="node not available; dynamic harness is a local/dev tool")
+def test_dynamic_roster_fixture_passes_dynamic():
+    """With node, the fully-dynamic fixture records a real trace and PASSES."""
+    rc, data = _run_json("--dir", str(FIXTURES))
+    res = _result_for(data, "dynamic-roster.js")
+    assert res["status"] == "pass", res
+    assert res.get("dynamic_ran") is True
+    assert not res["dynamic_errors"], res["dynamic_errors"]
+
+
+# --- The real fan-out workflow MUST conform (static) -------------------------
+
+
+def test_real_fan_out_workflow_passes_static():
+    rc, data = _run_json("--dir", str(REAL_WORKFLOW_DIR), "--static-only")
+    res = _result_for(data, "fan-out-workflow.js")
+    assert res["status"] == "pass", res

--- a/scripts/validate-workflow-conformance.py
+++ b/scripts/validate-workflow-conformance.py
@@ -7,18 +7,31 @@ the dispatch shape it promises:
     contract: {
       phases: ["wave-1", ...],                 // phase() titles entered
       roster: [{agentType, skill}, ...],       // the FIXED (static) Wave-1 barrier
+        // OR  roster: { dynamic: true }        // a FULLY-DYNAMIC, caller-supplied roster
       agents: { static: <N>, dynamic: <bool> },// fixed barrier size
       dynamic: <bool>,                          // data-driven passes present?
     }
+
+Two roster shapes are supported:
+
+* STATIC roster (list of ``{agentType, skill}``): the fixed Wave-1 barrier. Each
+  name is pinned (SHAPE + SKILLS) and the barrier size is COUNT-checked. This is
+  the comprehensive-review shape (static Wave-1 + dynamic tail).
+* FULLY-DYNAMIC roster (``roster: {dynamic: true}``): the roster is supplied
+  entirely by the caller (e.g. fan-out-workflow), so there are NO static
+  agentType:/Skill("..") literals to pin. The gate asserts the STRUCTURAL
+  INVARIANT instead — source emits a per-roster ``Skill(`` directive built from a
+  variable AND dispatches ``agentType`` from a roster variable — NOT specific
+  names, and LABELS the check as STRUCTURAL (no silent vacuous pass).
 
 This script asserts the actual script against that contract, in two layers:
 
 * STATIC (pure stdlib, always runs, the CI gate):
   - ``meta.phases`` (the phase()/enterPhase() titles in source) == ``contract.phases``
-  - every ``contract.roster`` agentType is dispatched in source (``agentType:`` token)
-  - every ``contract.roster`` skill appears as a ``Skill("..")`` token in source
-  - ``contract.agents.static`` == ``len(contract.roster)`` (the fixed barrier size),
-    and there are at least that many ``agent(`` call-sites
+  - static roster: every agentType dispatched + every skill resolvable in source;
+    ``contract.agents.static`` == ``len(roster)`` and >= that many ``agent(`` call-sites
+  - fully-dynamic roster: the STRUCTURAL invariant (Skill(-from-variable +
+    agentType-from-variable) is present in source
 * DYNAMIC (shells to scripts/conformance-harness.mjs IF node is available):
   - every recorded ``phases_entered`` (per tier) is a subset of ``contract.phases``
   - the recorded static Wave-1 roster (agentType + skills) matches ``contract.roster``
@@ -81,6 +94,15 @@ _SKILL_LITERAL = re.compile(r"""\bSkill\(\s*["'`]([^"'`$]+)["'`]\s*\)""")
 # Any Skill( directive at all — proves the skill-attach wiring is emitted, even
 # when the name is template-interpolated (Skill("${roster.skill}")).
 _SKILL_DIRECTIVE = re.compile(r"\bSkill\(")
+# A template-interpolated Skill directive: Skill("${...}") — the per-roster
+# methodology attach where the skill name is supplied by a (roster) variable.
+# This is the fully-dynamic-roster invariant: a Skill directive built from a
+# variable, not a fixed literal.
+_SKILL_INTERPOLATED = re.compile(r"""\bSkill\(\s*["'`][^"'`]*\$\{[^}]+\}""")
+# agentType dispatched from a VARIABLE (e.g. agentType: r.agentType), not a
+# string literal. The fully-dynamic-roster invariant: the dispatched specialist
+# is chosen at runtime from the roster, not pinned to a name in source.
+_AGENT_TYPE_VAR = re.compile(r"""\bagentType\s*:\s*(?!["'`])[A-Za-z_$][\w$.\[\]]*""")
 # Literal `skill: "name"` values declared on roster entries / maps in source.
 _SKILL_FIELD = re.compile(r"""\bskill\s*:\s*["'`]([^"'`$]+)["'`]""")
 # Quoted string values inside an AGENT_SKILL-style map (key: "value").
@@ -244,6 +266,36 @@ def has_skill_directive(source: str) -> bool:
     return _SKILL_DIRECTIVE.search(source) is not None
 
 
+def has_dynamic_skill_directive(source: str) -> bool:
+    """True if source emits a TEMPLATE-INTERPOLATED Skill directive (Skill("${..}")).
+
+    This is the fully-dynamic-roster invariant: the per-agent methodology attach is
+    built from a roster variable, not pinned to a fixed skill name.
+    """
+    return _SKILL_INTERPOLATED.search(source) is not None
+
+
+def has_dynamic_agent_dispatch(source: str) -> bool:
+    """True if source dispatches agentType from a VARIABLE (agentType: r.agentType).
+
+    The fully-dynamic-roster invariant: the dispatched specialist is selected at
+    runtime from the roster, not pinned to a literal name in source.
+    """
+    return _AGENT_TYPE_VAR.search(source) is not None
+
+
+def roster_is_fully_dynamic(contract: dict) -> bool:
+    """True if the contract declares a FULLY-DYNAMIC roster (no static entries).
+
+    The static roster is a list of {agentType, skill}. A fully-dynamic roster is
+    caller-supplied, so the contract declares it as ``roster: {dynamic: true}``
+    (an object, not a list). There are no names to pin — the gate asserts the
+    STRUCTURAL invariant instead.
+    """
+    roster = contract.get("roster")
+    return isinstance(roster, dict) and bool(roster.get("dynamic"))
+
+
 def count_agent_callsites(source: str) -> int:
     """Count agent( call-sites in source."""
     return len(_AGENT_CALL.findall(source))
@@ -264,7 +316,8 @@ def _static_checks(source: str, contract: dict) -> tuple[list[str], list[str]]:
     # contract is the spec being validated; comments prove nothing).
     body = evidence_body(source)
 
-    # 1. phases (SHAPE): declared set == entered set.
+    # 1. phases (SHAPE): declared set == entered set. Asserted statically for BOTH
+    #    the static-roster and fully-dynamic-roster shapes.
     declared_phases = set(contract.get("phases", []))
     entered_phases = extract_phase_titles(body)
     labels.append("phases: SHAPE (declared set == phase() titles in source)")
@@ -278,11 +331,50 @@ def _static_checks(source: str, contract: dict) -> tuple[list[str], list[str]]:
             parts.append(f"entered-but-not-declared={sorted(extra)}")
         errors.append("phase mismatch: " + "; ".join(parts))
 
+    # 2. roster checks. Two shapes:
+    #    (a) STATIC roster (list of {agentType, skill}) — pin each name (SHAPE +
+    #        SKILLS + COUNT of the fixed barrier).
+    #    (b) FULLY-DYNAMIC roster ({dynamic:true}) — the roster is caller-supplied,
+    #        so there are NO names to pin. Assert the STRUCTURAL invariant: source
+    #        emits a per-roster Skill( directive built from a variable AND dispatches
+    #        agentType from a variable. Label it STRUCTURAL (honest limits — no names,
+    #        no silent vacuous pass).
+    if roster_is_fully_dynamic(contract):
+        labels.append(
+            "roster: STRUCTURAL (fully-dynamic, caller-supplied roster — assert the "
+            "INVARIANT not specific names: source emits a Skill( directive derived from "
+            "a roster variable AND dispatches agentType from a roster variable)"
+        )
+        if not has_dynamic_skill_directive(body):
+            errors.append(
+                "fully-dynamic roster invariant violated: source emits no per-roster "
+                'Skill( directive built from a variable (expected Skill("${...}") — the '
+                "proven per-agent methodology attach)"
+            )
+        if not has_dynamic_agent_dispatch(body):
+            errors.append(
+                "fully-dynamic roster invariant violated: source dispatches no agentType "
+                "from a roster variable (expected agentType: <var>, e.g. agentType: r.agentType)"
+            )
+        # agents.static must be absent/0 for a fully-dynamic roster (nothing to count).
+        agents = contract.get("agents", {})
+        static_n = agents.get("static")
+        if static_n:
+            errors.append(
+                f"agents.static={static_n} declared but roster is fully-dynamic "
+                "(no static barrier to count — declare agents:{dynamic:true})"
+            )
+        labels.append(
+            "agents: SHAPE-only, NOT COUNT (fully-dynamic roster — agent count is "
+            "caller-supplied and not statically countable)"
+        )
+        return errors, labels
+
     roster = contract.get("roster", [])
     src_agent_types = extract_agent_types(body)
     src_skills = extract_skill_tokens(body)
 
-    # 2. roster agentType present in source (SHAPE).
+    # 2a. roster agentType present in source (SHAPE).
     labels.append("roster.agentType: SHAPE (each present as agentType: in source)")
     for entry in roster:
         at = entry.get("agentType")
@@ -370,7 +462,8 @@ def _dynamic_checks(js_path: Path, contract: dict) -> tuple[list[str], list[str]
             errors.append(f"harness error at tier {e.get('tier')}: {e.get('error')}")
 
     declared_phases = set(contract.get("phases", []))
-    roster = contract.get("roster", [])
+    fully_dynamic = roster_is_fully_dynamic(contract)
+    roster = [] if fully_dynamic else contract.get("roster", [])
     expected_roster = [(e.get("agentType"), tuple(sorted([e.get("skill")] if e.get("skill") else []))) for e in roster]
 
     traces = harness_out.get("traces", {})
@@ -383,14 +476,34 @@ def _dynamic_checks(js_path: Path, contract: dict) -> tuple[list[str], list[str]
                 f"tier {tier}: entered phases {sorted(entered)} not a subset of "
                 f"contract.phases {sorted(declared_phases)}"
             )
-        # static Wave-1 roster: SHAPE + SKILLS (agentType + its skills), NOT COUNT.
         recorded_roster = [(r.get("agentType"), tuple(sorted(r.get("skills", [])))) for r in trace.get("rosters", [])]
-        if recorded_roster != expected_roster:
+        if fully_dynamic:
+            # Fully-dynamic roster: NO names to pin. Assert the STRUCTURAL invariant
+            # in the recorded trace — the first-phase fan-out dispatched at least one
+            # worker via agentType AND each carried a Skill( directive (the per-agent
+            # methodology attach). NOT count, NOT specific names (honest limit).
+            if recorded_roster and not all(at for at, _ in recorded_roster):
+                errors.append(
+                    f"tier {tier}: fan-out dispatched a worker with no agentType (roster variable not applied)"
+                )
+            if recorded_roster and not all(skills for _, skills in recorded_roster):
+                errors.append(
+                    f"tier {tier}: a fan-out worker carried no Skill( directive "
+                    "(per-roster methodology attach missing in the recorded trace)"
+                )
+        elif recorded_roster != expected_roster:
+            # static Wave-1 roster: SHAPE + SKILLS (agentType + its skills), NOT COUNT.
             errors.append(
                 f"tier {tier}: recorded Wave-1 roster {recorded_roster} != "
                 f"contract.roster (agentType+skills) {expected_roster}"
             )
-    if contract.get("dynamic"):
+    if fully_dynamic:
+        notes.append(
+            "dynamic: fully-dynamic roster — agent_count and names are caller-supplied "
+            "and NOT asserted (honest limit); only phase-subset + the STRUCTURAL "
+            "invariant (agentType-from-variable + Skill(-from-variable per worker) are checked"
+        )
+    elif contract.get("dynamic"):
         notes.append(
             "dynamic: agent_count is data-driven and NOT asserted (honest limit); "
             "only phase-subset + static Wave-1 roster SHAPE+SKILLS are checked"

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -326,17 +326,23 @@ pick = haiku_route.pipeline                         # #686, may be null
 cap  = scripts/detect-workflow-capability.py        # env proxy: {harness, workflow_capable}
 reg  = scripts/workflow-registry.py                 # auto-derived {meta.name: path}
 {scope, tier} = scripts/right-size-review.py        # #688 right-sizing (review picks)
+complex4 = (complexity == Complex) or (tier == 4)   # ADR native-fast-path Stage 2
 
-if pick is None:                                            -> agent + skill direct (no pipeline)
-elif reg.get(pick) and cap.workflow_capable and (Workflow tool in MY tool list):
-        # env proxy AND LLM tool-list self-check (the authoritative gate)
-                                                            -> Workflow tool: run(reg[pick], {scope, tier})
-else:                                                       -> run the prose pipeline markdown (unchanged)
+if pick is not None and reg.get(pick) and cap.workflow_capable and (Workflow tool in MY tool list):
+        # NAMED pipeline: env proxy AND LLM tool-list self-check (authoritative gate)
+                                                            -> Workflow.run(reg[pick], {scope, tier})
+elif pick is not None and reg.get(pick):                    -> run the prose pipeline markdown (unchanged)
+elif pick is None and complex4 and cap.workflow_capable and (Workflow tool in MY tool list):
+        # NO named pipeline + Complex/tier-4: generic native fan-out (Stage 2)
+                                                            -> Workflow.run("fan-out-workflow", {scope, tier, roster})
+elif pick is None and complex4:                             # Workflow tool absent -> floor
+                                                            -> dispatching-parallel-agents (prose fan-out, unchanged)
+else:                                                       -> agent + skill direct (simpler; unchanged)
 ```
 
-The native path (e.g. `comprehensive-review-workflow.js`) scales waves to tier, passes schema-validated typed findings between waves without disk round-trips, runs a per-finding adversarial verify, and bounds the fix loop by the native token budget. The prose markdown flow is the always-safe fallback and runs identically on Codex/Gemini/Factory or when the `Workflow` tool is absent. `cap.workflow_capable` is an env-derived PROXY; the orchestrator's own tool-list check is the authoritative gate — both must hold. A `pick` with no registry entry is prose-only.
+`roster` is built from the Phase-3 enhancement signals (e.g. "comprehensive" → 3 reviewers with `systematic-code-review`; research → research subagents with `research-pipeline`), scaled by `tier` per `right-size-review.py`: each entry is `{agentType, skill, lens}`. The native path scales work to scope, passes schema-validated typed results in-memory (no disk round-trips), and bounds synthesis by the native token budget. `comprehensive-review-workflow.js` is the named-pipeline form; `fan-out-workflow.js` is the generic complexity-trigger form for Complex/tier-4 work with no named pipeline. The prose floor (`dispatching-parallel-agents` for fan-out, the pipeline markdown for named picks) runs identically on Codex/Gemini/Factory or when the `Workflow` tool is absent. `cap.workflow_capable` is an env-derived PROXY; the orchestrator's own tool-list check is the authoritative gate — both must hold. A `pick` with no registry entry is prose-only.
 
-**Banner parity (R4):** expand the pipeline name → phase list for the routing banner on BOTH paths, so the banner reads identically regardless of executor.
+**Banner parity (R4):** expand the pipeline name → phase list for the routing banner on BOTH paths, so the banner reads identically regardless of executor. For the complexity-trigger fan-out, both the native `fan-out-workflow` and the prose `dispatching-parallel-agents` floor expand to the same phases (`fan-out → synthesize`) — the banner reads identically whether the Workflow tool runs or the floor does.
 
 **Step 2: Invoke agent with skill**
 

--- a/skills/workflow/references/fan-out-workflow.js
+++ b/skills/workflow/references/fan-out-workflow.js
@@ -1,0 +1,186 @@
+// fan-out-workflow.js
+//
+// Generic, parameterized native fan-out/synthesize Workflow. This is the
+// default deterministic-runtime executor for Complex / tier-4 work that has NO
+// named pipeline (a `pick=null` complexity-trigger from /do Phase 4 Step 1b).
+// Unlike comprehensive-review-workflow.js (a STATIC Wave-1 roster + dynamic
+// tail), this workflow's roster is supplied ENTIRELY by the caller — there are
+// no fixed agent/skill literals in source. The prose `dispatching-parallel-
+// agents` flow is the always-safe floor when the Workflow tool is absent.
+//
+// Runtime contract (see ../../../dynamic-workflows-vs-vexjoy-diff.md):
+//   - meta is a pure object literal (name + description + contract) parsed
+//     before the body.
+//   - parallel(thunks) is a hard barrier; a failed agent resolves to null.
+//   - agent({prompt, schema, model, agentType}) forces a StructuredOutput tool
+//     call, validates against schema at the tool layer, and returns a typed
+//     object — no markdown re-parse, no disk read.
+//   - budget.remaining() returns run-wide tokens left; agent() throws when
+//     exhausted. The synthesize pass is budget-aware (no unbounded loop).
+//   - Wall-clock and randomness are unavailable by design (determinism is
+//     bit-stable across replay). This script uses neither.
+
+export const meta = {
+  name: "fan-out-workflow",
+  description:
+    "Generic native fan-out/synthesize Workflow for Complex / tier-4 work with no named pipeline: dispatch a caller-supplied roster of specialists in a single parallel barrier (each attaching its own methodology by name via Skill(...)), then synthesize the typed worker results in-memory with one budget-aware synthesizer. The roster, skills, lenses, and synthesizer are all caller-supplied — the floor is the prose dispatching-parallel-agents flow.",
+  // --- Conformance contract (pure literal — no calls/variables; see
+  //     scripts/validate-workflow-conformance.py + adr/native-fast-path-portable-floor.md
+  //     Stage 2). This is a FULLY-DYNAMIC-roster contract: the roster is
+  //     caller-supplied, so there are NO static agent/skill literals to pin.
+  //     The gate asserts the STRUCTURAL invariant (source emits a Skill(
+  //     directive derived from a roster variable AND dispatches agentType from a
+  //     roster variable), NOT specific names. name + description stay BEFORE this
+  //     nested object so the non-greedy meta-name parser in workflow-registry.py
+  //     still resolves meta.name.
+  contract: {
+    // Phase titles this script enters at runtime via enterPhase(). Order matters.
+    phases: ["fan-out", "synthesize"],
+    // Fully-dynamic roster: caller-supplied at run({roster}). No static names to
+    // pin — the gate asserts the structural invariant instead.
+    roster: { dynamic: true },
+    // No static barrier to count: every dispatched agent comes from the runtime
+    // roster (roster.length workers + 1 synthesizer).
+    agents: { dynamic: true },
+    // Data-driven fan-out: count + names are caller-supplied (honest limit — the
+    // gate asserts SHAPE + the structural Skill(/agentType invariant, NOT COUNT).
+    dynamic: true,
+  },
+};
+
+// --- Schemas (mirror the STYLE of comprehensive-review-workflow.js / -----------
+//     skills/shared-patterns/schemas/). Worker results and the synthesis are
+//     schema-validated typed objects, not re-parsed markdown.
+
+// One worker's typed output. `findings` mirrors the FINDING/WAVE_OUTPUT shape so
+// downstream synthesis is uniform regardless of the worker's lens.
+const FINDING_SCHEMA = {
+  type: "object",
+  required: ["title"],
+  properties: {
+    title: { type: "string" },
+    location: { type: "string" },
+    severity: { type: "string", enum: ["critical", "high", "medium", "low", "info"] },
+    detail: { type: "string" },
+  },
+};
+
+const WORKER_SCHEMA = {
+  type: "object",
+  required: ["verdict", "summary"],
+  properties: {
+    verdict: { type: "string", enum: ["PASS", "CONCERN", "BLOCK", "INFO"] },
+    summary: { type: "string", minLength: 1 },
+    findings: { type: "array", items: FINDING_SCHEMA },
+    lens: { type: "string" },
+  },
+};
+
+// The single synthesizer's typed output over the worker results.
+const SYNTH_SCHEMA = {
+  type: "object",
+  required: ["verdict", "summary"],
+  properties: {
+    verdict: { type: "string", enum: ["PASS", "CONCERN", "BLOCK", "INFO"] },
+    summary: { type: "string", minLength: 1 },
+    key_findings: { type: "array", items: FINDING_SCHEMA },
+    recommendations: { type: "array", items: { type: "string" } },
+  },
+};
+
+// --- Helpers ------------------------------------------------------------------
+
+// Defensive phase marker: the native runtime guarantees agent/parallel/budget,
+// but does NOT document a phase() global. Guard the call so the real runtime
+// never throws if phase is absent, while the conformance harness's mock records
+// the entered phase. Phase titles match meta.contract.phases.
+function enterPhase(title) {
+  if (typeof phase === "function") {
+    phase(title);
+  }
+}
+
+// Build one worker's prompt from its roster entry. The roster entry supplies the
+// dispatched specialist (agentType), the methodology skill it attaches by name
+// (Skill("...") — resolves path-independent inside a native Workflow agent()
+// dispatch, proven this session), and the lens that focuses its pass. `scope` is
+// the shared diff/task descriptor. The Skill directive is built FROM the roster
+// variable r.skill — this is the fully-dynamic structural invariant the
+// conformance gate asserts.
+function workerPrompt(r, scope) {
+  const skillDirective = r.skill
+    ? `\nInvoke your methodology by name first: Skill("${r.skill}"). ` +
+      `Run it, then report through its structure.`
+    : "";
+  const lens = r.lens ? `Apply this lens: ${r.lens}.` : "Apply your specialist lens.";
+  return (
+    `You are ${r.agentType}. ${lens}` +
+    skillDirective +
+    `\nWork this scope:\n${JSON.stringify(scope)}\n` +
+    `Return a typed result: verdict (PASS|CONCERN|BLOCK|INFO), a summary, and any ` +
+    `findings within your lens. Stay within your lens — the synthesizer merges across workers.`
+  );
+}
+
+// --- Workflow body ------------------------------------------------------------
+//
+// run({scope, tier, roster, synthAgentType, fixThreshold}):
+//   - scope: the shared task/diff descriptor passed to every worker.
+//   - tier: right-size-review tier (carried into scope for the workers; this
+//     workflow does not gate phases on tier — the CALLER sizes the roster).
+//   - roster: [{agentType, skill, lens}] — caller-supplied; the fan-out set.
+//   - synthAgentType: the synthesizer agent (default a general synthesizer).
+//   - fixThreshold: min budget to attempt the synthesis pass (default 8000).
+
+export default async function run({ scope, tier, roster, synthAgentType, fixThreshold } = {}) {
+  const workers = Array.isArray(roster) ? roster : [];
+  // Default general synthesizer: research-coordinator-engineer (its role is
+  // multi-source synthesis). The caller overrides via synthAgentType.
+  const synthesizer = synthAgentType || "research-coordinator-engineer";
+  const minSynthBudget = typeof fixThreshold === "number" ? fixThreshold : 8000;
+
+  // Phase fan-out: one hard barrier over the caller-supplied roster. Each slot
+  // dispatches the roster's specialist via agentType (a runtime variable) and
+  // embeds a per-roster Skill( directive built from r.skill. A failed slot
+  // resolves to null; nulls are filtered before synthesis.
+  enterPhase("fan-out");
+  const rawResults = await parallel(
+    workers.map((r) => () =>
+      agent({
+        prompt: workerPrompt(r, scope),
+        schema: WORKER_SCHEMA,
+        model: "sonnet",
+        agentType: r.agentType,
+        phase: "fan-out",
+      }),
+    ),
+  );
+  const results = rawResults.filter((x) => x != null);
+
+  // Phase synthesize: one synthesizer over the typed worker results in-memory
+  // (no disk). Budget-aware — skip the pass if the run can no longer afford it,
+  // and report the workers directly rather than looping unboundedly.
+  enterPhase("synthesize");
+  let synthesis = null;
+  if (results.length > 0 && budget.remaining() >= minSynthBudget) {
+    synthesis = await agent({
+      prompt:
+        `Synthesize these ${results.length} typed specialist results into one ` +
+        `verdict + summary. Merge overlapping findings, keep the highest severity, ` +
+        `and list concrete recommendations. Results (typed, in-memory):\n` +
+        `${JSON.stringify(results)}`,
+      schema: SYNTH_SCHEMA,
+      model: "sonnet",
+      agentType: synthesizer,
+      phase: "synthesize",
+    });
+  }
+
+  return {
+    tier: typeof tier === "number" ? tier : null,
+    workers_ran: results.length,
+    roster: workers.map((r) => ({ agentType: r.agentType, skill: r.skill, lens: r.lens })),
+    synthesis,
+    budget_remaining: budget.remaining(),
+  };
+}


### PR DESCRIPTION
Implements ADR `native-fast-path-portable-floor` **Stage 2** (execution limb).

## What
- **`fan-out-workflow.js`** — generic parameterized native workflow: caller supplies a roster `[{agentType, skill, lens}]`; runs a parallel barrier where each agent loads its skill via `Skill()` by name, then synthesizes the typed results. `meta.contract` declares a fully-dynamic roster.
- **Conformance gate extended** (`validate-workflow-conformance.py` + `conformance-harness.mjs`) to verify fully-dynamic-roster workflows by **structural invariant** (emits `Skill()` from the roster + dispatches `agentType` from the roster), with the honest-limit labeled (count not asserted for data-driven fan-out). Gate passes for **both** workflows (2/2).
- **`/do` Phase 4 Step 1b** — added the complexity-trigger rows: `pick=None AND (Complex OR tier-4) AND Workflow-capable` -> run `fan-out-workflow`; tool absent -> `dispatching-parallel-agents` floor (unchanged). Banner parity preserved.

## Scope guard
EXECUTION limb only. Phase 2 (the routing decision / Haiku hop) is untouched; no `UserPromptSubmit` hook; OD1-OD6 remain open.

## Verification
- conformance gate: `{total:2, passed:2, failed:0}`
- `pytest scripts/tests/test_validate_workflow_conformance.py`: 25 passed
- ruff check + format clean

Salvaged from a rate-limited build agent (work was complete but uncommitted).