### PR TITLE
feat(workflow): native fast-path for research + explore pipelines (ADR Stage 3)

### DIFF
--- a/skills/workflow/references/explore-pipeline.js
+++ b/skills/workflow/references/explore-pipeline.js
@@ -1,0 +1,428 @@
+// explore-pipeline.js
+//
+// Native dynamic-Workflow variant of the systematic codebase-exploration
+// pipeline. The markdown flow at ./explore-pipeline.md remains the cross-harness
+// floor; this script is the deterministic-runtime FAST-PATH for Claude Code
+// (+Factory) when the native Workflow tool is present. It mirrors the prose
+// tiered flow SCAN -> MAP -> ANALYZE -> (COMPILE -> ASSESS -> SYNTHESIZE ->
+// REFINE) -> REPORT, replacing the per-phase *.md disk artifacts with schema-
+// validated typed agent() returns and a real parallel() barrier for the SCAN
+// fan-out. It is READ-ONLY (the dispatched specialists explore, never modify).
+//
+// Tiered depth (the prose Quick/Standard/Deep model) maps to the right-size
+// review tier carried in by /do: tier <= 3 runs the Standard set (SCAN, MAP,
+// ANALYZE, REPORT — 4 phases); tier 4 runs the Deep set (all 8 phases, adding
+// COMPILE, ASSESS, SYNTHESIZE, REFINE for quality assessment + false-positive
+// verification before REPORT). Phases within the selected tier are not skipped.
+//
+// SCAN is a FIXED barrier of 3 read-only scanner specialists (Structure, Entry
+// Point, Pattern — the prose Phase 1), the static-roster shape (like
+// comprehensive-review-workflow.js Wave 1). MAP/ANALYZE/.../REPORT are single
+// coordinator passes; their presence is tier-gated (data-driven), so the tail is
+// declared dynamic:true (honest limit).
+//
+// Runtime contract (see ./comprehensive-review-workflow.js for the canonical
+// description of the native primitives): meta is a pure object literal parsed
+// before the body; parallel(thunks) is a hard barrier (failed slot -> null);
+// agent({prompt, schema, model, agentType}) returns a typed object; budget.
+// remaining() bounds the tail. No Date.now()/Math.random()/new Date().
+
+import { skillDirectives, mandatoryInjections } from "./workflow-helpers.js";
+
+export const meta = {
+  name: "explore-pipeline",
+  description:
+    "Systematic codebase-exploration pipeline as a deterministic native Workflow: tiered SCAN -> MAP -> ANALYZE -> (COMPILE -> ASSESS -> SYNTHESIZE -> REFINE) -> REPORT. SCAN is a fixed parallel barrier of 3 read-only scanner specialists (Structure, Entry Point, Pattern); a codebase coordinator then maps architecture, analyzes core abstractions, and (at deep tier) compiles, assesses quality, synthesizes ranked findings, and verifies them against source before REPORT. Each agent attaches its full skill stack (one Skill() per skill) plus the /do mandatory injections. Read-only. Mirrors explore-pipeline.md; that markdown flow stays the cross-harness floor.",
+  // --- Conformance contract (pure literal — no calls/variables; see
+  //     scripts/validate-workflow-conformance.py + adr/native-fast-path-portable-floor.md
+  //     Stage 3). STATIC validation pins the phases + the FIXED 3-scanner SCAN
+  //     barrier (countable). DYNAMIC validation records the real dispatch trace
+  //     and asserts SHAPE + SKILLS, NOT count, where dynamic:true (the tier-gated
+  //     tail phases run conditionally). name + description stay BEFORE this nested
+  //     object so the non-greedy meta-name parser in workflow-registry.py still
+  //     resolves meta.name.
+  contract: {
+    // All phase titles entered at runtime via enterPhase(). SCAN (the barrier) is
+    // the first entered phase. Tier-gated phases still have a literal enterPhase()
+    // call-site in source (the STATIC check is set-equality of titles), but only
+    // run at the selected tier (the DYNAMIC check is per-tier subset).
+    phases: ["scan", "map", "analyze", "compile", "assess", "synthesize", "refine", "report"],
+    // SCAN is a FIXED barrier: 3 read-only scanner specialists on every run (the
+    // prose Phase 1 Structure/Entry-Point/Pattern scanners). Each carries a
+    // `skills` LIST (the full read-only-exploration stack attached via one Skill()
+    // per element). The distinct scanner lens is a RUNTIME property of the prompt,
+    // so the static roster is three identical-type entries (type + skills + count).
+    roster: [
+      { agentType: "research-subagent-executor", skills: ["codebase-overview", "codebase-analyzer"] },
+      { agentType: "research-subagent-executor", skills: ["codebase-overview", "codebase-analyzer"] },
+      { agentType: "research-subagent-executor", skills: ["codebase-overview", "codebase-analyzer"] },
+    ],
+    // The SCAN barrier dispatches exactly the fixed 3 on every run (static).
+    agents: { static: 3, dynamic: false },
+    // MAP/ANALYZE/.../REPORT are single coordinator passes whose PRESENCE is
+    // tier-gated (Standard = 4 phases, Deep = 8). The tail count is data-driven.
+    // Honest limit: the gate asserts SHAPE + SKILLS for the tail, not COUNT.
+    dynamic: true,
+  },
+};
+
+// Map each dispatched agent to the FULL skill stack it invokes by name (one
+// Skill() per element). The read-only scanners + the coordinator both run the
+// codebase methodology skills (codebase-overview = structure/architecture,
+// codebase-analyzer = pattern/quality discovery). The literal skill names live in
+// these `skills: [...]` arrays so the conformance gate resolves them; the body
+// emits the directives by delegating each entry's list to skillDirectives().
+const AGENT_SKILLS = {
+  "research-subagent-executor": ["codebase-overview", "codebase-analyzer"],
+  "research-coordinator-engineer": ["codebase-overview", "codebase-analyzer"],
+};
+
+const COORDINATOR_AGENT = "research-coordinator-engineer";
+
+// The three fixed SCAN scanners (the prose Phase 1). Each is a distinct read-only
+// lens dispatched in one parallel barrier; minimum 2-of-3 is the prose gate, but
+// all 3 are dispatched (failed slots resolve to null and are filtered).
+const SCANNERS = [
+  { lens: "Structure: top-level directories + purposes, languages/frameworks, config (build/CI/lint/env), test layout, infra files" },
+  { lens: "Entry points: main executables, CLI arg parsers, API route definitions + server startup, worker/queue entry points (file paths + brief descriptions)" },
+  { lens: "Patterns: naming conventions, directory organization, import/dependency patterns, error-handling approach, testing patterns + coverage strategy" },
+];
+
+// --- Schemas (mirror the STYLE of comprehensive-review-workflow.js) -----------
+
+// One scanner's typed output (mirrors a raw scan finding-set).
+const SCAN_SCHEMA = {
+  type: "object",
+  required: ["lens", "observations"],
+  properties: {
+    lens: { type: "string" },
+    observations: { type: "array", items: { type: "string" } },
+    file_paths: { type: "array", items: { type: "string" } },
+  },
+};
+
+// MAP output: the architecture map (layers + component relationships + data flow).
+const MAP_SCHEMA = {
+  type: "object",
+  required: ["layers"],
+  properties: {
+    layers: { type: "array", items: { type: "string" } },
+    components: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["name"],
+        properties: {
+          name: { type: "string" },
+          depends_on: { type: "array", items: { type: "string" } },
+          dependents: { type: "array", items: { type: "string" } },
+        },
+      },
+    },
+    data_flow: { type: "string" },
+  },
+};
+
+// ANALYZE output: core abstractions, critical paths, conventions.
+const ANALYZE_SCHEMA = {
+  type: "object",
+  required: ["abstractions"],
+  properties: {
+    abstractions: { type: "array", items: { type: "string" } },
+    critical_paths: { type: "array", items: { type: "string" } },
+    conventions: { type: "array", items: { type: "string" } },
+  },
+};
+
+// COMPILE output: findings grouped by evaluation dimension (deep tier).
+const COMPILE_SCHEMA = {
+  type: "object",
+  required: ["dimensions"],
+  properties: {
+    dimensions: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["dimension"],
+        properties: {
+          dimension: { type: "string", enum: ["consistency", "quality", "coverage", "patterns"] },
+          findings: { type: "array", items: { type: "string" } },
+        },
+      },
+    },
+  },
+};
+
+// ASSESS output: scored dimensions + cataloged deviations (deep tier).
+const ASSESS_SCHEMA = {
+  type: "object",
+  required: ["scores"],
+  properties: {
+    scores: { type: "array", items: { type: "string" } },
+    deviations: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["description", "severity"],
+        properties: {
+          description: { type: "string" },
+          severity: { type: "string", enum: ["critical", "high", "medium", "low"] },
+          root_cause: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+// SYNTHESIZE output: ranked, theme-grouped recommendations (deep tier).
+const SYNTHESIZE_SCHEMA = {
+  type: "object",
+  required: ["recommendations"],
+  properties: {
+    recommendations: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["title", "severity"],
+        properties: {
+          title: { type: "string" },
+          severity: { type: "string", enum: ["critical", "high", "medium", "low"] },
+          theme: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+// REFINE output: verified findings with false positives removed (deep tier).
+const REFINE_SCHEMA = {
+  type: "object",
+  required: ["verified"],
+  properties: {
+    verified: { type: "array", items: { type: "string" } },
+    removed_false_positives: { type: "array", items: { type: "string" } },
+  },
+};
+
+// REPORT output: the final exploration report descriptor.
+const REPORT_SCHEMA = {
+  type: "object",
+  required: ["executive_summary"],
+  properties: {
+    executive_summary: { type: "string", minLength: 1 },
+    quick_facts: { type: "array", items: { type: "string" } },
+    key_components: { type: "array", items: { type: "string" } },
+    next_steps: { type: "array", items: { type: "string" } },
+  },
+};
+
+// --- Helpers ------------------------------------------------------------------
+
+// Defensive phase marker: the native runtime guarantees agent/parallel/budget,
+// but does NOT document a phase() global. Guard the call so the real runtime
+// never throws if phase is absent, while the conformance harness's mock records
+// the entered phase. Phase titles match meta.contract.phases.
+function enterPhase(title) {
+  if (typeof phase === "function") {
+    phase(title);
+  }
+}
+
+// Build one SCAN scanner's prompt for its read-only lens. skillDirectives emits
+// one Skill("...") per element of the scanner skill stack (resolves path-
+// independent inside a native Workflow agent() dispatch). mandatoryInjections()
+// embeds the /do completeness/density/base-instructions/reference-loading block.
+// Each scanner gets a DISTINCT lens and returns its own typed result.
+function scanPrompt(lens, scope) {
+  return (
+    `You are a read-only codebase scanner (research-subagent-executor). Explore ` +
+    `and report only; leave all files unchanged.` +
+    skillDirectives(AGENT_SKILLS["research-subagent-executor"]) +
+    `\nYour scanner lens: ${lens}.\nExplore this scope:\n${JSON.stringify(scope)}\n` +
+    `Return typed observations with concrete file paths as evidence. Stay within ` +
+    `your lens — the coordinator maps and analyzes across scanners.` +
+    mandatoryInjections()
+  );
+}
+
+// Build a coordinator prompt (MAP/ANALYZE/COMPILE/ASSESS/SYNTHESIZE/REFINE/
+// REPORT). Same skill stack + mandatory injections as a direct /do dispatch of
+// the coordinator. Read-only: the coordinator reasons over evidence, never edits.
+function coordinatorPrompt(task, payload) {
+  return (
+    task +
+    skillDirectives(AGENT_SKILLS[COORDINATOR_AGENT]) +
+    `\n${JSON.stringify(payload)}` +
+    mandatoryInjections()
+  );
+}
+
+// --- Workflow body ------------------------------------------------------------
+//
+// run({scope, tier, deep}):
+//   - scope: the exploration descriptor (target repo/subsystem + focus).
+//   - tier: right-size tier from /do. tier <= 3 -> Standard (4 phases); tier 4 ->
+//     Deep (all 8). The prose Quick/Standard/Deep model mapped onto the tier dial.
+//   - deep: explicit override — force the Deep 8-phase set regardless of tier.
+
+export default async function run({ scope, tier, deep } = {}) {
+  const effectiveTier = typeof tier === "number" ? tier : 2;
+  const runDeep = deep === true || effectiveTier >= 4;
+  const minTailBudget = 8000;
+
+  // Phase SCAN: the fixed parallel barrier of 3 read-only scanners (Structure,
+  // Entry Point, Pattern). Dispatched in one parallel() call; failed slots resolve
+  // to null and are filtered (the prose minimum-2-of-3 gate). This is the static
+  // barrier the contract pins.
+  enterPhase("scan");
+  const rawScans = await parallel(
+    SCANNERS.map((s) => () =>
+      agent({
+        prompt: scanPrompt(s.lens, scope),
+        schema: SCAN_SCHEMA,
+        model: "sonnet",
+        agentType: "research-subagent-executor",
+      }),
+    ),
+  );
+  const scans = rawScans.filter((x) => x != null);
+
+  // Phase MAP: one coordinator builds the architecture map from the scan findings.
+  enterPhase("map");
+  let architectureMap = null;
+  if (scans.length > 0 && budget.remaining() >= minTailBudget) {
+    architectureMap = await agent({
+      prompt: coordinatorPrompt(
+        `Build an architecture map from these parallel scanner findings: identify ` +
+          `layers, component relationships (depends_on/dependents), and data flow. ` +
+          `Scanner findings (typed, in-memory):\n`,
+        scans,
+      ),
+      schema: MAP_SCHEMA,
+      model: "sonnet",
+      agentType: COORDINATOR_AGENT,
+    });
+  }
+
+  // Phase ANALYZE: deep investigation of core abstractions + critical paths +
+  // conventions, grounded in the architecture map.
+  enterPhase("analyze");
+  let analysis = null;
+  if (architectureMap && budget.remaining() >= minTailBudget) {
+    analysis = await agent({
+      prompt: coordinatorPrompt(
+        `Analyze the key components from this architecture map: single ` +
+          `responsibility + patterns per abstraction, trace the critical execution ` +
+          `paths end-to-end, and document the implicit conventions. Map + scans ` +
+          `(typed):\n`,
+        { architectureMap, scans },
+      ),
+      schema: ANALYZE_SCHEMA,
+      model: "sonnet",
+      agentType: COORDINATOR_AGENT,
+    });
+  }
+
+  // Deep-tier quality limb: COMPILE -> ASSESS -> SYNTHESIZE -> REFINE. These run
+  // ONLY at the Deep tier (the prose Phases 4-7). Their presence is tier-gated, so
+  // the contract declares the tail dynamic:true (honest limit — not count-checked).
+  let compilation = null;
+  let assessment = null;
+  let synthesis = null;
+  let refinement = null;
+  if (runDeep && analysis) {
+    // Phase COMPILE: structure raw findings into evaluation dimensions.
+    enterPhase("compile");
+    if (budget.remaining() >= minTailBudget) {
+      compilation = await agent({
+        prompt: coordinatorPrompt(
+          `Compile the exploration findings into the evaluation dimensions ` +
+            `(consistency, quality, coverage, patterns) with per-component data. ` +
+            `Analysis + map (typed):\n`,
+          { analysis, architectureMap },
+        ),
+        schema: COMPILE_SCHEMA,
+        model: "sonnet",
+        agentType: COORDINATOR_AGENT,
+      });
+    }
+
+    // Phase ASSESS: score each dimension; catalog deviations with root causes.
+    enterPhase("assess");
+    if (compilation && budget.remaining() >= minTailBudget) {
+      assessment = await agent({
+        prompt: coordinatorPrompt(
+          `Score each evaluation dimension (compliance %, outliers), and catalog ` +
+            `each deviation with severity (critical|high|medium|low) and root ` +
+            `cause (intentional vs drift). Compiled dimensions (typed):\n`,
+          compilation,
+        ),
+        schema: ASSESS_SCHEMA,
+        model: "sonnet",
+        agentType: COORDINATOR_AGENT,
+      });
+    }
+
+    // Phase SYNTHESIZE: rank findings by impact; group by theme.
+    enterPhase("synthesize");
+    if (assessment && budget.remaining() >= minTailBudget) {
+      synthesis = await agent({
+        prompt: coordinatorPrompt(
+          `Rank the assessed deviations by severity and group them into themes ` +
+            `(e.g. error-handling consistency, test-coverage gaps, naming drift). ` +
+            `Assessment (typed):\n`,
+          assessment,
+        ),
+        schema: SYNTHESIZE_SCHEMA,
+        model: "sonnet",
+        agentType: COORDINATOR_AGENT,
+      });
+    }
+
+    // Phase REFINE: verify top findings against actual source; drop false positives.
+    enterPhase("refine");
+    if (synthesis && budget.remaining() >= minTailBudget) {
+      refinement = await agent({
+        prompt: coordinatorPrompt(
+          `Verify the top-ranked findings against the actual source code; remove ` +
+            `any that turn out to be intentional (false positives). Ranked ` +
+            `recommendations (typed):\n`,
+          synthesis,
+        ),
+        schema: REFINE_SCHEMA,
+        model: "sonnet",
+        agentType: COORDINATOR_AGENT,
+      });
+    }
+  }
+
+  // Phase REPORT: the final exploration report (the prose exploration-report.md),
+  // built from everything gathered. One coordinator pass (runs for all tiers).
+  enterPhase("report");
+  let report = null;
+  if (scans.length > 0 && budget.remaining() >= minTailBudget) {
+    report = await agent({
+      prompt: coordinatorPrompt(
+        `Produce the final exploration report: executive summary, quick facts ` +
+          `(language/framework/architecture/test-strategy), key components, and ` +
+          `next steps for understanding. Include the quality assessment + ranked ` +
+          `recommendations when present (deep tier). All findings (typed):\n`,
+        { scans, architectureMap, analysis, compilation, assessment, synthesis, refinement },
+      ),
+      schema: REPORT_SCHEMA,
+      model: "sonnet",
+      agentType: COORDINATOR_AGENT,
+    });
+  }
+
+  return {
+    tier: effectiveTier,
+    deep: runDeep,
+    scanners_ran: scans.length,
+    architecture_mapped: architectureMap != null,
+    analyzed: analysis != null,
+    quality_limb_ran: runDeep,
+    report,
+    budget_remaining: budget.remaining(),
+  };
+}

--- a/skills/workflow/references/research-pipeline.js
+++ b/skills/workflow/references/research-pipeline.js
@@ -1,0 +1,320 @@
+// research-pipeline.js
+//
+// Native dynamic-Workflow variant of the formal research pipeline. The markdown
+// flow at ./research-pipeline.md remains the cross-harness floor; this script is
+// the deterministic-runtime FAST-PATH for Claude Code (+Factory) when the native
+// Workflow tool is present. It mirrors the prose GATHER -> SYNTHESIZE -> VALIDATE
+// -> DELIVER agent flow, replacing the research/{topic}/*.md disk round-trips
+// with schema-validated typed agent() returns and a real parallel() barrier for
+// the mandatory multi-agent gather.
+//
+// The prose pipeline MANDATES a minimum of 3 parallel research agents (sequential
+// research is forbidden — A/B-validated). This workflow honors that as a FIXED
+// 3-agent GATHER barrier of research-subagent-executor specialists (the
+// static-roster shape, like comprehensive-review-workflow.js Wave 1), then runs a
+// dynamic SYNTHESIZE/VALIDATE/DELIVER tail through the research-coordinator-
+// engineer (the prose pipeline's owning agent). The prose SCOPE phase is a
+// deterministic decision step (angle + depth selection from a fixed table), so it
+// runs in-body before the barrier — no LLM round-trip (PHILOSOPHY: everything
+// deterministic should be).
+//
+// Runtime contract (see ./comprehensive-review-workflow.js for the canonical
+// description of the native primitives): meta is a pure object literal parsed
+// before the body; parallel(thunks) is a hard barrier (failed slot -> null);
+// agent({prompt, schema, model, agentType}) returns a typed object; budget.
+// remaining() bounds the tail. No Date.now()/Math.random()/new Date().
+
+import { skillDirectives, mandatoryInjections } from "./workflow-helpers.js";
+
+export const meta = {
+  name: "research-pipeline",
+  description:
+    "Formal research pipeline as a deterministic native Workflow: a deterministic scope step then GATHER -> SYNTHESIZE -> VALIDATE -> DELIVER. GATHER is a mandatory parallel barrier of >=3 research-subagent-executor specialists (distinct angles, no shared file), each attaching its full skill stack (one Skill() per skill) plus the /do mandatory injections; the research-coordinator-engineer then synthesizes the typed findings in-memory, runs a source-quality VALIDATE gate, and DELIVERs the report. Mirrors research-pipeline.md; that markdown flow stays the cross-harness floor.",
+  // --- Conformance contract (pure literal — no calls/variables; see
+  //     scripts/validate-workflow-conformance.py + adr/native-fast-path-portable-floor.md
+  //     Stage 3). STATIC validation pins the phases + the FIXED 3-agent GATHER
+  //     barrier (the parallel-agents mandate, countable). DYNAMIC validation
+  //     records the real dispatch trace and asserts SHAPE + SKILLS, NOT count,
+  //     where dynamic:true. name + description stay BEFORE this nested object so
+  //     the non-greedy meta-name parser in workflow-registry.py still resolves
+  //     meta.name.
+  contract: {
+    // Phase titles entered at runtime via enterPhase(). GATHER (the barrier) is
+    // the first entered phase; the deterministic scope step precedes it in-body.
+    phases: ["gather", "synthesize", "validate", "deliver"],
+    // GATHER is a FIXED barrier: 3 research-subagent-executor agents on every run
+    // (the minimum-3 mandate from the prose pipeline). Each carries a `skills` LIST
+    // (the full stack attached via one Skill() per element). Distinct angles are a
+    // RUNTIME property of the prompt, not the roster shape, so the static roster is
+    // three identical-type entries (the gate pins the type + skills + count).
+    roster: [
+      { agentType: "research-subagent-executor", skills: ["research-pipeline", "verification-before-completion"] },
+      { agentType: "research-subagent-executor", skills: ["research-pipeline", "verification-before-completion"] },
+      { agentType: "research-subagent-executor", skills: ["research-pipeline", "verification-before-completion"] },
+    ],
+    // The GATHER barrier dispatches at least the fixed 3 on every run (static).
+    agents: { static: 3, dynamic: false },
+    // SYNTHESIZE/VALIDATE/DELIVER are single coordinator passes, and GATHER can
+    // scale ABOVE 3 angles for deeper requests (depth setting) — the count beyond
+    // the fixed-3 floor is data-driven. Honest limit: the gate asserts SHAPE +
+    // SKILLS for the tail, not COUNT.
+    dynamic: true,
+  },
+};
+
+// Map each dispatched agent to the FULL skill stack it invokes by name (one
+// Skill() per element). research-subagent-executor runs the research methodology
+// and earns the source-quality verification gate; the coordinator synthesizes,
+// validates, and delivers with the same stack. The literal skill names live in
+// these `skills: [...]` arrays so the conformance gate resolves them; the body
+// emits the directives by delegating each entry's list to skillDirectives().
+const AGENT_SKILLS = {
+  "research-subagent-executor": ["research-pipeline", "verification-before-completion"],
+  "research-coordinator-engineer": ["research-pipeline", "verification-before-completion"],
+};
+
+// The mandated minimum gather size; a deeper request scales angles ABOVE this
+// floor (the prose depth setting), never below it.
+const MIN_GATHER_AGENTS = 3;
+const COORDINATOR_AGENT = "research-coordinator-engineer";
+
+// Default research angles (mirrors the prose angle table). One distinct angle per
+// gather agent; deeper depth adds more from the tail of this list.
+const DEFAULT_ANGLES = [
+  "current-state",
+  "tradeoffs",
+  "expert-opinions",
+  "alternatives",
+  "technical-details",
+];
+
+// --- Schemas (mirror the STYLE of comprehensive-review-workflow.js) -----------
+
+// One angle's raw research output. Findings carry an evidence-strength note so
+// SYNTHESIZE can rate consensus vs single-source (the prose Strong/Moderate/Weak
+// gate). Mirrors the raw-{angle}.md structure as a typed object.
+const CLAIM_SCHEMA = {
+  type: "object",
+  required: ["claim", "evidence"],
+  properties: {
+    claim: { type: "string" },
+    evidence: { type: "string", enum: ["strong", "moderate", "weak"] },
+    source: { type: "string" },
+  },
+};
+
+const RAW_RESEARCH_SCHEMA = {
+  type: "object",
+  required: ["angle", "claims"],
+  properties: {
+    angle: { type: "string" },
+    claims: { type: "array", items: CLAIM_SCHEMA },
+    gaps: { type: "array", items: { type: "string" } },
+    sources: { type: "array", items: { type: "string" } },
+  },
+};
+
+// SYNTHESIZE output: consensus findings, contradictions, open gaps — the prose
+// synthesis.md as a typed object.
+const SYNTHESIS_SCHEMA = {
+  type: "object",
+  required: ["findings"],
+  properties: {
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["title", "evidence_quality"],
+        properties: {
+          title: { type: "string" },
+          evidence_quality: { type: "string", enum: ["strong", "moderate", "weak"] },
+          summary: { type: "string" },
+        },
+      },
+    },
+    contradictions: { type: "array", items: { type: "string" } },
+    open_gaps: { type: "array", items: { type: "string" } },
+  },
+};
+
+// VALIDATE output: the prose Quality Assessment + research verdict gate.
+const VALIDATION_SCHEMA = {
+  type: "object",
+  required: ["verdict"],
+  properties: {
+    verdict: { type: "string", enum: ["sufficient", "partial", "insufficient"] },
+    coverage: { type: "string" },
+    bias_flags: { type: "array", items: { type: "string" } },
+    flagged_weak_findings: { type: "array", items: { type: "string" } },
+  },
+};
+
+// DELIVER output: the final report descriptor (the prose report.md).
+const REPORT_SCHEMA = {
+  type: "object",
+  required: ["executive_summary"],
+  properties: {
+    executive_summary: { type: "array", items: { type: "string" } },
+    detailed_findings: { type: "string" },
+    sources: { type: "array", items: { type: "string" } },
+    limitations: { type: "array", items: { type: "string" } },
+  },
+};
+
+// --- Helpers ------------------------------------------------------------------
+
+// Defensive phase marker: the native runtime guarantees agent/parallel/budget,
+// but does NOT document a phase() global. Guard the call so the real runtime
+// never throws if phase is absent, while the conformance harness's mock records
+// the entered phase. Phase titles match meta.contract.phases.
+function enterPhase(title) {
+  if (typeof phase === "function") {
+    phase(title);
+  }
+}
+
+// Build one gather agent's prompt for its assigned angle. skillDirectives emits
+// one Skill("...") per element of the research-subagent-executor skill stack
+// (resolves path-independent inside a native Workflow agent() dispatch).
+// mandatoryInjections() embeds the /do completeness/density/base-instructions/
+// reference-loading block so a workflow agent gets the same context as a direct
+// /do dispatch. Each agent gets a DISTINCT angle and writes its own typed result
+// (no shared file), mirroring the prose raw-{angle}.md isolation that preserves
+// distinct perspectives.
+function gatherPrompt(angle, scope) {
+  return (
+    `You are the "${angle}" research agent (research-subagent-executor).` +
+    skillDirectives(AGENT_SKILLS["research-subagent-executor"]) +
+    `\nYour angle: investigate the "${angle}" dimension of this research scope:\n` +
+    `${JSON.stringify(scope)}\n` +
+    `Return ONLY findings within your angle. Rate each claim's evidence strength ` +
+    `(strong|moderate|weak); "strong" requires specific independent sources, not ` +
+    `just agreement. List the gaps you could not fill and the sources you used. ` +
+    `Stay within your angle — the coordinator synthesizes across angles.` +
+    mandatoryInjections()
+  );
+}
+
+// Build a coordinator prompt (SYNTHESIZE/VALIDATE/DELIVER). Same skill stack +
+// mandatory injections as a direct /do dispatch of the coordinator.
+function coordinatorPrompt(task, payload) {
+  return (
+    task +
+    skillDirectives(AGENT_SKILLS[COORDINATOR_AGENT]) +
+    `\n${JSON.stringify(payload)}` +
+    mandatoryInjections()
+  );
+}
+
+// Build the angle list for this run: the fixed-3 floor (quick/standard), scaled
+// up only for `deep` (the prose depth setting allows 3-5 angles). Deterministic —
+// no LLM round-trip needed to scope. The default/standard path dispatches exactly
+// the mandated 3 (matching the static contract roster); `deep` scales above it
+// (honestly covered by contract.dynamic:true).
+function anglesForDepth(depth) {
+  const count = depth === "deep" ? 5 : MIN_GATHER_AGENTS;
+  return DEFAULT_ANGLES.slice(0, count);
+}
+
+// --- Workflow body ------------------------------------------------------------
+//
+// run({scope, tier, depth}):
+//   - scope: the research descriptor (primary question + sub-questions + source
+//     types). Passed to every gather agent and into synthesis.
+//   - tier: right-size tier (carried through; this pipeline scales angles by
+//     `depth`, the prose pipeline's own dial, not by review tier).
+//   - depth: quick | standard | deep — scales the gather angle count ABOVE the
+//     mandated 3. Default standard.
+
+export default async function run({ scope, tier, depth } = {}) {
+  const effectiveDepth = typeof depth === "string" ? depth : "standard";
+  const minTailBudget = 8000;
+
+  // SCOPE (deterministic, in-body): select the distinct angles + depth from the
+  // prose decision table. No agent dispatch — scoping is a deterministic choice.
+  const angles = anglesForDepth(effectiveDepth);
+
+  // Phase GATHER: the mandatory parallel barrier. At LEAST 3 research-subagent-
+  // executor agents, each on a DISTINCT angle, dispatched in one parallel() call
+  // (sequential research is forbidden by the prose pipeline). Failed slots resolve
+  // to null and are filtered; the barrier never drops below the mandated floor.
+  enterPhase("gather");
+  const rawResults = await parallel(
+    angles.map((angle) => () =>
+      agent({
+        prompt: gatherPrompt(angle, scope),
+        schema: RAW_RESEARCH_SCHEMA,
+        model: "sonnet",
+        agentType: "research-subagent-executor",
+      }),
+    ),
+  );
+  const raw = rawResults.filter((x) => x != null);
+
+  // Phase SYNTHESIZE: one coordinator over the typed raw results in-memory (no
+  // disk). Identifies consensus, contradictions, gaps; rates evidence quality.
+  enterPhase("synthesize");
+  let synthesis = null;
+  if (raw.length > 0 && budget.remaining() >= minTailBudget) {
+    synthesis = await agent({
+      prompt: coordinatorPrompt(
+        `Synthesize these ${raw.length} typed per-angle research results into ` +
+          `consensus findings, contradictions, and open gaps. Rate each finding's ` +
+          `evidence quality (strong only when backed by specific independent ` +
+          `sources, not mere agreement). Raw results (typed, in-memory):\n`,
+        raw,
+      ),
+      schema: SYNTHESIS_SCHEMA,
+      model: "sonnet",
+      agentType: COORDINATOR_AGENT,
+    });
+  }
+
+  // Phase VALIDATE: source-quality + coverage + bias gate before delivery (the
+  // prose Phase 4 quality assessment). One coordinator pass over the synthesis.
+  enterPhase("validate");
+  let validation = null;
+  if (synthesis && budget.remaining() >= minTailBudget) {
+    validation = await agent({
+      prompt: coordinatorPrompt(
+        `Run the research-quality gate over this synthesis: confirm "strong" ` +
+          `findings are backed by specific independent sources (not shared bias), ` +
+          `flag load-bearing weak findings, assess source diversity, and return a ` +
+          `verdict (sufficient|partial|insufficient). Synthesis (typed):\n`,
+        synthesis,
+      ),
+      schema: VALIDATION_SCHEMA,
+      model: "sonnet",
+      agentType: COORDINATOR_AGENT,
+    });
+  }
+
+  // Phase DELIVER: the final formatted report (the prose report.md), built from
+  // the validated synthesis. One coordinator pass.
+  enterPhase("deliver");
+  let report = null;
+  if (synthesis && budget.remaining() >= minTailBudget) {
+    report = await agent({
+      prompt: coordinatorPrompt(
+        `Produce the final research report from the validated synthesis: an ` +
+          `executive summary (3-5 bullets), detailed findings per angle with ` +
+          `sources, and explicit gaps/limitations. Synthesis + validation (typed):\n`,
+        { synthesis, validation },
+      ),
+      schema: REPORT_SCHEMA,
+      model: "sonnet",
+      agentType: COORDINATOR_AGENT,
+    });
+  }
+
+  return {
+    depth: effectiveDepth,
+    tier: typeof tier === "number" ? tier : null,
+    angles,
+    gather_agents_ran: raw.length,
+    synthesis,
+    validation,
+    report,
+    budget_remaining: budget.remaining(),
+  };
+}


### PR DESCRIPTION
## Summary

Implements ADR \`native-fast-path-portable-floor\` **Stage 3** (execution limb): migrates two prose pipelines to native \`.js\` workflows so the /do router has more native fast-path workflows. Prose \`.md\` definitions stay as the cross-harness floor (untouched).

- **research-pipeline.js** — GATHER (fixed >=3 \`research-subagent-executor\` barrier) -> SYNTHESIZE -> VALIDATE -> DELIVER (\`research-coordinator-engineer\`). SCOPE is a deterministic in-body step. Static 3-agent roster + dynamic tail.
- **explore-pipeline.js** — (incoming in this PR) tiered SCAN -> ... -> REPORT.

## Scope guard
EXECUTION limb only. No Phase 2 / Haiku / UserPromptSubmit / OD changes. Prose floors untouched.

## Conformance
Both new \`.js\` PASS \`scripts/validate-workflow-conformance.py\` (STATIC + DYNAMIC). \`workflow-registry.py\` resolves both by \`meta.name\`. The existing two workflows still pass.

Draft until both pipelines land and CI is green.