### PR TITLE
fix(do): validate Haiku agent slot before Agent dispatch

### DIFF
--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -155,6 +155,13 @@ Return your answer as JSON:
   "confidence": "high/medium/low"
 }
 
+SECTION-INTEGRITY RULE (HARD CONSTRAINT — never violate):
+- The `agent` field MUST be a name listed in the `AGENTS:` section of the manifest, or null. Never put a skill name in `agent`.
+- The `skill` field MUST be a name listed in the `SKILLS:` section of the manifest, or null. Never put an agent name in `skill`.
+- The `pipeline` field MUST be a name listed in the `PIPELINES:` section of the manifest, or null.
+- If no agent fits the request, return `"agent": null` — DO NOT promote a skill into the `agent` slot. The router will fall back to a default agent (e.g. `general-purpose`) and pair it with your chosen skill.
+- Skills marked `FORCE (process)` are still skills, not agents. They go in the `skill` field only. Example: `zsh-shell-config` is a SKILL — if it matches, set `"skill": "zsh-shell-config"` and pick a separate agent (or null) for `agent`.
+
 FORCE-ROUTE RULE: Entries marked "FORCE" in the manifest MUST be selected when their domain clearly matches the user's intent. However, FORCE matching is SEMANTIC, not keyword-based. Match on what the user MEANS, not individual words. Examples:
 - "push my changes" → pr-workflow (FORCE) ✓ (user means git push)
 - "push back on this design" → NOT pr-workflow (user means resist/argue)
@@ -188,6 +195,27 @@ Rules:
 **Step 0b: Apply the Haiku agent's recommendation**
 
 Use `agent` and `skill` fields directly. If `confidence` is "low", verify against INDEX files and `INDEX files`. Haiku response is internal — never print to user.
+
+**Dispatch-time section validator (MANDATORY before every `Agent(subagent_type=...)` call).** The Haiku router can mis-place a skill name in the `agent` field, and the harness then rejects the dispatch with `Agent type 'X' not found`. Before invoking the Agent tool, assert the `agent` field maps to a name in the manifest's `AGENTS:` section. Pseudocode:
+
+```
+agents_section = grep_section(manifest, "AGENTS:", "SKILLS:")
+skills_section = grep_section(manifest, "SKILLS:", "PIPELINES:")
+agent_names = [first_token(line) for line in agents_section]
+skill_names = [first_token(line) for line in skills_section]
+
+if haiku.agent and haiku.agent not in agent_names:
+    if haiku.agent in skill_names:
+        # Cross-section slip: Haiku put a skill in the agent slot.
+        haiku.skill = haiku.skill or haiku.agent  # promote to skill if empty
+        haiku.agent = None                         # clear bad agent pick
+    record_misroute(reason="agent-slot held skill name", value=haiku.agent)
+
+if haiku.agent is None:
+    haiku.agent = "general-purpose"  # safe fallback; pair with chosen skill
+```
+
+If the Haiku JSON is malformed, fall back to `general-purpose` + verification-before-completion. Always validate the agent name against the AGENTS: section before passing it to `subagent_type`.
 
 Route to the simplest agent+skill that satisfies the request. When `[cross-repo]` output is present, route to `.claude/agents/` local agents. Route all code modifications to domain agents.
 


### PR DESCRIPTION
## Summary

The Haiku routing agent occasionally returns a skill name (e.g. `zsh-shell-config`) in the `agent` field of its JSON. The harness then rejects the dispatch with `Agent type 'zsh-shell-config' not found`, surfacing the full agents list to the user. Two reinforcing fixes in `skills/meta/do/SKILL.md`:

- **Tighten the Haiku prompt** with a `SECTION-INTEGRITY RULE` that explicitly binds `agent` to the AGENTS: section, `skill` to SKILLS:, and `pipeline` to PIPELINES:. Includes a worked example showing FORCE-tagged skills are still skills.
- **Add a dispatch-time section validator** at Step 0b: before calling `Agent(subagent_type=...)`, assert the `agent` field appears in the manifest's AGENTS: section. On cross-section slip, promote the misplaced name to the skill slot, fall back to `general-purpose` for the agent, and record the misroute.

Documentation-only change. No code paths or tests were modified.

## Test plan

- [x] `ruff check . --config pyproject.toml` — clean
- [x] `ruff format --check . --config pyproject.toml` — 405 files already formatted
- [x] `python scripts/validate-references.py --check-do-framing` — pass
- [x] `python scripts/validate-skill-frontmatter.py` — 123 files OK
- [x] `python scripts/validate-index-integrity.py` — VERDICT: PASS (0 errors, 48 pre-existing warnings)
- [x] `python scripts/validate-doc-links.py` — 115 links resolve
- [x] `python scripts/validate-doc-counts.py` — 13 count claims agree
- [x] `python scripts/validate-doc-commands.py` — 26 script refs resolve
- [x] `pytest scripts/tests/ hooks/tests/` — 3136 passed (excludes 4 pre-existing macOS-specific tmp-path failures unrelated to this change)
- [x] `pytest scripts/tests/test_joy_check_instruction_mode.py` — 186 passed (verifies positive-instruction framing on the edited file)
- [ ] CI (`Tests` workflow) green on PR