### PR TITLE
docs(pr-workflow): canonical PR template + mandate consistent --body structure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Summary
+
+<!-- 1-3 sentences: WHAT changed and WHY. State the goal, not the diff. If this implements an ADR or closes an issue, name it. -->
+
+## Changes
+
+<!-- Bullet list of concrete changes, one per file or area: `path/or/area` — what changed. Keep each bullet to the actual edit, not intent. -->
+- `path/to/file` — what changed
+
+## Testing
+
+<!-- Show EVIDENCE, not "tests pass". Paste the command AND its result: ruff exit, pytest counts, gate traces, dogfood output. The reviewer must be able to see the proof, not take your word for it. -->
+```
+$ <command>
+<pasted output: counts / exit code / trace>
+```
+
+## Scope & Risk
+
+<!-- Which limb/area this touches; what was deliberately NOT touched (name the files/limbs); how to roll back. -->
+- **Touches:** <limb / area>
+- **NOT touched:** <files/limbs deliberately left alone — e.g. router, Phase 2, execution-limb .js>
+- **Rollback:** <revert the commit; no data migration / state change> 
+
+## Checklist
+
+<!-- Check the gates that apply. These mirror this repo's CI (.github/workflows/test.yml). Omit a line only if it genuinely does not apply. -->
+- [ ] `ruff check . --config pyproject.toml` clean (excl `venv.312.bak`) — *if any `.py` touched*
+- [ ] `ruff format --check . --config pyproject.toml` clean (excl `venv.312.bak`) — *if any `.py` touched*
+- [ ] `python -m pytest --tb=short -q` green (paste counts above)
+- [ ] `python scripts/validate-doc-counts.py` → 0 drift
+- [ ] `python scripts/validate-workflow-conformance.py` passes — *if any workflow `.js` touched*
+- [ ] `python scripts/validate-skill-frontmatter.py` / `validate-references.py --check-do-framing` clean — *if any skill/agent touched*
+- [ ] joy-check / positive-instruction prose floors untouched — *if any prose floor touched*
+- [ ] No forbidden files staged (no `git add -A`; no `INDEX.json`, `venv.312.bak/`, chmod-only churn, or untracked junk)

--- a/skills/process/pr-workflow/SKILL.md
+++ b/skills/process/pr-workflow/SKILL.md
@@ -117,8 +117,48 @@ Detect the user's intent and load the appropriate reference file:
 | "commit changes", "stage and commit", "commit my changes", "commit my files", "commit these" | `commit.md` | **Commit** |
 | "codex review", "second opinion", "code review codex", "gpt review", "cross-model review" | `codex-review.md` | **Codex review** |
 
+## Mandatory PR Body Structure
+
+`gh pr create --body "..."` is how every agent in this toolkit opens PRs, and it **bypasses `.github/pull_request_template.md` entirely** — GitHub only applies that file to the web UI and to a bare `gh pr create` with no `--body`. So the structure must be reproduced in the `--body` string by hand.
+
+Every agent-authored PR body MUST follow the same five sections as `.github/pull_request_template.md`, in this order: **Summary → Changes → Testing → Scope & Risk → Checklist**. This keeps PR bodies consistent across models (Opus, Sonnet, and every other harness produce the same shape).
+
+The **Testing** section requires pasted command output (ruff exit, pytest counts, gate traces, dogfood output), never the bare claim "tests pass" — this ties to `verification-before-completion`: evidence, not assertion.
+
+Copy this canonical skeleton into `--body`:
+
+```markdown
+## Summary
+<!-- 1-3 sentences: what changed and why. Name the ADR/issue if any. -->
+
+## Changes
+- `path/to/file` — what changed
+
+## Testing
+<!-- Paste command + result. Evidence, not "tests pass". -->
+\`\`\`
+$ <command>
+<pasted output: counts / exit code / trace>
+\`\`\`
+
+## Scope & Risk
+- **Touches:** <limb / area>
+- **NOT touched:** <files/limbs deliberately left alone>
+- **Rollback:** <revert the commit; any state notes>
+
+## Checklist
+- [ ] ruff check + format clean (excl `venv.312.bak`) — if any `.py` touched
+- [ ] pytest green (counts pasted above)
+- [ ] `validate-doc-counts.py` → 0 drift
+- [ ] conformance gate passes — if any workflow `.js` touched
+- [ ] No forbidden files staged
+```
+
+The sync (`sync.md` Step 5) and pipeline (`pipeline.md` Phase 5) references carry this same skeleton at their `gh pr create` call sites. When either path writes a `--body`, it uses this structure.
+
 ## Instructions
 
 1. Identify the user's PR task from their message
 2. Load the matching reference file from the table above
 3. Follow the instructions in that reference file exactly
+4. When the task creates a PR, build the `--body` from the canonical five-section skeleton above (Summary / Changes / Testing / Scope & Risk / Checklist), because `--body` bypasses the GitHub template file

--- a/skills/process/pr-workflow/references/pipeline.md
+++ b/skills/process/pr-workflow/references/pipeline.md
@@ -252,20 +252,33 @@ See `references/pr-templates.md` for the full artifact table, PR body template, 
 
 This pipeline cannot create PRs without staged changes -- if nothing is staged, the earlier phases would have caught this.
 
+**PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's five sections in the `--body` string, in order: **Summary → Changes → Testing → Scope & Risk → Checklist**. This keeps PR bodies consistent across models. The **Testing** section requires pasted command output (ruff exit, pytest counts, gate traces, reviewer verdicts) — evidence, not the bare claim "tests pass" — which ties to `verification-before-completion`.
+
 ```bash
 CLAUDE_GATE_BYPASS=1 gh pr create --title "type(scope): description" --body "$(cat <<'EOF'
 ## Summary
-- [Key change 1]
-- [Key change 2]
+[1-3 sentences: what changed and why. Name the ADR/issue if any.]
 
-## Test Plan
-- [ ] Tests pass
-- [ ] Manual verification of [specific behavior]
+## Changes
+- `path/to/file` — what changed
 
-## Review Findings
-Security: PASS
-Business Logic: PASS
-Code Quality: PASS
+## Testing
+[Paste command + result. Evidence, not "tests pass". Include Phase 2/4b reviewer verdicts. Wrap output in a fenced block.]
+$ <command>
+<pasted output: counts / exit code / trace>
+Security: PASS  Business Logic: PASS  Code Quality: PASS
+
+## Scope & Risk
+- **Touches:** <limb / area>
+- **NOT touched:** <files/limbs deliberately left alone>
+- **Rollback:** <revert the commit; any state notes>
+
+## Checklist
+- [ ] ruff check + format clean (excl `venv.312.bak`) — if any `.py` touched
+- [ ] pytest green (counts pasted above)
+- [ ] `validate-doc-counts.py` → 0 drift
+- [ ] conformance gate passes — if any workflow `.js` touched
+- [ ] No forbidden files staged
 EOF
 )"
 ```
@@ -656,40 +669,46 @@ Check for artifacts in this order and build the PR body from what's available:
 | Artifact | PR Section Generated | How to Extract |
 |----------|---------------------|----------------|
 | `task_plan.md` | **Summary** (from Goal section) and **Changes** (from completed tasks) | Read the Goal and Phases sections; list completed items as change bullets |
-| Verification reports (`*-verification.md`, test output) | **Test Plan** (from verification output) | Extract pass/fail counts and key assertions verified |
-| Review summaries (Phase 2 / Phase 4b output) | **Review Findings** (from reviewer results) | Summarize security/logic/quality verdicts |
-| Deviation logs (ADR-076 repair actions) | **Deviations** section | List repair actions taken and why the original plan changed |
+| Verification reports (`*-verification.md`, test output) | **Testing** (paste pass/fail counts) | Extract pass/fail counts and key assertions verified |
+| Review summaries (Phase 2 / Phase 4b output) | **Testing** (reviewer verdicts) | Summarize security/logic/quality verdicts |
+| Deviation logs (ADR-076 repair actions) | **Scope & Risk** (deviations) | List repair actions taken and why the original plan changed |
 
 **Fallback**: If no artifacts exist, fall back to diff-based generation -- summarize changes from the diff and commit messages. This is the existing behavior and remains the default for ad-hoc PRs without planning artifacts.
 
 ## PR Body Template (Artifact-Driven)
 
+Follows the canonical five-section structure from `.github/pull_request_template.md` (Summary / Changes / Testing / Scope & Risk / Checklist), with each section populated from artifacts. Reviewer verdicts and deviation logs fold into **Testing** and **Scope & Risk**.
+
 ```markdown
 ## Summary
 <!-- From task_plan.md Goal section, or from commit messages if no plan -->
-- [Goal statement]
-- [Key change 1 from completed tasks]
-- [Key change 2 from completed tasks]
+[Goal statement: what changed and why, 1-3 sentences. Name the ADR/issue if any.]
 
 ## Changes
 <!-- From task_plan.md completed phases/tasks -->
-- [Completed task description]
-- [Completed task description]
+- `path/to/file` — [completed task description]
+- `path/to/file` — [completed task description]
 
-## Test Plan
-<!-- From verification reports, or manual checklist if no reports -->
-- [ ] [Verification result 1]
-- [ ] [Verification result 2]
+## Testing
+<!-- From verification reports + Phase 2/4b review output. Paste evidence, not "tests pass". -->
+\`\`\`
+$ <command>
+<pasted output: counts / exit code / trace>
+Security: PASS  Business Logic: PASS  Code Quality: PASS
+\`\`\`
 
-## Review Findings
-<!-- From Phase 2 / Phase 4b review output -->
-Security: PASS
-Business Logic: PASS
-Code Quality: PASS
+## Scope & Risk
+- **Touches:** [limb / area from task_plan]
+- **NOT touched:** [files/limbs deliberately left alone]
+- **Rollback:** [revert the commit; any state notes]
+- **Deviations:** [from deviation logs (ADR-076); omit if none]
 
-## Deviations
-<!-- From deviation logs, omit section if none -->
-- [Deviation description and rationale]
+## Checklist
+- [ ] ruff check + format clean (excl `venv.312.bak`) — if any `.py` touched
+- [ ] pytest green (counts pasted above)
+- [ ] `validate-doc-counts.py` → 0 drift
+- [ ] conformance gate passes — if any workflow `.js` touched
+- [ ] No forbidden files staged
 ```
 
 ---

--- a/skills/process/pr-workflow/references/sync.md
+++ b/skills/process/pr-workflow/references/sync.md
@@ -140,19 +140,36 @@ After 3 iterations, proceed to Step 5 with any remaining issues documented in th
 
 Generate the PR title from the branch name or first commit when not provided by the user. Never create a PR with an empty description, because reviewers need context to understand the changes and a missing test plan signals incomplete work.
 
+**PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's five sections in the `--body` string, in order: **Summary → Changes → Testing → Scope & Risk → Checklist**. This keeps PR bodies consistent across models. The **Testing** section requires pasted command output (ruff exit, pytest counts, gate traces) — evidence, not the bare claim "tests pass" — which ties to `verification-before-completion`.
+
 ```bash
 # Check if PR already exists for this branch
 EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number' 2>/dev/null)
 
 if [[ -z "$EXISTING_PR" ]]; then
-    # Create new PR
+    # Create new PR — --body follows .github/pull_request_template.md's section structure
     CLAUDE_GATE_BYPASS=1 gh pr create --title "$PR_TITLE" --body "$(cat <<'EOF'
 ## Summary
-[Description of changes]
+[1-3 sentences: what changed and why. Name the ADR/issue if any.]
 
-## Test Plan
-- [ ] Tested locally
-- [ ] Tests pass
+## Changes
+- `path/to/file` — what changed
+
+## Testing
+[Paste command + result. Evidence, not "tests pass". Wrap output in a fenced block.]
+$ <command>
+<pasted output: counts / exit code / trace>
+
+## Scope & Risk
+- **Touches:** <limb / area>
+- **NOT touched:** <files/limbs deliberately left alone>
+- **Rollback:** <revert the commit; any state notes>
+
+## Checklist
+- [ ] ruff check + format clean (excl `venv.312.bak`) — if any `.py` touched
+- [ ] pytest green (counts pasted above)
+- [ ] `validate-doc-counts.py` → 0 drift
+- [ ] No forbidden files staged
 EOF
 )"
 else


### PR DESCRIPTION
## Summary

Adds `.github/pull_request_template.md` (the canonical PR structure) and mandates that agent-authored `gh pr create --body` reproduce the same five sections — because `--body` bypasses the GitHub template file entirely (GitHub applies it only to the web UI / a bare `gh pr create`). This makes PR bodies consistent across models (Opus 4.8 was producing radically different bodies than 4.6/4.7/Sonnet). PROCESS limb only.

## Changes

- `.github/pull_request_template.md` — new canonical structure: Summary / Changes / Testing / Scope & Risk / Checklist. Comment-guided (HTML hints); checklist mirrors this repo's actual CI gates (ruff check + format excl `venv.312.bak`, pytest, doc-counts, conformance-if-workflows, frontmatter/references-if-skill, prose floors, no forbidden files staged).
- `skills/process/pr-workflow/SKILL.md` — new **Mandatory PR Body Structure** section + canonical body skeleton inline; Instructions step 4 enforces it. States the `--body`-bypasses-template mechanism and that Testing requires pasted evidence (ties to `verification-before-completion`).
- `skills/process/pr-workflow/references/sync.md` — Step 5 `gh pr create --body` rewritten from the thin `## Summary / ## Test Plan` stub to the five-section structure, with the mandate stated above the call site.
- `skills/process/pr-workflow/references/pipeline.md` — Phase 5 Step 2 `--body` aligned to the five sections; artifact-driven PR body template + artifact→section mapping table updated to match (reviewer verdicts → Testing, deviations → Scope & Risk).

## Testing

Markdown fence balance (all edited files BALANCED; inner Testing fences escaped inside display blocks so renders are clean):
```
$ for f in .github/pull_request_template.md skills/process/pr-workflow/SKILL.md \
    skills/process/pr-workflow/references/sync.md skills/process/pr-workflow/references/pipeline.md; do
    n=$(grep -c '```' "$f"); echo "$f: $n ($([ $((n%2)) -eq 0 ] && echo BALANCED))"; done
.github/pull_request_template.md: 2 (BALANCED)
SKILL.md: 2 (BALANCED)
sync.md: 24 (BALANCED)
pipeline.md: 50 (BALANCED)

$ python3 scripts/validate-doc-counts.py --json   ->  "drifts": []
$ python3 scripts/validate-skill-frontmatter.py   ->  123 file(s) OK
$ python3 scripts/validate-references.py --check-do-framing  ->  no new unpaired anti-pattern blocks
$ python3 scripts/validate-doc-links.py           ->  116 links / 16 files, All links resolve
$ python3 scripts/validate_positive_instruction_docs.py  ->  exit 0; 0 new violations in edited files
$ python3 -m pytest scripts/tests/test_joy_check_instruction_mode.py -q  ->  186 passed
$ python3 scripts/check-routing-drift.py          ->  clean (no drift)
$ python3 scripts/validate-index-integrity.py     ->  VERDICT: PASS (0 errors)
```
No `.py` files changed, so ruff is N/A to this diff. This PR body itself uses the new template (dogfood).

## Scope & Risk

- **Touches:** PROCESS limb only — `.github/` + `skills/process/pr-workflow` (SKILL.md, sync.md, pipeline.md).
- **NOT touched:** the `/do` router, Phase 2 / Haiku / `UserPromptSubmit` / OD, execution-limb workflow `.js` files, any `INDEX.json`, `venv.312.bak/`, `skills/voice-shared-references/*`, chmod-only churn files, untracked junk. Staged exactly 4 files (no `git add -A`).
- **Rollback:** revert the single commit; docs/prose only, no state or schema change.

## Checklist

- [x] `python -m pytest scripts/tests/test_joy_check_instruction_mode.py` green (186 passed)
- [x] `validate-doc-counts.py` → 0 drift
- [x] `validate-skill-frontmatter.py` + `validate-references.py --check-do-framing` clean
- [x] joy-check / positive-instruction prose floors clean (0 new violations)
- [x] No forbidden files staged (only the 4 intended files)
- [ ] ruff — N/A (no `.py` touched)
- [ ] conformance gate — N/A (no workflow `.js` touched)