### PR TITLE
fix(install): replace deprecated datetime.utcnow() with timezone-aware equivalent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1705,7 +1705,7 @@ try:
 except Exception:
     commit = 'unknown'
 manifest = {
-    'installed_at': datetime.datetime.utcnow().isoformat() + 'Z',
+    'installed_at': datetime.datetime.now(datetime.timezone.utc).isoformat(),
     'toolkit_commit': commit,
     'toolkit_path': '${SCRIPT_DIR}',
     'mode': '${MODE}',


### PR DESCRIPTION
## Summary
- Replace `datetime.datetime.utcnow()` with `datetime.datetime.now(datetime.timezone.utc)` in `install.sh`

## Why
Python 3.12+ emits a `DeprecationWarning` for `utcnow()` on every `install.sh` run during index regeneration. Fix uses timezone-aware UTC — semantically equivalent, Python 3.9+ compatible, warning-free.

## Test plan
- [ ] Run `./install.sh` and confirm no `DeprecationWarning` about `datetime.utcnow()` appears