### PR TITLE
feat(harness): add reasonix as a sixth supported harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cd ~/vexjoy-agent
 ./install.sh
 ```
 
-Links into `~/.claude/` and mirrors into `~/.codex/`, `~/.gemini/`, `~/.factory/`. The installer asks symlink (live updates via `git pull`) or copy (stable snapshot).
+Links into `~/.claude/` and mirrors into `~/.codex/`, `~/.gemini/`, `~/.factory/`, `~/.reasonix/`. The installer asks symlink (live updates via `git pull`) or copy (stable snapshot).
 
 | CLI | Entry Point |
 |-----|-------------|
@@ -70,6 +70,7 @@ Links into `~/.claude/` and mirrors into `~/.codex/`, `~/.gemini/`, `~/.factory/
 | Codex | `$do` |
 | Gemini CLI | `/do` |
 | Factory | `/do` |
+| Reasonix | `/do` |
 
 **Full setup:** [docs/start-here.md](docs/start-here.md)
 
@@ -93,6 +94,13 @@ Mirrors agents, skills, and Phase 1 hooks into `~/.gemini/`. Translates event na
 <summary><b>Factory CLI Support</b></summary>
 
 Mirrors agents (as "droids"), skills, and all hooks into `~/.factory/`. Hook config merges into `~/.factory/settings.json` with paths rewritten.
+
+</details>
+
+<details>
+<summary><b>Reasonix Support</b></summary>
+
+Mirrors skills, scripts, and all hooks into `~/.reasonix/` (no agent or custom-command surface, so neither is installed; the `/do` router rides in as a skill). Reasonix's hook contract is Claude-Code-identical, so hook config is written to the `hooks` key of `~/.reasonix/settings.json` with paths rewritten. MCP/model/permissions in `~/.reasonix/config.json` are user-owned and left untouched.
 
 </details>
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,13 +13,14 @@ cd ~/vexjoy-agent
 ./install.sh
 ```
 
-Claude Code is the primary runtime. If you also use Codex CLI, Gemini CLI, or Factory, the same install mirrors toolkit skills and agents into `~/.codex/`, `~/.gemini/`, and `~/.factory/` so all four CLIs share the same skill and agent library.
+Claude Code is the primary runtime. If you also use Codex CLI, Gemini CLI, Factory, or Reasonix, the same install mirrors toolkit skills and agents into `~/.codex/`, `~/.gemini/`, `~/.factory/`, and `~/.reasonix/` so all the CLIs share the same skill and agent library.
 
 Command entry points:
 - Claude Code: `/do`
 - Codex: `$do`
 - Gemini CLI: `/do`
 - Factory: `/do`
+- Reasonix: `/do`
 
 **Alternative (bootstrap via Claude):** Start Claude Code in the vexjoy-agent directory. The sync hook will automatically copy agents, skills, hooks, commands, and scripts to `~/.claude/`.
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -12,9 +12,9 @@ claude --version
 
 If that prints a version number, you're good. If not, install Claude Code first and come back.
 
-Optional: Codex CLI, Gemini CLI, or Factory. The toolkit mirrors skills and agents into their directories (`~/.codex/`, `~/.gemini/`, `~/.factory/`), so all four CLIs dispatch the same domain expertise. Claude Code remains the full runtime for hooks, commands, and scripts.
+Optional: Codex CLI, Gemini CLI, Factory, or Reasonix. The toolkit mirrors skills and agents into their directories (`~/.codex/`, `~/.gemini/`, `~/.factory/`, `~/.reasonix/`), so all the CLIs dispatch the same domain expertise. Claude Code remains the full runtime for hooks, commands, and scripts.
 
-Verify optional tools: `codex --version` / `gemini --version` / `factory --version`.
+Verify optional tools: `codex --version` / `gemini --version` / `factory --version` / `reasonix --version`.
 
 Command entry points:
 
@@ -24,6 +24,7 @@ Command entry points:
 | Codex | `$do` |
 | Gemini CLI | `/do` |
 | Factory | `/do` |
+| Reasonix | `/do` |
 
 ## Install
 
@@ -35,7 +36,7 @@ cd vexjoy-agent
 
 The installer asks one question: symlink or copy. Symlink means updates via `git pull`. Copy means a stable snapshot. Either works.
 
-What it does: installs agents, skills, hooks, commands, and scripts into `~/.claude/` (symlinked or copied per your choice). Mirrors skills into `~/.codex/skills/` and `~/.gemini/skills/`, agents into `~/.codex/agents/` and `~/.gemini/agents/` and `~/.factory/droids/` (Factory calls agents "droids"). Configures hooks in settings so they activate automatically.
+What it does: installs agents, skills, hooks, commands, and scripts into `~/.claude/` (symlinked or copied per your choice). Mirrors skills into `~/.codex/skills/` and `~/.gemini/skills/`, agents into `~/.codex/agents/` and `~/.gemini/agents/` and `~/.factory/droids/` (Factory calls agents "droids"), and skills + scripts + hooks into `~/.reasonix/` (no agent surface there). Configures hooks in settings so they activate automatically.
 
 ## Verify
 

--- a/hooks/lib/hook_utils.py
+++ b/hooks/lib/hook_utils.py
@@ -459,7 +459,7 @@ def detect_cli() -> str:
     running Claude Code.
 
     Returns:
-        One of "gemini", "codex", or "claude".
+        One of "gemini", "codex", "reasonix", or "claude".
     """
     # Most specific: explicit CLI identification env var
     if os.environ.get("GEMINI_CLI"):
@@ -470,6 +470,10 @@ def detect_cli() -> str:
         return "gemini"
     if "codex" in invocation.lower():
         return "codex"
+    # Reasonix sets no session/home env var and spawns hooks with the ambient
+    # env inherited, so it is only identifiable via the _ invocation var.
+    if "reasonix" in invocation.lower():
+        return "reasonix"
     # Codex-specific env vars
     if os.environ.get("CODEX_HOME") or os.environ.get("CODEX_HOOKS_DIR"):
         return "codex"

--- a/install.sh
+++ b/install.sh
@@ -732,54 +732,51 @@ os.rename(tmp, dst)
     # Phase 3.11: Clean toolkit-owned Reasonix mirror (skills + scripts + hooks + settings.json)
     echo ""
     echo -e "${YELLOW}Cleaning Reasonix skills mirror...${NC}"
+    # Remove ONLY the toolkit-owned flatten-copy output, recomputed from the repo so it
+    # matches what the install wrote (skills/<cat>/<name> + top-level skills + private-skills
+    # flattened to <name>, voice skills as voice-<name>, support dirs copied by name). Skills
+    # a USER added by hand (real dirs we never wrote) are left intact. Also sweep stale
+    # toolkit symlinks left by the pre-flatten installer. Finally drop the dir if now empty.
     if [ -d "$REASONIX_SKILLS_DIR" ]; then
-        for item in "${SCRIPT_DIR}/skills/"*; do
-            [ -e "$item" ] || continue
-            target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
-            if [ -L "$target" ] || [ -e "$target" ]; then
-                if [ "$DRY_RUN" = true ]; then
-                    echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
-                else
-                    rm -rf "$target"
-                    echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
-                fi
-                REMOVED+=("Reasonix skill $(basename "$item")")
+        reasonix_uninstall_entry() {
+            local target="${REASONIX_SKILLS_DIR}/$1"
+            [ -e "$target" ] || [ -L "$target" ] || return 0
+            if [ "$DRY_RUN" = true ]; then
+                echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
+            else
+                rm -rf "$target"
+                echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
             fi
-        done
+            REMOVED+=("Reasonix skill $1")
+        }
 
+        # Flattened skills + private skills (basename of each dir holding a SKILL.md).
+        while IFS= read -r skill_md; do
+            [ -n "$skill_md" ] || continue
+            reasonix_uninstall_entry "$(basename "$(dirname "$skill_md")")"
+        done < <(find "${SCRIPT_DIR}/skills" "${SCRIPT_DIR}/private-skills" -name SKILL.md 2>/dev/null)
+
+        # Voice skills (voice-<name>).
         if [ -d "${SCRIPT_DIR}/private-voices" ]; then
             for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
-                [ -d "$voice_dir" ] || continue
-                skill_src="${voice_dir}/skill"
-                [ -d "$skill_src" ] || continue
-                voice_name=$(basename "$voice_dir")
-                target="${REASONIX_SKILLS_DIR}/voice-${voice_name}"
-                if [ -L "$target" ] || [ -e "$target" ]; then
-                    if [ "$DRY_RUN" = true ]; then
-                        echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
-                    else
-                        rm -rf "$target"
-                        echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
-                    fi
-                    REMOVED+=("Reasonix skill voice-${voice_name}")
-                fi
+                [ -f "${voice_dir}/skill/SKILL.md" ] || continue
+                reasonix_uninstall_entry "voice-$(basename "$voice_dir")"
             done
         fi
 
-        if [ -d "${SCRIPT_DIR}/private-skills" ]; then
-            for item in "${SCRIPT_DIR}/private-skills/"*; do
-                [ -e "$item" ] || continue
-                target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
-                if [ -L "$target" ] || [ -e "$target" ]; then
-                    if [ "$DRY_RUN" = true ]; then
-                        echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
-                    else
-                        rm -rf "$target"
-                        echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
-                    fi
-                    REMOVED+=("Reasonix skill $(basename "$item")")
-                fi
-            done
+        # Support dirs (no SKILL.md anywhere — shared-patterns, kb, voice-shared*).
+        for support_dir in "${SCRIPT_DIR}/skills/"*/; do
+            [ -d "$support_dir" ] || continue
+            [ -z "$(find "$support_dir" -name SKILL.md -print -quit)" ] || continue
+            reasonix_uninstall_entry "$(basename "$support_dir")"
+        done
+
+        # Stale toolkit symlinks from the pre-flatten installer (reasonix entries are always
+        # real dirs now, so any symlink here is toolkit-owned residue).
+        if [ "$DRY_RUN" != true ]; then
+            find "$REASONIX_SKILLS_DIR" -maxdepth 1 -mindepth 1 -type l -delete 2>/dev/null || true
+            rmdir "$REASONIX_SKILLS_DIR" 2>/dev/null && \
+                echo -e "${GREEN}  ✓ Removed empty ${REASONIX_SKILLS_DIR}${NC}" || true
         fi
     else
         echo "  No ~/.reasonix/skills mirror found. Nothing to clean."
@@ -1633,35 +1630,99 @@ fi
 # and runs Claude-Code-identical hooks declared in ~/.reasonix/settings.json (hooks key only;
 # MCP/model/permissions live in user-owned ~/.reasonix/config.json, which we never touch).
 echo ""
-echo -e "${YELLOW}Syncing Reasonix skills mirror...${NC}"
+echo -e "${YELLOW}Syncing Reasonix skills mirror (flatten + copy)...${NC}"
 REASONIX_ENTRY_COUNT=0
-for item in "${SCRIPT_DIR}/skills/"*; do
-    [ -e "$item" ] || continue
-    target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
-    sync_mirror_entry "$item" "$target" "Reasonix"
-    REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
-done
+REASONIX_SEEN_NAMES=" "  # space-delimited set of flat names claimed this run (collision guard)
+if [ "$DRY_RUN" != true ]; then
+    mkdir -p "$REASONIX_SKILLS_DIR"
+    # Sweep stale toolkit symlinks left by the pre-flatten installer (it symlinked
+    # skills/<category> dirs, which reasonix can't discover). Reasonix skill entries are
+    # ALWAYS real copied dirs now, so any symlink here is stale toolkit output — safe to
+    # drop. User-added skills are real dirs and are left untouched.
+    find "$REASONIX_SKILLS_DIR" -maxdepth 1 -mindepth 1 -type l -delete 2>/dev/null || true
+fi
 
+# Reasonix scans skill roots EXACTLY ONE LEVEL DEEP (src/skills.ts:251-258): a dir entry
+# <X> is a skill only when <X>/SKILL.md exists, and it never recurses. vexjoy skills live
+# at skills/<category>/<name>/SKILL.md (two levels), so a naive same-name mirror exposes
+# category dirs that hold no SKILL.md and reasonix discovers nothing. We therefore FLATTEN
+# every skill to ~/.reasonix/skills/<name>/SKILL.md (one level deep).
+#
+# COPY ALWAYS — even when MODE=symlink: the shipped reasonix npm build (v0.53.2) does NOT
+# traverse symlinked skill ENTRIES during discovery (only real directories are scanned), so
+# a symlinked skill is invisible while a real-dir copy is found instantly. The reasonix
+# skills mirror therefore forces real-directory copies regardless of the install MODE.
+reasonix_install_skill() {
+    # $1 = skill source dir (the dir containing SKILL.md); $2 = flat skill name
+    local skill_dir=$1
+    local name=$2
+    local target="${REASONIX_SKILLS_DIR}/${name}"
+
+    # Within-run collision guard: basenames are verified unique, but never clobber a name
+    # already claimed by this run. (A target left from a PRIOR run is refreshed below.)
+    case "$REASONIX_SEEN_NAMES" in
+        *" ${name} "*)
+            echo -e "${YELLOW}  Warning: duplicate Reasonix skill name '${name}', skipping ${skill_dir}${NC}"
+            return 0
+            ;;
+    esac
+    REASONIX_SEEN_NAMES="${REASONIX_SEEN_NAMES}${name} "
+
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would copy Reasonix skill (real dir, copy forced even in symlink mode): ${skill_dir} -> ${target}/${NC}"
+    else
+        rm -rf "$target"            # idempotent re-run: refresh content like the other mirrors
+        mkdir -p "$target"
+        cp -r "${skill_dir}/." "$target/"
+        echo -e "${GREEN}  ✓ Reasonix copied ${name}${NC}"
+    fi
+    REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
+}
+
+# Flatten every SKILL.md under skills/ (122 nested + 1 top-level = 123 skills).
+while IFS= read -r skill_md; do
+    [ -n "$skill_md" ] || continue
+    skill_dir=$(dirname "$skill_md")
+    reasonix_install_skill "$skill_dir" "$(basename "$skill_dir")"
+done < <(find "${SCRIPT_DIR}/skills" -name SKILL.md | sort)
+
+# Voice skills: private-voices/<name>/skill/SKILL.md -> ~/.reasonix/skills/voice-<name>/
 if [ -d "${SCRIPT_DIR}/private-voices" ]; then
     for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
         [ -d "$voice_dir" ] || continue
         skill_src="${voice_dir}/skill"
-        [ -d "$skill_src" ] || continue
+        [ -f "${skill_src}/SKILL.md" ] || continue
         voice_name=$(basename "$voice_dir")
-        target="${REASONIX_SKILLS_DIR}/voice-${voice_name}"
-        sync_mirror_entry "$skill_src" "$target" "Reasonix"
-        REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
+        reasonix_install_skill "$skill_src" "voice-${voice_name}"
     done
 fi
 
+# Private skills: flatten every SKILL.md (handles flat or category-nested layouts).
 if [ -d "${SCRIPT_DIR}/private-skills" ]; then
-    for item in "${SCRIPT_DIR}/private-skills/"*; do
-        [ -e "$item" ] || continue
-        target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
-        sync_mirror_entry "$item" "$target" "Reasonix"
-        REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
-    done
+    while IFS= read -r skill_md; do
+        [ -n "$skill_md" ] || continue
+        skill_dir=$(dirname "$skill_md")
+        reasonix_install_skill "$skill_dir" "$(basename "$skill_dir")"
+    done < <(find "${SCRIPT_DIR}/private-skills" -name SKILL.md | sort)
 fi
+
+# Support dirs (no SKILL.md anywhere — e.g. shared-patterns, kb): copy as real top-level
+# dirs so flattened skills' sibling references like ../shared-patterns/*.md resolve, and so
+# the downstream voice shared-references deploy (which targets ${REASONIX_SKILLS_DIR}/shared-patterns)
+# keeps working. These are not skills (reasonix ignores them: no SKILL.md) so they are not counted.
+for support_dir in "${SCRIPT_DIR}/skills/"*/; do
+    [ -d "$support_dir" ] || continue
+    [ -z "$(find "$support_dir" -name SKILL.md -print -quit)" ] || continue  # skip dirs that hold skills
+    support_name=$(basename "$support_dir")
+    support_target="${REASONIX_SKILLS_DIR}/${support_name}"
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would copy Reasonix support dir: ${support_dir} -> ${support_target}/${NC}"
+    else
+        rm -rf "$support_target"
+        cp -r "$support_dir" "$support_target"
+        echo -e "${GREEN}  ✓ Reasonix copied support dir ${support_name}${NC}"
+    fi
+done
 
 echo ""
 echo -e "${YELLOW}Syncing Reasonix scripts mirror...${NC}"
@@ -1970,7 +2031,7 @@ echo "  • Factory droids: ${FACTORY_DROID_COUNT} mirrored entries in ~/.factor
 echo "  • Factory hooks: ${FACTORY_HOOK_COUNT} mirrored entries in ~/.factory/hooks"
 echo "  • Hermes skills: ${HERMES_ENTRY_COUNT} mirrored entries in ~/.hermes/skills"
 echo "  • Hermes scripts: ${HERMES_SCRIPT_COUNT} mirrored scripts in ~/.hermes/scripts"
-echo "  • Reasonix skills: ${REASONIX_ENTRY_COUNT} mirrored entries in ~/.reasonix/skills"
+echo "  • Reasonix skills: ${REASONIX_ENTRY_COUNT} flattened skills (real dirs, one level deep) in ~/.reasonix/skills"
 echo "  • Reasonix scripts: ${REASONIX_SCRIPT_COUNT} mirrored scripts in ~/.reasonix/scripts"
 echo "  • Reasonix hooks: ${REASONIX_HOOK_COUNT} mirrored entries in ~/.reasonix/hooks"
 echo "  • Hooks: ${HOOK_COUNT} automation hooks"

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,10 @@ FACTORY_SCRIPTS_DIR="${FACTORY_DIR}/scripts"
 HERMES_DIR="${HOME}/.hermes"
 HERMES_SKILLS_DIR="${HERMES_DIR}/skills"
 HERMES_SCRIPTS_DIR="${HERMES_DIR}/scripts"
+REASONIX_DIR="${HOME}/.reasonix"
+REASONIX_SKILLS_DIR="${REASONIX_DIR}/skills"
+REASONIX_SCRIPTS_DIR="${REASONIX_DIR}/scripts"
+REASONIX_HOOKS_DIR="${REASONIX_DIR}/hooks"
 
 echo -e "${BLUE}╔════════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${BLUE}║                VexJoy Agent - Installation Script               ║${NC}"
@@ -725,6 +729,106 @@ os.rename(tmp, dst)
     # Note: ~/.hermes/config.yaml is intentionally left untouched.
     # Users may have other Hermes configurations we did not write.
 
+    # Phase 3.11: Clean toolkit-owned Reasonix mirror (skills + scripts + hooks + settings.json)
+    echo ""
+    echo -e "${YELLOW}Cleaning Reasonix skills mirror...${NC}"
+    if [ -d "$REASONIX_SKILLS_DIR" ]; then
+        for item in "${SCRIPT_DIR}/skills/"*; do
+            [ -e "$item" ] || continue
+            target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
+            if [ -L "$target" ] || [ -e "$target" ]; then
+                if [ "$DRY_RUN" = true ]; then
+                    echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
+                else
+                    rm -rf "$target"
+                    echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
+                fi
+                REMOVED+=("Reasonix skill $(basename "$item")")
+            fi
+        done
+
+        if [ -d "${SCRIPT_DIR}/private-voices" ]; then
+            for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
+                [ -d "$voice_dir" ] || continue
+                skill_src="${voice_dir}/skill"
+                [ -d "$skill_src" ] || continue
+                voice_name=$(basename "$voice_dir")
+                target="${REASONIX_SKILLS_DIR}/voice-${voice_name}"
+                if [ -L "$target" ] || [ -e "$target" ]; then
+                    if [ "$DRY_RUN" = true ]; then
+                        echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
+                    else
+                        rm -rf "$target"
+                        echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
+                    fi
+                    REMOVED+=("Reasonix skill voice-${voice_name}")
+                fi
+            done
+        fi
+
+        if [ -d "${SCRIPT_DIR}/private-skills" ]; then
+            for item in "${SCRIPT_DIR}/private-skills/"*; do
+                [ -e "$item" ] || continue
+                target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
+                if [ -L "$target" ] || [ -e "$target" ]; then
+                    if [ "$DRY_RUN" = true ]; then
+                        echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
+                    else
+                        rm -rf "$target"
+                        echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
+                    fi
+                    REMOVED+=("Reasonix skill $(basename "$item")")
+                fi
+            done
+        fi
+    else
+        echo "  No ~/.reasonix/skills mirror found. Nothing to clean."
+    fi
+
+    echo ""
+    echo -e "${YELLOW}Cleaning Reasonix scripts mirror...${NC}"
+    if [ -d "$REASONIX_SCRIPTS_DIR" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would remove: ${REASONIX_SCRIPTS_DIR}${NC}"
+        else
+            rm -rf "$REASONIX_SCRIPTS_DIR"
+            echo -e "${GREEN}  ✓ Removed ${REASONIX_SCRIPTS_DIR}${NC}"
+        fi
+        REMOVED+=("Reasonix scripts mirror directory")
+    else
+        echo "  No ~/.reasonix/scripts mirror found. Nothing to clean."
+    fi
+
+    echo ""
+    echo -e "${YELLOW}Cleaning Reasonix hooks mirror...${NC}"
+    if [ -d "$REASONIX_HOOKS_DIR" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would remove: ${REASONIX_HOOKS_DIR}${NC}"
+        else
+            rm -rf "$REASONIX_HOOKS_DIR"
+            echo -e "${GREEN}  ✓ Removed ${REASONIX_HOOKS_DIR}${NC}"
+        fi
+        REMOVED+=("Reasonix hooks mirror directory")
+    else
+        echo "  No ~/.reasonix/hooks mirror found. Nothing to clean."
+    fi
+
+    # Archive the generated Reasonix settings.json (hooks key). config.json is
+    # user-owned and never touched.
+    if [ -f "${REASONIX_DIR}/settings.json" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would archive: ${REASONIX_DIR}/settings.json${NC}"
+        else
+            ARCHIVE_TS=$(date +%Y%m%d-%H%M%S)
+            mv "${REASONIX_DIR}/settings.json" "${REASONIX_DIR}/settings.json.uninstalled.${ARCHIVE_TS}"
+            echo -e "${GREEN}  ✓ Archived ${REASONIX_DIR}/settings.json${NC}"
+        fi
+        REMOVED+=("Reasonix settings.json (archived)")
+    fi
+
+    # Note: ~/.reasonix/config.json is intentionally left untouched.
+    # Users own MCP/model/permissions config we did not write.
+
     # Phase 4: Remove install manifest
     echo ""
     echo -e "${YELLOW}Cleaning up manifest...${NC}"
@@ -900,6 +1004,15 @@ else
     mkdir -p "${HERMES_SKILLS_DIR}"
 fi
 echo -e "${GREEN}✓ ${HERMES_SKILLS_DIR} ready${NC}"
+
+echo ""
+echo -e "${YELLOW}Setting up ~/.reasonix/skills directory...${NC}"
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}  Would create: ${REASONIX_SKILLS_DIR}${NC}"
+else
+    mkdir -p "${REASONIX_SKILLS_DIR}"
+fi
+echo -e "${GREEN}✓ ${REASONIX_SKILLS_DIR} ready${NC}"
 
 # Install components
 echo ""
@@ -1515,6 +1628,107 @@ else
     HERMES_SCRIPT_COUNT=0
 fi
 
+# ── Reasonix mirror (skills + scripts + hooks; Claude-Code-compatible extension layer) ──
+# Reasonix natively reads ~/.reasonix/skills, shells out to scripts via the SDIR chain,
+# and runs Claude-Code-identical hooks declared in ~/.reasonix/settings.json (hooks key only;
+# MCP/model/permissions live in user-owned ~/.reasonix/config.json, which we never touch).
+echo ""
+echo -e "${YELLOW}Syncing Reasonix skills mirror...${NC}"
+REASONIX_ENTRY_COUNT=0
+for item in "${SCRIPT_DIR}/skills/"*; do
+    [ -e "$item" ] || continue
+    target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
+    sync_mirror_entry "$item" "$target" "Reasonix"
+    REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
+done
+
+if [ -d "${SCRIPT_DIR}/private-voices" ]; then
+    for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
+        [ -d "$voice_dir" ] || continue
+        skill_src="${voice_dir}/skill"
+        [ -d "$skill_src" ] || continue
+        voice_name=$(basename "$voice_dir")
+        target="${REASONIX_SKILLS_DIR}/voice-${voice_name}"
+        sync_mirror_entry "$skill_src" "$target" "Reasonix"
+        REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
+    done
+fi
+
+if [ -d "${SCRIPT_DIR}/private-skills" ]; then
+    for item in "${SCRIPT_DIR}/private-skills/"*; do
+        [ -e "$item" ] || continue
+        target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
+        sync_mirror_entry "$item" "$target" "Reasonix"
+        REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
+    done
+fi
+
+echo ""
+echo -e "${YELLOW}Syncing Reasonix scripts mirror...${NC}"
+if [ -d "${SCRIPT_DIR}/scripts" ]; then
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would mirror scripts to: ${REASONIX_SCRIPTS_DIR}${NC}"
+    else
+        mkdir -p "$REASONIX_SCRIPTS_DIR"
+    fi
+    sync_mirror_entry "${SCRIPT_DIR}/scripts" "$REASONIX_SCRIPTS_DIR" "Reasonix"
+    REASONIX_SCRIPT_COUNT=$(ls -1 "${SCRIPT_DIR}/scripts/"*.py 2>/dev/null | grep -cv '__init__')
+    echo -e "${GREEN}  ✓ Scripts mirrored to ${REASONIX_SCRIPTS_DIR}${NC}"
+else
+    REASONIX_SCRIPT_COUNT=0
+fi
+
+echo ""
+echo -e "${YELLOW}Syncing Reasonix hooks mirror...${NC}"
+if [ -d "${SCRIPT_DIR}/hooks" ]; then
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would mirror hooks to: ${REASONIX_HOOKS_DIR}${NC}"
+    else
+        mkdir -p "$REASONIX_HOOKS_DIR"
+    fi
+    sync_mirror_entry "${SCRIPT_DIR}/hooks" "$REASONIX_HOOKS_DIR" "Reasonix"
+    REASONIX_HOOK_COUNT=$(ls -1 "${SCRIPT_DIR}/hooks/"*.py 2>/dev/null | grep -cv '__init__')
+    echo -e "${GREEN}  ✓ Hooks mirrored to ${REASONIX_HOOKS_DIR}${NC}"
+else
+    REASONIX_HOOK_COUNT=0
+fi
+
+# Generate ~/.reasonix/settings.json (hooks key only; rewrite .claude paths to .reasonix).
+# config.json (MCP/model/permissions) is user-owned and never written here.
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}  Would sync hooks from ${SCRIPT_DIR}/.claude/settings.json to ${REASONIX_DIR}/settings.json (with path rewrite)${NC}"
+elif [ -f "${SCRIPT_DIR}/.claude/settings.json" ]; then
+    REASONIX_SETTINGS="${REASONIX_DIR}/settings.json"
+    if [ ! -f "$REASONIX_SETTINGS" ]; then
+        echo '{}' > "$REASONIX_SETTINGS"
+    fi
+    BACKUP_TS=$(date +%Y%m%d-%H%M%S)
+    cp "$REASONIX_SETTINGS" "${REASONIX_SETTINGS}.backup.${BACKUP_TS}"
+    $PYTHON_CMD -c "
+import json, os
+repo = json.load(open('${SCRIPT_DIR}/.claude/settings.json'))
+dst = '${REASONIX_SETTINGS}'
+try:
+    merged = json.load(open(dst, encoding='utf-8'))
+except (FileNotFoundError, json.JSONDecodeError):
+    merged = {}
+hooks_json = json.dumps(repo.get('hooks', {}))
+hooks_json = hooks_json.replace('\$HOME/.claude/', '\$HOME/.reasonix/')
+hooks_json = hooks_json.replace('\${HOME}/.claude/', '\${HOME}/.reasonix/')
+merged['hooks'] = json.loads(hooks_json)
+merged.setdefault('attribution', repo.get('attribution', {'commit': '', 'pr': ''}))
+tmp = dst + '.tmp'
+with open(tmp, 'w', encoding='utf-8') as f:
+    json.dump(merged, f, indent=2)
+    f.flush()
+    os.fsync(f.fileno())
+os.rename(tmp, dst)
+print('  Reasonix hooks configured from .claude/settings.json')
+"
+else
+    echo -e "${YELLOW}  Warning: ${SCRIPT_DIR}/.claude/settings.json not found, skipping Reasonix hook sync${NC}"
+fi
+
 # Deploy private-voices shared references into skills/shared-patterns/
 # These files were removed from the public repo and live in private-voices/shared-references/
 # (gitignored). They must be deployed at install time into every runtime's shared-patterns dir.
@@ -1525,7 +1739,7 @@ if [ -d "${SCRIPT_DIR}/private-voices/shared-references" ]; then
     for ref_file in "${SCRIPT_DIR}/private-voices/shared-references/"*.md; do
         [ -f "$ref_file" ] || continue
         ref_name=$(basename "$ref_file")
-        for target_dir in "${CLAUDE_DIR}/skills/shared-patterns" "${CODEX_SKILLS_DIR}/shared-patterns" "${GEMINI_SKILLS_DIR}/shared-patterns" "${FACTORY_SKILLS_DIR}/shared-patterns" "${HERMES_SKILLS_DIR}/shared-patterns"; do
+        for target_dir in "${CLAUDE_DIR}/skills/shared-patterns" "${CODEX_SKILLS_DIR}/shared-patterns" "${GEMINI_SKILLS_DIR}/shared-patterns" "${FACTORY_SKILLS_DIR}/shared-patterns" "${HERMES_SKILLS_DIR}/shared-patterns" "${REASONIX_SKILLS_DIR}/shared-patterns"; do
             # Resolve symlinks so we write into the actual directory
             resolved_dir="$target_dir"
             [ -L "$target_dir" ] && resolved_dir="$(readlink -f "$target_dir")"
@@ -1714,6 +1928,7 @@ manifest = {
     'gemini_components': ['skills', 'agents', 'hooks', 'scripts'],
     'factory_components': ['skills', 'droids', 'hooks'],
     'hermes_components': ['skills', 'scripts'],
+    'reasonix_components': ['skills', 'scripts', 'hooks'],
 }
 json.dump(manifest, open('${CLAUDE_DIR}/.install-manifest.json', 'w'), indent=2)
 print('  Install manifest written to ~/.claude/.install-manifest.json')
@@ -1755,6 +1970,9 @@ echo "  • Factory droids: ${FACTORY_DROID_COUNT} mirrored entries in ~/.factor
 echo "  • Factory hooks: ${FACTORY_HOOK_COUNT} mirrored entries in ~/.factory/hooks"
 echo "  • Hermes skills: ${HERMES_ENTRY_COUNT} mirrored entries in ~/.hermes/skills"
 echo "  • Hermes scripts: ${HERMES_SCRIPT_COUNT} mirrored scripts in ~/.hermes/scripts"
+echo "  • Reasonix skills: ${REASONIX_ENTRY_COUNT} mirrored entries in ~/.reasonix/skills"
+echo "  • Reasonix scripts: ${REASONIX_SCRIPT_COUNT} mirrored scripts in ~/.reasonix/scripts"
+echo "  • Reasonix hooks: ${REASONIX_HOOK_COUNT} mirrored entries in ~/.reasonix/hooks"
 echo "  • Hooks: ${HOOK_COUNT} automation hooks"
 echo "  • Commands: ${COMMAND_COUNT} slash commands"
 echo "  • Scripts: ${SCRIPT_COUNT} utility scripts"

--- a/scripts/detect-workflow-capability.py
+++ b/scripts/detect-workflow-capability.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Detect the running harness from environment variables (env proxy).
 
-Emits JSON: {"harness": "claude-code|codex|gemini|factory|unknown",
+Emits JSON: {"harness": "claude-code|codex|gemini|factory|reasonix|unknown",
              "workflow_capable": bool}
 
 Anthropic's native ``Workflow`` tool (deterministic JS orchestration) is
-Claude Code-only. Codex, Gemini, and Factory do not have it; the toolkit's
-prose pipelines run everywhere. ``workflow_capable`` is the env-derived proxy
-``harness == "claude-code"``.
+Claude Code-only. Codex, Gemini, Factory, and Reasonix do not have it; the
+toolkit's prose pipelines run everywhere. ``workflow_capable`` is the
+env-derived proxy ``harness == "claude-code"``.
 
 PROXY, NOT AUTHORITY. A subprocess cannot introspect the session's tool list,
 only the environment. So this script answers "which harness am I in?" and the
@@ -21,6 +21,9 @@ API-key vars like GEMINI_API_KEY, which are commonly set under any harness):
   codex       : CODEX_HOME, CODEX_HOOKS_DIR
   gemini      : GEMINI_CLI
   factory     : FACTORY_SESSION_ID, FACTORY_HOME, DROID_SESSION_ID, DROID_HOME
+  reasonix    : (no env marker) — keyed off the ``_`` invocation var, since
+                reasonix sets no session/home var and spawns hooks with the
+                ambient env inherited (src/hooks.ts:206-212).
 Mirrors hooks/lib/hook_utils.py:detect_cli(), extended with factory + the
 Claude Code session markers.
 
@@ -37,7 +40,7 @@ import json
 import os
 import sys
 
-HARNESSES = ("claude-code", "codex", "gemini", "factory", "unknown")
+HARNESSES = ("claude-code", "codex", "gemini", "factory", "reasonix", "unknown")
 
 # Marker var -> harness. Claude Code is checked first so it wins when env from
 # a Claude Code session leaks other harnesses' vars (config copied around).
@@ -62,6 +65,11 @@ def detect_harness(env: dict | None) -> str:
             for key in keys:
                 if env.get(key):
                     return harness
+        # Reasonix exposes no distinctive env marker. Fall back to the ``_``
+        # invocation var (path of the invoking binary), the same best-effort
+        # mechanism used for gemini/codex in detect_cli().
+        if "reasonix" in env.get("_", "").lower():
+            return "reasonix"
     except Exception:
         return "unknown"
     return "unknown"

--- a/scripts/install-doctor.py
+++ b/scripts/install-doctor.py
@@ -26,6 +26,7 @@ from pathlib import Path
 CLAUDE_DIR = Path.home() / ".claude"
 CODEX_DIR = Path.home() / ".codex"
 HERMES_DIR = Path.home() / ".hermes"
+REASONIX_DIR = Path.home() / ".reasonix"
 COMPONENTS = ["agents", "skills", "hooks", "commands", "scripts"]
 
 
@@ -322,6 +323,37 @@ def check_hermes_skills() -> dict:
         "label": "~/.hermes/skills mirror",
         "passed": entry_count > 0,
         "detail": f"{entry_count} entries present in Hermes skills mirror",
+    }
+
+
+def check_reasonix_skills() -> dict:
+    """Check that toolkit skills are mirrored into ~/.reasonix/skills."""
+    reasonix_skills_dir = REASONIX_DIR / "skills"
+
+    if not reasonix_skills_dir.is_dir():
+        return {
+            "name": "reasonix_skills",
+            "label": "~/.reasonix/skills mirror",
+            "passed": False,
+            "detail": "Directory not found. Run install.sh to mirror toolkit skills for Reasonix.",
+        }
+
+    repo_root = get_toolkit_repo_root()
+    if repo_root is None:
+        return {
+            "name": "reasonix_skills",
+            "label": "~/.reasonix/skills mirror",
+            "passed": True,
+            "detail": str(reasonix_skills_dir),
+        }
+
+    # Count entries present (simplified check — Reasonix uses same flat structure)
+    entry_count = sum(1 for _ in reasonix_skills_dir.iterdir())
+    return {
+        "name": "reasonix_skills",
+        "label": "~/.reasonix/skills mirror",
+        "passed": entry_count > 0,
+        "detail": f"{entry_count} entries present in Reasonix skills mirror",
     }
 
 
@@ -852,6 +884,7 @@ def run_all_checks() -> list[dict]:
     results.append(check_codex_skills())
     results.append(check_codex_agents())
     results.append(check_hermes_skills())
+    results.append(check_reasonix_skills())
     results.append(check_settings_json())
     results.extend(check_hook_files())
     results.append(check_python_version())

--- a/scripts/install-doctor.py
+++ b/scripts/install-doctor.py
@@ -327,33 +327,52 @@ def check_hermes_skills() -> dict:
 
 
 def check_reasonix_skills() -> dict:
-    """Check that toolkit skills are mirrored into ~/.reasonix/skills."""
+    """Verify toolkit skills are DISCOVERABLE by Reasonix in ~/.reasonix/skills.
+
+    Reasonix scans skill roots exactly one level deep (src/skills.ts:251-258): a dir
+    entry ``<name>`` is a skill only when ``<name>/SKILL.md`` exists, and it never
+    recurses. The shipped npm build also skips symlinked entries. So a passing check
+    requires a REAL ``~/.reasonix/skills/<name>/SKILL.md`` one level deep — counting
+    top-level entries is not enough (category dirs / symlinks count but stay invisible).
+    """
     reasonix_skills_dir = REASONIX_DIR / "skills"
 
     if not reasonix_skills_dir.is_dir():
         return {
             "name": "reasonix_skills",
-            "label": "~/.reasonix/skills mirror",
+            "label": "~/.reasonix/skills discoverable",
             "passed": False,
             "detail": "Directory not found. Run install.sh to mirror toolkit skills for Reasonix.",
         }
 
-    repo_root = get_toolkit_repo_root()
-    if repo_root is None:
+    # The /do router is always installed; use it as the canary for discoverability.
+    do_skill = reasonix_skills_dir / "do" / "SKILL.md"
+    if do_skill.is_file():
         return {
             "name": "reasonix_skills",
-            "label": "~/.reasonix/skills mirror",
+            "label": "~/.reasonix/skills discoverable",
             "passed": True,
-            "detail": str(reasonix_skills_dir),
+            "detail": f"'do' skill resolves at {do_skill} (real file, one level deep)",
         }
 
-    # Count entries present (simplified check — Reasonix uses same flat structure)
-    entry_count = sum(1 for _ in reasonix_skills_dir.iterdir())
+    # Fallback: any flattened skill resolving one level deep also proves discoverability.
+    discoverable = sum(1 for entry in reasonix_skills_dir.iterdir() if (entry / "SKILL.md").is_file())
+    if discoverable > 0:
+        return {
+            "name": "reasonix_skills",
+            "label": "~/.reasonix/skills discoverable",
+            "passed": True,
+            "detail": f"{discoverable} skill(s) resolve one level deep (canary 'do' missing)",
+        }
+
     return {
         "name": "reasonix_skills",
-        "label": "~/.reasonix/skills mirror",
-        "passed": entry_count > 0,
-        "detail": f"{entry_count} entries present in Reasonix skills mirror",
+        "label": "~/.reasonix/skills discoverable",
+        "passed": False,
+        "detail": (
+            "No <name>/SKILL.md resolves one level deep — Reasonix sees zero skills. "
+            "Skills must be flattened+copied (not symlinked, not category-nested). Re-run install.sh."
+        ),
     }
 
 

--- a/scripts/tests/test_detect_workflow_capability.py
+++ b/scripts/tests/test_detect_workflow_capability.py
@@ -2,9 +2,10 @@
 """Tests for scripts/detect-workflow-capability.py — harness identity from env.
 
 Covers the env-matrix harness classifier (claude-code / codex / gemini /
-factory / unknown), the workflow_capable proxy (true only for claude-code),
-the never-raises / exit-0 contract, and the JSON output shape. The env signal
-is a PROXY: the orchestrator LLM adds the authoritative tool-list gate.
+factory / reasonix / unknown), the workflow_capable proxy (true only for
+claude-code), the never-raises / exit-0 contract, and the JSON output shape.
+The env signal is a PROXY: the orchestrator LLM adds the authoritative
+tool-list gate.
 """
 
 import json
@@ -43,6 +44,9 @@ _spec.loader.exec_module(dwc)
         # factory / droid
         ({"FACTORY_SESSION_ID": "f1"}, "factory"),
         ({"DROID_SESSION_ID": "d1"}, "factory"),
+        # reasonix: no env marker — keyed off the _ invocation var
+        ({"_": "/usr/local/bin/reasonix"}, "reasonix"),
+        ({"_": "/opt/node/bin/Reasonix"}, "reasonix"),
         # nothing distinctive
         ({}, "unknown"),
     ],
@@ -75,6 +79,7 @@ def test_claude_code_wins_over_other_markers():
         ("codex", False),
         ("gemini", False),
         ("factory", False),
+        ("reasonix", False),
         ("unknown", False),
     ],
 )

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -132,7 +132,7 @@ If ANY creation signal found AND complexity Simple+: set `is_creation = true`, P
 Generate the manifest, then dispatch the Haiku routing agent. Its decision is the primary route.
 
 ```bash
-SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"
+SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
 python3 "$SDIR/routing-manifest.py"
 ```
 
@@ -224,7 +224,7 @@ Route to the simplest agent+skill that satisfies the request. When `[cross-repo]
 Run the pre-router and use its result ONLY as a guardrail over the semantic pick:
 
 ```bash
-SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"
+SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
 python3 "$SDIR/pre-route.py" --request "{user_request}" --json-compact
 ```
 


### PR DESCRIPTION
## Summary
Adds reasonix (DeepSeek-native coding agent, config root `~/.reasonix`) as a sixth supported harness at functional parity: skills, scripts, hooks, runtime detection, install-doctor, and docs. reasonix is Claude-Code-compatible at the extension layer (skills + hooks + MCP) but has no agent-file or custom-command system and no native Workflow tool.

## Changes
- `install.sh` — reasonix dir constants; flatten-and-copy skills install (real dirs, one level deep, copied even in `--symlink` mode); scripts + hooks mirror; `settings.json` hooks generation (`.claude`→`.reasonix` path rewrite); manifest entry; uninstall cleanup phase
- `scripts/detect-workflow-capability.py` — `reasonix` added to HARNESSES; detected via the `$_` invocation var; `workflow_capable` stays `False`
- `hooks/lib/hook_utils.py` — `detect_cli()` reasonix branch
- `skills/meta/do/SKILL.md` — `.reasonix/scripts` appended to both SDIR fallback chains
- `scripts/install-doctor.py` — discoverability-asserting `check_reasonix_skills()`
- `scripts/tests/test_detect_workflow_capability.py` — reasonix cases
- `README.md`, `docs/QUICKSTART.md`, `docs/start-here.md` — reasonix listed in runtime/invocation tables

## Testing
\`\`\`
$ uvx ruff check . --config pyproject.toml          -> All checks passed!
$ uvx ruff format --check . --config pyproject.toml  -> 418 files already formatted
$ python -m pytest scripts/tests/{test_detect_workflow_capability,test_install_doctor,test_validate_workflow_conformance}.py -q
  -> 61 passed
$ python scripts/validate-doc-counts.py             -> 0 drift
$ python scripts/validate-workflow-conformance.py   -> 6 contracted, 1 exempt, 0 failed
$ bash -n install.sh                                -> OK
\`\`\`
Live E2E (reasonix v0.53.2): `/skill list` discovers 128 skills (was 7 before the flatten fix); `/skill do` loads and executes the router skill against a real codebase.

## Scope & Risk
- **Touches:** reasonix harness install + runtime detection only
- **NOT touched:** the other 5 harnesses' install paths, the /do router Phase 2 logic, workflow `.js` execution limbs
- **Rollback:** revert the 2 commits; no state migration or data change

## Known limitations
- reasonix has no agent-file system and no custom slash commands, so vexjoy agents/commands ride in as skills; no native Workflow tool, so `workflow_capable=False` and the prose-pipeline fallback is used.
- Installed reasonix v0.53.2 does not traverse symlinked skill entries (fixed in reasonix source, not yet in the shipped build) — hence skills are flattened AND copied rather than symlinked.