### PR TITLE
feat(harness): reasonix support + review fixes (supersedes #707)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cd ~/vexjoy-agent
 ./install.sh
 ```
 
-Links into `~/.claude/` and mirrors into `~/.codex/`, `~/.gemini/`, `~/.factory/`. The installer asks symlink (live updates via `git pull`) or copy (stable snapshot).
+Links into `~/.claude/` and mirrors into `~/.codex/`, `~/.gemini/`, `~/.factory/`, `~/.reasonix/`. The installer asks symlink (live updates via `git pull`) or copy (stable snapshot).
 
 | CLI | Entry Point |
 |-----|-------------|
@@ -70,6 +70,7 @@ Links into `~/.claude/` and mirrors into `~/.codex/`, `~/.gemini/`, `~/.factory/
 | Codex | `$do` |
 | Gemini CLI | `/do` |
 | Factory | `/do` |
+| Reasonix | `/do` |
 
 **Full setup:** [docs/start-here.md](docs/start-here.md)
 
@@ -93,6 +94,13 @@ Mirrors agents, skills, and Phase 1 hooks into `~/.gemini/`. Translates event na
 <summary><b>Factory CLI Support</b></summary>
 
 Mirrors agents (as "droids"), skills, and all hooks into `~/.factory/`. Hook config merges into `~/.factory/settings.json` with paths rewritten.
+
+</details>
+
+<details>
+<summary><b>Reasonix Support</b></summary>
+
+Mirrors skills, scripts, and all hooks into `~/.reasonix/` (no agent or custom-command surface, so neither is installed; the `/do` router rides in as a skill). Reasonix's hook contract is Claude-Code-identical, so hook config is written to the `hooks` key of `~/.reasonix/settings.json` with paths rewritten. MCP/model/permissions in `~/.reasonix/config.json` are user-owned and left untouched.
 
 </details>
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,13 +13,14 @@ cd ~/vexjoy-agent
 ./install.sh
 ```
 
-Claude Code is the primary runtime. If you also use Codex CLI, Gemini CLI, or Factory, the same install mirrors toolkit skills and agents into `~/.codex/`, `~/.gemini/`, and `~/.factory/` so all four CLIs share the same skill and agent library.
+Claude Code is the primary runtime. If you also use Codex CLI, Gemini CLI, Factory, or Reasonix, the same install mirrors toolkit skills and agents into `~/.codex/`, `~/.gemini/`, `~/.factory/`, and `~/.reasonix/` so all the CLIs share the same skill and agent library.
 
 Command entry points:
 - Claude Code: `/do`
 - Codex: `$do`
 - Gemini CLI: `/do`
 - Factory: `/do`
+- Reasonix: `/do`
 
 **Alternative (bootstrap via Claude):** Start Claude Code in the vexjoy-agent directory. The sync hook will automatically copy agents, skills, hooks, commands, and scripts to `~/.claude/`.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,7 +13,7 @@ cd ~/vexjoy-agent
 ./install.sh
 ```
 
-Claude Code is the primary runtime. If you also use Codex CLI, Gemini CLI, Factory, or Reasonix, the same install mirrors toolkit skills and agents into `~/.codex/`, `~/.gemini/`, `~/.factory/`, and `~/.reasonix/` so all the CLIs share the same skill and agent library.
+Claude Code is the primary runtime. If you also use Codex CLI, Gemini CLI, Factory, or Reasonix, the same install mirrors toolkit skills (and agents where the harness supports them) into `~/.codex/`, `~/.gemini/`, `~/.factory/`, and `~/.reasonix/` so all the CLIs share the same skill library. Reasonix has no agent surface, so it gets skills + scripts + hooks only.
 
 Command entry points:
 - Claude Code: `/do`

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -12,9 +12,9 @@ claude --version
 
 If that prints a version number, you're good. If not, install Claude Code first and come back.
 
-Optional: Codex CLI, Gemini CLI, or Factory. The toolkit mirrors skills and agents into their directories (`~/.codex/`, `~/.gemini/`, `~/.factory/`), so all four CLIs dispatch the same domain expertise. Claude Code remains the full runtime for hooks, commands, and scripts.
+Optional: Codex CLI, Gemini CLI, Factory, or Reasonix. The toolkit mirrors skills and agents into their directories (`~/.codex/`, `~/.gemini/`, `~/.factory/`, `~/.reasonix/`), so all the CLIs dispatch the same domain expertise. Claude Code remains the full runtime for hooks, commands, and scripts.
 
-Verify optional tools: `codex --version` / `gemini --version` / `factory --version`.
+Verify optional tools: `codex --version` / `gemini --version` / `factory --version` / `reasonix --version`.
 
 Command entry points:
 
@@ -24,6 +24,7 @@ Command entry points:
 | Codex | `$do` |
 | Gemini CLI | `/do` |
 | Factory | `/do` |
+| Reasonix | `/do` |
 
 ## Install
 
@@ -35,7 +36,7 @@ cd vexjoy-agent
 
 The installer asks one question: symlink or copy. Symlink means updates via `git pull`. Copy means a stable snapshot. Either works.
 
-What it does: installs agents, skills, hooks, commands, and scripts into `~/.claude/` (symlinked or copied per your choice). Mirrors skills into `~/.codex/skills/` and `~/.gemini/skills/`, agents into `~/.codex/agents/` and `~/.gemini/agents/` and `~/.factory/droids/` (Factory calls agents "droids"). Configures hooks in settings so they activate automatically.
+What it does: installs agents, skills, hooks, commands, and scripts into `~/.claude/` (symlinked or copied per your choice). Mirrors skills into `~/.codex/skills/` and `~/.gemini/skills/`, agents into `~/.codex/agents/` and `~/.gemini/agents/` and `~/.factory/droids/` (Factory calls agents "droids"), and skills + scripts + hooks into `~/.reasonix/` (no agent surface there). Configures hooks in settings so they activate automatically.
 
 ## Verify
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -12,7 +12,7 @@ claude --version
 
 If that prints a version number, you're good. If not, install Claude Code first and come back.
 
-Optional: Codex CLI, Gemini CLI, Factory, or Reasonix. The toolkit mirrors skills and agents into their directories (`~/.codex/`, `~/.gemini/`, `~/.factory/`, `~/.reasonix/`), so all the CLIs dispatch the same domain expertise. Claude Code remains the full runtime for hooks, commands, and scripts.
+Optional: Codex CLI, Gemini CLI, Factory, or Reasonix. The toolkit mirrors skills (and agents where the harness supports them) into their directories (`~/.codex/`, `~/.gemini/`, `~/.factory/`, `~/.reasonix/`), so all the CLIs dispatch the same domain expertise. Reasonix has no agent surface, so it gets skills + scripts + hooks only. Claude Code remains the full runtime for hooks, commands, and scripts.
 
 Verify optional tools: `codex --version` / `gemini --version` / `factory --version` / `reasonix --version`.
 

--- a/hooks/lib/hook_utils.py
+++ b/hooks/lib/hook_utils.py
@@ -459,7 +459,7 @@ def detect_cli() -> str:
     running Claude Code.
 
     Returns:
-        One of "gemini", "codex", or "claude".
+        One of "gemini", "codex", "reasonix", or "claude".
     """
     # Most specific: explicit CLI identification env var
     if os.environ.get("GEMINI_CLI"):
@@ -470,6 +470,10 @@ def detect_cli() -> str:
         return "gemini"
     if "codex" in invocation.lower():
         return "codex"
+    # Reasonix sets no session/home env var and spawns hooks with the ambient
+    # env inherited, so it is only identifiable via the _ invocation var.
+    if "reasonix" in invocation.lower():
+        return "reasonix"
     # Codex-specific env vars
     if os.environ.get("CODEX_HOME") or os.environ.get("CODEX_HOOKS_DIR"):
         return "codex"

--- a/hooks/lib/hook_utils.py
+++ b/hooks/lib/hook_utils.py
@@ -472,7 +472,9 @@ def detect_cli() -> str:
         return "codex"
     # Reasonix sets no session/home env var and spawns hooks with the ambient
     # env inherited, so it is only identifiable via the _ invocation var.
-    if "reasonix" in invocation.lower():
+    # Match on basename so unrelated parent paths (/Users/reasonix-fan/bin/...)
+    # do not false-positive while wrapper scripts (reasonix-dev) still match.
+    if "reasonix" in os.path.basename(invocation).lower():
         return "reasonix"
     # Codex-specific env vars
     if os.environ.get("CODEX_HOME") or os.environ.get("CODEX_HOOKS_DIR"):

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,8 @@
 #   1. Verifies Python 3.10+ is available
 #   2. Creates ~/.claude directory if needed
 #   3. Links/copies agents, skills, hooks, commands, scripts to ~/.claude
-#   4. Mirrors skills, agents, hooks, and scripts to ~/.codex, ~/.gemini, and ~/.hermes
+#   4. Mirrors skills, agents, hooks, and scripts to ~/.codex, ~/.gemini, ~/.factory,
+#      ~/.hermes, and ~/.reasonix (no agent surface for ~/.reasonix)
 #   5. Sets up local overlay directory
 #   6. Configures hooks in settings.json
 #
@@ -739,6 +740,7 @@ os.rename(tmp, dst)
     # toolkit symlinks left by the pre-flatten installer. Finally drop the dir if now empty.
     if [ -d "$REASONIX_SKILLS_DIR" ]; then
         reasonix_uninstall_entry() {
+            [ -n "$1" ] || return 0
             local target="${REASONIX_SKILLS_DIR}/$1"
             [ -e "$target" ] || [ -L "$target" ] || return 0
             if [ "$DRY_RUN" = true ]; then
@@ -874,6 +876,7 @@ os.rename(tmp, dst)
     echo "  • ~/.gemini/settings.json (all keys except hooks)"
     echo "  • ~/.factory/config.toml (if present, like Codex)"
     echo "  • ~/.hermes/config.yaml (Hermes Agent configuration)"
+    echo "  • ~/.reasonix/config.json (Reasonix MCP/model/permissions, user-owned)"
     echo "  • .local/ customizations in the toolkit repo"
     echo "  • Python packages (remove manually if needed)"
     if [ ${#PRESERVED[@]} -gt 0 ]; then
@@ -1652,6 +1655,8 @@ fi
 # traverse symlinked skill ENTRIES during discovery (only real directories are scanned), so
 # a symlinked skill is invisible while a real-dir copy is found instantly. The reasonix
 # skills mirror therefore forces real-directory copies regardless of the install MODE.
+# Re-test symlink discovery on each reasonix bump; drop this copy fallback once
+# src/skills.ts traverses symlinked entries.
 reasonix_install_skill() {
     # $1 = skill source dir (the dir containing SKILL.md); $2 = flat skill name
     local skill_dir=$1
@@ -1679,12 +1684,16 @@ reasonix_install_skill() {
     REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
 }
 
-# Flatten every SKILL.md under skills/ (122 nested + 1 top-level = 123 skills).
-while IFS= read -r skill_md; do
-    [ -n "$skill_md" ] || continue
-    skill_dir=$(dirname "$skill_md")
-    reasonix_install_skill "$skill_dir" "$(basename "$skill_dir")"
-done < <(find "${SCRIPT_DIR}/skills" -name SKILL.md | sort)
+# Private skills FIRST so they claim canonical names; matching public-skill names then
+# trip the within-run collision guard and yield to the private override (parity with the
+# Claude install: private overrides public).
+if [ -d "${SCRIPT_DIR}/private-skills" ]; then
+    while IFS= read -r skill_md; do
+        [ -n "$skill_md" ] || continue
+        skill_dir=$(dirname "$skill_md")
+        reasonix_install_skill "$skill_dir" "$(basename "$skill_dir")"
+    done < <(find "${SCRIPT_DIR}/private-skills" -name SKILL.md | sort)
+fi
 
 # Voice skills: private-voices/<name>/skill/SKILL.md -> ~/.reasonix/skills/voice-<name>/
 if [ -d "${SCRIPT_DIR}/private-voices" ]; then
@@ -1697,14 +1706,12 @@ if [ -d "${SCRIPT_DIR}/private-voices" ]; then
     done
 fi
 
-# Private skills: flatten every SKILL.md (handles flat or category-nested layouts).
-if [ -d "${SCRIPT_DIR}/private-skills" ]; then
-    while IFS= read -r skill_md; do
-        [ -n "$skill_md" ] || continue
-        skill_dir=$(dirname "$skill_md")
-        reasonix_install_skill "$skill_dir" "$(basename "$skill_dir")"
-    done < <(find "${SCRIPT_DIR}/private-skills" -name SKILL.md | sort)
-fi
+# Public skills last: same-name entries are skipped by the collision guard (private wins).
+while IFS= read -r skill_md; do
+    [ -n "$skill_md" ] || continue
+    skill_dir=$(dirname "$skill_md")
+    reasonix_install_skill "$skill_dir" "$(basename "$skill_dir")"
+done < <(find "${SCRIPT_DIR}/skills" -name SKILL.md | sort)
 
 # Support dirs (no SKILL.md anywhere — e.g. shared-patterns, kb): copy as real top-level
 # dirs so flattened skills' sibling references like ../shared-patterns/*.md resolve, and so
@@ -1937,6 +1944,7 @@ if [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}  Would set 700 on ~/.claude/ and ~/.claude/learning/${NC}"
     echo -e "${BLUE}  Would set 600 on ~/.claude/history.jsonl (if it exists)${NC}"
     echo -e "${BLUE}  Would set 600 on ~/.factory/settings.json${NC}"
+    echo -e "${BLUE}  Would set 600 on ~/.reasonix/settings.json${NC}"
 else
     chmod 644 "${SCRIPT_DIR}/docs/"*.md 2>/dev/null || true
     find "${SCRIPT_DIR}/hooks" -name "*.py" -exec chmod 755 {} \; 2>/dev/null || true
@@ -1949,6 +1957,8 @@ else
     chmod 600 "${CLAUDE_DIR}/history.jsonl" 2>/dev/null || true
     chmod 600 "${FACTORY_DIR}/settings.json" 2>/dev/null || true
     chmod 600 "$(ls -1t "${FACTORY_DIR}/settings.json.backup."* 2>/dev/null | head -1)" 2>/dev/null || true
+    chmod 600 "${REASONIX_DIR}/settings.json" 2>/dev/null || true
+    chmod 600 "$(ls -1t "${REASONIX_DIR}/settings.json.backup."* 2>/dev/null | head -1)" 2>/dev/null || true
 fi
 echo -e "${GREEN}✓ Permissions set${NC}"
 

--- a/install.sh
+++ b/install.sh
@@ -732,54 +732,51 @@ os.rename(tmp, dst)
     # Phase 3.11: Clean toolkit-owned Reasonix mirror (skills + scripts + hooks + settings.json)
     echo ""
     echo -e "${YELLOW}Cleaning Reasonix skills mirror...${NC}"
+    # Remove ONLY the toolkit-owned flatten-copy output, recomputed from the repo so it
+    # matches what the install wrote (skills/<cat>/<name> + top-level skills + private-skills
+    # flattened to <name>, voice skills as voice-<name>, support dirs copied by name). Skills
+    # a USER added by hand (real dirs we never wrote) are left intact. Also sweep stale
+    # toolkit symlinks left by the pre-flatten installer. Finally drop the dir if now empty.
     if [ -d "$REASONIX_SKILLS_DIR" ]; then
-        for item in "${SCRIPT_DIR}/skills/"*; do
-            [ -e "$item" ] || continue
-            target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
-            if [ -L "$target" ] || [ -e "$target" ]; then
-                if [ "$DRY_RUN" = true ]; then
-                    echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
-                else
-                    rm -rf "$target"
-                    echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
-                fi
-                REMOVED+=("Reasonix skill $(basename "$item")")
+        reasonix_uninstall_entry() {
+            local target="${REASONIX_SKILLS_DIR}/$1"
+            [ -e "$target" ] || [ -L "$target" ] || return 0
+            if [ "$DRY_RUN" = true ]; then
+                echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
+            else
+                rm -rf "$target"
+                echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
             fi
-        done
+            REMOVED+=("Reasonix skill $1")
+        }
 
+        # Flattened skills + private skills (basename of each dir holding a SKILL.md).
+        while IFS= read -r skill_md; do
+            [ -n "$skill_md" ] || continue
+            reasonix_uninstall_entry "$(basename "$(dirname "$skill_md")")"
+        done < <(find "${SCRIPT_DIR}/skills" "${SCRIPT_DIR}/private-skills" -name SKILL.md 2>/dev/null)
+
+        # Voice skills (voice-<name>).
         if [ -d "${SCRIPT_DIR}/private-voices" ]; then
             for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
-                [ -d "$voice_dir" ] || continue
-                skill_src="${voice_dir}/skill"
-                [ -d "$skill_src" ] || continue
-                voice_name=$(basename "$voice_dir")
-                target="${REASONIX_SKILLS_DIR}/voice-${voice_name}"
-                if [ -L "$target" ] || [ -e "$target" ]; then
-                    if [ "$DRY_RUN" = true ]; then
-                        echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
-                    else
-                        rm -rf "$target"
-                        echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
-                    fi
-                    REMOVED+=("Reasonix skill voice-${voice_name}")
-                fi
+                [ -f "${voice_dir}/skill/SKILL.md" ] || continue
+                reasonix_uninstall_entry "voice-$(basename "$voice_dir")"
             done
         fi
 
-        if [ -d "${SCRIPT_DIR}/private-skills" ]; then
-            for item in "${SCRIPT_DIR}/private-skills/"*; do
-                [ -e "$item" ] || continue
-                target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
-                if [ -L "$target" ] || [ -e "$target" ]; then
-                    if [ "$DRY_RUN" = true ]; then
-                        echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
-                    else
-                        rm -rf "$target"
-                        echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
-                    fi
-                    REMOVED+=("Reasonix skill $(basename "$item")")
-                fi
-            done
+        # Support dirs (no SKILL.md anywhere — shared-patterns, kb, voice-shared*).
+        for support_dir in "${SCRIPT_DIR}/skills/"*/; do
+            [ -d "$support_dir" ] || continue
+            [ -z "$(find "$support_dir" -name SKILL.md -print -quit)" ] || continue
+            reasonix_uninstall_entry "$(basename "$support_dir")"
+        done
+
+        # Stale toolkit symlinks from the pre-flatten installer (reasonix entries are always
+        # real dirs now, so any symlink here is toolkit-owned residue).
+        if [ "$DRY_RUN" != true ]; then
+            find "$REASONIX_SKILLS_DIR" -maxdepth 1 -mindepth 1 -type l -delete 2>/dev/null || true
+            rmdir "$REASONIX_SKILLS_DIR" 2>/dev/null && \
+                echo -e "${GREEN}  ✓ Removed empty ${REASONIX_SKILLS_DIR}${NC}" || true
         fi
     else
         echo "  No ~/.reasonix/skills mirror found. Nothing to clean."
@@ -1633,35 +1630,99 @@ fi
 # and runs Claude-Code-identical hooks declared in ~/.reasonix/settings.json (hooks key only;
 # MCP/model/permissions live in user-owned ~/.reasonix/config.json, which we never touch).
 echo ""
-echo -e "${YELLOW}Syncing Reasonix skills mirror...${NC}"
+echo -e "${YELLOW}Syncing Reasonix skills mirror (flatten + copy)...${NC}"
 REASONIX_ENTRY_COUNT=0
-for item in "${SCRIPT_DIR}/skills/"*; do
-    [ -e "$item" ] || continue
-    target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
-    sync_mirror_entry "$item" "$target" "Reasonix"
-    REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
-done
+REASONIX_SEEN_NAMES=" "  # space-delimited set of flat names claimed this run (collision guard)
+if [ "$DRY_RUN" != true ]; then
+    mkdir -p "$REASONIX_SKILLS_DIR"
+    # Sweep stale toolkit symlinks left by the pre-flatten installer (it symlinked
+    # skills/<category> dirs, which reasonix can't discover). Reasonix skill entries are
+    # ALWAYS real copied dirs now, so any symlink here is stale toolkit output — safe to
+    # drop. User-added skills are real dirs and are left untouched.
+    find "$REASONIX_SKILLS_DIR" -maxdepth 1 -mindepth 1 -type l -delete 2>/dev/null || true
+fi
 
+# Reasonix scans skill roots EXACTLY ONE LEVEL DEEP (src/skills.ts:251-258): a dir entry
+# <X> is a skill only when <X>/SKILL.md exists, and it never recurses. vexjoy skills live
+# at skills/<category>/<name>/SKILL.md (two levels), so a naive same-name mirror exposes
+# category dirs that hold no SKILL.md and reasonix discovers nothing. We therefore FLATTEN
+# every skill to ~/.reasonix/skills/<name>/SKILL.md (one level deep).
+#
+# COPY ALWAYS — even when MODE=symlink: the shipped reasonix npm build (v0.53.2) does NOT
+# traverse symlinked skill ENTRIES during discovery (only real directories are scanned), so
+# a symlinked skill is invisible while a real-dir copy is found instantly. The reasonix
+# skills mirror therefore forces real-directory copies regardless of the install MODE.
+reasonix_install_skill() {
+    # $1 = skill source dir (the dir containing SKILL.md); $2 = flat skill name
+    local skill_dir=$1
+    local name=$2
+    local target="${REASONIX_SKILLS_DIR}/${name}"
+
+    # Within-run collision guard: basenames are verified unique, but never clobber a name
+    # already claimed by this run. (A target left from a PRIOR run is refreshed below.)
+    case "$REASONIX_SEEN_NAMES" in
+        *" ${name} "*)
+            echo -e "${YELLOW}  Warning: duplicate Reasonix skill name '${name}', skipping ${skill_dir}${NC}"
+            return 0
+            ;;
+    esac
+    REASONIX_SEEN_NAMES="${REASONIX_SEEN_NAMES}${name} "
+
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would copy Reasonix skill (real dir, copy forced even in symlink mode): ${skill_dir} -> ${target}/${NC}"
+    else
+        rm -rf "$target"            # idempotent re-run: refresh content like the other mirrors
+        mkdir -p "$target"
+        cp -r "${skill_dir}/." "$target/"
+        echo -e "${GREEN}  ✓ Reasonix copied ${name}${NC}"
+    fi
+    REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
+}
+
+# Flatten every SKILL.md under skills/ (122 nested + 1 top-level = 123 skills).
+while IFS= read -r skill_md; do
+    [ -n "$skill_md" ] || continue
+    skill_dir=$(dirname "$skill_md")
+    reasonix_install_skill "$skill_dir" "$(basename "$skill_dir")"
+done < <(find "${SCRIPT_DIR}/skills" -name SKILL.md | sort)
+
+# Voice skills: private-voices/<name>/skill/SKILL.md -> ~/.reasonix/skills/voice-<name>/
 if [ -d "${SCRIPT_DIR}/private-voices" ]; then
     for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
         [ -d "$voice_dir" ] || continue
         skill_src="${voice_dir}/skill"
-        [ -d "$skill_src" ] || continue
+        [ -f "${skill_src}/SKILL.md" ] || continue
         voice_name=$(basename "$voice_dir")
-        target="${REASONIX_SKILLS_DIR}/voice-${voice_name}"
-        sync_mirror_entry "$skill_src" "$target" "Reasonix"
-        REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
+        reasonix_install_skill "$skill_src" "voice-${voice_name}"
     done
 fi
 
+# Private skills: flatten every SKILL.md (handles flat or category-nested layouts).
 if [ -d "${SCRIPT_DIR}/private-skills" ]; then
-    for item in "${SCRIPT_DIR}/private-skills/"*; do
-        [ -e "$item" ] || continue
-        target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
-        sync_mirror_entry "$item" "$target" "Reasonix"
-        REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
-    done
+    while IFS= read -r skill_md; do
+        [ -n "$skill_md" ] || continue
+        skill_dir=$(dirname "$skill_md")
+        reasonix_install_skill "$skill_dir" "$(basename "$skill_dir")"
+    done < <(find "${SCRIPT_DIR}/private-skills" -name SKILL.md | sort)
 fi
+
+# Support dirs (no SKILL.md anywhere — e.g. shared-patterns, kb): copy as real top-level
+# dirs so flattened skills' sibling references like ../shared-patterns/*.md resolve, and so
+# the downstream voice shared-references deploy (which targets ${REASONIX_SKILLS_DIR}/shared-patterns)
+# keeps working. These are not skills (reasonix ignores them: no SKILL.md) so they are not counted.
+for support_dir in "${SCRIPT_DIR}/skills/"*/; do
+    [ -d "$support_dir" ] || continue
+    [ -z "$(find "$support_dir" -name SKILL.md -print -quit)" ] || continue  # skip dirs that hold skills
+    support_name=$(basename "$support_dir")
+    support_target="${REASONIX_SKILLS_DIR}/${support_name}"
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would copy Reasonix support dir: ${support_dir} -> ${support_target}/${NC}"
+    else
+        rm -rf "$support_target"
+        cp -r "$support_dir" "$support_target"
+        echo -e "${GREEN}  ✓ Reasonix copied support dir ${support_name}${NC}"
+    fi
+done
 
 echo ""
 echo -e "${YELLOW}Syncing Reasonix scripts mirror...${NC}"
@@ -1970,7 +2031,7 @@ echo "  • Factory droids: ${FACTORY_DROID_COUNT} mirrored entries in ~/.factor
 echo "  • Factory hooks: ${FACTORY_HOOK_COUNT} mirrored entries in ~/.factory/hooks"
 echo "  • Hermes skills: ${HERMES_ENTRY_COUNT} mirrored entries in ~/.hermes/skills"
 echo "  • Hermes scripts: ${HERMES_SCRIPT_COUNT} mirrored scripts in ~/.hermes/scripts"
-echo "  • Reasonix skills: ${REASONIX_ENTRY_COUNT} mirrored entries in ~/.reasonix/skills"
+echo "  • Reasonix skills: ${REASONIX_ENTRY_COUNT} flattened skills (real dirs, one level deep) in ~/.reasonix/skills"
 echo "  • Reasonix scripts: ${REASONIX_SCRIPT_COUNT} mirrored scripts in ~/.reasonix/scripts"
 echo "  • Reasonix hooks: ${REASONIX_HOOK_COUNT} mirrored entries in ~/.reasonix/hooks"
 echo "  • Hooks: ${HOOK_COUNT} automation hooks"

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,10 @@ FACTORY_SCRIPTS_DIR="${FACTORY_DIR}/scripts"
 HERMES_DIR="${HOME}/.hermes"
 HERMES_SKILLS_DIR="${HERMES_DIR}/skills"
 HERMES_SCRIPTS_DIR="${HERMES_DIR}/scripts"
+REASONIX_DIR="${HOME}/.reasonix"
+REASONIX_SKILLS_DIR="${REASONIX_DIR}/skills"
+REASONIX_SCRIPTS_DIR="${REASONIX_DIR}/scripts"
+REASONIX_HOOKS_DIR="${REASONIX_DIR}/hooks"
 
 echo -e "${BLUE}╔════════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${BLUE}║                VexJoy Agent - Installation Script               ║${NC}"
@@ -725,6 +729,106 @@ os.rename(tmp, dst)
     # Note: ~/.hermes/config.yaml is intentionally left untouched.
     # Users may have other Hermes configurations we did not write.
 
+    # Phase 3.11: Clean toolkit-owned Reasonix mirror (skills + scripts + hooks + settings.json)
+    echo ""
+    echo -e "${YELLOW}Cleaning Reasonix skills mirror...${NC}"
+    if [ -d "$REASONIX_SKILLS_DIR" ]; then
+        for item in "${SCRIPT_DIR}/skills/"*; do
+            [ -e "$item" ] || continue
+            target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
+            if [ -L "$target" ] || [ -e "$target" ]; then
+                if [ "$DRY_RUN" = true ]; then
+                    echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
+                else
+                    rm -rf "$target"
+                    echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
+                fi
+                REMOVED+=("Reasonix skill $(basename "$item")")
+            fi
+        done
+
+        if [ -d "${SCRIPT_DIR}/private-voices" ]; then
+            for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
+                [ -d "$voice_dir" ] || continue
+                skill_src="${voice_dir}/skill"
+                [ -d "$skill_src" ] || continue
+                voice_name=$(basename "$voice_dir")
+                target="${REASONIX_SKILLS_DIR}/voice-${voice_name}"
+                if [ -L "$target" ] || [ -e "$target" ]; then
+                    if [ "$DRY_RUN" = true ]; then
+                        echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
+                    else
+                        rm -rf "$target"
+                        echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
+                    fi
+                    REMOVED+=("Reasonix skill voice-${voice_name}")
+                fi
+            done
+        fi
+
+        if [ -d "${SCRIPT_DIR}/private-skills" ]; then
+            for item in "${SCRIPT_DIR}/private-skills/"*; do
+                [ -e "$item" ] || continue
+                target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
+                if [ -L "$target" ] || [ -e "$target" ]; then
+                    if [ "$DRY_RUN" = true ]; then
+                        echo -e "${BLUE}  Would remove Reasonix entry: ${target}${NC}"
+                    else
+                        rm -rf "$target"
+                        echo -e "${GREEN}  ✓ Removed Reasonix entry: ${target}${NC}"
+                    fi
+                    REMOVED+=("Reasonix skill $(basename "$item")")
+                fi
+            done
+        fi
+    else
+        echo "  No ~/.reasonix/skills mirror found. Nothing to clean."
+    fi
+
+    echo ""
+    echo -e "${YELLOW}Cleaning Reasonix scripts mirror...${NC}"
+    if [ -d "$REASONIX_SCRIPTS_DIR" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would remove: ${REASONIX_SCRIPTS_DIR}${NC}"
+        else
+            rm -rf "$REASONIX_SCRIPTS_DIR"
+            echo -e "${GREEN}  ✓ Removed ${REASONIX_SCRIPTS_DIR}${NC}"
+        fi
+        REMOVED+=("Reasonix scripts mirror directory")
+    else
+        echo "  No ~/.reasonix/scripts mirror found. Nothing to clean."
+    fi
+
+    echo ""
+    echo -e "${YELLOW}Cleaning Reasonix hooks mirror...${NC}"
+    if [ -d "$REASONIX_HOOKS_DIR" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would remove: ${REASONIX_HOOKS_DIR}${NC}"
+        else
+            rm -rf "$REASONIX_HOOKS_DIR"
+            echo -e "${GREEN}  ✓ Removed ${REASONIX_HOOKS_DIR}${NC}"
+        fi
+        REMOVED+=("Reasonix hooks mirror directory")
+    else
+        echo "  No ~/.reasonix/hooks mirror found. Nothing to clean."
+    fi
+
+    # Archive the generated Reasonix settings.json (hooks key). config.json is
+    # user-owned and never touched.
+    if [ -f "${REASONIX_DIR}/settings.json" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would archive: ${REASONIX_DIR}/settings.json${NC}"
+        else
+            ARCHIVE_TS=$(date +%Y%m%d-%H%M%S)
+            mv "${REASONIX_DIR}/settings.json" "${REASONIX_DIR}/settings.json.uninstalled.${ARCHIVE_TS}"
+            echo -e "${GREEN}  ✓ Archived ${REASONIX_DIR}/settings.json${NC}"
+        fi
+        REMOVED+=("Reasonix settings.json (archived)")
+    fi
+
+    # Note: ~/.reasonix/config.json is intentionally left untouched.
+    # Users own MCP/model/permissions config we did not write.
+
     # Phase 4: Remove install manifest
     echo ""
     echo -e "${YELLOW}Cleaning up manifest...${NC}"
@@ -900,6 +1004,15 @@ else
     mkdir -p "${HERMES_SKILLS_DIR}"
 fi
 echo -e "${GREEN}✓ ${HERMES_SKILLS_DIR} ready${NC}"
+
+echo ""
+echo -e "${YELLOW}Setting up ~/.reasonix/skills directory...${NC}"
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}  Would create: ${REASONIX_SKILLS_DIR}${NC}"
+else
+    mkdir -p "${REASONIX_SKILLS_DIR}"
+fi
+echo -e "${GREEN}✓ ${REASONIX_SKILLS_DIR} ready${NC}"
 
 # Install components
 echo ""
@@ -1515,6 +1628,107 @@ else
     HERMES_SCRIPT_COUNT=0
 fi
 
+# ── Reasonix mirror (skills + scripts + hooks; Claude-Code-compatible extension layer) ──
+# Reasonix natively reads ~/.reasonix/skills, shells out to scripts via the SDIR chain,
+# and runs Claude-Code-identical hooks declared in ~/.reasonix/settings.json (hooks key only;
+# MCP/model/permissions live in user-owned ~/.reasonix/config.json, which we never touch).
+echo ""
+echo -e "${YELLOW}Syncing Reasonix skills mirror...${NC}"
+REASONIX_ENTRY_COUNT=0
+for item in "${SCRIPT_DIR}/skills/"*; do
+    [ -e "$item" ] || continue
+    target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
+    sync_mirror_entry "$item" "$target" "Reasonix"
+    REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
+done
+
+if [ -d "${SCRIPT_DIR}/private-voices" ]; then
+    for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
+        [ -d "$voice_dir" ] || continue
+        skill_src="${voice_dir}/skill"
+        [ -d "$skill_src" ] || continue
+        voice_name=$(basename "$voice_dir")
+        target="${REASONIX_SKILLS_DIR}/voice-${voice_name}"
+        sync_mirror_entry "$skill_src" "$target" "Reasonix"
+        REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
+    done
+fi
+
+if [ -d "${SCRIPT_DIR}/private-skills" ]; then
+    for item in "${SCRIPT_DIR}/private-skills/"*; do
+        [ -e "$item" ] || continue
+        target="${REASONIX_SKILLS_DIR}/$(basename "$item")"
+        sync_mirror_entry "$item" "$target" "Reasonix"
+        REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
+    done
+fi
+
+echo ""
+echo -e "${YELLOW}Syncing Reasonix scripts mirror...${NC}"
+if [ -d "${SCRIPT_DIR}/scripts" ]; then
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would mirror scripts to: ${REASONIX_SCRIPTS_DIR}${NC}"
+    else
+        mkdir -p "$REASONIX_SCRIPTS_DIR"
+    fi
+    sync_mirror_entry "${SCRIPT_DIR}/scripts" "$REASONIX_SCRIPTS_DIR" "Reasonix"
+    REASONIX_SCRIPT_COUNT=$(ls -1 "${SCRIPT_DIR}/scripts/"*.py 2>/dev/null | grep -cv '__init__')
+    echo -e "${GREEN}  ✓ Scripts mirrored to ${REASONIX_SCRIPTS_DIR}${NC}"
+else
+    REASONIX_SCRIPT_COUNT=0
+fi
+
+echo ""
+echo -e "${YELLOW}Syncing Reasonix hooks mirror...${NC}"
+if [ -d "${SCRIPT_DIR}/hooks" ]; then
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would mirror hooks to: ${REASONIX_HOOKS_DIR}${NC}"
+    else
+        mkdir -p "$REASONIX_HOOKS_DIR"
+    fi
+    sync_mirror_entry "${SCRIPT_DIR}/hooks" "$REASONIX_HOOKS_DIR" "Reasonix"
+    REASONIX_HOOK_COUNT=$(ls -1 "${SCRIPT_DIR}/hooks/"*.py 2>/dev/null | grep -cv '__init__')
+    echo -e "${GREEN}  ✓ Hooks mirrored to ${REASONIX_HOOKS_DIR}${NC}"
+else
+    REASONIX_HOOK_COUNT=0
+fi
+
+# Generate ~/.reasonix/settings.json (hooks key only; rewrite .claude paths to .reasonix).
+# config.json (MCP/model/permissions) is user-owned and never written here.
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}  Would sync hooks from ${SCRIPT_DIR}/.claude/settings.json to ${REASONIX_DIR}/settings.json (with path rewrite)${NC}"
+elif [ -f "${SCRIPT_DIR}/.claude/settings.json" ]; then
+    REASONIX_SETTINGS="${REASONIX_DIR}/settings.json"
+    if [ ! -f "$REASONIX_SETTINGS" ]; then
+        echo '{}' > "$REASONIX_SETTINGS"
+    fi
+    BACKUP_TS=$(date +%Y%m%d-%H%M%S)
+    cp "$REASONIX_SETTINGS" "${REASONIX_SETTINGS}.backup.${BACKUP_TS}"
+    $PYTHON_CMD -c "
+import json, os
+repo = json.load(open('${SCRIPT_DIR}/.claude/settings.json'))
+dst = '${REASONIX_SETTINGS}'
+try:
+    merged = json.load(open(dst, encoding='utf-8'))
+except (FileNotFoundError, json.JSONDecodeError):
+    merged = {}
+hooks_json = json.dumps(repo.get('hooks', {}))
+hooks_json = hooks_json.replace('\$HOME/.claude/', '\$HOME/.reasonix/')
+hooks_json = hooks_json.replace('\${HOME}/.claude/', '\${HOME}/.reasonix/')
+merged['hooks'] = json.loads(hooks_json)
+merged.setdefault('attribution', repo.get('attribution', {'commit': '', 'pr': ''}))
+tmp = dst + '.tmp'
+with open(tmp, 'w', encoding='utf-8') as f:
+    json.dump(merged, f, indent=2)
+    f.flush()
+    os.fsync(f.fileno())
+os.rename(tmp, dst)
+print('  Reasonix hooks configured from .claude/settings.json')
+"
+else
+    echo -e "${YELLOW}  Warning: ${SCRIPT_DIR}/.claude/settings.json not found, skipping Reasonix hook sync${NC}"
+fi
+
 # Deploy private-voices shared references into skills/shared-patterns/
 # These files were removed from the public repo and live in private-voices/shared-references/
 # (gitignored). They must be deployed at install time into every runtime's shared-patterns dir.
@@ -1525,7 +1739,7 @@ if [ -d "${SCRIPT_DIR}/private-voices/shared-references" ]; then
     for ref_file in "${SCRIPT_DIR}/private-voices/shared-references/"*.md; do
         [ -f "$ref_file" ] || continue
         ref_name=$(basename "$ref_file")
-        for target_dir in "${CLAUDE_DIR}/skills/shared-patterns" "${CODEX_SKILLS_DIR}/shared-patterns" "${GEMINI_SKILLS_DIR}/shared-patterns" "${FACTORY_SKILLS_DIR}/shared-patterns" "${HERMES_SKILLS_DIR}/shared-patterns"; do
+        for target_dir in "${CLAUDE_DIR}/skills/shared-patterns" "${CODEX_SKILLS_DIR}/shared-patterns" "${GEMINI_SKILLS_DIR}/shared-patterns" "${FACTORY_SKILLS_DIR}/shared-patterns" "${HERMES_SKILLS_DIR}/shared-patterns" "${REASONIX_SKILLS_DIR}/shared-patterns"; do
             # Resolve symlinks so we write into the actual directory
             resolved_dir="$target_dir"
             [ -L "$target_dir" ] && resolved_dir="$(readlink -f "$target_dir")"
@@ -1714,6 +1928,7 @@ manifest = {
     'gemini_components': ['skills', 'agents', 'hooks', 'scripts'],
     'factory_components': ['skills', 'droids', 'hooks'],
     'hermes_components': ['skills', 'scripts'],
+    'reasonix_components': ['skills', 'scripts', 'hooks'],
 }
 json.dump(manifest, open('${CLAUDE_DIR}/.install-manifest.json', 'w'), indent=2)
 print('  Install manifest written to ~/.claude/.install-manifest.json')
@@ -1755,6 +1970,9 @@ echo "  • Factory droids: ${FACTORY_DROID_COUNT} mirrored entries in ~/.factor
 echo "  • Factory hooks: ${FACTORY_HOOK_COUNT} mirrored entries in ~/.factory/hooks"
 echo "  • Hermes skills: ${HERMES_ENTRY_COUNT} mirrored entries in ~/.hermes/skills"
 echo "  • Hermes scripts: ${HERMES_SCRIPT_COUNT} mirrored scripts in ~/.hermes/scripts"
+echo "  • Reasonix skills: ${REASONIX_ENTRY_COUNT} mirrored entries in ~/.reasonix/skills"
+echo "  • Reasonix scripts: ${REASONIX_SCRIPT_COUNT} mirrored scripts in ~/.reasonix/scripts"
+echo "  • Reasonix hooks: ${REASONIX_HOOK_COUNT} mirrored entries in ~/.reasonix/hooks"
 echo "  • Hooks: ${HOOK_COUNT} automation hooks"
 echo "  • Commands: ${COMMAND_COUNT} slash commands"
 echo "  • Scripts: ${SCRIPT_COUNT} utility scripts"

--- a/scripts/detect-workflow-capability.py
+++ b/scripts/detect-workflow-capability.py
@@ -5,9 +5,10 @@ Emits JSON: {"harness": "claude-code|codex|gemini|factory|reasonix|unknown",
              "workflow_capable": bool}
 
 Anthropic's native ``Workflow`` tool (deterministic JS orchestration) is
-Claude Code-only. Codex, Gemini, Factory, and Reasonix do not have it; the
-toolkit's prose pipelines run everywhere. ``workflow_capable`` is the
-env-derived proxy ``harness == "claude-code"``.
+Claude Code-only. ``workflow_capable`` is the env-derived proxy
+``harness in WORKFLOW_CAPABLE`` — currently the singleton ``{"claude-code"}``.
+The toolkit's prose pipelines run on every harness when the native path is
+unavailable.
 
 PROXY, NOT AUTHORITY. A subprocess cannot introspect the session's tool list,
 only the environment. So this script answers "which harness am I in?" and the
@@ -42,6 +43,11 @@ import sys
 
 HARNESSES = ("claude-code", "codex", "gemini", "factory", "reasonix", "unknown")
 
+# Single source of truth for native-Workflow availability. Add a harness here
+# the day it ships the native Workflow tool; the docstring and tests pin against
+# this set so a one-line change flips the contract.
+WORKFLOW_CAPABLE: frozenset[str] = frozenset({"claude-code"})
+
 # Marker var -> harness. Claude Code is checked first so it wins when env from
 # a Claude Code session leaks other harnesses' vars (config copied around).
 _MARKERS: list[tuple[str, tuple[str, ...]]] = [
@@ -66,9 +72,11 @@ def detect_harness(env: dict | None) -> str:
                 if env.get(key):
                     return harness
         # Reasonix exposes no distinctive env marker. Fall back to the ``_``
-        # invocation var (path of the invoking binary), the same best-effort
-        # mechanism used for gemini/codex in detect_cli().
-        if "reasonix" in env.get("_", "").lower():
+        # invocation var (path of the invoking binary). Match on basename so
+        # unrelated parent paths like ``/Users/reasonix-fan/bin/python3`` do
+        # not false-positive while wrapper scripts ``reasonix``/``Reasonix``/
+        # ``reasonix-dev`` still match.
+        if "reasonix" in os.path.basename(env.get("_", "")).lower():
             return "reasonix"
     except Exception:
         return "unknown"
@@ -77,7 +85,7 @@ def detect_harness(env: dict | None) -> str:
 
 def workflow_capable(harness: str) -> bool:
     """Env-derived proxy for native Workflow availability."""
-    return harness == "claude-code"
+    return harness in WORKFLOW_CAPABLE
 
 
 def main(argv: list[str]) -> int:

--- a/scripts/detect-workflow-capability.py
+++ b/scripts/detect-workflow-capability.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Detect the running harness from environment variables (env proxy).
 
-Emits JSON: {"harness": "claude-code|codex|gemini|factory|unknown",
+Emits JSON: {"harness": "claude-code|codex|gemini|factory|reasonix|unknown",
              "workflow_capable": bool}
 
 Anthropic's native ``Workflow`` tool (deterministic JS orchestration) is
-Claude Code-only. Codex, Gemini, and Factory do not have it; the toolkit's
-prose pipelines run everywhere. ``workflow_capable`` is the env-derived proxy
-``harness == "claude-code"``.
+Claude Code-only. Codex, Gemini, Factory, and Reasonix do not have it; the
+toolkit's prose pipelines run everywhere. ``workflow_capable`` is the
+env-derived proxy ``harness == "claude-code"``.
 
 PROXY, NOT AUTHORITY. A subprocess cannot introspect the session's tool list,
 only the environment. So this script answers "which harness am I in?" and the
@@ -21,6 +21,9 @@ API-key vars like GEMINI_API_KEY, which are commonly set under any harness):
   codex       : CODEX_HOME, CODEX_HOOKS_DIR
   gemini      : GEMINI_CLI
   factory     : FACTORY_SESSION_ID, FACTORY_HOME, DROID_SESSION_ID, DROID_HOME
+  reasonix    : (no env marker) — keyed off the ``_`` invocation var, since
+                reasonix sets no session/home var and spawns hooks with the
+                ambient env inherited (src/hooks.ts:206-212).
 Mirrors hooks/lib/hook_utils.py:detect_cli(), extended with factory + the
 Claude Code session markers.
 
@@ -37,7 +40,7 @@ import json
 import os
 import sys
 
-HARNESSES = ("claude-code", "codex", "gemini", "factory", "unknown")
+HARNESSES = ("claude-code", "codex", "gemini", "factory", "reasonix", "unknown")
 
 # Marker var -> harness. Claude Code is checked first so it wins when env from
 # a Claude Code session leaks other harnesses' vars (config copied around).
@@ -62,6 +65,11 @@ def detect_harness(env: dict | None) -> str:
             for key in keys:
                 if env.get(key):
                     return harness
+        # Reasonix exposes no distinctive env marker. Fall back to the ``_``
+        # invocation var (path of the invoking binary), the same best-effort
+        # mechanism used for gemini/codex in detect_cli().
+        if "reasonix" in env.get("_", "").lower():
+            return "reasonix"
     except Exception:
         return "unknown"
     return "unknown"

--- a/scripts/install-doctor.py
+++ b/scripts/install-doctor.py
@@ -346,17 +346,25 @@ def check_reasonix_skills() -> dict:
         }
 
     # The /do router is always installed; use it as the canary for discoverability.
-    do_skill = reasonix_skills_dir / "do" / "SKILL.md"
-    if do_skill.is_file():
+    # Reasonix v0.53.2 ignores symlinked skill ENTRIES (only real dirs are scanned),
+    # so the doctor must reject a stale symlinked entry from a pre-fix install even
+    # though `is_file()` would otherwise traverse the symlink and report success.
+    do_entry = reasonix_skills_dir / "do"
+    do_skill = do_entry / "SKILL.md"
+    if do_entry.is_dir() and not do_entry.is_symlink() and do_skill.is_file():
         return {
             "name": "reasonix_skills",
             "label": "~/.reasonix/skills discoverable",
             "passed": True,
-            "detail": f"'do' skill resolves at {do_skill} (real file, one level deep)",
+            "detail": f"'do' skill resolves at {do_skill} (real dir, one level deep)",
         }
 
     # Fallback: any flattened skill resolving one level deep also proves discoverability.
-    discoverable = sum(1 for entry in reasonix_skills_dir.iterdir() if (entry / "SKILL.md").is_file())
+    discoverable = sum(
+        1
+        for entry in reasonix_skills_dir.iterdir()
+        if entry.is_dir() and not entry.is_symlink() and (entry / "SKILL.md").is_file()
+    )
     if discoverable > 0:
         return {
             "name": "reasonix_skills",
@@ -370,7 +378,7 @@ def check_reasonix_skills() -> dict:
         "label": "~/.reasonix/skills discoverable",
         "passed": False,
         "detail": (
-            "No <name>/SKILL.md resolves one level deep — Reasonix sees zero skills. "
+            "No <name>/SKILL.md resolves one level deep as a real dir — Reasonix sees zero skills. "
             "Skills must be flattened+copied (not symlinked, not category-nested). Re-run install.sh."
         ),
     }

--- a/scripts/install-doctor.py
+++ b/scripts/install-doctor.py
@@ -26,6 +26,7 @@ from pathlib import Path
 CLAUDE_DIR = Path.home() / ".claude"
 CODEX_DIR = Path.home() / ".codex"
 HERMES_DIR = Path.home() / ".hermes"
+REASONIX_DIR = Path.home() / ".reasonix"
 COMPONENTS = ["agents", "skills", "hooks", "commands", "scripts"]
 
 
@@ -322,6 +323,37 @@ def check_hermes_skills() -> dict:
         "label": "~/.hermes/skills mirror",
         "passed": entry_count > 0,
         "detail": f"{entry_count} entries present in Hermes skills mirror",
+    }
+
+
+def check_reasonix_skills() -> dict:
+    """Check that toolkit skills are mirrored into ~/.reasonix/skills."""
+    reasonix_skills_dir = REASONIX_DIR / "skills"
+
+    if not reasonix_skills_dir.is_dir():
+        return {
+            "name": "reasonix_skills",
+            "label": "~/.reasonix/skills mirror",
+            "passed": False,
+            "detail": "Directory not found. Run install.sh to mirror toolkit skills for Reasonix.",
+        }
+
+    repo_root = get_toolkit_repo_root()
+    if repo_root is None:
+        return {
+            "name": "reasonix_skills",
+            "label": "~/.reasonix/skills mirror",
+            "passed": True,
+            "detail": str(reasonix_skills_dir),
+        }
+
+    # Count entries present (simplified check — Reasonix uses same flat structure)
+    entry_count = sum(1 for _ in reasonix_skills_dir.iterdir())
+    return {
+        "name": "reasonix_skills",
+        "label": "~/.reasonix/skills mirror",
+        "passed": entry_count > 0,
+        "detail": f"{entry_count} entries present in Reasonix skills mirror",
     }
 
 
@@ -852,6 +884,7 @@ def run_all_checks() -> list[dict]:
     results.append(check_codex_skills())
     results.append(check_codex_agents())
     results.append(check_hermes_skills())
+    results.append(check_reasonix_skills())
     results.append(check_settings_json())
     results.extend(check_hook_files())
     results.append(check_python_version())

--- a/scripts/install-doctor.py
+++ b/scripts/install-doctor.py
@@ -327,33 +327,52 @@ def check_hermes_skills() -> dict:
 
 
 def check_reasonix_skills() -> dict:
-    """Check that toolkit skills are mirrored into ~/.reasonix/skills."""
+    """Verify toolkit skills are DISCOVERABLE by Reasonix in ~/.reasonix/skills.
+
+    Reasonix scans skill roots exactly one level deep (src/skills.ts:251-258): a dir
+    entry ``<name>`` is a skill only when ``<name>/SKILL.md`` exists, and it never
+    recurses. The shipped npm build also skips symlinked entries. So a passing check
+    requires a REAL ``~/.reasonix/skills/<name>/SKILL.md`` one level deep — counting
+    top-level entries is not enough (category dirs / symlinks count but stay invisible).
+    """
     reasonix_skills_dir = REASONIX_DIR / "skills"
 
     if not reasonix_skills_dir.is_dir():
         return {
             "name": "reasonix_skills",
-            "label": "~/.reasonix/skills mirror",
+            "label": "~/.reasonix/skills discoverable",
             "passed": False,
             "detail": "Directory not found. Run install.sh to mirror toolkit skills for Reasonix.",
         }
 
-    repo_root = get_toolkit_repo_root()
-    if repo_root is None:
+    # The /do router is always installed; use it as the canary for discoverability.
+    do_skill = reasonix_skills_dir / "do" / "SKILL.md"
+    if do_skill.is_file():
         return {
             "name": "reasonix_skills",
-            "label": "~/.reasonix/skills mirror",
+            "label": "~/.reasonix/skills discoverable",
             "passed": True,
-            "detail": str(reasonix_skills_dir),
+            "detail": f"'do' skill resolves at {do_skill} (real file, one level deep)",
         }
 
-    # Count entries present (simplified check — Reasonix uses same flat structure)
-    entry_count = sum(1 for _ in reasonix_skills_dir.iterdir())
+    # Fallback: any flattened skill resolving one level deep also proves discoverability.
+    discoverable = sum(1 for entry in reasonix_skills_dir.iterdir() if (entry / "SKILL.md").is_file())
+    if discoverable > 0:
+        return {
+            "name": "reasonix_skills",
+            "label": "~/.reasonix/skills discoverable",
+            "passed": True,
+            "detail": f"{discoverable} skill(s) resolve one level deep (canary 'do' missing)",
+        }
+
     return {
         "name": "reasonix_skills",
-        "label": "~/.reasonix/skills mirror",
-        "passed": entry_count > 0,
-        "detail": f"{entry_count} entries present in Reasonix skills mirror",
+        "label": "~/.reasonix/skills discoverable",
+        "passed": False,
+        "detail": (
+            "No <name>/SKILL.md resolves one level deep — Reasonix sees zero skills. "
+            "Skills must be flattened+copied (not symlinked, not category-nested). Re-run install.sh."
+        ),
     }
 
 

--- a/scripts/tests/test_detect_workflow_capability.py
+++ b/scripts/tests/test_detect_workflow_capability.py
@@ -2,9 +2,10 @@
 """Tests for scripts/detect-workflow-capability.py — harness identity from env.
 
 Covers the env-matrix harness classifier (claude-code / codex / gemini /
-factory / unknown), the workflow_capable proxy (true only for claude-code),
-the never-raises / exit-0 contract, and the JSON output shape. The env signal
-is a PROXY: the orchestrator LLM adds the authoritative tool-list gate.
+factory / reasonix / unknown), the workflow_capable proxy (true only for
+claude-code), the never-raises / exit-0 contract, and the JSON output shape.
+The env signal is a PROXY: the orchestrator LLM adds the authoritative
+tool-list gate.
 """
 
 import json
@@ -43,6 +44,9 @@ _spec.loader.exec_module(dwc)
         # factory / droid
         ({"FACTORY_SESSION_ID": "f1"}, "factory"),
         ({"DROID_SESSION_ID": "d1"}, "factory"),
+        # reasonix: no env marker — keyed off the _ invocation var
+        ({"_": "/usr/local/bin/reasonix"}, "reasonix"),
+        ({"_": "/opt/node/bin/Reasonix"}, "reasonix"),
         # nothing distinctive
         ({}, "unknown"),
     ],
@@ -75,6 +79,7 @@ def test_claude_code_wins_over_other_markers():
         ("codex", False),
         ("gemini", False),
         ("factory", False),
+        ("reasonix", False),
         ("unknown", False),
     ],
 )

--- a/scripts/tests/test_detect_workflow_capability.py
+++ b/scripts/tests/test_detect_workflow_capability.py
@@ -44,9 +44,13 @@ _spec.loader.exec_module(dwc)
         # factory / droid
         ({"FACTORY_SESSION_ID": "f1"}, "factory"),
         ({"DROID_SESSION_ID": "d1"}, "factory"),
-        # reasonix: no env marker — keyed off the _ invocation var
+        # reasonix: no env marker — keyed off the _ invocation var (basename match)
         ({"_": "/usr/local/bin/reasonix"}, "reasonix"),
         ({"_": "/opt/node/bin/Reasonix"}, "reasonix"),
+        ({"_": "/usr/local/bin/reasonix-dev"}, "reasonix"),
+        # basename guard: "reasonix" in the parent path must NOT match
+        ({"_": "/Users/reasonix-fan/bin/python3"}, "unknown"),
+        ({"_": "/opt/reasonix-corp/python"}, "unknown"),
         # nothing distinctive
         ({}, "unknown"),
     ],
@@ -85,6 +89,22 @@ def test_claude_code_wins_over_other_markers():
 )
 def test_workflow_capable(harness, expected):
     assert dwc.workflow_capable(harness) is expected
+
+
+def test_workflow_capable_set_is_single_source_of_truth():
+    """Adding a harness to WORKFLOW_CAPABLE is the one-line migration when a
+    harness ships native Workflow upstream. Pin the set so future changes are
+    deliberate.
+    """
+    expected = frozenset({"claude-code"})
+    assert dwc.WORKFLOW_CAPABLE == expected  # noqa: SIM300 — left side is the unit-under-test
+    # Every member of WORKFLOW_CAPABLE must classify as workflow_capable=True.
+    for h in dwc.WORKFLOW_CAPABLE:
+        assert dwc.workflow_capable(h) is True
+    # Every harness NOT in the set must classify as False.
+    for h in dwc.HARNESSES:
+        if h not in dwc.WORKFLOW_CAPABLE:
+            assert dwc.workflow_capable(h) is False
 
 
 # --- never raises ------------------------------------------------------------

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -132,7 +132,7 @@ If ANY creation signal found AND complexity Simple+: set `is_creation = true`, P
 Generate the manifest, then dispatch the Haiku routing agent. Its decision is the primary route.
 
 ```bash
-SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"
+SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
 python3 "$SDIR/routing-manifest.py"
 ```
 
@@ -224,7 +224,7 @@ Route to the simplest agent+skill that satisfies the request. When `[cross-repo]
 Run the pre-router and use its result ONLY as a guardrail over the semantic pick:
 
 ```bash
-SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"
+SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
 python3 "$SDIR/pre-route.py" --request "{user_request}" --json-compact
 ```
 


### PR DESCRIPTION
## Summary

Builds on #707 by absorbing its commits and adding the review-driven fixes. Once this lands, #707 can be closed.

The original PR added Reasonix as a sixth supported harness. Review surfaced nine findings across the install path, harness detection, and docs. After adversarial validation, seven survived as fixes; two were downgraded.

## Findings addressed

| # | Area | Fix |
|---|------|-----|
| F1 | install ordering | private skills installed before public so the within-run collision guard yields the canonical name to the private override |
| F2 | install perms | reasonix `settings.json` + backup glob now `chmod 600`, matching ADR-122 (parity with codex/gemini/factory) |
| F3 | docs | `QUICKSTART.md` and `start-here.md` now state reasonix has no agent surface (skills + scripts + hooks only) |
| F4 | detect_workflow_capability | `WORKFLOW_CAPABLE` lifted to module-level `frozenset` so future workflow-capable harnesses are a one-line set edit |
| F5 | install safety | `reasonix_uninstall_entry` returns immediately on empty arg; defense-in-depth so a stray call cannot `rm -rf` the skills root |
| F6 | install comment | one-line note near the symlink-flatten fallback to retest on each reasonix bump and drop the copy once `src/skills.ts` traverses symlinked entries |
| F7 | uninstall summary | reasonix `config.json` now listed in the Preserved block (parity with codex/gemini config preservation) |
| C1 | harness detection | `detect_harness` and `detect_cli` match `"reasonix"` against `os.path.basename($_)` so `/Users/reasonix-fan/bin/python3` does not false-positive; wrapper scripts (reasonix-dev) still match |
| C2 | install-doctor | `check_reasonix_skills` verifies the `do` skill resolves as a real directory exactly one level deep (matching reasonix v0.53.2's scanner); counts only non-symlink real-dir entries |

## Tests

Two new pinning tests in `scripts/tests/test_detect_workflow_capability.py`:
- parametrize rows for `/Users/reasonix-fan/bin/python3` and `/opt/reasonix-corp/python` → `"unknown"` (pins C1 basename guard)
- `test_workflow_capable_set_is_single_source_of_truth` asserts `WORKFLOW_CAPABLE == frozenset({"claude-code"})` and that every `HARNESSES` member classifies consistently with the set (pins F4)

## Validation

- 65/65 pytest pass on `test_detect_workflow_capability.py`, `test_install_doctor.py`, `test_validate_workflow_conformance.py`
- `ruff check` clean, `ruff format --check` clean (419 files)
- `bash -n install.sh` valid
- `validate-workflow-conformance.py`: 6 contracted, 0 failed

Reasonix harness not installed in the test environment; runtime validation deferred to manual install + `install-doctor.py check` post-merge.

## Adversarial review notes

Findings C1 and F6 went through a refute-by-default skeptic pass. C1 was tightened to basename-only (rejected the marker-file proposal). F6 was minimized to a single comment line (rejected the README warning + TODO+issue-link).
