### PR TITLE
docs(pr-workflow): enforce dense PR-body vibe in canonical template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,4 @@
 
 ## Notes
 
-<!-- Optional, short. Anything a reviewer needs beyond the diff: context, rollback, follow-ups, "supersedes #N". Tests run in CI — the Checks tab is the test record, so paste no command output here. Omit this section when there's nothing to add. -->
+<!-- Optional, and usually omitted. Include only what a reviewer cannot infer from the diff or assume by default: a non-obvious decision, a deliberate omission, a follow-up, a gotcha. Skip what is always true (a PR can be reverted; CI runs the tests). When nothing qualifies, drop this section. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,23 @@
 ## Summary
 
-<!-- 1-3 sentences: WHAT changed and WHY. State the goal, not the diff. If this implements an ADR or closes an issue, name it. -->
+<!-- State the goal plainly in 1-3 sentences (or a few crisp bullets). Say WHAT changed and WHY, in plain words. Name the ADR or issue if one applies. Write for a reviewer scanning in ~15 seconds: one fact per line, declarative. Keep metrics to the single number that matters; let the diff carry the rest. -->
 
 ## Changes
 
-<!-- Bullet list of concrete changes, one per file or area: `path/or/area` — what changed. Keep each bullet to the actual edit, not intent. -->
+<!-- One line per change: verb + what + where, declaratively (`path/or/area` — what changed). Keep each line to a single fact a reviewer needs. When a change has many sub-items, state the SHAPE and count ("add 21 PR-creation trigger phrases") and let the diff list them. One line per change keeps rationale terse. -->
 - `path/to/file` — what changed
 
 ## Testing
 
-<!-- Show EVIDENCE, not "tests pass". Paste the command AND its result: ruff exit, pytest counts, gate traces, dogfood output. The reviewer must be able to see the proof, not take your word for it. -->
+<!-- Paste the SUMMARY of evidence: the command and its final result line (counts, exit code, the verdict). e.g. `pytest -q` → 55 passed; `ruff check` → All checks passed!. A few lines of proof read fast and prove the work. Let the command and its result line stand in for the full run. -->
 ```
 $ <command>
-<pasted output: counts / exit code / trace>
+<result line: counts / exit code / verdict>
 ```
 
 ## Scope & Risk
 
-<!-- Which limb/area this touches; what was deliberately NOT touched (name the files/limbs); how to roll back. -->
+<!-- One line each, terse: what this touches, what stays untouched (name the files/limbs), how to roll back. Each line states a fact a reviewer needs to gauge blast radius. Keep it to facts; skip defensive prose. -->
 - **Touches:** <limb / area>
 - **NOT touched:** <files/limbs deliberately left alone — e.g. router, Phase 2, execution-limb .js>
 - **Rollback:** <revert the commit; no data migration / state change> 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,35 +1,12 @@
 ## Summary
 
-<!-- State the goal plainly in 1-3 sentences (or a few crisp bullets). Say WHAT changed and WHY, in plain words. Name the ADR or issue if one applies. Write for a reviewer scanning in ~15 seconds: one fact per line, declarative. Keep metrics to the single number that matters; let the diff carry the rest. -->
+<!-- 1-3 sentences (or a few crisp bullets): what changed and why. Name the ADR or issue if one applies. Write so a reviewer grasps it in ~15 seconds. -->
 
 ## Changes
 
-<!-- One line per change: verb + what + where, declaratively (`path/or/area` — what changed). Keep each line to a single fact a reviewer needs. When a change has many sub-items, state the SHAPE and count ("add 21 PR-creation trigger phrases") and let the diff list them. One line per change keeps rationale terse. -->
+<!-- One line per change: `path/or/area` — what changed, declaratively (verb + what + where). State the fact and let the diff carry detail. For many sub-items, give the shape and count ("add 21 trigger phrases") instead of listing each. -->
 - `path/to/file` — what changed
 
-## Testing
+## Notes
 
-<!-- Paste the SUMMARY of evidence: the command and its final result line (counts, exit code, the verdict). e.g. `pytest -q` → 55 passed; `ruff check` → All checks passed!. A few lines of proof read fast and prove the work. Let the command and its result line stand in for the full run. -->
-```
-$ <command>
-<result line: counts / exit code / verdict>
-```
-
-## Scope & Risk
-
-<!-- One line each, terse: what this touches, what stays untouched (name the files/limbs), how to roll back. Each line states a fact a reviewer needs to gauge blast radius. Keep it to facts; skip defensive prose. -->
-- **Touches:** <limb / area>
-- **NOT touched:** <files/limbs deliberately left alone — e.g. router, Phase 2, execution-limb .js>
-- **Rollback:** <revert the commit; no data migration / state change> 
-
-## Checklist
-
-<!-- Check the gates that apply. These mirror this repo's CI (.github/workflows/test.yml). Omit a line only if it genuinely does not apply. -->
-- [ ] `ruff check . --config pyproject.toml` clean (excl `venv.312.bak`) — *if any `.py` touched*
-- [ ] `ruff format --check . --config pyproject.toml` clean (excl `venv.312.bak`) — *if any `.py` touched*
-- [ ] `python -m pytest --tb=short -q` green (paste counts above)
-- [ ] `python scripts/validate-doc-counts.py` → 0 drift
-- [ ] `python scripts/validate-workflow-conformance.py` passes — *if any workflow `.js` touched*
-- [ ] `python scripts/validate-skill-frontmatter.py` / `validate-references.py --check-do-framing` clean — *if any skill/agent touched*
-- [ ] joy-check / positive-instruction prose floors untouched — *if any prose floor touched*
-- [ ] No forbidden files staged (no `git add -A`; no `INDEX.json`, `venv.312.bak/`, chmod-only churn, or untracked junk)
+<!-- Optional, short. Anything a reviewer needs beyond the diff: context, rollback, follow-ups, "supersedes #N". Tests run in CI — the Checks tab is the test record, so paste no command output here. Omit this section when there's nothing to add. -->

--- a/skills/process/pr-workflow/SKILL.md
+++ b/skills/process/pr-workflow/SKILL.md
@@ -142,31 +142,28 @@ Detect the user's intent and load the appropriate reference file:
 
 `gh pr create --body "..."` is how every agent in this toolkit opens PRs, and it **bypasses `.github/pull_request_template.md` entirely** — GitHub only applies that file to the web UI and to a bare `gh pr create` with no `--body`. So the structure must be reproduced in the `--body` string by hand.
 
-Every agent-authored PR body MUST follow the same five sections as `.github/pull_request_template.md`, in this order: **Summary → Changes → Testing → Scope & Risk → Checklist**. This keeps PR bodies consistent across models (Opus, Sonnet, and every other harness produce the same shape).
+Every agent-authored PR body uses the same three sections as `.github/pull_request_template.md`, in this order: **Summary → Changes → Notes**. This keeps PR bodies consistent across models (Opus, Sonnet, and every other harness produce the same shape).
 
-The **Testing** section requires pasted command output (ruff exit, pytest counts, gate traces, dogfood output), never the bare claim "tests pass" — this ties to `verification-before-completion`: evidence, not assertion.
+Tests run as GitHub Actions, so the Checks tab is the test record. Let CI carry the proof: keep command output (ruff exit, pytest counts, gate traces, dogfood runs) out of the body. Pasting `$ pytest → N passed` duplicates the Checks tab and bloats the PR — leave it to CI.
 
 ### Write for Density
 
-Aim for high meaning per word: each line states one fact about the change, declaratively, so a reviewer understands it fast. Density is the target, not minimal length — a large change keeps all five sections and carries the detail it needs; it earns that length by packing each line with signal. Six rules carry the vibe:
+Aim for high meaning per word: each line states one fact about the change, declaratively, so a reviewer understands it fast. Density is the target, not minimal length — a large change keeps the three sections and carries the detail it needs; it earns that length by packing each line with signal. Four rules carry the vibe:
 
 1. **One fact per line.** Each Summary/Changes line reads verb + what + where. Plain words, high meaning.
 2. **Summary states the goal.** 1-3 plain sentences or a few crisp bullets. Keep metrics to the single number that matters.
 3. **One line per change.** When a change has many sub-items, state the shape and count ("add 21 PR-creation trigger phrases") and let the diff enumerate them. Keep rationale to the clause that earns its place.
-4. **Testing pastes the result line.** Show the command and its final verdict — counts, exit code, the summary line (`pytest -q` → 55 passed; `ruff check` → All checks passed!). A few lines of proof, summarized from the run.
-5. **Scope & Risk stays terse.** Touches / not-touched / rollback, one line each, facts only.
-6. **Every line earns its place.** Keep the lines a reviewer needs; let the diff carry the rest.
+4. **Notes stays short and optional.** Context, rollback, follow-ups, "supersedes #N" — one terse line each. Omit the section when there's nothing to add.
 
-**Worked example — the shape to emulate:**
+**Worked example — the shape to emulate (#608-good vs #710-bad):**
 
-| Section | Dense (emulate) | Bloated (rewrite toward dense) |
+| Section | Dense (emulate, like #608) | Bloated (rewrite toward dense, the #710 shape) |
 |---------|-----------------|--------------------------------|
 | Summary | "Registers 3 hooks in settings.json; integrates `pre-route.py` into /do Phase 2 as a deterministic pre-filter." | One 5-sentence block stuffed with jargon and four metrics. |
 | Changes | "`SKILL.md` — add 21 PR-creation trigger phrases." | One bullet inlining all 21 phrases verbatim; another a 3-sentence rationale paragraph. |
-| Testing | "`pytest -q` → 55 passed; `ruff check` → All checks passed!" | 25 lines of `pytest -v` per-test output. |
-| Scope & Risk | "Touches: routing layer. NOT touched: scoring logic. Rollback: revert the commit." | Five defensive paragraphs. |
+| Notes | "Supersedes #705. Roll back by reverting the branch commits." | A pasted `pytest -v` dump plus a Scope & Risk wall and a CI-mirroring checklist. |
 
-The dense column reads in seconds because each cell carries facts; the bloated column buries the same facts in volume. Aim every body at the dense column.
+The dense column reads in seconds because each cell carries facts; the bloated column buries the same facts in volume (and re-states what the Checks tab already shows). Aim every body at the dense column.
 
 Copy this canonical skeleton into `--body`:
 
@@ -178,24 +175,8 @@ Copy this canonical skeleton into `--body`:
 <!-- One line per change: verb + what + where. State shape and count for many sub-items; let the diff enumerate them. -->
 - `path/to/file` — what changed
 
-## Testing
-<!-- Paste the command and its result line. Evidence, summarized: counts, exit code, verdict. -->
-\`\`\`
-$ <command>
-<result line: counts / exit code / verdict>
-\`\`\`
-
-## Scope & Risk
-- **Touches:** <limb / area>
-- **NOT touched:** <files/limbs deliberately left alone>
-- **Rollback:** <revert the commit; any state notes>
-
-## Checklist
-- [ ] ruff check + format clean (excl `venv.312.bak`) — if any `.py` touched
-- [ ] pytest green (counts pasted above)
-- [ ] `validate-doc-counts.py` → 0 drift
-- [ ] conformance gate passes — if any workflow `.js` touched
-- [ ] No forbidden files staged
+## Notes
+<!-- Optional, short. Context, rollback, follow-ups, "supersedes #N". Tests run in CI — the Checks tab is the test record, so paste no command output here. Omit when there's nothing to add. -->
 ```
 
 The sync (`sync.md` Step 5) and pipeline (`pipeline.md` Phase 5) references carry this same skeleton at their `gh pr create` call sites. When either path writes a `--body`, it uses this structure and the density rules above.
@@ -205,4 +186,4 @@ The sync (`sync.md` Step 5) and pipeline (`pipeline.md` Phase 5) references carr
 1. Identify the user's PR task from their message
 2. Load the matching reference file from the table above
 3. Follow the instructions in that reference file exactly
-4. When the task creates a PR, build the `--body` from the canonical five-section skeleton above (Summary / Changes / Testing / Scope & Risk / Checklist), because `--body` bypasses the GitHub template file
+4. When the task creates a PR, build the `--body` from the canonical three-section skeleton above (Summary / Changes / Notes), because `--body` bypasses the GitHub template file. Tests run in CI — the Checks tab is the test record, so keep command output out of the body

--- a/skills/process/pr-workflow/SKILL.md
+++ b/skills/process/pr-workflow/SKILL.md
@@ -146,20 +146,43 @@ Every agent-authored PR body MUST follow the same five sections as `.github/pull
 
 The **Testing** section requires pasted command output (ruff exit, pytest counts, gate traces, dogfood output), never the bare claim "tests pass" — this ties to `verification-before-completion`: evidence, not assertion.
 
+### Write for Density
+
+Aim for high meaning per word: each line states one fact about the change, declaratively, so a reviewer understands it fast. Density is the target, not minimal length — a large change keeps all five sections and carries the detail it needs; it earns that length by packing each line with signal. Six rules carry the vibe:
+
+1. **One fact per line.** Each Summary/Changes line reads verb + what + where. Plain words, high meaning.
+2. **Summary states the goal.** 1-3 plain sentences or a few crisp bullets. Keep metrics to the single number that matters.
+3. **One line per change.** When a change has many sub-items, state the shape and count ("add 21 PR-creation trigger phrases") and let the diff enumerate them. Keep rationale to the clause that earns its place.
+4. **Testing pastes the result line.** Show the command and its final verdict — counts, exit code, the summary line (`pytest -q` → 55 passed; `ruff check` → All checks passed!). A few lines of proof, summarized from the run.
+5. **Scope & Risk stays terse.** Touches / not-touched / rollback, one line each, facts only.
+6. **Every line earns its place.** Keep the lines a reviewer needs; let the diff carry the rest.
+
+**Worked example — the shape to emulate:**
+
+| Section | Dense (emulate) | Bloated (rewrite toward dense) |
+|---------|-----------------|--------------------------------|
+| Summary | "Registers 3 hooks in settings.json; integrates `pre-route.py` into /do Phase 2 as a deterministic pre-filter." | One 5-sentence block stuffed with jargon and four metrics. |
+| Changes | "`SKILL.md` — add 21 PR-creation trigger phrases." | One bullet inlining all 21 phrases verbatim; another a 3-sentence rationale paragraph. |
+| Testing | "`pytest -q` → 55 passed; `ruff check` → All checks passed!" | 25 lines of `pytest -v` per-test output. |
+| Scope & Risk | "Touches: routing layer. NOT touched: scoring logic. Rollback: revert the commit." | Five defensive paragraphs. |
+
+The dense column reads in seconds because each cell carries facts; the bloated column buries the same facts in volume. Aim every body at the dense column.
+
 Copy this canonical skeleton into `--body`:
 
 ```markdown
 ## Summary
-<!-- 1-3 sentences: what changed and why. Name the ADR/issue if any. -->
+<!-- State the goal plainly: 1-3 sentences or a few crisp bullets, one fact per line. Name the ADR/issue if any. Keep metrics to the single number that matters. -->
 
 ## Changes
+<!-- One line per change: verb + what + where. State shape and count for many sub-items; let the diff enumerate them. -->
 - `path/to/file` — what changed
 
 ## Testing
-<!-- Paste command + result. Evidence, not "tests pass". -->
+<!-- Paste the command and its result line. Evidence, summarized: counts, exit code, verdict. -->
 \`\`\`
 $ <command>
-<pasted output: counts / exit code / trace>
+<result line: counts / exit code / verdict>
 \`\`\`
 
 ## Scope & Risk
@@ -175,7 +198,7 @@ $ <command>
 - [ ] No forbidden files staged
 ```
 
-The sync (`sync.md` Step 5) and pipeline (`pipeline.md` Phase 5) references carry this same skeleton at their `gh pr create` call sites. When either path writes a `--body`, it uses this structure.
+The sync (`sync.md` Step 5) and pipeline (`pipeline.md` Phase 5) references carry this same skeleton at their `gh pr create` call sites. When either path writes a `--body`, it uses this structure and the density rules above.
 
 ## Instructions
 

--- a/skills/process/pr-workflow/SKILL.md
+++ b/skills/process/pr-workflow/SKILL.md
@@ -153,7 +153,7 @@ Aim for high meaning per word: each line states one fact about the change, decla
 1. **One fact per line.** Each Summary/Changes line reads verb + what + where. Plain words, high meaning.
 2. **Summary states the goal.** 1-3 plain sentences or a few crisp bullets. Keep metrics to the single number that matters.
 3. **One line per change.** When a change has many sub-items, state the shape and count ("add 21 PR-creation trigger phrases") and let the diff enumerate them. Keep rationale to the clause that earns its place.
-4. **Notes stays short and optional.** Context, rollback, follow-ups, "supersedes #N" — one terse line each. Omit the section when there's nothing to add.
+4. **Notes carries non-obvious signal only.** Usually omitted. Include only what a reviewer cannot infer from the diff or assume by default: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, a "supersedes #N" — one terse line each. Skip what is always true (a PR can be reverted; CI runs the tests). Drop the section when nothing qualifies.
 
 **Worked example — the shape to emulate (#608-good vs #710-bad):**
 
@@ -161,7 +161,7 @@ Aim for high meaning per word: each line states one fact about the change, decla
 |---------|-----------------|--------------------------------|
 | Summary | "Registers 3 hooks in settings.json; integrates `pre-route.py` into /do Phase 2 as a deterministic pre-filter." | One 5-sentence block stuffed with jargon and four metrics. |
 | Changes | "`SKILL.md` — add 21 PR-creation trigger phrases." | One bullet inlining all 21 phrases verbatim; another a 3-sentence rationale paragraph. |
-| Notes | "Supersedes #705. Roll back by reverting the branch commits." | A pasted `pytest -v` dump plus a Scope & Risk wall and a CI-mirroring checklist. |
+| Notes | "Supersedes #705." (non-obvious signal) — or omitted entirely when nothing qualifies | "Roll back by reverting the branch commits. Tests run in CI — see Checks." (always-true filler) plus a pasted `pytest -v` dump and a Scope & Risk wall. |
 
 The dense column reads in seconds because each cell carries facts; the bloated column buries the same facts in volume (and re-states what the Checks tab already shows). Aim every body at the dense column.
 
@@ -176,7 +176,7 @@ Copy this canonical skeleton into `--body`:
 - `path/to/file` — what changed
 
 ## Notes
-<!-- Optional, short. Context, rollback, follow-ups, "supersedes #N". Tests run in CI — the Checks tab is the test record, so paste no command output here. Omit when there's nothing to add. -->
+<!-- Optional, and usually omitted. Include only what a reviewer cannot infer from the diff or assume by default: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, a "supersedes #N". Skip what is always true (a PR can be reverted; CI runs the tests). When nothing qualifies, drop this section. -->
 ```
 
 The sync (`sync.md` Step 5) and pipeline (`pipeline.md` Phase 5) references carry this same skeleton at their `gh pr create` call sites. When either path writes a `--body`, it uses this structure and the density rules above.

--- a/skills/process/pr-workflow/references/pipeline.md
+++ b/skills/process/pr-workflow/references/pipeline.md
@@ -244,7 +244,7 @@ Analyze the full diff against the base branch and all commit messages to draft:
 
 **Step 1.5: Artifact-Driven PR Body Generation**
 
-When planning artifacts exist (`task_plan.md`, verification reports, review summaries, deviation logs), generate the PR body from them rather than writing freeform. Artifacts capture *intent*, which is more valuable to reviewers than a mechanical diff summary. Fall back to diff-based generation when no artifacts exist.
+When planning artifacts exist (`task_plan.md`, verification reports, review summaries, deviation logs), generate the PR body from them rather than writing freeform. Artifacts capture *intent*, which is more valuable to reviewers than a mechanical diff summary. Summarize each artifact into dense lines — pull the goal, the completed-task shapes, and the result/exit lines, so each PR line carries one fact. Fall back to diff-based generation when no artifacts exist.
 
 See `references/pr-templates.md` for the full artifact table, PR body template, and fallback guidance.
 
@@ -252,20 +252,22 @@ See `references/pr-templates.md` for the full artifact table, PR body template, 
 
 This pipeline cannot create PRs without staged changes -- if nothing is staged, the earlier phases would have caught this.
 
-**PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's five sections in the `--body` string, in order: **Summary → Changes → Testing → Scope & Risk → Checklist**. This keeps PR bodies consistent across models. The **Testing** section requires pasted command output (ruff exit, pytest counts, gate traces, reviewer verdicts) — evidence, not the bare claim "tests pass" — which ties to `verification-before-completion`.
+**PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's five sections in the `--body` string, in order: **Summary → Changes → Testing → Scope & Risk → Checklist**. This keeps PR bodies consistent across models.
+
+**Write for density.** Each line states one fact about the change, declaratively (verb + what + where), so a reviewer scans the body fast. State the goal plainly in Summary; write one line per change in Changes (give shape and count for many sub-items, e.g. "add 21 trigger phrases", and let the diff enumerate them); keep Scope & Risk to one terse line each. The **Testing** section pastes the command and its result line plus reviewer verdicts — evidence summarized from the run, which ties to `verification-before-completion`. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
 
 ```bash
 CLAUDE_GATE_BYPASS=1 gh pr create --title "type(scope): description" --body "$(cat <<'EOF'
 ## Summary
-[1-3 sentences: what changed and why. Name the ADR/issue if any.]
+[State the goal plainly: 1-3 sentences or a few crisp bullets, one fact per line. Name the ADR/issue if any.]
 
 ## Changes
-- `path/to/file` — what changed
+- `path/to/file` — what changed [one line per change; give shape + count for many sub-items]
 
 ## Testing
-[Paste command + result. Evidence, not "tests pass". Include Phase 2/4b reviewer verdicts. Wrap output in a fenced block.]
+[Paste the command and its result line. Evidence summarized: counts, exit code, verdict. Include Phase 2/4b reviewer verdicts. Wrap in a fenced block.]
 $ <command>
-<pasted output: counts / exit code / trace>
+<result line: counts / exit code / verdict>
 Security: PASS  Business Logic: PASS  Code Quality: PASS
 
 ## Scope & Risk
@@ -662,16 +664,16 @@ Full details for Phase 5 (CREATE PR) of the PR Pipeline: artifact-driven body ge
 
 ## Artifact-Driven PR Body Generation
 
-When planning artifacts exist, generate the PR body from them rather than writing freeform. Artifacts capture *intent* (why the change was made), which is more valuable to reviewers than a mechanical diff summary.
+When planning artifacts exist, generate the PR body from them rather than writing freeform. Artifacts capture *intent* (why the change was made), which is more valuable to reviewers than a mechanical diff summary. Summarize each artifact into dense lines — one fact per line — so a reviewer scans the body fast. Pull the goal, the completed-task shapes, and the result/exit lines; let the diff and the linked reports carry the rest.
 
 Check for artifacts in this order and build the PR body from what's available:
 
 | Artifact | PR Section Generated | How to Extract |
 |----------|---------------------|----------------|
-| `task_plan.md` | **Summary** (from Goal section) and **Changes** (from completed tasks) | Read the Goal and Phases sections; list completed items as change bullets |
-| Verification reports (`*-verification.md`, test output) | **Testing** (paste pass/fail counts) | Extract pass/fail counts and key assertions verified |
-| Review summaries (Phase 2 / Phase 4b output) | **Testing** (reviewer verdicts) | Summarize security/logic/quality verdicts |
-| Deviation logs (ADR-076 repair actions) | **Scope & Risk** (deviations) | List repair actions taken and why the original plan changed |
+| `task_plan.md` | **Summary** (from Goal section) and **Changes** (from completed tasks) | Read the Goal and Phases sections; state the goal plainly; write one line per completed item (shape + count for many sub-items) |
+| Verification reports (`*-verification.md`, test output) | **Testing** (result line) | Extract the final result line: pass/fail counts and exit code. Summarize; the result line stands in for the full run |
+| Review summaries (Phase 2 / Phase 4b output) | **Testing** (reviewer verdicts) | Summarize security/logic/quality verdicts to one line |
+| Deviation logs (ADR-076 repair actions) | **Scope & Risk** (deviations) | List repair actions taken and why the original plan changed, one terse line each |
 
 **Fallback**: If no artifacts exist, fall back to diff-based generation -- summarize changes from the diff and commit messages. This is the existing behavior and remains the default for ad-hoc PRs without planning artifacts.
 
@@ -681,19 +683,19 @@ Follows the canonical five-section structure from `.github/pull_request_template
 
 ```markdown
 ## Summary
-<!-- From task_plan.md Goal section, or from commit messages if no plan -->
-[Goal statement: what changed and why, 1-3 sentences. Name the ADR/issue if any.]
+<!-- From task_plan.md Goal section, or from commit messages if no plan. State the goal plainly: 1-3 sentences, one fact per line. Name the ADR/issue if any. -->
+[Goal statement: what changed and why, plainly, in 1-3 sentences.]
 
 ## Changes
-<!-- From task_plan.md completed phases/tasks -->
+<!-- From task_plan.md completed phases/tasks. One line per change: verb + what + where. Give shape + count for many sub-items. -->
 - `path/to/file` — [completed task description]
 - `path/to/file` — [completed task description]
 
 ## Testing
-<!-- From verification reports + Phase 2/4b review output. Paste evidence, not "tests pass". -->
+<!-- From verification reports + Phase 2/4b review output. Paste the command and its result line: counts, exit code, verdict. Summarized evidence, one-to-few lines. -->
 \`\`\`
 $ <command>
-<pasted output: counts / exit code / trace>
+<result line: counts / exit code / verdict>
 Security: PASS  Business Logic: PASS  Code Quality: PASS
 \`\`\`
 

--- a/skills/process/pr-workflow/references/pipeline.md
+++ b/skills/process/pr-workflow/references/pipeline.md
@@ -254,7 +254,7 @@ This pipeline cannot create PRs without staged changes -- if nothing is staged, 
 
 **PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's three sections in the `--body` string, in order: **Summary → Changes → Notes**. This keeps PR bodies consistent across models.
 
-**Write for density.** Each line states one fact about the change, declaratively (verb + what + where), so a reviewer scans the body fast. State the goal plainly in Summary; write one line per change in Changes (give shape and count for many sub-items, e.g. "add 21 trigger phrases", and let the diff enumerate them); keep Notes short and optional — context, rollback, follow-ups, "supersedes #N". Tests run as GitHub Actions and the Checks tab is the test record; reviewer verdicts likewise show on the PR, so leave command output to CI and keep it out of the body. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
+**Write for density.** Each line states one fact about the change, declaratively (verb + what + where), so a reviewer scans the body fast. State the goal plainly in Summary; write one line per change in Changes (give shape and count for many sub-items, e.g. "add 21 trigger phrases", and let the diff enumerate them); keep Notes for non-obvious signal only — include just what a reviewer cannot infer from the diff or assume by default (a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N"), skip what is always true (a PR can be reverted; CI runs the tests), and drop the section when nothing qualifies. Tests run as GitHub Actions and the Checks tab is the test record; reviewer verdicts likewise show on the PR, so leave command output to CI and keep it out of the body. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
 
 ```bash
 CLAUDE_GATE_BYPASS=1 gh pr create --title "type(scope): description" --body "$(cat <<'EOF'
@@ -265,7 +265,7 @@ CLAUDE_GATE_BYPASS=1 gh pr create --title "type(scope): description" --body "$(c
 - `path/to/file` — what changed [one line per change; give shape + count for many sub-items]
 
 ## Notes
-[Optional, short. Context, rollback, follow-ups, "supersedes #N". Tests run in CI — the Checks tab is the test record, so paste no command output here. Omit when there's nothing to add.]
+[Optional, and usually omitted. Include only what a reviewer cannot infer from the diff or assume by default: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N". Skip what is always true (a PR can be reverted; CI runs the tests). When nothing qualifies, drop this section.]
 EOF
 )"
 ```
@@ -656,8 +656,8 @@ Check for artifacts in this order and build the PR body from what's available:
 | Artifact | PR Section Generated | How to Extract |
 |----------|---------------------|----------------|
 | `task_plan.md` | **Summary** (from Goal section) and **Changes** (from completed tasks) | Read the Goal and Phases sections; state the goal plainly; write one line per completed item (shape + count for many sub-items) |
-| Deviation logs (ADR-076 repair actions) | **Notes** (deviations) | List repair actions taken and why the original plan changed, one terse line each |
-| Context for reviewers (rollback, follow-ups, supersedes) | **Notes** (optional) | One terse line each; omit Notes when there's nothing to add. Verification reports and review summaries stay in CI — the Checks tab carries the result |
+| Deviation logs (ADR-076 repair actions) | **Notes** (deviations) | List repair actions taken and why the original plan changed, one terse line each — these are non-obvious by nature |
+| Context a reviewer cannot infer (non-obvious decision, deliberate omission, follow-up, gotcha, supersedes) | **Notes** (optional) | One terse line each. Populate Notes only when an artifact surfaces something non-obvious; skip what is always true (a PR can be reverted; CI runs the tests) and drop the section when nothing qualifies. Verification reports and review summaries stay in CI — the Checks tab carries the result |
 
 **Fallback**: If no artifacts exist, fall back to diff-based generation -- summarize changes from the diff and commit messages. This is the existing behavior and remains the default for ad-hoc PRs without planning artifacts.
 
@@ -676,8 +676,8 @@ Follows the canonical three-section structure from `.github/pull_request_templat
 - `path/to/file` — [completed task description]
 
 ## Notes
-<!-- Optional, short. Context, rollback, follow-ups, "supersedes #N", deviations from deviation logs (ADR-076). Tests run in CI — the Checks tab is the test record, so paste no command output here. Omit when there's nothing to add. -->
-[Optional context a reviewer needs beyond the diff.]
+<!-- Optional, and usually omitted. Populate only when an artifact surfaces something a reviewer cannot infer from the diff or assume by default: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N", a deviation log (ADR-076). Skip what is always true (a PR can be reverted; CI runs the tests). When nothing qualifies, drop this section. -->
+[Optional context a reviewer cannot infer from the diff.]
 ```
 
 ---

--- a/skills/process/pr-workflow/references/pipeline.md
+++ b/skills/process/pr-workflow/references/pipeline.md
@@ -244,7 +244,7 @@ Analyze the full diff against the base branch and all commit messages to draft:
 
 **Step 1.5: Artifact-Driven PR Body Generation**
 
-When planning artifacts exist (`task_plan.md`, verification reports, review summaries, deviation logs), generate the PR body from them rather than writing freeform. Artifacts capture *intent*, which is more valuable to reviewers than a mechanical diff summary. Summarize each artifact into dense lines — pull the goal, the completed-task shapes, and the result/exit lines, so each PR line carries one fact. Fall back to diff-based generation when no artifacts exist.
+When planning artifacts exist (`task_plan.md`, review summaries, deviation logs), generate the PR body from them rather than writing freeform. Artifacts capture *intent*, which is more valuable to reviewers than a mechanical diff summary. Feed them into the three sections: the goal into Summary, the completed-task shapes into Changes, and context/rollback/deviations into Notes, so each line carries one fact. Tests run as GitHub Actions — the Checks tab is the test record, so leave verification output to CI rather than pasting it. Fall back to diff-based generation when no artifacts exist.
 
 See `references/pr-templates.md` for the full artifact table, PR body template, and fallback guidance.
 
@@ -252,9 +252,9 @@ See `references/pr-templates.md` for the full artifact table, PR body template, 
 
 This pipeline cannot create PRs without staged changes -- if nothing is staged, the earlier phases would have caught this.
 
-**PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's five sections in the `--body` string, in order: **Summary → Changes → Testing → Scope & Risk → Checklist**. This keeps PR bodies consistent across models.
+**PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's three sections in the `--body` string, in order: **Summary → Changes → Notes**. This keeps PR bodies consistent across models.
 
-**Write for density.** Each line states one fact about the change, declaratively (verb + what + where), so a reviewer scans the body fast. State the goal plainly in Summary; write one line per change in Changes (give shape and count for many sub-items, e.g. "add 21 trigger phrases", and let the diff enumerate them); keep Scope & Risk to one terse line each. The **Testing** section pastes the command and its result line plus reviewer verdicts — evidence summarized from the run, which ties to `verification-before-completion`. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
+**Write for density.** Each line states one fact about the change, declaratively (verb + what + where), so a reviewer scans the body fast. State the goal plainly in Summary; write one line per change in Changes (give shape and count for many sub-items, e.g. "add 21 trigger phrases", and let the diff enumerate them); keep Notes short and optional — context, rollback, follow-ups, "supersedes #N". Tests run as GitHub Actions and the Checks tab is the test record; reviewer verdicts likewise show on the PR, so leave command output to CI and keep it out of the body. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
 
 ```bash
 CLAUDE_GATE_BYPASS=1 gh pr create --title "type(scope): description" --body "$(cat <<'EOF'
@@ -264,23 +264,8 @@ CLAUDE_GATE_BYPASS=1 gh pr create --title "type(scope): description" --body "$(c
 ## Changes
 - `path/to/file` — what changed [one line per change; give shape + count for many sub-items]
 
-## Testing
-[Paste the command and its result line. Evidence summarized: counts, exit code, verdict. Include Phase 2/4b reviewer verdicts. Wrap in a fenced block.]
-$ <command>
-<result line: counts / exit code / verdict>
-Security: PASS  Business Logic: PASS  Code Quality: PASS
-
-## Scope & Risk
-- **Touches:** <limb / area>
-- **NOT touched:** <files/limbs deliberately left alone>
-- **Rollback:** <revert the commit; any state notes>
-
-## Checklist
-- [ ] ruff check + format clean (excl `venv.312.bak`) — if any `.py` touched
-- [ ] pytest green (counts pasted above)
-- [ ] `validate-doc-counts.py` → 0 drift
-- [ ] conformance gate passes — if any workflow `.js` touched
-- [ ] No forbidden files staged
+## Notes
+[Optional, short. Context, rollback, follow-ups, "supersedes #N". Tests run in CI — the Checks tab is the test record, so paste no command output here. Omit when there's nothing to add.]
 EOF
 )"
 ```
@@ -664,22 +649,21 @@ Full details for Phase 5 (CREATE PR) of the PR Pipeline: artifact-driven body ge
 
 ## Artifact-Driven PR Body Generation
 
-When planning artifacts exist, generate the PR body from them rather than writing freeform. Artifacts capture *intent* (why the change was made), which is more valuable to reviewers than a mechanical diff summary. Summarize each artifact into dense lines — one fact per line — so a reviewer scans the body fast. Pull the goal, the completed-task shapes, and the result/exit lines; let the diff and the linked reports carry the rest.
+When planning artifacts exist, generate the PR body from them rather than writing freeform. Artifacts capture *intent* (why the change was made), which is more valuable to reviewers than a mechanical diff summary. Summarize each artifact into dense lines — one fact per line — so a reviewer scans the body fast. Pull the goal, the completed-task shapes, and any context a reviewer needs beyond the diff; let the diff and the linked reports carry the rest. Tests are covered by CI — the Checks tab is the test record, so leave command output to CI rather than pasting it.
 
 Check for artifacts in this order and build the PR body from what's available:
 
 | Artifact | PR Section Generated | How to Extract |
 |----------|---------------------|----------------|
 | `task_plan.md` | **Summary** (from Goal section) and **Changes** (from completed tasks) | Read the Goal and Phases sections; state the goal plainly; write one line per completed item (shape + count for many sub-items) |
-| Verification reports (`*-verification.md`, test output) | **Testing** (result line) | Extract the final result line: pass/fail counts and exit code. Summarize; the result line stands in for the full run |
-| Review summaries (Phase 2 / Phase 4b output) | **Testing** (reviewer verdicts) | Summarize security/logic/quality verdicts to one line |
-| Deviation logs (ADR-076 repair actions) | **Scope & Risk** (deviations) | List repair actions taken and why the original plan changed, one terse line each |
+| Deviation logs (ADR-076 repair actions) | **Notes** (deviations) | List repair actions taken and why the original plan changed, one terse line each |
+| Context for reviewers (rollback, follow-ups, supersedes) | **Notes** (optional) | One terse line each; omit Notes when there's nothing to add. Verification reports and review summaries stay in CI — the Checks tab carries the result |
 
 **Fallback**: If no artifacts exist, fall back to diff-based generation -- summarize changes from the diff and commit messages. This is the existing behavior and remains the default for ad-hoc PRs without planning artifacts.
 
 ## PR Body Template (Artifact-Driven)
 
-Follows the canonical five-section structure from `.github/pull_request_template.md` (Summary / Changes / Testing / Scope & Risk / Checklist), with each section populated from artifacts. Reviewer verdicts and deviation logs fold into **Testing** and **Scope & Risk**.
+Follows the canonical three-section structure from `.github/pull_request_template.md` (Summary / Changes / Notes), with each section populated from artifacts. Deviation logs and reviewer context fold into **Notes**.
 
 ```markdown
 ## Summary
@@ -691,26 +675,9 @@ Follows the canonical five-section structure from `.github/pull_request_template
 - `path/to/file` — [completed task description]
 - `path/to/file` — [completed task description]
 
-## Testing
-<!-- From verification reports + Phase 2/4b review output. Paste the command and its result line: counts, exit code, verdict. Summarized evidence, one-to-few lines. -->
-\`\`\`
-$ <command>
-<result line: counts / exit code / verdict>
-Security: PASS  Business Logic: PASS  Code Quality: PASS
-\`\`\`
-
-## Scope & Risk
-- **Touches:** [limb / area from task_plan]
-- **NOT touched:** [files/limbs deliberately left alone]
-- **Rollback:** [revert the commit; any state notes]
-- **Deviations:** [from deviation logs (ADR-076); omit if none]
-
-## Checklist
-- [ ] ruff check + format clean (excl `venv.312.bak`) — if any `.py` touched
-- [ ] pytest green (counts pasted above)
-- [ ] `validate-doc-counts.py` → 0 drift
-- [ ] conformance gate passes — if any workflow `.js` touched
-- [ ] No forbidden files staged
+## Notes
+<!-- Optional, short. Context, rollback, follow-ups, "supersedes #N", deviations from deviation logs (ADR-076). Tests run in CI — the Checks tab is the test record, so paste no command output here. Omit when there's nothing to add. -->
+[Optional context a reviewer needs beyond the diff.]
 ```
 
 ---

--- a/skills/process/pr-workflow/references/sync.md
+++ b/skills/process/pr-workflow/references/sync.md
@@ -142,7 +142,7 @@ Generate the PR title from the branch name or first commit when not provided by 
 
 **PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's three sections in the `--body` string, in order: **Summary → Changes → Notes**. This keeps PR bodies consistent across models.
 
-**Write for density.** Each line states one fact about the change, declaratively (verb + what + where), so a reviewer scans the body fast. State the goal plainly in Summary; write one line per change in Changes (give shape and count for many sub-items, like "add 21 trigger phrases", and let the diff enumerate them); keep Notes short and optional — context, rollback, follow-ups, "supersedes #N". Tests run as GitHub Actions, so the Checks tab is the test record; leave command output to CI and keep it out of the body. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
+**Write for density.** Each line states one fact about the change, declaratively (verb + what + where), so a reviewer scans the body fast. State the goal plainly in Summary; write one line per change in Changes (give shape and count for many sub-items, like "add 21 trigger phrases", and let the diff enumerate them); keep Notes for non-obvious signal only — include just what a reviewer cannot infer from the diff or assume by default (a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N"), skip what is always true (a PR can be reverted; CI runs the tests), and drop the section when nothing qualifies. Tests run as GitHub Actions, so the Checks tab is the test record; leave command output to CI and keep it out of the body. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
 
 ```bash
 # Check if PR already exists for this branch
@@ -158,7 +158,7 @@ if [[ -z "$EXISTING_PR" ]]; then
 - `path/to/file` — what changed [one line per change; give shape + count for many sub-items, e.g. "add 21 trigger phrases"]
 
 ## Notes
-[Optional, short. Context, rollback, follow-ups, "supersedes #N". Tests run in CI — the Checks tab is the test record, so paste no command output here. Omit when there's nothing to add.]
+[Optional, and usually omitted. Include only what a reviewer cannot infer from the diff or assume by default: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N". Skip what is always true (a PR can be reverted; CI runs the tests). When nothing qualifies, drop this section.]
 EOF
 )"
 else

--- a/skills/process/pr-workflow/references/sync.md
+++ b/skills/process/pr-workflow/references/sync.md
@@ -140,7 +140,9 @@ After 3 iterations, proceed to Step 5 with any remaining issues documented in th
 
 Generate the PR title from the branch name or first commit when not provided by the user. Never create a PR with an empty description, because reviewers need context to understand the changes and a missing test plan signals incomplete work.
 
-**PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's five sections in the `--body` string, in order: **Summary → Changes → Testing → Scope & Risk → Checklist**. This keeps PR bodies consistent across models. The **Testing** section requires pasted command output (ruff exit, pytest counts, gate traces) — evidence, not the bare claim "tests pass" — which ties to `verification-before-completion`.
+**PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's five sections in the `--body` string, in order: **Summary → Changes → Testing → Scope & Risk → Checklist**. This keeps PR bodies consistent across models.
+
+**Write for density.** Each line states one fact about the change, declaratively (verb + what + where), so a reviewer scans the body fast. State the goal plainly in Summary; write one line per change in Changes (give shape and count for many sub-items, like "add 21 trigger phrases", and let the diff enumerate them); keep Scope & Risk to one terse line each. The **Testing** section pastes the command and its result line (counts, exit code, verdict) — evidence summarized from the run, which ties to `verification-before-completion`. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
 
 ```bash
 # Check if PR already exists for this branch
@@ -150,15 +152,15 @@ if [[ -z "$EXISTING_PR" ]]; then
     # Create new PR — --body follows .github/pull_request_template.md's section structure
     CLAUDE_GATE_BYPASS=1 gh pr create --title "$PR_TITLE" --body "$(cat <<'EOF'
 ## Summary
-[1-3 sentences: what changed and why. Name the ADR/issue if any.]
+[State the goal plainly: 1-3 sentences or a few crisp bullets, one fact per line. Name the ADR/issue if any.]
 
 ## Changes
-- `path/to/file` — what changed
+- `path/to/file` — what changed [one line per change; give shape + count for many sub-items, e.g. "add 21 trigger phrases"]
 
 ## Testing
-[Paste command + result. Evidence, not "tests pass". Wrap output in a fenced block.]
+[Paste the command and its result line. Evidence summarized: counts, exit code, verdict. Wrap in a fenced block.]
 $ <command>
-<pasted output: counts / exit code / trace>
+<result line: counts / exit code / verdict>
 
 ## Scope & Risk
 - **Touches:** <limb / area>

--- a/skills/process/pr-workflow/references/sync.md
+++ b/skills/process/pr-workflow/references/sync.md
@@ -140,9 +140,9 @@ After 3 iterations, proceed to Step 5 with any remaining issues documented in th
 
 Generate the PR title from the branch name or first commit when not provided by the user. Never create a PR with an empty description, because reviewers need context to understand the changes and a missing test plan signals incomplete work.
 
-**PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's five sections in the `--body` string, in order: **Summary → Changes → Testing → Scope & Risk → Checklist**. This keeps PR bodies consistent across models.
+**PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's three sections in the `--body` string, in order: **Summary → Changes → Notes**. This keeps PR bodies consistent across models.
 
-**Write for density.** Each line states one fact about the change, declaratively (verb + what + where), so a reviewer scans the body fast. State the goal plainly in Summary; write one line per change in Changes (give shape and count for many sub-items, like "add 21 trigger phrases", and let the diff enumerate them); keep Scope & Risk to one terse line each. The **Testing** section pastes the command and its result line (counts, exit code, verdict) — evidence summarized from the run, which ties to `verification-before-completion`. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
+**Write for density.** Each line states one fact about the change, declaratively (verb + what + where), so a reviewer scans the body fast. State the goal plainly in Summary; write one line per change in Changes (give shape and count for many sub-items, like "add 21 trigger phrases", and let the diff enumerate them); keep Notes short and optional — context, rollback, follow-ups, "supersedes #N". Tests run as GitHub Actions, so the Checks tab is the test record; leave command output to CI and keep it out of the body. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
 
 ```bash
 # Check if PR already exists for this branch
@@ -157,21 +157,8 @@ if [[ -z "$EXISTING_PR" ]]; then
 ## Changes
 - `path/to/file` — what changed [one line per change; give shape + count for many sub-items, e.g. "add 21 trigger phrases"]
 
-## Testing
-[Paste the command and its result line. Evidence summarized: counts, exit code, verdict. Wrap in a fenced block.]
-$ <command>
-<result line: counts / exit code / verdict>
-
-## Scope & Risk
-- **Touches:** <limb / area>
-- **NOT touched:** <files/limbs deliberately left alone>
-- **Rollback:** <revert the commit; any state notes>
-
-## Checklist
-- [ ] ruff check + format clean (excl `venv.312.bak`) — if any `.py` touched
-- [ ] pytest green (counts pasted above)
-- [ ] `validate-doc-counts.py` → 0 drift
-- [ ] No forbidden files staged
+## Notes
+[Optional, short. Context, rollback, follow-ups, "supersedes #N". Tests run in CI — the Checks tab is the test record, so paste no command output here. Omit when there's nothing to add.]
 EOF
 )"
 else


### PR DESCRIPTION
## Summary
Cuts the canonical PR-body template (added in #705) down to the clean three-section #608 shape — Summary / Changes / Notes — and away from the #710 wall-of-text. Drops the pasted test-output, the Scope & Risk section, and the CI-duplicating checklist, because GitHub Actions is the test record.

## Changes
- `.github/pull_request_template.md` — three-section template; remove Testing-dump, Scope & Risk, Checklist; sharpen Notes to non-obvious-only
- `skills/process/pr-workflow/SKILL.md` — replace the five-section mandate with the three-section shape + density guidance and the good/bad example
- `skills/process/pr-workflow/references/sync.md` — align the `gh pr create --body` skeleton
- `skills/process/pr-workflow/references/pipeline.md` — align the Phase 5 artifact-driven template