### PR TITLE
feat(do): move Phase 5 LEARN into routing hooks (ADR learn-step-to-hook)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -112,6 +112,12 @@
             "command": "python3 \"$HOME/.claude/hooks/prompt-capture.py\"",
             "description": "Capture user prompts as voice samples (git repos only)",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/routing-outcome-finalizer.py\"",
+            "description": "Finalize routing-decision outcomes on the next user turn (tool-errors + user reaction + re-route); replaces eager SubagentStop boost/decay",
+            "timeout": 3000
           }
         ]
       }
@@ -480,7 +486,7 @@
           {
             "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/routing-outcome-recorder.py\"",
-            "description": "Record routing decision outcome (boost/decay) per subagent stop (replaces /do Phase 5 action B)",
+            "description": "Validate routing-decision pending outcomes per subagent stop (decision-row existence + bounded re-queue); next-turn finalizer applies boost/decay",
             "timeout": 3000
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -395,6 +395,12 @@
             "command": "python3 \"$HOME/.claude/hooks/instruction-compliance.py\"",
             "description": "Instruction compliance measurement after agent dispatch",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/routing-decision-recorder.py\"",
+            "description": "Record routing-decision row per Agent dispatch (replaces /do Phase 5 action A)",
+            "timeout": 3000
           }
         ]
       },
@@ -470,6 +476,12 @@
             "command": "python3 \"$HOME/.claude/hooks/subagent-completion-guard.py\"",
             "description": "Enforce branch safety, reviewer READ-ONLY contracts, and sapcc workflow gates",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/routing-outcome-recorder.py\"",
+            "description": "Record routing decision outcome (boost/decay) per subagent stop (replaces /do Phase 5 action B)",
+            "timeout": 3000
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-This toolkit prevents that. 44 domain agents, 123 workflow skills, 79 hooks, 105 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+This toolkit prevents that. 44 domain agents, 123 workflow skills, 81 hooks, 105 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Factory (`/do`).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-This toolkit prevents that. 44 domain agents, 123 workflow skills, 81 hooks, 105 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+This toolkit prevents that. 44 domain agents, 123 workflow skills, 82 hooks, 105 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Factory (`/do`).
 

--- a/hooks/lib/routing_outcome_score.py
+++ b/hooks/lib/routing_outcome_score.py
@@ -1,0 +1,62 @@
+"""Shared routing-outcome scoring: decision-row existence + boost/decay apply.
+
+Used by the SubagentStop validator (existence check only), the UserPromptSubmit
+finalizer, and the Stop fallback finalizer. Centralizing this here keeps the
+keyed read-only existence query and the boost/decay deltas identical across all
+three resolution points, and keeps the (read-only) coupling to learning_db_v2 in
+ONE place. learning_db_v2.py itself is never edited — we only read its DB path,
+init the schema, and call its public boost/decay/record helpers.
+"""
+
+import sqlite3
+
+# Route-health parity with the old `record-routing-outcome` CLI: identical
+# deltas and the routing/effectiveness slice (topic=routing, key={agent}:{skill}).
+BOOST_DELTA = 0.05
+DECAY_DELTA = 0.08
+
+
+def decision_row_exists(key: str) -> bool:
+    """True iff a routing decision row was already written for ``key``.
+
+    KEYED existence check with NO row cap. boost/decay are no-ops on a missing
+    row and return 0.0 (indistinguishable from a legitimate decayed-to-zero
+    confidence), so callers MUST gate scoring on this before applying an
+    outcome. A prior top-1000 confidence-DESC scan dropped low-confidence rows
+    once the table exceeded 1000 rows (data loss); the exact (topic, key,
+    category) SELECT avoids that.
+
+    Read-only: opens learning_db_v2's DB path directly. learning_db_v2.py is not
+    edited (a pre-existing SQLi false-positive trips the commit security gate),
+    only read. Category matches action A's exact write ('effectiveness');
+    topic+key alone is unique so category only narrows.
+    """
+    from learning_db_v2 import get_db_path, init_db
+
+    try:
+        init_db()  # ensure schema/file exist before SELECT
+        conn = sqlite3.connect(get_db_path(), timeout=5.0)
+        try:
+            row = conn.execute(
+                "SELECT 1 FROM learnings WHERE topic = ? AND key = ? AND category = ? LIMIT 1",
+                ("routing", key, "effectiveness"),
+            ).fetchone()
+            return row is not None
+        finally:
+            conn.close()
+    except Exception:
+        # Best-effort: on any read failure treat as "unknown" => caller skips
+        # scoring (and re-queues), never crashes, never double-counts.
+        return False
+
+
+def apply_outcome(key: str, failure: bool) -> float:
+    """Boost (success) or decay (failure) the routing row. Returns new confidence.
+
+    Caller MUST gate on decision_row_exists(key) first.
+    """
+    from learning_db_v2 import boost_confidence, decay_confidence
+
+    if failure:
+        return decay_confidence("routing", key, delta=DECAY_DELTA)
+    return boost_confidence("routing", key, delta=BOOST_DELTA)

--- a/hooks/lib/routing_outcome_score.py
+++ b/hooks/lib/routing_outcome_score.py
@@ -30,11 +30,18 @@ def decision_row_exists(key: str) -> bool:
     edited (a pre-existing SQLi false-positive trips the commit security gate),
     only read. Category matches action A's exact write ('effectiveness');
     topic+key alone is unique so category only narrows.
+
+    LOW-1: this function NO LONGER calls ``init_db()`` per key. Callers that
+    invoke it in a loop MUST call ``init_db()`` once before the loop (the
+    finalizer does so at the top of its scoring block). The DB path/file is
+    expected to already exist by the time an outcome is being scored (action A
+    wrote a decision row through ``init_db`` first). If the file is genuinely
+    absent the SELECT raises and is caught below => treated as "unknown" (skip),
+    identical to the prior best-effort behavior.
     """
-    from learning_db_v2 import get_db_path, init_db
+    from learning_db_v2 import get_db_path
 
     try:
-        init_db()  # ensure schema/file exist before SELECT
         conn = sqlite3.connect(get_db_path(), timeout=5.0)
         try:
             row = conn.execute(

--- a/hooks/lib/routing_outcome_state.py
+++ b/hooks/lib/routing_outcome_state.py
@@ -10,6 +10,17 @@ State lives in a per-session JSON file under /tmp. All writes are atomic
 Every function is best-effort and swallows errors — this bridge must never
 block a hook.
 
+Concurrency: parallel same-session ``PostToolUse:Agent`` dispatches (the NORMAL
+case — /do Phase 4 and pr-review both fan out agents) issue concurrent
+read-modify-write cycles against the same state file. Without serialization
+those cycles lose updates (two readers see the same ``pending`` list, both
+append one entry, the later writer's atomic rename clobbers the earlier one →
+B drains fewer outcomes than A wrote → route-health under-counts). To prevent
+this, every read-modify-write holds an EXCLUSIVE ``fcntl.flock`` on a sidecar
+lock file across the WHOLE load→modify→write, so appends serialize and no
+outcome is lost. The lock is advisory and best-effort: if locking is
+unavailable the operation still proceeds (degraded, never blocking).
+
 File shape:
     {
       "seen": ["<dispatch-sig>", ...],     # idempotency for the decision hook
@@ -17,20 +28,71 @@ File shape:
     }
 """
 
+import fcntl
 import json
 import os
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
 _STATE_DIR = Path("/tmp")
 
 
+def _state_dir() -> Path:
+    """Resolve the state directory. Honors CLAUDE_ROUTING_STATE_DIR so separate
+    processes (real cross-process dispatch, the concurrency test) agree on one
+    location; falls back to the module default otherwise."""
+    override = os.environ.get("CLAUDE_ROUTING_STATE_DIR")
+    return Path(override) if override else _STATE_DIR
+
+
 def _state_file(session_id: str) -> Path:
     sid = session_id or "nosession"
     # Keep the filename filesystem-safe.
     safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in sid)[:64]
-    return _STATE_DIR / f"claude-routing-outcomes-{safe}.json"
+    return _state_dir() / f"claude-routing-outcomes-{safe}.json"
+
+
+def _lock_file(path: Path) -> Path:
+    """Sidecar lock path for a state file (the state file is rename-replaced,
+    so the lock must live on a stable inode that is never replaced)."""
+    return path.with_suffix(path.suffix + ".lock")
+
+
+@contextmanager
+def _state_lock(path: Path):
+    """Hold an exclusive advisory lock across a read-modify-write cycle.
+
+    Best-effort: if the lock file cannot be opened or flock is unavailable the
+    body still runs (degraded to the old unlocked behavior) so the bridge never
+    blocks a hook. The lock lives on a sidecar inode because the state file
+    itself is replaced via ``os.replace`` (which swaps inodes and would drop a
+    lock held on the old one)."""
+    lock_fd = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lock_fd = os.open(str(_lock_file(path)), os.O_CREAT | os.O_RDWR, 0o600)
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+    except OSError:
+        if lock_fd is not None:
+            try:
+                os.close(lock_fd)
+            except OSError:
+                pass
+            lock_fd = None
+    try:
+        yield
+    finally:
+        if lock_fd is not None:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+            try:
+                os.close(lock_fd)
+            except OSError:
+                pass
 
 
 def _load(path: Path) -> dict[str, Any]:
@@ -77,12 +139,13 @@ def mark_dispatch_seen(session_id: str, signature: str) -> None:
     """Mark a dispatch signature as recorded (idempotency for the decision hook)."""
     try:
         path = _state_file(session_id)
-        data = _load(path)
-        if signature not in data["seen"]:
-            data["seen"].append(signature)
-            # Bound the seen list so a long session can't grow it unbounded.
-            data["seen"] = data["seen"][-500:]
-            _atomic_write(path, data)
+        with _state_lock(path):
+            data = _load(path)
+            if signature not in data["seen"]:
+                data["seen"].append(signature)
+                # Bound the seen list so a long session can't grow it unbounded.
+                data["seen"] = data["seen"][-500:]
+                _atomic_write(path, data)
     except Exception:
         pass
 
@@ -91,10 +154,11 @@ def append_pending_outcome(session_id: str, key: str, errors: bool) -> None:
     """Append a pending outcome for the SubagentStop hook to drain."""
     try:
         path = _state_file(session_id)
-        data = _load(path)
-        data["pending"].append({"key": key, "errors": bool(errors)})
-        data["pending"] = data["pending"][-500:]
-        _atomic_write(path, data)
+        with _state_lock(path):
+            data = _load(path)
+            data["pending"].append({"key": key, "errors": bool(errors)})
+            data["pending"] = data["pending"][-500:]
+            _atomic_write(path, data)
     except Exception:
         pass
 
@@ -107,11 +171,12 @@ def drain_pending_outcomes(session_id: str) -> list[dict[str, Any]]:
     """
     try:
         path = _state_file(session_id)
-        data = _load(path)
-        pending = data.get("pending", [])
-        if pending:
-            data["pending"] = []
-            _atomic_write(path, data)
+        with _state_lock(path):
+            data = _load(path)
+            pending = data.get("pending", [])
+            if pending:
+                data["pending"] = []
+                _atomic_write(path, data)
         return pending
     except Exception:
         return []

--- a/hooks/lib/routing_outcome_state.py
+++ b/hooks/lib/routing_outcome_state.py
@@ -196,32 +196,10 @@ def claim_dispatch(session_id: str, signature: str) -> bool:
         return True
 
 
-def dispatch_seen(session_id: str, signature: str) -> bool:
-    """Deprecated: non-atomic read. Use claim_dispatch for check-and-set.
-
-    Retained for backward compatibility / diagnostics only. Callers that gate
-    recording on this RACE: pair it with mark_dispatch_seen and two concurrent
-    duplicate deliveries can both pass. Prefer claim_dispatch.
-    """
-    try:
-        return signature in _load(_state_file(session_id)).get("seen", [])
-    except Exception:
-        return False
-
-
-def mark_dispatch_seen(session_id: str, signature: str) -> None:
-    """Deprecated: locked write half of the old split protocol. See claim_dispatch."""
-    try:
-        path = _state_file(session_id)
-        with _state_lock(path):
-            data = _load(path)
-            if signature not in data["seen"]:
-                data["seen"].append(signature)
-                # Bound the seen list so a long session can't grow it unbounded.
-                data["seen"] = data["seen"][-500:]
-                _atomic_write(path, data)
-    except Exception:
-        pass
+# NIT (removed): the split ``dispatch_seen`` (unlocked read) + ``mark_dispatch_seen``
+# (locked write) pair was superseded by the atomic ``claim_dispatch`` check-and-set
+# above. They were dead (no caller) and their split read/write protocol is exactly
+# the TOCTOU race ``claim_dispatch`` closes — deleted so it cannot be re-introduced.
 
 
 def append_pending_outcome(session_id: str, key: str, errors: bool) -> None:

--- a/hooks/lib/routing_outcome_state.py
+++ b/hooks/lib/routing_outcome_state.py
@@ -24,8 +24,23 @@ unavailable the operation still proceeds (degraded, never blocking).
 File shape:
     {
       "seen": ["<dispatch-sig>", ...],     # idempotency for the decision hook
-      "pending": [{"key": "agent:skill", "errors": false}, ...]
+      "pending": [{"key": "agent:skill", "errors": false, "attempts": 0}, ...]
     }
+
+Idempotency (MEDIUM, TOCTOU): the decision hook claims a dispatch signature via
+``claim_dispatch`` — an atomic check-and-set under the SAME flock as the write.
+The previous split of ``dispatch_seen`` (unlocked read) + ``mark_dispatch_seen``
+(locked write) let two concurrent duplicate deliveries both observe "unseen"
+and double-record/double-score. ``claim_dispatch`` collapses both into one
+locked critical section so exactly one caller wins.
+
+Ordering (HIGH, A-before-B): action A (PostToolUse:Agent) writes the decision
+row BEFORE appending the pending bridge entry, and PostToolUse:Agent fires
+before SubagentStop — so the decision row is normally present when B drains.
+If a B drains a pending key whose decision row is not yet visible (mistiming),
+B RE-QUEUES that entry via ``requeue_pending_outcomes`` (bounded by
+``MAX_REQUEUE_ATTEMPTS``) instead of discarding it, so a late-arriving decision
+row gets scored on a subsequent stop. See adr/learn-step-to-hook.md.
 """
 
 import fcntl
@@ -37,6 +52,12 @@ from pathlib import Path
 from typing import Any
 
 _STATE_DIR = Path("/tmp")
+
+# Bounded re-queue: how many SubagentStop drains a pending entry may survive
+# while its decision row is still not visible (HIGH, A-before-B mistiming).
+# After this many attempts the entry is dropped so a permanently-orphaned
+# pending key (decision row never written) cannot grow the file unbounded.
+MAX_REQUEUE_ATTEMPTS = 5
 
 
 def _state_dir() -> Path:
@@ -127,8 +148,42 @@ def _atomic_write(path: Path, data: dict[str, Any]) -> None:
         pass
 
 
+def claim_dispatch(session_id: str, signature: str) -> bool:
+    """Atomic check-and-set: claim a dispatch signature for recording.
+
+    Returns True iff THIS caller is the first to claim ``signature`` (the row
+    should be recorded). Returns False if it was already seen (skip — a
+    duplicate delivery). The check and the mark happen under ONE flock, so N
+    concurrent duplicate deliveries see exactly one True (MEDIUM, TOCTOU fix:
+    replaces the split dispatch_seen-read + mark_dispatch_seen-write that let
+    two racers both observe "unseen").
+
+    Best-effort: if state I/O fails entirely it returns True (record rather than
+    silently drop a real dispatch); the DB upsert on (topic, key) is itself
+    idempotent, so a rare double-claim under total I/O failure is bounded.
+    """
+    try:
+        path = _state_file(session_id)
+        with _state_lock(path):
+            data = _load(path)
+            if signature in data["seen"]:
+                return False
+            data["seen"].append(signature)
+            # Bound the seen list so a long session can't grow it unbounded.
+            data["seen"] = data["seen"][-500:]
+            _atomic_write(path, data)
+            return True
+    except Exception:
+        return True
+
+
 def dispatch_seen(session_id: str, signature: str) -> bool:
-    """Return True if this dispatch signature was already recorded this session."""
+    """Deprecated: non-atomic read. Use claim_dispatch for check-and-set.
+
+    Retained for backward compatibility / diagnostics only. Callers that gate
+    recording on this RACE: pair it with mark_dispatch_seen and two concurrent
+    duplicate deliveries can both pass. Prefer claim_dispatch.
+    """
     try:
         return signature in _load(_state_file(session_id)).get("seen", [])
     except Exception:
@@ -136,7 +191,7 @@ def dispatch_seen(session_id: str, signature: str) -> bool:
 
 
 def mark_dispatch_seen(session_id: str, signature: str) -> None:
-    """Mark a dispatch signature as recorded (idempotency for the decision hook)."""
+    """Deprecated: locked write half of the old split protocol. See claim_dispatch."""
     try:
         path = _state_file(session_id)
         with _state_lock(path):
@@ -156,7 +211,7 @@ def append_pending_outcome(session_id: str, key: str, errors: bool) -> None:
         path = _state_file(session_id)
         with _state_lock(path):
             data = _load(path)
-            data["pending"].append({"key": key, "errors": bool(errors)})
+            data["pending"].append({"key": key, "errors": bool(errors), "attempts": 0})
             data["pending"] = data["pending"][-500:]
             _atomic_write(path, data)
     except Exception:
@@ -180,3 +235,35 @@ def drain_pending_outcomes(session_id: str) -> list[dict[str, Any]]:
         return pending
     except Exception:
         return []
+
+
+def requeue_pending_outcomes(session_id: str, items: list[dict[str, Any]]) -> None:
+    """Re-queue pending outcomes whose decision row was not yet visible at drain.
+
+    HIGH (A-before-B mistiming): when B drains a key before A's decision row is
+    visible, the entry is put BACK so a later SubagentStop can score it once the
+    row lands — instead of being silently dropped. Each re-queue increments the
+    entry's ``attempts``; entries that exceed ``MAX_REQUEUE_ATTEMPTS`` are
+    dropped (the decision row was likely never written — e.g. A errored) so the
+    pending list cannot grow unbounded.
+    """
+    if not items:
+        return
+    try:
+        path = _state_file(session_id)
+        with _state_lock(path):
+            data = _load(path)
+            for item in items:
+                attempts = int(item.get("attempts", 0)) + 1
+                if attempts > MAX_REQUEUE_ATTEMPTS:
+                    continue  # give up on a permanently-orphaned pending key
+                entry = {
+                    "key": item.get("key"),
+                    "errors": bool(item.get("errors")),
+                    "attempts": attempts,
+                }
+                data["pending"].append(entry)
+            data["pending"] = data["pending"][-500:]
+            _atomic_write(path, data)
+    except Exception:
+        pass

--- a/hooks/lib/routing_outcome_state.py
+++ b/hooks/lib/routing_outcome_state.py
@@ -1,0 +1,117 @@
+"""Per-session bridge between the routing decision hook and the outcome hook.
+
+The PostToolUse:Agent hook (routing-decision-recorder.py) records the routing
+decision row and appends a *pending outcome* (routing key + observed error
+flag) here. The SubagentStop hook (routing-outcome-recorder.py) drains the
+pending outcomes and applies boost/decay to the matching decision rows.
+
+State lives in a per-session JSON file under /tmp. All writes are atomic
+(write-to-temp-then-rename) so an interrupted hook never corrupts the file.
+Every function is best-effort and swallows errors — this bridge must never
+block a hook.
+
+File shape:
+    {
+      "seen": ["<dispatch-sig>", ...],     # idempotency for the decision hook
+      "pending": [{"key": "agent:skill", "errors": false}, ...]
+    }
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+_STATE_DIR = Path("/tmp")
+
+
+def _state_file(session_id: str) -> Path:
+    sid = session_id or "nosession"
+    # Keep the filename filesystem-safe.
+    safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in sid)[:64]
+    return _STATE_DIR / f"claude-routing-outcomes-{safe}.json"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    try:
+        if path.exists():
+            data = json.loads(path.read_text())
+            if isinstance(data, dict):
+                data.setdefault("seen", [])
+                data.setdefault("pending", [])
+                return data
+    except (json.JSONDecodeError, OSError, ValueError):
+        pass
+    return {"seen": [], "pending": []}
+
+
+def _atomic_write(path: Path, data: dict[str, Any]) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(data, f)
+            os.replace(tmp, str(path))
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except Exception:
+        # Best-effort: at worst we lose one bridge record.
+        pass
+
+
+def dispatch_seen(session_id: str, signature: str) -> bool:
+    """Return True if this dispatch signature was already recorded this session."""
+    try:
+        return signature in _load(_state_file(session_id)).get("seen", [])
+    except Exception:
+        return False
+
+
+def mark_dispatch_seen(session_id: str, signature: str) -> None:
+    """Mark a dispatch signature as recorded (idempotency for the decision hook)."""
+    try:
+        path = _state_file(session_id)
+        data = _load(path)
+        if signature not in data["seen"]:
+            data["seen"].append(signature)
+            # Bound the seen list so a long session can't grow it unbounded.
+            data["seen"] = data["seen"][-500:]
+            _atomic_write(path, data)
+    except Exception:
+        pass
+
+
+def append_pending_outcome(session_id: str, key: str, errors: bool) -> None:
+    """Append a pending outcome for the SubagentStop hook to drain."""
+    try:
+        path = _state_file(session_id)
+        data = _load(path)
+        data["pending"].append({"key": key, "errors": bool(errors)})
+        data["pending"] = data["pending"][-500:]
+        _atomic_write(path, data)
+    except Exception:
+        pass
+
+
+def drain_pending_outcomes(session_id: str) -> list[dict[str, Any]]:
+    """Return and clear all pending outcomes for this session.
+
+    Returns a list of {"key": str, "errors": bool}. Clears the pending list
+    (keeps the seen list) so each pending outcome is applied at most once.
+    """
+    try:
+        path = _state_file(session_id)
+        data = _load(path)
+        pending = data.get("pending", [])
+        if pending:
+            data["pending"] = []
+            _atomic_write(path, data)
+        return pending
+    except Exception:
+        return []

--- a/hooks/lib/routing_outcome_state.py
+++ b/hooks/lib/routing_outcome_state.py
@@ -1,9 +1,19 @@
-"""Per-session bridge between the routing decision hook and the outcome hook.
+"""Per-session bridge for next-turn routing-outcome resolution.
 
 The PostToolUse:Agent hook (routing-decision-recorder.py) records the routing
-decision row and appends a *pending outcome* (routing key + observed error
-flag) here. The SubagentStop hook (routing-outcome-recorder.py) drains the
-pending outcomes and applies boost/decay to the matching decision rows.
+decision row and appends a PROVISIONAL pending outcome (routing key + observed
+error flag) here. Resolution happens at a SINGLE point per dispatch, when the
+next-turn signal is available:
+
+  - SubagentStop (routing-outcome-recorder.py): validates each pending entry's
+    decision row exists; re-queues late rows (bounded) and revalidates healthy
+    entries to stay pending. It NO LONGER applies boost/decay.
+  - UserPromptSubmit (routing-outcome-finalizer.py): on the next user turn,
+    finalizes still-pending entries from tool-errors + user reaction + re-route,
+    applying boost/decay ONCE then clearing them (idempotent).
+  - Stop (session-learning-recorder.py fallback): resolves any STILL-pending
+    entries via the error flag alone (the deterministic floor) so autonomous /
+    no-next-prompt runs still record an outcome.
 
 State lives in a per-session JSON file under /tmp. All writes are atomic
 (write-to-temp-then-rename) so an interrupted hook never corrupts the file.
@@ -24,7 +34,8 @@ unavailable the operation still proceeds (degraded, never blocking).
 File shape:
     {
       "seen": ["<dispatch-sig>", ...],     # idempotency for the decision hook
-      "pending": [{"key": "agent:skill", "errors": false, "attempts": 0}, ...]
+      "pending": [{"key": "agent:skill", "errors": false,
+                   "attempts": 0, "created": 1735000000.0}, ...]
     }
 
 Idempotency (MEDIUM, TOCTOU): the decision hook claims a dispatch signature via
@@ -47,6 +58,7 @@ import fcntl
 import json
 import os
 import tempfile
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -58,6 +70,13 @@ _STATE_DIR = Path("/tmp")
 # After this many attempts the entry is dropped so a permanently-orphaned
 # pending key (decision row never written) cannot grow the file unbounded.
 MAX_REQUEUE_ATTEMPTS = 5
+
+# Bounded pending age: a provisional pending entry that is never finalized by
+# UserPromptSubmit or Stop (e.g. a crashed session that emits neither a next
+# user prompt nor a clean Stop) must not live forever. ``finalize_pending_outcomes``
+# drops entries older than this so the per-session state file cannot grow
+# unbounded across long-lived or abandoned sessions.
+MAX_PENDING_AGE_SEC = 24 * 3600  # 24h
 
 
 def _state_dir() -> Path:
@@ -206,12 +225,94 @@ def mark_dispatch_seen(session_id: str, signature: str) -> None:
 
 
 def append_pending_outcome(session_id: str, key: str, errors: bool) -> None:
-    """Append a pending outcome for the SubagentStop hook to drain."""
+    """Append a PROVISIONAL pending outcome.
+
+    The entry carries this dispatch's own observed ``errors`` flag and is left
+    pending (not scored) until a resolver finalizes it: UserPromptSubmit on the
+    next user turn (reaction + error + re-route) or Stop at session end (error
+    flag alone). ``created`` bounds its lifetime; ``attempts`` bounds re-queues
+    while the decision row is still not visible at SubagentStop.
+    """
     try:
         path = _state_file(session_id)
         with _state_lock(path):
             data = _load(path)
-            data["pending"].append({"key": key, "errors": bool(errors), "attempts": 0})
+            data["pending"].append({"key": key, "errors": bool(errors), "attempts": 0, "created": time.time()})
+            data["pending"] = data["pending"][-500:]
+            _atomic_write(path, data)
+    except Exception:
+        pass
+
+
+def peek_pending_outcomes(session_id: str) -> list[dict[str, Any]]:
+    """Return a copy of the still-pending outcomes WITHOUT clearing them.
+
+    Read-only helper for diagnostics / the SubagentStop validator, which must
+    inspect pending entries but leave them in place for a later finalizer.
+    """
+    try:
+        return list(_load(_state_file(session_id)).get("pending", []))
+    except Exception:
+        return []
+
+
+def finalize_pending_outcomes(session_id: str) -> list[dict[str, Any]]:
+    """Atomically read-AND-clear all still-pending outcomes for resolution.
+
+    Used by the single resolution point on each turn (UserPromptSubmit) and by
+    the session-end fallback (Stop). Returns the pending entries; the caller is
+    responsible for applying boost/decay exactly once. Entries older than
+    ``MAX_PENDING_AGE_SEC`` are dropped (returned but the caller skips scoring
+    via the age check) — handled here by simply clearing them so abandoned
+    sessions cannot grow state unbounded.
+
+    Clearing here makes finalization idempotent across re-delivered events: a
+    second UserPromptSubmit for the same prompt finds an empty pending list and
+    applies nothing (no double boost/decay).
+    """
+    try:
+        path = _state_file(session_id)
+        with _state_lock(path):
+            data = _load(path)
+            pending = data.get("pending", [])
+            if pending:
+                data["pending"] = []
+                _atomic_write(path, data)
+        return pending
+    except Exception:
+        return []
+
+
+def revalidate_pending_outcomes(session_id: str, items: list[dict[str, Any]]) -> None:
+    """Re-queue VALIDATED provisional entries that are not yet finalizable.
+
+    SubagentStop confirms each pending entry's decision row exists, then puts
+    the still-unresolved entries BACK (so a later UserPromptSubmit/Stop can
+    finalize them) WITHOUT advancing the re-queue attempt counter — these are
+    healthy entries awaiting a next-turn signal, not late-row mistimings. Stale
+    entries (older than ``MAX_PENDING_AGE_SEC``) are dropped here too.
+    """
+    if not items:
+        return
+    try:
+        now = time.time()
+        path = _state_file(session_id)
+        with _state_lock(path):
+            data = _load(path)
+            for item in items:
+                if not item.get("key"):
+                    continue
+                created = float(item.get("created", now))
+                if now - created > MAX_PENDING_AGE_SEC:
+                    continue  # drop abandoned provisional entry
+                data["pending"].append(
+                    {
+                        "key": item.get("key"),
+                        "errors": bool(item.get("errors")),
+                        "attempts": int(item.get("attempts", 0)),
+                        "created": created,
+                    }
+                )
             data["pending"] = data["pending"][-500:]
             _atomic_write(path, data)
     except Exception:
@@ -261,6 +362,7 @@ def requeue_pending_outcomes(session_id: str, items: list[dict[str, Any]]) -> No
                     "key": item.get("key"),
                     "errors": bool(item.get("errors")),
                     "attempts": attempts,
+                    "created": float(item.get("created", time.time())),
                 }
                 data["pending"].append(entry)
             data["pending"] = data["pending"][-500:]

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -55,7 +55,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
-from routing_outcome_state import append_pending_outcome, dispatch_seen, mark_dispatch_seen
+from routing_outcome_state import append_pending_outcome, claim_dispatch
 from stdin_timeout import read_stdin
 
 EVENT_NAME = "PostToolUse"
@@ -66,9 +66,12 @@ EVENT_NAME = "PostToolUse"
 # fan-out (pr-review reviewers, nested dispatches) carries no marker → skipped.
 #   [do-route] agent=python-general-engineer skill=test-driven-development complexity=Medium
 # skill may be empty/"-"/absent (agent-only routing).
+# Anchored to line start (^\s*, MULTILINE) so a quoted/forwarded marker
+# mid-prose (e.g. a user pasting "...the [do-route] line...") doesn't get
+# recorded — only a marker /do itself emitted at the head of a line counts.
 _DO_ROUTE_RE = re.compile(
-    r"\[do-route\]\s+agent=([a-z0-9][a-z0-9-]*)(?:\s+skill=([a-z0-9-]*|-)?)?",
-    re.IGNORECASE,
+    r"^\s*\[do-route\]\s+agent=([a-z0-9][a-z0-9-]*)(?:\s+skill=([a-z0-9-]*|-)?)?",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 # Right-sizing banner, e.g. "rightsizing: tier=2 files=8 packages=3 agents_dispatched=12"
@@ -172,10 +175,12 @@ def main() -> None:
             return  # malformed marker => nothing to key on
         key = build_routing_key(agent, skill)
 
-        # Idempotency: skip if we've already recorded this exact dispatch.
+        # Idempotency (atomic, MEDIUM/TOCTOU): claim this dispatch signature.
+        # claim_dispatch performs check-and-set under one flock, so N concurrent
+        # duplicate deliveries record exactly once. False => already claimed.
         sig = dispatch_signature(agent, skill, description, prompt)
         session_id = event.get("session_id") or ""
-        if dispatch_seen(session_id, sig):
+        if not claim_dispatch(session_id, sig):
             return
 
         has_errors = detect_errors(event)
@@ -204,9 +209,10 @@ def main() -> None:
         if isinstance(output, str):
             record_rightsizing(output)
 
-        # Bridge to the SubagentStop outcome hook (action B).
+        # Bridge to the SubagentStop outcome hook (action B). The dispatch was
+        # already claimed (marked seen) atomically above, so no separate mark.
+        # Decision row is written BEFORE this append (ordering: A-before-B).
         append_pending_outcome(session_id, key, has_errors)
-        mark_dispatch_seen(session_id, sig)
 
     except Exception as e:
         if os.environ.get("CLAUDE_HOOKS_DEBUG"):

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -8,12 +8,25 @@ feedback loop (`learning-db.py route-health`) keeps receiving the rows it
 needs. Replaces the hand-run `learning-db.py record routing ...` step that
 lived in /do Phase 2 Step 4 + Phase 5 action A.
 
+SCOPING — record ONLY /do-routed dispatches.
+Every Agent dispatch fires PostToolUse:Agent, including pr-review's reviewer
+sub-agents (code-reviewer, security-reviewer, reviewer-*) and any other
+nested fan-out. Recording all of them would inflate route-health's denominator
+with dispatches /do never routed. So /do stamps a machine-readable marker on
+the prompts IT routes (Phase 4 Step 2):
+
+    [do-route] agent={agent} skill={skill} complexity={complexity}
+
+This hook records ONLY when that marker is present, and reads the agent + skill
+directly FROM the marker (structured intent emitted by the router — not fragile
+prompt-sniffing). No marker → not a /do routing decision → skip. This is the
+sole scoping mechanism (no reviewer-name denylist).
+
 PostToolUse:Agent fires AFTER the subagent completes, so the event carries
 both the dispatch metadata (tool_input.subagent_type / .prompt / .description)
 and the subagent's tool_result. From these we:
-  1. Reconstruct the routing key {agent}:{skill} (skill parsed from the
-     dispatch prompt; agent-only "{agent}:" when the skill is undiscoverable —
-     matching the key format Phase 5 used).
+  1. Read the routing key {agent}:{skill} from the [do-route] marker
+     (agent-only "{agent}:" when the marker carries no skill).
   2. Record topic="routing", category="effectiveness" with observable fields
      (tool_errors, request/description snippet).
   3. (C) Parse a `rightsizing:tier{N}` banner from the subagent output and
@@ -47,12 +60,16 @@ from stdin_timeout import read_stdin
 
 EVENT_NAME = "PostToolUse"
 
-# Skill discovery from the dispatch prompt, in priority order.
-_SKILL_PATTERNS = [
-    re.compile(r"""Skill\(\s*["']([a-z0-9][a-z0-9-]*)["']""", re.IGNORECASE),
-    re.compile(r"\bskill\s*[:=]\s*([a-z0-9][a-z0-9-]*)", re.IGNORECASE),
-    re.compile(r"\b(?:load|use|run|invoke)\s+the\s+([a-z0-9][a-z0-9-]*)\s+skill\b", re.IGNORECASE),
-]
+# The /do routing marker. /do (SKILL.md Phase 4 Step 2) prepends this to every
+# agent prompt IT routes. Its presence is the SOLE signal that a dispatch is a
+# /do routing decision; agent + skill are read straight from it. Sub-agent
+# fan-out (pr-review reviewers, nested dispatches) carries no marker → skipped.
+#   [do-route] agent=python-general-engineer skill=test-driven-development complexity=Medium
+# skill may be empty/"-"/absent (agent-only routing).
+_DO_ROUTE_RE = re.compile(
+    r"\[do-route\]\s+agent=([a-z0-9][a-z0-9-]*)(?:\s+skill=([a-z0-9-]*|-)?)?",
+    re.IGNORECASE,
+)
 
 # Right-sizing banner, e.g. "rightsizing: tier=2 files=8 packages=3 agents_dispatched=12"
 _RIGHTSIZING_RE = re.compile(
@@ -61,15 +78,22 @@ _RIGHTSIZING_RE = re.compile(
 )
 
 
-def extract_skill(prompt: str) -> str:
-    """Return the first skill name discoverable in the dispatch prompt, else ''."""
-    if not prompt:
-        return ""
-    for pat in _SKILL_PATTERNS:
-        m = pat.search(prompt)
-        if m:
-            return m.group(1).lower()
-    return ""
+def parse_do_route_marker(prompt: str) -> tuple[str, str] | None:
+    """Read (agent, skill) from the [do-route] marker, or None when absent.
+
+    None means this dispatch was not routed by /do (no marker) → the caller
+    skips recording. skill is "" when the marker carries no skill or "-".
+    """
+    if not prompt or "[do-route]" not in prompt.lower():
+        return None
+    m = _DO_ROUTE_RE.search(prompt)
+    if not m:
+        return None
+    agent = m.group(1).strip().lower()
+    skill = (m.group(2) or "").strip().lower()
+    if skill == "-":
+        skill = ""
+    return agent, skill
 
 
 def build_routing_key(agent: str, skill: str) -> str:
@@ -84,20 +108,20 @@ def dispatch_signature(agent: str, skill: str, description: str, prompt: str) ->
 
 
 def detect_errors(event: dict) -> bool:
-    """Return True if the subagent's tool_result shows an error. Best-effort."""
+    """Return True if the subagent's tool_result shows an error. Best-effort.
+
+    Uses hook_utils.is_tool_error as the intended detector. (The earlier
+    `from error_learner import detect_error` branch was dead code: the module
+    file is hooks/error-learner.py — hyphenated, so the import always raised
+    ImportError and silently fell through to is_tool_error. Removed to make the
+    real detector explicit.)
+    """
     try:
-        from error_learner import detect_error
+        from hook_utils import get_tool_result, is_tool_error
 
-        has_error, _ = detect_error(event)
-        return bool(has_error)
+        return is_tool_error(get_tool_result(event))
     except Exception:
-        # Fallback: direct error field on the result.
-        try:
-            from hook_utils import get_tool_result, is_tool_error
-
-            return is_tool_error(get_tool_result(event))
-        except Exception:
-            return False
+        return False
 
 
 def record_rightsizing(output: str) -> None:
@@ -133,13 +157,19 @@ def main() -> None:
             return
 
         tool_input = event.get("tool_input") or event.get("input") or {}
-        agent = (tool_input.get("subagent_type") or "").strip()
-        if not agent:
-            return  # no agent => nothing to key on
-
         prompt = tool_input.get("prompt") or ""
         description = tool_input.get("description") or ""
-        skill = extract_skill(prompt)
+
+        # SCOPING: record ONLY /do-routed dispatches. No [do-route] marker =>
+        # this is a sub-agent fan-out (pr-review reviewers, nested dispatch),
+        # not a /do routing decision — skip so route-health's denominator stays
+        # clean. agent + skill are read straight from the marker.
+        routed = parse_do_route_marker(prompt)
+        if routed is None:
+            return
+        agent, skill = routed
+        if not agent:
+            return  # malformed marker => nothing to key on
         key = build_routing_key(agent, skill)
 
         # Idempotency: skip if we've already recorded this exact dispatch.

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+PostToolUse Hook: Routing Decision Recorder (action A, formerly /do Phase 5)
+
+Records the routing-decision row for every Agent dispatch so the routing
+feedback loop (`learning-db.py route-health`) keeps receiving the rows it
+needs. Replaces the hand-run `learning-db.py record routing ...` step that
+lived in /do Phase 2 Step 4 + Phase 5 action A.
+
+PostToolUse:Agent fires AFTER the subagent completes, so the event carries
+both the dispatch metadata (tool_input.subagent_type / .prompt / .description)
+and the subagent's tool_result. From these we:
+  1. Reconstruct the routing key {agent}:{skill} (skill parsed from the
+     dispatch prompt; agent-only "{agent}:" when the skill is undiscoverable —
+     matching the key format Phase 5 used).
+  2. Record topic="routing", category="effectiveness" with observable fields
+     (tool_errors, request/description snippet).
+  3. (C) Parse a `rightsizing:tier{N}` banner from the subagent output and
+     record a separate rightsizing row, parse-only and silent when absent.
+  4. Write a pending-outcome entry to a per-session file so the SubagentStop
+     hook (routing-outcome-recorder.py) can recover the full key + the error
+     verdict and apply boost/decay. PostToolUse:Agent fires before
+     SubagentStop, so the decision row is committed before the outcome runs —
+     the ordering dependency is honored structurally.
+
+Idempotency: a per-session state file keyed by a dispatch signature stops the
+same dispatch being recorded twice (e.g. on retries). The DB upsert on
+(topic, key) is also idempotent.
+
+Design Principles:
+- SILENT (records to DB, no context injection)
+- Non-blocking (always exits 0)
+- Fast execution (<50ms target); lazy imports
+"""
+
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from routing_outcome_state import append_pending_outcome, dispatch_seen, mark_dispatch_seen
+from stdin_timeout import read_stdin
+
+EVENT_NAME = "PostToolUse"
+
+# Skill discovery from the dispatch prompt, in priority order.
+_SKILL_PATTERNS = [
+    re.compile(r"""Skill\(\s*["']([a-z0-9][a-z0-9-]*)["']""", re.IGNORECASE),
+    re.compile(r"\bskill\s*[:=]\s*([a-z0-9][a-z0-9-]*)", re.IGNORECASE),
+    re.compile(r"\b(?:load|use|run|invoke)\s+the\s+([a-z0-9][a-z0-9-]*)\s+skill\b", re.IGNORECASE),
+]
+
+# Right-sizing banner, e.g. "rightsizing: tier=2 files=8 packages=3 agents_dispatched=12"
+_RIGHTSIZING_RE = re.compile(
+    r"rightsizing:\s*tier=(\d+)\s+files=(\d+)\s+packages=(\d+)\s+agents_dispatched=(\d+)",
+    re.IGNORECASE,
+)
+
+
+def extract_skill(prompt: str) -> str:
+    """Return the first skill name discoverable in the dispatch prompt, else ''."""
+    if not prompt:
+        return ""
+    for pat in _SKILL_PATTERNS:
+        m = pat.search(prompt)
+        if m:
+            return m.group(1).lower()
+    return ""
+
+
+def build_routing_key(agent: str, skill: str) -> str:
+    """Build the {agent}:{skill} key; agent-only "{agent}:" when skill unknown."""
+    return f"{agent}:{skill}" if skill else f"{agent}:"
+
+
+def dispatch_signature(agent: str, skill: str, description: str, prompt: str) -> str:
+    """Stable signature for one dispatch, used for idempotency."""
+    raw = f"{agent}|{skill}|{description}|{prompt[:200]}"
+    return hashlib.md5(raw.encode("utf-8", errors="replace")).hexdigest()[:16]
+
+
+def detect_errors(event: dict) -> bool:
+    """Return True if the subagent's tool_result shows an error. Best-effort."""
+    try:
+        from error_learner import detect_error
+
+        has_error, _ = detect_error(event)
+        return bool(has_error)
+    except Exception:
+        # Fallback: direct error field on the result.
+        try:
+            from hook_utils import get_tool_result, is_tool_error
+
+            return is_tool_error(get_tool_result(event))
+        except Exception:
+            return False
+
+
+def record_rightsizing(output: str) -> None:
+    """(C) Record a rightsizing row when the output carries the banner. Silent otherwise."""
+    if not output or "rightsizing:" not in output.lower():
+        return
+    m = _RIGHTSIZING_RE.search(output)
+    if not m:
+        return
+    tier, files, packages, agents = m.group(1), m.group(2), m.group(3), m.group(4)
+    from learning_db_v2 import record_learning
+
+    record_learning(
+        topic="routing",
+        key=f"rightsizing:tier{tier}",
+        value=f"rightsizing: tier={tier} files={files} packages={packages} agents_dispatched={agents}",
+        category="effectiveness",
+        tags=["routing", "rightsizing"],
+        source="hook:routing-decision-recorder",
+    )
+
+
+def main() -> None:
+    try:
+        raw = read_stdin(timeout=2)
+        if not raw:
+            return
+        event = json.loads(raw)
+
+        # matcher "Agent" in settings.json scopes this hook; guard defensively.
+        tool_name = event.get("tool_name") or event.get("tool", "")
+        if tool_name != "Agent":
+            return
+
+        tool_input = event.get("tool_input") or event.get("input") or {}
+        agent = (tool_input.get("subagent_type") or "").strip()
+        if not agent:
+            return  # no agent => nothing to key on
+
+        prompt = tool_input.get("prompt") or ""
+        description = tool_input.get("description") or ""
+        skill = extract_skill(prompt)
+        key = build_routing_key(agent, skill)
+
+        # Idempotency: skip if we've already recorded this exact dispatch.
+        sig = dispatch_signature(agent, skill, description, prompt)
+        session_id = event.get("session_id") or ""
+        if dispatch_seen(session_id, sig):
+            return
+
+        has_errors = detect_errors(event)
+        request_snippet = (description or prompt)[:200].replace("\n", " ").strip()
+
+        from learning_db_v2 import record_learning
+
+        record_learning(
+            topic="routing",
+            key=key,
+            value=(
+                f"routing-decision: agent={agent} skill={skill or '-'} "
+                f"tool_errors={1 if has_errors else 0} user_rerouted=0 "
+                f"request: {request_snippet}"
+            ),
+            category="effectiveness",
+            tags=["routing", agent] + ([skill] if skill else []),
+            source="hook:routing-decision-recorder",
+            session_id=session_id or None,
+        )
+
+        # (C) right-sizing feedback, parse-only.
+        from hook_utils import get_tool_output, get_tool_result
+
+        output = get_tool_output(get_tool_result(event))
+        if isinstance(output, str):
+            record_rightsizing(output)
+
+        # Bridge to the SubagentStop outcome hook (action B).
+        append_pending_outcome(session_id, key, has_errors)
+        mark_dispatch_seen(session_id, sig)
+
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[routing-decision-recorder] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+    finally:
+        sys.exit(0)  # Never block
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/routing-outcome-finalizer.py
+++ b/hooks/routing-outcome-finalizer.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+UserPromptSubmit Hook: Routing Outcome Finalizer (next-turn resolution)
+
+Resolves each /do-routed dispatch's outcome at the SINGLE point where the
+next-turn signal exists: the user's next prompt. This is the deferred work the
+SubagentStop validator can't do — a hook firing when a subagent stops cannot
+see whether the USER accepted the result, asked for rework, or re-routed the
+same intent. Those signals live in the NEXT user turn. This hook reads them.
+
+Resolution per still-pending dispatch (drained atomically, scored ONCE):
+
+    failure  = tool errors recorded for THIS dispatch  OR  clear user rejection
+    success  = otherwise (acceptance, OR neutral / new topic — no complaint)
+
+then boost (success) / decay (failure) the routing/{key} row, ONCE, and clear
+the pending list so a re-delivered prompt resolves nothing further (idempotent).
+
+HIGH-PRECISION FAILURE DETECTION (critical):
+A FALSE failure poisons route-health worse than recording nothing — it decays a
+route that actually worked. So failure fires ONLY on strong, unambiguous
+markers (rejection/rework verbs, or a re-route of the same intent). Everything
+else — including prompts that merely mention the word "wrong" in a NEW,
+unrelated request — defaults to SUCCESS, matching the old LLM's "user accepted"
+default. The marker sets below are module-level constants, conservative and
+tunable. This is deliberately NOT full semantic judgment: it is a high-precision
+deterministic detector that errs toward success on ambiguity.
+
+Per-agent attribution is preserved: each pending entry carries its OWN tool
+``errors`` flag (recorded by action A). The user reaction is a session-level
+signal; combined per entry as ``errors OR rejection``.
+
+Design Principles:
+- SILENT (touches state/DB only; no context injection)
+- Non-blocking: every RUNTIME path exits 0 (finally: sys.exit(0))
+- Fast execution (<50ms target); lazy imports
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from routing_outcome_state import finalize_pending_outcomes
+from stdin_timeout import read_stdin
+
+EVENT_NAME = "UserPromptSubmit"
+
+# -----------------------------------------------------------------------------
+# Reaction marker sets (module-level constants — conservative + tunable).
+#
+# REJECTION markers fire FAILURE. Kept deliberately strong/unambiguous: each is
+# a phrase a user uses to reject or demand rework of the immediately-prior work.
+# Matched as whole-phrase / word-boundary regexes so a substring like the word
+# "wrong" inside an unrelated new request does NOT trip them (see the benign
+# "wrong" non-decay test). Tune by adding/removing entries here.
+# -----------------------------------------------------------------------------
+_REJECTION_PATTERNS = [
+    r"that'?s (wrong|worse|broken|not (right|what i wanted))",
+    r"this (is|isn'?t) (wrong|worse|broken|not (right|what i wanted))",
+    r"\bnot what i (wanted|asked for)\b",
+    r"\b(redo|re-?do) (it|that|this)\b",
+    r"\b(revert|undo|roll ?back) (it|that|this|your|the (change|edit|commit))\b",
+    r"\bthat (didn'?t|did not) work\b",
+    r"\bthis (didn'?t|did not) work\b",
+    r"\b(start over|try again)\b",
+    r"\byou (broke|messed up|got it wrong)\b",
+    r"\b(no,? that'?s|nope,? that'?s)\b",
+    r"\bwrong (agent|skill|approach|route|routing)\b",
+    r"\b(fix|undo) (your|the) (mistake|error|mess)\b",
+]
+
+# RE-ROUTE markers fire FAILURE too: the user redirects the SAME intent to a
+# different agent/skill/approach, i.e. the route was wrong. Distinct from a
+# brand-new unrelated request (which is neutral => success).
+_REROUTE_PATTERNS = [
+    r"\b(use|try|switch to|route (this )?to) (a )?different (agent|skill|approach)\b",
+    r"\bwrong (agent|skill|route|routing)\b",
+    r"\bre-?route\b",
+    r"\bthat'?s the wrong (agent|skill|approach)\b",
+    r"\b(should|shouldn'?t) (have )?(use|used|been) .*(agent|skill)\b",
+]
+
+# ACCEPTANCE markers are documented for clarity / future tuning, but they are NOT
+# required: acceptance and neutral both resolve to SUCCESS. They exist so the
+# classifier can be made stricter later without restructuring.
+_ACCEPTANCE_PATTERNS = [
+    r"\b(thanks|thank you|great|perfect|looks good|lgtm|nice work|well done)\b",
+    r"\b(merge it|ship it|ship that|approve|approved)\b",
+]
+
+_REJECTION_RE = re.compile("|".join(_REJECTION_PATTERNS), re.IGNORECASE)
+_REROUTE_RE = re.compile("|".join(_REROUTE_PATTERNS), re.IGNORECASE)
+
+
+def is_rejection(prompt: str) -> bool:
+    """High-precision: True only on a clear rejection / rework / re-route signal.
+
+    Conservative by design — ambiguous prompts (a NEW request that merely
+    contains the word "wrong") return False so the prior dispatch is not falsely
+    decayed. Returns False on empty / non-string input.
+    """
+    if not prompt or not isinstance(prompt, str):
+        return False
+    return bool(_REJECTION_RE.search(prompt) or _REROUTE_RE.search(prompt))
+
+
+def main() -> None:
+    try:
+        raw = read_stdin(timeout=2)
+        if not raw:
+            return
+        event = json.loads(raw)
+
+        event_type = event.get("hook_event_name") or event.get("type", "")
+        if event_type and event_type != EVENT_NAME:
+            return
+
+        session_id = event.get("session_id") or ""
+        # Atomic read-AND-clear: makes finalization idempotent — a re-delivered
+        # or duplicate prompt finds an empty pending list and scores nothing.
+        pending = finalize_pending_outcomes(session_id)
+        if not pending:
+            return  # no routed dispatches awaiting resolution this turn
+
+        prompt = (event.get("prompt") or "").strip()
+        rejected = is_rejection(prompt)
+
+        # Lazy: only import the scorer (and thus learning_db_v2) when there is
+        # actually something to resolve.
+        import time
+
+        from routing_outcome_score import apply_outcome, decision_row_exists
+        from routing_outcome_state import MAX_PENDING_AGE_SEC, revalidate_pending_outcomes
+
+        debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
+        now = time.time()
+        seen_keys: set[str] = set()
+        to_revalidate: list[dict] = []
+        for item in pending:
+            key = item.get("key")
+            if not key:
+                continue
+            # Drop abandoned provisional entries; never score a stale one.
+            created = float(item.get("created", now))
+            if now - created > MAX_PENDING_AGE_SEC:
+                continue
+            # A row whose decision write is still not visible (rare at this
+            # point) is put back so a later resolver scores it — never dropped,
+            # never double-counted.
+            if not decision_row_exists(key):
+                to_revalidate.append(item)
+                continue
+            # Per-agent attribution: THIS dispatch's own error flag, OR a
+            # session-level clear rejection => failure. Else success.
+            failure = bool(item.get("errors")) or rejected
+            new_conf = apply_outcome(key, failure)
+            seen_keys.add(key)
+            if debug:
+                outcome = "failure" if failure else "success"
+                reason = "tool-errors" if item.get("errors") else ("rejection" if rejected else "accepted/neutral")
+                print(
+                    f"[routing-outcome-finalizer] {outcome} routing/{key} ({reason}) conf={new_conf:.4f}",
+                    file=sys.stderr,
+                )
+
+        if to_revalidate:
+            revalidate_pending_outcomes(session_id, to_revalidate)
+
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[routing-outcome-finalizer] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+    finally:
+        sys.exit(0)  # Never block
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/routing-outcome-finalizer.py
+++ b/hooks/routing-outcome-finalizer.py
@@ -118,7 +118,6 @@ _REJECTION_PATTERNS = [
     r"\bthis (didn'?t|did not) work\b",
     r"\b(start over|try again)\b",
     r"\byou (broke|messed up|got it wrong)\b",
-    r"\b(no,? that'?s|nope,? that'?s)\b",
     # Sole surviving re-route signal: anchored on the literal complaint "wrong".
     r"\bwrong (agent|skill|route|routing)\b",
     r"\b(fix|undo) (your|the) (mistake|error|mess)\b",
@@ -144,6 +143,24 @@ _INSTRUCTIONAL_CUE_PATTERNS = [
 _REJECTION_RE = re.compile("|".join(_REJECTION_PATTERNS), re.IGNORECASE)
 _ACCEPTANCE_RE = re.compile("|".join(_ACCEPTANCE_PATTERNS), re.IGNORECASE)
 _INSTRUCTIONAL_CUE_RE = re.compile("|".join(_INSTRUCTIONAL_CUE_PATTERNS), re.IGNORECASE)
+
+# LEADING "no"/"nope" REACTION (dead-pattern fix). The old rejection regex
+# `\b(no,? that'?s|nope,? that'?s)\b` was written to span a comma ("no, that's")
+# but the clause splitter severs "no" from "that's" FIRST, so it could never
+# match — a genuine complaint "no, that's not what I asked for" silently fell
+# back to SUCCESS. This special-case detects the leading bare reaction token
+# WITHOUT depending on comma-adjacency the splitter destroys:
+#   (1) `^\s*(no|nope)\b` — the reaction must be at the ABSOLUTE START of the
+#       RAW prompt, so "no" inside "there is no cache" or "undo is hard" / a
+#       mid-sentence "nope" never qualifies; AND
+#   (2) a `that'?s` complaint marker anywhere in the prompt — a negation/fault
+#       ("that's wrong", "that's not what I asked for"). The complaint anchor
+#       keeps the leading "no" from firing on benign "no, go ahead and ship it".
+_LEADING_NO_RE = re.compile(r"^\s*(no|nope)\b", re.IGNORECASE)
+_THATS_COMPLAINT_RE = re.compile(
+    r"\bthat'?s (wrong|worse|broken|not (right|what i (wanted|asked for)))\b",
+    re.IGNORECASE,
+)
 
 # Clause boundary: split on sentence/clause terminators (incl. comma) so only the
 # user's immediate reaction (the first clause) is tested for rejection. The comma
@@ -187,6 +204,12 @@ def is_rejection(prompt: str) -> bool:
         return False  # acceptance precedence — later "redo" clauses are new work
     if _INSTRUCTIONAL_CUE_RE.search(first):
         return False  # instructional/conditional/spec clause — not a complaint
+    # Dead-pattern fix: a leading bare "no"/"nope" reaction at the ABSOLUTE start
+    # of the raw prompt, paired with a `that's <complaint>` anywhere, is a genuine
+    # rejection the comma-splitter would otherwise hide (it severs "no" from
+    # "that's"). Anchored at ^ so "no" inside "there is no cache" never fires.
+    if _LEADING_NO_RE.match(prompt) and _THATS_COMPLAINT_RE.search(prompt):
+        return True
     return bool(_REJECTION_RE.search(first))
 
 

--- a/hooks/routing-outcome-finalizer.py
+++ b/hooks/routing-outcome-finalizer.py
@@ -103,20 +103,31 @@ EVENT_NAME = "UserPromptSubmit"
 # "document when to use a different agent" is a docs task.)
 #
 # ACCEPTANCE PRECEDENCE: if an acceptance marker appears in the first clause, the
-# turn scores SUCCESS even when a later clause contains "redo/start over".
+# turn scores SUCCESS even when a later clause looks rework-shaped. (Bare rework
+# verbs "redo/start over/try again" no longer fire at all — see C1 note below —
+# so acceptance precedence now guards only genuine first-clause complaints.)
 # -----------------------------------------------------------------------------
 _REJECTION_PATTERNS = [
     r"that'?s (wrong|worse|broken|not (right|what i wanted))",
     r"this (is|isn'?t) (wrong|worse|broken|not (right|what i wanted))",
     r"\bnot what i (wanted|asked for)\b",
-    r"\b(redo|re-?do) (it|that|this)\b",
+    # NOTE: the STANDALONE rework arms `\b(redo|re-?do) (it|that|this)\b` and
+    # `\b(start over|try again)\b` were REMOVED (codex C1). Bare imperatives like
+    # "redo it for the other file", "start over on the README", "try again with a
+    # smaller batch size" are benign FOLLOW-UPS (apply same work elsewhere / new
+    # task / parameter change), NOT complaints about the just-completed route, so
+    # firing FAILURE on them decayed a route that SUCCEEDED — strictly worse than
+    # the proxy floor. Recall loss is the safe direction (asymmetric costs). Genuine
+    # complaints that happen to contain these verbs still fire via their COMPLAINT
+    # clause: "that's wrong, redo it" → `that's wrong`; "no, that's not what I asked
+    # for" → leading-no arm; "revert that, you broke the build" → `revert that` /
+    # `you broke`.
     # Complaint-anchored only: object must be it/that/this/your (the prior work),
     # NOT "the change" — that is a conditional/spec use ("roll back the change on
     # failure", "undo the change only if …"), excluded by the cue guard too.
     r"\b(revert|undo|roll ?back) (it|that|this|your)\b",
     r"\bthat (didn'?t|did not) work\b",
     r"\bthis (didn'?t|did not) work\b",
-    r"\b(start over|try again)\b",
     r"\byou (broke|messed up|got it wrong)\b",
     # Sole surviving re-route signal: anchored on the literal complaint "wrong".
     r"\bwrong (agent|skill|route|routing)\b",

--- a/hooks/routing-outcome-finalizer.py
+++ b/hooks/routing-outcome-finalizer.py
@@ -28,8 +28,21 @@ tunable. This is deliberately NOT full semantic judgment: it is a high-precision
 deterministic detector that errs toward success on ambiguity.
 
 Per-agent attribution is preserved: each pending entry carries its OWN tool
-``errors`` flag (recorded by action A). The user reaction is a session-level
-signal; combined per entry as ``errors OR rejection``.
+``errors`` flag (recorded by action A). The user reaction is a turn-level signal
+that can only be ATTRIBUTED when exactly ONE dispatch is pending this turn —
+/do Phase 4 fans out multiple agents per turn, and a single "that's wrong"
+cannot be pinned to one of N parallel siblings. So:
+
+  - single pending dispatch  => failure = ``errors OR rejection``
+  - >1 pending dispatches     => failure = ``errors`` per entry ONLY; the
+                                  turn-level reaction is IGNORED (it would
+                                  otherwise broadcast a decay across correct
+                                  siblings — the sibling-misattribution bug on
+                                  the reaction axis).
+
+This makes the parallel-fan-out case at-least-as-good as the old proxy (never
+worse): clean siblings default to success exactly as the deterministic floor
+did, while a genuine single-dispatch rejection is still captured.
 
 Design Principles:
 - SILENT (touches state/DB only; no context injection)
@@ -57,6 +70,19 @@ EVENT_NAME = "UserPromptSubmit"
 # Matched as whole-phrase / word-boundary regexes so a substring like the word
 # "wrong" inside an unrelated new request does NOT trip them (see the benign
 # "wrong" non-decay test). Tune by adding/removing entries here.
+#
+# CLAUSE-SCOPING (HIGH-2 precision): rejection/re-route markers are tested ONLY
+# against the FIRST clause of the prompt (split on `. ; \n`). The first clause is
+# the user's immediate reaction to the prior work; a later clause is new work,
+# not a complaint. So "thanks, that worked. redo it for the other file" or
+# "great, now start over on the README" score SUCCESS — the reaction clause is
+# acceptance/neutral; "redo it"/"start over" land in a SEPARATE clause that
+# describes the NEXT task. Greedy `.*` in re-route patterns is replaced with the
+# bounded `[^.;\n]{0,40}` so a reroute marker cannot span unrelated clauses.
+#
+# ACCEPTANCE PRECEDENCE: if an acceptance marker appears in the first clause, the
+# turn scores SUCCESS even when a later clause contains "redo/start over" (that's
+# new work, not a complaint about the prior route).
 # -----------------------------------------------------------------------------
 _REJECTION_PATTERNS = [
     r"that'?s (wrong|worse|broken|not (right|what i wanted))",
@@ -75,37 +101,64 @@ _REJECTION_PATTERNS = [
 
 # RE-ROUTE markers fire FAILURE too: the user redirects the SAME intent to a
 # different agent/skill/approach, i.e. the route was wrong. Distinct from a
-# brand-new unrelated request (which is neutral => success).
+# brand-new unrelated request (which is neutral => success). Bounded
+# `[^.;\n]{0,40}` (NOT greedy `.*`) keeps a marker from spanning unrelated clauses.
 _REROUTE_PATTERNS = [
     r"\b(use|try|switch to|route (this )?to) (a )?different (agent|skill|approach)\b",
     r"\bwrong (agent|skill|route|routing)\b",
     r"\bre-?route\b",
     r"\bthat'?s the wrong (agent|skill|approach)\b",
-    r"\b(should|shouldn'?t) (have )?(use|used|been) .*(agent|skill)\b",
+    r"\b(should|shouldn'?t) (have )?(use|used|been) [^.;\n]{0,40}(agent|skill)\b",
 ]
 
-# ACCEPTANCE markers are documented for clarity / future tuning, but they are NOT
-# required: acceptance and neutral both resolve to SUCCESS. They exist so the
-# classifier can be made stricter later without restructuring.
+# ACCEPTANCE markers: when one appears in the FIRST clause it takes precedence
+# over any later rejection-shaped clause (acceptance precedence). Word-boundary
+# anchored so a substring cannot trip them.
 _ACCEPTANCE_PATTERNS = [
-    r"\b(thanks|thank you|great|perfect|looks good|lgtm|nice work|well done)\b",
+    r"\b(thanks|thank you|thx|great|perfect|looks good|lgtm|nice work|well done|that worked)\b",
     r"\b(merge it|ship it|ship that|approve|approved)\b",
 ]
 
 _REJECTION_RE = re.compile("|".join(_REJECTION_PATTERNS), re.IGNORECASE)
 _REROUTE_RE = re.compile("|".join(_REROUTE_PATTERNS), re.IGNORECASE)
+_ACCEPTANCE_RE = re.compile("|".join(_ACCEPTANCE_PATTERNS), re.IGNORECASE)
+
+# Clause boundary: split on sentence/clause terminators so only the user's
+# immediate reaction (the first clause) is tested for rejection.
+_CLAUSE_SPLIT_RE = re.compile(r"[.;\n]")
+
+
+def _first_clause(prompt: str) -> str:
+    """The user's immediate reaction: text up to the first `. ; \\n` terminator.
+
+    Empty/whitespace leading clauses are skipped so a prompt that opens with a
+    bare terminator still yields the first substantive clause.
+    """
+    for part in _CLAUSE_SPLIT_RE.split(prompt):
+        if part.strip():
+            return part
+    return prompt
 
 
 def is_rejection(prompt: str) -> bool:
-    """High-precision: True only on a clear rejection / rework / re-route signal.
+    """High-precision: True only on a clear rejection / rework / re-route signal
+    in the user's IMMEDIATE reaction (the first clause).
 
+    Precision rules (HIGH-2):
+    - Clause-scoped: only the FIRST clause is tested. A rejection verb in a later
+      clause ("thanks. redo it for the other file") is NEW work, not a complaint.
+    - Acceptance precedence: an acceptance marker in the first clause => not a
+      rejection, even if a later clause looks rework-shaped.
     Conservative by design — ambiguous prompts (a NEW request that merely
-    contains the word "wrong") return False so the prior dispatch is not falsely
-    decayed. Returns False on empty / non-string input.
+    contains the word "wrong") return False. Returns False on empty / non-string
+    input.
     """
     if not prompt or not isinstance(prompt, str):
         return False
-    return bool(_REJECTION_RE.search(prompt) or _REROUTE_RE.search(prompt))
+    first = _first_clause(prompt)
+    if _ACCEPTANCE_RE.search(first):
+        return False  # acceptance precedence — later "redo" clauses are new work
+    return bool(_REJECTION_RE.search(first) or _REROUTE_RE.search(first))
 
 
 def main() -> None:
@@ -133,13 +186,36 @@ def main() -> None:
         # actually something to resolve.
         import time
 
+        from learning_db_v2 import init_db
         from routing_outcome_score import apply_outcome, decision_row_exists
-        from routing_outcome_state import MAX_PENDING_AGE_SEC, revalidate_pending_outcomes
+        from routing_outcome_state import (
+            MAX_PENDING_AGE_SEC,
+            requeue_pending_outcomes,
+            revalidate_pending_outcomes,
+        )
+
+        # LOW-1: init the schema ONCE per scoring block, not per key
+        # (decision_row_exists no longer calls init_db itself).
+        init_db()
+        now = time.time()
+
+        # HIGH-1: a turn-level rejection can only be ATTRIBUTED to a route when
+        # exactly ONE dispatch is pending resolution this turn. /do Phase 4 fans
+        # out multiple agents per turn; a single "that's wrong" cannot be pinned
+        # to one of N parallel siblings, so broadcasting it would re-decay
+        # correct routes (the sibling-misattribution bug on the reaction axis).
+        # Rule: when >1 dispatches are pending, IGNORE the turn-level reaction and
+        # resolve each entry by its OWN per-entry `errors` flag (an entry with
+        # tool errors still fails; a clean sibling defaults to success). The
+        # reaction is applied ONLY in the unambiguous single-dispatch case. Stale
+        # entries (dropped by the age check below) do not count toward the live
+        # pending population for this decision.
+        live = [it for it in pending if it.get("key") and (now - float(it.get("created", now))) <= MAX_PENDING_AGE_SEC]
+        attributable = len(live) == 1
 
         debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
-        now = time.time()
-        seen_keys: set[str] = set()
         to_revalidate: list[dict] = []
+        to_requeue: list[dict] = []
         for item in pending:
             key = item.get("key")
             if not key:
@@ -148,25 +224,39 @@ def main() -> None:
             created = float(item.get("created", now))
             if now - created > MAX_PENDING_AGE_SEC:
                 continue
-            # A row whose decision write is still not visible (rare at this
-            # point) is put back so a later resolver scores it — never dropped,
-            # never double-counted.
+            # MED-1: a pending entry whose decision row was NEVER written is an
+            # orphan — route it through the attempt-bounded requeue (increments
+            # attempts, dropped at MAX_REQUEUE_ATTEMPTS) so a never-written-row
+            # key cannot linger up to 24h. `revalidate` (preserves attempts) is
+            # reserved for entries whose row IS visible but aren't finalizable.
+            # At UserPromptSubmit every visible-row entry IS finalizable, so the
+            # only no-score path here is the orphan path => requeue.
             if not decision_row_exists(key):
-                to_revalidate.append(item)
+                to_requeue.append(item)
                 continue
-            # Per-agent attribution: THIS dispatch's own error flag, OR a
-            # session-level clear rejection => failure. Else success.
-            failure = bool(item.get("errors")) or rejected
+            # Per-entry attribution (HIGH-1): own error flag => failure. The
+            # turn-level rejection is OR'd in ONLY when it is attributable (a
+            # single pending dispatch this turn); with >1 pending it is ignored.
+            reaction_failure = rejected if attributable else False
+            failure = bool(item.get("errors")) or reaction_failure
             new_conf = apply_outcome(key, failure)
-            seen_keys.add(key)
             if debug:
                 outcome = "failure" if failure else "success"
-                reason = "tool-errors" if item.get("errors") else ("rejection" if rejected else "accepted/neutral")
+                if item.get("errors"):
+                    reason = "tool-errors"
+                elif reaction_failure:
+                    reason = "rejection"
+                elif rejected and not attributable:
+                    reason = "rejection-ignored-multi-dispatch"
+                else:
+                    reason = "accepted/neutral"
                 print(
                     f"[routing-outcome-finalizer] {outcome} routing/{key} ({reason}) conf={new_conf:.4f}",
                     file=sys.stderr,
                 )
 
+        if to_requeue:
+            requeue_pending_outcomes(session_id, to_requeue)
         if to_revalidate:
             revalidate_pending_outcomes(session_id, to_revalidate)
 

--- a/hooks/routing-outcome-finalizer.py
+++ b/hooks/routing-outcome-finalizer.py
@@ -65,50 +65,63 @@ EVENT_NAME = "UserPromptSubmit"
 # -----------------------------------------------------------------------------
 # Reaction marker sets (module-level constants — conservative + tunable).
 #
-# REJECTION markers fire FAILURE. Kept deliberately strong/unambiguous: each is
-# a phrase a user uses to reject or demand rework of the immediately-prior work.
-# Matched as whole-phrase / word-boundary regexes so a substring like the word
-# "wrong" inside an unrelated new request does NOT trip them (see the benign
-# "wrong" non-decay test). Tune by adding/removing entries here.
+# GOVERNING PRINCIPLE — ASYMMETRIC COSTS => NEAR-ZERO FALSE POSITIVES:
+# A MISSED rejection falls back to SUCCESS = the old proxy floor (never worse).
+# A FALSE rejection decays a route that actually WORKED = strictly worse than the
+# proxy. So the bar is near-zero false-positives; recall is secondary. When in
+# any doubt, classify SUCCESS. Only decay on an unambiguous complaint about the
+# just-completed work.
 #
-# CLAUSE-SCOPING (HIGH-2 precision): rejection/re-route markers are tested ONLY
-# against the FIRST clause of the prompt (split on `. ; \n`). The first clause is
-# the user's immediate reaction to the prior work; a later clause is new work,
-# not a complaint. So "thanks, that worked. redo it for the other file" or
-# "great, now start over on the README" score SUCCESS — the reaction clause is
-# acceptance/neutral; "redo it"/"start over" land in a SEPARATE clause that
-# describes the NEXT task. Greedy `.*` in re-route patterns is replaced with the
-# bounded `[^.;\n]{0,40}` so a reroute marker cannot span unrelated clauses.
+# PROSE RE-ROUTE DETECTION REMOVED (HIGH-2): the old `_REROUTE_PATTERNS` ("use a
+# different approach", "should have used … agent/skill", …) were the biggest
+# false-positive source — they fired on instructional/spec prose like "explain
+# when to use a different approach", "we should have used a cache, and document
+# the skill matrix", "try a different approach to memoization". Re-route is rare
+# and unreliable to detect from prose; capturing it is not worth poisoning
+# route-health. The ONLY surviving re-route signal is the complaint-anchored
+# literal "wrong agent/skill/route/routing" (it requires the word "wrong"), kept
+# inside the rejection set below.
+#
+# REJECTION markers fire FAILURE. Each is an unambiguous complaint about the
+# immediately-prior work, matched as whole-phrase / word-boundary regexes so a
+# substring (e.g. "wrong" inside an unrelated new request) does NOT trip them.
+# "revert/undo/roll back" require a complaint OBJECT (it|that|this|your) — never
+# the spec-shaped "the change" — so "undo the change only if the checksum fails"
+# / "roll back the change on failure" are NOT complaints.
+#
+# CLAUSE-SCOPING: rejection markers are tested ONLY against the FIRST clause of
+# the prompt (split on `, . ; \n`). The first clause is the user's immediate
+# reaction; a later clause is new work. So "thanks, that worked. redo it for the
+# other file" and "we should have used a cache, and document the skill matrix"
+# score SUCCESS.
+#
+# INSTRUCTIONAL/CONDITIONAL EXCLUSION: if the first clause carries an
+# instructional / conditional / explanatory cue — should, when, if, whether,
+# explain, document, how to, can you, try — the clause is a feature request or
+# spec, NOT a complaint, so it scores SUCCESS regardless of marker presence.
+# ("the migration should roll back the change on failure" is a requirement;
+# "document when to use a different agent" is a docs task.)
 #
 # ACCEPTANCE PRECEDENCE: if an acceptance marker appears in the first clause, the
-# turn scores SUCCESS even when a later clause contains "redo/start over" (that's
-# new work, not a complaint about the prior route).
+# turn scores SUCCESS even when a later clause contains "redo/start over".
 # -----------------------------------------------------------------------------
 _REJECTION_PATTERNS = [
     r"that'?s (wrong|worse|broken|not (right|what i wanted))",
     r"this (is|isn'?t) (wrong|worse|broken|not (right|what i wanted))",
     r"\bnot what i (wanted|asked for)\b",
     r"\b(redo|re-?do) (it|that|this)\b",
-    r"\b(revert|undo|roll ?back) (it|that|this|your|the (change|edit|commit))\b",
+    # Complaint-anchored only: object must be it/that/this/your (the prior work),
+    # NOT "the change" — that is a conditional/spec use ("roll back the change on
+    # failure", "undo the change only if …"), excluded by the cue guard too.
+    r"\b(revert|undo|roll ?back) (it|that|this|your)\b",
     r"\bthat (didn'?t|did not) work\b",
     r"\bthis (didn'?t|did not) work\b",
     r"\b(start over|try again)\b",
     r"\byou (broke|messed up|got it wrong)\b",
     r"\b(no,? that'?s|nope,? that'?s)\b",
-    r"\bwrong (agent|skill|approach|route|routing)\b",
-    r"\b(fix|undo) (your|the) (mistake|error|mess)\b",
-]
-
-# RE-ROUTE markers fire FAILURE too: the user redirects the SAME intent to a
-# different agent/skill/approach, i.e. the route was wrong. Distinct from a
-# brand-new unrelated request (which is neutral => success). Bounded
-# `[^.;\n]{0,40}` (NOT greedy `.*`) keeps a marker from spanning unrelated clauses.
-_REROUTE_PATTERNS = [
-    r"\b(use|try|switch to|route (this )?to) (a )?different (agent|skill|approach)\b",
+    # Sole surviving re-route signal: anchored on the literal complaint "wrong".
     r"\bwrong (agent|skill|route|routing)\b",
-    r"\bre-?route\b",
-    r"\bthat'?s the wrong (agent|skill|approach)\b",
-    r"\b(should|shouldn'?t) (have )?(use|used|been) [^.;\n]{0,40}(agent|skill)\b",
+    r"\b(fix|undo) (your|the) (mistake|error|mess)\b",
 ]
 
 # ACCEPTANCE markers: when one appears in the FIRST clause it takes precedence
@@ -119,13 +132,24 @@ _ACCEPTANCE_PATTERNS = [
     r"\b(merge it|ship it|ship that|approve|approved)\b",
 ]
 
-_REJECTION_RE = re.compile("|".join(_REJECTION_PATTERNS), re.IGNORECASE)
-_REROUTE_RE = re.compile("|".join(_REROUTE_PATTERNS), re.IGNORECASE)
-_ACCEPTANCE_RE = re.compile("|".join(_ACCEPTANCE_PATTERNS), re.IGNORECASE)
+# INSTRUCTIONAL / CONDITIONAL / EXPLANATORY cues. A first clause carrying any of
+# these describes a feature/spec/docs task or a conditional, NOT a complaint
+# about the prior work => SUCCESS. `if` is matched at a word boundary that also
+# allows a leading non-word char so "only if" / "if the" are caught.
+_INSTRUCTIONAL_CUE_PATTERNS = [
+    r"\b(should|when|whether|explain|document|how to|can you|try)\b",
+    r"(?:^|\W)if\b",
+]
 
-# Clause boundary: split on sentence/clause terminators so only the user's
-# immediate reaction (the first clause) is tested for rejection.
-_CLAUSE_SPLIT_RE = re.compile(r"[.;\n]")
+_REJECTION_RE = re.compile("|".join(_REJECTION_PATTERNS), re.IGNORECASE)
+_ACCEPTANCE_RE = re.compile("|".join(_ACCEPTANCE_PATTERNS), re.IGNORECASE)
+_INSTRUCTIONAL_CUE_RE = re.compile("|".join(_INSTRUCTIONAL_CUE_PATTERNS), re.IGNORECASE)
+
+# Clause boundary: split on sentence/clause terminators (incl. comma) so only the
+# user's immediate reaction (the first clause) is tested for rejection. The comma
+# split lets "we should have used a cache, and document …" surface its cue-laden
+# first clause and lets "revert that, you broke the build" test "revert that".
+_CLAUSE_SPLIT_RE = re.compile(r"[.,;\n]")
 
 
 def _first_clause(prompt: str) -> str:
@@ -141,24 +165,29 @@ def _first_clause(prompt: str) -> str:
 
 
 def is_rejection(prompt: str) -> bool:
-    """High-precision: True only on a clear rejection / rework / re-route signal
+    """High-precision: True only on an UNAMBIGUOUS complaint about the prior work
     in the user's IMMEDIATE reaction (the first clause).
 
-    Precision rules (HIGH-2):
-    - Clause-scoped: only the FIRST clause is tested. A rejection verb in a later
+    Precision rules (asymmetric-cost — near-zero false positives, recall second):
+    - Clause-scoped: only the FIRST clause is tested. A rework verb in a later
       clause ("thanks. redo it for the other file") is NEW work, not a complaint.
     - Acceptance precedence: an acceptance marker in the first clause => not a
       rejection, even if a later clause looks rework-shaped.
-    Conservative by design — ambiguous prompts (a NEW request that merely
-    contains the word "wrong") return False. Returns False on empty / non-string
-    input.
+    - Instructional/conditional exclusion: a first clause carrying should / when /
+      if / whether / explain / document / how to / can you / try is a feature
+      request, spec, or conditional ("should roll back on failure", "document when
+      to use a different agent") — NOT a complaint => not a rejection.
+    Conservative by design — when in any doubt, return False (=> SUCCESS), which
+    falls back to the old proxy floor. Returns False on empty / non-string input.
     """
     if not prompt or not isinstance(prompt, str):
         return False
     first = _first_clause(prompt)
     if _ACCEPTANCE_RE.search(first):
         return False  # acceptance precedence — later "redo" clauses are new work
-    return bool(_REJECTION_RE.search(first) or _REROUTE_RE.search(first))
+    if _INSTRUCTIONAL_CUE_RE.search(first):
+        return False  # instructional/conditional/spec clause — not a complaint
+    return bool(_REJECTION_RE.search(first))
 
 
 def main() -> None:
@@ -210,7 +239,21 @@ def main() -> None:
         # reaction is applied ONLY in the unambiguous single-dispatch case. Stale
         # entries (dropped by the age check below) do not count toward the live
         # pending population for this decision.
-        live = [it for it in pending if it.get("key") and (now - float(it.get("created", now))) <= MAX_PENDING_AGE_SEC]
+        #
+        # LOW: parse `created` defensively — a malformed entry must not abort the
+        # whole turn. `_created_or_none` returns None on a bad value; such an
+        # entry is excluded from `live` (not attributable) and skipped in the loop.
+        def _created_or_none(it: dict) -> float | None:
+            try:
+                return float(it.get("created", now))
+            except (TypeError, ValueError):
+                return None
+
+        live = [
+            it
+            for it in pending
+            if it.get("key") and (c := _created_or_none(it)) is not None and (now - c) <= MAX_PENDING_AGE_SEC
+        ]
         attributable = len(live) == 1
 
         debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
@@ -220,8 +263,13 @@ def main() -> None:
             key = item.get("key")
             if not key:
                 continue
+            # LOW: per-entry robustness — one malformed pending entry (e.g. a
+            # non-numeric `created`) must NOT abort scoring for the rest of the
+            # turn's entries. Parse defensively; skip only the bad entry.
+            created = _created_or_none(item)
+            if created is None:
+                continue
             # Drop abandoned provisional entries; never score a stale one.
-            created = float(item.get("created", now))
             if now - created > MAX_PENDING_AGE_SEC:
                 continue
             # MED-1: a pending entry whose decision row was NEVER written is an

--- a/hooks/routing-outcome-recorder.py
+++ b/hooks/routing-outcome-recorder.py
@@ -83,7 +83,12 @@ def main() -> None:
 
         # Lazy import of the shared scorer so a B run that drains nothing pays no
         # learning_db_v2 import cost.
+        from learning_db_v2 import init_db
         from routing_outcome_score import decision_row_exists
+
+        # LOW-1: decision_row_exists no longer self-inits; init the schema ONCE
+        # before the per-key loop so the keyed SELECT has a DB to open.
+        init_db()
 
         debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
         # HIGH (A-before-B): pending entries whose decision row is not yet

--- a/hooks/routing-outcome-recorder.py
+++ b/hooks/routing-outcome-recorder.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+SubagentStop Hook: Routing Outcome Recorder (action B, formerly /do Phase 5)
+
+Records whether each routing decision succeeded or failed, replacing the
+hand-run `learning-db.py record-routing-outcome ...` step from /do Phase 5.
+
+Ordering dependency (honored structurally): PostToolUse:Agent fires BEFORE
+SubagentStop, so the decision row written by routing-decision-recorder.py
+(action A) is already committed when this hook runs. A drops a per-session
+pending-outcome bridge entry (routing key + observed error flag); this hook
+drains it and applies the same confidence semantics the old CLI used:
+  - no errors / no re-route -> boost_confidence("routing", key, 0.05)  [success]
+  - errors detected         -> decay_confidence("routing", key, 0.08)  [failure]
+
+SubagentStop carries transcript_path; we scan it for additional tool-error
+evidence to refine the verdict beyond what A observed.
+
+----------------------------------------------------------------------------
+FIDELITY TRADEOFF (read before changing the verdict logic)
+
+A hook CANNOT observe what the old LLM Phase 5 could: "the user rejected the
+result," "the user asked for rework next turn," "the user accepted it." Those
+signals live in the NEXT user turn, which does not exist when SubagentStop
+fires. So this hook uses a DETERMINISTIC FLOOR:
+    success = no tool errors AND no re-route observed in this dispatch
+    failure = tool errors detected
+This is a strictly LOWER-FIDELITY proxy than the old LLM evaluation. It will
+miss silent-rejection failures (clean tool stream, user discards the work) and
+may score a recovered-from-error run as failure. Accepted deliberately: an
+automatic signal on every route beats a perfect signal skipped half the time.
+See adr/learn-step-to-hook.md.
+----------------------------------------------------------------------------
+
+Crash-safe on missing decision record: the old CLI exits 1 when no decision
+row exists for the key. boost_confidence/decay_confidence return 0.0 for a
+missing row instead of raising, so we treat 0.0 as "no decision row, skip" and
+never crash. (The hook exits 0 regardless, per the always-exit-0 contract.)
+
+Design Principles:
+- SILENT (records to DB, stderr only on debug)
+- Non-blocking (always exits 0)
+- Fast execution (<50ms target); lazy imports
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from routing_outcome_state import drain_pending_outcomes
+from stdin_timeout import read_stdin
+
+EVENT_NAME = "SubagentStop"
+
+# Tool-error indicators scanned in the subagent transcript.
+_ERROR_INDICATORS = (
+    "permission denied",
+    "no such file",
+    "command not found",
+    "traceback (most recent call last)",
+    "fatal:",
+    "syntaxerror",
+)
+
+
+def transcript_has_errors(transcript_path: str) -> bool:
+    """Best-effort scan of the subagent transcript for tool-error evidence."""
+    if not transcript_path:
+        return False
+    path = Path(transcript_path)
+    if not path.exists() or not path.is_file():
+        return False
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace").lower()
+    except OSError:
+        return False
+    return any(ind in content for ind in _ERROR_INDICATORS)
+
+
+def apply_outcome(key: str, failure: bool) -> float:
+    """Boost (success) or decay (failure) the routing row. Returns new confidence.
+
+    Returns 0.0 when no decision row exists for the key (boost/decay no-op),
+    which the caller treats as a skip — crash-safe replacement for the old
+    CLI's exit-1 behavior.
+    """
+    from learning_db_v2 import boost_confidence, decay_confidence
+
+    if failure:
+        return decay_confidence("routing", key, delta=0.08)
+    return boost_confidence("routing", key, delta=0.05)
+
+
+def main() -> None:
+    try:
+        raw = read_stdin(timeout=2)
+        if not raw:
+            return
+        event = json.loads(raw)
+
+        event_type = event.get("hook_event_name") or event.get("type", "")
+        if event_type and event_type != EVENT_NAME:
+            return
+
+        session_id = event.get("session_id") or ""
+        pending = drain_pending_outcomes(session_id)
+        if not pending:
+            return  # nothing to score
+
+        # Transcript-level error evidence applies to this subagent run.
+        transcript_errors = transcript_has_errors(event.get("transcript_path", ""))
+
+        debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
+        for item in pending:
+            key = item.get("key")
+            if not key:
+                continue
+            failure = bool(item.get("errors")) or transcript_errors
+            new_conf = apply_outcome(key, failure)
+            if new_conf == 0.0:
+                # No decision row for this key — skip, never crash.
+                if debug:
+                    print(
+                        f"[routing-outcome-recorder] no decision row for '{key}' — skipped",
+                        file=sys.stderr,
+                    )
+                continue
+            if debug:
+                outcome = "failure" if failure else "success"
+                print(
+                    f"[routing-outcome-recorder] {outcome} routing/{key} conf={new_conf:.4f}",
+                    file=sys.stderr,
+                )
+
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            print(f"[routing-outcome-recorder] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+    finally:
+        sys.exit(0)  # Never block
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/routing-outcome-recorder.py
+++ b/hooks/routing-outcome-recorder.py
@@ -1,64 +1,44 @@
 #!/usr/bin/env python3
 # hook-version: 1.0.0
 """
-SubagentStop Hook: Routing Outcome Recorder (action B, formerly /do Phase 5)
+SubagentStop Hook: Routing Outcome Validator (action B, formerly /do Phase 5)
 
-Records whether each routing decision succeeded or failed, replacing the
-hand-run `learning-db.py record-routing-outcome ...` step from /do Phase 5.
+VALIDATES each routing decision's pending outcome — it NO LONGER applies
+boost/decay. Scoring moved to the next-turn resolution point: UserPromptSubmit
+(routing-outcome-finalizer.py) finalizes from tool-errors + user reaction +
+re-route, with a Stop fallback for autonomous runs. See adr/learn-step-to-hook.md.
 
-Ordering dependency (HIGH, A-before-B): PostToolUse:Agent fires BEFORE
-SubagentStop, so the decision row written by routing-decision-recorder.py
-(action A) is NORMALLY committed when this hook runs. A drops a per-session
-pending-outcome bridge entry (routing key + observed error flag); this hook
-drains it and applies the same confidence semantics the old CLI used:
-  - no errors -> boost_confidence("routing", key, 0.05)  [success]
-  - errors    -> decay_confidence("routing", key, 0.08)  [failure]
-If a pending key is drained before its decision row is visible (mistiming), the
-entry is RE-QUEUED (bounded, requeue_pending_outcomes) so a late-landing row
-gets scored on a subsequent stop instead of being silently dropped.
+Why move scoring off SubagentStop: a hook firing at SubagentStop CANNOT observe
+"the user rejected the result / asked for rework / accepted it" — those signals
+live in the NEXT user turn, which does not exist yet here. Eagerly scoring
+success="no tool errors this dispatch" is a low-fidelity floor that misses
+silent-rejection failures. The pending entry is therefore left PROVISIONAL and
+resolved once, on the next turn, by the finalizer.
 
-Verdict source (HIGH, per-agent attribution): each pending entry carries its
-OWN ``errors`` flag, recorded by action A from THAT dispatch's structured tool
-result (hook_utils.is_tool_error). We score each key by its own flag. We do NOT
-scan the whole subagent transcript for substrings and OR that into every key's
-verdict — that broadcast (a) cross-attributes one agent's error onto sibling
-keys drained from the same session, and (b) false-positives on prose that
-merely mentions "permission denied"/"traceback". The structured per-agent flag
-is strictly more accurate, so the transcript substring scan was DROPPED. See
-adr/learn-step-to-hook.md (HIGH-2 attribution decision).
+What B still does (the A-before-B ordering guard is preserved):
 
-----------------------------------------------------------------------------
-FIDELITY TRADEOFF (read before changing the verdict logic)
+  - Drains the per-session pending list (atomic), and for each entry runs the
+    KEYED, no-row-cap decision-row existence check (decision_row_exists). A
+    prior top-1000 confidence-DESC scan dropped decayed rows once the table grew
+    past 1000 (data loss); the exact (topic, key, category) SELECT has no cap.
+  - Entries whose decision row is NOT yet visible (A-before-B mistiming) are
+    RE-QUEUED with attempts+1, bounded by MAX_REQUEUE_ATTEMPTS, so a late row
+    gets validated on a subsequent stop instead of being dropped.
+  - Entries whose decision row IS visible are REVALIDATED — put back pending
+    (without advancing the re-queue counter) so the next-turn finalizer can
+    resolve them. Stale entries (older than MAX_PENDING_AGE_SEC) are dropped.
 
-A hook CANNOT observe what the old LLM Phase 5 could: "the user rejected the
-result," "the user asked for rework next turn," "the user accepted it." Those
-signals live in the NEXT user turn, which does not exist when SubagentStop
-fires. So this hook uses a DETERMINISTIC FLOOR, scored PER AGENT from that
-dispatch's own recorded error flag:
-    success = no tool errors recorded for this dispatch
-    failure = tool errors recorded for this dispatch
-This is a strictly LOWER-FIDELITY proxy than the old LLM evaluation. It will
-miss silent-rejection failures (clean tool stream, user discards the work) and
-may score a recovered-from-error run as failure. Accepted deliberately: an
-automatic signal on every route beats a perfect signal skipped half the time.
-See adr/learn-step-to-hook.md.
-----------------------------------------------------------------------------
-
-Crash-safe on missing decision record: the old CLI exits 1 when no decision
-row exists for the key. boost_confidence/decay_confidence are no-ops on a
-missing row (they return 0.0), so we DON'T rely on the return value to tell
-"missing row" from "decayed to zero" — both are 0.0. Instead we run a KEYED
-row-existence pre-check (decision_row_exists) BEFORE calling boost/decay: no
-row => re-queue (bounded), never crash; row present => score it, even when its
-confidence is a legitimate 0.0. The pre-check is an exact (topic, key) lookup
-with NO row cap — a prior top-1000 confidence-DESC scan dropped decayed rows
-once the table grew past 1000 (data loss). The hook exits 0 regardless.
+Per-agent attribution (HIGH-2) is preserved end to end: each pending entry
+carries its OWN ``errors`` flag recorded by action A from THAT dispatch's
+structured tool result. No whole-transcript substring scan is performed (it
+cross-attributed one agent's error onto sibling keys and false-positived on
+prose). The finalizer scores each key by its own flag combined with the
+session-level user reaction.
 
 Design Principles:
-- SILENT (records to DB, stderr only on debug)
-- Non-blocking: every RUNTIME path after module load exits 0 (the finally:
-  sys.exit(0)). A failure at module-load time (import error) is not caught here
-  and is treated as non-blocking by the harness.
+- SILENT (touches state only, stderr only on debug)
+- Non-blocking: every RUNTIME path after module load exits 0 (finally:
+  sys.exit(0)).
 - Fast execution (<50ms target); lazy imports
 """
 
@@ -68,49 +48,14 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
-from routing_outcome_state import drain_pending_outcomes, requeue_pending_outcomes
+from routing_outcome_state import (
+    drain_pending_outcomes,
+    requeue_pending_outcomes,
+    revalidate_pending_outcomes,
+)
 from stdin_timeout import read_stdin
 
 EVENT_NAME = "SubagentStop"
-
-
-def decision_row_exists(key: str) -> bool:
-    """True iff a routing decision row was already written for ``key``.
-
-    KEYED existence check (CRITICAL fix). The old implementation paged the
-    routing/effectiveness slice via query_learnings(..., limit=1000), which
-    orders ``confidence DESC``. Once that table exceeds 1000 rows a decayed
-    (low-confidence) decision row falls outside the window, so this returned
-    False and the outcome was silently skipped — defeating the pre-check and
-    losing data. We now do an exact-key lookup with no row cap.
-
-    query_learnings has no key filter, so we run a direct READ-ONLY,
-    parameterized SELECT against the same learning.db (get_db_path), matching
-    the (topic, key) UNIQUE constraint action A writes on. We deliberately do
-    NOT edit learning_db_v2.py — only read its DB path + open a connection.
-    Category is included to match action A's exact write (always
-    'effectiveness'); topic+key alone is unique, so category only narrows.
-    """
-    from learning_db_v2 import get_db_path, init_db
-
-    try:
-        init_db()  # ensure schema/file exist before SELECT
-        import sqlite3
-
-        conn = sqlite3.connect(get_db_path(), timeout=5.0)
-        try:
-            row = conn.execute(
-                "SELECT 1 FROM learnings WHERE topic = ? AND key = ? AND category = ? LIMIT 1",
-                ("routing", key, "effectiveness"),
-            ).fetchone()
-            return row is not None
-        finally:
-            conn.close()
-    except Exception:
-        # Best-effort: on any read failure, treat as "exists unknown" => do not
-        # score (skip), never crash. The pending entry is re-queued by main()
-        # so a transient read failure does not lose the outcome.
-        return False
 
 
 def _max_requeue() -> int:
@@ -118,20 +63,6 @@ def _max_requeue() -> int:
     from routing_outcome_state import MAX_REQUEUE_ATTEMPTS
 
     return MAX_REQUEUE_ATTEMPTS
-
-
-def apply_outcome(key: str, failure: bool) -> float:
-    """Boost (success) or decay (failure) the routing row. Returns new confidence.
-
-    Caller MUST gate this on decision_row_exists(key): boost/decay are no-ops
-    on a missing row and return 0.0, indistinguishable from a legitimate
-    decayed-to-zero confidence.
-    """
-    from learning_db_v2 import boost_confidence, decay_confidence
-
-    if failure:
-        return decay_confidence("routing", key, delta=0.08)
-    return boost_confidence("routing", key, delta=0.05)
 
 
 def main() -> None:
@@ -148,20 +79,26 @@ def main() -> None:
         session_id = event.get("session_id") or ""
         pending = drain_pending_outcomes(session_id)
         if not pending:
-            return  # nothing to score
+            return  # nothing to validate
+
+        # Lazy import of the shared scorer so a B run that drains nothing pays no
+        # learning_db_v2 import cost.
+        from routing_outcome_score import decision_row_exists
 
         debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
         # HIGH (A-before-B): pending entries whose decision row is not yet
-        # visible are re-queued (bounded) so a late-landing row gets scored on a
-        # subsequent stop, rather than being dropped.
+        # visible are RE-QUEUED (attempts+1, bounded) so a late-landing row gets
+        # validated on a subsequent stop, rather than being dropped. Entries
+        # whose row IS visible are REVALIDATED — put back pending (no attempt
+        # advance) so the next-turn finalizer (UserPromptSubmit) / Stop fallback
+        # can resolve them. B does NOT apply boost/decay anymore.
         to_requeue: list[dict] = []
+        to_revalidate: list[dict] = []
         for item in pending:
             key = item.get("key")
             if not key:
                 continue
             if not decision_row_exists(key):
-                # Decision row not visible yet (ordering mistiming) OR a read
-                # failure. Re-queue (bounded) instead of dropping; never crash.
                 to_requeue.append(item)
                 if debug:
                     print(
@@ -170,19 +107,18 @@ def main() -> None:
                         file=sys.stderr,
                     )
                 continue
-            # Per-agent attribution (HIGH-2): score by THIS dispatch's own error
-            # flag only. No session-wide transcript scan broadcast across keys.
-            failure = bool(item.get("errors"))
-            new_conf = apply_outcome(key, failure)
+            # Decision row present: keep PROVISIONAL for next-turn resolution.
+            to_revalidate.append(item)
             if debug:
-                outcome = "failure" if failure else "success"
                 print(
-                    f"[routing-outcome-recorder] {outcome} routing/{key} conf={new_conf:.4f}",
+                    f"[routing-outcome-recorder] validated routing/{key} — pending next-turn resolution",
                     file=sys.stderr,
                 )
 
         if to_requeue:
             requeue_pending_outcomes(session_id, to_requeue)
+        if to_revalidate:
+            revalidate_pending_outcomes(session_id, to_revalidate)
 
     except Exception as e:
         if os.environ.get("CLAUDE_HOOKS_DEBUG"):

--- a/hooks/routing-outcome-recorder.py
+++ b/hooks/routing-outcome-recorder.py
@@ -34,9 +34,12 @@ See adr/learn-step-to-hook.md.
 ----------------------------------------------------------------------------
 
 Crash-safe on missing decision record: the old CLI exits 1 when no decision
-row exists for the key. boost_confidence/decay_confidence return 0.0 for a
-missing row instead of raising, so we treat 0.0 as "no decision row, skip" and
-never crash. (The hook exits 0 regardless, per the always-exit-0 contract.)
+row exists for the key. boost_confidence/decay_confidence are no-ops on a
+missing row (they return 0.0), so we DON'T rely on the return value to tell
+"missing row" from "decayed to zero" — both are 0.0. Instead we run a cheap
+row-existence pre-check (decision_row_exists) BEFORE calling boost/decay: no
+row => skip, never crash; row present => score it, even when its confidence is
+a legitimate 0.0. (The hook exits 0 regardless, per the always-exit-0 contract.)
 
 Design Principles:
 - SILENT (records to DB, stderr only on debug)
@@ -80,12 +83,34 @@ def transcript_has_errors(transcript_path: str) -> bool:
     return any(ind in content for ind in _ERROR_INDICATORS)
 
 
+def decision_row_exists(key: str) -> bool:
+    """True iff a routing decision row was already written for ``key``.
+
+    Row-existence pre-check that replaces the None-return sentinel: it lets the
+    caller distinguish "no decision row" (skip) from "row decayed to 0.0"
+    (score it) WITHOUT relying on boost/decay's return value, which is 0.0 in
+    both cases. Reads only the routing/effectiveness slice, including
+    test-source and graduated rows so the outcome path matches what action A
+    wrote.
+    """
+    from learning_db_v2 import query_learnings
+
+    rows = query_learnings(
+        topic="routing",
+        category="effectiveness",
+        exclude_graduated=False,
+        exclude_test_sources=False,
+        limit=1000,
+    )
+    return any(r.get("key") == key for r in rows)
+
+
 def apply_outcome(key: str, failure: bool) -> float:
     """Boost (success) or decay (failure) the routing row. Returns new confidence.
 
-    Returns 0.0 when no decision row exists for the key (boost/decay no-op),
-    which the caller treats as a skip — crash-safe replacement for the old
-    CLI's exit-1 behavior.
+    Caller MUST gate this on decision_row_exists(key): boost/decay are no-ops
+    on a missing row and return 0.0, indistinguishable from a legitimate
+    decayed-to-zero confidence.
     """
     from learning_db_v2 import boost_confidence, decay_confidence
 
@@ -118,16 +143,17 @@ def main() -> None:
             key = item.get("key")
             if not key:
                 continue
-            failure = bool(item.get("errors")) or transcript_errors
-            new_conf = apply_outcome(key, failure)
-            if new_conf == 0.0:
-                # No decision row for this key — skip, never crash.
+            if not decision_row_exists(key):
+                # No decision row for this key — skip, never crash. (Pre-check,
+                # not a 0.0-return sentinel: a row at confidence 0.0 still scores.)
                 if debug:
                     print(
                         f"[routing-outcome-recorder] no decision row for '{key}' — skipped",
                         file=sys.stderr,
                     )
                 continue
+            failure = bool(item.get("errors")) or transcript_errors
+            new_conf = apply_outcome(key, failure)
             if debug:
                 outcome = "failure" if failure else "success"
                 print(

--- a/hooks/routing-outcome-recorder.py
+++ b/hooks/routing-outcome-recorder.py
@@ -6,16 +6,26 @@ SubagentStop Hook: Routing Outcome Recorder (action B, formerly /do Phase 5)
 Records whether each routing decision succeeded or failed, replacing the
 hand-run `learning-db.py record-routing-outcome ...` step from /do Phase 5.
 
-Ordering dependency (honored structurally): PostToolUse:Agent fires BEFORE
+Ordering dependency (HIGH, A-before-B): PostToolUse:Agent fires BEFORE
 SubagentStop, so the decision row written by routing-decision-recorder.py
-(action A) is already committed when this hook runs. A drops a per-session
+(action A) is NORMALLY committed when this hook runs. A drops a per-session
 pending-outcome bridge entry (routing key + observed error flag); this hook
 drains it and applies the same confidence semantics the old CLI used:
-  - no errors / no re-route -> boost_confidence("routing", key, 0.05)  [success]
-  - errors detected         -> decay_confidence("routing", key, 0.08)  [failure]
+  - no errors -> boost_confidence("routing", key, 0.05)  [success]
+  - errors    -> decay_confidence("routing", key, 0.08)  [failure]
+If a pending key is drained before its decision row is visible (mistiming), the
+entry is RE-QUEUED (bounded, requeue_pending_outcomes) so a late-landing row
+gets scored on a subsequent stop instead of being silently dropped.
 
-SubagentStop carries transcript_path; we scan it for additional tool-error
-evidence to refine the verdict beyond what A observed.
+Verdict source (HIGH, per-agent attribution): each pending entry carries its
+OWN ``errors`` flag, recorded by action A from THAT dispatch's structured tool
+result (hook_utils.is_tool_error). We score each key by its own flag. We do NOT
+scan the whole subagent transcript for substrings and OR that into every key's
+verdict — that broadcast (a) cross-attributes one agent's error onto sibling
+keys drained from the same session, and (b) false-positives on prose that
+merely mentions "permission denied"/"traceback". The structured per-agent flag
+is strictly more accurate, so the transcript substring scan was DROPPED. See
+adr/learn-step-to-hook.md (HIGH-2 attribution decision).
 
 ----------------------------------------------------------------------------
 FIDELITY TRADEOFF (read before changing the verdict logic)
@@ -23,9 +33,10 @@ FIDELITY TRADEOFF (read before changing the verdict logic)
 A hook CANNOT observe what the old LLM Phase 5 could: "the user rejected the
 result," "the user asked for rework next turn," "the user accepted it." Those
 signals live in the NEXT user turn, which does not exist when SubagentStop
-fires. So this hook uses a DETERMINISTIC FLOOR:
-    success = no tool errors AND no re-route observed in this dispatch
-    failure = tool errors detected
+fires. So this hook uses a DETERMINISTIC FLOOR, scored PER AGENT from that
+dispatch's own recorded error flag:
+    success = no tool errors recorded for this dispatch
+    failure = tool errors recorded for this dispatch
 This is a strictly LOWER-FIDELITY proxy than the old LLM evaluation. It will
 miss silent-rejection failures (clean tool stream, user discards the work) and
 may score a recovered-from-error run as failure. Accepted deliberately: an
@@ -36,14 +47,18 @@ See adr/learn-step-to-hook.md.
 Crash-safe on missing decision record: the old CLI exits 1 when no decision
 row exists for the key. boost_confidence/decay_confidence are no-ops on a
 missing row (they return 0.0), so we DON'T rely on the return value to tell
-"missing row" from "decayed to zero" — both are 0.0. Instead we run a cheap
+"missing row" from "decayed to zero" — both are 0.0. Instead we run a KEYED
 row-existence pre-check (decision_row_exists) BEFORE calling boost/decay: no
-row => skip, never crash; row present => score it, even when its confidence is
-a legitimate 0.0. (The hook exits 0 regardless, per the always-exit-0 contract.)
+row => re-queue (bounded), never crash; row present => score it, even when its
+confidence is a legitimate 0.0. The pre-check is an exact (topic, key) lookup
+with NO row cap — a prior top-1000 confidence-DESC scan dropped decayed rows
+once the table grew past 1000 (data loss). The hook exits 0 regardless.
 
 Design Principles:
 - SILENT (records to DB, stderr only on debug)
-- Non-blocking (always exits 0)
+- Non-blocking: every RUNTIME path after module load exits 0 (the finally:
+  sys.exit(0)). A failure at module-load time (import error) is not caught here
+  and is treated as non-blocking by the harness.
 - Fast execution (<50ms target); lazy imports
 """
 
@@ -53,56 +68,56 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
-from routing_outcome_state import drain_pending_outcomes
+from routing_outcome_state import drain_pending_outcomes, requeue_pending_outcomes
 from stdin_timeout import read_stdin
 
 EVENT_NAME = "SubagentStop"
-
-# Tool-error indicators scanned in the subagent transcript.
-_ERROR_INDICATORS = (
-    "permission denied",
-    "no such file",
-    "command not found",
-    "traceback (most recent call last)",
-    "fatal:",
-    "syntaxerror",
-)
-
-
-def transcript_has_errors(transcript_path: str) -> bool:
-    """Best-effort scan of the subagent transcript for tool-error evidence."""
-    if not transcript_path:
-        return False
-    path = Path(transcript_path)
-    if not path.exists() or not path.is_file():
-        return False
-    try:
-        content = path.read_text(encoding="utf-8", errors="replace").lower()
-    except OSError:
-        return False
-    return any(ind in content for ind in _ERROR_INDICATORS)
 
 
 def decision_row_exists(key: str) -> bool:
     """True iff a routing decision row was already written for ``key``.
 
-    Row-existence pre-check that replaces the None-return sentinel: it lets the
-    caller distinguish "no decision row" (skip) from "row decayed to 0.0"
-    (score it) WITHOUT relying on boost/decay's return value, which is 0.0 in
-    both cases. Reads only the routing/effectiveness slice, including
-    test-source and graduated rows so the outcome path matches what action A
-    wrote.
-    """
-    from learning_db_v2 import query_learnings
+    KEYED existence check (CRITICAL fix). The old implementation paged the
+    routing/effectiveness slice via query_learnings(..., limit=1000), which
+    orders ``confidence DESC``. Once that table exceeds 1000 rows a decayed
+    (low-confidence) decision row falls outside the window, so this returned
+    False and the outcome was silently skipped — defeating the pre-check and
+    losing data. We now do an exact-key lookup with no row cap.
 
-    rows = query_learnings(
-        topic="routing",
-        category="effectiveness",
-        exclude_graduated=False,
-        exclude_test_sources=False,
-        limit=1000,
-    )
-    return any(r.get("key") == key for r in rows)
+    query_learnings has no key filter, so we run a direct READ-ONLY,
+    parameterized SELECT against the same learning.db (get_db_path), matching
+    the (topic, key) UNIQUE constraint action A writes on. We deliberately do
+    NOT edit learning_db_v2.py — only read its DB path + open a connection.
+    Category is included to match action A's exact write (always
+    'effectiveness'); topic+key alone is unique, so category only narrows.
+    """
+    from learning_db_v2 import get_db_path, init_db
+
+    try:
+        init_db()  # ensure schema/file exist before SELECT
+        import sqlite3
+
+        conn = sqlite3.connect(get_db_path(), timeout=5.0)
+        try:
+            row = conn.execute(
+                "SELECT 1 FROM learnings WHERE topic = ? AND key = ? AND category = ? LIMIT 1",
+                ("routing", key, "effectiveness"),
+            ).fetchone()
+            return row is not None
+        finally:
+            conn.close()
+    except Exception:
+        # Best-effort: on any read failure, treat as "exists unknown" => do not
+        # score (skip), never crash. The pending entry is re-queued by main()
+        # so a transient read failure does not lose the outcome.
+        return False
+
+
+def _max_requeue() -> int:
+    """Re-queue cap (for debug logging). Mirrors routing_outcome_state."""
+    from routing_outcome_state import MAX_REQUEUE_ATTEMPTS
+
+    return MAX_REQUEUE_ATTEMPTS
 
 
 def apply_outcome(key: str, failure: bool) -> float:
@@ -135,24 +150,29 @@ def main() -> None:
         if not pending:
             return  # nothing to score
 
-        # Transcript-level error evidence applies to this subagent run.
-        transcript_errors = transcript_has_errors(event.get("transcript_path", ""))
-
         debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
+        # HIGH (A-before-B): pending entries whose decision row is not yet
+        # visible are re-queued (bounded) so a late-landing row gets scored on a
+        # subsequent stop, rather than being dropped.
+        to_requeue: list[dict] = []
         for item in pending:
             key = item.get("key")
             if not key:
                 continue
             if not decision_row_exists(key):
-                # No decision row for this key — skip, never crash. (Pre-check,
-                # not a 0.0-return sentinel: a row at confidence 0.0 still scores.)
+                # Decision row not visible yet (ordering mistiming) OR a read
+                # failure. Re-queue (bounded) instead of dropping; never crash.
+                to_requeue.append(item)
                 if debug:
                     print(
-                        f"[routing-outcome-recorder] no decision row for '{key}' — skipped",
+                        f"[routing-outcome-recorder] no decision row for '{key}' — re-queued "
+                        f"(attempt {int(item.get('attempts', 0)) + 1}/{_max_requeue()})",
                         file=sys.stderr,
                     )
                 continue
-            failure = bool(item.get("errors")) or transcript_errors
+            # Per-agent attribution (HIGH-2): score by THIS dispatch's own error
+            # flag only. No session-wide transcript scan broadcast across keys.
+            failure = bool(item.get("errors"))
             new_conf = apply_outcome(key, failure)
             if debug:
                 outcome = "failure" if failure else "success"
@@ -160,6 +180,9 @@ def main() -> None:
                     f"[routing-outcome-recorder] {outcome} routing/{key} conf={new_conf:.4f}",
                     file=sys.stderr,
                 )
+
+        if to_requeue:
+            requeue_pending_outcomes(session_id, to_requeue)
 
     except Exception as e:
         if os.environ.get("CLAUDE_HOOKS_DEBUG"):

--- a/hooks/session-learning-recorder.py
+++ b/hooks/session-learning-recorder.py
@@ -59,6 +59,47 @@ def count_session_learnings(session_id: str) -> int:
         return row[0] if row else 0
 
 
+def finalize_routing_outcomes(session_id: str) -> None:
+    """Stop fallback: resolve any STILL-pending routed dispatches.
+
+    The next-turn finalizer (UserPromptSubmit, routing-outcome-finalizer.py)
+    resolves a dispatch's outcome from tool-errors + user reaction + re-route.
+    But an autonomous / headless run may end with NO next user prompt, leaving
+    its dispatches provisional forever. This fallback resolves whatever the
+    UserPromptSubmit finalizer did not, using the DETERMINISTIC FLOOR — this
+    dispatch's own ``errors`` flag alone (the old proxy): errors => decay, else
+    boost. It NEVER double-resolves: finalize_pending_outcomes atomically
+    read-and-clears, so anything UserPromptSubmit already scored (and cleared)
+    is simply absent here. Best-effort, silent, never raises.
+    """
+    try:
+        from routing_outcome_score import apply_outcome, decision_row_exists
+        from routing_outcome_state import (
+            MAX_PENDING_AGE_SEC,
+            finalize_pending_outcomes,
+        )
+
+        pending = finalize_pending_outcomes(session_id)
+        if not pending:
+            return
+        import time
+
+        now = time.time()
+        for item in pending:
+            key = item.get("key")
+            if not key:
+                continue
+            if now - float(item.get("created", now)) > MAX_PENDING_AGE_SEC:
+                continue  # drop abandoned provisional entry, do not score
+            if not decision_row_exists(key):
+                continue  # no row to score (orphaned); drop quietly at session end
+            # Deterministic floor: per-dispatch error flag only (no next turn).
+            apply_outcome(key, bool(item.get("errors")))
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            print(f"[session-learning-recorder] routing finalize error: {e}", file=sys.stderr)
+
+
 def is_substantive_session(event: dict) -> bool:
     """Determine if the session was substantive enough to warrant a gap check."""
     session_data = event.get("session_data", {})
@@ -85,6 +126,11 @@ def main():
 
         event = json.loads(event_data)
         session_id = event.get("session_id") or get_session_id()
+
+        # Stop fallback: resolve routed dispatches the next-turn finalizer never
+        # saw (autonomous / no-next-prompt runs). Runs BEFORE the trivial-session
+        # gate so an outcome is recorded even on otherwise-quiet sessions.
+        finalize_routing_outcomes(session_id)
 
         # Skip trivial sessions
         if not is_substantive_session(event):

--- a/hooks/session-learning-recorder.py
+++ b/hooks/session-learning-recorder.py
@@ -84,6 +84,9 @@ def finalize_routing_outcomes(session_id: str) -> None:
             return
         import time
 
+        # LOW-1: decision_row_exists no longer self-inits; ensure the schema
+        # exists once before the per-key existence checks below.
+        init_db()
         now = time.time()
         for item in pending:
             key = item.get("key")

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -3,11 +3,14 @@
 
 Covers:
 - A records the expected `routing` decision row from a synthetic PostToolUse:Agent event.
-- A discovers the skill from the dispatch prompt; falls back to agent-only key.
+- A reads agent + skill from the [do-route] marker; agent-only when skill=-.
+- A records ONLY /do-routed dispatches: marker present => recorded; marker
+  absent (reviewer sub-agent / nested fan-out) => skipped.
 - A records a rightsizing row when the banner is present (C), silent otherwise.
 - A is idempotent: the same dispatch is recorded once.
 - B records success (boost) / failure (decay) from drained pending outcomes.
-- B NEVER crashes when the decision record is absent.
+- B NEVER crashes when the decision record is absent (row-existence pre-check skip).
+- The A->B bridge state survives concurrent parallel appends (no lost outcomes).
 - Both hooks exit 0 on empty / malformed input.
 
 Uses a throwaway learning.db via CLAUDE_LEARNING_DIR and a per-session bridge
@@ -69,7 +72,26 @@ def _run_hook(path: Path, event: dict) -> subprocess.CompletedProcess:
     )
 
 
-def _agent_event(skill_prompt="", description="do work", output="ok", is_error=False, session="s1"):
+def _agent_event(
+    skill="",
+    *,
+    marker=True,
+    body="do work",
+    description="do work",
+    output="ok",
+    is_error=False,
+    session="s1",
+):
+    """Build a synthetic PostToolUse:Agent event.
+
+    marker=True stamps the [do-route] marker /do prepends to routed prompts
+    (the sole signal the recorder uses). marker=False simulates a sub-agent
+    fan-out (pr-review reviewer / nested dispatch) that carries no marker.
+    """
+    if marker:
+        prefix = f"[do-route] agent=python-general-engineer skill={skill or '-'} complexity=Medium\n"
+    else:
+        prefix = ""
     return {
         "hook_event_name": "PostToolUse",
         "tool_name": "Agent",
@@ -77,7 +99,7 @@ def _agent_event(skill_prompt="", description="do work", output="ok", is_error=F
         "tool_input": {
             "subagent_type": "python-general-engineer",
             "description": description,
-            "prompt": skill_prompt,
+            "prompt": prefix + body,
         },
         "tool_result": {"output": output, "is_error": is_error},
     }
@@ -107,7 +129,7 @@ class TestDecisionRecorder:
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
         monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
         monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
-        event = _agent_event(skill_prompt='Skill("test-driven-development")\nWrite tests.')
+        event = _agent_event(skill="test-driven-development", body="Write tests.")
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             a.main()
         rows = _query_routing(db_env)
@@ -121,11 +143,28 @@ class TestDecisionRecorder:
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
         monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
         monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
-        event = _agent_event(skill_prompt="Just do the thing, no skill named.")
+        # marker present with skill=- => agent-only key.
+        event = _agent_event(skill="", body="Just do the thing, no skill named.")
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             a.main()
         keys = {r["key"] for r in _query_routing(db_env)}
         assert "python-general-engineer:" in keys
+
+    def test_skipped_when_marker_absent(self, db_env, monkeypatch):
+        # Sub-agent fan-out (pr-review reviewer / nested dispatch) has no marker
+        # => not a /do routing decision => recorder records NOTHING.
+        a = _load(A_PATH, "rdr_a_nomarker")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
+        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        # A reviewer-style prompt that even names a skill the OLD sniffer would catch.
+        event = _agent_event(
+            marker=False,
+            body='Review this PR. Skill("systematic-code-review") load the security-review skill.',
+        )
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        assert _query_routing(db_env) == []
 
     def test_error_flag_when_result_errored(self, db_env, monkeypatch):
         a = _load(A_PATH, "rdr_a3")
@@ -133,7 +172,7 @@ class TestDecisionRecorder:
         monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
         monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
         event = _agent_event(
-            skill_prompt='Skill("go-patterns")',
+            skill="go-patterns",
             output="fatal: permission denied",
             is_error=True,
         )
@@ -148,7 +187,7 @@ class TestDecisionRecorder:
         monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
         monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
         event = _agent_event(
-            skill_prompt='Skill("systematic-code-review")',
+            skill="systematic-code-review",
             output="done. rightsizing: tier=3 files=15 packages=4 agents_dispatched=17",
         )
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
@@ -161,7 +200,7 @@ class TestDecisionRecorder:
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
         monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
         monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
-        event = _agent_event(skill_prompt='Skill("go-patterns")', output="plain output")
+        event = _agent_event(skill="go-patterns", output="plain output")
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             a.main()
         keys = {r["key"] for r in _query_routing(db_env)}
@@ -170,7 +209,7 @@ class TestDecisionRecorder:
     def test_idempotent_same_dispatch_recorded_once(self, db_env):
         # Use the real bridge state (redirected to tmp) so dedup engages.
         a = _load(A_PATH, "rdr_a6")
-        event = _agent_event(skill_prompt='Skill("go-patterns")', session="dup-session")
+        event = _agent_event(skill="go-patterns", session="dup-session")
         for _ in range(3):
             with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
                 a.main()
@@ -237,8 +276,37 @@ class TestOutcomeRecorder:
         assert after_row["confidence"] < before
         assert after_row["failure_count"] == 1
 
+    def test_decayed_to_zero_row_is_scored_not_skipped(self, db_env, monkeypatch):
+        # LOW 1: a row that legitimately reaches confidence 0.0 must still be
+        # scored (failure_count increments) — NOT mistaken for a missing row.
+        # The row-existence pre-check sees the row, so it is scored even though
+        # boost/decay return 0.0 (which a missing row would also return).
+        sys.path.insert(0, str(LIB_DIR))
+        import learning_db_v2 as ldb
+
+        key = "python-general-engineer:near-zero"
+        ldb.record_learning(
+            topic="routing",
+            key=key,
+            value=f"routing-decision: {key} tool_errors=0",
+            category="effectiveness",
+            source="test",
+        )
+        # Drive confidence to exactly 0.0 with a large decay.
+        assert ldb.decay_confidence("routing", key, delta=1.0) == 0.0
+        before = next(r for r in _query_routing(db_env) if r["key"] == key)["failure_count"]
+
+        b = _load(B_PATH, "ror_zero")
+        monkeypatch.setattr(b, "drain_pending_outcomes", lambda _sid: [{"key": key, "errors": True}])
+        event = {"hook_event_name": "SubagentStop", "session_id": "s1", "transcript_path": ""}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            b.main()
+        after = next(r for r in _query_routing(db_env) if r["key"] == key)
+        # Confidence already 0.0; the outcome is still applied => failure_count grows.
+        assert after["failure_count"] == before + 1
+
     def test_never_crashes_when_decision_record_absent(self, db_env, monkeypatch):
-        # No decision row seeded — boost/decay return 0.0, hook must skip cleanly.
+        # No decision row seeded — the row-existence pre-check skips cleanly.
         b = _load(B_PATH, "ror_b3")
         monkeypatch.setattr(
             b, "drain_pending_outcomes", lambda _sid: [{"key": "ghost-agent:ghost-skill", "errors": False}]
@@ -269,7 +337,7 @@ class TestEndToEndLoop:
         # Real bridge (tmp-redirected): A writes decision + pending; B drains and scores.
         a = _load(A_PATH, "rdr_e1")
         b = _load(B_PATH, "ror_e1")
-        event_a = _agent_event(skill_prompt='Skill("go-patterns")', session="loop-1")
+        event_a = _agent_event(skill="go-patterns", session="loop-1")
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event_a)):
             a.main()
         event_b = {"hook_event_name": "SubagentStop", "session_id": "loop-1", "transcript_path": ""}
@@ -279,3 +347,90 @@ class TestEndToEndLoop:
         decision = next(r for r in rows if r["key"] == "python-general-engineer:go-patterns")
         # Decision row exists AND has an outcome (success_count incremented) => loop closed.
         assert decision["success_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# HIGH 1 / MEDIUM 2 — A->B bridge concurrency: no lost outcomes under parallel append
+# ---------------------------------------------------------------------------
+
+# Source for a child process that appends ONE pending outcome under the shared
+# state dir (set via CLAUDE_ROUTING_STATE_DIR). Models a real parallel dispatch
+# writing through routing_outcome_state from a separate process.
+_PROC_APPEND_SRC = """
+import sys
+sys.path.insert(0, {lib!r})
+from routing_outcome_state import append_pending_outcome
+append_pending_outcome({session!r}, "agent:skill-" + sys.argv[1], False)
+"""
+
+
+class TestBridgeConcurrency:
+    def _drain(self, session, state_dir):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        # Point the module at the same dir the appenders used.
+        old = getattr(ros, "_STATE_DIR", None)
+        ros._STATE_DIR = Path(state_dir)
+        try:
+            return ros.drain_pending_outcomes(session)
+        finally:
+            if old is not None:
+                ros._STATE_DIR = old
+
+    def test_parallel_thread_appends_no_lost_outcomes(self, tmp_path, monkeypatch):
+        """N threads append concurrently to one session; the drain must see all N.
+
+        Without locking the read-modify-write races and the file ends up with
+        far fewer than N entries (lost-update). The flock serialization fixes it.
+        """
+        import threading
+
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        state_dir = tmp_path / "state"
+        monkeypatch.setattr(ros, "_STATE_DIR", state_dir)
+        session = "concurrent-threads"
+        n = 60
+
+        barrier = threading.Barrier(n)
+
+        def worker(i):
+            barrier.wait()  # maximize overlap of the read-modify-write windows
+            ros.append_pending_outcome(session, f"agent:skill-{i}", False)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        drained = ros.drain_pending_outcomes(session)
+        assert len(drained) == n, f"lost outcomes: drained {len(drained)} of {n}"
+        assert {d["key"] for d in drained} == {f"agent:skill-{i}" for i in range(n)}
+
+    def test_parallel_process_appends_no_lost_outcomes(self, tmp_path):
+        """N separate PROCESSES append concurrently; the drain must see all N.
+
+        Threads share the GIL; only multi-process exercises the cross-process
+        flock. Each child writes through routing_outcome_state independently.
+        """
+        import os as _os
+
+        state_dir = tmp_path / "state-proc"
+        state_dir.mkdir()
+        session = "concurrent-procs"
+        n = 25
+
+        env = dict(_os.environ)
+        env["CLAUDE_ROUTING_STATE_DIR"] = str(state_dir)
+        src = _PROC_APPEND_SRC.format(lib=str(LIB_DIR), session=session)
+
+        procs = [subprocess.Popen([sys.executable, "-c", src, str(i)], env=env) for i in range(n)]
+        for p in procs:
+            assert p.wait() == 0
+
+        drained = self._drain(session, state_dir)
+        assert len(drained) == n, f"lost outcomes: drained {len(drained)} of {n}"
+        assert {d["key"] for d in drained} == {f"agent:skill-{i}" for i in range(n)}

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -231,85 +231,67 @@ class TestDecisionRecorder:
 # ---------------------------------------------------------------------------
 
 
-class TestOutcomeRecorder:
-    def _seed_decision(self, key="python-general-engineer:go-patterns"):
+def _seed_decision(key="python-general-engineer:go-patterns"):
+    sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    ldb.record_learning(
+        topic="routing",
+        key=key,
+        value=f"routing-decision: {key} tool_errors=0 user_rerouted=0",
+        category="effectiveness",
+        source="test",
+    )
+    return key
+
+
+class TestOutcomeValidator:
+    """B (SubagentStop) NO LONGER scores. It validates the decision row exists
+    and keeps the entry PROVISIONAL (revalidated) for the next-turn finalizer;
+    late rows are re-queued. Confidence must NOT change at SubagentStop."""
+
+    def test_validated_entry_kept_pending_not_scored(self, db_env, monkeypatch):
         sys.path.insert(0, str(LIB_DIR))
-        import learning_db_v2 as ldb
+        import routing_outcome_state as ros
 
-        ldb.record_learning(
-            topic="routing",
-            key=key,
-            value=f"routing-decision: {key} tool_errors=0 user_rerouted=0",
-            category="effectiveness",
-            source="test",
-        )
-        return key
+        state_dir = db_env["state"]
+        monkeypatch.setattr(ros, "_STATE_DIR", state_dir)
+        session = "validate-1"
+        key = _seed_decision()
+        ros.append_pending_outcome(session, key, errors=False)
+        before = next(r for r in _query_routing(db_env) if r["key"] == key)
 
-    def test_success_boosts_confidence(self, db_env, monkeypatch):
-        key = self._seed_decision()
-        b = _load(B_PATH, "ror_b1")
-        monkeypatch.setattr(b, "drain_pending_outcomes", lambda _sid: [{"key": key, "errors": False}])
-        before = next(r for r in _query_routing(db_env) if r["key"] == key)["confidence"]
-        event = {"hook_event_name": "SubagentStop", "session_id": "s1", "transcript_path": ""}
+        b = _load(B_PATH, "ror_validate")
+        event = {"hook_event_name": "SubagentStop", "session_id": session}
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             b.main()
-        after_row = next(r for r in _query_routing(db_env) if r["key"] == key)
-        assert after_row["confidence"] > before
-        assert after_row["success_count"] == 1
 
-    def test_failure_decays_confidence(self, db_env, monkeypatch):
-        key = self._seed_decision("python-general-engineer:debug")
-        b = _load(B_PATH, "ror_b2")
-        monkeypatch.setattr(b, "drain_pending_outcomes", lambda _sid: [{"key": key, "errors": True}])
-        before = next(r for r in _query_routing(db_env) if r["key"] == key)["confidence"]
-        event = {"hook_event_name": "SubagentStop", "session_id": "s1", "transcript_path": ""}
-        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
-            b.main()
-        after_row = next(r for r in _query_routing(db_env) if r["key"] == key)
-        assert after_row["confidence"] < before
-        assert after_row["failure_count"] == 1
-
-    def test_decayed_to_zero_row_is_scored_not_skipped(self, db_env, monkeypatch):
-        # LOW 1: a row that legitimately reaches confidence 0.0 must still be
-        # scored (failure_count increments) — NOT mistaken for a missing row.
-        # The row-existence pre-check sees the row, so it is scored even though
-        # boost/decay return 0.0 (which a missing row would also return).
-        sys.path.insert(0, str(LIB_DIR))
-        import learning_db_v2 as ldb
-
-        key = "python-general-engineer:near-zero"
-        ldb.record_learning(
-            topic="routing",
-            key=key,
-            value=f"routing-decision: {key} tool_errors=0",
-            category="effectiveness",
-            source="test",
-        )
-        # Drive confidence to exactly 0.0 with a large decay.
-        assert ldb.decay_confidence("routing", key, delta=1.0) == 0.0
-        before = next(r for r in _query_routing(db_env) if r["key"] == key)["failure_count"]
-
-        b = _load(B_PATH, "ror_zero")
-        monkeypatch.setattr(b, "drain_pending_outcomes", lambda _sid: [{"key": key, "errors": True}])
-        event = {"hook_event_name": "SubagentStop", "session_id": "s1", "transcript_path": ""}
-        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
-            b.main()
         after = next(r for r in _query_routing(db_env) if r["key"] == key)
-        # Confidence already 0.0; the outcome is still applied => failure_count grows.
-        assert after["failure_count"] == before + 1
+        # No scoring at SubagentStop.
+        assert after["success_count"] == before["success_count"]
+        assert after["failure_count"] == before["failure_count"]
+        assert after["confidence"] == before["confidence"]
+        # Entry stayed pending (revalidated), attempts NOT advanced.
+        still = ros.peek_pending_outcomes(session)
+        assert len(still) == 1 and still[0]["key"] == key
+        assert still[0]["attempts"] == 0
 
-    def test_never_crashes_when_decision_record_absent(self, db_env, monkeypatch):
-        # No decision row seeded — the row-existence pre-check skips cleanly.
-        b = _load(B_PATH, "ror_b3")
-        monkeypatch.setattr(
-            b, "drain_pending_outcomes", lambda _sid: [{"key": "ghost-agent:ghost-skill", "errors": False}]
-        )
-        event = {"hook_event_name": "SubagentStop", "session_id": "s1", "transcript_path": ""}
-        with patch("sys.exit") as ex, patch("sys.stdin.read", return_value=json.dumps(event)):
+    def test_missing_row_requeued_with_attempt(self, db_env, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        session = "validate-late"
+        key = "python-general-engineer:no-row-yet"
+        ros.append_pending_outcome(session, key, errors=True)
+
+        b = _load(B_PATH, "ror_validate_late")
+        event = {"hook_event_name": "SubagentStop", "session_id": session}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             b.main()
-        # No row created, no exception raised.
-        assert all(r["key"] != "ghost-agent:ghost-skill" for r in _query_routing(db_env))
-        ex.assert_called_with(0)
+        still = ros.peek_pending_outcomes(session)
+        assert len(still) == 1
+        assert still[0]["attempts"] == 1  # re-queued, not revalidated
 
     def test_exit_zero_on_empty_and_malformed(self, db_env):
         assert _run_hook(B_PATH, {}).returncode == 0
@@ -321,24 +303,221 @@ class TestOutcomeRecorder:
 
 
 # ---------------------------------------------------------------------------
+# Finalizer (UserPromptSubmit) — next-turn resolution: reaction + error + re-route
+# ---------------------------------------------------------------------------
+
+F_PATH = HOOKS_DIR / "routing-outcome-finalizer.py"
+
+
+def _prompt_event(prompt, session="s1"):
+    return {"hook_event_name": "UserPromptSubmit", "session_id": session, "prompt": prompt}
+
+
+class TestFinalizer:
+    def _pend(self, ros, session, key, errors=False):
+        ros.append_pending_outcome(session, key, errors=errors)
+
+    def test_acceptance_boosts(self, db_env, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision()
+        self._pend(ros, "fin-acc", key, errors=False)
+        before = next(r for r in _query_routing(db_env) if r["key"] == key)["confidence"]
+
+        f = _load(F_PATH, "fin1")
+        ev = _prompt_event("looks good, merge it", session="fin-acc")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        after = next(r for r in _query_routing(db_env) if r["key"] == key)
+        assert after["success_count"] == 1
+        assert after["confidence"] > before
+
+    def test_neutral_new_topic_boosts(self, db_env, monkeypatch):
+        # No complaint = success, matching the old LLM's "user accepted" default.
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:neutral")
+        self._pend(ros, "fin-neu", key, errors=False)
+
+        f = _load(F_PATH, "fin2")
+        ev = _prompt_event("now add a CHANGELOG entry for the release", session="fin-neu")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        after = next(r for r in _query_routing(db_env) if r["key"] == key)
+        assert after["success_count"] == 1
+        assert after["failure_count"] == 0
+
+    def test_rejection_decays(self, db_env, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:rejected")
+        self._pend(ros, "fin-rej", key, errors=False)
+
+        f = _load(F_PATH, "fin3")
+        ev = _prompt_event("that's wrong, redo it", session="fin-rej")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        after = next(r for r in _query_routing(db_env) if r["key"] == key)
+        assert after["failure_count"] == 1
+        assert after["success_count"] == 0
+
+    def test_reroute_decays(self, db_env, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:rerouted")
+        self._pend(ros, "fin-rr", key, errors=False)
+
+        f = _load(F_PATH, "fin_rr")
+        ev = _prompt_event("wrong agent — use a different agent for this", session="fin-rr")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        after = next(r for r in _query_routing(db_env) if r["key"] == key)
+        assert after["failure_count"] == 1
+
+    def test_tool_error_fails_despite_positive_turn(self, db_env, monkeypatch):
+        # errors=True dispatch => failure even when the next turn is praise.
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:errored")
+        self._pend(ros, "fin-err", key, errors=True)
+
+        f = _load(F_PATH, "fin4")
+        ev = _prompt_event("thanks, looks great!", session="fin-err")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        after = next(r for r in _query_routing(db_env) if r["key"] == key)
+        assert after["failure_count"] == 1
+        assert after["success_count"] == 0
+
+    def test_benign_wrong_in_new_request_does_not_decay(self, db_env, monkeypatch):
+        # HIGH-PRECISION: a NEW unrelated request that merely contains the word
+        # "wrong" must NOT falsely decay the prior dispatch.
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:benign")
+        self._pend(ros, "fin-benign", key, errors=False)
+
+        f = _load(F_PATH, "fin5")
+        # "wrong" appears, but as part of a new feature request, not a rejection.
+        ev = _prompt_event(
+            "Add a unit test for the function that detects wrong-format input dates.",
+            session="fin-benign",
+        )
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        after = next(r for r in _query_routing(db_env) if r["key"] == key)
+        assert after["failure_count"] == 0, "benign 'wrong' falsely decayed the prior dispatch"
+        assert after["success_count"] == 1
+
+    def test_idempotent_double_prompt_scores_once(self, db_env, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:idem")
+        self._pend(ros, "fin-idem", key, errors=False)
+
+        ev = _prompt_event("looks good", session="fin-idem")
+        for i in range(3):  # re-delivered / duplicate prompts
+            f = _load(F_PATH, f"fin_idem_{i}")
+            with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+                f.main()
+        after = next(r for r in _query_routing(db_env) if r["key"] == key)
+        assert after["success_count"] == 1, "double prompt double-scored"
+
+    def test_missing_decision_row_revalidated_not_crashed(self, db_env, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        session = "fin-norow"
+        ros.append_pending_outcome(session, "ghost:skill", errors=False)
+
+        f = _load(F_PATH, "fin6")
+        ev = _prompt_event("ok next", session=session)
+        with patch("sys.exit") as ex, patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        ex.assert_called_with(0)
+        # Put back (revalidated) for a later resolver, not lost.
+        assert ros.peek_pending_outcomes(session)
+
+    def test_exit_zero_on_empty_and_malformed(self, db_env):
+        assert _run_hook(F_PATH, {}).returncode == 0
+        assert (
+            subprocess.run([sys.executable, str(F_PATH)], input="not json", capture_output=True, text=True).returncode
+            == 0
+        )
+        assert subprocess.run([sys.executable, str(F_PATH)], input="", capture_output=True, text=True).returncode == 0
+
+    def test_marker_unit_high_precision(self):
+        f = _load(F_PATH, "fin_unit")
+        # Clear rejections / re-routes => True.
+        for p in [
+            "that's wrong",
+            "that's worse",
+            "redo it",
+            "revert that",
+            "that didn't work",
+            "not what I wanted",
+            "wrong agent",
+            "use a different skill",
+        ]:
+            assert f.is_rejection(p) is True, p
+        # Benign / neutral / acceptance => False.
+        for p in [
+            "Add a test for wrong-format dates.",
+            "looks good, merge it",
+            "now write the docs",
+            "thanks!",
+            "",
+            None,
+        ]:
+            assert f.is_rejection(p) is False, p
+
+
+# ---------------------------------------------------------------------------
 # A + B integration: route-health closes the loop
 # ---------------------------------------------------------------------------
 
 
 class TestEndToEndLoop:
-    def test_decision_then_outcome_closes_loop(self, db_env):
-        # Real bridge (tmp-redirected): A writes decision + pending; B drains and scores.
+    def test_decision_validate_finalize_closes_loop(self, db_env, monkeypatch):
+        # Full path: A writes decision + pending; B validates (no score); the
+        # next-turn finalizer (UserPromptSubmit) scores once on user acceptance.
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
         a = _load(A_PATH, "rdr_e1")
         b = _load(B_PATH, "ror_e1")
-        event_a = _agent_event(skill="go-patterns", session="loop-1")
+        f = _load(HOOKS_DIR / "routing-outcome-finalizer.py", "fin_e1")
+        session = "loop-1"
+        event_a = _agent_event(skill="go-patterns", session=session)
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event_a)):
             a.main()
-        event_b = {"hook_event_name": "SubagentStop", "session_id": "loop-1", "transcript_path": ""}
+        # SubagentStop validates only — confidence unchanged here.
+        event_b = {"hook_event_name": "SubagentStop", "session_id": session}
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event_b)):
             b.main()
-        rows = _query_routing(db_env)
-        decision = next(r for r in rows if r["key"] == "python-general-engineer:go-patterns")
-        # Decision row exists AND has an outcome (success_count incremented) => loop closed.
+        mid = next(r for r in _query_routing(db_env) if r["key"] == "python-general-engineer:go-patterns")
+        assert mid["success_count"] == 0
+        # Next user turn (acceptance) finalizes => success.
+        event_f = {"hook_event_name": "UserPromptSubmit", "session_id": session, "prompt": "great, thanks"}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event_f)):
+            f.main()
+        decision = next(r for r in _query_routing(db_env) if r["key"] == "python-general-engineer:go-patterns")
         assert decision["success_count"] == 1
 
 
@@ -447,6 +626,7 @@ class TestDecisionRowExistsBeyondTop1000:
     def test_decayed_target_beyond_1000_rows_is_scored(self, db_env, monkeypatch):
         sys.path.insert(0, str(LIB_DIR))
         import learning_db_v2 as ldb
+        import routing_outcome_state as ros
 
         target = "python-general-engineer:rare-route"
         # Seed the target FIRST and decay it to a low confidence so it sorts
@@ -482,16 +662,20 @@ class TestDecisionRowExistsBeyondTop1000:
         )
         assert target not in {r["key"] for r in top1000}, "test premise broken: target still in top-1000"
 
-        # The hook's keyed existence check MUST still find it.
-        b = _load(B_PATH, "ror_keyed")
-        assert b.decision_row_exists(target) is True
+        # The shared scorer's keyed existence check MUST still find it.
+        import routing_outcome_score as score
 
-        # And the outcome is applied (failure_count increments) — not skipped.
+        assert score.decision_row_exists(target) is True
+
+        # And the finalizer applies the outcome (failure_count increments) —
+        # not skipped — even for a beyond-top-1000 decayed target.
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        ros.append_pending_outcome("beyond1000", target, errors=True)
         before = next(r for r in _query_routing_all(db_env) if r["key"] == target)["failure_count"]
-        monkeypatch.setattr(b, "drain_pending_outcomes", lambda _sid: [{"key": target, "errors": True}])
-        event = {"hook_event_name": "SubagentStop", "session_id": "s1"}
+        f = _load(HOOKS_DIR / "routing-outcome-finalizer.py", "fin_keyed")
+        event = {"hook_event_name": "UserPromptSubmit", "session_id": "beyond1000", "prompt": "ok next"}
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
-            b.main()
+            f.main()
         after = next(r for r in _query_routing_all(db_env) if r["key"] == target)["failure_count"]
         assert after == before + 1, "decayed beyond-top-1000 target was not scored"
 
@@ -528,7 +712,9 @@ class TestPerAgentAttribution:
     def test_sibling_key_not_decayed_by_other_agents_error(self, db_env, monkeypatch):
         sys.path.insert(0, str(LIB_DIR))
         import learning_db_v2 as ldb
+        import routing_outcome_state as ros
 
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
         good = "python-general-engineer:clean"
         bad = "golang-general-engineer:broken"
         for key in (good, bad):
@@ -541,17 +727,17 @@ class TestPerAgentAttribution:
             )
         good_before = next(r for r in _query_routing_all(db_env) if r["key"] == good)["confidence"]
 
-        b = _load(B_PATH, "ror_attrib")
-        # Two pending entries drained together: only `bad` carries errors=True.
-        monkeypatch.setattr(
-            b,
-            "drain_pending_outcomes",
-            lambda _sid: [{"key": good, "errors": False}, {"key": bad, "errors": True}],
-        )
-        # A transcript full of error prose must NOT influence the clean key.
-        event = {"hook_event_name": "SubagentStop", "session_id": "s1"}
+        # Two pending entries in the SAME session: only `bad` carries errors=True.
+        session = "attrib"
+        ros.append_pending_outcome(session, good, errors=False)
+        ros.append_pending_outcome(session, bad, errors=True)
+
+        # Neutral next turn (no rejection): good=success (own flag), bad=failure
+        # (own flag). The session-level reaction does NOT broadcast errors.
+        f = _load(HOOKS_DIR / "routing-outcome-finalizer.py", "fin_attrib")
+        event = {"hook_event_name": "UserPromptSubmit", "session_id": session, "prompt": "ok, next task"}
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
-            b.main()
+            f.main()
 
         good_after = next(r for r in _query_routing_all(db_env) if r["key"] == good)
         bad_after = next(r for r in _query_routing_all(db_env) if r["key"] == bad)
@@ -569,9 +755,10 @@ class TestPerAgentAttribution:
 
 
 class TestLateDecisionRowRequeue:
-    def test_missing_row_requeued_then_scored_on_next_stop(self, db_env, monkeypatch):
-        """B fires before A's decision row is visible => entry re-queued; once
-        the row lands, a subsequent SubagentStop scores it (no data loss)."""
+    def test_missing_row_requeued_then_finalized(self, db_env, monkeypatch):
+        """B fires before A's decision row is visible => entry re-queued. Once
+        the row lands, B revalidates it (still pending) and the next-turn
+        finalizer scores it (no data loss)."""
         sys.path.insert(0, str(LIB_DIR))
         import routing_outcome_state as ros
 
@@ -588,13 +775,11 @@ class TestLateDecisionRowRequeue:
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             b.main()
 
-        # Entry must be RE-QUEUED (attempts incremented), not dropped.
-        requeued = ros.drain_pending_outcomes(session)
-        assert len(requeued) == 1
-        assert requeued[0]["key"] == key
-        assert requeued[0]["attempts"] == 1
-        # Put it back for the next stop.
-        ros.requeue_pending_outcomes(session, [{"key": key, "errors": True, "attempts": 0}])
+        # Entry must be RE-QUEUED (attempts incremented), not dropped or scored.
+        still = ros.peek_pending_outcomes(session)
+        assert len(still) == 1
+        assert still[0]["key"] == key
+        assert still[0]["attempts"] == 1
 
         # Now the decision row lands (action A late).
         import learning_db_v2 as ldb
@@ -607,11 +792,20 @@ class TestLateDecisionRowRequeue:
             source="test",
         )
 
+        # Next SubagentStop revalidates (row now visible) — still no scoring.
         b2 = _load(B_PATH, "ror_late2")
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             b2.main()
+        row_mid = next(r for r in _query_routing_all(db_env) if r["key"] == key)
+        assert row_mid["failure_count"] == 0
+
+        # Next user turn finalizes: errors=True dispatch => failure.
+        f = _load(HOOKS_DIR / "routing-outcome-finalizer.py", "fin_late")
+        evf = {"hook_event_name": "UserPromptSubmit", "session_id": session, "prompt": "ok next"}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(evf)):
+            f.main()
         row = next(r for r in _query_routing_all(db_env) if r["key"] == key)
-        assert row["failure_count"] == 1, "late-landing decision row was not scored"
+        assert row["failure_count"] == 1, "late-landing decision row was not finalized"
 
     def test_requeue_is_bounded_and_drops_orphan(self, db_env, monkeypatch):
         """A pending key whose decision row never lands is dropped after
@@ -636,6 +830,73 @@ class TestLateDecisionRowRequeue:
         # After exceeding the cap, the orphan is gone from pending.
         remaining = ros.drain_pending_outcomes(session)
         assert remaining == [], f"orphan pending not dropped after cap: {remaining}"
+
+
+# ---------------------------------------------------------------------------
+# Stop fallback — autonomous / no-next-prompt runs resolve via error flag alone
+# ---------------------------------------------------------------------------
+
+STOP_PATH = HOOKS_DIR / "session-learning-recorder.py"
+
+
+class TestStopFallback:
+    def test_session_end_resolves_pending_via_error_flag(self, db_env, monkeypatch):
+        """No next user prompt: the Stop hook resolves still-pending dispatches
+        using each dispatch's own error flag (the deterministic floor)."""
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        ok = _seed_decision("python-general-engineer:auto-ok")
+        bad = _seed_decision("python-general-engineer:auto-bad")
+        session = "autorun"
+        ros.append_pending_outcome(session, ok, errors=False)
+        ros.append_pending_outcome(session, bad, errors=True)
+
+        s = _load(STOP_PATH, "stop1")
+        event = {"hook_event_name": "Stop", "session_id": session, "session_data": {"files_modified": ["x"]}}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            s.main()
+
+        ok_row = next(r for r in _query_routing_all(db_env) if r["key"] == ok)
+        bad_row = next(r for r in _query_routing_all(db_env) if r["key"] == bad)
+        assert ok_row["success_count"] == 1  # no error => boost
+        assert bad_row["failure_count"] == 1  # error => decay
+        # Pending cleared — nothing left to double-resolve.
+        assert ros.peek_pending_outcomes(session) == []
+
+    def test_stop_does_not_double_resolve_finalized(self, db_env, monkeypatch):
+        """A dispatch already finalized (and cleared) by UserPromptSubmit must
+        NOT be scored a second time at Stop."""
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:once")
+        session = "once-session"
+        ros.append_pending_outcome(session, key, errors=False)
+
+        # UserPromptSubmit finalizes (success) and clears pending.
+        f = _load(F_PATH, "fin_once")
+        evf = {"hook_event_name": "UserPromptSubmit", "session_id": session, "prompt": "thanks, great"}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(evf)):
+            f.main()
+        # Stop fallback runs afterwards — pending already empty => no second score.
+        s = _load(STOP_PATH, "stop2")
+        evs = {"hook_event_name": "Stop", "session_id": session, "session_data": {"files_modified": ["x"]}}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(evs)):
+            s.main()
+        row = next(r for r in _query_routing_all(db_env) if r["key"] == key)
+        assert row["success_count"] == 1, "Stop double-resolved a finalized dispatch"
+
+    def test_stop_exits_zero_on_malformed(self):
+        assert _run_hook(STOP_PATH, {}).returncode == 0
+        assert (
+            subprocess.run(
+                [sys.executable, str(STOP_PATH)], input="not json", capture_output=True, text=True
+            ).returncode
+            == 0
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -127,8 +127,7 @@ class TestDecisionRecorder:
     def test_records_decision_row_with_skill(self, db_env, monkeypatch):
         a = _load(A_PATH, "rdr_a1")
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
-        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
-        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
         event = _agent_event(skill="test-driven-development", body="Write tests.")
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             a.main()
@@ -141,8 +140,7 @@ class TestDecisionRecorder:
     def test_agent_only_key_when_no_skill(self, db_env, monkeypatch):
         a = _load(A_PATH, "rdr_a2")
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
-        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
-        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
         # marker present with skill=- => agent-only key.
         event = _agent_event(skill="", body="Just do the thing, no skill named.")
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
@@ -155,8 +153,7 @@ class TestDecisionRecorder:
         # => not a /do routing decision => recorder records NOTHING.
         a = _load(A_PATH, "rdr_a_nomarker")
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
-        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
-        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
         # A reviewer-style prompt that even names a skill the OLD sniffer would catch.
         event = _agent_event(
             marker=False,
@@ -169,8 +166,7 @@ class TestDecisionRecorder:
     def test_error_flag_when_result_errored(self, db_env, monkeypatch):
         a = _load(A_PATH, "rdr_a3")
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
-        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
-        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
         event = _agent_event(
             skill="go-patterns",
             output="fatal: permission denied",
@@ -184,8 +180,7 @@ class TestDecisionRecorder:
     def test_rightsizing_row_recorded(self, db_env, monkeypatch):
         a = _load(A_PATH, "rdr_a4")
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
-        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
-        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
         event = _agent_event(
             skill="systematic-code-review",
             output="done. rightsizing: tier=3 files=15 packages=4 agents_dispatched=17",
@@ -198,8 +193,7 @@ class TestDecisionRecorder:
     def test_no_rightsizing_row_when_banner_absent(self, db_env, monkeypatch):
         a = _load(A_PATH, "rdr_a5")
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
-        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
-        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
         event = _agent_event(skill="go-patterns", output="plain output")
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             a.main()
@@ -225,8 +219,7 @@ class TestDecisionRecorder:
     def test_non_agent_tool_ignored(self, db_env, monkeypatch):
         a = _load(A_PATH, "rdr_a7")
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
-        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
-        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
         event = {"hook_event_name": "PostToolUse", "tool_name": "Bash", "tool_input": {"command": "ls"}}
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             a.main()
@@ -434,3 +427,256 @@ class TestBridgeConcurrency:
         drained = self._drain(session, state_dir)
         assert len(drained) == n, f"lost outcomes: drained {len(drained)} of {n}"
         assert {d["key"] for d in drained} == {f"agent:skill-{i}" for i in range(n)}
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL — decision_row_exists keyed lookup survives a >1000-row table
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionRowExistsBeyondTop1000:
+    """A decayed target row beyond a confidence-DESC top-1000 window must still
+    be found by the KEYED existence check, so its outcome is still scored.
+
+    The old top-1000 query_learnings scan ordered confidence DESC; once the
+    routing/effectiveness table exceeded 1000 rows, a low-confidence target
+    fell out of the window => decision_row_exists False => outcome silently
+    skipped (data loss). The keyed SELECT has no row cap.
+    """
+
+    def test_decayed_target_beyond_1000_rows_is_scored(self, db_env, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import learning_db_v2 as ldb
+
+        target = "python-general-engineer:rare-route"
+        # Seed the target FIRST and decay it to a low confidence so it sorts
+        # LAST under confidence DESC.
+        ldb.record_learning(
+            topic="routing",
+            key=target,
+            value=f"routing-decision: {target} tool_errors=0",
+            category="effectiveness",
+            source="test",
+        )
+        ldb.decay_confidence("routing", target, delta=0.45)  # -> ~0.05, near floor
+
+        # Now flood the table with >1000 HIGH-confidence routing rows so the
+        # target is pushed past any top-1000 confidence-DESC window.
+        for i in range(1100):
+            ldb.record_learning(
+                topic="routing",
+                key=f"filler-agent:skill-{i}",
+                value=f"routing-decision: filler {i} tool_errors=0",
+                category="effectiveness",
+                confidence=0.95,
+                source="test",
+            )
+
+        # Sanity: the OLD top-1000 confidence-DESC scan would NOT see the target.
+        top1000 = ldb.query_learnings(
+            topic="routing",
+            category="effectiveness",
+            exclude_graduated=False,
+            exclude_test_sources=False,
+            limit=1000,
+        )
+        assert target not in {r["key"] for r in top1000}, "test premise broken: target still in top-1000"
+
+        # The hook's keyed existence check MUST still find it.
+        b = _load(B_PATH, "ror_keyed")
+        assert b.decision_row_exists(target) is True
+
+        # And the outcome is applied (failure_count increments) — not skipped.
+        before = next(r for r in _query_routing_all(db_env) if r["key"] == target)["failure_count"]
+        monkeypatch.setattr(b, "drain_pending_outcomes", lambda _sid: [{"key": target, "errors": True}])
+        event = {"hook_event_name": "SubagentStop", "session_id": "s1"}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            b.main()
+        after = next(r for r in _query_routing_all(db_env) if r["key"] == target)["failure_count"]
+        assert after == before + 1, "decayed beyond-top-1000 target was not scored"
+
+
+def _query_routing_all(db_env):
+    """Keyed-safe routing fetch for assertions: read every routing row directly
+    (no confidence-DESC top-N cap) so a decayed target is always visible."""
+    sys.path.insert(0, str(LIB_DIR))
+    import sqlite3
+
+    import learning_db_v2 as ldb
+
+    ldb.init_db()
+    conn = sqlite3.connect(ldb.get_db_path())
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute("SELECT * FROM learnings WHERE topic = 'routing'").fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# HIGH-2 — per-agent attribution: one key's error must NOT decay a sibling
+# ---------------------------------------------------------------------------
+
+
+class TestPerAgentAttribution:
+    """Each pending entry is scored by its OWN errors flag. A failing agent in
+    the same session/transcript must not broadcast failure onto a clean
+    sibling key (the dropped whole-transcript substring scan used to do this).
+    """
+
+    def test_sibling_key_not_decayed_by_other_agents_error(self, db_env, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import learning_db_v2 as ldb
+
+        good = "python-general-engineer:clean"
+        bad = "golang-general-engineer:broken"
+        for key in (good, bad):
+            ldb.record_learning(
+                topic="routing",
+                key=key,
+                value=f"routing-decision: {key} tool_errors=0",
+                category="effectiveness",
+                source="test",
+            )
+        good_before = next(r for r in _query_routing_all(db_env) if r["key"] == good)["confidence"]
+
+        b = _load(B_PATH, "ror_attrib")
+        # Two pending entries drained together: only `bad` carries errors=True.
+        monkeypatch.setattr(
+            b,
+            "drain_pending_outcomes",
+            lambda _sid: [{"key": good, "errors": False}, {"key": bad, "errors": True}],
+        )
+        # A transcript full of error prose must NOT influence the clean key.
+        event = {"hook_event_name": "SubagentStop", "session_id": "s1"}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            b.main()
+
+        good_after = next(r for r in _query_routing_all(db_env) if r["key"] == good)
+        bad_after = next(r for r in _query_routing_all(db_env) if r["key"] == bad)
+        # Clean key boosted (success), NOT decayed by the sibling's error.
+        assert good_after["success_count"] == 1
+        assert good_after["failure_count"] == 0
+        assert good_after["confidence"] > good_before
+        # Failing key decayed on its own flag.
+        assert bad_after["failure_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# HIGH-3 — late decision row is re-queued (bounded), not dropped
+# ---------------------------------------------------------------------------
+
+
+class TestLateDecisionRowRequeue:
+    def test_missing_row_requeued_then_scored_on_next_stop(self, db_env, monkeypatch):
+        """B fires before A's decision row is visible => entry re-queued; once
+        the row lands, a subsequent SubagentStop scores it (no data loss)."""
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        state_dir = db_env["state"]
+        monkeypatch.setattr(ros, "_STATE_DIR", state_dir)
+        session = "late-row"
+        key = "python-general-engineer:late"
+
+        # Pending exists but NO decision row yet.
+        ros.append_pending_outcome(session, key, errors=True)
+
+        b = _load(B_PATH, "ror_late1")
+        event = {"hook_event_name": "SubagentStop", "session_id": session}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            b.main()
+
+        # Entry must be RE-QUEUED (attempts incremented), not dropped.
+        requeued = ros.drain_pending_outcomes(session)
+        assert len(requeued) == 1
+        assert requeued[0]["key"] == key
+        assert requeued[0]["attempts"] == 1
+        # Put it back for the next stop.
+        ros.requeue_pending_outcomes(session, [{"key": key, "errors": True, "attempts": 0}])
+
+        # Now the decision row lands (action A late).
+        import learning_db_v2 as ldb
+
+        ldb.record_learning(
+            topic="routing",
+            key=key,
+            value=f"routing-decision: {key} tool_errors=1",
+            category="effectiveness",
+            source="test",
+        )
+
+        b2 = _load(B_PATH, "ror_late2")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            b2.main()
+        row = next(r for r in _query_routing_all(db_env) if r["key"] == key)
+        assert row["failure_count"] == 1, "late-landing decision row was not scored"
+
+    def test_requeue_is_bounded_and_drops_orphan(self, db_env, monkeypatch):
+        """A pending key whose decision row never lands is dropped after
+        MAX_REQUEUE_ATTEMPTS so the pending list cannot grow unbounded."""
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        state_dir = db_env["state"]
+        monkeypatch.setattr(ros, "_STATE_DIR", state_dir)
+        session = "orphan"
+        key = "ghost-agent:ghost-skill"
+        ros.append_pending_outcome(session, key, errors=False)
+
+        event = {"hook_event_name": "SubagentStop", "session_id": session}
+        # Drain repeatedly; the decision row never exists. Each stop re-queues
+        # with attempts+1 until the cap is exceeded, then the entry is dropped.
+        for i in range(ros.MAX_REQUEUE_ATTEMPTS + 2):
+            b = _load(B_PATH, f"ror_orphan_{i}")
+            with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+                b.main()
+
+        # After exceeding the cap, the orphan is gone from pending.
+        remaining = ros.drain_pending_outcomes(session)
+        assert remaining == [], f"orphan pending not dropped after cap: {remaining}"
+
+
+# ---------------------------------------------------------------------------
+# MEDIUM — claim_dispatch atomicity: N concurrent identical deliveries -> once
+# ---------------------------------------------------------------------------
+
+_PROC_CLAIM_SRC = """
+import sys
+sys.path.insert(0, {lib!r})
+from routing_outcome_state import claim_dispatch
+won = claim_dispatch({session!r}, {sig!r})
+sys.exit(0 if won else 3)  # exit 0 == this proc claimed (won)
+"""
+
+
+class TestClaimDispatchAtomicity:
+    def test_concurrent_identical_claims_record_once(self, tmp_path):
+        """N separate processes claim the SAME signature concurrently; exactly
+        one must win (return True). The old split read+write let several win =>
+        double-record/double-score. claim_dispatch is one locked check-and-set.
+        """
+        import os as _os
+
+        state_dir = tmp_path / "state-claim"
+        state_dir.mkdir()
+        session = "claim-session"
+        sig = "deadbeefcafef00d"
+        n = 30
+
+        env = dict(_os.environ)
+        env["CLAUDE_ROUTING_STATE_DIR"] = str(state_dir)
+        src = _PROC_CLAIM_SRC.format(lib=str(LIB_DIR), session=session, sig=sig)
+
+        procs = [subprocess.Popen([sys.executable, "-c", src], env=env) for _ in range(n)]
+        winners = sum(1 for p in procs if p.wait() == 0)
+        assert winners == 1, f"expected exactly one claimer, got {winners}"
+
+    def test_claim_then_reclaim_same_signature_is_false(self, tmp_path, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", tmp_path / "state")
+        assert ros.claim_dispatch("s", "sig-1") is True
+        assert ros.claim_dispatch("s", "sig-1") is False

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -503,7 +503,6 @@ class TestFinalizer:
         for p in [
             "that's wrong",
             "that's worse",
-            "redo it",
             "revert that",
             "that didn't work",
             "not what I wanted",
@@ -511,13 +510,21 @@ class TestFinalizer:
             "wrong skill",
         ]:
             assert f.is_rejection(p) is True, p
-        # Benign / neutral / acceptance / instructional => False.
+        # Benign / neutral / acceptance / instructional => False. The STANDALONE
+        # rework arms (redo it/that/this, start over, try again) were removed
+        # (codex C1): a bare rework imperative is a benign follow-up (new task /
+        # apply-elsewhere / parameter change), NOT a complaint about the prior
+        # route, so it must score SUCCESS. Genuine complaints carrying these verbs
+        # still fire via their complaint clause (covered above + in NAMED_GENUINE).
         for p in [
             "Add a test for wrong-format dates.",
             "looks good, merge it",
             "now write the docs",
             "thanks!",
             "use a different skill",  # bare re-route prose — no complaint anchor
+            "redo it",  # bare rework imperative — benign follow-up (C1)
+            "start over",  # bare rework imperative — benign follow-up (C1)
+            "try again",  # bare rework imperative — benign follow-up (C1)
             "",
             None,
         ]:
@@ -1135,6 +1142,16 @@ class TestRejectionPrecision:
         "there is no cache here, document it",
         "undo is hard here; explain how to revert a squashed merge",
         "the rollback procedure didn't work in staging, document it",
+        # codex C1: BARE rework imperatives are benign follow-ups, not complaints
+        # about the just-completed route (apply-elsewhere / new task / parameter
+        # change). The standalone redo/start-over/try-again arms were removed, so
+        # these must classify SUCCESS — decaying them violates "never worse than
+        # the proxy" in the common single-dispatch path.
+        "redo it for the other file",
+        "start over on the README",
+        "try again with a smaller batch size",
+        "redo the diagram so it matches",
+        "start over with a cleaner schema",
     ]
     # Genuine complaints the review named as must-still-FAIL.
     NAMED_GENUINE: ClassVar = [

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Tests for the routing-decision-recorder (A) and routing-outcome-recorder (B) hooks.
+
+Covers:
+- A records the expected `routing` decision row from a synthetic PostToolUse:Agent event.
+- A discovers the skill from the dispatch prompt; falls back to agent-only key.
+- A records a rightsizing row when the banner is present (C), silent otherwise.
+- A is idempotent: the same dispatch is recorded once.
+- B records success (boost) / failure (decay) from drained pending outcomes.
+- B NEVER crashes when the decision record is absent.
+- Both hooks exit 0 on empty / malformed input.
+
+Uses a throwaway learning.db via CLAUDE_LEARNING_DIR and a per-session bridge
+file under tmp_path — never the real DB.
+
+Run with: python3 -m pytest hooks/tests/test_routing_decision_recorder.py -v
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parent.parent
+LIB_DIR = HOOKS_DIR / "lib"
+A_PATH = HOOKS_DIR / "routing-decision-recorder.py"
+B_PATH = HOOKS_DIR / "routing-outcome-recorder.py"
+
+
+@pytest.fixture()
+def db_env(tmp_path, monkeypatch):
+    """Point the learning DB and the bridge state dir at a throwaway location."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    sys.path.insert(0, str(LIB_DIR))
+    # Force a fresh DB init against this tmp dir: learning_db_v2 caches
+    # _initialized as a module global across in-process tests.
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    # Redirect the bridge state dir away from /tmp into tmp_path.
+    import routing_outcome_state as ros
+
+    monkeypatch.setattr(ros, "_STATE_DIR", tmp_path / "state")
+    yield {"db_dir": db_dir, "state": tmp_path / "state"}
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    with patch("sys.exit"):
+        spec.loader.exec_module(mod)
+    return mod
+
+
+def _run_hook(path: Path, event: dict) -> subprocess.CompletedProcess:
+    """Run a hook as a subprocess feeding the event on stdin. Returns the result."""
+    return subprocess.run(
+        [sys.executable, str(path)],
+        input=json.dumps(event),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _agent_event(skill_prompt="", description="do work", output="ok", is_error=False, session="s1"):
+    return {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Agent",
+        "session_id": session,
+        "tool_input": {
+            "subagent_type": "python-general-engineer",
+            "description": description,
+            "prompt": skill_prompt,
+        },
+        "tool_result": {"output": output, "is_error": is_error},
+    }
+
+
+def _query_routing(db_env):
+    sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    return ldb.query_learnings(
+        topic="routing",
+        category="effectiveness",
+        exclude_graduated=False,
+        exclude_test_sources=False,
+        limit=1000,
+    )
+
+
+# ---------------------------------------------------------------------------
+# A — routing-decision-recorder
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionRecorder:
+    def test_records_decision_row_with_skill(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_a1")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
+        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        event = _agent_event(skill_prompt='Skill("test-driven-development")\nWrite tests.')
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        rows = _query_routing(db_env)
+        keys = {r["key"] for r in rows}
+        assert "python-general-engineer:test-driven-development" in keys
+        row = next(r for r in rows if r["key"] == "python-general-engineer:test-driven-development")
+        assert "tool_errors=0" in row["value"]
+
+    def test_agent_only_key_when_no_skill(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_a2")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
+        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        event = _agent_event(skill_prompt="Just do the thing, no skill named.")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        keys = {r["key"] for r in _query_routing(db_env)}
+        assert "python-general-engineer:" in keys
+
+    def test_error_flag_when_result_errored(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_a3")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
+        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        event = _agent_event(
+            skill_prompt='Skill("go-patterns")',
+            output="fatal: permission denied",
+            is_error=True,
+        )
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        row = next(r for r in _query_routing(db_env) if r["key"] == "python-general-engineer:go-patterns")
+        assert "tool_errors=1" in row["value"]
+
+    def test_rightsizing_row_recorded(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_a4")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
+        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        event = _agent_event(
+            skill_prompt='Skill("systematic-code-review")',
+            output="done. rightsizing: tier=3 files=15 packages=4 agents_dispatched=17",
+        )
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        keys = {r["key"] for r in _query_routing(db_env)}
+        assert "rightsizing:tier3" in keys
+
+    def test_no_rightsizing_row_when_banner_absent(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_a5")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
+        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        event = _agent_event(skill_prompt='Skill("go-patterns")', output="plain output")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        keys = {r["key"] for r in _query_routing(db_env)}
+        assert not any(k.startswith("rightsizing:") for k in keys)
+
+    def test_idempotent_same_dispatch_recorded_once(self, db_env):
+        # Use the real bridge state (redirected to tmp) so dedup engages.
+        a = _load(A_PATH, "rdr_a6")
+        event = _agent_event(skill_prompt='Skill("go-patterns")', session="dup-session")
+        for _ in range(3):
+            with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+                a.main()
+        row = next(r for r in _query_routing(db_env) if r["key"] == "python-general-engineer:go-patterns")
+        assert row["observation_count"] == 1
+
+    def test_exit_zero_on_empty_and_malformed(self, db_env):
+        assert _run_hook(A_PATH, {}).returncode == 0
+        p = subprocess.run([sys.executable, str(A_PATH)], input="not json", capture_output=True, text=True)
+        assert p.returncode == 0
+        assert subprocess.run([sys.executable, str(A_PATH)], input="", capture_output=True, text=True).returncode == 0
+
+    def test_non_agent_tool_ignored(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_a7")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "dispatch_seen", lambda *_a, **_k: False)
+        monkeypatch.setattr(a, "mark_dispatch_seen", lambda *_a, **_k: None)
+        event = {"hook_event_name": "PostToolUse", "tool_name": "Bash", "tool_input": {"command": "ls"}}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        assert _query_routing(db_env) == []
+
+
+# ---------------------------------------------------------------------------
+# B — routing-outcome-recorder
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeRecorder:
+    def _seed_decision(self, key="python-general-engineer:go-patterns"):
+        sys.path.insert(0, str(LIB_DIR))
+        import learning_db_v2 as ldb
+
+        ldb.record_learning(
+            topic="routing",
+            key=key,
+            value=f"routing-decision: {key} tool_errors=0 user_rerouted=0",
+            category="effectiveness",
+            source="test",
+        )
+        return key
+
+    def test_success_boosts_confidence(self, db_env, monkeypatch):
+        key = self._seed_decision()
+        b = _load(B_PATH, "ror_b1")
+        monkeypatch.setattr(b, "drain_pending_outcomes", lambda _sid: [{"key": key, "errors": False}])
+        before = next(r for r in _query_routing(db_env) if r["key"] == key)["confidence"]
+        event = {"hook_event_name": "SubagentStop", "session_id": "s1", "transcript_path": ""}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            b.main()
+        after_row = next(r for r in _query_routing(db_env) if r["key"] == key)
+        assert after_row["confidence"] > before
+        assert after_row["success_count"] == 1
+
+    def test_failure_decays_confidence(self, db_env, monkeypatch):
+        key = self._seed_decision("python-general-engineer:debug")
+        b = _load(B_PATH, "ror_b2")
+        monkeypatch.setattr(b, "drain_pending_outcomes", lambda _sid: [{"key": key, "errors": True}])
+        before = next(r for r in _query_routing(db_env) if r["key"] == key)["confidence"]
+        event = {"hook_event_name": "SubagentStop", "session_id": "s1", "transcript_path": ""}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            b.main()
+        after_row = next(r for r in _query_routing(db_env) if r["key"] == key)
+        assert after_row["confidence"] < before
+        assert after_row["failure_count"] == 1
+
+    def test_never_crashes_when_decision_record_absent(self, db_env, monkeypatch):
+        # No decision row seeded — boost/decay return 0.0, hook must skip cleanly.
+        b = _load(B_PATH, "ror_b3")
+        monkeypatch.setattr(
+            b, "drain_pending_outcomes", lambda _sid: [{"key": "ghost-agent:ghost-skill", "errors": False}]
+        )
+        event = {"hook_event_name": "SubagentStop", "session_id": "s1", "transcript_path": ""}
+        with patch("sys.exit") as ex, patch("sys.stdin.read", return_value=json.dumps(event)):
+            b.main()
+        # No row created, no exception raised.
+        assert all(r["key"] != "ghost-agent:ghost-skill" for r in _query_routing(db_env))
+        ex.assert_called_with(0)
+
+    def test_exit_zero_on_empty_and_malformed(self, db_env):
+        assert _run_hook(B_PATH, {}).returncode == 0
+        assert (
+            subprocess.run([sys.executable, str(B_PATH)], input="not json", capture_output=True, text=True).returncode
+            == 0
+        )
+        assert subprocess.run([sys.executable, str(B_PATH)], input="", capture_output=True, text=True).returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# A + B integration: route-health closes the loop
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndLoop:
+    def test_decision_then_outcome_closes_loop(self, db_env):
+        # Real bridge (tmp-redirected): A writes decision + pending; B drains and scores.
+        a = _load(A_PATH, "rdr_e1")
+        b = _load(B_PATH, "ror_e1")
+        event_a = _agent_event(skill_prompt='Skill("go-patterns")', session="loop-1")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event_a)):
+            a.main()
+        event_b = {"hook_event_name": "SubagentStop", "session_id": "loop-1", "transcript_path": ""}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event_b)):
+            b.main()
+        rows = _query_routing(db_env)
+        decision = next(r for r in rows if r["key"] == "python-general-engineer:go-patterns")
+        # Decision row exists AND has an outcome (success_count incremented) => loop closed.
+        assert decision["success_count"] == 1

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -1103,12 +1103,15 @@ class TestRejectionPrecision:
         "that's wrong, redo it",
         "wrong agent, use a different agent",
         # "that's not what I wanted" is a self-contained first-clause complaint.
-        # (A leading "no, …" would split off "no" as the first clause under the
-        # comma split — that is an acceptable MISS under the asymmetric-cost rule,
-        # not a false failure.)
         "that's not what I wanted",
         "that didn't work, try again",
         "revert that change",
+        # Dead-pattern fix: a leading bare "no"/"nope" reaction + a `that's`
+        # complaint is now caught on the RAW prompt (not the comma-severed first
+        # clause). The old `\b(no,? that's…)\b` pattern could never match because
+        # the clause splitter severed "no" from "that's" first.
+        "no, that's not what I asked for",
+        "nope, that's wrong",
     ]
 
     # The EXACT phrases the confirmation review named as false-positives. Prose
@@ -1125,6 +1128,13 @@ class TestRejectionPrecision:
         "we should have used a different skill for this",
         "thanks, that worked. redo it for the other file",
         "great, now start over on the README",
+        # Leading-"no"/"undo" benign guards: a bare "no"/"undo"/"rollback" token
+        # that is NOT the absolute-start reaction + complaint must stay SUCCESS.
+        # These guard the dead-pattern fix's `^\s*(no|nope)\b` anchor against
+        # over-firing on the word "no"/"undo" mid-sentence.
+        "there is no cache here, document it",
+        "undo is hard here; explain how to revert a squashed merge",
+        "the rollback procedure didn't work in staging, document it",
     ]
     # Genuine complaints the review named as must-still-FAIL.
     NAMED_GENUINE: ClassVar = [
@@ -1132,6 +1142,9 @@ class TestRejectionPrecision:
         "that didn't work",
         "revert that, you broke the build",
         "that's worse than before",
+        # Dead-pattern fix: leading "no"/"nope" reaction + `that's` complaint.
+        "no, that's not what I asked for",
+        "nope, that's wrong",
     ]
 
     def test_benign_first_clause_not_rejection(self):

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -941,3 +942,218 @@ class TestClaimDispatchAtomicity:
         monkeypatch.setattr(ros, "_STATE_DIR", tmp_path / "state")
         assert ros.claim_dispatch("s", "sig-1") is True
         assert ros.claim_dispatch("s", "sig-1") is False
+
+
+# ---------------------------------------------------------------------------
+# HIGH-1 — turn-level rejection is attributable only on a SINGLE pending dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestSingleDispatchAttribution:
+    """A turn-level reaction ("that's wrong, redo it") can only be pinned to a
+    route when exactly ONE dispatch is pending this turn. /do Phase 4 fans out
+    multiple agents per turn; broadcasting the reaction across N parallel
+    siblings would re-decay correct routes (the sibling-misattribution bug on the
+    reaction axis). So with >1 pending, each entry resolves by its OWN errors flag
+    and the turn-level reaction is IGNORED."""
+
+    def _seed(self, ldb, key):
+        ldb.record_learning(
+            topic="routing",
+            key=key,
+            value=f"routing-decision: {key} tool_errors=0",
+            category="effectiveness",
+            source="test",
+        )
+
+    def test_multi_dispatch_rejection_not_broadcast(self, db_env, monkeypatch):
+        # Two CLEAN parallel dispatches + "that's wrong, redo it" => NEITHER
+        # sibling is decayed (the reaction is unattributable across siblings).
+        sys.path.insert(0, str(LIB_DIR))
+        import learning_db_v2 as ldb
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        a = "python-general-engineer:sib-a"
+        b = "golang-general-engineer:sib-b"
+        for key in (a, b):
+            self._seed(ldb, key)
+        a_before = next(r for r in _query_routing_all(db_env) if r["key"] == a)["confidence"]
+        b_before = next(r for r in _query_routing_all(db_env) if r["key"] == b)["confidence"]
+
+        session = "multi-rej"
+        ros.append_pending_outcome(session, a, errors=False)
+        ros.append_pending_outcome(session, b, errors=False)
+
+        f = _load(F_PATH, "fin_multi_rej")
+        ev = _prompt_event("that's wrong, redo it", session=session)
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+
+        a_after = next(r for r in _query_routing_all(db_env) if r["key"] == a)
+        b_after = next(r for r in _query_routing_all(db_env) if r["key"] == b)
+        # Both clean siblings score SUCCESS, neither decayed by the ambiguous turn.
+        assert a_after["failure_count"] == 0 and b_after["failure_count"] == 0
+        assert a_after["success_count"] == 1 and b_after["success_count"] == 1
+        assert a_after["confidence"] > a_before and b_after["confidence"] > b_before
+
+    def test_multi_dispatch_per_entry_error_still_fails(self, db_env, monkeypatch):
+        # With >1 pending, the IGNORED turn-reaction does not stop a per-entry
+        # tool error from failing its own key (per-entry attribution preserved).
+        sys.path.insert(0, str(LIB_DIR))
+        import learning_db_v2 as ldb
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        clean = "python-general-engineer:multi-clean"
+        errd = "golang-general-engineer:multi-errd"
+        for key in (clean, errd):
+            self._seed(ldb, key)
+
+        session = "multi-mixed"
+        ros.append_pending_outcome(session, clean, errors=False)
+        ros.append_pending_outcome(session, errd, errors=True)
+
+        f = _load(F_PATH, "fin_multi_mixed")
+        # Even a benign-looking turn: per-entry error decides each key.
+        ev = _prompt_event("ok, next task", session=session)
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        clean_after = next(r for r in _query_routing_all(db_env) if r["key"] == clean)
+        errd_after = next(r for r in _query_routing_all(db_env) if r["key"] == errd)
+        assert clean_after["success_count"] == 1 and clean_after["failure_count"] == 0
+        assert errd_after["failure_count"] == 1 and errd_after["success_count"] == 0
+
+    def test_single_dispatch_rejection_decays(self, db_env, monkeypatch):
+        # A SINGLE clean dispatch + "that's wrong" => attributable => decayed.
+        sys.path.insert(0, str(LIB_DIR))
+        import learning_db_v2 as ldb
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        only = "python-general-engineer:solo"
+        self._seed(ldb, only)
+
+        session = "single-rej"
+        ros.append_pending_outcome(session, only, errors=False)
+
+        f = _load(F_PATH, "fin_single_rej")
+        ev = _prompt_event("that's wrong, redo it", session=session)
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        after = next(r for r in _query_routing_all(db_env) if r["key"] == only)
+        assert after["failure_count"] == 1 and after["success_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# HIGH-2 — clause-scoped, acceptance-precedence false-failure precision
+# ---------------------------------------------------------------------------
+
+
+class TestRejectionPrecision:
+    """is_rejection() must be high-precision: benign prompts that merely contain
+    a rework verb in a LATER clause (new work, not a complaint) score SUCCESS;
+    only the user's IMMEDIATE reaction (first clause) is tested. Acceptance in
+    the first clause takes precedence over a later rework-shaped clause."""
+
+    BENIGN: ClassVar = [
+        "thanks, that worked. redo it for the other file",
+        "great, now start over on the README",
+        "the workflow should roll back on failure; document that",
+        "looks good. now refactor the parser",
+        "perfect, switch to a different file and add the same test",
+    ]
+    GENUINE: ClassVar = [
+        "that's wrong, redo it",
+        "wrong agent, use a different agent",
+        "no, that's not what I wanted",
+        "that didn't work, try again",
+        "revert that change",
+    ]
+
+    def test_benign_first_clause_not_rejection(self):
+        f = _load(F_PATH, "fin_precision_benign")
+        for p in self.BENIGN:
+            assert f.is_rejection(p) is False, f"benign prompt falsely flagged: {p!r}"
+
+    def test_genuine_rejection_is_rejection(self):
+        f = _load(F_PATH, "fin_precision_genuine")
+        for p in self.GENUINE:
+            assert f.is_rejection(p) is True, f"genuine rejection missed: {p!r}"
+
+    def test_benign_prompt_scores_success_end_to_end(self, db_env, monkeypatch):
+        # A single dispatch + a benign "redo it in a later clause" prompt => the
+        # reaction is acceptance/neutral in the first clause => SUCCESS, no decay.
+        sys.path.insert(0, str(LIB_DIR))
+        import learning_db_v2 as ldb
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        for i, prompt in enumerate(self.BENIGN):
+            key = f"python-general-engineer:benign-{i}"
+            ldb.record_learning(
+                topic="routing",
+                key=key,
+                value=f"routing-decision: {key} tool_errors=0",
+                category="effectiveness",
+                source="test",
+            )
+            session = f"benign-e2e-{i}"
+            ros.append_pending_outcome(session, key, errors=False)
+            f = _load(F_PATH, f"fin_benign_e2e_{i}")
+            ev = _prompt_event(prompt, session=session)
+            with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+                f.main()
+            after = next(r for r in _query_routing_all(db_env) if r["key"] == key)
+            assert after["failure_count"] == 0, f"benign prompt decayed route: {prompt!r}"
+            assert after["success_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# MEDIUM-1 — orphan (no decision row) is attempt-bounded at the finalizer too
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizerOrphanBounded:
+    """A pending entry whose decision row was NEVER written must be routed
+    through the attempt-bounded requeue at UserPromptSubmit (increments attempts,
+    dropped at MAX_REQUEUE_ATTEMPTS) — not the attempt-preserving revalidate that
+    lets a never-written-row orphan linger up to 24h."""
+
+    def test_orphan_dropped_after_max_requeue_passes(self, db_env, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        session = "fin-orphan"
+        key = "ghost-agent:ghost-skill"
+        ros.append_pending_outcome(session, key, errors=False)
+
+        # Each finalizer pass finds no decision row => requeue (attempts+1).
+        # After MAX_REQUEUE_ATTEMPTS passes the orphan is dropped.
+        for i in range(ros.MAX_REQUEUE_ATTEMPTS + 1):
+            f = _load(F_PATH, f"fin_orphan_{i}")
+            ev = _prompt_event("ok next", session=session)
+            with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+                f.main()
+
+        remaining = ros.peek_pending_outcomes(session)
+        assert remaining == [], f"orphan not dropped by finalizer after cap: {remaining}"
+
+    def test_orphan_attempts_increment_each_pass(self, db_env, monkeypatch):
+        # Distinguishes requeue (increments) from revalidate (preserves): after
+        # one finalizer pass the orphan's attempts must be 1, not 0.
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        session = "fin-orphan-attempt"
+        key = "ghost-agent:ghost-skill"
+        ros.append_pending_outcome(session, key, errors=False)
+
+        f = _load(F_PATH, "fin_orphan_attempt")
+        ev = _prompt_event("ok next", session=session)
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        still = ros.peek_pending_outcomes(session)
+        assert len(still) == 1 and still[0]["attempts"] == 1, still

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -377,6 +377,9 @@ class TestFinalizer:
         self._pend(ros, "fin-rr", key, errors=False)
 
         f = _load(F_PATH, "fin_rr")
+        # Re-route now decays ONLY via the complaint-anchored literal "wrong agent"
+        # (prose re-route detection was removed); the trailing "use a different
+        # agent" no longer matters.
         ev = _prompt_event("wrong agent — use a different agent for this", session="fin-rr")
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
             f.main()
@@ -454,6 +457,36 @@ class TestFinalizer:
         # Put back (revalidated) for a later resolver, not lost.
         assert ros.peek_pending_outcomes(session)
 
+    def test_malformed_created_entry_does_not_abort_sibling_scoring(self, db_env, monkeypatch):
+        # LOW: one pending entry with a non-numeric `created` must be SKIPPED
+        # without aborting scoring for the other (valid) entries this turn.
+        import json as _json
+
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        session = "fin-malformed-created"
+        good_key = _seed_decision("python-general-engineer:good-sibling")
+        # Append a valid sibling, then inject a malformed-`created` entry directly.
+        ros.append_pending_outcome(session, good_key, errors=False)
+        path = ros._state_file(session)
+        with ros._state_lock(path):
+            data = ros._load(path)
+            data["pending"].append(
+                {"key": "python-general-engineer:bad-sibling", "errors": False, "attempts": 0, "created": "NaN-oops"}
+            )
+            ros._atomic_write(path, data)
+
+        f = _load(F_PATH, "fin_malformed")
+        ev = _prompt_event("now write the docs", session=session)  # neutral => success
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=_json.dumps(ev)):
+            f.main()
+        # The valid sibling still scored (success); the malformed one was skipped.
+        after = next(r for r in _query_routing(db_env) if r["key"] == good_key)
+        assert after["success_count"] == 1, "malformed sibling aborted scoring of the valid entry"
+        assert after["failure_count"] == 0
+
     def test_exit_zero_on_empty_and_malformed(self, db_env):
         assert _run_hook(F_PATH, {}).returncode == 0
         assert (
@@ -464,7 +497,9 @@ class TestFinalizer:
 
     def test_marker_unit_high_precision(self):
         f = _load(F_PATH, "fin_unit")
-        # Clear rejections / re-routes => True.
+        # Clear complaints about the prior work => True. (Prose re-route detection
+        # was REMOVED; the only surviving re-route signal is the complaint-anchored
+        # literal "wrong agent/skill" — bare "use a different skill" is now benign.)
         for p in [
             "that's wrong",
             "that's worse",
@@ -473,15 +508,16 @@ class TestFinalizer:
             "that didn't work",
             "not what I wanted",
             "wrong agent",
-            "use a different skill",
+            "wrong skill",
         ]:
             assert f.is_rejection(p) is True, p
-        # Benign / neutral / acceptance => False.
+        # Benign / neutral / acceptance / instructional => False.
         for p in [
             "Add a test for wrong-format dates.",
             "looks good, merge it",
             "now write the docs",
             "thanks!",
+            "use a different skill",  # bare re-route prose — no complaint anchor
             "",
             None,
         ]:
@@ -1066,9 +1102,36 @@ class TestRejectionPrecision:
     GENUINE: ClassVar = [
         "that's wrong, redo it",
         "wrong agent, use a different agent",
-        "no, that's not what I wanted",
+        # "that's not what I wanted" is a self-contained first-clause complaint.
+        # (A leading "no, …" would split off "no" as the first clause under the
+        # comma split — that is an acceptable MISS under the asymmetric-cost rule,
+        # not a false failure.)
+        "that's not what I wanted",
         "that didn't work, try again",
         "revert that change",
+    ]
+
+    # The EXACT phrases the confirmation review named as false-positives. Prose
+    # re-route / spec / conditional / docs prompts that must ALL classify SUCCESS.
+    # Listed verbatim — these are the regression guards for HIGH-2.
+    NAMED_BENIGN: ClassVar = [
+        "the migration should roll back the change on failure",
+        "explain when to use a different approach for caching",
+        "we should have used a cache here, and document the skill matrix",
+        "can you use a different approach here",
+        "try a different approach to memoization",
+        "undo the change only if the checksum fails",
+        "document when to use a different agent",
+        "we should have used a different skill for this",
+        "thanks, that worked. redo it for the other file",
+        "great, now start over on the README",
+    ]
+    # Genuine complaints the review named as must-still-FAIL.
+    NAMED_GENUINE: ClassVar = [
+        "that's wrong, redo it",
+        "that didn't work",
+        "revert that, you broke the build",
+        "that's worse than before",
     ]
 
     def test_benign_first_clause_not_rejection(self):
@@ -1080,6 +1143,18 @@ class TestRejectionPrecision:
         f = _load(F_PATH, "fin_precision_genuine")
         for p in self.GENUINE:
             assert f.is_rejection(p) is True, f"genuine rejection missed: {p!r}"
+
+    def test_named_benign_phrases_classify_success(self):
+        # The exact review-named false-positives must NOT be rejections.
+        f = _load(F_PATH, "fin_named_benign")
+        for p in self.NAMED_BENIGN:
+            assert f.is_rejection(p) is False, f"review-named benign falsely flagged: {p!r}"
+
+    def test_named_genuine_phrases_classify_failure(self):
+        # The exact review-named genuine complaints must remain rejections.
+        f = _load(F_PATH, "fin_named_genuine")
+        for p in self.NAMED_GENUINE:
+            assert f.is_rejection(p) is True, f"review-named genuine missed: {p!r}"
 
     def test_benign_prompt_scores_success_end_to_end(self, db_env, monkeypatch):
         # A single dispatch + a benign "redo it in a later clause" prompt => the
@@ -1107,6 +1182,32 @@ class TestRejectionPrecision:
             after = next(r for r in _query_routing_all(db_env) if r["key"] == key)
             assert after["failure_count"] == 0, f"benign prompt decayed route: {prompt!r}"
             assert after["success_count"] == 1
+
+    def test_named_rollback_phrase_scores_success_end_to_end(self, db_env, monkeypatch):
+        # Spec-required E2E: a single clean dispatch + the review's roll-back spec
+        # phrase => SUCCESS (success_count=1, failure_count=0), no decay.
+        sys.path.insert(0, str(LIB_DIR))
+        import learning_db_v2 as ldb
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = "python-general-engineer:rollback-spec"
+        ldb.record_learning(
+            topic="routing",
+            key=key,
+            value=f"routing-decision: {key} tool_errors=0",
+            category="effectiveness",
+            source="test",
+        )
+        session = "named-rollback-e2e"
+        ros.append_pending_outcome(session, key, errors=False)
+        f = _load(F_PATH, "fin_named_rollback_e2e")
+        ev = _prompt_event("the migration should roll back the change on failure", session=session)
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        after = next(r for r in _query_routing_all(db_env) if r["key"] == key)
+        assert after["success_count"] == 1, "named roll-back spec phrase failed to score success"
+        assert after["failure_count"] == 0, "named roll-back spec phrase falsely decayed route"
 
 
 # ---------------------------------------------------------------------------

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -424,6 +424,8 @@ Extraction: Intent from verb+object. Constraints include branch safety (never me
 
 **MANDATORY: Inject base instructions for ALL dispatched agents.** Every agent prompt MUST include: "Before starting work, also load `agents/base-instructions.md` for universal operational rules."
 
+**MANDATORY: Stamp the routing marker on every routed agent prompt.** Prepend verbatim: `[do-route] agent={agent} skill={skill} complexity={complexity}` (use `skill=-` when routing agent-only). This is the SOLE signal the `routing-decision-recorder` hook uses to record a `routing` decision row — dispatches without it (pr-review reviewer sub-agents, nested fan-out) are correctly excluded from route-health, and the hook reads `agent`/`skill` straight from the marker (no prompt-sniffing). Stamp it on each agent in a parallel roster.
+
 **Token budget signal (optional, documented).** Read `orchestration.token_budget` from `.claude/settings.json` (default 500000 when absent). Subtract a rough estimate of tokens already spent this session; prepend to each dispatched agent prompt: "~{remaining} tokens available for this task; prioritize accordingly." This is an advisory signal, not a hard runtime cap — it nudges agents to right-size their own work. Keep it cheap: read the key once per session, skip injection if the key is absent and no default is desired.
 
 ```bash

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -259,19 +259,9 @@ For Trivial: show `Classification: Trivial - [reason]` and `Handling directly (n
 
 **Optional: Verbose Routing** — OFF by default. When enabled, explain why each alternative was rejected.
 
-**Step 4: Record routing decision** (Simple+ only — skip Trivial):
+**Learning capture is automatic.** The router records nothing by hand. The `routing-decision-recorder` hook (PostToolUse:Agent) writes the `routing` decision row on every dispatch; `routing-outcome-recorder` (SubagentStop) records the success/failure outcome; `error-learner` and `review-capture` capture the rest. See the note after Phase 4 and ADR `learn-step-to-hook`.
 
-```bash
-python3 ~/.claude/scripts/learning-db.py record \
-    routing "{selected_agent}:{selected_skill}" \
-    "routing-decision: agent={selected_agent} skill={selected_skill} request: {first_200_chars} complexity: {complexity} enhancements: {comma_separated_list}" \
-    --category effectiveness \
-    --tags "{applicable_flags}"
-```
-
-Tags: `thinking:slow` or `thinking:fast` (from Step 2 directive). Advisory — continue if it fails. Categories: `effectiveness` (success), `misroute` (reroutes).
-
-**Gate**: Agent+skill selected. Banner displayed. Decision recorded. Proceed to Phase 3.
+**Gate**: Agent+skill selected. Banner displayed. Proceed to Phase 3.
 
 ---
 
@@ -451,7 +441,7 @@ TOKEN_BUDGET=$(python3 -c "import json,sys; print(json.load(open('.claude/settin
 
 **Category overrides** (regardless of complexity): `thinking:slow` for security work, API/schema design, migrations, 5+ file reviews, architectural decisions. `thinking:fast` for lookups, status checks, single-function renames/refactors.
 
-Record as `thinking:slow` or `thinking:fast` in Phase 2 Step 4 `--tags`.
+Thinking class (`thinking:slow` / `thinking:fast`) is captured automatically by the routing hooks via the dispatch metadata; the router sets the directive but records nothing by hand.
 
 **Verb-based model dispatch for Complex tasks (3+ data sources).** Extraction verbs use parallel Haiku readers; analysis verbs use single Opus agent (38% cheaper, 23% faster for extraction — A/B tested).
 
@@ -478,59 +468,34 @@ Invoke `auto-pipeline` for unmatched requests. If no pipeline matches, fall back
 
 When uncertain: **ROUTE ANYWAY** with verification-before-completion as safety net.
 
-**Gate**: Agent invoked, results delivered. Proceed to Phase 5.
+**Gate**: Agent invoked, results delivered. Learning capture runs automatically (see note below) — the router does not record by hand.
 
 ---
 
-### Phase 5: LEARN
+### Learning Capture (automatic — no router step)
 
-**Goal**: Capture session insights to `learning.db`.
+Learning capture is fully automatic via hooks. The router records nothing by hand:
 
-**Routing decision** (Simple+, observable facts only):
-```bash
-python3 ~/.claude/scripts/learning-db.py record \
-    routing "{selected_agent}:{selected_skill}" \
-    "routing-decision: agent={selected_agent} skill={selected_skill} tool_errors: {0|1} user_rerouted: {0|1}" \
-    --category effectiveness
-```
+| Capture | Hook | Event |
+|---------|------|-------|
+| Routing decision row (`{agent}:{skill}`, `category=effectiveness`) | `routing-decision-recorder` | PostToolUse:Agent |
+| Routing outcome (boost on success / decay on failure) | `routing-outcome-recorder` | SubagentStop |
+| Right-sizing tier feedback (when a `rightsizing:` banner is emitted) | `routing-decision-recorder` | PostToolUse:Agent |
+| Tool errors and fixes | `error-learner` | PostToolUse |
+| Review findings | `review-capture` | PostToolUse:Agent |
 
-**Routing outcome** (MANDATORY for Simple+ — records whether the route succeeded):
-After the agent completes, evaluate the outcome based on observable facts:
-- **Success signals**: agent produced commits, tests passed, no tool errors, user accepted result
-- **Failure signals**: agent errored, user re-routed, rework required, `tool_errors=1`
+These keep the routing feedback loop fed: `learning-db.py route-health` reads the decision rows (denominator) and the boost/decay outcomes (numerator) the hooks write. See ADR `learn-step-to-hook`.
 
-```bash
-# On success:
-python3 ~/.claude/scripts/learning-db.py record-routing-outcome \
-    "{selected_agent}:{selected_skill}" --success
+**Outcome fidelity (note).** The hook-derived outcome is a deterministic proxy: success = no tool errors and no re-route this dispatch; failure = errors detected. It cannot see a *next-turn* user rejection, so it is lower-fidelity than a manual LLM judgment — accepted deliberately for zero-cost coverage on every route.
 
-# On failure (include reason):
-python3 ~/.claude/scripts/learning-db.py record-routing-outcome \
-    "{selected_agent}:{selected_skill}" --failure --reason "{brief reason}"
-```
+**OPTIONAL (not a gate):** curated free-text insight and graduation of review findings are now opt-in, handled via the `retro` skill (`retro graduate`), not a forced router step:
 
-Do not skip this step.
-
-**Right-sizing feedback** (when a tiered review/parallel-analysis ran): record the actual agent count against the detected file scope so the heuristic can be refined later.
-
-```bash
-python3 ~/.claude/scripts/learning-db.py record \
-    routing "rightsizing:tier{tier}" \
-    "rightsizing: tier={tier} files={file_count} packages={package_count} agents_dispatched={actual_count}" \
-    --category effectiveness --tags rightsizing
-```
-
-**Auto-capture** (hooks, zero LLM cost): `error-learner.py`, `review-capture.py` (PostToolUse), `session-learning-recorder.py` (Stop).
-
-**Skill-scoped recording**:
 ```bash
 python3 ~/.claude/scripts/learning-db.py learn --skill go-patterns "insight"
 python3 ~/.claude/scripts/learning-db.py learn --agent golang-general-engineer "insight"
 ```
 
-**Immediate graduation for review findings** (MANDATORY): Issue found + fixed in same PR → (1) Record scoped, (2) Boost to 1.0, (3) Embed into failure modes, (4) Graduate, (5) Stage in same PR.
-
-**Gate**: Record at least one learning AND one routing outcome for Simple+ tasks. Review findings get immediate graduation.
+Routing rows are `category=effectiveness`, which `retro graduate` excludes — so these never require graduation.
 
 ---
 

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -481,14 +481,16 @@ Learning capture is fully automatic via hooks. The router records nothing by han
 | Capture | Hook | Event |
 |---------|------|-------|
 | Routing decision row (`{agent}:{skill}`, `category=effectiveness`) | `routing-decision-recorder` | PostToolUse:Agent |
-| Routing outcome (boost on success / decay on failure) | `routing-outcome-recorder` | SubagentStop |
+| Routing outcome - validate pending (decision-row exists, re-queue late rows) | `routing-outcome-recorder` | SubagentStop |
+| Routing outcome - finalize (boost/decay) on the next user turn | `routing-outcome-finalizer` | UserPromptSubmit |
+| Routing outcome - session-end fallback for autonomous runs | `session-learning-recorder` | Stop |
 | Right-sizing tier feedback (when a `rightsizing:` banner is emitted) | `routing-decision-recorder` | PostToolUse:Agent |
 | Tool errors and fixes | `error-learner` | PostToolUse |
 | Review findings | `review-capture` | PostToolUse:Agent |
 
 These keep the routing feedback loop fed: `learning-db.py route-health` reads the decision rows (denominator) and the boost/decay outcomes (numerator) the hooks write. See ADR `learn-step-to-hook`.
 
-**Outcome fidelity (note).** The hook-derived outcome is a deterministic proxy: success = no tool errors and no re-route this dispatch; failure = errors detected. It cannot see a *next-turn* user rejection, so it is lower-fidelity than a manual LLM judgment — accepted deliberately for zero-cost coverage on every route.
+**Outcome fidelity (note).** A routed dispatch's outcome is resolved on the user's NEXT turn from three deterministic inputs - this dispatch's tool errors, the user's reaction, and whether they re-routed the same intent - at zero LLM cost. `routing-decision-recorder` writes the decision row; `routing-outcome-recorder` (SubagentStop) records a *provisional* pending outcome (no eager boost/decay); `routing-outcome-finalizer` (UserPromptSubmit) finalizes it once: **failure** on tool errors OR a clear rejection/rework/re-route, **success** otherwise (explicit acceptance, or a neutral/new topic - no complaint = accepted, matching the prior LLM step's default). A Stop fallback resolves any dispatch with no next prompt (autonomous runs) from the error flag alone. Residual: the reaction detector is **deterministic and high-precision** - it fires failure only on strong, unambiguous markers and errs toward success on ambiguity, so it is conservative rather than full semantic judgment. It does not eagerly score "no error = success" anymore.
 
 **OPTIONAL (not a gate):** curated free-text insight and graduation of review findings are now opt-in, handled via the `retro` skill (`retro graduate`), not a forced router step:
 

--- a/skills/process/pr-workflow/references/codex-review-cli-patterns.md
+++ b/skills/process/pr-workflow/references/codex-review-cli-patterns.md
@@ -23,7 +23,8 @@ wastes tokens and hits prompt-length limits.
 | Single commit review | `codex exec review --commit <SHA>` | `--commit <SHA>` |
 | Unstaged changes only | `codex exec review --uncommitted` | `--uncommitted` |
 | Custom focus areas | `codex exec "YOUR PROMPT"` | no `--base/--commit` |
-| High-quality analysis | add to any | `-m gpt-5.4 -c 'model_reasoning_effort="xhigh"'` |
+| High-quality analysis (default) | add to any | `-m gpt-5.4 -c 'model_reasoning_effort="high"'` |
+| Hard correctness escalation (security/concurrency/migrations) | opt-in only | `-m gpt-5.4 -c 'model_reasoning_effort="xhigh"'` |
 | Capture output | add to any | `-o "$TMPFILE"` |
 | One-shot (no persist) | add to any | `--ephemeral` |
 | Container/VM bypass | add to any | `--dangerously-bypass-approvals-and-sandbox` |
@@ -40,7 +41,7 @@ TMPFILE=$(mktemp /tmp/codex-review.XXXXXXXX)
 codex exec review \
   --base main \
   -m gpt-5.4 \
-  -c 'model_reasoning_effort="xhigh"' \
+  -c 'model_reasoning_effort="high"' \
   --ephemeral \
   --dangerously-bypass-approvals-and-sandbox \
   -o "$TMPFILE"
@@ -57,7 +58,7 @@ TMPFILE=$(mktemp /tmp/codex-review.XXXXXXXX)
 
 codex exec \
   -m gpt-5.4 \
-  -c 'model_reasoning_effort="xhigh"' \
+  -c 'model_reasoning_effort="high"' \
   --ephemeral \
   --dangerously-bypass-approvals-and-sandbox \
   -o "$TMPFILE" \

--- a/skills/process/pr-workflow/references/codex-review-invocation.md
+++ b/skills/process/pr-workflow/references/codex-review-invocation.md
@@ -58,7 +58,7 @@ what's the biggest strength.]
 codex exec review \
   --base main \
   -m gpt-5.4 \
-  -c 'model_reasoning_effort="xhigh"' \
+  -c 'model_reasoning_effort="high"' \
   --ephemeral \
   --dangerously-bypass-approvals-and-sandbox \
   -o "$TMPFILE"
@@ -75,7 +75,7 @@ or custom instructions:
 ```bash
 codex exec \
   -m gpt-5.4 \
-  -c 'model_reasoning_effort="xhigh"' \
+  -c 'model_reasoning_effort="high"' \
   --ephemeral \
   --dangerously-bypass-approvals-and-sandbox \
   -o "$TMPFILE" \
@@ -87,7 +87,7 @@ For multi-line prompts, use a heredoc:
 ```bash
 codex exec \
   -m gpt-5.4 \
-  -c 'model_reasoning_effort="xhigh"' \
+  -c 'model_reasoning_effort="high"' \
   --ephemeral \
   --dangerously-bypass-approvals-and-sandbox \
   -o "$TMPFILE" \
@@ -99,8 +99,9 @@ PROMPT
 
 Flag explanation:
 - `-m gpt-5.4` -- use GPT-5.4 for maximum review quality
-- `-c 'model_reasoning_effort="xhigh"'` -- maximize reasoning depth so Codex
-  doesn't shortcut analysis of complex code paths
+- `-c 'model_reasoning_effort="high"'` -- default `high` is the sensible baseline
+  for routine review/triage; use `xhigh` only for hard correctness analysis
+  (security/concurrency/migrations) where the extra depth justifies the slowdown
 - `--ephemeral` -- don't persist the Codex session (this is a one-shot review)
 - `--dangerously-bypass-approvals-and-sandbox` -- bypass the bwrap sandbox
   which fails in containerized/VM environments with "loopback: Failed
@@ -173,7 +174,7 @@ Gate: Every Codex finding has been assessed. Proceed to Phase 4.
 Structure the report as:
 
 ```markdown
-## Codex Code Review (GPT-5.4 xhigh)
+## Codex Code Review (GPT-5.4 high)
 
 **Scope**: [what was reviewed -- e.g., "git diff main...HEAD (12 files)"]
 

--- a/skills/process/pr-workflow/references/codex-review-methodology.md
+++ b/skills/process/pr-workflow/references/codex-review-methodology.md
@@ -157,7 +157,7 @@ Codex's Positive Notes section affirms — confirm those patterns are actually c
 ## Report Structure Template
 
 ```markdown
-## Codex Code Review (GPT-5.4 xhigh)
+## Codex Code Review (GPT-5.4 high)
 
 **Scope**: {what was reviewed — e.g., "git diff main...HEAD (12 files, +340/-120 lines)"}
 **Review date**: {date}

--- a/skills/process/pr-workflow/references/pipeline.md
+++ b/skills/process/pr-workflow/references/pipeline.md
@@ -119,7 +119,7 @@ Invoke: /pr-workflow codex-review
 Scope: git diff --cached (staged changes)
 ```
 
-Codex runs in read-only sandbox mode with GPT-5.4 xhigh reasoning. It produces structured findings (CRITICAL / IMPROVEMENTS / POSITIVE / SUMMARY). Claude assesses each finding before incorporating -- Codex feedback is a second opinion, not authoritative.
+Codex runs in read-only sandbox mode with GPT-5.4 `high` reasoning by default (`xhigh` is opt-in for hard correctness analysis -- security/concurrency/migrations). It produces structured findings (CRITICAL / IMPROVEMENTS / POSITIVE / SUMMARY). Claude assesses each finding before incorporating -- Codex feedback is a second opinion, not authoritative.
 
 **If Codex finds CRITICAL issues that Claude agrees with**: Fix them and re-stage before proceeding.
 **If Codex is unavailable or errors**: Log the skip reason and proceed. This phase must never block the pipeline.


### PR DESCRIPTION
## Summary
Moves `/do`'s Phase 5 LEARN out of the router and into hooks, so routing learning is automatic and the router prose is lighter. A `[do-route]` marker on routed dispatches feeds a PostToolUse:Agent recorder (decision) and a SubagentStop recorder (outcome); the feedback loop `route-health` measures is preserved.

## Changes
- `hooks/routing-decision-recorder.py` — new PostToolUse:Agent hook; records the routing decision from the `[do-route]` marker (scoped to /do dispatches, so reviewer sub-agents don't pollute stats)
- `hooks/routing-outcome-recorder.py` — new SubagentStop hook; records success/failure via a deterministic proxy (no tool errors → success); a `query_learnings` row-existence pre-check distinguishes a missing decision row from one decayed to 0.0
- `hooks/lib/routing_outcome_state.py` — new per-session A→B bridge; `flock`-serialized to survive parallel dispatch
- `skills/meta/do/SKILL.md` — remove the Phase 5 LEARN block + the Phase 2 Step 4 duplicate; add the `[do-route]` marker injection; learning is now hook-driven
- `.claude/settings.json` — register both hooks
- `README.md` — hook count 79 → 81
- `hooks/tests/test_routing_decision_recorder.py` — decision/outcome/concurrency/marker-scoping coverage

## Notes
Outcome (success/failure) is a deterministic proxy — a hook can't see next-turn user rejection, so it's lower-fidelity than the old LLM evaluation; a future UserPromptSubmit hook could close that gap (ADR `learn-step-to-hook`).