### PR TITLE
fix(hooks): wire up worktree-edit-guard PreToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -139,6 +139,17 @@
         ]
       },
       {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/pretool-worktree-edit-guard.py\"",
+            "description": "Worktree edit guard: blocks worktree-isolated agents from editing main-repo files outside their worktree (ADR worktree-edit-guard)",
+            "timeout": 3000
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-This toolkit prevents that. 44 domain agents, 123 workflow skills, 79 hooks, 105 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+This toolkit prevents that. 44 domain agents, 123 workflow skills, 80 hooks, 105 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Factory (`/do`).
 

--- a/hooks/pretool-worktree-edit-guard.py
+++ b/hooks/pretool-worktree-edit-guard.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+PreToolUse Hook: Worktree Edit Guard (ADR: worktree-edit-guard)
+
+Blocks Write/Edit/MultiEdit/NotebookEdit calls made by a worktree-isolated agent
+that target files in the SHARED main working tree instead of the agent's own
+worktree copy. Worktree agents repeatedly Read/Edit absolute main-repo paths
+(e.g. /home/feedgen/road-to-aew/src/foo.ts) bypassing their worktree CWD, which
+writes into the main tree and destroys isolation. Advisory skill text failed to
+stop this; this hook enforces it.
+
+Block rule (precise, do NOT over-block):
+  - Read cwd / tool_name / tool_input.file_path from stdin JSON.
+    Handle MultiEdit (top-level file_path) and NotebookEdit (notebook_path).
+    Fall back to os.getcwd() if cwd absent.
+  - If cwd does NOT contain "/.claude/worktrees/": ALLOW (parent session and
+    non-worktree agents are entirely unaffected).
+  - Otherwise derive:
+      worktree_root  = path up to and including ".../.claude/worktrees/<id>"
+      main_repo_root = path BEFORE "/.claude/worktrees/"
+    Resolve target (relative -> join cwd; absolute -> as-is) to a realpath.
+  - BLOCK only if resolved target is INSIDE main_repo_root AND NOT inside
+    worktree_root. (Edits inside the worktree are allowed; /tmp, ~/.claude, and
+    other out-of-repo paths are allowed -- only main-repo escapes are blocked.)
+
+Deny mechanism: JSON permissionDecision:deny on stdout + exit 0 (matches
+pretool-config-protection.py / pretool-unified-gate.py convention). The deny
+message names worktree_root and the corrected path the agent should edit.
+
+Properties: dependency-free (stdlib only), <300ms (no subprocess), fails OPEN on
+any internal error -- never blocks legitimate work due to a hook bug.
+Bypass: WORKTREE_EDIT_GUARD_BYPASS=1.
+"""
+
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+
+try:
+    from stdin_timeout import read_stdin
+except Exception:  # pragma: no cover - lib import must never hard-fail the hook
+
+    def read_stdin(timeout: int = 10) -> str:
+        return sys.stdin.read()
+
+
+_BYPASS_ENV = "WORKTREE_EDIT_GUARD_BYPASS"
+_WORKTREE_MARKER = "/.claude/worktrees/"
+_GUARDED_TOOLS = ("Write", "Edit", "MultiEdit", "NotebookEdit")
+
+
+def _split_worktree(cwd: str) -> tuple[str, str] | None:
+    """Given a cwd inside a worktree, return (main_repo_root, worktree_root).
+
+    worktree_root  = main_repo_root + "/.claude/worktrees/<id>"
+    main_repo_root = everything before "/.claude/worktrees/"
+
+    Returns None if cwd is not inside a worktree.
+    """
+    idx = cwd.find(_WORKTREE_MARKER)
+    if idx == -1:
+        return None
+    main_repo_root = cwd[:idx]
+    after = cwd[idx + len(_WORKTREE_MARKER) :]
+    # Assumes the worktree id is a single path segment directly after the marker
+    # (e.g. ".../.claude/worktrees/<id>/..."). If a layout nests the id deeper,
+    # worktree_root is computed too shallow -> we under-block (fail-open direction).
+    worktree_id = after.split("/", 1)[0]
+    if not worktree_id:
+        return None
+    worktree_root = f"{main_repo_root}{_WORKTREE_MARKER}{worktree_id}"
+    return main_repo_root, worktree_root
+
+
+def _is_inside(child: str, parent: str) -> bool:
+    """True if realpath `child` is `parent` or nested within `parent`.
+
+    Uses os.path.commonpath on normalized absolute paths to avoid the
+    "/repo-evil" startswith("/repo") false positive.
+    """
+    try:
+        child_n = os.path.normpath(child)
+        parent_n = os.path.normpath(parent)
+        return os.path.commonpath([child_n, parent_n]) == parent_n
+    except (ValueError, TypeError):
+        # commonpath raises ValueError for mixed absolute/relative or drives.
+        return False
+
+
+def _resolve_target(file_path: str, cwd: str) -> str:
+    """Resolve a tool target path to a realpath.
+
+    Relative paths are joined against cwd; absolute paths are used as-is.
+    realpath collapses symlinks and `..` so escapes cannot hide behind them.
+    """
+    if not os.path.isabs(file_path):
+        file_path = os.path.join(cwd, file_path)
+    return os.path.realpath(file_path)
+
+
+def _iter_target_paths(tool_name: str, tool_input: dict):
+    """Yield every file path a guarded tool intends to write.
+
+    Write/Edit: tool_input["file_path"]
+    MultiEdit:  top-level tool_input["file_path"] (single file, many edits);
+                also tolerate the alternate edits[].file_path shape.
+    NotebookEdit: tool_input["notebook_path"] (fall back to file_path).
+    """
+    if tool_name == "NotebookEdit":
+        fp = tool_input.get("notebook_path") or tool_input.get("file_path")
+        if fp:
+            yield fp
+        return
+
+    fp = tool_input.get("file_path")
+    if fp:
+        yield fp
+
+    # MultiEdit historically may carry per-edit file_path entries.
+    for edit in tool_input.get("edits", []) or []:
+        if isinstance(edit, dict):
+            efp = edit.get("file_path")
+            if efp:
+                yield efp
+
+
+def _deny(target_real: str, main_repo_root: str, worktree_root: str, tool_name: str) -> None:
+    """Emit JSON permissionDecision:deny naming the corrected worktree path; exit 0."""
+    # Compute the relative path from the main repo so we can point the agent at
+    # the equivalent file inside its own worktree.
+    try:
+        rel = os.path.relpath(target_real, main_repo_root)
+    except ValueError:
+        rel = os.path.basename(target_real)
+    corrected = os.path.join(worktree_root, rel)
+
+    reason = (
+        f"[worktree-edit-guard] BLOCKED: this worktree agent tried to edit a MAIN-REPO file "
+        f"({target_real}) instead of its own worktree copy. That contaminates the shared "
+        f"main working tree and destroys isolation. Your worktree root is {worktree_root}. "
+        f"Edit {corrected} instead (use a path relative to your CWD, never an absolute main-repo path). "
+        f"Bypass only if intentional: WORKTREE_EDIT_GUARD_BYPASS=1."
+    )
+    print(reason, file=sys.stderr)
+
+    # Best-effort governance record; never let it prevent the block.
+    try:
+        from learning_db_v2 import record_governance_event
+
+        record_governance_event(
+            "policy_violation",
+            tool_name=tool_name,
+            hook_phase="pre",
+            severity="high",
+            blocked=True,
+        )
+    except Exception:
+        pass
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        )
+    )
+    sys.exit(0)
+
+
+def main() -> None:
+    debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
+
+    if os.environ.get(_BYPASS_ENV) == "1":
+        if debug:
+            print("[worktree-edit-guard] Bypassed via WORKTREE_EDIT_GUARD_BYPASS=1", file=sys.stderr)
+        sys.exit(0)
+
+    raw = read_stdin(timeout=2)
+    try:
+        event = json.loads(raw)
+    except (json.JSONDecodeError, ValueError, TypeError):
+        sys.exit(0)  # Fail open on malformed payload.
+    if not isinstance(event, dict):
+        sys.exit(0)
+
+    tool_name = event.get("tool_name") or event.get("tool", "")
+    if tool_name not in _GUARDED_TOOLS:
+        sys.exit(0)
+
+    tool_input = event.get("tool_input", event.get("input", {}))
+    if not isinstance(tool_input, dict):
+        sys.exit(0)
+
+    # cwd from event; fall back to process cwd if absent.
+    cwd = event.get("cwd") or os.getcwd()
+    if not isinstance(cwd, str) or not cwd:
+        sys.exit(0)
+
+    split = _split_worktree(cwd)
+    if split is None:
+        sys.exit(0)  # Not a worktree agent -> never interfere.
+    main_repo_root, worktree_root = split
+
+    for fp in _iter_target_paths(tool_name, tool_input):
+        if not isinstance(fp, str) or not fp:
+            continue
+        target_real = _resolve_target(fp, cwd)
+        # BLOCK only if inside the main repo AND not inside the worktree.
+        if _is_inside(target_real, main_repo_root) and not _is_inside(target_real, worktree_root):
+            if debug:
+                print(
+                    f"[worktree-edit-guard] {tool_name} escape: {target_real} "
+                    f"(main={main_repo_root}, wt={worktree_root})",
+                    file=sys.stderr,
+                )
+            _deny(target_real, main_repo_root, worktree_root, tool_name)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise  # Preserve intentional exit code (0).
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            traceback.print_exc(file=sys.stderr)
+        else:
+            print(f"[worktree-edit-guard] Error: {type(e).__name__}: {e}", file=sys.stderr)
+        # A crashed hook must fail OPEN -- never block tools on a hook bug.
+        sys.exit(0)

--- a/hooks/pretool-worktree-edit-guard.py
+++ b/hooks/pretool-worktree-edit-guard.py
@@ -28,13 +28,27 @@ Deny mechanism: JSON permissionDecision:deny on stdout + exit 0 (matches
 pretool-config-protection.py / pretool-unified-gate.py convention). The deny
 message names worktree_root and the corrected path the agent should edit.
 
-Properties: dependency-free (stdlib only), <300ms (no subprocess), fails OPEN on
-any internal error -- never blocks legitimate work due to a hook bug.
-Bypass: WORKTREE_EDIT_GUARD_BYPASS=1.
+Properties: dependency-free (stdlib only). Fails OPEN on any internal error --
+never blocks legitimate work due to a hook bug. Bypass:
+WORKTREE_EDIT_GUARD_BYPASS=1.
+
+Path namespace (HIGH-1): cwd is realpath-canonicalized ONCE in main() before
+roots/targets are derived, so containment checks never compare a canonical
+target against a raw symlinked root (which both allowed escapes and blocked
+legitimate in-worktree edits under symlinked /tmp, $HOME, NFS).
+
+Worktree-root derivation (MEDIUM-1): the worktree root comes from
+`git -C <cwd> rev-parse --show-toplevel` (0.5s timeout), which is robust to
+nested `.../worktrees/<group>/<id>/` layouts that the single-segment
+string-split computed too shallow (letting sibling-worktree edits slip
+through). Git is invoked ONLY when cwd is inside a worktree (rare hot path),
+not on the common pass-through. Any git failure (missing, not-a-repo, timeout,
+non-zero) falls back to the string-split and ultimately fails OPEN.
 """
 
 import json
 import os
+import subprocess
 import sys
 import traceback
 from pathlib import Path
@@ -51,14 +65,61 @@ except Exception:  # pragma: no cover - lib import must never hard-fail the hook
 
 _BYPASS_ENV = "WORKTREE_EDIT_GUARD_BYPASS"
 _WORKTREE_MARKER = "/.claude/worktrees/"
+# This hook is the SOLE PreToolUse guard covering MultiEdit and NotebookEdit
+# (pretool-unified-gate.py matches only Bash|Write|Edit). The MultiEdit/
+# NotebookEdit schema-parsing in _iter_target_paths and the tests that exercise
+# it must never be weakened: nothing else blocks those two tools.
 _GUARDED_TOOLS = ("Write", "Edit", "MultiEdit", "NotebookEdit")
+_GIT_TOPLEVEL_TIMEOUT_S = 0.5
+
+
+def _git_worktree_root(cwd: str) -> str | None:
+    """Return the realpath-resolved worktree root via `git rev-parse`, or None.
+
+    `git -C <cwd> rev-parse --show-toplevel` returns the top of the *current*
+    working tree, which for a worktree CWD is the worktree root itself
+    (already realpath-resolved by git). This is the source of truth and is
+    robust to ANY nesting layout under the marker.
+
+    Returns None on any failure (git missing, not a repo, timeout, non-zero
+    exit, empty output) so the caller can fall back to string-splitting and,
+    ultimately, fail OPEN.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TOPLEVEL_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    root = proc.stdout.strip()
+    if not root:
+        return None
+    # Canonicalize so it shares the same resolved namespace as the (already
+    # realpath'd) cwd and targets, regardless of git's own normalization.
+    try:
+        return os.path.realpath(root)
+    except OSError:
+        return root
 
 
 def _split_worktree(cwd: str) -> tuple[str, str] | None:
     """Given a cwd inside a worktree, return (main_repo_root, worktree_root).
 
-    worktree_root  = main_repo_root + "/.claude/worktrees/<id>"
-    main_repo_root = everything before "/.claude/worktrees/"
+    `cwd` is expected to already be realpath-canonicalized by the caller so
+    that roots and targets are compared in one resolved namespace.
+
+    main_repo_root = everything before "/.claude/worktrees/".
+    worktree_root  = the worktree's own toplevel. Preferred source is
+                     `git rev-parse --show-toplevel` (robust to nested
+                     `.../<group>/<id>/` layouts). If git is unavailable we
+                     fall back to the single-segment string-split, and if that
+                     also fails we return None -> ALLOW (fail open).
 
     Returns None if cwd is not inside a worktree.
     """
@@ -66,10 +127,27 @@ def _split_worktree(cwd: str) -> tuple[str, str] | None:
     if idx == -1:
         return None
     main_repo_root = cwd[:idx]
+    if not main_repo_root:
+        return None
+
+    # Preferred: ask git for the worktree's true toplevel. This handles nested
+    # worktree-id layouts (e.g. ".../worktrees/<group>/<id>/") that the
+    # single-segment string-split computes too shallow, which would let edits
+    # into a SIBLING worktree slip through (the exact clobber this hook stops).
+    git_root = _git_worktree_root(cwd)
+    if git_root is not None and _is_inside(cwd, git_root):
+        # Sanity: the git toplevel must itself live under the worktrees marker
+        # of this main repo. Otherwise git resolved to something unexpected
+        # (e.g. cwd is inside the marker dir but not an actual worktree) and we
+        # fall back to the string-split below.
+        if _is_inside(git_root, f"{main_repo_root}{_WORKTREE_MARKER}".rstrip("/")):
+            return main_repo_root, git_root
+
+    # Fallback: single-segment string-split. This assumes the worktree id is a
+    # single path segment directly after the marker. For a nested layout this
+    # computes worktree_root too shallow; we keep it only as a degraded path
+    # when git is unavailable, and ultimately fail OPEN if even this fails.
     after = cwd[idx + len(_WORKTREE_MARKER) :]
-    # Assumes the worktree id is a single path segment directly after the marker
-    # (e.g. ".../.claude/worktrees/<id>/..."). If a layout nests the id deeper,
-    # worktree_root is computed too shallow -> we under-block (fail-open direction).
     worktree_id = after.split("/", 1)[0]
     if not worktree_id:
         return None
@@ -203,6 +281,17 @@ def main() -> None:
     # cwd from event; fall back to process cwd if absent.
     cwd = event.get("cwd") or os.getcwd()
     if not isinstance(cwd, str) or not cwd:
+        sys.exit(0)
+
+    # HIGH-1 fix: canonicalize cwd ONCE here so the worktree/main roots derived
+    # from it and the realpath'd targets are compared in the SAME resolved
+    # namespace. Without this, a symlinked path (macOS /tmp->/private/tmp,
+    # symlinked $HOME, NFS) makes _is_inside compare canonical-vs-raw, which
+    # both allows out-of-worktree escapes and blocks legitimate in-worktree
+    # edits. Fail OPEN if realpath raises.
+    try:
+        cwd = os.path.realpath(cwd)
+    except OSError:
         sys.exit(0)
 
     split = _split_worktree(cwd)

--- a/hooks/tests/test_pretool_worktree_edit_guard.py
+++ b/hooks/tests/test_pretool_worktree_edit_guard.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Tests for the pretool-worktree-edit-guard hook.
+
+Covers the 5 required cases plus path-prefix false-positive defenses.
+
+Run with: python3 -m pytest hooks/tests/test_pretool_worktree_edit_guard.py -v
+Or standalone: python3 hooks/tests/test_pretool_worktree_edit_guard.py
+"""
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+HOOK_PATH = Path(__file__).parent.parent / "pretool-worktree-edit-guard.py"
+
+spec = importlib.util.spec_from_file_location("pretool_worktree_edit_guard", HOOK_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# A realistic main repo + worktree pair.
+MAIN_REPO = "/home/feedgen/road-to-aew"
+WT_ID = "abc123"
+WORKTREE = f"{MAIN_REPO}/.claude/worktrees/{WT_ID}"
+
+
+def _event(tool_name, *, cwd=None, file_path=None, notebook_path=None, edits=None, omit_cwd=False):
+    tool_input = {}
+    if file_path is not None:
+        tool_input["file_path"] = file_path
+    if notebook_path is not None:
+        tool_input["notebook_path"] = notebook_path
+    if edits is not None:
+        tool_input["edits"] = edits
+    ev = {"tool_name": tool_name, "tool_input": tool_input}
+    if not omit_cwd:
+        ev["cwd"] = cwd
+    return json.dumps(ev)
+
+
+def _run(stdin_payload, env=None):
+    """Run main() in-process; return (exit_code, denied: bool)."""
+    base_env = {k: v for k, v in os.environ.items() if k != mod._BYPASS_ENV}
+    if env:
+        base_env.update(env)
+
+    captured = {}
+    real_print = print
+
+    def fake_print(*args, **kwargs):
+        # Capture only stdout JSON (the deny decision), ignore stderr.
+        if kwargs.get("file") in (None, sys.stdout):
+            captured["stdout"] = (captured.get("stdout", "") + " ".join(str(a) for a in args)).strip()
+        real_print(*args, **kwargs)
+
+    with (
+        patch.dict(os.environ, base_env, clear=True),
+        patch.object(mod, "read_stdin", return_value=stdin_payload),
+        patch("builtins.print", fake_print),
+    ):
+        try:
+            mod.main()
+            code = 0
+        except SystemExit as e:
+            code = int(e.code) if e.code is not None else 0
+
+    denied = False
+    out = captured.get("stdout", "")
+    if out:
+        try:
+            denied = json.loads(out).get("hookSpecificOutput", {}).get("permissionDecision") == "deny"
+        except (json.JSONDecodeError, ValueError):
+            denied = False
+    return code, denied
+
+
+# ---------------------------------------------------------------------------
+# Required cases
+# ---------------------------------------------------------------------------
+
+
+def test_case1_worktree_agent_edits_main_repo_absolute_BLOCKS():
+    payload = _event("Edit", cwd=WORKTREE, file_path=f"{MAIN_REPO}/src/foo.ts")
+    code, denied = _run(payload)
+    assert code == 0
+    assert denied is True
+
+
+def test_case2_worktree_agent_edits_in_worktree_file_ALLOWS():
+    payload = _event("Edit", cwd=WORKTREE, file_path=f"{WORKTREE}/src/foo.ts")
+    code, denied = _run(payload)
+    assert code == 0
+    assert denied is False
+
+
+def test_case2b_relative_path_resolves_into_worktree_ALLOWS():
+    payload = _event("Edit", cwd=WORKTREE, file_path="src/foo.ts")
+    code, denied = _run(payload)
+    assert code == 0
+    assert denied is False
+
+
+def test_case3_worktree_agent_edits_tmp_ALLOWS():
+    payload = _event("Write", cwd=WORKTREE, file_path="/tmp/foo.png")
+    code, denied = _run(payload)
+    assert code == 0
+    assert denied is False
+
+
+def test_case3b_worktree_agent_edits_user_claude_ALLOWS():
+    payload = _event("Write", cwd=WORKTREE, file_path="/home/feedgen/.claude/hooks/x.py")
+    code, denied = _run(payload)
+    assert code == 0
+    assert denied is False
+
+
+def test_case4_parent_session_main_repo_ALLOWS():
+    # cwd is the main repo, NOT a worktree -> pass through.
+    payload = _event("Edit", cwd=MAIN_REPO, file_path=f"{MAIN_REPO}/src/foo.ts")
+    code, denied = _run(payload)
+    assert code == 0
+    assert denied is False
+
+
+def test_case5_missing_cwd_fails_open():
+    # No cwd key; falls back to os.getcwd() which is not a worktree -> ALLOW.
+    payload = _event("Edit", omit_cwd=True, file_path=f"{MAIN_REPO}/src/foo.ts")
+    code, denied = _run(payload)
+    assert code == 0
+    assert denied is False
+
+
+def test_case5b_malformed_json_fails_open():
+    code, denied = _run("{ not json")
+    assert code == 0
+    assert denied is False
+
+
+# ---------------------------------------------------------------------------
+# Extra hardening
+# ---------------------------------------------------------------------------
+
+
+def test_multiedit_main_repo_BLOCKS():
+    payload = _event("MultiEdit", cwd=WORKTREE, file_path=f"{MAIN_REPO}/src/a.ts")
+    code, denied = _run(payload)
+    assert denied is True
+
+
+def test_notebookedit_main_repo_BLOCKS():
+    payload = _event("NotebookEdit", cwd=WORKTREE, notebook_path=f"{MAIN_REPO}/nb.ipynb")
+    code, denied = _run(payload)
+    assert denied is True
+
+
+def test_notebookedit_in_worktree_ALLOWS():
+    payload = _event("NotebookEdit", cwd=WORKTREE, notebook_path=f"{WORKTREE}/nb.ipynb")
+    code, denied = _run(payload)
+    assert denied is False
+
+
+def test_sibling_repo_prefix_not_false_positive_ALLOWS():
+    # "/home/feedgen/road-to-aew-evil" must NOT be treated as inside "/home/feedgen/road-to-aew".
+    payload = _event("Edit", cwd=WORKTREE, file_path=f"{MAIN_REPO}-evil/src/foo.ts")
+    code, denied = _run(payload)
+    assert denied is False
+
+
+def test_non_guarded_tool_ALLOWS():
+    payload = _event("Bash", cwd=WORKTREE, file_path=f"{MAIN_REPO}/src/foo.ts")
+    code, denied = _run(payload)
+    assert denied is False
+
+
+def test_bypass_env_ALLOWS():
+    payload = _event("Edit", cwd=WORKTREE, file_path=f"{MAIN_REPO}/src/foo.ts")
+    code, denied = _run(payload, env={mod._BYPASS_ENV: "1"})
+    assert denied is False
+
+
+# ---------------------------------------------------------------------------
+# Standalone runner (no pytest required)
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    tests = [(n, f) for n, f in sorted(globals().items()) if n.startswith("test_") and callable(f)]
+    failures = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"PASS  {name}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL  {name}: {e}")
+        except Exception as e:
+            failures += 1
+            print(f"ERROR {name}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    sys.exit(1 if failures else 0)

--- a/hooks/tests/test_pretool_worktree_edit_guard.py
+++ b/hooks/tests/test_pretool_worktree_edit_guard.py
@@ -11,9 +11,14 @@ Or standalone: python3 hooks/tests/test_pretool_worktree_edit_guard.py
 import importlib.util
 import json
 import os
+import shutil
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 HOOK_PATH = Path(__file__).parent.parent / "pretool-worktree-edit-guard.py"
 
@@ -187,21 +192,169 @@ def test_bypass_env_ALLOWS():
 
 
 # ---------------------------------------------------------------------------
+# Regression: symlinked roots (HIGH-1 C1/C2) and nested worktree-id (MEDIUM-1)
+#
+# These use REAL temp dirs + real git worktrees so the git-toplevel derivation
+# and realpath canonicalization are exercised end to end. They skip gracefully
+# where git or os.symlink is unavailable.
+# ---------------------------------------------------------------------------
+
+_HAS_GIT = shutil.which("git") is not None
+
+
+def _git(args, cwd):
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "GIT_CONFIG_NOSYSTEM": "1", "HOME": cwd},
+    )
+
+
+def _init_repo(path):
+    os.makedirs(path, exist_ok=True)
+    _git(["init", "-q"], path)
+    _git(["config", "user.email", "t@t.t"], path)
+    _git(["config", "user.name", "t"], path)
+    Path(path, "seed.txt").write_text("seed\n")
+    _git(["add", "seed.txt"], path)
+    _git(["commit", "-q", "-m", "seed"], path)
+
+
+def _make_real_worktree(base, worktree_relpath):
+    """Create main repo at base/main and a git worktree at base/main/<relpath>.
+
+    Returns (main_repo_root, worktree_root) as real (non-symlinked) abspaths.
+    """
+    main_repo = os.path.join(base, "main")
+    _init_repo(main_repo)
+    worktree_root = os.path.join(main_repo, worktree_relpath)
+    os.makedirs(os.path.dirname(worktree_root), exist_ok=True)
+    _git(["worktree", "add", "-q", worktree_root, "-b", "wt-branch"], main_repo)
+    return main_repo, worktree_root
+
+
+@pytest.mark.skipif(not _HAS_GIT, reason="git not available")
+def test_symlinked_root_out_of_worktree_escape_BLOCKS():
+    """HIGH-1 C1: under a symlinked path, a main-repo escape is still BLOCKED."""
+    base = tempfile.mkdtemp(prefix="wtguard_sym_")
+    try:
+        main_repo, worktree_root = _make_real_worktree(base, ".claude/worktrees/abc123")
+        # Symlink the whole base so the agent's cwd is a symlinked path.
+        link = os.path.join(tempfile.mkdtemp(prefix="wtguard_link_"), "linked")
+        try:
+            os.symlink(base, link)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unsupported")
+        linked_cwd = os.path.join(link, "main", ".claude", "worktrees", "abc123")
+        # Target: a main-repo file via the SYMLINKED absolute path (the escape).
+        target = os.path.join(link, "main", "src", "foo.ts")
+        payload = _event("Edit", cwd=linked_cwd, file_path=target)
+        code, denied = _run(payload)
+        assert code == 0
+        assert denied is True, "symlinked out-of-worktree escape must be blocked"
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+@pytest.mark.skipif(not _HAS_GIT, reason="git not available")
+def test_symlinked_root_in_worktree_edit_ALLOWS():
+    """HIGH-1 C2: under a symlinked path, a legitimate in-worktree edit is ALLOWED."""
+    base = tempfile.mkdtemp(prefix="wtguard_sym_")
+    try:
+        main_repo, worktree_root = _make_real_worktree(base, ".claude/worktrees/abc123")
+        link = os.path.join(tempfile.mkdtemp(prefix="wtguard_link_"), "linked")
+        try:
+            os.symlink(base, link)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unsupported")
+        linked_cwd = os.path.join(link, "main", ".claude", "worktrees", "abc123")
+        # Target: a file INSIDE the worktree via the symlinked path.
+        target = os.path.join(linked_cwd, "src", "foo.ts")
+        payload = _event("Edit", cwd=linked_cwd, file_path=target)
+        code, denied = _run(payload)
+        assert code == 0
+        assert denied is False, "symlinked in-worktree edit must be allowed"
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+@pytest.mark.skipif(not _HAS_GIT, reason="git not available")
+def test_nested_worktree_id_sibling_edit_BLOCKS():
+    """MEDIUM-1: with a nested .../worktrees/<group>/<id>/ layout, an edit into a
+    SIBLING worktree (same group, different id) must be BLOCKED.
+
+    The single-segment string-split would compute worktree_root as
+    .../worktrees/<group> (too shallow) and treat the sibling as in-tree ->
+    under-block. The git-toplevel derivation pins worktree_root to the actual
+    worktree, so the sibling is correctly outside it.
+    """
+    base = tempfile.mkdtemp(prefix="wtguard_nest_")
+    try:
+        main_repo = os.path.join(base, "main")
+        _init_repo(main_repo)
+        wt_a = os.path.join(main_repo, ".claude/worktrees/group1/idA")
+        wt_b = os.path.join(main_repo, ".claude/worktrees/group1/idB")
+        os.makedirs(os.path.dirname(wt_a), exist_ok=True)
+        _git(["worktree", "add", "-q", wt_a, "-b", "branch-a"], main_repo)
+        _git(["worktree", "add", "-q", wt_b, "-b", "branch-b"], main_repo)
+        # Agent runs in idA; tries to edit a file in sibling idB.
+        target = os.path.join(wt_b, "src", "foo.ts")
+        payload = _event("Edit", cwd=wt_a, file_path=target)
+        code, denied = _run(payload)
+        assert code == 0
+        assert denied is True, "sibling-worktree edit under nested id must be blocked"
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+@pytest.mark.skipif(not _HAS_GIT, reason="git not available")
+def test_nested_worktree_id_in_worktree_edit_ALLOWS():
+    """MEDIUM-1 companion: an edit INSIDE the agent's own nested worktree is ALLOWED."""
+    base = tempfile.mkdtemp(prefix="wtguard_nest_")
+    try:
+        main_repo = os.path.join(base, "main")
+        _init_repo(main_repo)
+        wt_a = os.path.join(main_repo, ".claude/worktrees/group1/idA")
+        os.makedirs(os.path.dirname(wt_a), exist_ok=True)
+        _git(["worktree", "add", "-q", wt_a, "-b", "branch-a"], main_repo)
+        target = os.path.join(wt_a, "src", "foo.ts")
+        payload = _event("Edit", cwd=wt_a, file_path=target)
+        code, denied = _run(payload)
+        assert code == 0
+        assert denied is False, "own nested-worktree edit must be allowed"
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
 # Standalone runner (no pytest required)
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
+    _skipped_exc = getattr(getattr(pytest, "skip", None), "Exception", Exception)
+    try:
+        from _pytest.outcomes import Skipped as _skipped_exc  # type: ignore
+    except Exception:
+        pass
+
     tests = [(n, f) for n, f in sorted(globals().items()) if n.startswith("test_") and callable(f)]
     failures = 0
+    skipped = 0
     for name, fn in tests:
         try:
             fn()
             print(f"PASS  {name}")
+        except _skipped_exc as e:  # type: ignore[misc]
+            skipped += 1
+            print(f"SKIP  {name}: {e}")
         except AssertionError as e:
             failures += 1
             print(f"FAIL  {name}: {e}")
         except Exception as e:
             failures += 1
             print(f"ERROR {name}: {type(e).__name__}: {e}")
-    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    print(f"\n{len(tests) - failures - skipped}/{len(tests)} passed, {skipped} skipped")
     sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Summary
Registers and tracks the `pretool-worktree-edit-guard` PreToolUse hook so agents working in a git worktree cannot edit files outside their own worktree — the failure mode that just clobbered a sibling branch during concurrent multi-agent work. The hook had tested code but was never wired in, so it gave zero protection.

## Changes
- `hooks/pretool-worktree-edit-guard.py` — new PreToolUse hook (Write|Edit|MultiEdit|NotebookEdit); blocks edits outside the active worktree via realpath `commonpath` containment, fails open
- `hooks/tests/test_pretool_worktree_edit_guard.py` — guard test suite
- `.claude/settings.json` — register the guard after `pretool-unified-gate`
- `README.md` — hook count

## Notes
Fails open by design: any resolution error allows the edit, so a guard bug can never block legitimate work — it only ever adds protection. (ADR `worktree-edit-guard`.)