### PR TITLE
docs(pr-workflow): require Notes on risk triggers; path/or/area

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,8 +5,8 @@
 ## Changes
 
 <!-- One line per change: `path/or/area` — what changed, declaratively (verb + what + where). State the fact and let the diff carry detail. For many sub-items, give the shape and count ("add 21 trigger phrases") instead of listing each. -->
-- `path/to/file` — what changed
+- `path/or/area` — what changed
 
 ## Notes
 
-<!-- Optional, and usually omitted. Include only what a reviewer cannot infer from the diff or assume by default: a non-obvious decision, a deliberate omission, a follow-up, a gotcha. Skip what is always true (a PR can be reverted; CI runs the tests). When nothing qualifies, drop this section. -->
+<!-- Omit this section for routine PRs (drop it when nothing qualifies). Note it here when a trigger applies, one terse declarative line per point: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, a "supersedes #N". Also note it when a RISK/VERIFICATION trigger holds — manual verification was performed; part of the change sits outside CI coverage; migration/rollout ordering matters; a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). State the caveat as one fact; let CI carry command output. Skip what is always true (a PR can be reverted; CI runs the tests). -->

--- a/skills/process/pr-workflow/SKILL.md
+++ b/skills/process/pr-workflow/SKILL.md
@@ -150,10 +150,10 @@ Tests run as GitHub Actions, so the Checks tab is the test record. Let CI carry 
 
 Aim for high meaning per word: each line states one fact about the change, declaratively, so a reviewer understands it fast. Density is the target, not minimal length — a large change keeps the three sections and carries the detail it needs; it earns that length by packing each line with signal. Four rules carry the vibe:
 
-1. **One fact per line.** Each Summary/Changes line reads verb + what + where. Plain words, high meaning.
+1. **One fact per line.** Each Changes line reads verb + what + where; Summary states the goal and why. Plain words, high meaning.
 2. **Summary states the goal.** 1-3 plain sentences or a few crisp bullets. Keep metrics to the single number that matters.
 3. **One line per change.** When a change has many sub-items, state the shape and count ("add 21 PR-creation trigger phrases") and let the diff enumerate them. Keep rationale to the clause that earns its place.
-4. **Notes carries non-obvious signal only.** Usually omitted. Include only what a reviewer cannot infer from the diff or assume by default: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, a "supersedes #N" — one terse line each. Skip what is always true (a PR can be reverted; CI runs the tests). Drop the section when nothing qualifies.
+4. **Notes carries non-obvious signal — required when a trigger applies.** Omit it for routine PRs and drop the section when nothing qualifies. Note it, one terse declarative line per point, when a reviewer cannot infer the signal from the diff: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, a "supersedes #N". Note it too when a RISK/VERIFICATION trigger holds — manual verification was performed; part of the change sits outside CI coverage; migration/rollout ordering matters; a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). State each caveat as one fact and let CI carry command output. Skip what is always true (a PR can be reverted; CI runs the tests).
 
 **Worked example — the shape to emulate (#608-good vs #710-bad):**
 
@@ -161,7 +161,7 @@ Aim for high meaning per word: each line states one fact about the change, decla
 |---------|-----------------|--------------------------------|
 | Summary | "Registers 3 hooks in settings.json; integrates `pre-route.py` into /do Phase 2 as a deterministic pre-filter." | One 5-sentence block stuffed with jargon and four metrics. |
 | Changes | "`SKILL.md` — add 21 PR-creation trigger phrases." | One bullet inlining all 21 phrases verbatim; another a 3-sentence rationale paragraph. |
-| Notes | "Supersedes #705." (non-obvious signal) — or omitted entirely when nothing qualifies | "Roll back by reverting the branch commits. Tests run in CI — see Checks." (always-true filler) plus a pasted `pytest -v` dump and a Scope & Risk wall. |
+| Notes | "Not covered by CI — the Terraform plan is applied manually." or "Apply the column migration before deploying." (a required risk/verification caveat) — or omitted entirely when nothing qualifies | "Roll back by reverting the branch commits. Tests run in CI — see Checks." (always-true filler) plus a pasted `pytest -v` dump and a Scope & Risk wall. |
 
 The dense column reads in seconds because each cell carries facts; the bloated column buries the same facts in volume (and re-states what the Checks tab already shows). Aim every body at the dense column.
 
@@ -173,10 +173,10 @@ Copy this canonical skeleton into `--body`:
 
 ## Changes
 <!-- One line per change: verb + what + where. State shape and count for many sub-items; let the diff enumerate them. -->
-- `path/to/file` — what changed
+- `path/or/area` — what changed
 
 ## Notes
-<!-- Optional, and usually omitted. Include only what a reviewer cannot infer from the diff or assume by default: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, a "supersedes #N". Skip what is always true (a PR can be reverted; CI runs the tests). When nothing qualifies, drop this section. -->
+<!-- Omit for routine PRs (drop the section when nothing qualifies). Note it, one terse declarative line per point, when a reviewer cannot infer the signal from the diff: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, a "supersedes #N". Note it too when a RISK/VERIFICATION trigger holds — manual verification was performed; part of the change sits outside CI coverage; migration/rollout ordering matters; a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). Let CI carry command output. Skip what is always true (a PR can be reverted; CI runs the tests). -->
 ```
 
 The sync (`sync.md` Step 5) and pipeline (`pipeline.md` Phase 5) references carry this same skeleton at their `gh pr create` call sites. When either path writes a `--body`, it uses this structure and the density rules above.

--- a/skills/process/pr-workflow/references/pipeline.md
+++ b/skills/process/pr-workflow/references/pipeline.md
@@ -254,7 +254,7 @@ This pipeline cannot create PRs without staged changes -- if nothing is staged, 
 
 **PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's three sections in the `--body` string, in order: **Summary → Changes → Notes**. This keeps PR bodies consistent across models.
 
-**Write for density.** Each line states one fact about the change, declaratively (verb + what + where), so a reviewer scans the body fast. State the goal plainly in Summary; write one line per change in Changes (give shape and count for many sub-items, e.g. "add 21 trigger phrases", and let the diff enumerate them); keep Notes for non-obvious signal only — include just what a reviewer cannot infer from the diff or assume by default (a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N"), skip what is always true (a PR can be reverted; CI runs the tests), and drop the section when nothing qualifies. Tests run as GitHub Actions and the Checks tab is the test record; reviewer verdicts likewise show on the PR, so leave command output to CI and keep it out of the body. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
+**Write for density.** Each Changes line states one fact, declaratively (verb + what + where), so a reviewer scans the body fast; Summary states the goal and why. Write one line per change in Changes (give shape and count for many sub-items, e.g. "add 21 trigger phrases", and let the diff enumerate them). Omit Notes for routine PRs and drop the section when nothing qualifies; note it, one terse line per point, when a reviewer cannot infer the signal from the diff (a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N") or when a risk/verification trigger holds — manual verification was performed, part of the change sits outside CI coverage, migration/rollout ordering matters, or a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). Skip what is always true (a PR can be reverted; CI runs the tests). Tests run as GitHub Actions and the Checks tab is the test record; reviewer verdicts likewise show on the PR, so leave command output to CI and keep it out of the body. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
 
 ```bash
 CLAUDE_GATE_BYPASS=1 gh pr create --title "type(scope): description" --body "$(cat <<'EOF'
@@ -262,10 +262,10 @@ CLAUDE_GATE_BYPASS=1 gh pr create --title "type(scope): description" --body "$(c
 [State the goal plainly: 1-3 sentences or a few crisp bullets, one fact per line. Name the ADR/issue if any.]
 
 ## Changes
-- `path/to/file` — what changed [one line per change; give shape + count for many sub-items]
+- `path/or/area` — what changed [one line per change; give shape + count for many sub-items]
 
 ## Notes
-[Optional, and usually omitted. Include only what a reviewer cannot infer from the diff or assume by default: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N". Skip what is always true (a PR can be reverted; CI runs the tests). When nothing qualifies, drop this section.]
+[Omit for routine PRs (drop the section when nothing qualifies). Note it, one terse line per point, when a reviewer cannot infer the signal from the diff: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N". Note it too when a risk/verification trigger holds — manual verification was performed; part of the change sits outside CI coverage; migration/rollout ordering matters; a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). Skip what is always true (a PR can be reverted; CI runs the tests).]
 EOF
 )"
 ```
@@ -657,7 +657,7 @@ Check for artifacts in this order and build the PR body from what's available:
 |----------|---------------------|----------------|
 | `task_plan.md` | **Summary** (from Goal section) and **Changes** (from completed tasks) | Read the Goal and Phases sections; state the goal plainly; write one line per completed item (shape + count for many sub-items) |
 | Deviation logs (ADR-076 repair actions) | **Notes** (deviations) | List repair actions taken and why the original plan changed, one terse line each — these are non-obvious by nature |
-| Context a reviewer cannot infer (non-obvious decision, deliberate omission, follow-up, gotcha, supersedes) | **Notes** (optional) | One terse line each. Populate Notes only when an artifact surfaces something non-obvious; skip what is always true (a PR can be reverted; CI runs the tests) and drop the section when nothing qualifies. Verification reports and review summaries stay in CI — the Checks tab carries the result |
+| Context a reviewer cannot infer (non-obvious decision, deliberate omission, follow-up, gotcha, supersedes) or a risk/verification trigger (manual verification performed, CI-coverage gap, migration/rollout ordering, security-surface change) | **Notes** (required on trigger) | One terse line each. Omit Notes for routine PRs and drop the section when nothing qualifies; note it when an artifact surfaces non-obvious context or a risk/verification trigger holds (e.g. `Not covered by CI — terraform plan is manual`). Skip what is always true (a PR can be reverted; CI runs the tests). Verification reports and review summaries stay in CI — the Checks tab carries the result |
 
 **Fallback**: If no artifacts exist, fall back to diff-based generation -- summarize changes from the diff and commit messages. This is the existing behavior and remains the default for ad-hoc PRs without planning artifacts.
 
@@ -672,11 +672,11 @@ Follows the canonical three-section structure from `.github/pull_request_templat
 
 ## Changes
 <!-- From task_plan.md completed phases/tasks. One line per change: verb + what + where. Give shape + count for many sub-items. -->
-- `path/to/file` — [completed task description]
-- `path/to/file` — [completed task description]
+- `path/or/area` — [completed task description]
+- `path/or/area` — [completed task description]
 
 ## Notes
-<!-- Optional, and usually omitted. Populate only when an artifact surfaces something a reviewer cannot infer from the diff or assume by default: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N", a deviation log (ADR-076). Skip what is always true (a PR can be reverted; CI runs the tests). When nothing qualifies, drop this section. -->
+<!-- Omit for routine PRs (drop the section when nothing qualifies). Note it, one terse line per point, when an artifact surfaces something a reviewer cannot infer from the diff: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N", a deviation log (ADR-076). Note it too when a risk/verification trigger holds — manual verification was performed; part of the change sits outside CI coverage; migration/rollout ordering matters; a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). Skip what is always true (a PR can be reverted; CI runs the tests). -->
 [Optional context a reviewer cannot infer from the diff.]
 ```
 

--- a/skills/process/pr-workflow/references/sync.md
+++ b/skills/process/pr-workflow/references/sync.md
@@ -142,7 +142,7 @@ Generate the PR title from the branch name or first commit when not provided by 
 
 **PR body structure is mandatory.** `gh pr create --body` bypasses `.github/pull_request_template.md` (GitHub applies that file only to the web UI and to a bare `gh pr create`). Reproduce the template's three sections in the `--body` string, in order: **Summary → Changes → Notes**. This keeps PR bodies consistent across models.
 
-**Write for density.** Each line states one fact about the change, declaratively (verb + what + where), so a reviewer scans the body fast. State the goal plainly in Summary; write one line per change in Changes (give shape and count for many sub-items, like "add 21 trigger phrases", and let the diff enumerate them); keep Notes for non-obvious signal only — include just what a reviewer cannot infer from the diff or assume by default (a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N"), skip what is always true (a PR can be reverted; CI runs the tests), and drop the section when nothing qualifies. Tests run as GitHub Actions, so the Checks tab is the test record; leave command output to CI and keep it out of the body. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
+**Write for density.** Each Changes line states one fact, declaratively (verb + what + where), so a reviewer scans the body fast; Summary states the goal and why. Write one line per change in Changes (give shape and count for many sub-items, like "add 21 trigger phrases", and let the diff enumerate them). Omit Notes for routine PRs and drop the section when nothing qualifies; note it, one terse line per point, when a reviewer cannot infer the signal from the diff (a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N") or when a risk/verification trigger holds — manual verification was performed, part of the change sits outside CI coverage, migration/rollout ordering matters, or a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). Skip what is always true (a PR can be reverted; CI runs the tests). Tests run as GitHub Actions, so the Checks tab is the test record; leave command output to CI and keep it out of the body. See the SKILL.md "Write for Density" rules for the full vibe and worked example.
 
 ```bash
 # Check if PR already exists for this branch
@@ -155,10 +155,10 @@ if [[ -z "$EXISTING_PR" ]]; then
 [State the goal plainly: 1-3 sentences or a few crisp bullets, one fact per line. Name the ADR/issue if any.]
 
 ## Changes
-- `path/to/file` — what changed [one line per change; give shape + count for many sub-items, e.g. "add 21 trigger phrases"]
+- `path/or/area` — what changed [one line per change; give shape + count for many sub-items, e.g. "add 21 trigger phrases"]
 
 ## Notes
-[Optional, and usually omitted. Include only what a reviewer cannot infer from the diff or assume by default: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N". Skip what is always true (a PR can be reverted; CI runs the tests). When nothing qualifies, drop this section.]
+[Omit for routine PRs (drop the section when nothing qualifies). Note it, one terse line per point, when a reviewer cannot infer the signal from the diff: a non-obvious decision, a deliberate omission, a follow-up, a gotcha, "supersedes #N". Note it too when a risk/verification trigger holds — manual verification was performed; part of the change sits outside CI coverage; migration/rollout ordering matters; a security-sensitive surface changed (e.g. `Not covered by CI — terraform plan is manual`). Skip what is always true (a PR can be reverted; CI runs the tests).]
 EOF
 )"
 else


### PR DESCRIPTION
## Summary
Tightens the canonical PR-body template's `Notes` rule (added in #711): Notes stays omitted for routine PRs but becomes required when a risk trigger applies, so a reviewer keeps every migration-ordering, CI-gap, manual-verification, or security-surface caveat instead of losing it to a mechanical "usually omitted". From a Codex review of the template.

## Changes
- `.github/pull_request_template.md` — reframe `Notes` to required-on-trigger; add risk/verification triggers; allow one terse verification line; `path/or/area` in the example bullet
- `skills/process/pr-workflow/SKILL.md` — update the density Notes rule + worked example; scope "verb + what + where" to Changes lines; `path/or/area`
- `skills/process/pr-workflow/references/sync.md`, `references/pipeline.md` — align the `--body` skeleton guidance for Notes + `path/or/area`

## Notes
Not covered by CI — the template guidance is prose; verified by the joy-check, doc-count, and do-framing gates only.