### PR TITLE
docs(philosophy): record why /do Phase 2 uses the Haiku semantic router

### DIFF
--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -66,6 +66,14 @@ Skills route at four confidence tiers driven by trigger-match count and the `for
 
 `force_route: true` belongs on umbrella, setup, and methodology skills where a single high-specificity trigger phrase carries unambiguous intent (`pr-workflow`, `install`, `quick`). Domain task skills earn confidence through multiple trigger matches — preventing misroute when phrases like "fix" or "review" overlap.
 
+### The Haiku Router Reads Intent; Keywords Cannot
+
+`/do` Phase 2 runs a Haiku semantic router. Its value is **not** skill discovery — the harness already injects the full `available-skills` list (~140 skills, with descriptions) into every session, so dropping the router would not reclaim that context. The router earns its keep doing what native skill auto-invocation cannot: agent+skill *pairing*, safety-critical force-routes that drag git/security work through the quality gates (lint/tests/CI), the quality-loop wrapper, complexity classification, parallel decomposition, and task-spec injection.
+
+The decisive number: dropping Haiku for pure deterministic `pre-route.py` keyword routing collapses strict routing accuracy **63.3% → 34.7%** (corpus n=49). It scores **0% on every paraphrase bucket** — "send my commits to the server" carries no keyword trigger — so **22 of 49 requests** lose their correct agent+skill and fall to a skill-less general handler. Cost of keeping the router: ~+0.1 Haiku calls/request. Trivial, by design (see `skills/meta/do/references/semantic-first-ab-results.md`; drop-Haiku A/B in `tmp/drophaiku-ab-report.md`).
+
+**Known follow-up.** The honest cost is the manifest, not the router: the ~31.9 KB routing manifest duplicates skill descriptions the native list already carries. Trim it to router-only metadata (FORCE flags, agent pairings, `not_for`) — that, not removing the router, is the real optimization.
+
 ---
 
 ## Triple-Validation Extraction Gate

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -68,11 +68,11 @@ Skills route at four confidence tiers driven by trigger-match count and the `for
 
 ### The Haiku Router Reads Intent; Keywords Cannot
 
-`/do` Phase 2 runs a Haiku semantic router. Its value is **not** skill discovery — the harness already injects the full `available-skills` list (~140 skills, with descriptions) into every session, so dropping the router would not reclaim that context. The router earns its keep doing what native skill auto-invocation cannot: agent+skill *pairing*, safety-critical force-routes that drag git/security work through the quality gates (lint/tests/CI), the quality-loop wrapper, complexity classification, parallel decomposition, and task-spec injection.
+`/do` Phase 2 runs a Haiku semantic router. Its value is **not** skill discovery — the harness already injects the full `available-skills` list (~123 skills, with descriptions) into every session, so dropping the router would not reclaim that context. The router earns its keep doing what keyword pre-routing cannot: agent+skill *pairing*, safety-critical force-routes that drag git/security work through the quality gates (lint/tests/CI), the quality-loop wrapper, complexity classification, parallel decomposition, and task-spec injection.
 
 The decisive number: dropping Haiku for pure deterministic `pre-route.py` keyword routing collapses strict routing accuracy **63.3% → 34.7%** (corpus n=49). It scores **0% on every paraphrase bucket** — "send my commits to the server" carries no keyword trigger — so **22 of 49 requests** lose their correct agent+skill and fall to a skill-less general handler. Cost of keeping the router: ~+0.1 Haiku calls/request. Trivial, by design (see `skills/meta/do/references/semantic-first-ab-results.md`; drop-Haiku A/B in `tmp/drophaiku-ab-report.md`).
 
-**Known follow-up.** The honest cost is the manifest, not the router: the ~31.9 KB routing manifest duplicates skill descriptions the native list already carries. Trim it to router-only metadata (FORCE flags, agent pairings, `not_for`) — that, not removing the router, is the real optimization.
+**Known follow-up.** The honest cost is the manifest, not the router: the routing manifest (full ~31.9 KB, compact ~21.4 KB) duplicates skill descriptions the native list already carries. Trim it to router-only metadata (FORCE flags, agent pairings, `not_for`) — that, not removing the router, is the real optimization. A newer 3-arm A/B finds native self-route by the orchestrator model ties the Haiku router (63.3% vs 63.3%), so the deeper open question is whether the Haiku sub-dispatch is still needed at all.
 
 ---
 


### PR DESCRIPTION
## Summary

Record as doctrine in `docs/PHILOSOPHY.md` why `/do` Phase 2 uses the Haiku semantic router, so a maintainer reconsidering it doesn't re-litigate from scratch. The router's value is reading intent (agent+skill pairing, safety force-routes, quality loop), not skill discovery — the harness injects the full skill list natively either way.

## Changes
- `docs/PHILOSOPHY.md` — add `### The Haiku Router Reads Intent; Keywords Cannot` under "Everything That Can Be Deterministic, Should Be"; leads with the principle, cites the drop-Haiku A/B (63.3% → 34.7%, 22/49 requests lose their agent+skill on paraphrases), and flags the real follow-up (trim the routing manifest, not the router).
