### PR TITLE
fix(hooks): wire up dormant prevent-homedir-server gate + close 3 bypasses

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -160,6 +160,12 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/prevent-homedir-server.py\"",
+            "description": "Home-dir server safety: blocks python http.server/SimpleHTTPServer started from the bare home directory (would serve ~/.ssh, ~/.git-credentials publicly)",
+            "timeout": 3000
+          },
+          {
+            "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/pretool-branch-safety.py\"",
             "description": "Branch safety: blocks git commit on main/master, forces feature branches",
             "timeout": 3000

--- a/hooks/prevent-homedir-server.py
+++ b/hooks/prevent-homedir-server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.2.0
+# hook-version: 1.3.0
 """
 PreToolUse:Bash Hook: Home Directory HTTP Server Safety Gate
 
@@ -43,9 +43,11 @@ DEBUG_LOG = "/tmp/claude_hook_debug.log"
 # Patterns that indicate an http server invocation.
 # Only match explicit `python -m http.server` invocations — broad patterns
 # like bare `http.server` would false-positive on grep, pip install, etc.
+# `-m\s*` (not `-m\s+`) so the no-space form `python3 -mhttp.server`, which
+# Python accepts, is matched too — otherwise it is a trivial bypass.
 HTTP_SERVER_PATTERNS = [
-    r"\bpython3?\s+.*-m\s+http\.server\b",
-    r"\bpython3?\s+.*-m\s+SimpleHTTPServer\b",
+    r"\bpython3?\s+.*-m\s*http\.server\b",
+    r"\bpython3?\s+.*-m\s*SimpleHTTPServer\b",
 ]
 
 # --directory flag pointing somewhere — we need to verify where it points.
@@ -109,13 +111,23 @@ def _extract_directory_flag(command: str) -> str | None:
     return m.group(1) if m else None
 
 
-def _directory_flag_is_safe(directory_value: str) -> bool:
-    """Return True if --directory points outside the protected home."""
+def _directory_flag_is_safe(directory_value: str, base_cwd: str) -> bool:
+    """Return True if --directory points outside the protected home.
+
+    Relative values (e.g. ``--directory .``) are resolved against the session
+    ``base_cwd`` from the event envelope, NOT the hook process cwd — otherwise
+    ``--directory .`` from a home-directory session would be judged against
+    wherever the hook happens to run. Symlinks are resolved so a link into
+    home cannot mask the target.
+    """
     # Normalize: resolve ~ shorthand
     if directory_value.startswith("~"):
         directory_value = PROTECTED_HOME + directory_value[1:]
     try:
-        resolved = Path(directory_value).resolve()
+        candidate = Path(directory_value)
+        if not candidate.is_absolute():
+            candidate = Path(base_cwd) / candidate
+        resolved = candidate.resolve()
         home = Path(PROTECTED_HOME).resolve()
         if resolved == home:
             return False  # Exactly home — dangerous
@@ -149,10 +161,18 @@ def main() -> None:
 
         _debug("http.server command detected")
 
+        # Resolve the session CWD up front — Check 1 needs it to resolve a
+        # relative --directory against the right base. Claude Code exposes cwd
+        # via the event envelope; fall back to CLAUDE_CWD or os.getcwd().
+        session_cwd = (
+            data.get("cwd") or data.get("session", {}).get("cwd") or os.environ.get("CLAUDE_CWD") or os.getcwd()
+        )
+        _debug(f"session_cwd={session_cwd}")
+
         # --- Check 1: --directory flag pointing to a safe path ---
         dir_flag = _extract_directory_flag(command)
         if dir_flag is not None:
-            if _directory_flag_is_safe(dir_flag):
+            if _directory_flag_is_safe(dir_flag, session_cwd):
                 _debug(f"allow: --directory={dir_flag} is safe")
                 _allow()
             else:
@@ -170,20 +190,17 @@ def main() -> None:
             _debug("allow: command cd's into a subdir first")
             _allow()
 
-        # --- Check 3: inspect the session CWD ---
-        # Claude Code exposes cwd via the event envelope.
-        # Fall back to CLAUDE_CWD env var or os.getcwd() (hook process CWD
-        # reflects the session CWD in Claude Code).
-        session_cwd = (
-            data.get("cwd") or data.get("session", {}).get("cwd") or os.environ.get("CLAUDE_CWD") or os.getcwd()
-        )
+        # --- Check 3: inspect the session CWD (computed above) ---
+        # Compare both raw and symlink-resolved forms: a cwd that is a symlink
+        # pointing at home (e.g. /tmp/link -> /home/user) must still block.
+        home_resolved = Path(PROTECTED_HOME).resolve()
+        cwd_matches_home = str(session_cwd).rstrip("/") == PROTECTED_HOME.rstrip("/")
+        try:
+            cwd_matches_home = cwd_matches_home or Path(session_cwd).resolve() == home_resolved
+        except Exception:
+            pass
 
-        _debug(f"session_cwd={session_cwd}")
-
-        cwd_norm = str(session_cwd).rstrip("/")
-        home_norm = PROTECTED_HOME.rstrip("/")
-
-        if cwd_norm == home_norm:
+        if cwd_matches_home:
             _debug(f"block: CWD is home ({session_cwd})")
             _deny(
                 f"BLOCKED: http.server would serve your home directory publicly.\n\n"

--- a/hooks/tests/test_prevent_homedir_server.py
+++ b/hooks/tests/test_prevent_homedir_server.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Tests for the prevent-homedir-server hook.
+
+Covers the documented BLOCKED cases (python http.server from the bare home
+directory) and SAFE cases (--directory to a project path, `cd ~/project`
+first, non-home CWD, commands without http.server), plus the non-blocking
+contract (exit 0 on every path, including empty/malformed stdin).
+
+The hook reads the protected home from Path.home() at import time, so each
+subprocess run sets HOME explicitly and passes a matching `cwd` in the event
+envelope.
+
+Run with: python3 -m pytest hooks/tests/test_prevent_homedir_server.py -v
+Or standalone: python3 hooks/tests/test_prevent_homedir_server.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK_PATH = Path(__file__).parent.parent / "prevent-homedir-server.py"
+
+FAKE_HOME = "/home/testuser"
+
+
+def _event(command, *, cwd=None, omit_cwd=False):
+    ev = {"tool_name": "Bash", "tool_input": {"command": command}}
+    if not omit_cwd:
+        ev["cwd"] = cwd
+    return json.dumps(ev)
+
+
+def _run(stdin_payload, *, home=FAKE_HOME):
+    """Run the hook as a subprocess. Return (exit_code, decision_or_None)."""
+    env = dict(os.environ)
+    env["HOME"] = home
+    # Ensure the hook's CWD fallback (os.getcwd) cannot accidentally equal home.
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=stdin_payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd="/tmp",
+    )
+    decision = None
+    out = proc.stdout.strip()
+    if out:
+        try:
+            parsed = json.loads(out)
+            decision = parsed.get("hookSpecificOutput", {}).get("permissionDecision")
+        except json.JSONDecodeError:
+            decision = "INVALID_JSON"
+    return proc.returncode, decision
+
+
+# ---------------------------------------------------------------------------
+# BLOCKED cases
+# ---------------------------------------------------------------------------
+
+
+def test_http_server_from_bare_home_is_blocked():
+    code, decision = _run(_event("python3 -m http.server 8080", cwd=FAKE_HOME))
+    assert code == 0
+    assert decision == "deny"
+
+
+def test_simplehttpserver_from_bare_home_is_blocked():
+    code, decision = _run(_event("python -m SimpleHTTPServer 8000", cwd=FAKE_HOME))
+    assert code == 0
+    assert decision == "deny"
+
+
+def test_http_server_no_3_from_bare_home_is_blocked():
+    # `python -m http.server` (no 3) must also be blocked.
+    code, decision = _run(_event("python -m http.server", cwd=FAKE_HOME))
+    assert code == 0
+    assert decision == "deny"
+
+
+def test_directory_flag_pointing_at_home_is_blocked():
+    code, decision = _run(_event(f"python3 -m http.server --directory {FAKE_HOME} 8080", cwd="/tmp"))
+    assert code == 0
+    assert decision == "deny"
+
+
+def test_home_cwd_via_envelope_even_when_process_cwd_differs():
+    # Process runs in /tmp but the session envelope reports home as CWD.
+    code, decision = _run(_event("python3 -m http.server", cwd=FAKE_HOME))
+    assert code == 0
+    assert decision == "deny"
+
+
+def test_no_space_dash_m_form_is_blocked():
+    # Bypass regression: Python accepts `-mhttp.server` (no space); must block.
+    code, decision = _run(_event("python3 -mhttp.server 8080", cwd=FAKE_HOME))
+    assert code == 0
+    assert decision == "deny"
+
+
+def test_no_space_dash_m_simplehttpserver_is_blocked():
+    code, decision = _run(_event("python -mSimpleHTTPServer 8000", cwd=FAKE_HOME))
+    assert code == 0
+    assert decision == "deny"
+
+
+def test_symlinked_cwd_to_home_is_blocked(tmp_path):
+    # Bypass regression: a cwd that is a symlink pointing at home must block.
+    link = tmp_path / "homelink"
+    link.symlink_to(FAKE_HOME)
+    code, decision = _run(_event("python3 -m http.server 8080", cwd=str(link)))
+    assert code == 0
+    assert decision == "deny"
+
+
+def test_directory_dot_from_home_is_blocked():
+    # Bypass regression: relative `--directory .` resolves against the session
+    # cwd (home here), not the hook process cwd, so it must block.
+    code, decision = _run(_event("python3 -m http.server --directory . 8080", cwd=FAKE_HOME))
+    assert code == 0
+    assert decision == "deny"
+
+
+# ---------------------------------------------------------------------------
+# SAFE cases
+# ---------------------------------------------------------------------------
+
+
+def test_directory_flag_to_project_path_is_allowed():
+    code, decision = _run(_event(f"python3 -m http.server --directory {FAKE_HOME}/myproject 8080", cwd=FAKE_HOME))
+    assert code == 0
+    assert decision is None
+
+
+def test_cd_into_subdir_first_is_allowed():
+    code, decision = _run(_event("cd ~/myproject && python3 -m http.server 8080", cwd=FAKE_HOME))
+    assert code == 0
+    assert decision is None
+
+
+def test_non_home_cwd_is_allowed():
+    code, decision = _run(_event("python3 -m http.server 8080", cwd=f"{FAKE_HOME}/myproject"))
+    assert code == 0
+    assert decision is None
+
+
+def test_command_without_http_server_is_allowed():
+    code, decision = _run(_event("ls -la && grep http.server notes.txt", cwd=FAKE_HOME))
+    assert code == 0
+    assert decision is None
+
+
+def test_unrelated_command_from_home_is_allowed():
+    code, decision = _run(_event("git status", cwd=FAKE_HOME))
+    assert code == 0
+    assert decision is None
+
+
+def test_directory_flag_outside_home_is_allowed():
+    code, decision = _run(_event("python3 -m http.server --directory /srv/www 8080", cwd=FAKE_HOME))
+    assert code == 0
+    assert decision is None
+
+
+def test_relative_directory_subdir_from_home_is_allowed():
+    # `--directory ./proj` from home resolves to a subdir of home -> safe.
+    code, decision = _run(_event("python3 -m http.server --directory ./proj 8080", cwd=FAKE_HOME))
+    assert code == 0
+    assert decision is None
+
+
+# ---------------------------------------------------------------------------
+# Non-blocking contract: exit 0 on every input shape
+# ---------------------------------------------------------------------------
+
+
+def test_empty_stdin_exits_zero_and_allows():
+    code, decision = _run("")
+    assert code == 0
+    assert decision is None
+
+
+def test_whitespace_stdin_exits_zero_and_allows():
+    code, decision = _run("   \n  ")
+    assert code == 0
+    assert decision is None
+
+
+def test_malformed_json_exits_zero_and_allows():
+    code, decision = _run("{not valid json")
+    assert code == 0
+    assert decision is None
+
+
+def test_missing_cwd_in_envelope_does_not_crash():
+    # No cwd key at all -> falls back to env/os.getcwd (/tmp), so allowed.
+    code, decision = _run(_event("python3 -m http.server 8080", omit_cwd=True))
+    assert code == 0
+    assert decision is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Wire up the dormant home-directory HTTP-server safety hook. `hooks/prevent-homedir-server.py` was merged in #673 but never registered in `.claude/settings.json`, so it never ran — the same dormant-hook pattern #713 fixed for the worktree-edit-guard. This registers it as a `PreToolUse:Bash` gate and closes three bypasses surfaced by a Codex review.

## Changes

- **`.claude/settings.json`**: register `prevent-homedir-server.py` under `PreToolUse` matcher `Bash` (same shape/path convention as the existing branch-safety Bash gate).
- **`hooks/prevent-homedir-server.py`**: close 3 confirmed bypasses (version 1.2.0 -> 1.3.0):
  - `python3 -mhttp.server` (no space after `-m`, which Python accepts): detection regex `-m\s+` -> `-m\s*`.
  - cwd that is a symlink pointing at `$HOME`: final cwd check now also compares `Path(...).resolve()`.
  - relative `--directory .`: now resolved against the envelope `session_cwd`, not the hook process cwd.
- **`hooks/tests/test_prevent_homedir_server.py`**: new suite, 20 cases — BLOCKED (http.server / SimpleHTTPServer from bare `$HOME`, `--directory $HOME`), SAFE (`--directory` to a project path, `cd ~/project` first, non-home cwd, no http.server), the 3 bypass regressions, and the exit-0 non-blocking contract on empty/malformed/valid stdin.

## Notes

Security-surface change (it activates a previously-inert block). The hook stays non-blocking: exit 0 on every path, block communicated only via JSON `permissionDecision=deny`. Codex (gpt-5.4, high reasoning) confirmed matcher correctness and the exit-0 contract; the 3 bypasses it flagged are fixed and regression-tested. Fire simulation: `python3 -m http.server` with cwd=`$HOME` -> deny; with cwd=a subdir -> allow.
