### PR TITLE
voice-writer: enforce short-paragraph ceiling in VARIETY-GATE (extracted from feat/local-security-review)

### DIFF
--- a/skills/content/voice-writer/SKILL.md
+++ b/skills/content/voice-writer/SKILL.md
@@ -247,17 +247,18 @@ Where `{voice_profile}` is the voice skill selected in Phase 1 (e.g., `voice-myp
    - Long (21+ words): target 10-25%
 2. Verify all three clusters appear at least 15% of the time
 3. If any cluster is below 15%: rewrite sentences in the dominant cluster to redistribute
-4. Check paragraph length variation:
-   - At least 1 single-sentence paragraph per 500 words
-   - At least 1 paragraph of 4+ sentences per 1000 words
-   - Consecutive paragraphs should vary in length (avoid runs of all 2-3 sentence paragraphs)
+4. Check paragraph length (hard ceiling, enforces short paragraphs with spacing between thoughts):
+   - Every paragraph holds 3 sentences or fewer. Count sentences per paragraph (split on blank lines).
+   - Any paragraph of 4+ sentences fails the gate: split it at the thought boundary and insert a blank line.
+   - At least 1 single-sentence paragraph per 500 words (single-sentence paragraphs are welcome whenever a thought stands alone).
+   - This applies to ALL voices and modes. Walls of text read as AI output; short paragraphs with spacing read as a person thinking.
 5. Calculate variety score: standard deviation of sentence word counts
 6. If variety score < 8.0 words:
-   - Inject longer exploratory sentences (complex thoughts, compound structures)
+   - Inject longer exploratory sentences (complex thoughts, compound structures) while keeping each paragraph at 3 sentences or fewer
    - Inject shorter fragment punches (declarations, observations, reactions)
    - Recalculate until stddev >= 8.0
 
-**Gate**: All three sentence clusters >= 15%. Paragraph length variation requirements met. Variety score (stddev of sentence lengths) >= 8.0. If below, rewrite and re-measure. Max 3 attempts.
+**Gate**: All three sentence clusters >= 15%. Every paragraph is 3 sentences or fewer (no walls of text), with at least 1 single-sentence paragraph per 500 words. Variety score (stddev of sentence lengths) >= 8.0. If any check fails, rewrite and re-measure. Max 3 attempts.
 
 ---
 

--- a/skills/voice-shared/workflow-refs/voice-writer.md
+++ b/skills/voice-shared/workflow-refs/voice-writer.md
@@ -254,14 +254,15 @@ Count words per sentence across the entire article:
 
 All three clusters must appear at least 15% of the time.
 
-**Step 2: Check paragraph variation**
-- At least 1 single-sentence paragraph per 500 words
-- At least 1 paragraph of 4+ sentences per 1000 words
-- No 3+ consecutive paragraphs of the same length
+**Step 2: Check paragraph length (hard ceiling, enforces short paragraphs with spacing between thoughts)**
+- Every paragraph holds 3 sentences or fewer. Count sentences per paragraph (split on blank lines).
+- Any paragraph of 4+ sentences fails the gate: split it at the thought boundary and insert a blank line.
+- At least 1 single-sentence paragraph per 500 words (single-sentence paragraphs are welcome whenever a thought stands alone).
+- This applies to ALL voices and modes. Walls of text read as AI output; short paragraphs with spacing read as a person thinking.
 
-**Step 3: Calculate standard deviation** of sentence word counts. Must be >= 8.0. If below, inject longer exploratory sentences and shorter fragment punches to redistribute.
+**Step 3: Calculate standard deviation** of sentence word counts. Must be >= 8.0. If below, inject longer exploratory sentences and shorter fragment punches to redistribute, while keeping each paragraph at 3 sentences or fewer.
 
-**Gate**: All distribution thresholds met. Stddev >= 8.0. Proceed only when gate passes.
+**Gate**: All distribution thresholds met. Every paragraph is 3 sentences or fewer (no walls of text), with at least 1 single-sentence paragraph per 500 words. Stddev >= 8.0. Proceed only when gate passes.
 
 ### Phase 6: JOY-CHECK (Mandatory)
 


### PR DESCRIPTION
## What

Extracts the one genuinely-new, not-on-main, self-contained delta from the partially-superseded `feat/local-security-review` branch: the **voice-writer VARIETY-GATE short-paragraph ceiling**.

- `skills/content/voice-writer/SKILL.md` (Phase 8 VARIETY-GATE): replaces the old "paragraph length variation" rule — which *required* `>=1 paragraph of 4+ sentences per 1000 words` — with a **hard ceiling of 3 sentences per paragraph**. Walls of text read as AI output; short paragraphs with spacing read as a person thinking. (cherry-picked from `feat/local-security-review`)
- `skills/voice-shared/workflow-refs/voice-writer.md`: the duplicate VARIETY-GATE still carried the old contradictory `4+ sentence` rule. Brought Step 2, the Step 3 low-stddev remediation, and the Gate line to parity with the canonical copy so both agree on the ceiling.

The other 4 commits on `feat/local-security-review` were triaged and **dropped** — main already has a more complete security-review system. See triage table below.

## Why

The branch predates main's security-review work, so its scanner / hook / index commits would have **regressed** main (main's scanner is a strict superset; its hook has DiffDedup/TTL/PostToolUse-advisory that the branch lacks). Only the voice-writer paragraph change is new and independent. Leaving the duplicate workflow-ref unfixed would have shipped a self-contradicting gate (ceiling of 3 vs. a requirement for 4+).

### Per-commit triage of `feat/local-security-review`

| Commit | Classification | Evidence |
|---|---|---|
| `1c66ae06` security-review skill + commit/stop hooks | **SUPERSEDED** | main has skill, scan, hook, `references/coverage.md`, tests already |
| `411b1836` voice-writer paragraph ceiling | **NEW-VALUABLE → extracted** | main's voice-writer still had old "4+ sentences" wording |
| `68d1ec86` scanner reach-detection parity | **SUPERSEDED** | branch scanner is *missing* main's doc-ext scanning, consolidated SQLi rules, path-traversal rule — would regress |
| `028a75dc` advisory edit-hook + index symlink fix | **ALREADY-ON-MAIN** | main's `security-review-hook.py` has the PostToolUse advisory handler; `generate-skill-index.py` symlink fix is byte-identical on main |
| `a5c10d66` regen `skills/INDEX.json` | **OBSOLETE** | `skills/INDEX.json` is gitignored on main (untrack-generated-indexes); regenerated at runtime |

## Testing

- `ruff check` + `ruff format --check`: pass
- `validate-skill-frontmatter.py`: 123 files OK
- `audit-skill-content.py --root skills/content --severity high`: 0 violations
- `validate-doc-counts.py`: all count claims agree
- Codex (gpt-5.4, high reasoning) on the final diff: no regression; both copies agree on the paragraph ceiling across Step 2 / Step 3 / Gate. Residual phrasing differences (clusters vs. distribution wording, retry-cap) pre-date this change and are out of scope.

## Notes

Docs/skill-only change; no code or security-scanner paths touched. The duplicate `voice-writer.md` workflow-ref has no inbound references (standalone doc) — fixing it removes a latent contradiction rather than altering runtime wiring.
