### PR TITLE
feat(hooks): permanent hook-health gate — kill the dormant-hook bug class

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -82,6 +82,20 @@
             "description": "Warn if .adr-session.json is orphaned (referenced ADR file missing); silent when no session exists",
             "timeout": 2000,
             "once": true
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/team-config-loader.py\"",
+            "description": "Load optional team-config.yaml into session context; silent when no config file exists",
+            "timeout": 2000,
+            "once": true
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/rules-distill-injector.py\"",
+            "description": "Inject pending rules-distillation candidates at session start (ADR-114); silent when none pending",
+            "timeout": 2000,
+            "once": true
           }
         ]
       }
@@ -355,6 +369,12 @@
             "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/posttool-rename-sweep.py\"",
             "description": "After git mv, scan for stale references to the old filename stem (ADR-129)",
+            "timeout": 3000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/posttool-bash-injection-scan.py\"",
+            "description": "Advisory scan of files written by Bash commands for prompt-injection patterns (ADR-121); never blocks",
             "timeout": 3000
           }
         ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,3 +81,27 @@ jobs:
       - run: pip install pytest
       - name: Joy-check golden fixtures and fleet scan (agents + SKILL.md)
         run: python -m pytest scripts/tests/test_joy_check_instruction_mode.py -v --tb=short
+
+  hook-health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml
+      # Static checks (dormancy, schema, mirror, allowlist) read the repo
+      # directly. Liveness (smoke-test) + register-hook validate read
+      # ~/.claude, so deploy hooks + settings.json there first.
+      - name: Deploy hooks and settings to ~/.claude
+        run: |
+          mkdir -p "$HOME/.claude/hooks/lib"
+          cp hooks/*.py "$HOME/.claude/hooks/"
+          cp hooks/lib/*.py "$HOME/.claude/hooks/lib/" 2>/dev/null || true
+          cp .claude/settings.json "$HOME/.claude/settings.json"
+      - name: Registered hooks resolve to backing files
+        run: python scripts/register-hook.py validate
+      - name: Hook-health gate (no-dormant, schema, mirror, liveness)
+        run: python scripts/validate-hook-health.py --ci
+      - name: Smoke-test all registered hooks
+        run: python scripts/smoke-test-hooks.py --ci

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-This toolkit prevents that. 44 domain agents, 124 workflow skills, 82 hooks, 105 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+This toolkit prevents that. 44 domain agents, 124 workflow skills, 82 hooks, 106 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Factory (`/do`).
 

--- a/hooks/tests/test_hook_registration_coverage.py
+++ b/hooks/tests/test_hook_registration_coverage.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Fast static coverage test for hook registration health (ADR hook-health-gate).
+
+Mirrors scripts/validate-hook-health.py so dormancy/schema/mirror/allowlist
+regressions surface in the `test` job too, not only the dedicated `hook-health`
+CI job. No subprocess, no ~/.claude dependency — reads repo files directly.
+
+Run with: python3 -m pytest hooks/tests/test_hook_registration_coverage.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+VALIDATOR = REPO_ROOT / "scripts" / "validate-hook-health.py"
+
+# Import the validator module under test (filename has a hyphen).
+_spec = importlib.util.spec_from_file_location("validate_hook_health", VALIDATOR)
+vhh = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(vhh)
+
+
+def _settings() -> dict:
+    return vhh.load_settings()
+
+
+def test_no_dormant_hooks():
+    """Every disk hook is registered, dispatched, or allowlisted-with-reason."""
+    msgs = vhh.check_no_dormant(_settings())
+    assert not msgs, "Dormant hooks found:\n" + "\n".join(msgs)
+
+
+def test_every_registered_hook_has_repo_file():
+    """No registered command points at a missing repo file (deadlock guard)."""
+    msgs = vhh.check_registered_files_exist(_settings())
+    assert not msgs, "Registered hooks without backing files:\n" + "\n".join(msgs)
+
+
+def test_settings_hooks_schema():
+    """Event names known, matchers are strings, commands are canonical."""
+    msgs = vhh.check_schema(_settings())
+    assert not msgs, "Settings schema violations:\n" + "\n".join(msgs)
+
+
+def test_allowlist_has_no_stale_entries():
+    """Every allowlist entry names a file that still exists on disk."""
+    msgs = vhh.check_allowlist_not_stale()
+    assert not msgs, "Stale allowlist entries:\n" + "\n".join(msgs)
+
+
+def test_mirror_allowlists_have_no_phantom_entries():
+    """Every codex/gemini mirror entry exists AND is registered (no phantoms)."""
+    msgs = vhh.check_mirror(_settings())
+    assert not msgs, "Phantom mirror entries:\n" + "\n".join(msgs)
+
+
+def test_allowlist_entries_all_have_reasons():
+    """No allowlist entry may silence the gate without a '# reason'."""
+    msgs = vhh.check_allowlist_entries_have_reasons()
+    assert not msgs, "Allowlist entries missing reasons:\n" + "\n".join(msgs)
+
+
+def test_bare_allowlist_filename_does_not_silence_gate(tmp_path):
+    """A bare filename (no reason) is NOT parsed as an allowlist entry, so it
+    cannot mask a dormant hook — closes the bare-filename bypass."""
+    al = tmp_path / "al.txt"
+    al.write_text("foo.py            # has a legitimate reason\nbare-no-reason.py\n")
+    parsed = vhh.parse_allowlist(al)
+    assert "foo.py" in parsed
+    assert "bare-no-reason.py" not in parsed
+    assert "bare-no-reason.py" in vhh.allowlist_entries_missing_reason(al)
+
+
+def test_invisible_unicode_reason_does_not_silence_gate(tmp_path):
+    """A reason made of zero-width/invisible characters is NOT meaningful, so it
+    cannot mask a dormant hook — closes the hidden-Unicode bypass."""
+    al = tmp_path / "al.txt"
+    # ghost.py followed by '#' + a zero-width space (U+200B) only.
+    al.write_text("ghost.py            # ​‌\nreal.py  # legitimate deferred reason here\n")
+    parsed = vhh.parse_allowlist(al)
+    assert "real.py" in parsed
+    assert "ghost.py" not in parsed
+    assert "ghost.py" in vhh.allowlist_entries_missing_reason(al)
+
+
+def test_placeholder_reason_does_not_silence_gate(tmp_path):
+    """Single-token / non-word placeholders ('___', '123', 'aaa') are NOT
+    meaningful reasons and cannot mask a dormant hook."""
+    al = tmp_path / "al.txt"
+    al.write_text("p1.py  # ___\np2.py  # 123\np3.py  # aaa\nok.py  # legitimate deferred reason\n")
+    parsed = vhh.parse_allowlist(al)
+    assert set(parsed) == {"ok.py"}
+    missing = set(vhh.allowlist_entries_missing_reason(al))
+    assert {"p1.py", "p2.py", "p3.py"} <= missing
+
+
+def test_meaningful_reason_floor():
+    """Syntactic substance floor: real reasons pass; trivial/gibberish fail.
+
+    The floor (>=2 distinct words AND >=12 letters) is intentionally syntactic —
+    semantic truthfulness is a code-review concern. It rejects placeholders and
+    short multi-token gibberish ('aa bb', 'aaa bbb') while accepting genuine
+    justifications.
+    """
+    for good in (
+        "deferred opt-in pending",
+        "retired stub superseded",
+        "superseded by voice-writer skill",
+    ):
+        assert vhh._meaningful_reason(good), good
+    for bad in ("", "___", "123", "aaa", "x", "aa bb", "aaa bbb", "aa bb cc"):
+        assert not vhh._meaningful_reason(bad), bad
+
+
+def test_dispatched_detection_is_precise():
+    """Dispatched-detection must not be fooled by prose mentions of a basename.
+
+    Guards against the regression where comment/docstring references to a hook
+    filename mask a genuinely dormant hook (a dispatched false-positive is a
+    dormancy escape hatch). Only true subprocess CLI helpers should appear.
+    """
+    dispatched = vhh.dispatched_basenames()
+    # voice-pipeline-tracker.py is dispatched by pretool-voice-publish-gate.py.
+    assert "voice-pipeline-tracker.py" in dispatched
+    # These are only ever mentioned in comments/docstrings of other hooks; they
+    # must NOT be classified as dispatched.
+    for prose_only in ("pretool-config-protection.py", "retro-knowledge-injector.py"):
+        assert prose_only not in dispatched, (
+            f"{prose_only} is mentioned in prose, not dispatched — detection is too loose and would mask dormancy."
+        )
+
+
+def _ast_dispatched(code: str, names: set[str]) -> set[str]:
+    """Exercise the production dispatch logic over an in-memory hook source."""
+    return vhh.dispatched_targets_in_source(code, names)
+
+
+# Built at runtime so the literal "shell=<true>" never appears in this test
+# file's source (it would otherwise trip the repo's static shell-injection
+# scanner, even though these strings are only AST-parsed test fixtures, never
+# executed as subprocess calls).
+_SHELL = "shell=" + "True"
+
+
+def test_dead_string_literal_is_not_dispatched():
+    """A *.py string literal that never reaches a subprocess call must NOT be
+    treated as dispatched — closes the dead-literal silent-dormancy bypass."""
+    code = 'import subprocess\nUNUSED = "new-hook.py"\nsubprocess.run(["ls"])\n'
+    assert _ast_dispatched(code, {"new-hook.py"}) == set()
+
+
+def test_py_string_in_non_command_arg_is_not_dispatched():
+    """A *.py string buried in env=/input= (data, not the command) must NOT be
+    treated as dispatched — only the command argument counts."""
+    env_case = 'import subprocess\nsubprocess.run(["ls"], env={"HOOK": "new-hook.py"})\n'
+    input_case = 'import subprocess\nsubprocess.run(["ls"], input="x new-hook.py")\n'
+    assert _ast_dispatched(env_case, {"new-hook.py"}) == set()
+    assert _ast_dispatched(input_case, {"new-hook.py"}) == set()
+
+
+def test_trailing_argv_py_is_not_dispatched():
+    """Only the EXECUTED script (first .py in argv, or first shell-parsed token)
+    is dispatched; a later argv slot holding another hook basename is data, not
+    a dispatch target — closes the 'extra argv slot' silent-dormancy bypass."""
+    argv_list = 'import subprocess\nsubprocess.run(["python3", "hooks/real.py", "hooks/dormant.py"])\n'
+    # Multi-token strings only shell-parse in shell mode.
+    bare_str = f'import subprocess\nsubprocess.run("python3 hooks/real.py hooks/dormant.py", {_SHELL})\n'
+    assert _ast_dispatched(argv_list, {"real.py", "dormant.py"}) == {"real.py"}
+    assert _ast_dispatched(bare_str, {"real.py", "dormant.py"}) == {"real.py"}
+
+
+def test_shell_payload_py_is_not_dispatched():
+    """A .py inside a shell payload (bash -c '...echo hooks/x.py') or as a
+    non-program argument ('echo hooks/x.py') is NOT the executed script —
+    closes the shell-payload silent-dormancy bypass."""
+    bash_lc = 'import subprocess\nsubprocess.run(["bash", "-lc", "echo hooks/dormant.py"])\n'
+    echo_arg = f'import subprocess\nsubprocess.run("echo hooks/dormant.py", {_SHELL})\n'
+    assert _ast_dispatched(bash_lc, {"dormant.py"}) == set()
+    assert _ast_dispatched(echo_arg, {"dormant.py"}) == set()
+    # ...but a script at the program position or after the interpreter IS (shell):
+    prog_first = f'import subprocess\nsubprocess.run("hooks/real.py --flag", {_SHELL})\n'
+    interp = f'import subprocess\nsubprocess.run("python3 hooks/real.py hooks/dormant.py", {_SHELL})\n'
+    assert _ast_dispatched(prog_first, {"real.py", "dormant.py"}) == {"real.py"}
+    assert _ast_dispatched(interp, {"real.py", "dormant.py"}) == {"real.py"}
+
+
+def test_variable_shell_payload_is_not_dispatched():
+    """A hook basename inside a variable-held shell payload, a variable non-
+    program arg to a non-python program, or an f-string payload is NOT the
+    executed script — closes the variable/f-string silent-dormancy bypasses."""
+    var_payload = 'import subprocess\npayload = "echo hooks/dormant.py"\nsubprocess.run(["bash", "-lc", payload])\n'
+    var_arg_to_echo = 'import subprocess\narg = "hooks/dormant.py"\nsubprocess.run(["echo", arg])\n'
+    fstring = 'import subprocess\nname = "dormant"\nsubprocess.run(["bash", "-lc", f"echo hooks/{name}"])\n'
+    assert _ast_dispatched(var_payload, {"dormant.py"}) == set()
+    assert _ast_dispatched(var_arg_to_echo, {"dormant.py"}) == set()
+    assert _ast_dispatched(fstring, {"dormant.py"}) == set()
+
+
+def test_basename_alias_and_path_composition_not_dispatched():
+    """A same-named script in an unrelated absolute dir (/tmp/x.py), or a
+    composed path whose FINAL component is not the hook (.../x.py + '.bak',
+    Path('hooks/x.py') / 'extra'), must NOT alias onto a hook — closes the
+    basename-alias and path-composition false positives."""
+    tmp_alias = 'import subprocess\nsubprocess.run(["/tmp/x.py"])\n'
+    concat = 'import subprocess\nsubprocess.run(["hooks/x.py" + ".bak"])\n'
+    joined = 'import subprocess\nfrom pathlib import Path\nsubprocess.run([Path("hooks/x.py") / "extra"])\n'
+    assert _ast_dispatched(tmp_alias, {"x.py"}) == set()
+    assert _ast_dispatched(concat, {"x.py"}) == set()
+    assert _ast_dispatched(joined, {"x.py"}) == set()
+
+
+def test_attribute_and_external_hooks_path_not_dispatched():
+    """A standalone attribute ('.parent', '.upper'), an absolute path into an
+    unrelated dir that merely contains 'hooks', and a locally-defined Popen
+    must NOT be treated as dispatch — closes the round-12 false positives."""
+    parent_attr = 'import subprocess\nfrom pathlib import Path\nsubprocess.run(Path("hooks/x.py").parent)\n'
+    upper_attr = 'import subprocess\ntarget = "hooks/x.py"\nsubprocess.run(target.upper)\n'
+    ext_hooks = 'import subprocess\nsubprocess.run("/tmp/other/hooks/x.py")\n'
+    local_popen = 'def Popen(*a, **k):\n    pass\nPopen(["hooks/x.py"])\n'
+    assert _ast_dispatched(parent_attr, {"x.py"}) == set()
+    assert _ast_dispatched(upper_attr, {"x.py"}) == set()
+    assert _ast_dispatched(ext_hooks, {"x.py"}) == set()
+    assert _ast_dispatched(local_popen, {"x.py"}) == set()
+
+
+def test_real_popen_import_and_claude_hooks_path_detected():
+    """A real `from subprocess import Popen` call and an absolute
+    .claude/hooks/<file> script ARE detected."""
+    real_popen = 'from subprocess import Popen\nPopen(["hooks/x.py"])\n'
+    abs_hooks = 'import subprocess\nsubprocess.run(["/home/u/.claude/hooks/x.py"])\n'
+    assert _ast_dispatched(real_popen, {"x.py"}) == {"x.py"}
+    assert _ast_dispatched(abs_hooks, {"x.py"}) == {"x.py"}
+
+
+def test_interpreter_flags_and_executable_override_not_dispatched():
+    """A .py after a python -c/-m flag (data, not the script) or argv combined
+    with executable= (overrides the program) must NOT be dispatched — closes the
+    round-13 false positives."""
+    dash_c = 'import subprocess\nsubprocess.run(["python3", "-c", "print(1)", "hooks/x.py"])\n'
+    dash_m = 'import subprocess\nsubprocess.run(["python3", "-m", "mod", "hooks/x.py"])\n'
+    exe_override = 'import subprocess\nsubprocess.run(["python3", "hooks/x.py"], executable="/bin/echo")\n'
+    bare_dash_c = 'import subprocess\nsubprocess.run("python3 -c print hooks/x.py")\n'
+    assert _ast_dispatched(dash_c, {"x.py"}) == set()
+    assert _ast_dispatched(dash_m, {"x.py"}) == set()
+    assert _ast_dispatched(exe_override, {"x.py"}) == set()
+    assert _ast_dispatched(bare_dash_c, {"x.py"}) == set()
+
+
+def test_shell_run_of_hook_script_is_detected():
+    """Running a hook directly through a shell (os.system, shell command with
+    the script at the program position) IS a real dispatch and is detected."""
+    os_system = 'import os\nos.system("hooks/x.py")\n'
+    shell_python = f'import subprocess\nsubprocess.run("python3 hooks/x.py", {_SHELL})\n'
+    assert _ast_dispatched(os_system, {"x.py"}) == {"x.py"}
+    assert _ast_dispatched(shell_python, {"x.py"}) == {"x.py"}
+
+
+def test_multitoken_string_without_shell_is_not_dispatched():
+    """A multi-token string command with the default shell=False does NOT run
+    the script (the whole string is one program name -> FileNotFound), so it is
+    not a dispatch. A single-token string command, or shell mode, still counts."""
+    no_shell = 'import subprocess\nsubprocess.run("python3 hooks/dormant.py")\n'
+    single = 'import subprocess\nsubprocess.run("hooks/x.py")\n'
+    with_shell = f'import subprocess\nsubprocess.run("python3 hooks/x.py", {_SHELL})\n'
+    os_shell = 'import os\nos.system("python3 hooks/x.py")\n'
+    assert _ast_dispatched(no_shell, {"dormant.py"}) == set()
+    assert _ast_dispatched(single, {"x.py"}) == {"x.py"}
+    assert _ast_dispatched(with_shell, {"x.py"}) == {"x.py"}
+    assert _ast_dispatched(os_shell, {"x.py"}) == {"x.py"}
+
+
+def test_scripts_dir_dispatch_does_not_alias_hook():
+    """A subprocess call to `repo_root / "scripts" / "<name>.py"` (a real,
+    common pattern in this repo) must NOT be counted as dispatching a same-named
+    hooks/<name>.py — the script lives in scripts/, not hooks/."""
+    scripts_call = (
+        "import subprocess, sys\n"
+        "from pathlib import Path\n"
+        "repo_root = Path(__file__).resolve().parent.parent\n"
+        'script = repo_root / "scripts" / "x.py"\n'
+        "subprocess.run([sys.executable, str(script)])\n"
+    )
+    rel_scripts = 'import subprocess\nsubprocess.run(["python3", "scripts/x.py"])\n'
+    # evals/, or any non-hooks dir, must also not alias (allowlist model).
+    evals_call = (
+        "import subprocess, sys\n"
+        "from pathlib import Path\n"
+        'script = Path(__file__).parent.parent / "evals" / "harness.py"\n'
+        "subprocess.run([sys.executable, str(script)])\n"
+    )
+    opaque_dir = 'import subprocess, sys\nd = some_unknown_dir()\nsubprocess.run([sys.executable, str(d / "x.py")])\n'
+    assert _ast_dispatched(scripts_call, {"x.py"}) == set()
+    assert _ast_dispatched(rel_scripts, {"x.py"}) == set()
+    assert _ast_dispatched(evals_call, {"harness.py"}) == set()
+    assert _ast_dispatched(opaque_dir, {"x.py"}) == set()
+
+
+def test_real_subprocess_dispatch_is_detected():
+    """A basename at an executable position (slot 0, or after a python
+    interpreter / sys.executable), directly, via a bound variable, or via a
+    Path(__file__).parent / 'x.py' construction, IS detected."""
+    via_var = (
+        "import subprocess, sys\n"
+        "from pathlib import Path\n"
+        'T = str(Path(__file__).parent / "tracker.py")\n'
+        "subprocess.run([sys.executable, T])\n"
+    )
+    inline = 'import subprocess\nsubprocess.run(["python3", "hooks/x.py"])\n'
+    slot0 = 'import subprocess\nsubprocess.run(["hooks/x.py", "--flag"])\n'
+    path_join = (
+        "import subprocess, sys\n"
+        "from pathlib import Path\n"
+        'subprocess.run([sys.executable, str(Path(__file__).parent / "x.py")])\n'
+    )
+    assert _ast_dispatched(via_var, {"tracker.py"}) == {"tracker.py"}
+    assert _ast_dispatched(inline, {"x.py"}) == {"x.py"}
+    assert _ast_dispatched(slot0, {"x.py"}) == {"x.py"}
+    assert _ast_dispatched(path_join, {"x.py"}) == {"x.py"}

--- a/scripts/hook-health-allowlist.txt
+++ b/scripts/hook-health-allowlist.txt
@@ -1,0 +1,30 @@
+# hook-health-allowlist.txt — INTENTIONALLY unregistered hook files.
+#
+# Format:  filename.py  # reason
+# Lines starting with # are comments. Blank lines ignored.
+#
+# Every hooks/*.py that is NOT registered in .claude/settings.json and NOT
+# dispatched by another hook MUST appear here with a reason, or the
+# hook-health gate (scripts/validate-hook-health.py --ci) fails. A stale entry
+# (file removed) also fails the gate. This is the artifact that would have
+# caught prevent-homedir-server.py before it became an incident.
+#
+# Dispatched helpers (e.g. voice-pipeline-tracker.py, invoked via subprocess by
+# pretool-voice-publish-gate.py) are detected automatically and do NOT need an
+# entry here.
+
+# --- Retired / superseded stubs (kept on disk for compatibility) ---
+instruction-reminder.py                   # retired stub: superseded by session-context.py (settings.json compat)
+retro-knowledge-injector.py               # retired stub: dream payload now injected by session-context.py (ADR-147)
+creation-request-enforcer-userprompt.py   # retired stub: /do Phase 1 handles creation-request enforcement
+skill-evaluator.py                        # disabled stub: main() is a no-op; routing-injection superseded by /do SKILL.md routing tables (overlaps /do)
+
+# --- Deferred blockers (false-block risk; opt-in only) ---
+mcp-health-check.py                        # deferred: PreToolUse exits 2 (BLOCK) on unhealthy MCP within backoff; would block tool use on a session with a transiently-failing MCP server — needs explicit opt-in, not default-on
+pretool-main-thread-discipline.py          # pending: blocks Edit/Write/Bash during an active /do session marker; /do dispatches agents to do exactly that work, so default-on risks false-blocking agent edits
+pretool-config-protection.py               # deferred (ADR-115): denies ANY Write/Edit whose stdin payload exceeds 1 MB (truncation-safety path, before file_path check), so registering on Write|Edit false-blocks large writes to non-config files; register only after the hook fails-open on oversize
+
+# --- Voice hooks superseded by the voice-writer skill pipeline ---
+voice-output-gate.py                       # superseded: voice-writer skill internalizes output gating (HOOK-GATE/CLOSE-GATE phases); private-skills install registers it separately when voice stack is active
+posttool-voice-quality-check.py            # superseded: voice-writer ANTI-AI phase covers AI-pattern checks; advisory-only, not needed default-on
+pretool-voice-publish-gate.py              # superseded: voice-writer pipeline phases enforce publish-readiness; dispatches voice-pipeline-tracker.py; private voice-stack installer registers it when active

--- a/scripts/validate-hook-health.py
+++ b/scripts/validate-hook-health.py
@@ -1,0 +1,774 @@
+#!/usr/bin/env python3
+"""Composing hook-health validator — permanent defense against dormant/broken hooks.
+
+Read-only. Reads repo `hooks/` and repo `.claude/settings.json` directly, so the
+dormancy / schema / mirror checks need NO sync to ~/.claude. Only the liveness
+check (--with-liveness) shells out to smoke-test-hooks.py, which reads the
+deployed hooks at ~/.claude/hooks.
+
+Checks (ADR hook-health-gate):
+  (a) Zero dormant: disk hooks/*.py - __init__.py - lib/ - tests/ - registered
+      - dispatched - allowlist  MUST be empty.
+  (b) Every registered command resolves to a repo hooks/ file (existence, not +x).
+  (c) Liveness: delegate to smoke-test-hooks.py --ci (opt-in via --with-liveness;
+      always on under --ci).
+  (d) Schema: settings.json parses; event names ∈ known set; matcher is a string;
+      each command matches the canonical python3 "$HOME/.claude/hooks/<file>.py" form.
+  (e) Mirror sanity: every file named in codex-/gemini-hooks-allowlist.txt exists
+      AND is registered in .claude/settings.json (no phantom mirror entries).
+      Mirrors are intentional subsets — full coverage is NOT required.
+
+Usage:
+    python3 scripts/validate-hook-health.py            # report, exit 0
+    python3 scripts/validate-hook-health.py --ci       # exit 1 on any failure (incl liveness)
+    python3 scripts/validate-hook-health.py --with-liveness
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SETTINGS_PATH = REPO_ROOT / ".claude" / "settings.json"
+HOOKS_DIR = REPO_ROOT / "hooks"
+ALLOWLIST_PATH = REPO_ROOT / "scripts" / "hook-health-allowlist.txt"
+CODEX_MIRROR = REPO_ROOT / "scripts" / "codex-hooks-allowlist.txt"
+GEMINI_MIRROR = REPO_ROOT / "scripts" / "gemini-hooks-allowlist.txt"
+
+KNOWN_EVENTS = {
+    "SessionStart",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PostToolUse",
+    "PreCompact",
+    "PostCompact",
+    "Stop",
+    "StopFailure",
+    "SubagentStop",
+    "TaskCompleted",
+}
+
+# Canonical command form: python3 "$HOME/.claude/hooks/<file>.py"
+CANONICAL_CMD = re.compile(r'^python3\s+"\$HOME/\.claude/hooks/([A-Za-z0-9._-]+\.py)"$')
+# Extract a hooks/<file>.py basename from any command (looser, for registered set)
+CMD_BASENAME = re.compile(r"hooks/([A-Za-z0-9._-]+\.py)")
+
+
+def load_settings() -> dict:
+    return json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+
+
+def iter_hook_entries(settings: dict):
+    """Yield (event, matcher, command) for each registered hook entry."""
+    for event, groups in settings.get("hooks", {}).items():
+        if not isinstance(groups, list):
+            groups = [groups]
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            matcher = group.get("matcher", "")
+            for entry in group.get("hooks", []):
+                if isinstance(entry, dict):
+                    yield event, matcher, entry.get("command", "")
+
+
+def registered_basenames(settings: dict) -> set[str]:
+    out: set[str] = set()
+    for _event, _matcher, cmd in iter_hook_entries(settings):
+        m = CMD_BASENAME.search(cmd)
+        if m:
+            out.add(m.group(1))
+    return out
+
+
+def disk_hooks() -> set[str]:
+    """Top-level hooks/*.py basenames, excluding __init__.py (lib/ and tests/
+    are subdirs, so glob('*.py') already excludes them)."""
+    return {p.name for p in HOOKS_DIR.glob("*.py") if p.name != "__init__.py"}
+
+
+_SUBPROCESS_FUNCS = {"run", "call", "check_call", "check_output", "Popen"}
+
+
+def _is_subprocess_call(node: ast.Call, popen_imported: bool = False) -> bool:
+    """True if `node` is subprocess.run/.Popen/... or os.system / os.popen.
+
+    A bare `Popen(...)` counts ONLY when `popen_imported` is True (i.e. the file
+    actually did `from subprocess import Popen`), so a locally-defined function
+    named Popen is not mistaken for subprocess dispatch."""
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        attr = func.attr
+        base = func.value
+        if attr in _SUBPROCESS_FUNCS and isinstance(base, ast.Name) and base.id == "subprocess":
+            return True
+        if attr in {"system", "popen"} and isinstance(base, ast.Name) and base.id == "os":
+            return True
+    if popen_imported and isinstance(func, ast.Name) and func.id == "Popen":
+        return True
+    return False
+
+
+def _lone_path_basename(value: str) -> str | None:
+    """If `value` is a SINGLE path token ending in .py (no whitespace, so not a
+    shell payload like 'echo hooks/x.py'), return its basename; else None."""
+    if not value or any(c.isspace() for c in value):
+        return None
+    base = value.rsplit("/", 1)[-1]
+    return base if base.endswith(".py") else None
+
+
+def _hookish_basename(path: str) -> str | None:
+    """Return the .py basename of `path` ONLY if the path's DIRECTORY is the
+    hooks dir — using an ALLOWLIST (not a denylist), so an unrelated repo dir
+    (evals/, scripts/, /tmp/, ...) can never alias onto a same-named hook.
+
+    Accepted directories:
+      - empty (a bare basename like "x.py" — real hooks dispatch builds these
+        via `Path(__file__).parent / "x.py"`, whose left resolves to nothing),
+      - a relative path whose LAST segment is "hooks" (e.g. "hooks/x.py"),
+      - an absolute path containing a ".claude/hooks" segment.
+    Anything else yields None. Whitespace-bearing strings (shell payloads) are
+    already rejected by _lone_path_basename."""
+    base = _lone_path_basename(path)
+    if not base:
+        return None
+    head = path[: -len(base)].rstrip("/")
+    if head == "":
+        return base  # bare basename
+    segs = [s for s in head.split("/") if s not in ("", ".")]
+    if not head.startswith("/") and segs and segs[-1] == "hooks":
+        return base  # relative .../hooks/<base>
+    if head.startswith("/") and ".claude/hooks" in head:
+        return base  # absolute .../.claude/hooks/<base>
+    return None
+
+
+def _is_file_relative_dir(node: ast.AST) -> bool:
+    """True if `node` denotes the CURRENT hook file's own directory — i.e.
+    `Path(__file__).parent` (optionally `.resolve()` before `.parent`). This is
+    the one unresolvable left-side `/` operand we trust as the hooks dir; any
+    other unresolvable directory is rejected (fail-safe), so `repo_root /
+    "scripts" / "x.py"`, `some_dir / "x.py"`, etc. never alias onto a hook."""
+    # Walk down through .parent / .resolve() attribute chains.
+    cur = node
+    saw_parent = False
+    while isinstance(cur, ast.Attribute):
+        if cur.attr == "parent":
+            saw_parent = True
+        elif cur.attr not in {"resolve", "absolute"}:
+            return False
+        cur = cur.value
+    # A .resolve() / .parent chain ends at a call: Path(__file__) or
+    # Path(__file__).resolve().
+    if isinstance(cur, ast.Call):
+        func = cur.func
+        is_path = isinstance(func, ast.Name) and func.id in {"Path", "PurePath"}
+        is_path_attr = isinstance(func, ast.Attribute) and func.attr in {"Path", "PurePath", "resolve"}
+        if (is_path or is_path_attr) and cur.args:
+            arg = cur.args[0]
+            if isinstance(arg, ast.Name) and arg.id == "__file__":
+                return saw_parent
+    return False
+
+
+def _resolve_path_strings(node: ast.AST, str_paths: dict[str, set[str]]) -> set[str]:
+    """Resolve an expression to the set of concrete PATH STRINGS it can denote,
+    composing `a + b` and `a / b` so the FINAL path is evaluated (not each
+    operand independently). Recognizes only simple static forms; anything else
+    (calls returning values, subscripts, attributes, f-strings) yields NOTHING
+    — fail-safe, so an unresolved path never silently exempts a hook."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return {node.value}
+    if isinstance(node, ast.Name):
+        return set(str_paths.get(node.id, set()))
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _resolve_path_strings(node.left, str_paths)
+        right = _resolve_path_strings(node.right, str_paths)
+        return {a + b for a in left for b in right} if left and right else set()
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+        # pathlib join: the final component (basename) comes from the RIGHT
+        # operand. The left is the directory; it may be an unresolvable
+        # `Path(__file__).parent` (the hooks dir) — fine, the script name is on
+        # the right. BUT if the left names a DIFFERENT dir (e.g.
+        # `repo_root / "scripts" / "x.py"`), the script lives in scripts/, not
+        # hooks/, so it must NOT be reported as a hook dispatch.
+        right = _resolve_path_strings(node.right, str_paths)
+        if not right:
+            return set()
+        left = _resolve_path_strings(node.left, str_paths)
+        if not left:
+            # Left unresolved. Trust it as the hooks dir ONLY when it is
+            # `Path(__file__).parent` (the current hook's own directory); any
+            # other unresolvable directory is rejected (fail-safe) so a script
+            # outside hooks/ never aliases onto a same-named hook. We emit a
+            # bare basename (the right component) so _hookish_basename accepts it
+            # as a hooks-dir script.
+            if _is_file_relative_dir(node.left):
+                return {b for b in right}
+            return set()
+        return {a.rstrip("/") + "/" + b for a in left for b in right}
+    # NOTE: ast.Attribute (e.g. `<expr>.parent`, `<expr>.upper`) is deliberately
+    # NOT resolved as a path. A standalone attribute does not denote a script,
+    # and as the left side of a `/` join its value is irrelevant (the basename
+    # comes from the right operand — see the Div branch, which falls back to the
+    # right component when the left is unresolvable). Resolving attributes would
+    # produce silent false positives like `Path("hooks/x.py").parent` -> x.py.
+    if isinstance(node, ast.Call):
+        func = node.func
+        is_str = isinstance(func, ast.Name) and func.id in {"str", "Path", "PurePath"}
+        is_fspath = isinstance(func, ast.Attribute) and func.attr == "fspath"
+        is_pathctor = isinstance(func, ast.Attribute) and func.attr in {"Path", "PurePath"}
+        if (is_str or is_fspath or is_pathctor) and node.args:
+            out: set[str] = set()
+            for a in node.args:
+                out |= _resolve_path_strings(a, str_paths)
+            return out
+    return set()
+
+
+def _py_basenames_in_expr(node: ast.AST, str_paths: dict[str, set[str]]) -> set[str]:
+    """Resolve an expression to the *.py hook SCRIPT basename(s) it denotes,
+    STRUCTURALLY and FAIL-SAFE. Composes path arithmetic first (so
+    "hooks/x.py" + ".bak" -> x.py.bak, not x.py), then keeps only hook-plausible
+    .py basenames (see _hookish_basename). Unresolvable forms yield nothing."""
+    bases: set[str] = set()
+    for path in _resolve_path_strings(node, str_paths):
+        base = _hookish_basename(path)
+        if base:
+            bases.add(base)
+    return bases
+
+
+_INTERPRETERS = {"python", "python3", "python2"}
+
+
+def _is_interpreter_elt(elt: ast.AST) -> bool:
+    """True if an argv element denotes a python interpreter — a literal
+    'python3' etc., or `sys.executable`."""
+    if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+        return elt.value.rsplit("/", 1)[-1] in _INTERPRETERS
+    if isinstance(elt, ast.Attribute) and elt.attr == "executable":
+        return isinstance(elt.value, ast.Name) and elt.value.id == "sys"
+    return False
+
+
+def _executed_py_basename(cmd: ast.AST, str_bindings: dict[str, set[str]], shell: bool = False) -> set[str]:
+    """Return the EXECUTED script basename from a command expression.
+
+    The executed script is a SINGLE path token ending in .py at an EXECUTABLE
+    position. This excludes:
+      - later argv slots that hold another hook path (data, not the script),
+      - a .py arg passed to a non-python program (e.g. ['echo', 'hooks/x.py']),
+      - shell payloads ('echo hooks/x.py' to bash -c / a shell), which contain
+        whitespace and are not a lone path token.
+
+    For an argv list/tuple, a .py element is the script only if it is slot 0 or
+    a preceding slot is a python interpreter (literal or sys.executable). For a
+    bare command STRING, a multi-token string is only shell-parsed when
+    shell mode; with the default (no shell) the whole string is one program
+    name (a multi-token string like "python3 hooks/x.py" raises FileNotFound and
+    runs nothing), so only a single-token string command can name a script.
+    """
+    if isinstance(cmd, (ast.List, ast.Tuple)):
+        seen_interpreter = False
+        for i, elt in enumerate(cmd.elts):
+            # A python flag like -c / -m / -X puts the interpreter in code/module
+            # mode: subsequent .py tokens are DATA, not the executed script.
+            if (
+                seen_interpreter
+                and isinstance(elt, ast.Constant)
+                and isinstance(elt.value, str)
+                and elt.value.startswith("-")
+            ):
+                return set()
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                base = _hookish_basename(elt.value)
+                if base:
+                    return {base} if (i == 0 or seen_interpreter) else set()
+            else:
+                # Name/BinOp (a bound var, or Path(...) / "x.py"): resolves to a
+                # single constructed path — the script if at slot 0 or post-interp.
+                bases = _py_basenames_in_expr(elt, str_bindings)
+                if bases:
+                    return bases if (i == 0 or seen_interpreter) else set()
+            if _is_interpreter_elt(elt):
+                seen_interpreter = True
+        return set()
+    # Bare command string. With the default shell=False, the WHOLE string is one
+    # program name — a multi-token string ("python3 hooks/x.py") is not parsed
+    # and runs nothing, so only a single-token string can name a script. With
+    # shell mode the string is shell-parsed: a .py is the script only at the
+    # program position or directly after a python interpreter token (a -c/-m
+    # flag switches to code/module mode -> no script).
+    if isinstance(cmd, ast.Constant) and isinstance(cmd.value, str):
+        toks = cmd.value.split()
+        if not shell:
+            return {b for b in [_hookish_basename(cmd.value)] if b} if len(toks) == 1 else set()
+        interp = {"python", "python3", "python2"}
+        for i, tok in enumerate(toks):
+            if i > 0 and toks[i - 1].rsplit("/", 1)[-1] in interp and tok.startswith("-"):
+                return set()
+            prog = _hookish_basename(tok)
+            if not prog:
+                continue
+            prev = toks[i - 1].rsplit("/", 1)[-1] if i > 0 else ""
+            if i == 0 or prev in interp:
+                return {prog}
+            return set()  # first .py is a non-program arg => not a dispatch
+        return set()
+    # A variable/expression holding a single path (e.g. a bound _TRACKER var).
+    return _py_basenames_in_expr(cmd, str_bindings)
+
+
+def dispatched_targets_in_source(source: str, candidates: set[str], self_name: str = "") -> set[str]:
+    """Return the subset of `candidates` (*.py basenames) that `source` passes
+    into an ACTUAL subprocess/os.system call as the COMMAND argument.
+
+    A basename qualifies only if it appears (directly, via a bound variable, or
+    via `Path(...) / "x.py"`) in the first positional arg or the
+    `args=`/`executable=` kwargs of a subprocess/os.system call. Dead literals
+    and strings buried in env=/input=/cwd= are data, NOT dispatch targets —
+    counting them would be a silent-dormancy escape hatch. Importable so the
+    coverage test exercises the exact production logic.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return set()
+
+    # Detect `from subprocess import Popen` so a bare Popen(...) call is only
+    # treated as dispatch when it is the real subprocess.Popen.
+    popen_imported = False
+    for sub in ast.walk(tree):
+        if isinstance(sub, ast.ImportFrom) and sub.module == "subprocess":
+            if any(alias.name == "Popen" for alias in sub.names):
+                popen_imported = True
+
+    # Pass 1: resolve variables that hold a PATH STRING, FAIL-SAFE on ambiguity.
+    # A name is usable only if it is assigned EXACTLY ONCE in the whole module
+    # and that one assignment resolves (structurally) to one or more path
+    # strings. A name assigned more than once (rebinding, or a different value
+    # in another scope) is dropped — we cannot statically know which value
+    # reaches the call, and a wrong guess would silently exempt a dormant hook.
+    # Path strings (not basenames) are stored so `+`/`/` compose correctly.
+    assign_counts: dict[str, int] = {}
+    assign_paths: dict[str, set[str]] = {}
+    for sub in ast.walk(tree):
+        if isinstance(sub, ast.Assign):
+            paths = _resolve_path_strings(sub.value, {})
+            for tgt in sub.targets:
+                if isinstance(tgt, ast.Name):
+                    assign_counts[tgt.id] = assign_counts.get(tgt.id, 0) + 1
+                    assign_paths[tgt.id] = paths
+    str_bindings: dict[str, set[str]] = {
+        name: paths for name, paths in assign_paths.items() if paths and assign_counts[name] == 1
+    }
+
+    # Pass 2: subprocess/os.system calls — inspect only the command argument.
+    out: set[str] = set()
+    for sub in ast.walk(tree):
+        if not (isinstance(sub, ast.Call) and _is_subprocess_call(sub, popen_imported)):
+            continue
+        kw_names = {kw.arg for kw in sub.keywords}
+        # `executable=` overrides which program actually runs, so argv[0] is no
+        # longer the executed script. Fail-safe: skip such calls (do not claim a
+        # dispatch we cannot statically verify).
+        if "executable" in kw_names:
+            continue
+        # A bare string command is only shell-parsed in shell mode; os.system /
+        # os.popen always run through a shell.
+        func = sub.func
+        is_os_shell = isinstance(func, ast.Attribute) and func.attr in {"system", "popen"}
+        shell = is_os_shell or any(
+            kw.arg == "shell" and isinstance(kw.value, ast.Constant) and kw.value.value is True for kw in sub.keywords
+        )
+        cmd_exprs: list[ast.AST] = []
+        if sub.args:
+            cmd_exprs.append(sub.args[0])
+        for kw in sub.keywords:
+            if kw.arg == "args":
+                cmd_exprs.append(kw.value)
+        for expr in cmd_exprs:
+            for base in _executed_py_basename(expr, str_bindings, shell=shell):
+                if base in candidates and base != self_name:
+                    out.add(base)
+    return out
+
+
+def dispatched_basenames() -> set[str]:
+    """Hooks dispatched (subprocess-invoked) by another hook, via AST analysis.
+
+    A hook X is 'dispatched' only if some OTHER hook passes a "X.py" path into
+    an ACTUAL subprocess/os.system command. A bare/dead string literal that
+    never reaches such a call does NOT count — a dispatched false-positive is a
+    silent-dormancy escape hatch.
+    """
+    files = list(HOOKS_DIR.glob("*.py"))
+    names = {p.name for p in files if p.name != "__init__.py"}
+    dispatched: set[str] = set()
+    for src in files:
+        if src.name == "__init__.py":
+            continue
+        try:
+            raw = src.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        dispatched |= dispatched_targets_in_source(raw, names, self_name=src.name)
+    return dispatched
+
+
+# Zero-width / invisible code points that must NOT count toward a "reason"
+# (built from code points so the source file stays free of ambiguous Unicode).
+_INVISIBLE = {
+    0x200B,  # ZERO WIDTH SPACE
+    0x200C,  # ZERO WIDTH NON-JOINER
+    0x200D,  # ZERO WIDTH JOINER
+    0x2060,  # WORD JOINER
+    0xFEFF,  # ZERO WIDTH NO-BREAK SPACE / BOM
+    0x00A0,  # NO-BREAK SPACE
+    0x180E,  # MONGOLIAN VOWEL SEPARATOR
+    0x2061,  # FUNCTION APPLICATION
+    0x2062,  # INVISIBLE TIMES
+    0x2063,  # INVISIBLE SEPARATOR
+    0x2064,  # INVISIBLE PLUS
+}
+
+
+# Minimum substance for an allowlist reason. This is a SYNTACTIC floor, not a
+# semantic check: it guarantees every allowlist entry carries a visible,
+# non-trivial justification that a PR reviewer will see in the diff. Detecting
+# whether that justification is *truthful* is a code-review responsibility, by
+# design — the gate's job is to make silent dormancy impossible, not to grade
+# prose. The floor is tuned so all real reasons (>=51 letters here) pass while
+# placeholders ('', '___', '123', 'aaa', 'aa bb', invisible-Unicode) fail.
+_MIN_REASON_WORDS = 2
+_MIN_REASON_LETTERS = 12
+
+
+def _meaningful_reason(reason: str) -> bool:
+    """True if `reason` clears the syntactic substance floor (see above):
+    >=2 distinct alphabetic words AND >=12 total alphabetic characters, after
+    stripping zero-width/invisible code points."""
+    cleaned = "".join(ch for ch in reason if ord(ch) not in _INVISIBLE)
+    words = re.findall(r"[A-Za-z]{2,}", cleaned)
+    total_letters = sum(len(w) for w in words)
+    return len({w.lower() for w in words}) >= _MIN_REASON_WORDS and total_letters >= _MIN_REASON_LETTERS
+
+
+def parse_allowlist(path: Path) -> dict[str, str]:
+    """Parse 'filename.py  # reason' manifest. Returns {filename: reason} ONLY
+    for entries with a MEANINGFUL reason (see _meaningful_reason).
+
+    A bare filename or an invisible/whitespace-only "reason" is intentionally
+    NOT returned, so it cannot silence the dormancy gate: such a file stays
+    dormant AND is flagged by check_allowlist_entries_have_reasons(). This
+    closes the bare-filename and hidden-Unicode bypasses — every allowlisted
+    hook must carry an explicit, human-readable justification.
+    """
+    out: dict[str, str] = {}
+    if not path.exists():
+        return out
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "#" in line:
+            name, reason = line.split("#", 1)
+            name, reason = name.strip(), reason.strip()
+            if name and _meaningful_reason(reason):
+                out[name] = reason
+    return out
+
+
+def allowlist_entries_missing_reason(path: Path) -> list[str]:
+    """Return allowlist filenames present without a meaningful '# reason'."""
+    bad: list[str] = []
+    if not path.exists():
+        return bad
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "#" in line:
+            name, reason = line.split("#", 1)
+            if name.strip() and not _meaningful_reason(reason):
+                bad.append(name.strip())
+        else:
+            bad.append(line)
+    return bad
+
+
+def parse_mirror(path: Path) -> list[tuple[str, str]]:
+    """Parse mirror allowlist lines 'EVENT:filename [matcher]'. Returns
+    list of (event, filename)."""
+    out: list[tuple[str, str]] = []
+    if not path.exists():
+        return out
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        spec = line.split()[0]  # drop trailing matcher token
+        if ":" not in spec:
+            continue
+        event, fname = spec.split(":", 1)
+        out.append((event.strip(), fname.strip()))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Individual checks: each returns list[str] of failure messages (empty == pass)
+# --------------------------------------------------------------------------- #
+
+
+def check_no_dormant(settings: dict) -> list[str]:
+    disk = disk_hooks()
+    registered = registered_basenames(settings)
+    dispatched = dispatched_basenames()
+    allowlist = set(parse_allowlist(ALLOWLIST_PATH))
+    dormant = disk - registered - dispatched - allowlist
+    if not dormant:
+        return []
+    msgs = []
+    for f in sorted(dormant):
+        msgs.append(
+            f"DORMANT hook: hooks/{f} is on disk but not registered, not dispatched, "
+            f"not allowlisted. Register it (scripts/register-hook.py) or add it to "
+            f"scripts/hook-health-allowlist.txt with a reason."
+        )
+    return msgs
+
+
+def check_registered_files_exist(settings: dict) -> list[str]:
+    msgs = []
+    for event, _matcher, cmd in iter_hook_entries(settings):
+        m = CMD_BASENAME.search(cmd)
+        if not m:
+            continue
+        fname = m.group(1)
+        if not (HOOKS_DIR / fname).exists():
+            msgs.append(
+                f"MISSING FILE: {event} registers hooks/{fname} but no repo file exists "
+                f"(would deadlock: Python exit 2 = BLOCK)."
+            )
+    return msgs
+
+
+def check_schema(settings: dict) -> list[str]:
+    msgs = []
+    hooks = settings.get("hooks", {})
+    if not isinstance(hooks, dict):
+        return ["SCHEMA: settings.json 'hooks' is not an object."]
+    for event, groups in hooks.items():
+        if event not in KNOWN_EVENTS:
+            msgs.append(f"SCHEMA: unknown event name '{event}' (not in {sorted(KNOWN_EVENTS)}).")
+        if not isinstance(groups, list):
+            msgs.append(f"SCHEMA: hooks['{event}'] is not a list.")
+            continue
+        for group in groups:
+            if not isinstance(group, dict):
+                msgs.append(f"SCHEMA: {event} group is not an object.")
+                continue
+            if "matcher" in group and not isinstance(group["matcher"], str):
+                msgs.append(f"SCHEMA: {event} matcher is not a string: {group['matcher']!r}.")
+            for entry in group.get("hooks", []):
+                if not isinstance(entry, dict):
+                    msgs.append(f"SCHEMA: {event} hook entry is not an object.")
+                    continue
+                cmd = entry.get("command", "")
+                if not CANONICAL_CMD.match(cmd):
+                    msgs.append(
+                        f"SCHEMA: {event} command not in canonical form "
+                        f'python3 "$HOME/.claude/hooks/<file>.py": {cmd!r}.'
+                    )
+    return msgs
+
+
+def check_mirror(settings: dict) -> list[str]:
+    registered = registered_basenames(settings)
+    msgs = []
+    for path in (CODEX_MIRROR, GEMINI_MIRROR):
+        for event, fname in parse_mirror(path):
+            if not (HOOKS_DIR / fname).exists():
+                msgs.append(f"MIRROR: {path.name} names hooks/{fname} but no repo file exists (phantom).")
+            elif fname not in registered:
+                msgs.append(
+                    f"MIRROR: {path.name} names {fname} (event {event}) but it is NOT registered "
+                    f"in .claude/settings.json (phantom mirror entry)."
+                )
+    return msgs
+
+
+def check_allowlist_not_stale() -> list[str]:
+    msgs = []
+    for fname in parse_allowlist(ALLOWLIST_PATH):
+        if not (HOOKS_DIR / fname).exists():
+            msgs.append(
+                f"STALE ALLOWLIST: scripts/hook-health-allowlist.txt lists hooks/{fname} "
+                f"but no repo file exists — remove the entry."
+            )
+    return msgs
+
+
+def check_allowlist_entries_have_reasons() -> list[str]:
+    """Every allowlist entry must carry a non-empty '# reason'. A bare filename
+    must not be able to silence the dormancy gate."""
+    return [
+        f"ALLOWLIST: hooks/{fname} is listed without a '# reason' in "
+        f"scripts/hook-health-allowlist.txt — add an explicit justification "
+        f"(a bare filename cannot silence the gate)."
+        for fname in allowlist_entries_missing_reason(ALLOWLIST_PATH)
+    ]
+
+
+# Per-event base payloads; matcher selects a representative tool_name so the
+# hook actually enters its registered code path (smoke-test uses a single
+# generic mock and ignores the matcher, which can mark a matcher-gated hook
+# "live" without ever exercising its real path).
+_EVENT_BASE = {
+    "SessionStart": {"hook_event_name": "SessionStart", "session_id": "hh"},
+    "UserPromptSubmit": {"hook_event_name": "UserPromptSubmit", "prompt": "hello", "session_id": "hh"},
+    "PreToolUse": {"hook_event_name": "PreToolUse", "session_id": "hh"},
+    "PostToolUse": {"hook_event_name": "PostToolUse", "tool_result": "ok", "session_id": "hh"},
+    "PreCompact": {"hook_event_name": "PreCompact", "summary": "x"},
+    "PostCompact": {"hook_event_name": "PostCompact"},
+    "Stop": {"hook_event_name": "Stop", "stop_hook_active": False, "session_id": "hh"},
+    "StopFailure": {"hook_event_name": "StopFailure"},
+    "SubagentStop": {"hook_event_name": "SubagentStop", "tool_name": "Agent", "tool_result": "ok", "session_id": "hh"},
+    "TaskCompleted": {"hook_event_name": "TaskCompleted", "task": "x", "session_id": "hh"},
+}
+
+
+def _matcher_tool(matcher: str) -> str | None:
+    """Pick a representative tool_name from a pipe-delimited matcher string."""
+    if not matcher:
+        return None
+    return matcher.split("|")[0].strip()
+
+
+def check_matcher_liveness() -> list[str]:
+    """Run each registered hook against a payload whose tool_name matches its
+    group matcher, asserting exit code in {0,2}. Proves every registered hook
+    RUNS on its real registered path (closes the smoke-test matcher gap)."""
+    import os
+
+    settings = load_settings()
+    msgs: list[str] = []
+    deployed = Path.home() / ".claude" / "hooks"
+    env = {**os.environ, "REF_GATE_BYPASS": "1", "CLAUDE_HOOKS_DEBUG": ""}
+    for event, matcher, cmd in iter_hook_entries(settings):
+        m = CMD_BASENAME.search(cmd)
+        if not m:
+            continue
+        fname = m.group(1)
+        script = deployed / fname
+        if not script.exists():
+            # registered-files-exist + register-hook validate cover deployment;
+            # skip here so this check is purely about runtime behavior.
+            continue
+        payload = dict(_EVENT_BASE.get(event, _EVENT_BASE["PostToolUse"]))
+        tool = _matcher_tool(matcher)
+        if tool and "tool_name" not in payload:
+            payload["tool_name"] = tool
+            payload.setdefault("tool_input", {"file_path": "/tmp/hh-probe.txt", "command": "ls"})
+        elif tool:
+            payload["tool_name"] = tool
+            payload["tool_input"] = {"file_path": "/tmp/hh-probe.txt", "command": "ls"}
+        try:
+            result = subprocess.run(
+                [sys.executable, str(script)],
+                input=json.dumps(payload),
+                capture_output=True,
+                text=True,
+                timeout=15,
+                cwd=str(REPO_ROOT),
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            msgs.append(f"MATCHER-LIVENESS: {event}/{fname} timed out on matcher '{matcher}'.")
+            continue
+        except Exception as e:
+            msgs.append(f"MATCHER-LIVENESS: {event}/{fname} crashed: {e}.")
+            continue
+        if result.returncode not in (0, 2):
+            msgs.append(
+                f"MATCHER-LIVENESS: {event}/{fname} exited {result.returncode} on matcher "
+                f"'{matcher}' (tool={tool}) — expected 0 or 2."
+            )
+    return msgs
+
+
+def check_liveness() -> list[str]:
+    """Delegate to smoke-test-hooks.py --ci. Returns failure msgs if it exits nonzero."""
+    smoke = REPO_ROOT / "scripts" / "smoke-test-hooks.py"
+    if not smoke.exists():
+        return ["LIVENESS: scripts/smoke-test-hooks.py not found."]
+    result = subprocess.run(
+        [sys.executable, str(smoke), "--ci"],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    if result.returncode != 0:
+        tail = (result.stdout or result.stderr).strip().splitlines()[-5:]
+        return ["LIVENESS: smoke-test-hooks.py --ci failed:"] + [f"  {ln}" for ln in tail]
+    return []
+
+
+def run_all(with_liveness: bool) -> list[str]:
+    settings = load_settings()
+    failures: list[str] = []
+    failures += check_schema(settings)
+    failures += check_no_dormant(settings)
+    failures += check_registered_files_exist(settings)
+    failures += check_mirror(settings)
+    failures += check_allowlist_not_stale()
+    failures += check_allowlist_entries_have_reasons()
+    if with_liveness:
+        failures += check_matcher_liveness()
+        failures += check_liveness()
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Composing hook-health validator")
+    parser.add_argument("--ci", action="store_true", help="Exit 1 on any failure; runs liveness too")
+    parser.add_argument("--with-liveness", action="store_true", help="Also run smoke-test liveness")
+    args = parser.parse_args()
+
+    with_liveness = args.ci or args.with_liveness
+    failures = run_all(with_liveness=with_liveness)
+
+    checks = [
+        "schema",
+        "no-dormant",
+        "registered-files-exist",
+        "mirror-sanity",
+        "allowlist-not-stale",
+        "allowlist-reasons",
+    ]
+    if with_liveness:
+        checks.append("matcher-liveness")
+        checks.append("liveness")
+    print(f"hook-health: ran {len(checks)} checks ({', '.join(checks)})")
+
+    if failures:
+        print(f"\n{len(failures)} FAILURE(S):", file=sys.stderr)
+        for f in failures:
+            print(f"  FAIL: {f}", file=sys.stderr)
+        if args.ci:
+            return 1
+        return 0
+    print("hook-health: ALL CHECKS PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Intent
Make *"every hook is registered-or-explicitly-accounted-for, and every registered hook runs"* a **permanent CI gate**, and wire up the dormant hooks that add value. Kills the `prevent-homedir-server` dormancy bug class forever. Implements ADR `hook-health-gate`.

## New artifacts
| File | Purpose |
|------|---------|
| `scripts/validate-hook-health.py` | Composing read-only validator. `--ci` exits 1 on failure. Checks: **no-dormant**, **registered-files-exist**, **schema** (event∈known, matcher str, canonical command), **mirror-sanity** (codex/gemini phantom check), **allowlist-reasons**, **matcher-liveness** (runs each registered hook on its real matcher payload), **liveness** (delegates to `smoke-test-hooks.py --ci`). |
| `scripts/hook-health-allowlist.txt` | Tracked `filename.py # reason` manifest of intentionally-unregistered hooks. Stale entry or missing reason fails the gate. |
| `hooks/tests/test_hook_registration_coverage.py` | Fast static pytest mirroring the validator + a dispatch-detection regression battery (24 tests). |
| `.github/workflows/test.yml` | New parallel `hook-health` job: deploy hooks+settings to `~/.claude`, then `register-hook validate` + `validate-hook-health --ci` + `smoke-test-hooks --ci`. |

## Dormancy decisions
**REGISTER (3):** `team-config-loader.py` (SessionStart), `rules-distill-injector.py` (SessionStart), `posttool-bash-injection-scan.py` (PostToolUse:Bash) — all smoke-pass, non-blocking, and resolve the codex/gemini mirror phantom entries. Each proven not to false-block.

**ALLOWLIST (with reasons):** `pretool-config-protection.py` (deny-on-oversize-payload false-blocks large writes — deferred), `mcp-health-check.py` + `pretool-main-thread-discipline.py` (exit-2 / active-/do false-block risk — deferred), voice hooks (superseded by voice-writer skill), `skill-evaluator.py` (disabled stub), retired stubs. `voice-pipeline-tracker.py` auto-detected as dispatched.

## Dispatched-detection hardening
AST-based: a hook counts as dispatched only when its path is the **executed command target** of a real `subprocess`/`os.system` call (fail-safe on ambiguity; allowlist dir model). Closes dead-literal, env/input-buried, trailing-argv, shell-payload, interpreter-flag, executable-override, basename-alias, path-composition, and scripts/evals-dir false positives — verified against the real hook corpus.

## Verification
- `smoke-test-hooks.py --ci`: **69 → 72** PASS, **0 FAIL** after registrations.
- `validate-hook-health.py --ci`: green; injected dormant probe → exit 1 (gate catches dormancy).
- Coverage pytest: 24 passed; full suite green (pre-existing unrelated `test_ci_merge_gate` failures only).
- Dual-track codex HIGH review: iterated to **NO BLOCKING FINDINGS**.
- ruff check + format clean; doc-counts updated (105→106 scripts).

Do **not** merge (per request).