### PR TITLE
feat(hallmark): structural-variety slice + rendered-CSS slop gates + Russell density standard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,21 @@ The toolkit uses **agents, skills, hooks, and scripts** to absorb complexity tha
 
 **LLMs orchestrate, programs execute.** If a process is deterministic and measurable (file searching, test execution, build validation, frontmatter checking), use a script. Reserve LLM judgment for contextual diagnosis, design decisions, and code review.
 
-**Write dense.** High fidelity, minimum words. Cut every word that carries no instruction, rule, or decision. Prefer tables and lists over paragraphs. If cutting a sentence loses no instruction, cut it.
+**Write dense.** High fidelity, minimum words. Prefer tables and lists over paragraphs. See the Communication Standard below.
+
+---
+
+## Communication Standard
+
+The Russell density standard governs **every** generation: replies to the user, plain text, the model's own thinking, skill and instruction files, and code comments.
+
+1. Shortest accurate word; never a long word where a short one serves.
+2. Cut every word that carries no instruction, rule, or decision.
+3. Plain English, not jargon.
+4. Concrete over abstract.
+5. Put heavy qualifications in separate short sentences.
+
+Test: say everything the task needs, and not one word more. Full rules and scope: `skills/shared-patterns/russell-density.md`.
 
 ---
 

--- a/agents/base-instructions.md
+++ b/agents/base-instructions.md
@@ -2,6 +2,18 @@
 
 Universal operational rules injected by /do at agent dispatch. Domain-specific rules live in each agent's .md file.
 
+## Writing standard
+
+The Russell density standard governs every generation: your output, your thinking, code comments, and any skill or reference files you write or edit.
+
+1. Shortest accurate word; never a long word where a short one serves.
+2. Cut every word that carries no instruction, rule, or decision.
+3. Plain English, not jargon.
+4. Concrete over abstract.
+5. Put heavy qualifications in separate short sentences.
+
+Test: say everything the task needs, and not one word more. Full rules: `skills/shared-patterns/russell-density.md`.
+
 ## Communication Style
 
 - Fact-based progress: Report what was done without self-congratulation ("Fixed 3 issues" not "Successfully completed the challenging task")

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -164,19 +164,11 @@ Complex work decomposes into phases. Phases have gates. Gates prevent cascading 
 
 ## Density — The Russell Standard
 
-High fidelity, minimum words. The standard is Bertrand Russell's prose rules ("How I Write"), and it governs every generation: output to the user, plain text, the model's own thinking, skill and instruction files, and code comments.
-
-1. Shortest accurate word; never a long word where a short one serves.
-2. Cut every word that carries no instruction, rule, or decision.
-3. Plain English, not jargon.
-4. Concrete over abstract.
-5. Put heavy qualifications in separate short sentences.
-
-Prefer tables and lists over paragraphs for structured content. Paragraphs for reasoning.
+High fidelity, minimum words. The standard is Bertrand Russell's five prose rules ("How I Write"): shortest accurate word, cut words carrying no instruction, plain English, concrete over abstract, heavy qualifications in separate sentences. It governs every generation — output, plain text, the model's own thinking, skill and instruction files, code comments. Prefer tables and lists for structured content, paragraphs for reasoning.
 
 This is not minimalism, which drops information for aesthetics. Density keeps all information and drops everything else.
 
-The canonical statement lives at `skills/shared-patterns/russell-density.md`. Every other surface (CLAUDE.md, `agents/base-instructions.md`, the `/do` router) carries a brief summary and points there.
+The canonical wording lives at `skills/shared-patterns/russell-density.md`. Three high-traffic surfaces reproduce the five rules verbatim so they sit in context every turn — `CLAUDE.md`, `agents/base-instructions.md`, the `/do` router injection (`skills/meta/do/SKILL.md`); edit the canonical file first, then propagate to those three. This reference doc and `skill-creator` carry a summary plus the pointer above.
 
 **Test:** Read each sentence. Does it carry an instruction, rule, or decision? If none, cut it.
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -162,11 +162,21 @@ Complex work decomposes into phases. Phases have gates. Gates prevent cascading 
 
 ---
 
-## Density
+## Density — The Russell Standard
 
-High fidelity, minimum words. Cut every word that carries no instruction, rule, or decision. Prefer tables and lists over paragraphs for structured content. Paragraphs for reasoning.
+High fidelity, minimum words. The standard is Bertrand Russell's prose rules ("How I Write"), and it governs every generation: output to the user, plain text, the model's own thinking, skill and instruction files, and code comments.
 
-This is not minimalism (drops information for aesthetics). Density keeps all information and drops everything else.
+1. Shortest accurate word; never a long word where a short one serves.
+2. Cut every word that carries no instruction, rule, or decision.
+3. Plain English, not jargon.
+4. Concrete over abstract.
+5. Put heavy qualifications in separate short sentences.
+
+Prefer tables and lists over paragraphs for structured content. Paragraphs for reasoning.
+
+This is not minimalism, which drops information for aesthetics. Density keeps all information and drops everything else.
+
+The canonical statement lives at `skills/shared-patterns/russell-density.md`. Every other surface (CLAUDE.md, `agents/base-instructions.md`, the `/do` router) carries a brief summary and points there.
 
 **Test:** Read each sentence. Does it carry an instruction, rule, or decision? If none, cut it.
 

--- a/scripts/tests/test_score_component.py
+++ b/scripts/tests/test_score_component.py
@@ -37,10 +37,10 @@ class TestSingleComponent:
         assert "TOTAL:" in result.stdout
 
     def test_score_skill(self) -> None:
-        # skills/meta/do/SKILL.md grades C due to pre-existing check failures
-        # (path resolution bug in referenced-files, missing patterns section).
-        # Accept rc=1 here; the test validates scoring runs, not grade.
-        result = run_script("skills/meta/do/SKILL.md", expect_rc=1)
+        # skills/meta/do/SKILL.md grades B (70/90). The test validates scoring
+        # runs against a real skill, not a specific grade. Couples to the live
+        # file by design; rc tracks whatever grade that file currently earns.
+        result = run_script("skills/meta/do/SKILL.md", expect_rc=0)
         assert "Component Health Score" in result.stdout
         assert "Type: skill" in result.stdout
 
@@ -94,7 +94,7 @@ class TestJsonOutput:
         assert isinstance(entry["checks"], list)
 
     def test_json_check_fields(self) -> None:
-        result = run_script("skills/meta/do/SKILL.md", "--json", expect_rc=1)
+        result = run_script("skills/meta/do/SKILL.md", "--json", expect_rc=0)
         data = json.loads(result.stdout)
         check = data["results"][0]["checks"][0]
         assert "name" in check
@@ -141,7 +141,7 @@ class TestCheckLogic:
 
     def test_workflow_instructions_check(self) -> None:
         """Workflow instructions check detects phases/gates in /do skill."""
-        result = run_script("skills/meta/do/SKILL.md", "--json", expect_rc=1)
+        result = run_script("skills/meta/do/SKILL.md", "--json", expect_rc=0)
         data = json.loads(result.stdout)
         checks = {c["name"]: c for c in data["results"][0]["checks"]}
         assert checks["Workflow instructions"]["status"] == "PASS"

--- a/skills/frontend/distinctive-frontend-design/SKILL.md
+++ b/skills/frontend/distinctive-frontend-design/SKILL.md
@@ -45,6 +45,7 @@ Optional capabilities (off unless explicitly enabled by the user): design system
 | example-driven tasks | `implementation-examples.md` | Loads detailed guidance from `implementation-examples.md`. |
 | performance work | `performance-budgets.md` | Loads detailed guidance from `performance-budgets.md`. |
 | tasks related to this reference | `phase-details.md` | Loads detailed guidance from `phase-details.md`. |
+| picking a page structure in Phase 1 | `macrostructure-catalog.md` | Load only the single chosen `macro:*` entry by its heading anchor (e.g. `#macrostat-led`), never the whole file — one entry carries every rule the build needs. |
 | tasks related to this reference | `vocabulary.md` | Loads detailed guidance from `vocabulary.md`. |
 
 ## Instructions
@@ -69,13 +70,15 @@ See `references/vocabulary.md` for term definitions (Hero, Full-bleed, Narrative
 8. **Real content**: Gather the actual copy, real product name, real imagery, real product context. Placeholder text produces placeholder thinking. If final content is not yet available, secure at minimum the hero headline, product name, and the single promise you want the first viewport to convey.
 9. **Previous projects**: Any recent frontend work? Variety across projects is mandatory, so check for choices that would overlap with recent work and avoid them.
 
+**Step 1b: Pick one macrostructure** before any aesthetic direction. Choose a single `macro:*` page-structure id from `references/macrostructure-catalog.md` based on the purpose and content from Step 1 (e.g. `macro:stat-led`, `macro:long-document`, `macro:split-hero`). Load only the one entry you pick, addressed by its heading anchor — not the whole catalog. Structure chosen before color and type keeps every page from collapsing into the same hero-then-cards template. Record the chosen id; it becomes the `macrostructure` field in the spec output and feeds the variety check in Phase 6.
+
 **Step 2: Define 3-5 distinct aesthetic directions** using `references/color-inspirations.json` and `references/font-catalog.json` as starting points. Providing multiple directions prevents anchoring on a first instinct, which is the primary source of generic "AI slop" output. See `references/phase-details.md` for example directions (Neo-Brutalist Technical, Warm Artisan, Midnight Synthwave, Botanical Minimal, Arctic Technical).
 
 **Step 3: Output** `aesthetic_direction.json` with chosen direction(s) and contextual justification. Every direction must link back to project purpose, audience, and emotion -- context-driven justification is what separates distinctive design from arbitrary choices. See `references/implementation-examples.md` for template.
 
 **Step 4: Write the narrative brief**. Before any code or visual exploration, commit three sentences to the page: visual thesis, content plan, interaction thesis. See `references/phase-details.md` for the full definition with examples.
 
-**Gate**: Aesthetic direction is defined with contextual justification linking project purpose, audience, and emotion to the chosen direction. Narrative brief from Step 4 is written with visual thesis, content plan, and interaction thesis. Proceed only after both gate items pass.
+**Gate**: A single `macro:*` macrostructure id is chosen and recorded. Aesthetic direction is defined with contextual justification linking project purpose, audience, and emotion to the chosen direction. Narrative brief from Step 4 is written with visual thesis, content plan, and interaction thesis. Proceed only after all three gate items pass.
 
 **Skip-if-answered**: If the user's original request already provides the surface type, the product name, and a clear promise for the hero, treat those answers as already gathered. Ask only for missing context. The context-gathering questions exist to close gaps, not to gate every request on ceremony.
 
@@ -154,10 +157,15 @@ See `references/app-vs-landing-rules.md` for the full rule sets, app litmus test
 **Step 1: Run comprehensive validation**
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/validate_design.py design-spec.json
+python3 ${CLAUDE_SKILL_DIR}/scripts/validate_design.py \
+  --fonts "Display,Body" --palette palette.json --project NAME \
+  --macrostructure macro:CHOSEN-ID --animation --background \
+  --emitted-css generated.html
 ```
 
-**Step 2: Review** validation report. See `references/phase-details.md` for the full list of report checks (banned fonts, cliche colors, dominance ratio, motion count, hero composition, etc.).
+Pass `--macrostructure` so the variety check penalizes a structure matching the last two projects (mirrors the font/palette step-down). Pass `--emitted-css` once generated output exists (Phase 7) to scan the rendered CSS for slop. The slop scan reports warnings and does not fail the build yet; promote a rule to error in `css_slop_rules.py` to make it blocking.
+
+**Step 2: Review** validation report and the rendered-CSS slop scan. See `references/phase-details.md` for the full list of report checks (banned fonts, cliche colors, dominance ratio, motion count, hero composition, macrostructure variety, rendered-CSS slop rules, etc.).
 
 **Step 3: Address issues** -- if overall score < 80:
 1. Review each failed check in the report
@@ -170,6 +178,14 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/validate_design.py design-spec.json
 ### Phase 7: Design Specification Output
 
 **Goal**: Deliver a complete, implementable design specification. Only implement what was directly requested -- focus on distinctive aesthetics, not unnecessary abstractions or design system scaffolding unless the user explicitly asked for it.
+
+**Step 0: Emit the design stamp** as the first line of the generated CSS. The stamp is a one-line comment recording the build's structural and quality results so a later run can re-audit statelessly and the variety check can recover the macro id from output:
+
+```
+/* vexjoy-design: macro=<id> theme=<name> contrast=<pass|fail> nav=<id> footer=<id> mobile=<pass|fail> */
+```
+
+Fill each field from this build's decisions: `macro` is the Phase 1 id, `theme` the palette name, `contrast`/`mobile` the WCAG and responsive results, `nav`/`footer` the chosen patterns. The stamp is a claim, not proof — the Phase 6 slop scan (`css_slop_rules.py`) verifies the rendered CSS independently rather than trusting the stamp. See `references/phase-details.md` for the field reference.
 
 **Step 1: Generate CSS custom properties** (design tokens) covering typography, colors, spacing, shadows, and animation values. Reference `references/implementation-examples.md` for comprehensive token template.
 
@@ -210,6 +226,7 @@ These reference files contain the curated domain knowledge that drives design de
 - `${CLAUDE_SKILL_DIR}/references/implementation-examples.md`: CSS tokens, base styles, framework templates, specification document templates
 - `${CLAUDE_SKILL_DIR}/references/project-history.json`: Aesthetic choices across projects (auto-generated by validation)
 - `${CLAUDE_SKILL_DIR}/references/vocabulary.md`: Term definitions used as hard rules across phases
+- `${CLAUDE_SKILL_DIR}/references/macrostructure-catalog.md`: Named `macro:*` page structures (skeleton + anti-cliche note per entry); pick one in Phase 1, load only the chosen entry by heading anchor
 - `${CLAUDE_SKILL_DIR}/references/phase-details.md`: Detailed selection processes, validation blocks, easing/timing tables, hero composition rules, validation checks
 - `${CLAUDE_SKILL_DIR}/references/app-vs-landing-rules.md`: Full rule sets for landing vs app surface types
 - `${CLAUDE_SKILL_DIR}/references/examples.md`: Worked examples for new landing page and design audit
@@ -234,3 +251,4 @@ See `references/error-handling.md` for recovery procedures covering banned fonts
 - `${CLAUDE_SKILL_DIR}/references/game-ui-polish.md`
 - `${CLAUDE_SKILL_DIR}/references/css-audit-patterns.md`
 - `${CLAUDE_SKILL_DIR}/references/performance-budgets.md`
+- `${CLAUDE_SKILL_DIR}/references/macrostructure-catalog.md`

--- a/skills/frontend/distinctive-frontend-design/references/macrostructure-catalog.md
+++ b/skills/frontend/distinctive-frontend-design/references/macrostructure-catalog.md
@@ -1,0 +1,211 @@
+# Macrostructure Catalog
+
+Named page structures. Pick exactly one `macro:*` id in Phase 1, before aesthetic
+directions, and emit it as the `macrostructure` field in the spec. The macrostructure
+is the categorical shape of the page — the order and role of its sections — chosen
+before any color, type, or motion decision. Choosing structure first prevents every
+page from collapsing into the same hero-then-three-cards template.
+
+These are OUR names, deliberately distinct from any external catalog and from the
+component terms in `vocabulary.md` (Hero, Full-bleed, Surface type). Those describe
+parts; these describe whole-page skeletons.
+
+**Lazy loading:** load only the one entry you picked, addressed by its heading anchor
+(e.g. `#macrostat-led`). Reading the whole catalog wastes context — the chosen entry
+carries every rule the build needs.
+
+**Variety rule:** `validate_design.py` penalizes a macrostructure that matches either
+of the last two projects (mirrors the font/palette step-down). Vary the structural
+axis across consecutive builds, not just the colors.
+
+| id | one-line when-to-use |
+|---|---|
+| `macro:stat-led` | a single number or proof point is the whole argument |
+| `macro:long-document` | dense reading: docs, essays, legal, changelogs |
+| `macro:bento` | many small features of unequal weight, shown at a glance |
+| `macro:manifesto` | a point of view to argue, not a product to sell |
+| `macro:split-hero` | product and its proof sit side by side, equally weighted |
+| `macro:gallery-grid` | the work is visual and the images are the pitch |
+| `macro:timeline` | sequence or progression is the core idea |
+| `macro:comparison` | the decision is "this versus that" |
+| `macro:single-focus` | one action, nothing else; capture or convert |
+| `macro:dashboard` | an operator surface for live data and controls |
+
+---
+
+## macro:stat-led
+
+**When to use:** one metric, result, or proof point carries the entire argument
+(uptime, dollars saved, users served). Lead with the number, justify it after.
+
+**Layout skeleton:**
+1. Oversized stat block — the figure set larger than the headline, with a one-line claim under it.
+2. Context strip — two or three supporting figures or a short sentence that frames the big number.
+3. Evidence — how the number is earned (method, source, customer).
+4. Narrative body — the story behind the figure, scannable.
+5. Single call to action tied to the claim.
+
+**Anti-cliche note:** the stat must be a real measured figure, set as type, not a
+spinning odometer or count-up animation on scroll. A fabricated round number ("10x
+faster") with no source reads as filler; show the actual figure and where it came from.
+
+---
+
+## macro:long-document
+
+**When to use:** the value is in dense, sustained reading — documentation, an essay,
+legal text, a detailed changelog. Comprehension and navigation beat visual drama.
+
+**Layout skeleton:**
+1. Title block — title, one-line summary, last-updated date.
+2. Sticky table of contents (sidebar on wide screens, collapsible on mobile).
+3. Body sections with stable heading anchors and generous measure (60-75ch).
+4. Inline asides or callouts for warnings and tips.
+5. Prev/next or related-document footer.
+
+**Anti-cliche note:** resist breaking a reading page into floating cards or a grid.
+Long-form reading wants one calm column with strong typographic hierarchy, not a
+dashboard of boxes. Line length and vertical rhythm do the work here.
+
+---
+
+## macro:bento
+
+**When to use:** several features of unequal importance, shown together so the eye
+grasps the whole offering at a glance. The grid itself communicates relative weight.
+
+**Layout skeleton:**
+1. Short framing headline.
+2. Bento grid — tiles of mixed sizes; the largest tile holds the lead feature, smaller tiles hold secondary ones.
+3. Each tile: one icon-or-visual, a short label, one sentence. One job per tile.
+4. Single closing action below the grid.
+
+**Anti-cliche note:** vary tile sizes to express priority — a uniform grid of equal
+cards is the templated look this structure exists to avoid. If every tile is the same
+size, it is a card grid, not a bento. Give the lead feature visibly more room.
+
+---
+
+## macro:manifesto
+
+**When to use:** there is a point of view to argue, a stance to take, a belief to
+state — not a product to demo. Editorial weight over conversion mechanics.
+
+**Layout skeleton:**
+1. Statement — a single bold claim, full width, set large.
+2. Argument sections — short numbered or titled positions, each one paragraph.
+3. Pull quotes or emphasized lines that carry the through-line.
+4. Signature or attribution.
+5. One quiet action (subscribe, read more) — low-pressure.
+
+**Anti-cliche note:** keep chrome minimal. Manifestos lose force when wrapped in
+product-marketing furniture (badge rows, logo walls, "trusted by"). The words are the
+design; let typography and whitespace carry the conviction.
+
+---
+
+## macro:split-hero
+
+**When to use:** the product and its proof deserve equal weight in the first viewport —
+a screenshot beside the pitch, a demo beside the claim. Neither dominates.
+
+**Layout skeleton:**
+1. Two-column first viewport: left holds headline, subhead, action; right holds the product visual or live demo.
+2. Below the fold: alternating split rows, each pairing one claim with one supporting visual.
+3. Proof band — logos or a single testimonial, full width.
+4. Closing action.
+
+**Anti-cliche note:** the right-hand visual must be real product, not a generic
+floating-laptop mockup or abstract gradient blob. A split hero with a stock device
+frame and placeholder UI signals the page has nothing real to show.
+
+---
+
+## macro:gallery-grid
+
+**When to use:** the work is inherently visual — photography, design, art, physical
+product — and the images themselves are the argument. Text is caption, not pitch.
+
+**Layout skeleton:**
+1. Minimal title bar — name and one line, nothing more.
+2. Image grid or masonry — the dominant element; let images run large.
+3. Optional filter or category strip.
+4. Per-item detail on click or hover — title, short note.
+5. Contact or inquiry action in the footer.
+
+**Anti-cliche note:** let the images breathe at full strength; avoid burying them under
+heavy overlays, uniform hover-zoom, or text scrims on every tile. If the grid needs
+explanatory copy on each image to make sense, the images are not carrying their job.
+
+---
+
+## macro:timeline
+
+**When to use:** sequence or progression is the core idea — a roadmap, a history, a
+process, a journey. The order of events is the message.
+
+**Layout skeleton:**
+1. Framing headline naming the span (years, stages, steps).
+2. Spine — a vertical or horizontal axis with dated or numbered nodes.
+3. Each node: a moment with a short title, one-line description, optional visual.
+4. Direction is unmistakable (top-to-bottom or left-to-right, never both at once).
+5. Closing node that points at the present or the next step.
+
+**Anti-cliche note:** the sequence must carry real meaning — dates, ordered stages,
+causal steps. A timeline used to decorate unordered features (where the order is
+arbitrary) misleads the reader; use `macro:bento` for unordered features instead.
+
+---
+
+## macro:comparison
+
+**When to use:** the reader's decision is "this versus that" — plans, us-versus-them,
+before-and-after. The structure exists to make the difference legible.
+
+**Layout skeleton:**
+1. Headline naming the choice.
+2. Comparison table or paired columns — shared rows, one column per option.
+3. Each row is one dimension; differences are visually marked, not just listed.
+4. A recommended or highlighted option, clearly but fairly indicated.
+5. Action per option.
+
+**Anti-cliche note:** keep the comparison honest. A table engineered so one column wins
+every row (strawman competitor, cherry-picked rows) reads as manipulative and erodes
+trust. Show real trade-offs; a fair comparison persuades better than a rigged one.
+
+---
+
+## macro:single-focus
+
+**When to use:** exactly one action matters — sign up, download, book, subscribe.
+Everything on the page serves that one conversion; nothing competes with it.
+
+**Layout skeleton:**
+1. One headline stating the single promise.
+2. One supporting line.
+3. One form or one button — the only interactive focus.
+4. Minimal proof (one line, one logo row) only if it lifts conversion.
+5. No secondary navigation that leads away.
+
+**Anti-cliche note:** resist adding a second competing call to action or a full nav bar
+— they leak attention from the one job. If a second action feels necessary, the page is
+probably trying to be two pages; split it or pick the one action that matters most.
+
+---
+
+## macro:dashboard
+
+**When to use:** an operator surface — live data, controls, status. Function over
+persuasion. Follows app rules, not landing-page rules (see `app-vs-landing-rules.md`).
+
+**Layout skeleton:**
+1. Top bar — product, primary context switcher, account.
+2. Left navigation — sections of the app.
+3. Main region — data tables, charts, or the primary work surface, dense but readable.
+4. Detail panel or drawer for the selected item.
+5. Status and system feedback in a consistent, quiet location.
+
+**Anti-cliche note:** apply Linear-style restraint — calm surfaces, few colors, strong
+typography, tight spacing. Decorative gradients, marketing-style hero blocks, and card
+mosaics belong on landing pages; on a dashboard they add noise and hide the data the
+operator came for.

--- a/skills/frontend/distinctive-frontend-design/references/phase-details.md
+++ b/skills/frontend/distinctive-frontend-design/references/phase-details.md
@@ -165,3 +165,24 @@ The report checks:
 - Surface type classified as landing page or app, with matching rule set applied
 - For landing pages: hero reads as one composition, no cards in hero, full-bleed hero confirmed
 - For apps: Linear-style restraint applied, no decorative gradients or card mosaics
+- Macrostructure variety: chosen `macro:*` id differs from the last two projects (variety check step-down)
+- Rendered-CSS slop scan (when `--emitted-css` is passed): warnings reported for `transition-all`, `universal-hover-scale`, `gradient-text-headline`, `focus-ring-fade`, `emoji-feature-icon`, `two-line-cta`, `contrast-canary`
+
+### Phase 7: Design Stamp Field Reference
+
+The first line of generated CSS is a one-line stamp recording the build's results so a later run can re-audit statelessly and the variety check can recover the macro id from output:
+
+```
+/* vexjoy-design: macro=<id> theme=<name> contrast=<pass|fail> nav=<id> footer=<id> mobile=<pass|fail> */
+```
+
+| field | value |
+|---|---|
+| `macro` | the Phase 1 `macro:*` id |
+| `theme` | palette name from Phase 3 |
+| `contrast` | `pass` if text meets WCAG AA against its background, else `fail` |
+| `nav` | navigation pattern id used (e.g. `top-bar`, `sidebar`, `none`) |
+| `footer` | footer pattern id used (e.g. `slim`, `sitemap`, `none`) |
+| `mobile` | `pass` if the layout is verified responsive, else `fail` |
+
+The stamp is a claim, not proof. `scripts/css_slop_rules.py` re-scans the rendered CSS independently; the slop scan verifies the output rather than trusting the stamp text.

--- a/skills/frontend/distinctive-frontend-design/scripts/css_slop_rules.py
+++ b/skills/frontend/distinctive-frontend-design/scripts/css_slop_rules.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Canonical rendered-CSS slop rules. Self-contained, dependency-free.
+
+Public surface:
+    scan_css(css_text: str) -> list[Finding]
+    Finding(rule_id, severity, message, line)
+
+Deterministic regex/parse only — no LLM. Designed to be vendored as-is into
+other skills (e.g. html-artifact). Findings start at "warning" severity; the
+promote-to-error path is documented per rule below and gated by the caller.
+
+Rules:
+    transition-all          `transition: all` (shorthand spanning all properties)
+    universal-hover-scale   :hover whose only effect is a broad transform: scale()
+    gradient-text-headline  background-clip:text / -webkit-background-clip:text on h1/h2
+    focus-ring-fade         focus outline/ring animated via transition (fades in)
+    emoji-feature-icon      emoji codepoint as a feature/list icon (CSS content or markup)
+    two-line-cta            clickable/button text that wraps to two lines (heuristic)
+    contrast-canary         adjacent fg/bg within delta-L <= 0.05 AND delta-chroma <= 0.05
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One slop-rule hit.
+
+    rule_id:  stable identifier (see module docstring table).
+    severity: "warning" for every rule today; callers promote to "error".
+    message:  human-readable explanation and fix direction.
+    line:     1-based best-effort source line.
+    """
+
+    rule_id: str
+    severity: str
+    message: str
+    line: int
+
+
+# Contrast-canary thresholds (oklch space): treat as too-low-contrast when BOTH hold.
+_CONTRAST_DELTA_L = 0.05  # lightness L is 0..1; <=5% apart
+_CONTRAST_DELTA_C = 0.05  # chroma
+
+_EMOJI_RE = re.compile(
+    "["
+    "\U0001f300-\U0001faff"  # symbols, pictographs, emoji
+    "\U00002600-\U000027bf"  # misc symbols + dingbats
+    "\U0001f000-\U0001f0ff"  # mahjong/dominoes/cards
+    "\U00002190-\U000021ff"  # arrows (often used as icons)
+    "\U00002b00-\U00002bff"  # misc symbols and arrows (stars, checks)
+    "\U0000fe0f"  # variation selector-16
+    "]"
+)
+
+
+def _line_of(text: str, index: int) -> int:
+    """Return the 1-based line number for a character offset."""
+    return text.count("\n", 0, index) + 1
+
+
+# --- color parsing (hex + oklch) → (L, chroma) in oklch space ---
+
+
+def _parse_hex(token: str) -> tuple[float, float, float] | None:
+    """Parse #rgb / #rrggbb (alpha ignored) → sRGB 0..1 triple."""
+    h = token.lstrip("#")
+    if len(h) in (3, 4):
+        h = "".join(c * 2 for c in h[:3])
+    elif len(h) in (6, 8):
+        h = h[:6]
+    else:
+        return None
+    try:
+        r = int(h[0:2], 16) / 255.0
+        g = int(h[2:4], 16) / 255.0
+        b = int(h[4:6], 16) / 255.0
+    except ValueError:
+        return None
+    return (r, g, b)
+
+
+def _srgb_to_linear(c: float) -> float:
+    return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+
+def _srgb_to_oklch_lc(rgb: tuple[float, float, float]) -> tuple[float, float]:
+    """sRGB triple → (L, chroma) in OKLCH. Hue is dropped (not needed here)."""
+    r, g, b = (_srgb_to_linear(c) for c in rgb)
+    lm = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b
+    mm = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b
+    sm = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b
+    l_ = lm ** (1 / 3)
+    m_ = mm ** (1 / 3)
+    s_ = sm ** (1 / 3)
+    big_l = 0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_
+    a = 1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_
+    b2 = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_
+    chroma = math.hypot(a, b2)
+    return (big_l, chroma)
+
+
+_OKLCH_RE = re.compile(r"oklch\(\s*([0-9.]+%?)\s+([0-9.]+)\s+", re.IGNORECASE)
+
+
+def _parse_oklch(token: str) -> tuple[float, float] | None:
+    """Parse oklch(L C H ...) → (L, chroma). L may be a percentage."""
+    m = _OKLCH_RE.search(token)
+    if not m:
+        return None
+    raw_l, raw_c = m.group(1), m.group(2)
+    try:
+        big_l = float(raw_l[:-1]) / 100.0 if raw_l.endswith("%") else float(raw_l)
+        chroma = float(raw_c)
+    except ValueError:
+        return None
+    return (big_l, chroma)
+
+
+def _color_to_lc(value: str) -> tuple[float, float] | None:
+    """Resolve a single CSS color value to (L, chroma) in oklch space."""
+    value = value.strip()
+    if value.lower().startswith("oklch("):
+        return _parse_oklch(value)
+    hexmatch = re.search(r"#[0-9a-fA-F]{3,8}\b", value)
+    if hexmatch:
+        rgb = _parse_hex(hexmatch.group(0))
+        if rgb is not None:
+            return _srgb_to_oklch_lc(rgb)
+    return None
+
+
+# --- rule scanners ---
+
+_BLOCK_RE = re.compile(r"([^{}]*)\{([^{}]*)\}", re.DOTALL)
+
+
+def _iter_blocks(css: str):
+    """Yield (selector, body, body_offset) for each top-level rule block."""
+    for m in _BLOCK_RE.finditer(css):
+        selector = m.group(1).strip()
+        body = m.group(2)
+        yield selector, body, m.start(2)
+
+
+def _decls(body: str) -> list[tuple[str, str]]:
+    """Split a declaration block into (property, value) pairs (lowercased prop)."""
+    out: list[tuple[str, str]] = []
+    for chunk in body.split(";"):
+        if ":" in chunk:
+            prop, _, val = chunk.partition(":")
+            out.append((prop.strip().lower(), val.strip()))
+    return out
+
+
+def _scan_transition_all(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for m in re.finditer(r"transition(?:-property)?\s*:\s*([^;}]*)", css, re.IGNORECASE):
+        if re.match(r"all\b", m.group(1).strip(), re.IGNORECASE):
+            findings.append(
+                Finding(
+                    "transition-all",
+                    "warning",
+                    "transition: all animates every property; name the properties you "
+                    "actually change (e.g. transition: opacity, transform).",
+                    _line_of(css, m.start()),
+                )
+            )
+    return findings
+
+
+def _scan_universal_hover_scale(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for selector, body, offset in _iter_blocks(css):
+        if ":hover" not in selector.lower():
+            continue
+        decls = _decls(body)
+        effective = [(p, v) for p, v in decls if p and v]
+        if len(effective) != 1:
+            continue
+        prop, val = effective[0]
+        if prop == "transform" and re.match(r"scale\(\s*1(\.0\d*)?\s*\)", val, re.IGNORECASE):
+            findings.append(
+                Finding(
+                    "universal-hover-scale",
+                    "warning",
+                    "the only hover effect is a small transform: scale(); a uniform "
+                    "scale-on-hover reads as templated. Give hover a purposeful change.",
+                    _line_of(css, offset),
+                )
+            )
+    return findings
+
+
+def _scan_gradient_text_headline(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for selector, body, offset in _iter_blocks(css):
+        sel = selector.lower()
+        if not re.search(r"\bh[12]\b", sel):
+            continue
+        if re.search(r"(?:-webkit-)?background-clip\s*:\s*text", body, re.IGNORECASE):
+            findings.append(
+                Finding(
+                    "gradient-text-headline",
+                    "warning",
+                    "gradient-clipped headline text (background-clip: text on h1/h2) is a "
+                    "signature template look; use a solid headline color.",
+                    _line_of(css, offset),
+                )
+            )
+    return findings
+
+
+def _scan_focus_ring_fade(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for selector, body, offset in _iter_blocks(css):
+        if ":focus" not in selector.lower():
+            continue
+        decls = _decls(body)
+        has_ring = any(p in ("outline", "box-shadow", "border", "outline-color") for p, _ in decls)
+        trans = next((v for p, v in decls if p in ("transition", "transition-property")), "")
+        if has_ring and re.search(r"\b(all|outline|box-shadow|border)\b", trans, re.IGNORECASE):
+            findings.append(
+                Finding(
+                    "focus-ring-fade",
+                    "warning",
+                    "focus ring is animated via transition; focus indicators must appear "
+                    "instantly for accessibility. Remove the transition on the ring.",
+                    _line_of(css, offset),
+                )
+            )
+    return findings
+
+
+def _scan_emoji_feature_icon(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    # CSS: content property carrying an emoji (pseudo-element icon).
+    for m in re.finditer(r"content\s*:\s*([\"'])(.*?)\1", css, re.IGNORECASE | re.DOTALL):
+        if _EMOJI_RE.search(m.group(2)):
+            findings.append(
+                Finding(
+                    "emoji-feature-icon",
+                    "warning",
+                    "emoji used as a feature/list icon (CSS content); use an inline SVG "
+                    "icon set for a deliberate look.",
+                    _line_of(css, m.start()),
+                )
+            )
+    # Markup hook: emoji directly inside a list item / feature element.
+    for m in re.finditer(r"<li\b[^>]*>(.*?)</li>", css, re.IGNORECASE | re.DOTALL):
+        if _EMOJI_RE.search(m.group(1)):
+            findings.append(
+                Finding(
+                    "emoji-feature-icon",
+                    "warning",
+                    "emoji used as a feature/list icon in markup; use an inline SVG icon set.",
+                    _line_of(css, m.start()),
+                )
+            )
+    return findings
+
+
+def _scan_two_line_cta(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    # Heuristic: a button/CTA-classed clickable whose text contains a forced break.
+    pattern = re.compile(
+        r"<(?:button|a)\b[^>]*(?:class\s*=\s*\"[^\"]*(?:btn|button|cta)[^\"]*\"|role\s*=\s*\"button\")[^>]*>(.*?)</(?:button|a)>",
+        re.IGNORECASE | re.DOTALL,
+    )
+    for m in pattern.finditer(css):
+        inner = m.group(1)
+        if re.search(r"<br\s*/?>", inner, re.IGNORECASE) or "\n" in inner.strip():
+            findings.append(
+                Finding(
+                    "two-line-cta",
+                    "warning",
+                    "call-to-action text wraps to two lines; keep CTA labels to one short "
+                    "line so the action stays scannable.",
+                    _line_of(css, m.start()),
+                )
+            )
+    return findings
+
+
+def _scan_contrast_canary(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for _selector, body, offset in _iter_blocks(css):
+        fg = bg = None
+        for prop, val in _decls(body):
+            if prop == "color":
+                fg = _color_to_lc(val)
+            elif prop in ("background-color", "background"):
+                cand = _color_to_lc(val)
+                if cand is not None:
+                    bg = cand
+        if fg is None or bg is None:
+            continue
+        if abs(fg[0] - bg[0]) <= _CONTRAST_DELTA_L and abs(fg[1] - bg[1]) <= _CONTRAST_DELTA_C:
+            findings.append(
+                Finding(
+                    "contrast-canary",
+                    "warning",
+                    "foreground and background are nearly identical "
+                    f"(delta-L<={_CONTRAST_DELTA_L}, delta-chroma<={_CONTRAST_DELTA_C}); text "
+                    "will be unreadable. Widen the lightness gap.",
+                    _line_of(css, offset),
+                )
+            )
+    return findings
+
+
+_SCANNERS = (
+    _scan_transition_all,
+    _scan_universal_hover_scale,
+    _scan_gradient_text_headline,
+    _scan_focus_ring_fade,
+    _scan_emoji_feature_icon,
+    _scan_two_line_cta,
+    _scan_contrast_canary,
+)
+
+
+def scan_css(css_text: str) -> list[Finding]:
+    """Scan CSS (or HTML containing CSS/markup) for slop patterns.
+
+    Returns findings sorted by line, then rule_id. Deterministic.
+    """
+    findings: list[Finding] = []
+    for scanner in _SCANNERS:
+        findings.extend(scanner(css_text))
+    findings.sort(key=lambda f: (f.line, f.rule_id))
+    return findings

--- a/skills/frontend/distinctive-frontend-design/scripts/css_slop_rules.py
+++ b/skills/frontend/distinctive-frontend-design/scripts/css_slop_rules.py
@@ -136,15 +136,28 @@ def _color_to_lc(value: str) -> tuple[float, float] | None:
 
 # --- rule scanners ---
 
-_BLOCK_RE = re.compile(r"([^{}]*)\{([^{}]*)\}", re.DOTALL)
+# Anchored on the literal "{" so finditer scans directly to each brace instead
+# of trying "[^{}]*" from every offset. The old shape r"([^{}]*)\{([^{}]*)\}"
+# was O(n^2) on large brace-free input (e.g. a ~500KB minified single line): the
+# pre-brace run succeeded to end-of-string, the "\{" failed, and the engine
+# retried from the next start position. This form is linear. The selector (the
+# pre-brace text) is recovered by slicing from the previous block's close brace.
+_BLOCK_RE = re.compile(r"\{([^{}]*)\}", re.DOTALL)
 
 
 def _iter_blocks(css: str):
-    """Yield (selector, body, body_offset) for each top-level rule block."""
+    """Yield (selector, body, body_offset) for each top-level rule block.
+
+    Behavior matches the prior "([^{}]*)\\{([^{}]*)\\}" form: the selector is the
+    run of non-brace text immediately preceding the block.
+    """
+    last_close = 0
     for m in _BLOCK_RE.finditer(css):
-        selector = m.group(1).strip()
-        body = m.group(2)
-        yield selector, body, m.start(2)
+        gap = css[last_close : m.start()]
+        cut = max(gap.rfind("{"), gap.rfind("}"))
+        selector = (gap[cut + 1 :] if cut != -1 else gap).strip()
+        yield selector, m.group(1), m.start(1)
+        last_close = m.end()
 
 
 def _decls(body: str) -> list[tuple[str, str]]:

--- a/skills/frontend/distinctive-frontend-design/scripts/tests/test_css_slop_rules.py
+++ b/skills/frontend/distinctive-frontend-design/scripts/tests/test_css_slop_rules.py
@@ -7,6 +7,7 @@ The contrast canary covers both the hex and the oklch color paths.
 from __future__ import annotations
 
 import sys
+import time
 from importlib import import_module
 from pathlib import Path
 
@@ -146,3 +147,30 @@ def test_finding_has_required_fields() -> None:
 def test_clean_css_silent() -> None:
     css = ".btn { transition: opacity 0.2s ease; color: #1a1a1a; background: #fafafa; }"
     assert scan_css(css) == []
+
+
+# --- ReDoS regression: large single-line input must scan fast ---
+
+
+def test_scan_css_fast_on_large_single_line() -> None:
+    """A ~1MB single-line artifact must scan in well under a second.
+
+    Guards the block-iterating scanners against the O(n^2) backtracking that
+    hung scan_css on minified single-line input (the "[^{}]*" pre-brace run).
+    """
+    unit = '<div class="btn cta" style="color:#111;background:#222">text</div>'
+    big = "<html><body>" + unit * 16000 + "</body></html>"
+    assert len(big) >= 1_000_000
+    start = time.perf_counter()
+    scan_css(big)
+    assert time.perf_counter() - start < 1.0
+
+
+def test_scan_css_correct_after_large_block_fix() -> None:
+    """Fix must not change findings on normal nested CSS (at-rule + blocks)."""
+    css = (
+        "h1 { -webkit-background-clip: text; } "
+        ".card:hover { transform: scale(1.0); } "
+        "@media (min-width: 600px) { .x { color: #1a1a1a; background-color: #1e1e1e; } }"
+    )
+    assert ids(css) == {"gradient-text-headline", "universal-hover-scale", "contrast-canary"}

--- a/skills/frontend/distinctive-frontend-design/scripts/tests/test_css_slop_rules.py
+++ b/skills/frontend/distinctive-frontend-design/scripts/tests/test_css_slop_rules.py
@@ -1,0 +1,148 @@
+"""Golden-fixture tests for css_slop_rules.scan_css.
+
+Each rule has one positive fixture (rule fires) and one negative (rule silent).
+The contrast canary covers both the hex and the oklch color paths.
+"""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+slop = import_module("css_slop_rules")
+scan_css = slop.scan_css
+
+
+def ids(css: str) -> set[str]:
+    """Return the set of rule_ids fired for a CSS string."""
+    return {f.rule_id for f in scan_css(css)}
+
+
+# --- transition-all ---
+
+
+def test_transition_all_fires() -> None:
+    css = ".btn { transition: all 0.2s ease; }"
+    assert "transition-all" in ids(css)
+
+
+def test_transition_all_silent_on_named_property() -> None:
+    css = ".btn { transition: opacity 0.2s ease, transform 0.2s ease; }"
+    assert "transition-all" not in ids(css)
+
+
+# --- universal-hover-scale ---
+
+
+def test_universal_hover_scale_fires() -> None:
+    css = ".card:hover { transform: scale(1.05); }"
+    assert "universal-hover-scale" in ids(css)
+
+
+def test_universal_hover_scale_silent_when_hover_does_more() -> None:
+    css = ".card:hover { transform: scale(1.05); box-shadow: 0 4px 12px #0003; }"
+    assert "universal-hover-scale" not in ids(css)
+
+
+# --- gradient-text-headline ---
+
+
+def test_gradient_text_headline_fires_webkit() -> None:
+    css = "h1 { -webkit-background-clip: text; color: transparent; }"
+    assert "gradient-text-headline" in ids(css)
+
+
+def test_gradient_text_headline_fires_standard() -> None:
+    css = "h2 { background-clip: text; }"
+    assert "gradient-text-headline" in ids(css)
+
+
+def test_gradient_text_headline_silent_on_body() -> None:
+    css = ".badge { -webkit-background-clip: text; }"
+    assert "gradient-text-headline" not in ids(css)
+
+
+# --- focus-ring-fade ---
+
+
+def test_focus_ring_fade_fires() -> None:
+    css = ".input:focus { outline: 2px solid #09f; transition: outline 0.3s ease; }"
+    assert "focus-ring-fade" in ids(css)
+
+
+def test_focus_ring_fade_silent_when_instant() -> None:
+    css = ".input:focus { outline: 2px solid #09f; }"
+    assert "focus-ring-fade" not in ids(css)
+
+
+# --- emoji-feature-icon ---
+
+
+def test_emoji_feature_icon_fires() -> None:
+    css = '.feature li::before { content: "\U0001f680"; }'
+    assert "emoji-feature-icon" in ids(css)
+
+
+def test_emoji_feature_icon_silent_on_text_content() -> None:
+    css = '.tag::before { content: "New"; }'
+    assert "emoji-feature-icon" not in ids(css)
+
+
+# --- two-line-cta ---
+
+
+def test_two_line_cta_fires() -> None:
+    html = '<button class="cta">Start your free<br>trial today</button>'
+    assert "two-line-cta" in ids(html)
+
+
+def test_two_line_cta_silent_on_single_line() -> None:
+    html = '<button class="cta">Get started</button>'
+    assert "two-line-cta" not in ids(html)
+
+
+# --- contrast-canary (hex path) ---
+
+
+def test_contrast_canary_fires_hex() -> None:
+    # dark-gray text on a marginally different dark-gray surface (black-on-black slop)
+    css = ".x { color: #1a1a1a; background-color: #1e1e1e; }"
+    assert "contrast-canary" in ids(css)
+
+
+def test_contrast_canary_silent_hex_high_contrast() -> None:
+    css = ".x { color: #ffffff; background-color: #111111; }"
+    assert "contrast-canary" not in ids(css)
+
+
+# --- contrast-canary (oklch path) ---
+
+
+def test_contrast_canary_fires_oklch() -> None:
+    css = ".y { color: oklch(0.20 0.02 250); background-color: oklch(0.22 0.03 250); }"
+    assert "contrast-canary" in ids(css)
+
+
+def test_contrast_canary_silent_oklch_high_contrast() -> None:
+    css = ".y { color: oklch(0.95 0.02 250); background-color: oklch(0.20 0.03 250); }"
+    assert "contrast-canary" not in ids(css)
+
+
+# --- Finding shape contract ---
+
+
+def test_finding_has_required_fields() -> None:
+    findings = scan_css(".btn { transition: all 0.2s; }")
+    assert findings
+    f = findings[0]
+    assert f.rule_id
+    assert f.severity == "warning"
+    assert isinstance(f.message, str) and f.message
+    assert isinstance(f.line, int) and f.line >= 1
+
+
+def test_clean_css_silent() -> None:
+    css = ".btn { transition: opacity 0.2s ease; color: #1a1a1a; background: #fafafa; }"
+    assert scan_css(css) == []

--- a/skills/frontend/distinctive-frontend-design/scripts/tests/test_validate_design_macro.py
+++ b/skills/frontend/distinctive-frontend-design/scripts/tests/test_validate_design_macro.py
@@ -1,0 +1,130 @@
+"""Tests for the macrostructure + emitted-CSS additions to validate_design.py.
+
+Covers: variety step-down on repeated macrostructure, back-compat with old
+history entries (no macrostructure field), history write of the new field,
+stamp parsing, and the emitted-CSS slop scan helper.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from importlib import import_module
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+vd = import_module("validate_design")
+
+
+def _patch_history(monkeypatch, tmp_path, projects):
+    """Point validate_design's history lookups at a real temp file.
+
+    skill_dir = Path(__file__).parent.parent, so faking __file__ to
+    tmp/scripts/validate_design.py makes the history land at tmp/references/.
+    """
+    (tmp_path / "references").mkdir(exist_ok=True)
+    hist = tmp_path / "references" / "project-history.json"
+    hist.write_text(json.dumps({"projects": projects}), encoding="utf-8")
+    fake_script = tmp_path / "scripts" / "validate_design.py"
+    fake_script.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(vd, "__file__", str(fake_script))
+    return hist
+
+
+# --- variety penalty on repeated macrostructure ---
+
+
+def test_macro_repeat_penalizes(monkeypatch, tmp_path):
+    _patch_history(
+        monkeypatch,
+        tmp_path,
+        [{"name": "prev", "fonts": ["A", "B"], "palette_name": "X", "macrostructure": "macro:bento"}],
+    )
+    score, details = vd.calculate_variety_score("new", ["C", "D"], "Y", "macro:bento")
+    assert score == 70
+    assert "macro:bento" in details
+
+
+def test_macro_distinct_no_penalty(monkeypatch, tmp_path):
+    _patch_history(
+        monkeypatch,
+        tmp_path,
+        [{"name": "prev", "fonts": ["A", "B"], "palette_name": "X", "macrostructure": "macro:bento"}],
+    )
+    score, _ = vd.calculate_variety_score("new", ["C", "D"], "Y", "macro:timeline")
+    assert score == 90
+
+
+# --- back-compat: old entries lack the macrostructure field ---
+
+
+def test_old_entry_without_macro_loads(monkeypatch, tmp_path):
+    _patch_history(
+        monkeypatch,
+        tmp_path,
+        [{"name": "prev", "fonts": ["A", "B"], "palette_name": "X", "timestamp": "2025-01-01"}],
+    )
+    # No KeyError; a new macro is simply not a repeat.
+    score, _ = vd.calculate_variety_score("new", ["C", "D"], "Y", "macro:bento")
+    assert score == 90
+
+
+def test_empty_macro_never_penalizes(monkeypatch, tmp_path):
+    _patch_history(
+        monkeypatch,
+        tmp_path,
+        [{"name": "prev", "fonts": ["A", "B"], "palette_name": "X", "macrostructure": "macro:bento"}],
+    )
+    score, _ = vd.calculate_variety_score("new", ["C", "D"], "Y", "")
+    assert score == 90
+
+
+# --- history write includes the field ---
+
+
+def test_update_history_writes_macro(tmp_path, monkeypatch):
+    # skill_dir = Path(__file__).parent.parent, so faking __file__ at tmp/scripts/x.py
+    # makes skill_dir == tmp and the history file land in tmp/references/.
+    (tmp_path / "references").mkdir()
+    hist = tmp_path / "references" / "project-history.json"
+    fake_script = tmp_path / "scripts" / "validate_design.py"
+    fake_script.parent.mkdir(parents=True)
+
+    orig_file = vd.__file__
+    try:
+        monkeypatch.setattr(vd, "__file__", str(fake_script))
+        vd.update_project_history("proj", ["F1", "F2"], "Pal", "macro:gallery-grid")
+        rec = json.loads(hist.read_text(encoding="utf-8"))["projects"][-1]
+        assert rec["macrostructure"] == "macro:gallery-grid"
+        assert rec["name"] == "proj"
+        assert "timestamp" in rec
+    finally:
+        vd.__file__ = orig_file
+
+
+# --- stamp parsing ---
+
+
+def test_read_macro_from_stamp():
+    css = "/* vexjoy-design: macro=macro:split-hero theme=Dusk contrast=pass nav=top footer=slim mobile=pass */\nbody{}"
+    assert vd.read_macro_from_stamp(css) == "macro:split-hero"
+
+
+def test_read_macro_from_stamp_absent():
+    assert vd.read_macro_from_stamp("body { color: #111; }") == ""
+
+
+# --- emitted-css slop scan helper ---
+
+
+def test_scan_emitted_css(tmp_path):
+    f = tmp_path / "out.css"
+    f.write_text(".btn { transition: all 0.2s; }", encoding="utf-8")
+    findings = vd.scan_emitted_css(f)
+    assert any(x["rule_id"] == "transition-all" for x in findings)
+
+
+def test_scan_emitted_css_clean(tmp_path):
+    f = tmp_path / "out.css"
+    f.write_text(".btn { transition: opacity 0.2s; }", encoding="utf-8")
+    assert vd.scan_emitted_css(f) == []

--- a/skills/frontend/distinctive-frontend-design/scripts/validate_design.py
+++ b/skills/frontend/distinctive-frontend-design/scripts/validate_design.py
@@ -193,9 +193,16 @@ def validate_palette(palette_path: Path) -> Tuple[int, bool, str, List[str]]:
     return (score, True, details, warnings)
 
 
-def calculate_variety_score(project_name: str, fonts: List[str], palette_name: str) -> Tuple[int, str]:
+def calculate_variety_score(
+    project_name: str, fonts: List[str], palette_name: str, macrostructure: str = ""
+) -> Tuple[int, str]:
     """
     Calculate variety score based on project history.
+
+    Penalizes reuse of fonts, palette theme, or page macrostructure versus recent
+    projects. Macrostructure mirrors the font/palette step-down: a match against the
+    last 1-2 projects drops the score to the same 70 threshold, because structural
+    sameness reads as templated just as font/palette sameness does.
 
     Returns: (score, details)
     """
@@ -227,14 +234,29 @@ def calculate_variety_score(project_name: str, fonts: List[str], palette_name: s
         if palette_name and project_palette and palette_name.lower() in project_palette.lower():
             similar_palette += 1
 
+    # Macrostructure repetition: penalize a match against the last 1-2 projects.
+    # Back-compat: old entries lack the field; .get("macrostructure", "") yields "".
+    similar_macro = 0
+    if macrostructure:
+        for project in recent_projects[-2:]:
+            if project.get("macrostructure", "") == macrostructure:
+                similar_macro += 1
+
     if similar_fonts > 0:
         return (70, f"⚠️  Font pairing matches {similar_fonts} recent project(s). Aim for more variety.")
+
+    if similar_macro > 0:
+        return (
+            70,
+            f"⚠️  Macrostructure '{macrostructure}' matches {similar_macro} recent project(s). "
+            f"Pick a different macro:* page structure for variety.",
+        )
 
     if similar_palette > 0:
         return (80, f"⚠️  Similar palette theme used in {similar_palette} recent project(s).")
 
     score = 90
-    details = f"✅ Aesthetic differs significantly from {len(recent_projects)} recent project(s)."
+    details = f"✅ Aesthetic is distinct across the {len(recent_projects)} most recent project(s)."
 
     return (score, details)
 
@@ -289,7 +311,12 @@ def calculate_distinctiveness_score(
 
 
 def run_validation(
-    fonts: List[str], palette_path: Path, project_name: str, has_animation: bool = False, has_background: bool = False
+    fonts: List[str],
+    palette_path: Path,
+    project_name: str,
+    has_animation: bool = False,
+    has_background: bool = False,
+    macrostructure: str = "",
 ) -> Dict[str, Any]:
     """Run comprehensive validation and return results."""
 
@@ -316,7 +343,7 @@ def run_validation(
 
     # Variety check
     palette_name = palette.get("palette_name", "")
-    variety_score, variety_details = calculate_variety_score(project_name, fonts, palette_name)
+    variety_score, variety_details = calculate_variety_score(project_name, fonts, palette_name, macrostructure)
     results["checks"]["variety"] = {"score": variety_score, "passed": variety_score >= 70, "details": variety_details}
 
     # Distinctiveness check
@@ -364,8 +391,12 @@ def run_validation(
     return results
 
 
-def update_project_history(project_name: str, fonts: List[str], palette_name: str):
-    """Update project history with new project."""
+def update_project_history(project_name: str, fonts: List[str], palette_name: str, macrostructure: str = ""):
+    """Update project history with new project.
+
+    Writes the macrostructure axis alongside fonts/palette so the next run's variety
+    check can penalize structural repetition. Old entries lacking the field still load.
+    """
     skill_dir = Path(__file__).parent.parent
     history_path = skill_dir / "references" / "project-history.json"
 
@@ -382,7 +413,13 @@ def update_project_history(project_name: str, fonts: List[str], palette_name: st
     from datetime import datetime
 
     history["projects"].append(
-        {"name": project_name, "fonts": fonts, "palette_name": palette_name, "timestamp": datetime.now().isoformat()}
+        {
+            "name": project_name,
+            "fonts": fonts,
+            "palette_name": palette_name,
+            "macrostructure": macrostructure,
+            "timestamp": datetime.now().isoformat(),
+        }
     )
 
     # Save updated history
@@ -433,6 +470,36 @@ def print_validation_report(results: Dict[str, Any]):
     print("=" * 70 + "\n")
 
 
+def read_macro_from_stamp(css_text: str) -> str:
+    """Recover the macro id from a vexjoy-design stamp comment, or "" if absent.
+
+    The stamp is the first CSS comment in generated output:
+        /* vexjoy-design: macro=<id> theme=<name> contrast=<pass|fail> ... */
+    Never trusted blindly — the slop rules verify the rendered CSS independently.
+    """
+    import re
+
+    m = re.search(r"vexjoy-design:.*?\bmacro=(\S+)", css_text)
+    return m.group(1) if m else ""
+
+
+def scan_emitted_css(css_path: Path) -> List[Dict[str, Any]]:
+    """Route emitted CSS/HTML through the slop rules. Returns finding dicts.
+
+    Warnings do not fail the build yet. Promote-to-error path: a caller raises the
+    exit code once a rule_id graduates from "warning" to "error" in css_slop_rules.
+    """
+    import sys as _sys
+    from importlib import import_module
+
+    _sys.path.insert(0, str(Path(__file__).parent))
+    slop = import_module("css_slop_rules")
+
+    text = css_path.read_text(encoding="utf-8")
+    findings = slop.scan_css(text)
+    return [{"rule_id": f.rule_id, "severity": f.severity, "message": f.message, "line": f.line} for f in findings]
+
+
 def main():
     """Main entry point."""
     parser = argparse.ArgumentParser(
@@ -449,12 +516,27 @@ def main():
     parser.add_argument(
         "--background", action="store_true", help="Flag indicating atmospheric background is implemented"
     )
+    parser.add_argument(
+        "--macrostructure",
+        default="",
+        help="Chosen macro:* page structure id (e.g. macro:stat-led) for structural variety tracking",
+    )
+    parser.add_argument(
+        "--emitted-css",
+        type=Path,
+        help="Path to generated CSS/HTML to scan for rendered-CSS slop (warnings, non-blocking)",
+    )
 
     args = parser.parse_args()
 
     try:
         # Parse fonts
         fonts = [f.strip() for f in args.fonts.split(",")]
+
+        # If a macro id was not passed but emitted CSS carries a stamp, recover it.
+        macrostructure = args.macrostructure
+        if not macrostructure and args.emitted_css and args.emitted_css.exists():
+            macrostructure = read_macro_from_stamp(args.emitted_css.read_text(encoding="utf-8"))
 
         # Run validation
         results = run_validation(
@@ -463,10 +545,27 @@ def main():
             project_name=args.project,
             has_animation=args.animation,
             has_background=args.background,
+            macrostructure=macrostructure,
         )
 
         # Print report
         print_validation_report(results)
+
+        # Scan emitted CSS for rendered-CSS slop (advisory warnings, do not fail build).
+        if args.emitted_css:
+            if not args.emitted_css.exists():
+                raise DesignValidationError(f"Emitted CSS file not found: {args.emitted_css}")
+            slop_findings = scan_emitted_css(args.emitted_css)
+            results["css_slop"] = slop_findings
+            print("-" * 70)
+            print(f"RENDERED-CSS SLOP SCAN: {args.emitted_css}")
+            if slop_findings:
+                for f in slop_findings:
+                    print(f"  ⚠️  [{f['rule_id']}] line {f['line']}: {f['message']}")
+                print("  (warnings are advisory; promote a rule to error to fail the build)")
+            else:
+                print("  ✅ No slop patterns detected.")
+            print("-" * 70 + "\n")
 
         # Save JSON output if requested
         if args.output:
@@ -479,7 +578,7 @@ def main():
         if results["overall_score"] >= 70:
             palette = load_json_file(args.palette)
             palette_name = palette.get("palette_name", "")
-            update_project_history(args.project, fonts, palette_name)
+            update_project_history(args.project, fonts, palette_name, macrostructure)
 
         # Exit with appropriate code
         sys.exit(0 if results["overall_score"] >= 80 else 1)

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -59,6 +59,16 @@ Every sentence the router prints is a sentence the user reads before seeing resu
 5. Everyday English over jargon.
 6. Break any rule sooner than say anything barbarous.
 
+**Russell's density rules** (1956) extend Orwell and apply to the same surfaces *plus* the model's own thinking, code comments, and any skill or reference files written:
+
+1. Shortest accurate word; never a long word where a short one serves.
+2. Cut every word that carries no instruction, rule, or decision.
+3. Plain English, not jargon.
+4. Concrete over abstract.
+5. Put heavy qualifications in separate short sentences.
+
+Russell's distinct contribution over Orwell is rule 5 — heavy qualifications go in their own sentences — and the explicit scope: thinking, comments, and authored skill files, not just user-facing prose. Canonical statement: `skills/shared-patterns/russell-density.md`.
+
 These rules apply equally to agent prompts. Every word in a dispatched prompt costs tokens on that agent's context window.
 
 **User sees:** phase banners, routing decision banner, brief post-agent summary (what changed, not how).
@@ -420,7 +430,7 @@ Extraction: Intent from verb+object. Constraints include branch safety (never me
 
 **MANDATORY: Inject the completeness standard for ALL Simple+ dispatches.** Every agent prompt MUST include: "Deliver the finished product. Ship the complete thing."
 
-**MANDATORY: Inject density standard for ALL Simple+ dispatches.** Every agent prompt MUST include: "Write dense: high fidelity, minimum words. Cut filler, prefer tables over paragraphs, report what changed — not how."
+**MANDATORY: Inject the Russell density standard for ALL Simple+ dispatches.** Every agent prompt MUST include: "Write to the Russell density standard — it governs your output, code comments, any skill or reference files you write, AND your own thinking: (1) shortest accurate word; (2) cut every word that carries no instruction, rule, or decision; (3) plain English, not jargon; (4) concrete over abstract; (5) heavy qualifications in separate short sentences. Say everything the task needs and not one word more. Report what changed, not how. Full rules: `skills/shared-patterns/russell-density.md`."
 
 **MANDATORY: Inject base instructions for ALL dispatched agents.** Every agent prompt MUST include: "Before starting work, also load `agents/base-instructions.md` for universal operational rules."
 

--- a/skills/meta/html-artifact/SKILL.md
+++ b/skills/meta/html-artifact/SKILL.md
@@ -109,6 +109,14 @@ The script reads CSS/JS from `templates/` and injects:
 3. Shape-specific layout CSS (`templates/shapes/{shape}.css`)
 4. Component CSS + JS (`templates/components/{name}.{css,js}`)
 
+The assembler also emits a self-describing stamp as the FIRST CSS comment, so a later run can re-audit the build statelessly (recover shape/theme from output):
+
+```
+/* vexjoy-artifact: shape=<shape> theme=<name> contrast=<pass|fail|n/a> */
+```
+
+`shape` and `theme` come from this build's decisions. `contrast=n/a` at assembly time because the assembler runs no WCAG check; the stamp is a claim, not proof — Phase 4's slop scan verifies the rendered CSS independently rather than trusting it.
+
 Select components based on shape needs:
 
 | Shape | Typical Components |
@@ -197,6 +205,9 @@ The script checks:
 | Has viewport meta | Missing viewport meta tag |
 | File size under 500KB | Excessive inline assets or animation keyframes |
 | No broken internal refs | `href="#id"` pointing to nonexistent `id` attributes |
+| Rendered-CSS slop scan | `css_slop_rules.scan_css` over the file content (warnings only, non-blocking) |
+
+The slop scan (vendored `css_slop_rules.py`) flags 7 rendered-CSS patterns — `transition-all`, `universal-hover-scale`, `gradient-text-headline`, `focus-ring-fade`, `emoji-feature-icon`, `two-line-cta`, `contrast-canary`. It is shape-agnostic (checks CSS/markup, not page structure), so it applies to all 8 shapes including hero-less ones. Findings surface as warnings and do not fail the build yet; promote a rule to error in `css_slop_rules.py` to make it blocking.
 
 Gate: All validation checks pass.
 -- because an HTML file with external dependencies fails offline, missing meta tags render inconsistently across browsers, and missing structure breaks accessibility.
@@ -377,7 +388,8 @@ This skill uses:
 - `references/pptx-export.md`: Phase 7 EXPORT-PPTX — trigger conditions, layout types, THEME dict, CLI reference, failure modes
 - `scripts/detect-shape.py`: Deterministic shape classification from user request
 - `scripts/assemble-template.py`: Template assembly with theme, shape, and component CSS/JS injection
-- `scripts/validate-artifact.py`: HTML structure and self-containment validation
+- `scripts/validate-artifact.py`: HTML structure, self-containment, and rendered-CSS slop validation
+- `scripts/css_slop_rules.py`: vendored slop scanner (`scan_css`) — 7 rendered-CSS rules, dependency-free. Keep in sync with distinctive-frontend-design.
 - `scripts/to-pdf.py`: Playwright-based PDF rendering with per-shape page sizing
 - `scripts/pptx-bridge/`: HTML deck → editable PPTX (extract_slides.py, _pptx_engine.py, render_pptx.py, run-unified.py)
 - `templates/`: CSS/JS template files organized by themes/, shapes/, components/, print/

--- a/skills/meta/html-artifact/scripts/assemble-template.py
+++ b/skills/meta/html-artifact/scripts/assemble-template.py
@@ -102,8 +102,13 @@ def assemble_template(
     # detect it without re-running shape classification.
     html = html.replace("<body>", f'<body data-shape="{shape}">', 1)
 
-    # Build CSS injection: reset + theme + shape + components
+    # Build CSS injection: stamp + reset + theme + shape + components
     css_parts: list[str] = []
+
+    # 0. Self-describing stamp — first CSS comment in the output. Lets a later run
+    #    re-audit the build statelessly (shape/theme recovery). contrast=n/a because
+    #    the assembler runs no WCAG check; a contrast-aware caller may overwrite it.
+    css_parts.append(f"/* vexjoy-artifact: shape={shape} theme={resolved_theme} contrast=n/a */")
 
     # 1. Base reset
     reset_css = _read_template("base-reset.css")

--- a/skills/meta/html-artifact/scripts/css_slop_rules.py
+++ b/skills/meta/html-artifact/scripts/css_slop_rules.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+# Vendored verbatim from skills/frontend/distinctive-frontend-design/scripts/css_slop_rules.py — keep in sync.
+"""Canonical rendered-CSS slop rules. Self-contained, dependency-free.
+
+Public surface:
+    scan_css(css_text: str) -> list[Finding]
+    Finding(rule_id, severity, message, line)
+
+Deterministic regex/parse only — no LLM. Designed to be vendored as-is into
+other skills (e.g. html-artifact). Findings start at "warning" severity; the
+promote-to-error path is documented per rule below and gated by the caller.
+
+Rules:
+    transition-all          `transition: all` (shorthand spanning all properties)
+    universal-hover-scale   :hover whose only effect is a broad transform: scale()
+    gradient-text-headline  background-clip:text / -webkit-background-clip:text on h1/h2
+    focus-ring-fade         focus outline/ring animated via transition (fades in)
+    emoji-feature-icon      emoji codepoint as a feature/list icon (CSS content or markup)
+    two-line-cta            clickable/button text that wraps to two lines (heuristic)
+    contrast-canary         adjacent fg/bg within delta-L <= 0.05 AND delta-chroma <= 0.05
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One slop-rule hit.
+
+    rule_id:  stable identifier (see module docstring table).
+    severity: "warning" for every rule today; callers promote to "error".
+    message:  human-readable explanation and fix direction.
+    line:     1-based best-effort source line.
+    """
+
+    rule_id: str
+    severity: str
+    message: str
+    line: int
+
+
+# Contrast-canary thresholds (oklch space): treat as too-low-contrast when BOTH hold.
+_CONTRAST_DELTA_L = 0.05  # lightness L is 0..1; <=5% apart
+_CONTRAST_DELTA_C = 0.05  # chroma
+
+_EMOJI_RE = re.compile(
+    "["
+    "\U0001f300-\U0001faff"  # symbols, pictographs, emoji
+    "\U00002600-\U000027bf"  # misc symbols + dingbats
+    "\U0001f000-\U0001f0ff"  # mahjong/dominoes/cards
+    "\U00002190-\U000021ff"  # arrows (often used as icons)
+    "\U00002b00-\U00002bff"  # misc symbols and arrows (stars, checks)
+    "\U0000fe0f"  # variation selector-16
+    "]"
+)
+
+
+def _line_of(text: str, index: int) -> int:
+    """Return the 1-based line number for a character offset."""
+    return text.count("\n", 0, index) + 1
+
+
+# --- color parsing (hex + oklch) → (L, chroma) in oklch space ---
+
+
+def _parse_hex(token: str) -> tuple[float, float, float] | None:
+    """Parse #rgb / #rrggbb (alpha ignored) → sRGB 0..1 triple."""
+    h = token.lstrip("#")
+    if len(h) in (3, 4):
+        h = "".join(c * 2 for c in h[:3])
+    elif len(h) in (6, 8):
+        h = h[:6]
+    else:
+        return None
+    try:
+        r = int(h[0:2], 16) / 255.0
+        g = int(h[2:4], 16) / 255.0
+        b = int(h[4:6], 16) / 255.0
+    except ValueError:
+        return None
+    return (r, g, b)
+
+
+def _srgb_to_linear(c: float) -> float:
+    return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+
+def _srgb_to_oklch_lc(rgb: tuple[float, float, float]) -> tuple[float, float]:
+    """sRGB triple → (L, chroma) in OKLCH. Hue is dropped (not needed here)."""
+    r, g, b = (_srgb_to_linear(c) for c in rgb)
+    lm = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b
+    mm = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b
+    sm = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b
+    l_ = lm ** (1 / 3)
+    m_ = mm ** (1 / 3)
+    s_ = sm ** (1 / 3)
+    big_l = 0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_
+    a = 1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_
+    b2 = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_
+    chroma = math.hypot(a, b2)
+    return (big_l, chroma)
+
+
+_OKLCH_RE = re.compile(r"oklch\(\s*([0-9.]+%?)\s+([0-9.]+)\s+", re.IGNORECASE)
+
+
+def _parse_oklch(token: str) -> tuple[float, float] | None:
+    """Parse oklch(L C H ...) → (L, chroma). L may be a percentage."""
+    m = _OKLCH_RE.search(token)
+    if not m:
+        return None
+    raw_l, raw_c = m.group(1), m.group(2)
+    try:
+        big_l = float(raw_l[:-1]) / 100.0 if raw_l.endswith("%") else float(raw_l)
+        chroma = float(raw_c)
+    except ValueError:
+        return None
+    return (big_l, chroma)
+
+
+def _color_to_lc(value: str) -> tuple[float, float] | None:
+    """Resolve a single CSS color value to (L, chroma) in oklch space."""
+    value = value.strip()
+    if value.lower().startswith("oklch("):
+        return _parse_oklch(value)
+    hexmatch = re.search(r"#[0-9a-fA-F]{3,8}\b", value)
+    if hexmatch:
+        rgb = _parse_hex(hexmatch.group(0))
+        if rgb is not None:
+            return _srgb_to_oklch_lc(rgb)
+    return None
+
+
+# --- rule scanners ---
+
+_BLOCK_RE = re.compile(r"([^{}]*)\{([^{}]*)\}", re.DOTALL)
+
+
+def _iter_blocks(css: str):
+    """Yield (selector, body, body_offset) for each top-level rule block."""
+    for m in _BLOCK_RE.finditer(css):
+        selector = m.group(1).strip()
+        body = m.group(2)
+        yield selector, body, m.start(2)
+
+
+def _decls(body: str) -> list[tuple[str, str]]:
+    """Split a declaration block into (property, value) pairs (lowercased prop)."""
+    out: list[tuple[str, str]] = []
+    for chunk in body.split(";"):
+        if ":" in chunk:
+            prop, _, val = chunk.partition(":")
+            out.append((prop.strip().lower(), val.strip()))
+    return out
+
+
+def _scan_transition_all(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for m in re.finditer(r"transition(?:-property)?\s*:\s*([^;}]*)", css, re.IGNORECASE):
+        if re.match(r"all\b", m.group(1).strip(), re.IGNORECASE):
+            findings.append(
+                Finding(
+                    "transition-all",
+                    "warning",
+                    "transition: all animates every property; name the properties you "
+                    "actually change (e.g. transition: opacity, transform).",
+                    _line_of(css, m.start()),
+                )
+            )
+    return findings
+
+
+def _scan_universal_hover_scale(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for selector, body, offset in _iter_blocks(css):
+        if ":hover" not in selector.lower():
+            continue
+        decls = _decls(body)
+        effective = [(p, v) for p, v in decls if p and v]
+        if len(effective) != 1:
+            continue
+        prop, val = effective[0]
+        if prop == "transform" and re.match(r"scale\(\s*1(\.0\d*)?\s*\)", val, re.IGNORECASE):
+            findings.append(
+                Finding(
+                    "universal-hover-scale",
+                    "warning",
+                    "the only hover effect is a small transform: scale(); a uniform "
+                    "scale-on-hover reads as templated. Give hover a purposeful change.",
+                    _line_of(css, offset),
+                )
+            )
+    return findings
+
+
+def _scan_gradient_text_headline(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for selector, body, offset in _iter_blocks(css):
+        sel = selector.lower()
+        if not re.search(r"\bh[12]\b", sel):
+            continue
+        if re.search(r"(?:-webkit-)?background-clip\s*:\s*text", body, re.IGNORECASE):
+            findings.append(
+                Finding(
+                    "gradient-text-headline",
+                    "warning",
+                    "gradient-clipped headline text (background-clip: text on h1/h2) is a "
+                    "signature template look; use a solid headline color.",
+                    _line_of(css, offset),
+                )
+            )
+    return findings
+
+
+def _scan_focus_ring_fade(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for selector, body, offset in _iter_blocks(css):
+        if ":focus" not in selector.lower():
+            continue
+        decls = _decls(body)
+        has_ring = any(p in ("outline", "box-shadow", "border", "outline-color") for p, _ in decls)
+        trans = next((v for p, v in decls if p in ("transition", "transition-property")), "")
+        if has_ring and re.search(r"\b(all|outline|box-shadow|border)\b", trans, re.IGNORECASE):
+            findings.append(
+                Finding(
+                    "focus-ring-fade",
+                    "warning",
+                    "focus ring is animated via transition; focus indicators must appear "
+                    "instantly for accessibility. Remove the transition on the ring.",
+                    _line_of(css, offset),
+                )
+            )
+    return findings
+
+
+def _scan_emoji_feature_icon(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    # CSS: content property carrying an emoji (pseudo-element icon).
+    for m in re.finditer(r"content\s*:\s*([\"'])(.*?)\1", css, re.IGNORECASE | re.DOTALL):
+        if _EMOJI_RE.search(m.group(2)):
+            findings.append(
+                Finding(
+                    "emoji-feature-icon",
+                    "warning",
+                    "emoji used as a feature/list icon (CSS content); use an inline SVG "
+                    "icon set for a deliberate look.",
+                    _line_of(css, m.start()),
+                )
+            )
+    # Markup hook: emoji directly inside a list item / feature element.
+    for m in re.finditer(r"<li\b[^>]*>(.*?)</li>", css, re.IGNORECASE | re.DOTALL):
+        if _EMOJI_RE.search(m.group(1)):
+            findings.append(
+                Finding(
+                    "emoji-feature-icon",
+                    "warning",
+                    "emoji used as a feature/list icon in markup; use an inline SVG icon set.",
+                    _line_of(css, m.start()),
+                )
+            )
+    return findings
+
+
+def _scan_two_line_cta(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    # Heuristic: a button/CTA-classed clickable whose text contains a forced break.
+    pattern = re.compile(
+        r"<(?:button|a)\b[^>]*(?:class\s*=\s*\"[^\"]*(?:btn|button|cta)[^\"]*\"|role\s*=\s*\"button\")[^>]*>(.*?)</(?:button|a)>",
+        re.IGNORECASE | re.DOTALL,
+    )
+    for m in pattern.finditer(css):
+        inner = m.group(1)
+        if re.search(r"<br\s*/?>", inner, re.IGNORECASE) or "\n" in inner.strip():
+            findings.append(
+                Finding(
+                    "two-line-cta",
+                    "warning",
+                    "call-to-action text wraps to two lines; keep CTA labels to one short "
+                    "line so the action stays scannable.",
+                    _line_of(css, m.start()),
+                )
+            )
+    return findings
+
+
+def _scan_contrast_canary(css: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for _selector, body, offset in _iter_blocks(css):
+        fg = bg = None
+        for prop, val in _decls(body):
+            if prop == "color":
+                fg = _color_to_lc(val)
+            elif prop in ("background-color", "background"):
+                cand = _color_to_lc(val)
+                if cand is not None:
+                    bg = cand
+        if fg is None or bg is None:
+            continue
+        if abs(fg[0] - bg[0]) <= _CONTRAST_DELTA_L and abs(fg[1] - bg[1]) <= _CONTRAST_DELTA_C:
+            findings.append(
+                Finding(
+                    "contrast-canary",
+                    "warning",
+                    "foreground and background are nearly identical "
+                    f"(delta-L<={_CONTRAST_DELTA_L}, delta-chroma<={_CONTRAST_DELTA_C}); text "
+                    "will be unreadable. Widen the lightness gap.",
+                    _line_of(css, offset),
+                )
+            )
+    return findings
+
+
+_SCANNERS = (
+    _scan_transition_all,
+    _scan_universal_hover_scale,
+    _scan_gradient_text_headline,
+    _scan_focus_ring_fade,
+    _scan_emoji_feature_icon,
+    _scan_two_line_cta,
+    _scan_contrast_canary,
+)
+
+
+def scan_css(css_text: str) -> list[Finding]:
+    """Scan CSS (or HTML containing CSS/markup) for slop patterns.
+
+    Returns findings sorted by line, then rule_id. Deterministic.
+    """
+    findings: list[Finding] = []
+    for scanner in _SCANNERS:
+        findings.extend(scanner(css_text))
+    findings.sort(key=lambda f: (f.line, f.rule_id))
+    return findings

--- a/skills/meta/html-artifact/scripts/css_slop_rules.py
+++ b/skills/meta/html-artifact/scripts/css_slop_rules.py
@@ -137,15 +137,28 @@ def _color_to_lc(value: str) -> tuple[float, float] | None:
 
 # --- rule scanners ---
 
-_BLOCK_RE = re.compile(r"([^{}]*)\{([^{}]*)\}", re.DOTALL)
+# Anchored on the literal "{" so finditer scans directly to each brace instead
+# of trying "[^{}]*" from every offset. The old shape r"([^{}]*)\{([^{}]*)\}"
+# was O(n^2) on large brace-free input (e.g. a ~500KB minified single line): the
+# pre-brace run succeeded to end-of-string, the "\{" failed, and the engine
+# retried from the next start position. This form is linear. The selector (the
+# pre-brace text) is recovered by slicing from the previous block's close brace.
+_BLOCK_RE = re.compile(r"\{([^{}]*)\}", re.DOTALL)
 
 
 def _iter_blocks(css: str):
-    """Yield (selector, body, body_offset) for each top-level rule block."""
+    """Yield (selector, body, body_offset) for each top-level rule block.
+
+    Behavior matches the prior "([^{}]*)\\{([^{}]*)\\}" form: the selector is the
+    run of non-brace text immediately preceding the block.
+    """
+    last_close = 0
     for m in _BLOCK_RE.finditer(css):
-        selector = m.group(1).strip()
-        body = m.group(2)
-        yield selector, body, m.start(2)
+        gap = css[last_close : m.start()]
+        cut = max(gap.rfind("{"), gap.rfind("}"))
+        selector = (gap[cut + 1 :] if cut != -1 else gap).strip()
+        yield selector, m.group(1), m.start(1)
+        last_close = m.end()
 
 
 def _decls(body: str) -> list[tuple[str, str]]:

--- a/skills/meta/html-artifact/scripts/tests/test_css_slop_emission.py
+++ b/skills/meta/html-artifact/scripts/tests/test_css_slop_emission.py
@@ -103,14 +103,32 @@ class TestSlopScanWiring:
         finally:
             path.unlink()
 
-    def test_oversized_file_skips_slop_scan(self) -> None:
-        # Oversized file is already flagged by the size check; the slop scan is
-        # bounded out to stay deterministic. Must return quickly, not hang.
+    def test_oversized_file_still_scanned_fast(self) -> None:
+        # The slop scanner is linear, so oversized files are scanned, not skipped.
+        # Slop in an oversized file is still flagged; the size check fires
+        # independently. Must complete quickly, not hang.
+        import time
+
         path = _write_tmp(SLOP_HTML + ("x" * (501 * 1024)))
         try:
+            start = time.perf_counter()
             result = validate_artifact(path)
-            assert result.checks["css_slop_clean"] is True
+            assert time.perf_counter() - start < 1.0
+            assert result.checks["css_slop_clean"] is False
             assert not result.checks["reasonable_size"]
+        finally:
+            path.unlink()
+
+    def test_oversized_single_line_does_not_hang(self) -> None:
+        # Adversarial ~1MB minified single line: the old O(n^2) block regex hung.
+        import time
+
+        unit = '<div class="btn cta" style="color:#111;background:#222">x</div>'
+        path = _write_tmp("<html><body>" + unit * 16000 + "</body></html>")
+        try:
+            start = time.perf_counter()
+            validate_artifact(path)
+            assert time.perf_counter() - start < 1.0
         finally:
             path.unlink()
 

--- a/skills/meta/html-artifact/scripts/tests/test_css_slop_emission.py
+++ b/skills/meta/html-artifact/scripts/tests/test_css_slop_emission.py
@@ -1,0 +1,170 @@
+"""Tests for the vendored slop scan wired into validate-artifact.py and the
+self-describing stamp emitted by assemble-template.py."""
+
+from __future__ import annotations
+
+import re
+import sys
+import tempfile
+from importlib import import_module
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+validate_mod = import_module("validate-artifact")
+validate_artifact = validate_mod.validate_artifact
+
+assemble_mod = import_module("assemble-template")
+assemble_template = assemble_mod.assemble_template
+
+slop = import_module("css_slop_rules")
+scan_css = slop.scan_css
+
+STAMP_RE = re.compile(r"/\* vexjoy-artifact: shape=(\S+) theme=(\S+) contrast=(pass|fail|n/a) \*/")
+
+# Clean CSS: no slop patterns.
+CLEAN_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Clean</title>
+    <style>
+    body { color: #111111; background-color: #ffffff; }
+    .card { transition: opacity 150ms, transform 150ms; }
+    h1 { color: #222222; }
+    </style>
+</head>
+<body><h1>Hello</h1><p>content</p></body>
+</html>"""
+
+# Slop CSS: transition-all + gradient-text-headline on h1.
+SLOP_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Slop</title>
+    <style>
+    .card { transition: all 200ms ease; }
+    h1 { background-clip: text; -webkit-background-clip: text; }
+    </style>
+</head>
+<body><h1>Headline</h1><p>content</p></body>
+</html>"""
+
+
+def _write_tmp(content: str) -> Path:
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False, encoding="utf-8")
+    f.write(content)
+    f.close()
+    return Path(f.name)
+
+
+class TestSlopScanWiring:
+    """The vendored scan_css fires on slop and stays silent on clean CSS."""
+
+    def test_clean_css_no_slop_warnings(self) -> None:
+        path = _write_tmp(CLEAN_HTML)
+        try:
+            result = validate_artifact(path)
+            assert result.checks["css_slop_clean"] is True
+            assert not any(w.startswith("CSS slop") for w in result.warnings)
+            # Slop warnings are non-blocking — clean file is still valid.
+            assert result.valid
+        finally:
+            path.unlink()
+
+    def test_slop_css_emits_warnings(self) -> None:
+        path = _write_tmp(SLOP_HTML)
+        try:
+            result = validate_artifact(path)
+            assert result.checks["css_slop_clean"] is False
+            slop_warnings = [w for w in result.warnings if w.startswith("CSS slop")]
+            assert any("transition-all" in w for w in slop_warnings)
+            assert any("gradient-text-headline" in w for w in slop_warnings)
+        finally:
+            path.unlink()
+
+    def test_slop_is_non_blocking(self) -> None:
+        # Structurally valid file with slop: warnings only, exit-equivalent valid.
+        path = _write_tmp(SLOP_HTML)
+        try:
+            result = validate_artifact(path)
+            assert result.valid
+        finally:
+            path.unlink()
+
+    def test_scan_shape_agnostic(self) -> None:
+        # Same slop CSS flagged regardless of declared shape (report has no hero).
+        path = _write_tmp(SLOP_HTML)
+        try:
+            for shape in ("report", "data-viz", "spec", "deck"):
+                result = validate_artifact(path, shape=shape)
+                assert result.checks["css_slop_clean"] is False
+        finally:
+            path.unlink()
+
+    def test_oversized_file_skips_slop_scan(self) -> None:
+        # Oversized file is already flagged by the size check; the slop scan is
+        # bounded out to stay deterministic. Must return quickly, not hang.
+        path = _write_tmp(SLOP_HTML + ("x" * (501 * 1024)))
+        try:
+            result = validate_artifact(path)
+            assert result.checks["css_slop_clean"] is True
+            assert not result.checks["reasonable_size"]
+        finally:
+            path.unlink()
+
+
+class TestVendoredModuleParity:
+    """The vendored scan_css is the same engine as the source module."""
+
+    def test_findings_match_direct_scan(self) -> None:
+        findings = scan_css(SLOP_HTML)
+        rule_ids = {f.rule_id for f in findings}
+        assert "transition-all" in rule_ids
+        assert "gradient-text-headline" in rule_ids
+
+    def test_clean_css_no_findings(self) -> None:
+        assert scan_css(CLEAN_HTML) == []
+
+
+class TestStampEmission:
+    """assemble-template.py emits a parseable vexjoy-artifact stamp."""
+
+    def test_stamp_present_and_parseable(self) -> None:
+        html = assemble_template("spec", "Test")
+        m = STAMP_RE.search(html)
+        assert m is not None
+        assert m.group(1) == "spec"
+        assert m.group(2) == "birchline"
+        assert m.group(3) == "n/a"
+
+    def test_stamp_is_first_css_comment(self) -> None:
+        html = assemble_template("report", "Test")
+        style_open = html.index("<style>")
+        first_comment = html.index("/*", style_open)
+        assert html[first_comment:].startswith("/* vexjoy-artifact:")
+
+    def test_stamp_reflects_theme_override(self) -> None:
+        html = assemble_template("spec", "Test", theme="dark-focus")
+        m = STAMP_RE.search(html)
+        assert m is not None
+        assert m.group(2) == "dark-focus"
+
+    def test_stamp_per_shape_default_theme(self) -> None:
+        html = assemble_template("code-review", "Test")
+        m = STAMP_RE.search(html)
+        assert m is not None
+        assert m.group(1) == "code-review"
+        assert m.group(2) == "dark-focus"
+
+    def test_stamp_survives_validation_as_clean(self) -> None:
+        # The stamp itself must not trip any slop rule.
+        html = assemble_template("report", "Stamped")
+        path = _write_tmp(html)
+        try:
+            result = validate_artifact(path)
+            stamp_warnings = [w for w in result.warnings if "vexjoy-artifact" in w]
+            assert stamp_warnings == []
+        finally:
+            path.unlink()

--- a/skills/meta/html-artifact/scripts/validate-artifact.py
+++ b/skills/meta/html-artifact/scripts/validate-artifact.py
@@ -154,14 +154,11 @@ def _check_emitted_css_slop(content: str, result: ValidationResult) -> None:
     Shape-agnostic: the rules check CSS/markup, not page structure, so they apply
     to every artifact shape (including hero-less shapes like report or data-viz).
 
-    Skip when content exceeds the size limit: an oversized file is already flagged
-    by the size check, and the slop regexes can backtrack pathologically over a
-    multi-hundred-KB single line. Bounding by size keeps the scan deterministic.
+    Scans every size. The slop rules are linear (the block scanner is anchored on
+    "{", not the old O(n^2) "[^{}]*" pre-brace run that hung on minified single
+    lines), so there is no ReDoS reason to cap by size. Oversized files are still
+    flagged independently by the reasonable_size check.
     """
-    if len(content.encode("utf-8")) >= MAX_FILE_SIZE_BYTES:
-        result.checks["css_slop_clean"] = True
-        return
-
     sys.path.insert(0, str(Path(__file__).parent))
     slop = import_module("css_slop_rules")
     findings = slop.scan_css(content)

--- a/skills/meta/html-artifact/scripts/validate-artifact.py
+++ b/skills/meta/html-artifact/scripts/validate-artifact.py
@@ -22,6 +22,7 @@ import json
 import re
 import sys
 from dataclasses import dataclass, field
+from importlib import import_module
 from pathlib import Path
 
 MAX_FILE_SIZE_BYTES = 500 * 1024  # 500KB
@@ -142,6 +143,33 @@ def _check_valid_structure(content: str, result: ValidationResult) -> None:
         result.errors.append(f"Missing structural tags: {', '.join(missing)}.")
 
 
+def _check_emitted_css_slop(content: str, result: ValidationResult) -> None:
+    """Scan emitted CSS/markup for slop patterns via the vendored slop rules.
+
+    Findings are reported as warnings — they do not fail the build (matches the
+    non-blocking choice in distinctive-frontend-design). Promote-to-error path:
+    raise a finding's rule_id to a build error here once a rule graduates from
+    "warning" to "error" in css_slop_rules.py.
+
+    Shape-agnostic: the rules check CSS/markup, not page structure, so they apply
+    to every artifact shape (including hero-less shapes like report or data-viz).
+
+    Skip when content exceeds the size limit: an oversized file is already flagged
+    by the size check, and the slop regexes can backtrack pathologically over a
+    multi-hundred-KB single line. Bounding by size keeps the scan deterministic.
+    """
+    if len(content.encode("utf-8")) >= MAX_FILE_SIZE_BYTES:
+        result.checks["css_slop_clean"] = True
+        return
+
+    sys.path.insert(0, str(Path(__file__).parent))
+    slop = import_module("css_slop_rules")
+    findings = slop.scan_css(content)
+    result.checks["css_slop_clean"] = not findings
+    for f in findings:
+        result.warnings.append(f"CSS slop [{f.rule_id}] line {f.line}: {f.message}")
+
+
 EXPORT_SHAPES = frozenset({"editor", "prototype"})
 
 
@@ -191,6 +219,7 @@ def validate_artifact(file_path: Path, shape: str | None = None) -> ValidationRe
     _check_reasonable_size(file_path, result)
     _check_no_empty_body(content, result)
     _check_valid_structure(content, result)
+    _check_emitted_css_slop(content, result)
 
     if shape is not None:
         _check_export_button(content, shape, result)

--- a/skills/meta/skill-creator/SKILL.md
+++ b/skills/meta/skill-creator/SKILL.md
@@ -50,6 +50,10 @@ text focused on accuracy**. Minimize prose, maximize signal, no filler.
 - Explanations of "why" stay short and attached to the rule they justify --
   one clause, not a paragraph.
 
+New and edited skill files are written to the **Russell density standard**:
+`skills/shared-patterns/russell-density.md`. That file is the canonical rule;
+the bullets above are its application to skill scaffolding.
+
 This is a generation constraint on the outputs of this skill, not a style note
 for this skill's own prose. Enforce it during the "Write the SKILL.md" phase
 and during any agent scaffolding.

--- a/skills/shared-patterns/russell-density.md
+++ b/skills/shared-patterns/russell-density.md
@@ -1,0 +1,33 @@
+# Russell Density Standard
+
+The toolkit's universal writing standard. Bertrand Russell's prose rules ("How I Write"), applied to every LLM generation.
+
+## Scope
+
+This standard governs **every generation**, with no exception:
+
+- Replies to the user
+- Plain-text output and reports
+- The model's own thinking
+- Skill, instruction, and reference files the agent writes or edits
+- Code comments
+
+Every surface points here. This file holds the rules; other surfaces carry a brief summary and a link back.
+
+## The Five Rules
+
+1. Shortest accurate word; never a long word where a short one serves.
+2. Cut every word that carries no instruction, rule, or decision.
+3. Plain English, not jargon.
+4. Concrete over abstract.
+5. Put heavy qualifications in separate short sentences.
+
+## The Test
+
+Say everything the task needs — omit no required instruction — and not one word more. Dense, complete, clear.
+
+This is not minimalism, which drops information for aesthetics. Density keeps all information and drops everything else.
+
+## Attribution
+
+Bertrand Russell, "How I Write" (1956). Complements Orwell's six rules (1946), which the `/do` router also applies. Russell adds rule 5 — heavy qualifications go in their own sentences — and the concrete-over-abstract bias.

--- a/skills/shared-patterns/russell-density.md
+++ b/skills/shared-patterns/russell-density.md
@@ -12,7 +12,7 @@ This standard governs **every generation**, with no exception:
 - Skill, instruction, and reference files the agent writes or edits
 - Code comments
 
-Every surface points here. This file holds the rules; other surfaces carry a brief summary and a link back.
+This file holds the canonical wording. Surfaces that must guarantee the rules are present every turn — `CLAUDE.md`, `agents/base-instructions.md`, the `/do` router injection (`skills/meta/do/SKILL.md`) — reproduce all five rules verbatim, because the model will not open this file each turn and the rules must sit in context. The duplication is intentional. Propagation rule: edit the canonical wording here first, then update those three high-traffic surfaces to match. Reference docs that the model reads on demand — `docs/PHILOSOPHY.md`, `skill-creator` — carry a one-line summary plus a pointer here instead.
 
 ## The Five Rules
 


### PR DESCRIPTION
## Summary
First slice of the hallmark design work named in `adr/hallmark-design-skill-evaluation.md`: we enforced visual variety but not structural variety, and validated spec JSON but never the emitted CSS. This closes both gaps and installs the toolkit-wide Russell density standard.

- Add a macrostructure catalog + structural diversification so layouts vary by structure, not just visuals.
- Add rendered-CSS slop gates (warn-only) and a self-describing stamp to html-artifact.
- Install the Russell density standard across the toolkit.
- Fix an O(n²) ReDoS in the slop scanner block-regex.

## Changes
- `distinctive-frontend-design` — macrostructure catalog + structural-variety gate; rendered-CSS slop gates.
- `html-artifact` — vendor slop scan over emitted CSS; emit self-describing stamp.
- toolkit-wide — install universal Russell density standard.
- slop scanner — kill O(n²) block-regex ReDoS in `css_slop_rules`.

## Commits
- `a08dba87` — distinctive-frontend-design: structural-variety + rendered-CSS slop gates
- `3fba6555` — toolkit: install universal Russell density standard
- `292929de` — html-artifact: vendor slop scan + emit self-describing stamp
- `3bcfae63` — slop: kill O(n²) block-regex ReDoS in css_slop_rules

## Notes
- Slop gates emit warnings only — non-blocking. Roll back by dropping the branch.
- Coverage: distinctive-frontend-design 21 tests + html-artifact 38 slop/validator tests; ruff clean. CI carries the proof.