### PR TITLE
feat(html-artifact): add diagram-layering and infographic-layout references

### DIFF
--- a/skills/meta/html-artifact/SKILL.md
+++ b/skills/meta/html-artifact/SKILL.md
@@ -358,6 +358,8 @@ See `references/pptx-export.md` for the full layout table, THEME dict, CLI refer
 | Request mentions scroll, reveal, animate on scroll, progressive | `references/scrollytelling-patterns.md` | IntersectionObserver scroll animations, stagger, counters, progress bar |
 | Request mentions PDF, export PDF, as PDF, PDF version | `references/pdf-export.md` | Phase 6 trigger conditions, page-size table, troubleshooting, install instructions |
 | Request mentions pptx, .pptx, powerpoint, editable deck, hand-off, corporate template | `references/pptx-export.md` | Phase 7 trigger conditions, layout types, THEME dict, CLI reference, failure modes |
+| Shape = `diagram` OR request contains "SVG", "architecture diagram", "flowchart", "sequence diagram" | `references/diagram-layering.md` | SVG layer order, masking rect technique, semantic color system for dark-theme diagrams |
+| Shape = `data-viz` OR request contains "infographic", "layout", "visualize data", "chart type" | `references/infographic-layouts.md` | 21 layout types with content-type pairings and 22 visual styles |
 
 ---
 
@@ -386,6 +388,8 @@ This skill uses:
 - `references/scrollytelling-patterns.md`: IntersectionObserver scroll animation patterns
 - `references/pdf-export.md`: Phase 6 EXPORT — trigger conditions, page-size table, print stylesheet inventory, troubleshooting
 - `references/pptx-export.md`: Phase 7 EXPORT-PPTX — trigger conditions, layout types, THEME dict, CLI reference, failure modes
+- `references/diagram-layering.md`: SVG layer order, masking rect technique, dark design system constants, semantic color palette
+- `references/infographic-layouts.md`: 21 layout types with structure and use guidance, 22 visual styles, content-type pairings
 - `scripts/detect-shape.py`: Deterministic shape classification from user request
 - `scripts/assemble-template.py`: Template assembly with theme, shape, and component CSS/JS injection
 - `scripts/validate-artifact.py`: HTML structure, self-containment, and rendered-CSS slop validation

--- a/skills/meta/html-artifact/references/diagram-layering.md
+++ b/skills/meta/html-artifact/references/diagram-layering.md
@@ -1,0 +1,105 @@
+# Diagram Layering Reference
+
+SVG layering technique for architecture diagrams and flowcharts. Produces dark-theme, readable diagrams where arrows appear between components without endpoint bleed-through.
+
+---
+
+## Dark Design System Constants
+
+| Token | Value | Use |
+|---|---|---|
+| Background | `#0f172a` | Page background, masking rectangles |
+| Grid overlay | `#1e293b` | Subtle dashed grid lines |
+| Font | JetBrains Mono | Code-style labels; Google Fonts fallback acceptable |
+
+---
+
+## Semantic Color Palette
+
+| Category | Name | Hex | Use for |
+|---|---|---|---|
+| Primary | Cyan | `#06b6d4` | Frontend, entry points, user-facing components |
+| Secondary | Emerald | `#10b981` | Backend services, APIs |
+| Tertiary | Violet | `#8b5cf6` | Databases, storage |
+| Accent | Amber | `#f59e0b` | Cloud services, external integrations |
+| Alert | Rose | `#f43f5e` | Security, auth components |
+| Connector | Orange | `#f97316` | Queues, message brokers |
+| Neutral | Slate | `#64748b` | Utilities, shared services |
+| Active | Blue | `#3b82f6` | Currently active state indicator |
+
+Apply at 15-20% opacity for box fills; use full hex for borders and text.
+
+---
+
+## SVG Layering Order
+
+Render exactly these 7 layers in sequence. Rendering out of order causes arrow endpoints to bleed through component boxes.
+
+| Step | Layer | How |
+|---|---|---|
+| 1 | Background rectangle | `fill: #0f172a`, full SVG width x height |
+| 2 | Grid overlay | Dashed lines, stroke `#1e293b`, low opacity |
+| 3 | Region/boundary outlines | Dashed, `stroke-dasharray`, group containers only |
+| 4 | Connection arrows | Drawn BEFORE boxes so boxes can cover endpoints |
+| 5 | Opaque masking rectangles | Same fill as background (`#0f172a`), one per component position |
+| 6 | Component boxes | Semi-transparent fill (color at 15-20% opacity), solid colored border |
+| 7 | Text labels and legends | Color matches component category |
+
+---
+
+## The Masking Rectangle Technique
+
+**Problem:** Semi-transparent component boxes let arrow endpoints show through the fill, producing a visible stab at each connection point.
+
+**Solution:** After drawing all arrows (step 4), place a solid opaque rectangle at every component location using the background color. Draw the component box on top in step 6. The arrow is hidden under the mask at the component but fully visible between components.
+
+```xml
+<!-- Step 4: arrow connecting two components -->
+<line x1="220" y1="70" x2="360" y2="70"
+      stroke="#06b6d4" stroke-width="1.5" marker-end="url(#arrowCyan)"/>
+
+<!-- Step 5: masking rect covers the arrow endpoint at the destination -->
+<rect x="360" y="50" width="120" height="40" fill="#0f172a"/>
+
+<!-- Step 6: component box on top of the mask -->
+<rect x="360" y="50" width="120" height="40"
+      fill="#06b6d420" stroke="#06b6d4" stroke-width="1.5" rx="4"/>
+<text x="420" y="74" fill="#06b6d4"
+      font-family="JetBrains Mono, monospace" font-size="11"
+      text-anchor="middle">API Gateway</text>
+```
+
+The same technique works for curved paths (`<path>`) and diagonal lines.
+
+---
+
+## Typography Scale
+
+| Element | Size | Color | Notes |
+|---|---|---|---|
+| Title | 16px | `#e2e8f0` (slate-200) | Single diagram title |
+| Component labels | 11px | Matches component color | Centered in component box |
+| Annotations | 7-8px | `#94a3b8` (slate-400) | Callout notes, port labels |
+| Legend | 9px | `#94a3b8` | Bottom-left legend entries |
+
+---
+
+## Arrow Markers
+
+Define one `<marker>` per category color at the top of `<defs>`. Reference by color name in `marker-end` attributes to keep arrows semantically matched to their source component.
+
+```xml
+<defs>
+  <marker id="arrowCyan" markerWidth="10" markerHeight="7"
+          refX="9" refY="3.5" orient="auto">
+    <polygon points="0 0, 10 3.5, 0 7" fill="#06b6d4"/>
+  </marker>
+  <!-- Repeat for each category color -->
+</defs>
+```
+
+---
+
+## Load Signal
+
+Load when: shape = `diagram` detected by `detect-shape.py`, OR request contains "SVG", "architecture diagram", "flowchart", or "sequence diagram".

--- a/skills/meta/html-artifact/references/infographic-layouts.md
+++ b/skills/meta/html-artifact/references/infographic-layouts.md
@@ -1,0 +1,112 @@
+# Infographic Layouts Reference
+
+Layout taxonomy and visual style system for infographic generation. Covers 21 layout types and 22 visual styles with pre-tuned content-type pairings.
+
+---
+
+## Layout Types (21)
+
+### Sequences
+
+| Layout | Structure | When to use |
+|---|---|---|
+| `linear-progression` | Step-by-step flow, left to right | Processes, timelines under 8 steps |
+| `comic-strip` | Panel-based narrative | Storytelling, cause-and-effect |
+| `winding-roadmap` | Curving path with milestones | Journeys, multi-stage milestones |
+| `circular-flow` | Cycle that loops back to start | Recurring processes, ecosystems |
+
+### Hierarchies
+
+| Layout | Structure | When to use |
+|---|---|---|
+| `hierarchical-layers` | Top-down tiers | Org charts, classification systems |
+| `tree-branching` | Root with radiating branches | Taxonomies, decision trees |
+| `funnel` | Wide-to-narrow progression | Conversion funnels, filtering steps |
+| `story-mountain` | Tension arc: setup / rising / climax / falling / resolution | Narrative arcs |
+
+### Comparisons
+
+| Layout | Structure | When to use |
+|---|---|---|
+| `binary-comparison` | Two columns side by side | A vs B, before/after |
+| `comparison-matrix` | Grid: items on both axes | Feature matrices, 3-6 items x 3-6 criteria |
+| `venn-diagram` | Overlapping circles | Overlap between 2-3 groups |
+
+### Spatial
+
+| Layout | Structure | When to use |
+|---|---|---|
+| `isometric-map` | 3D-perspective grid | System architecture, city/place metaphors |
+| `structural-breakdown` | Exploded view of a system | Anatomy of a product or system |
+| `hub-spoke` | Central node with radiating connections | Ecosystems, central concepts |
+| `jigsaw` | Interlocking pieces | Components that fit together |
+
+### Data-Focused
+
+| Layout | Structure | When to use |
+|---|---|---|
+| `dashboard` | Metric cards + charts in a grid | KPI overviews, 5-12 metrics |
+| `periodic-table` | Element-card grid | Categorized collections, 9-25 items |
+| `bento-grid` | Unequal-size tiles | Feature showcases, asymmetric content |
+| `dense-modules` | Compact card grid | Knowledge cards, reference sheets, 20-50 items |
+
+### Special
+
+| Layout | Structure | When to use |
+|---|---|---|
+| `iceberg` | Visible portion above, hidden bulk below | "More than meets the eye" concepts |
+| `bridge` | Two endpoints connected by an arch | Connecting two states or concepts |
+
+---
+
+## Visual Styles (22)
+
+| Style | Aesthetic | Best for |
+|---|---|---|
+| `craft-handmade` | Hand-drawn textures, paper feel | Personal, warm, approachable |
+| `cyberpunk-neon` | Dark bg, bright neon lines | Tech, futuristic, edgy |
+| `kawaii` | Cute, pastel, rounded | Consumer apps, playful |
+| `technical-schematic` | Blueprint, monochrome, precise | Engineering, technical docs |
+| `retro-pop-grid` | 80s grid, bold colors | Nostalgic, energetic |
+| `corporate-memphis` | Geometric shapes, bold outlines | Business, modern SaaS |
+| `minimal-flat` | White space, simple shapes | Clean, professional |
+| `isometric-3d` | 3D perspective, geometric | Architecture, product |
+| `watercolor-editorial` | Soft washes, editorial feel | Creative, premium |
+| `dark-premium` | Dark bg, gold accents | Luxury, sophisticated |
+| `newspaper` | High contrast, serif fonts | Editorial, authoritative |
+| `chalk-blackboard` | Dark bg, chalk texture | Educational, informal |
+| `data-sci-notebook` | Jupyter-like, light bg | Data science, research |
+| `vaporwave` | Gradient purples/pinks | Aesthetic, nostalgic |
+| `sketchnote` | Handwritten + sketches | Learning, notes |
+| `glassmorphism` | Frosted glass, blur | Modern UI, tech |
+| `brutalist` | Raw, bold borders, harsh | Edgy, statement |
+| `warm-editorial` | Warm tones, humanist | Lifestyle, wellness |
+| `science-textbook` | Clean, labeled diagrams | Academic, educational |
+| `comic-book` | Bold outlines, halftone | Fun, narrative |
+| `art-deco` | Geometric ornament, gold | Elegant, historic |
+| `y2k` | Chrome, gradients, pixel | Nostalgic, ironic |
+
+---
+
+## Content-Type to Layout Pairings
+
+Pre-tuned recommendations. Use as starting point; adjust for content specifics.
+
+| Content Type | Recommended Layout | Style Match |
+|---|---|---|
+| 5-step process | `linear-progression` | `corporate-memphis` or `minimal-flat` |
+| Timeline (6-12 events) | `winding-roadmap` | `watercolor-editorial` |
+| Recurring cycle | `circular-flow` | `isometric-3d` |
+| A vs B comparison | `binary-comparison` | `minimal-flat` |
+| Feature matrix (products) | `comparison-matrix` | `corporate-memphis` |
+| Taxonomy (10-20 items) | `periodic-table` | `technical-schematic` |
+| System architecture | `isometric-map` | `cyberpunk-neon` or `dark-premium` |
+| KPI dashboard | `dashboard` | `data-sci-notebook` |
+| Concept with hidden depth | `iceberg` | `dark-premium` |
+| Central concept + ecosystem | `hub-spoke` | `glassmorphism` |
+
+---
+
+## Load Signal
+
+Load when: shape = `data-viz` detected by `detect-shape.py`, OR request contains "infographic", "layout", "visual", "visualize data", or "chart type".


### PR DESCRIPTION
## Summary

- Adds `skills/meta/html-artifact/references/diagram-layering.md` — SVG 7-step layer order, masking rectangle technique (prevents arrow endpoint bleed-through on semi-transparent boxes), dark design system constants (`#0f172a` background, 8 semantic category colors), and typography scale
- Adds `skills/meta/html-artifact/references/infographic-layouts.md` — 21 layout types across 5 families (sequences, hierarchies, comparisons, spatial, data-focused/special), 22 visual styles with aesthetic descriptions, and pre-tuned content-type → layout pairings
- Updates `SKILL.md` Reference Loading Table with load signals for both files, and Reference Files section with entries for both

Patterns sourced from baoyu-skills analysis (baoyu-diagram + baoyu-infographic), rebuilt inside our architecture per PHILOSOPHY.md: "External Components Are Research Inputs, Not Imports."

## Test plan

- [ ] `python3 scripts/validate-references.py --check-do-framing` — passes (no new anti-pattern blocks)
- [ ] `python3 scripts/validate_positive_instruction_docs.py` — new files produce zero violations
- [ ] `python3 scripts/validate-doc-links.py` — broken link in `docs/for-claude-code.md` is pre-existing, not introduced by this PR
- [ ] `python3 scripts/validate-doc-counts.py` — all count claims agree with filesystem
- [ ] `ruff check . && ruff format --check .` — all checks passed
- [ ] Both reference files under 500-line budget (105 and 112 lines respectively)