### PR TITLE
feat(translate): standalone translate skill with 3-mode pipeline and glossary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-This toolkit prevents that. 44 domain agents, 124 workflow skills, 82 hooks, 106 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+This toolkit prevents that. 44 domain agents, 125 workflow skills, 82 hooks, 106 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Factory (`/do`).
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -68,7 +68,7 @@ Skills route at four confidence tiers driven by trigger-match count and the `for
 
 ### The Haiku Router Reads Intent; Keywords Cannot
 
-`/do` Phase 2 runs a Haiku semantic router. Its value is **not** skill discovery — the harness already injects the full `available-skills` list (~124 skills, with descriptions) into every session, so dropping the router would not reclaim that context. The router earns its keep doing what keyword pre-routing cannot: agent+skill *pairing*, safety-critical force-routes that drag git/security work through the quality gates (lint/tests/CI), the quality-loop wrapper, complexity classification, parallel decomposition, and task-spec injection.
+`/do` Phase 2 runs a Haiku semantic router. Its value is **not** skill discovery — the harness already injects the full `available-skills` list (~125 skills, with descriptions) into every session, so dropping the router would not reclaim that context. The router earns its keep doing what keyword pre-routing cannot: agent+skill *pairing*, safety-critical force-routes that drag git/security work through the quality gates (lint/tests/CI), the quality-loop wrapper, complexity classification, parallel decomposition, and task-spec injection.
 
 The decisive number: dropping Haiku for pure deterministic `pre-route.py` keyword routing collapses strict routing accuracy **63.3% → 34.7%** (corpus n=49). It scores **0% on every paraphrase bucket** — "send my commits to the server" carries no keyword trigger — so **22 of 49 requests** lose their correct agent+skill and fall to a skill-less general handler. Cost of keeping the router: ~+0.1 Haiku calls/request. Trivial, by design (see `skills/meta/do/references/semantic-first-ab-results.md`; drop-Haiku A/B in `tmp/drophaiku-ab-report.md`).
 

--- a/docs/for-knowledge-workers.md
+++ b/docs/for-knowledge-workers.md
@@ -2,7 +2,7 @@
 
 ## What This Gives You
 
-Writing, research, community moderation, data analysis, content publishing. 124 skills behind a single command. You describe work. The system routes it.
+Writing, research, community moderation, data analysis, content publishing. 125 skills behind a single command. You describe work. The system routes it.
 
 ## Interface
 

--- a/docs/for-linkedin.md
+++ b/docs/for-linkedin.md
@@ -69,7 +69,7 @@ A year of daily use on real work. Finding gaps, filling them, watching the syste
 The result:
 
 - 44 domain specialist agents across languages, infrastructure, review, research, content
-- 124 workflow skills covering everything from TDD to article writing to Reddit moderation
+- 125 workflow skills covering everything from TDD to article writing to Reddit moderation
 - 83 lifecycle hooks that fire at session boundaries to inject context, capture learnings, enforce gates
 - A learning database that tracks patterns and graduates them into agent behavior
 - Parallel review pipelines that catch issues before they reach production

--- a/scripts/migrate-skills-to-folders.py
+++ b/scripts/migrate-skills-to-folders.py
@@ -55,6 +55,7 @@ SKILL_MAPPING: dict[str, str] = {
     "create-voice": "content",
     "voice-writer": "content",
     "voice-validator": "content",
+    "translate": "content",
     # Private skills (anti-ai-editor, interactive-essay, voice-* persona clones)
     # live in ~/private-skills, not in this repo. Not mapped here.
     # engineering/ — language-specific patterns + domain engineering

--- a/skills/content/translate/SKILL.md
+++ b/skills/content/translate/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: translate
+description: "Document translation: quick/normal/refined modes with chunked parallel subagents and glossary support."
+user-invocable: true
+routing:
+  category: content
+  triggers:
+    - translate
+    - translation
+    - localize
+    - localise
+    - into English
+    - into Spanish
+    - into French
+    - into Japanese
+    - into Chinese
+    - into German
+    - into Portuguese
+    - from English to
+    - convert language
+  not_for: "reformatting or restructuring text without changing language"
+  pairs_with:
+    - professional-communication
+    - publish
+    - voice-writer
+---
+
+# Translate Skill
+
+Translate documents across languages using one of three modes: quick (single-pass), normal (analyze-then-translate), or refined (full four-step with polish). Core principle: **rewrite as a skilled native writer**, not word-for-word conversion.
+
+## Reference Loading Table
+
+| Signal | Load These Files | Why |
+|---|---|---|
+| Any translation task | `references/modes.md` | Mode detection, chunking algorithm, parallel dispatch pattern |
+| "technical", "specialized", "glossary", "terms", or domain vocabulary in request | `references/glossary-template.md` | Glossary build, chunk injection, term-preservation rules |
+
+---
+
+## Phase 1: DETECT MODE AND PREPARE
+
+**Goal**: Identify mode, language pair, and document scale before any translation work.
+
+**Step 1: Infer mode from request language**
+
+| Request contains | Mode |
+|---|---|
+| "quick", "fast", "draft", "rough" | quick |
+| "professional", "publication-quality", "polished", "refined" | refined |
+| anything else | normal (default) |
+
+**Step 2: Detect language pair**
+
+- Source language: identify from content if not stated; flag ambiguity to user.
+- Target language: take from request; ask if absent.
+
+**Step 3: Load references**
+
+- Load `references/modes.md` for all modes.
+- Load `references/glossary-template.md` when the request contains "technical", "specialized", "glossary", "terms", or a domain-specific vocabulary word.
+
+**Step 4: Assess document size**
+
+- Count approximate words.
+- Flag documents over 2000 words for chunked parallel translation (details in `references/modes.md`).
+
+**Gate**: Mode, language pair, and size class confirmed. Proceed only when gate passes.
+
+---
+
+## Phase 2: ANALYZE
+
+**Goal**: Extract structural and stylistic facts that guide accurate translation. Skip this phase in quick mode.
+
+**Step 1: Language and dialect**
+
+State the identified source language and dialect (e.g., Brazilian Portuguese vs European Portuguese, Simplified vs Traditional Chinese).
+
+**Step 2: Register and tone**
+
+Classify as one of: academic, technical, narrative, marketing, casual, legal. Register determines word-choice formality in the target language.
+
+**Step 3: Document type**
+
+Classify as one of: article, code comments, game text, marketing copy, legal text, UI strings, chat/informal. Document type determines sentence length conventions and formatting expectations in the target.
+
+**Step 4: Specialized terminology**
+
+List domain-specific terms that need consistent translation or should stay in the source language. For technical content, build an initial glossary using the format in `references/glossary-template.md`.
+
+**Gate**: Language/dialect, register, document type, and terminology list complete. Proceed only when gate passes.
+
+---
+
+## Phase 3: TRANSLATE
+
+**Goal**: Produce the translation using mode-specific approach from `references/modes.md`.
+
+**Translation principles** (apply in all modes):
+
+- Use idiomatic target-language word order, not source-language structure.
+- Break long source sentences at natural target-language pause points.
+- Render metaphors by their intended meaning, not literal equivalent.
+- Annotate specialized terms on first occurrence: "machine learning (机器学习)".
+- Match the register (formal/informal) established in Phase 2.
+- Preserve source-language terms for proper nouns, brand names, and internationally recognized technical identifiers.
+
+**For documents over 2000 words**: apply the chunking algorithm from `references/modes.md` — split at heading or paragraph boundaries, build a session glossary, dispatch parallel subagent calls per chunk with glossary injected, reassemble preserving document structure.
+
+**Output file**: write translation to `{source-file-stem}-{target-lang}.md` when a source file is present. For inline text, deliver in-response.
+
+**Gate**: All chunks translated, glossary consistent across chunks, document structure intact. Proceed only when gate passes.
+
+---
+
+## Phase 4: POLISH
+
+**Goal**: Improve register consistency and idiomatic flow. Apply in refined mode only.
+
+**Step 1: Register consistency scan**
+
+Read the full translated output. Flag passages where formality level shifts unexpectedly.
+
+**Step 2: Idiom review**
+
+Identify literal-sounding constructions that a skilled native writer would phrase differently. Rewrite each flagged passage.
+
+**Step 3: Specialized term audit**
+
+Confirm every specialized term is handled consistently: annotated on first use, same translation throughout, source-language terms preserved where appropriate.
+
+**Gate**: Register consistent, idiomatic constructions improved, term handling verified. Proceed only when gate passes.
+
+---
+
+## Phase 5: DELIVER
+
+**Goal**: Report outcome with full traceability.
+
+Deliver a brief summary:
+
+```
+Source: {source-file or "inline text"} ({source-language})
+Target: {output-file or "inline"} ({target-language})
+Mode: {quick | normal | refined}
+Words translated: ~{count}
+Chunks: {N} (if chunked)
+Untranslated terms: {list with reasons, or "none"}
+```
+
+For multi-chunk documents, list any terms that differ between chunks and confirm the session glossary resolved them.
+
+---
+
+## Error Handling
+
+### Ambiguous source language
+Ask the user to confirm before translating. Guessing produces plausible but wrong output for closely related languages (Serbian vs Croatian, Malay vs Indonesian).
+
+### Untranslatable term
+Preserve the source-language term, add a bracketed explanation in target language on first use, and list the term in the delivery summary with the reason it was kept.
+
+### Inconsistency detected across chunks
+Re-translate the inconsistent chunk with the session glossary injected, replace the passage, and note the correction in the delivery summary.
+
+### Source file has mixed languages
+Treat each section by its actual language. Flag the structure to the user in the delivery summary.
+
+---
+
+## References
+
+- `references/modes.md` — Mode detection table, quick/normal/refined workflow, chunk detection threshold, chunking algorithm, parallel dispatch pattern
+- `references/glossary-template.md` — Glossary format, build procedure, chunk injection, term-preservation rules, example glossary

--- a/skills/content/translate/references/glossary-template.md
+++ b/skills/content/translate/references/glossary-template.md
@@ -1,0 +1,124 @@
+# Translate Skill: Glossary Reference
+
+> **Load when**: Request contains "technical", "specialized", "glossary", "terms", or domain vocabulary.
+> **Scope**: Glossary format, build procedure, chunk injection, term-preservation rules, example.
+
+---
+
+## Glossary Format
+
+Use a markdown table with three columns:
+
+```markdown
+| Source Term | Target Term | Notes |
+|---|---|---|
+| machine learning | 機械学習 | Use consistently; annotate on first occurrence |
+| API | API | Preserve as-is; internationally recognized |
+| Docker | Docker | Brand name; preserve unchanged |
+| microservice | マイクロサービス | Transliteration preferred over translation |
+```
+
+**Column definitions**:
+
+| Column | Content |
+|---|---|
+| Source Term | Term exactly as it appears in the source document |
+| Target Term | Agreed translation or "preserve" if keeping source-language form |
+| Notes | Usage rule: annotate on first use, preserve unchanged, transliterate, etc. |
+
+---
+
+## Building a Glossary from the Source Document
+
+**Step 1: Scan for specialized vocabulary**
+
+Read the source document and list every term that falls into one of these categories:
+
+- Technical identifiers: function names, library names, protocol names, data formats
+- Domain vocabulary: field-specific terms that have a standard translation in the target language
+- Brand and product names: trademarks, software product names, company names
+- Proper nouns: person names, place names, organization names
+- Abbreviations and acronyms: expand on first use in the target language if the expansion differs
+
+**Step 2: Decide on treatment per term**
+
+| Term type | Default treatment |
+|---|---|
+| Internationally recognized technical term (API, JSON, HTTP) | Preserve source-language form |
+| Brand name or registered trademark | Preserve source-language form |
+| Person name, place name | Preserve source-language form unless a standard transliteration exists |
+| Domain vocabulary with a standard target-language equivalent | Translate; annotate on first use |
+| Abbreviation whose expansion differs in target language | Translate expansion; keep source abbreviation in parentheses on first use |
+| Culturally specific term with no equivalent | Preserve source-language form; add bracketed explanation on first use |
+
+**Step 3: Populate the glossary table**
+
+For each term identified in Step 1, add a row with the treatment decided in Step 2.
+
+**Step 4: Review for consistency**
+
+Check that no term appears in both "preserve" and "translate" rows. If the same concept appears in multiple surface forms in the source (e.g., "ML", "machine learning", "ML model"), unify them under one glossary entry.
+
+---
+
+## Injecting the Glossary into Chunk Translation Prompts
+
+Prepend the glossary to each chunk prompt in this format:
+
+```
+Session glossary — apply these translations consistently throughout this chunk:
+
+| Source Term | Target Term | Notes |
+|---|---|---|
+{glossary rows}
+
+On first occurrence of a translated term, annotate it: "target-term (source-term)".
+Preserve source-language form for all terms marked "preserve" in the Notes column.
+```
+
+Place the glossary block immediately after the context line and before the chunk text. Keep the glossary under 30 rows in a single prompt; if your glossary exceeds 30 rows, include only the rows relevant to the current chunk's content.
+
+---
+
+## Term Preservation Rules
+
+Apply these in order when deciding whether to translate a term:
+
+1. **Proper noun with no standard transliteration**: preserve unchanged.
+2. **Internationally recognized technical identifier** (API, HTTP, JSON, SQL, HTML): preserve unchanged.
+3. **Brand name or software product name**: preserve unchanged.
+4. **Domain term with a widely used target-language equivalent**: translate and annotate on first use.
+5. **Culturally specific concept with no equivalent**: preserve source term; add bracketed gloss explaining the concept on first use.
+
+When in doubt, preserve the source-language term and annotate. A reader who encounters a preserved term can look it up. A reader who encounters a wrong translation has no signal that anything is wrong.
+
+---
+
+## Example Glossary: Technical Document (English to Japanese)
+
+Source document: software architecture article discussing microservices, containers, and CI/CD pipelines.
+
+| Source Term | Target Term | Notes |
+|---|---|---|
+| microservice | マイクロサービス | Transliterate; annotate on first use |
+| container | コンテナ | Transliterate; annotate on first use |
+| Docker | Docker | Brand name; preserve unchanged |
+| Kubernetes | Kubernetes | Brand name; preserve unchanged |
+| CI/CD | CI/CD | Abbreviation; preserve unchanged; expand on first use: 継続的インテグレーション/継続的デリバリー (CI/CD) |
+| API gateway | APIゲートウェイ | Mixed: preserve API, transliterate gateway |
+| service mesh | サービスメッシュ | Transliterate; annotate on first use |
+| load balancer | ロードバランサー | Transliterate; annotate on first use |
+| deployment | デプロイメント | Transliterate preferred over 展開 in technical contexts |
+| pod | Pod | Kubernetes term; preserve source form; capitalize |
+| namespace | 名前空間 | Standard Japanese translation; use consistently |
+| YAML | YAML | Abbreviation; preserve unchanged |
+
+**First-use annotation example**:
+- Source: "A microservice handles one business capability."
+- Target: "マイクロサービス（microservice）は1つのビジネス機能を担当します。"
+
+---
+
+## See Also
+
+- `modes.md` — Chunking algorithm, parallel dispatch, per-mode workflow

--- a/skills/content/translate/references/modes.md
+++ b/skills/content/translate/references/modes.md
@@ -1,0 +1,122 @@
+# Translate Skill: Mode Reference
+
+> **Load when**: Phase 1 of every translation task.
+> **Scope**: Mode detection, per-mode workflow, chunk detection, chunking algorithm, parallel dispatch.
+
+---
+
+## Mode Detection Table
+
+| Request contains | Mode | Notes |
+|---|---|---|
+| "quick", "fast", "draft", "rough" | quick | Single-pass, no analysis phase |
+| "professional", "publication-quality", "polished", "refined" | refined | Full 4-step pipeline |
+| "slow", "careful", "accurate" | normal | Emphasizes analysis depth |
+| (no qualifier) | normal | Default |
+
+When multiple signals conflict ("quick professional translation"), prefer the higher-effort mode.
+
+---
+
+## Quick Mode
+
+**Use for**: Short text under 500 words, informal content, draft output where speed matters more than polish.
+
+**Workflow**:
+1. Detect source and target language.
+2. Translate in a single pass using translation principles from SKILL.md Phase 3.
+3. Deliver immediately. Skip Phase 2 (ANALYZE) and Phase 4 (POLISH).
+
+**Chunking in quick mode**: For documents over 2000 words that explicitly request quick mode, apply the chunking algorithm below but skip the analysis pass per chunk. Build only a minimal glossary (proper nouns and brand names only).
+
+---
+
+## Normal Mode
+
+**Use for**: Standard documents where accuracy and register matter but publication polish is not required.
+
+**Workflow**:
+1. Phase 2: ANALYZE — full analysis pass (language/dialect, register, document type, terminology list).
+2. Phase 3: TRANSLATE — single-pass translation using analysis output.
+3. Phase 5: DELIVER — report summary.
+
+**Offer refined pass**: After delivering, offer the user an optional refined pass if the output would benefit from idiom review.
+
+---
+
+## Refined Mode
+
+**Use for**: Publication-quality translation, formal documents, content that will be read by native speakers.
+
+**Workflow**:
+1. Phase 2: ANALYZE — full analysis pass.
+2. Phase 3: TRANSLATE — initial translation draft.
+3. Phase 4: POLISH — register scan, idiom review, term audit.
+4. Phase 5: DELIVER — report summary including what was changed in the polish pass.
+
+**Register note**: In refined mode, flag every passage where the initial translation sounds like a translation. A skilled native writer would rephrase these; the polish pass rewrites them.
+
+---
+
+## Chunk Detection
+
+Apply chunking when the document exceeds approximately 2000 words. Use this threshold because a single context window produces less consistent term handling and register over long documents than parallel bounded passes do.
+
+**Boundary detection order** (prefer the highest-structure boundary available):
+
+1. Level-2 headings (`## Heading`) — split after the heading, keep heading with its following content.
+2. Level-3 headings (`### Heading`) — use when no level-2 headings exist.
+3. Blank-line paragraph boundaries — for prose without headings.
+4. Sentence boundary — only as a last resort for very long paragraphs with no blank lines.
+
+**Minimum chunk size**: 200 words. Merge chunks below minimum with the preceding chunk.
+
+**Maximum chunk size**: 600 words. Split at next available boundary if a chunk exceeds this.
+
+---
+
+## Chunking Algorithm
+
+```
+1. Scan document and identify all split boundaries (in order of preference above).
+2. Assign each paragraph/section to a chunk, respecting min/max sizes.
+3. Build a session glossary:
+   a. In normal/refined mode: extract specialized terms from Phase 2 ANALYZE.
+   b. In quick mode: extract proper nouns and brand names only.
+   c. Format: markdown table with columns Source Term | Target Term | Notes.
+4. For each chunk (dispatch in parallel):
+   a. Inject session glossary as a prefix instruction.
+   b. Inject document context: "This is chunk N of M from a {document-type} in {register} register."
+   c. Translate the chunk using the translation principles from SKILL.md Phase 3.
+   d. Capture the translated chunk.
+5. Reassemble: concatenate translated chunks in original order, preserving headings and blank lines.
+6. Consistency check: scan reassembled output for term variations. If a glossary term appears in multiple forms, normalize to the session glossary form.
+```
+
+---
+
+## Parallel Subagent Dispatch Pattern
+
+When dispatching chunks as parallel subagents, structure each subagent call with:
+
+```
+System: You are a professional translator. Translate from {source-language} to {target-language}.
+Context: This is chunk {N} of {M} from a {document-type}. Register: {register}. 
+
+Session glossary (use these translations consistently):
+{glossary-table}
+
+Translate the following text. Preserve all markdown formatting, code blocks, and headings.
+Return only the translated text, no commentary.
+
+---
+{chunk-text}
+```
+
+After all subagents return, proceed to step 5 (reassemble) in the chunking algorithm above.
+
+---
+
+## See Also
+
+- `glossary-template.md` — Glossary format, build procedure, term-preservation rules, example


### PR DESCRIPTION
## Summary

- Adds `skills/content/translate/` with quick/normal/refined modes, chunked parallel subagent dispatch for documents over 2000 words, and glossary support for technical and specialized content
- Standalone skill (not embedded in `professional-communication`) because translation is needed across research, game, voice, and technical content contexts — per architecture decision in `~/.vexjoy-agent/vexjoy-agent/adrs/translate.md`
- All validators pass: frontmatter, positive-instruction (0 new violations), index integrity (PASS), ruff clean

## Test plan

- [ ] `python3 scripts/validate-skill-frontmatter.py skills/content/translate/SKILL.md` exits 0
- [ ] `python3 scripts/validate_positive_instruction_docs.py` shows no violations in `skills/content/translate/`
- [ ] `python3 scripts/validate-index-integrity.py` exits PASS
- [ ] `ruff check . --config pyproject.toml && ruff format --check . --config pyproject.toml` both pass
- [ ] Skill appears in `skills/INDEX.json` under key `translate` with correct triggers and category `content`
- [ ] `references/modes.md` and `references/glossary-template.md` exist with substantive content (≤500 lines each)