### PR TITLE
fix(worktree): cleanup script, preflight check, and branch-collision recovery

### DIFF
--- a/scripts/worktree-cleanup.sh
+++ b/scripts/worktree-cleanup.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# worktree-cleanup.sh — prune stale worktree refs and zombie branches.
+#
+# Run after PR merge or when `git worktree list` shows stale entries.
+# Safe to run at any time; only removes branches with no worktree checked out
+# and that point to commits already merged into main.
+#
+# Usage:
+#   bash scripts/worktree-cleanup.sh          # interactive, confirms each delete
+#   bash scripts/worktree-cleanup.sh --dry-run  # report only, no deletions
+#   bash scripts/worktree-cleanup.sh --force    # delete without prompts
+
+set -euo pipefail
+
+DRY_RUN=0
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        --force)   FORCE=1 ;;
+    esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+echo "[worktree-cleanup] repo: $REPO_ROOT"
+echo ""
+
+# Step 1: prune stale worktree administrative entries (.git/worktrees/<id>
+# where the actual directory no longer exists on disk).
+echo "=== Step 1: prune stale .git/worktrees entries ==="
+if [[ $DRY_RUN -eq 1 ]]; then
+    git worktree prune --dry-run --verbose 2>&1 || true
+else
+    git worktree prune --verbose 2>&1 || true
+fi
+echo ""
+
+# Step 2: identify zombie branches.
+# A zombie branch is a local branch that:
+#   (a) matches harness naming patterns (worktree-agent-* or worktree-wf_*)
+#   (b) has NO worktree checked out (worktreepath is empty in for-each-ref)
+#   OR
+#   (a) matches harness naming patterns
+#   (b) points to a commit reachable from main (already merged)
+echo "=== Step 2: zombie branch analysis ==="
+
+MAIN_BRANCH="main"
+# Fall back to master if main doesn't exist.
+if ! git rev-parse --verify "$MAIN_BRANCH" >/dev/null 2>&1; then
+    MAIN_BRANCH="master"
+fi
+
+ZOMBIES=()
+
+while IFS='|' read -r branch worktreepath; do
+    # Only inspect harness-created branch patterns.
+    case "$branch" in
+        worktree-agent-*|worktree-wf_*) ;;
+        *) continue ;;
+    esac
+
+    # If branch has an active worktree, skip.
+    if [[ -n "$worktreepath" ]]; then
+        echo "  ACTIVE  $branch  ->  $worktreepath"
+        continue
+    fi
+
+    # No worktree. Check if the branch tip is merged into main.
+    BRANCH_SHA="$(git rev-parse "$branch" 2>/dev/null)" || continue
+    MERGE_BASE="$(git merge-base "$MAIN_BRANCH" "$BRANCH_SHA" 2>/dev/null)" || continue
+
+    if [[ "$MERGE_BASE" == "$BRANCH_SHA" ]]; then
+        # Branch tip is an ancestor of main — fully merged.
+        echo "  ZOMBIE  $branch  (merged into $MAIN_BRANCH)"
+        ZOMBIES+=("$branch")
+    else
+        echo "  UNMERGED $branch  (has commits not in $MAIN_BRANCH)"
+    fi
+done < <(git for-each-ref --format="%(refname:short)|%(worktreepath)" refs/heads/)
+
+echo ""
+
+if [[ ${#ZOMBIES[@]} -eq 0 ]]; then
+    echo "No zombie branches found."
+else
+    echo "=== Step 3: delete zombie branches ==="
+    for branch in "${ZOMBIES[@]}"; do
+        if [[ $DRY_RUN -eq 1 ]]; then
+            echo "  DRY-RUN  would delete: $branch"
+        elif [[ $FORCE -eq 1 ]]; then
+            git branch -d "$branch" && echo "  DELETED  $branch" || echo "  SKIP (unmerged guard): $branch"
+        else
+            read -rp "  Delete zombie branch '$branch'? [y/N] " ans
+            case "$ans" in
+                [Yy]*) git branch -d "$branch" && echo "  DELETED  $branch" || echo "  SKIP (unmerged guard): $branch" ;;
+                *)     echo "  SKIPPED  $branch" ;;
+            esac
+        fi
+    done
+fi
+
+echo ""
+echo "=== Final worktree list ==="
+git worktree list

--- a/scripts/worktree-preflight.sh
+++ b/scripts/worktree-preflight.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# worktree-preflight.sh — validate worktree state before an agent starts work.
+#
+# Exits 0 if the environment is clean, 1 if stale state that could cause
+# failures is detected. Run this at the start of a worktree agent task.
+#
+# Checks:
+#   1. Current CWD is inside .claude/worktrees/ (Rule 1 validation)
+#   2. No stale .git/worktrees entries for directories that no longer exist
+#   3. Target branch (if provided) is not already checked out in another worktree
+#
+# Usage:
+#   bash scripts/worktree-preflight.sh                    # CWD check only
+#   bash scripts/worktree-preflight.sh feat/my-branch     # also check branch availability
+
+set -euo pipefail
+
+TARGET_BRANCH="${1:-}"
+ISSUES=0
+
+echo "[worktree-preflight] checking environment..."
+
+# Check 1: CWD contains .claude/worktrees/ (worktree isolation is active).
+CWD="$(pwd)"
+if [[ "$CWD" != *"/.claude/worktrees/"* ]]; then
+    echo "ERROR: CWD is not inside a worktree."
+    echo "  CWD: $CWD"
+    echo "  Expected path containing: /.claude/worktrees/"
+    echo "  Stop. Report to the dispatcher that the agent started in the wrong directory."
+    ISSUES=$((ISSUES + 1))
+else
+    echo "OK: CWD is inside a worktree: $CWD"
+fi
+
+# Check 2: Prune and report stale worktree admin entries.
+STALE="$(git worktree prune --dry-run 2>&1)" || true
+if [[ -n "$STALE" ]]; then
+    echo "WARN: Stale worktree entries detected (will be pruned by cleanup):"
+    echo "$STALE" | sed 's/^/  /'
+    git worktree prune 2>&1 || true
+    echo "  Auto-pruned."
+fi
+
+# Check 3: Target branch availability.
+if [[ -n "$TARGET_BRANCH" ]]; then
+    CHECKED_OUT="$(git for-each-ref --format="%(refname:short) %(worktreepath)" refs/heads/ | grep "^$TARGET_BRANCH " | awk '{print $2}')" || true
+    if [[ -n "$CHECKED_OUT" ]]; then
+        echo "ERROR: Branch '$TARGET_BRANCH' is already checked out at: $CHECKED_OUT"
+        echo "  Use a unique branch name. Append a timestamp or short UUID to the feature name."
+        ISSUES=$((ISSUES + 1))
+    else
+        # Check if branch exists locally (was created before, may be deleteable).
+        if git rev-parse --verify "$TARGET_BRANCH" >/dev/null 2>&1; then
+            echo "WARN: Branch '$TARGET_BRANCH' exists locally but is not checked out."
+            echo "  Options:"
+            echo "    a) Use it: git checkout $TARGET_BRANCH"
+            echo "    b) Use a fresh name: git checkout -b ${TARGET_BRANCH}-2"
+            echo "    c) Delete and recreate: git branch -D $TARGET_BRANCH && git checkout -b $TARGET_BRANCH"
+        else
+            echo "OK: Branch '$TARGET_BRANCH' is available for checkout."
+        fi
+    fi
+fi
+
+if [[ $ISSUES -gt 0 ]]; then
+    echo ""
+    echo "[worktree-preflight] FAILED: $ISSUES issue(s) require attention before proceeding."
+    exit 1
+fi
+
+echo "[worktree-preflight] PASSED: environment is clean."
+exit 0

--- a/skills/process/worktree-agent/SKILL.md
+++ b/skills/process/worktree-agent/SKILL.md
@@ -30,6 +30,24 @@ git checkout -b <branch-name>
 
 Never commit on the default `worktree-agent-*` branch. Create your feature branch FIRST.
 
+If `git checkout -b <branch-name>` fails with "a branch named X already exists":
+
+```bash
+# Option A: the branch has no commits beyond main — safe to reset and reuse
+git branch -D <branch-name>
+git checkout -b <branch-name>
+
+# Option B: the branch is checked out in another active worktree — use a unique name
+git checkout -b <branch-name>-2   # or append timestamp: $(date +%s)
+```
+
+If `git checkout -b <branch-name>` fails with "X is already used by worktree at Y":
+
+```bash
+# Branch is live in another worktree — use a unique suffix
+git checkout -b <branch-name>-$(date +%s)
+```
+
 ## Rule 3: Use Worktree-Relative Paths
 
 Never hardcode absolute paths from the main repo. Use `$(git rev-parse --show-toplevel)/path`.
@@ -66,6 +84,26 @@ ruff format --check . --config pyproject.toml
 
 Running only `ruff check` misses formatting violations. The `Tests / lint` CI job runs both — if you skip `ruff format --check`, the PR will fail CI and cannot merge due to branch protection.
 
+## Rule 9: Run Preflight Check on Start
+
+Run the preflight script at the start of any worktree task to confirm clean state:
+
+```bash
+bash scripts/worktree-preflight.sh <intended-branch-name>
+```
+
+If it exits 1, fix the reported issue before proceeding.
+
+## Post-Merge Cleanup
+
+After a PR is merged, the dispatcher runs:
+
+```bash
+bash scripts/worktree-cleanup.sh --force
+```
+
+This prunes stale `.git/worktrees` entries and deletes zombie branches (harness-created branches with no active worktree that are already merged into main). Run manually when `git worktree list` shows stale locked entries.
+
 ## Failure Modes This Prevents
 
 | Failure | Rule | Without It |
@@ -76,3 +114,4 @@ Running only `ruff check` misses formatting violations. The `Tests / lint` CI jo
 | PR has changes from 2 ADRs | 5, 6 | Cross-contamination between agents |
 | Branch locked by worktree | 2 | Fatal error on checkout |
 | PR fails CI on format | 8 | Merge blocked; `ruff format --check` was skipped |
+| New task fails to create worktree | 9 | Branch name collision from prior stale run |


### PR DESCRIPTION
## Summary

- **Root cause A**: Zombie branches (`worktree-agent-*`, `worktree-wf_*`) accumulate after PR merge. No cleanup runs post-merge. Confirmed 5 zombie branches on main at investigation time.
- **Root cause B**: No preflight check. Agents start without knowing if their intended branch is already checked out in another active worktree, causing `fatal: 'X' is already used by worktree at Y`.
- **Root cause C**: SKILL.md Rule 2 gave no recovery path for either branch-collision error message, leaving agents stranded on the initial `worktree-agent-*` branch.

## Changes

| File | Change |
|------|--------|
| `scripts/worktree-cleanup.sh` | Prunes stale `.git/worktrees` entries and deletes zombie harness branches (merged, no active worktree). `--dry-run` and `--force` modes. Run after PR merge. |
| `scripts/worktree-preflight.sh` | Validates CWD is inside a worktree, auto-prunes stale refs, checks branch availability. Exits 1 if issues found. |
| `skills/process/worktree-agent/SKILL.md` | Rule 2: recovery steps for both error messages. Rule 9: preflight check as required first step. Post-Merge Cleanup section: documents cleanup script as dispatcher duty. |

## Test plan

- [ ] `bash scripts/worktree-cleanup.sh --dry-run` reports zombie branches without deleting
- [ ] `bash scripts/worktree-preflight.sh feat/existing-branch` exits 1 when branch is checked out elsewhere
- [ ] `bash scripts/worktree-preflight.sh feat/new-branch` exits 0 when branch is free
- [ ] From main repo CWD: preflight exits 1 on CWD check
- [ ] `ruff check` and `ruff format --check` both pass
- [ ] All 81 existing hook tests pass

## Notes

The two `worktree-agent-a1046692381d78b2f` and `worktree-agent-ad4d3f81fe3cf952c` branches are correctly left as UNMERGED by the cleanup script — their tips predate the current main lineage. The cleanup script uses `git merge-base` comparison, not just branch name matching, so it does not delete branches with unmerged work.