### PR TITLE
Add Windows support: guard fcntl behind a no-op shim

### DIFF
--- a/hooks/lib/routing_outcome_state.py
+++ b/hooks/lib/routing_outcome_state.py
@@ -54,7 +54,18 @@ B RE-QUEUES that entry via ``requeue_pending_outcomes`` (bounded by
 row gets scored on a subsequent stop. See adr/learn-step-to-hook.md.
 """
 
-import fcntl
+try:
+    import fcntl
+except ImportError:  # Windows has no fcntl — supply a no-op shim so the advisory
+    # file-locking calls below become harmless no-ops (fail-open; single-user safe).
+    class _NoFcntl:
+        LOCK_EX = LOCK_SH = LOCK_UN = LOCK_NB = 0
+
+        @staticmethod
+        def flock(*_args, **_kwargs):
+            return None
+
+    fcntl = _NoFcntl()  # type: ignore[assignment]
 import json
 import os
 import tempfile

--- a/hooks/posttool-auto-test.py
+++ b/hooks/posttool-auto-test.py
@@ -12,7 +12,18 @@ Sanitizes output to strip potential secrets before returning context.
 ADR: adr/auto-test-after-edit-hook.md
 """
 
-import fcntl
+try:
+    import fcntl
+except ImportError:  # Windows has no fcntl — supply a no-op shim so the advisory
+    # file-locking calls below become harmless no-ops (fail-open; single-user safe).
+    class _NoFcntl:
+        LOCK_EX = LOCK_SH = LOCK_UN = LOCK_NB = 0
+
+        @staticmethod
+        def flock(*_args, **_kwargs):
+            return None
+
+    fcntl = _NoFcntl()  # type: ignore[assignment]
 import json
 import os
 import re

--- a/hooks/suggest-compact.py
+++ b/hooks/suggest-compact.py
@@ -27,7 +27,18 @@ State:
   from hooks.lib.hook_utils. Uses file locking to reduce race window.
 """
 
-import fcntl
+try:
+    import fcntl
+except ImportError:  # Windows has no fcntl — supply a no-op shim so the advisory
+    # file-locking calls below become harmless no-ops (fail-open; single-user safe).
+    class _NoFcntl:
+        LOCK_EX = LOCK_SH = LOCK_UN = LOCK_NB = 0
+
+        @staticmethod
+        def flock(*_args, **_kwargs):
+            return None
+
+    fcntl = _NoFcntl()  # type: ignore[assignment]
 import json
 import os
 import sys

--- a/scripts/task-status.py
+++ b/scripts/task-status.py
@@ -20,7 +20,18 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import fcntl
+try:
+    import fcntl
+except ImportError:  # Windows has no fcntl — supply a no-op shim so the advisory
+    # file-locking calls below become harmless no-ops (fail-open; single-user safe).
+    class _NoFcntl:
+        LOCK_EX = LOCK_SH = LOCK_UN = LOCK_NB = 0
+
+        @staticmethod
+        def flock(*_args, **_kwargs):
+            return None
+
+    fcntl = _NoFcntl()  # type: ignore[assignment]
 import json
 import sys
 from dataclasses import asdict, dataclass, field


### PR DESCRIPTION
## Problem
`fcntl` is a Unix-only stdlib module — it doesn't exist on Windows and can't be pip-installed. Four files imported it unguarded at module load, so on Windows they crashed with `ModuleNotFoundError: No module named 'fcntl'` every time they ran:

- `hooks/suggest-compact.py` — a `PreToolUse` hook with **no matcher**, so it fired (and errored) before *every* tool call (Read/Edit/Write/Bash). Most visible symptom: a flood of hook errors on every action.
- `hooks/posttool-auto-test.py` — `PostToolUse` on `Write|Edit`; errored after every edit.
- `hooks/lib/routing_outcome_state.py` — shared lib; any hook importing it fails on Windows.
- `scripts/task-status.py` — CLI helper.

Failures were non-blocking (exit 1), so tool calls still worked — but the errors were constant noise and the hooks' intended work silently did nothing on Windows.

## Fix
Wrap each `import fcntl` in `try/except ImportError` with a tiny no-op shim (LOCK_* constants + a flock() that does nothing). Every existing `fcntl.flock(...)` / `fcntl.LOCK_*` call site is **unchanged**. On Unix, behavior is identical (real `fcntl` is used). On Windows the advisory file-locking becomes a no-op (fail-open) — the locks only reduced concurrent-invocation races, safe to skip for single-user hook usage.

## Testing
- All 4 files `py_compile` clean.
- Both hooks run with a mock payload on Windows Python 3.13: **exit 0, zero ModuleNotFoundError** (previously crashed every invocation).
- `routing_outcome_state.py` imports cleanly under the shim on Windows.
- No behavior change on Unix.

## Scope
Import-guard only — no logic changes, no new dependencies.