### PR TITLE
Fix CI: sort imports in task-status.py (ruff I001)

### DIFF
--- a/scripts/task-status.py
+++ b/scripts/task-status.py
@@ -20,6 +20,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+
 try:
     import fcntl
 except ImportError:  # Windows has no fcntl — supply a no-op shim so the advisory


### PR DESCRIPTION
Follow-up to #731. The Windows `fcntl` shim wrapped the middle import in `scripts/task-status.py` in a `try/except`, which broke ruff's import-block ordering (`I001`) and **failed the `lint` job** on the merge to `main`.

Fix: add a blank line so the conditional `fcntl` import is its own import group. No behavior change.

## Testing
- `ruff check . --config pyproject.toml` → **All checks passed!** (the exact CI lint command, whole repo)
- `scripts/task-status.py` compiles clean; fcntl shim intact.
- 1-line diff (blank line only).