### PR TITLE
fix(gemini-hooks): set hook timeout to 60000 ms

### DIFF
--- a/scripts/generate-gemini-settings-hooks.py
+++ b/scripts/generate-gemini-settings-hooks.py
@@ -65,6 +65,11 @@ EVENT_ORDER = [
 
 ALL_KNOWN_EVENTS = set(EVENT_ORDER)
 
+# Per-hook timeout in milliseconds. Gemini reads this field as ms (its
+# DEFAULT_HOOK_TIMEOUT is 60000); Claude Code reads it as seconds. The old
+# value of 600 meant 600 ms to Gemini, which killed slow cold-start hooks.
+HOOK_TIMEOUT_MS = 60000
+
 
 def parse_allowlist(text: str) -> list[dict]:
     """Parse allowlist text into a list of entry dicts.
@@ -168,7 +173,7 @@ def build_hooks_json(entries: list[dict], gemini_hooks_dir: str | None = None) -
                 {
                     "type": "command",
                     "command": f'python3 "{gemini_hooks_dir}/{fname}"',
-                    "timeout": 600,
+                    "timeout": HOOK_TIMEOUT_MS,
                 }
                 for fname in filenames
             ]

--- a/scripts/tests/test_generate_gemini_hooks.py
+++ b/scripts/tests/test_generate_gemini_hooks.py
@@ -72,7 +72,7 @@ def test_single_session_start_no_matcher():
     hook = block["hooks"][0]
     assert hook["type"] == "command"
     assert "session-github-briefing.py" in hook["command"]
-    assert hook["timeout"] == 600
+    assert hook["timeout"] == 60000
 
 
 # ---------------------------------------------------------------------------
@@ -333,7 +333,7 @@ def test_cli_dry_run_produces_valid_json():
     session_hook = parsed["hooks"]["SessionStart"][0]["hooks"][0]
     assert session_hook["type"] == "command"
     assert "session-github-briefing.py" in session_hook["command"]
-    assert session_hook["timeout"] == 600
+    assert session_hook["timeout"] == 60000
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Gemini CLI reads the `settings.json` "timeout" field as **milliseconds**, while Claude Code reads the same field as **seconds**. The generator hardcoded `600`, which Gemini interpreted as **600 ms**. That killed slow cold-start Python hooks (those importing shared libs) and reported them as failed.

This bumps the per-hook timeout to **60000 ms (60s)**, matching Gemini's built-in `DEFAULT_HOOK_TIMEOUT`, and extracts it into a named `HOOK_TIMEOUT_MS` constant for clarity.

## Changes
- Add `HOOK_TIMEOUT_MS = 60000` constant with a concise explanatory comment in `scripts/generate-gemini-settings-hooks.py`.
- Use the constant in `build_hooks_json()` instead of the literal `600`.
- Update `scripts/tests/test_generate_gemini_hooks.py` to assert the new `60000` value.

## Testing
- `python3 -m pytest scripts/tests/test_generate_gemini_hooks.py` — 20 passed.