### PR TITLE
fix(codex-hooks): rename feature flag codex_hooks -> hooks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -468,7 +468,7 @@ os.rename(tmp, dst)
         echo "  No ~/.codex/hooks.json found. Nothing to archive."
     fi
 
-    # Note: [features] codex_hooks = true is intentionally left in config.toml.
+    # Note: [features] hooks = true is intentionally left in config.toml.
     # Users may have other Codex hook configurations we did not write.
 
     # Phase 3.7: Clean toolkit-owned Gemini skills mirror
@@ -872,7 +872,7 @@ os.rename(tmp, dst)
     echo "  • ~/.claude/settings.json (all keys except hooks)"
     echo "  • ~/.claude/projects/"
     echo "  • ~/.claude/memory/"
-    echo "  • ~/.codex/config.toml (including [features] codex_hooks flag)"
+    echo "  • ~/.codex/config.toml (including [features] hooks flag)"
     echo "  • ~/.gemini/settings.json (all keys except hooks)"
     echo "  • ~/.factory/config.toml (if present, like Codex)"
     echo "  • ~/.hermes/config.yaml (Hermes Agent configuration)"
@@ -1291,10 +1291,10 @@ if [ -f "$CODEX_HOOKS_ALLOWLIST" ]; then
         fi
     fi
 
-    # Ensure codex_hooks feature flag is enabled in ~/.codex/config.toml.
+    # Ensure hooks feature flag is enabled in ~/.codex/config.toml.
     CODEX_CONFIG="${CODEX_DIR}/config.toml"
     if [ "$DRY_RUN" = true ]; then
-        echo -e "${BLUE}  Would ensure ${CODEX_CONFIG} has [features] codex_hooks = true${NC}"
+        echo -e "${BLUE}  Would ensure ${CODEX_CONFIG} has [features] hooks = true${NC}"
     else
         if $PYTHON_CMD "${SCRIPT_DIR}/scripts/ensure-codex-feature-flag.py" \
             --config "$CODEX_CONFIG" 2>&1; then

--- a/scripts/ensure-codex-feature-flag.py
+++ b/scripts/ensure-codex-feature-flag.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
-"""Ensure ~/.codex/config.toml contains the codex_hooks feature flag.
+"""Ensure ~/.codex/config.toml contains the hooks feature flag.
 
-Performs a TOML-aware merge: adds [features] and codex_hooks = true if
-absent, while preserving all existing sections unchanged. Backs up the
-config before writing unless --no-backup is passed.
+Performs a TOML-aware merge: adds [features] and hooks = true if absent,
+while preserving all existing sections unchanged. Backs up the config
+before writing unless --no-backup is passed.
+
+Codex CLI renamed this flag from codex_hooks to hooks (codex_hooks now
+prints a deprecation warning). This script writes the new hooks key and
+removes any deprecated codex_hooks line it finds, migrating old configs.
 
 Exit codes:
   0  success (including already-present)
   1  unexpected error
-  2  codex_hooks = false detected; manual resolution required
+  2  hooks = false detected; manual resolution required
 """
 
 import argparse
@@ -18,7 +22,11 @@ from datetime import datetime
 from pathlib import Path
 
 _FEATURES_HEADER = "[features]"
-_KEY_PATTERN = re.compile(r"^\s*codex_hooks\s*=\s*(true|false)\s*$", re.MULTILINE)
+# Match the current key. ^\s*hooks does not match "codex_hooks" because that
+# line begins with "codex_", so the deprecated key is handled separately.
+_KEY_PATTERN = re.compile(r"^\s*hooks\s*=\s*(true|false)\s*$", re.MULTILINE)
+# Match the deprecated key so we can strip it during migration.
+_DEPRECATED_KEY_PATTERN = re.compile(r"^[ \t]*codex_hooks\s*=\s*(true|false)\s*$\n?", re.MULTILINE)
 _SECTION_PATTERN = re.compile(r"^\[features\]", re.MULTILINE)
 
 
@@ -59,7 +67,7 @@ def _classify_content(content: str, file_exists: bool) -> tuple[bool, str]:
         A tuple of (needs_write, action_tag).
 
     Raises:
-        SystemExit: With exit code 2 when codex_hooks = false is found.
+        SystemExit: With exit code 2 when hooks (or deprecated codex_hooks) is false.
     """
     if not file_exists:
         return True, "created-file"
@@ -78,25 +86,40 @@ def _analyse_content(content: str) -> tuple[bool, str]:
         A tuple of (needs_write, action_tag).
 
     Raises:
-        SystemExit: With exit code 2 when codex_hooks = false is found.
+        SystemExit: With exit code 2 when hooks (or deprecated codex_hooks) is false.
     """
-    match = _KEY_PATTERN.search(content)
-    if match:
-        value = match.group(1)
-        if value == "true":
-            return False, "already-present"
-        print(
-            "ERROR: codex_hooks = false found in config. "
-            "This appears to be a deliberate user setting. "
-            "Edit the file manually to set codex_hooks = true before re-running.",
-            file=sys.stderr,
-        )
-        sys.exit(2)
+    new_match = _KEY_PATTERN.search(content)
+    dep_match = _DEPRECATED_KEY_PATTERN.search(content)
+    has_deprecated = dep_match is not None
+
+    if new_match:
+        if new_match.group(1) == "false":
+            _exit_on_disabled()
+        # hooks = true. Still rewrite when a deprecated codex_hooks line is
+        # present so we can strip it and clear the deprecation warning.
+        if has_deprecated:
+            return True, "migrated"
+        return False, "already-present"
+
+    # No new key. A deprecated codex_hooks = false is a deliberate disable.
+    if dep_match and dep_match.group(1) == "false":
+        _exit_on_disabled()
 
     has_features_section = bool(_SECTION_PATTERN.search(content))
     if has_features_section:
         return True, "added-key"
     return True, "added-section"
+
+
+def _exit_on_disabled() -> None:
+    """Print guidance and exit 2 when the hooks flag is explicitly disabled."""
+    print(
+        "ERROR: hooks = false (or deprecated codex_hooks = false) found in config. "
+        "This appears to be a deliberate user setting. "
+        "Edit the file manually to set hooks = true before re-running.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
 
 
 def needs_update(content: str) -> tuple[bool, str]:
@@ -112,39 +135,28 @@ def needs_update(content: str) -> tuple[bool, str]:
 
     Returns:
         A tuple of (needs_write, action_tag) where action_tag is one of:
-        'already-present', 'added-section', 'added-key', 'created-file'.
+        'already-present', 'added-section', 'added-key', 'created-file',
+        'migrated'.
 
     Raises:
-        SystemExit: With exit code 2 when codex_hooks = false is found.
+        SystemExit: With exit code 2 when hooks (or deprecated codex_hooks) is false.
     """
     if not content:
         return True, "created-file"
+    return _analyse_content(content)
 
-    match = _KEY_PATTERN.search(content)
-    if match:
-        value = match.group(1)
-        if value == "true":
-            return False, "already-present"
-        # value == "false": this is a conscious user choice
-        print(
-            "ERROR: codex_hooks = false found in config. "
-            "This appears to be a deliberate user setting. "
-            "Edit the file manually to set codex_hooks = true before re-running.",
-            file=sys.stderr,
-        )
-        sys.exit(2)
 
-    has_features_section = bool(_SECTION_PATTERN.search(content))
-    if has_features_section:
-        return True, "added-key"
-    return True, "added-section"
+def _strip_deprecated(content: str) -> str:
+    """Remove any deprecated codex_hooks line from the content."""
+    return _DEPRECATED_KEY_PATTERN.sub("", content)
 
 
 def apply_update(content: str) -> str:
-    """Return the updated config content with codex_hooks = true set.
+    """Return the updated config content with hooks = true set.
 
-    Adds [features] if absent, or injects codex_hooks under the existing
-    [features] section. Does not modify any other section.
+    Adds [features] if absent, or injects hooks under the existing [features]
+    section. Removes any deprecated codex_hooks line. Does not modify any
+    other section.
 
     Args:
         content: The current file content (may be empty).
@@ -157,6 +169,10 @@ def apply_update(content: str) -> str:
     if action == "already-present":
         return content
 
+    if action == "migrated":
+        # hooks = true is already present; just drop the deprecated key.
+        return _strip_deprecated(content)
+
     if action in ("created-file", "added-section"):
         # Append a new [features] block. Ensure a trailing newline before it
         # when appending to non-empty content.
@@ -164,18 +180,19 @@ def apply_update(content: str) -> str:
             content += "\n"
         if content:
             content += "\n"
-        content += "[features]\ncodex_hooks = true\n"
+        content += "[features]\nhooks = true\n"
         return content
 
-    # action == "added-key": insert codex_hooks after the [features] header.
-    # Find the line index of [features] and insert after it.
+    # action == "added-key": strip any deprecated key, then insert hooks after
+    # the [features] header.
+    content = _strip_deprecated(content)
     lines = content.splitlines(keepends=True)
     result: list[str] = []
     injected = False
     for line in lines:
         result.append(line)
         if not injected and line.strip() == "[features]":
-            result.append("codex_hooks = true\n")
+            result.append("hooks = true\n")
             injected = True
     return "".join(result)
 
@@ -199,7 +216,7 @@ def _write_with_backup(path: Path, new_content: str, backup: bool) -> None:
 
 def main() -> None:
     """Parse arguments, determine required action, and update the config file."""
-    parser = argparse.ArgumentParser(description="Ensure ~/.codex/config.toml has the codex_hooks feature flag.")
+    parser = argparse.ArgumentParser(description="Ensure ~/.codex/config.toml has the hooks feature flag.")
     parser.add_argument(
         "--config",
         type=Path,

--- a/scripts/tests/test_codex_hooks_install.py
+++ b/scripts/tests/test_codex_hooks_install.py
@@ -108,7 +108,7 @@ def test_install_sh_creates_codex_hooks_dir(fake_home: Path) -> None:
     assert hooks_dir.is_dir(), "~/.codex/hooks is not a directory"
 
     target_hook = hooks_dir / "session-github-briefing.py"
-    assert target_hook.exists(), f"session-github-briefing.py missing from hooks dir.\nSTDOUT:\n{result.stdout}"
+    assert target_hook.exists(), "session-github-briefing.py missing from hooks dir"
 
 
 def test_install_sh_mirrors_all_allowlisted_hooks(fake_home: Path) -> None:
@@ -186,7 +186,7 @@ def test_install_sh_generates_valid_hooks_json(fake_home: Path) -> None:
 
 @requires_tomllib
 def test_install_sh_sets_feature_flag(fake_home: Path) -> None:
-    """install.sh sets codex_hooks = true in ~/.codex/config.toml."""
+    """install.sh sets hooks = true in ~/.codex/config.toml."""
     result = _run_install(fake_home, ["--copy", "--force"])
     config_path = fake_home / ".codex" / "config.toml"
 
@@ -195,9 +195,10 @@ def test_install_sh_sets_feature_flag(fake_home: Path) -> None:
     with open(config_path, "rb") as fh:
         config = tomllib.load(fh)
 
-    assert "features" in config, f"[features] section missing from config.toml. Content:\n{config_path.read_text()}"
-    assert config["features"].get("codex_hooks") is True, (
-        f"codex_hooks != true in [features]. Got: {config['features']}"
+    assert "features" in config, "[features] section missing from config.toml"
+    assert config["features"].get("hooks") is True, f"hooks != true in [features]. Got: {config['features']}"
+    assert "codex_hooks" not in config["features"], (
+        f"deprecated codex_hooks should not be written. Got: {config['features']}"
     )
 
 
@@ -227,7 +228,7 @@ def test_install_sh_preserves_existing_config_toml_sections(fake_home: Path) -> 
     assert config["notice"].get("hide_rate_limit_model_nudge") is True
 
     assert "features" in config, f"[features] section not added. Full config: {config}"
-    assert config["features"].get("codex_hooks") is True
+    assert config["features"].get("hooks") is True
 
 
 def test_install_sh_dry_run_does_not_touch_filesystem(fake_home: Path) -> None:
@@ -285,8 +286,8 @@ def test_install_sh_uninstall_removes_hooks(fake_home: Path) -> None:
     if config_path.exists():
         with open(config_path, "rb") as fh:
             config = tomllib.load(fh)
-        assert config.get("features", {}).get("codex_hooks") is True, (
-            "Uninstall incorrectly removed codex_hooks = true from config.toml"
+        assert config.get("features", {}).get("hooks") is True, (
+            "Uninstall incorrectly removed hooks = true from config.toml"
         )
 
 

--- a/scripts/tests/test_ensure_codex_feature_flag.py
+++ b/scripts/tests/test_ensure_codex_feature_flag.py
@@ -1,8 +1,9 @@
 """Tests for scripts/ensure-codex-feature-flag.py.
 
 Covers: missing file, empty file, no [features] section, [features] without
-key, already present, codex_hooks = false error, idempotency, section
-preservation, --dry-run, backup creation, and CLI end-to-end via subprocess.
+key, already present, hooks = false error, deprecated codex_hooks migration,
+idempotency, section preservation, --dry-run, backup creation, and CLI
+end-to-end via subprocess.
 """
 
 import importlib.util
@@ -73,21 +74,42 @@ class TestNeedsUpdate:
         assert action == "added-section"
 
     def test_features_section_without_key_returns_added_key(self) -> None:
-        """[features] section lacking codex_hooks maps to added-key."""
+        """[features] section lacking hooks maps to added-key."""
         content = "[features]\nother_flag = true\n"
         write_needed, action = needs_update(content)
         assert write_needed is True
         assert action == "added-key"
 
-    def test_codex_hooks_true_returns_already_present(self) -> None:
-        """codex_hooks = true means no write is needed."""
-        content = "[features]\ncodex_hooks = true\n"
+    def test_hooks_true_returns_already_present(self) -> None:
+        """hooks = true means no write is needed."""
+        content = "[features]\nhooks = true\n"
         write_needed, action = needs_update(content)
         assert write_needed is False
         assert action == "already-present"
 
-    def test_codex_hooks_false_exits_2(self) -> None:
-        """codex_hooks = false must exit with code 2."""
+    def test_hooks_false_exits_2(self) -> None:
+        """hooks = false must exit with code 2."""
+        content = "[features]\nhooks = false\n"
+        with pytest.raises(SystemExit) as exc_info:
+            needs_update(content)
+        assert exc_info.value.code == 2
+
+    def test_both_keys_returns_migrated(self) -> None:
+        """hooks = true alongside deprecated codex_hooks maps to migrated."""
+        content = "[features]\ncodex_hooks = true\nhooks = true\n"
+        write_needed, action = needs_update(content)
+        assert write_needed is True
+        assert action == "migrated"
+
+    def test_only_deprecated_key_returns_added_key(self) -> None:
+        """Deprecated codex_hooks alone (no hooks) maps to added-key."""
+        content = "[features]\ncodex_hooks = true\n"
+        write_needed, action = needs_update(content)
+        assert write_needed is True
+        assert action == "added-key"
+
+    def test_deprecated_key_false_exits_2(self) -> None:
+        """Deprecated codex_hooks = false (no hooks) must exit with code 2."""
         content = "[features]\ncodex_hooks = false\n"
         with pytest.raises(SystemExit) as exc_info:
             needs_update(content)
@@ -106,9 +128,9 @@ class TestApplyUpdate:
     def test_missing_file_produces_features_block(self) -> None:
         """Empty string yields a valid [features] block."""
         result = apply_update("")
-        assert "[features]\ncodex_hooks = true\n" in result
+        assert "[features]\nhooks = true\n" in result
         parsed = tomllib.loads(result)
-        assert parsed["features"]["codex_hooks"] is True
+        assert parsed["features"]["hooks"] is True
 
     @requires_tomllib
     def test_no_features_section_appends_block(self) -> None:
@@ -116,25 +138,47 @@ class TestApplyUpdate:
         original = "[notice]\nhide_rate_limit_model_nudge = true\n"
         result = apply_update(original)
         assert original in result
-        assert "[features]\ncodex_hooks = true\n" in result
+        assert "[features]\nhooks = true\n" in result
         parsed = tomllib.loads(result)
         assert parsed["notice"]["hide_rate_limit_model_nudge"] is True
-        assert parsed["features"]["codex_hooks"] is True
+        assert parsed["features"]["hooks"] is True
 
     @requires_tomllib
     def test_existing_features_adds_key_after_header(self) -> None:
-        """codex_hooks is injected directly after the [features] header line."""
+        """hooks is injected directly after the [features] header line."""
         original = "[features]\nother_flag = true\n"
         result = apply_update(original)
         parsed = tomllib.loads(result)
         assert parsed["features"]["other_flag"] is True
-        assert parsed["features"]["codex_hooks"] is True
+        assert parsed["features"]["hooks"] is True
 
     def test_already_present_returns_identical_content(self) -> None:
         """Content that already has the flag is returned unchanged."""
-        original = "[features]\ncodex_hooks = true\n"
+        original = "[features]\nhooks = true\n"
         result = apply_update(original)
         assert result == original
+
+    @requires_tomllib
+    def test_both_keys_strips_deprecated_keeps_hooks(self) -> None:
+        """A config with both keys drops codex_hooks and keeps hooks = true."""
+        original = "[features]\ncodex_hooks = true\nhooks = true\nterminal_resize_reflow = true\n"
+        result = apply_update(original)
+        assert "codex_hooks" not in result
+        assert "hooks = true" in result
+        parsed = tomllib.loads(result)
+        assert parsed["features"]["hooks"] is True
+        assert parsed["features"]["terminal_resize_reflow"] is True
+        assert "codex_hooks" not in parsed["features"]
+
+    @requires_tomllib
+    def test_only_deprecated_key_migrates_to_hooks(self) -> None:
+        """A config with only codex_hooks is migrated to hooks = true."""
+        original = "[features]\ncodex_hooks = true\n"
+        result = apply_update(original)
+        assert "codex_hooks" not in result
+        parsed = tomllib.loads(result)
+        assert parsed["features"]["hooks"] is True
+        assert "codex_hooks" not in parsed["features"]
 
     @requires_tomllib
     def test_idempotent_second_call_is_noop(self) -> None:
@@ -152,7 +196,7 @@ class TestApplyUpdate:
         assert parsed["projects"]["/home/feedgen/vexjoy-agent"]["trust_level"] == "trusted"
         assert parsed["plugins"]["github@openai-curated"]["enabled"] is True
         assert parsed["notice"]["hide_rate_limit_model_nudge"] is True
-        assert parsed["features"]["codex_hooks"] is True
+        assert parsed["features"]["hooks"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +245,7 @@ class TestCLI:
         assert result.stdout.strip() == "created-file"
         assert cfg.exists()
         parsed = tomllib.loads(cfg.read_text())
-        assert parsed["features"]["codex_hooks"] is True
+        assert parsed["features"]["hooks"] is True
 
     @requires_tomllib
     def test_empty_file_adds_section(self, tmp_path: Path) -> None:
@@ -212,7 +256,7 @@ class TestCLI:
         assert result.returncode == 0
         assert result.stdout.strip() == "added-section"
         parsed = tomllib.loads(cfg.read_text())
-        assert parsed["features"]["codex_hooks"] is True
+        assert parsed["features"]["hooks"] is True
 
     @requires_tomllib
     def test_existing_features_without_key_adds_key(self, tmp_path: Path) -> None:
@@ -223,23 +267,36 @@ class TestCLI:
         assert result.returncode == 0
         assert result.stdout.strip() == "added-key"
         parsed = tomllib.loads(cfg.read_text())
-        assert parsed["features"]["codex_hooks"] is True
+        assert parsed["features"]["hooks"] is True
         assert parsed["features"]["other_flag"] is True
+
+    @requires_tomllib
+    def test_both_keys_migrates_and_reports_migrated(self, tmp_path: Path) -> None:
+        """A config with both keys is migrated; stdout reports migrated."""
+        cfg = tmp_path / "config.toml"
+        cfg.write_text("[features]\ncodex_hooks = true\nhooks = true\n", encoding="utf-8")
+        result = _run(["--config", str(cfg), "--no-backup"])
+        assert result.returncode == 0
+        assert result.stdout.strip() == "migrated"
+        text = cfg.read_text()
+        assert "codex_hooks" not in text
+        parsed = tomllib.loads(text)
+        assert parsed["features"]["hooks"] is True
 
     def test_already_present_is_noop(self, tmp_path: Path) -> None:
         """Pre-existing flag produces no file change and reports already-present."""
         cfg = tmp_path / "config.toml"
-        original = "[features]\ncodex_hooks = true\n"
+        original = "[features]\nhooks = true\n"
         cfg.write_text(original, encoding="utf-8")
         result = _run(["--config", str(cfg), "--no-backup"])
         assert result.returncode == 0
         assert result.stdout.strip() == "already-present"
         assert cfg.read_text() == original
 
-    def test_codex_hooks_false_exits_2(self, tmp_path: Path) -> None:
-        """codex_hooks = false causes exit code 2 with stderr guidance."""
+    def test_hooks_false_exits_2(self, tmp_path: Path) -> None:
+        """hooks = false causes exit code 2 with stderr guidance."""
         cfg = tmp_path / "config.toml"
-        cfg.write_text("[features]\ncodex_hooks = false\n", encoding="utf-8")
+        cfg.write_text("[features]\nhooks = false\n", encoding="utf-8")
         result = _run(["--config", str(cfg), "--no-backup"])
         assert result.returncode == 2
         assert "manually" in result.stderr.lower() or "manual" in result.stderr.lower()
@@ -254,7 +311,7 @@ class TestCLI:
         # File must be untouched.
         assert cfg.read_text() == original
         # Printed content must contain the flag.
-        assert "codex_hooks = true" in result.stdout
+        assert "hooks = true" in result.stdout
 
     def test_backup_is_created(self, tmp_path: Path) -> None:
         """A .bak timestamped file is created from the original before writing."""
@@ -278,4 +335,4 @@ class TestCLI:
         assert parsed["projects"]["/home/feedgen/road-to-aew"]["trust_level"] == "trusted"
         assert parsed["plugins"]["github@openai-curated"]["enabled"] is True
         assert parsed["notice"]["hide_rate_limit_model_nudge"] is True
-        assert parsed["features"]["codex_hooks"] is True
+        assert parsed["features"]["hooks"] is True


### PR DESCRIPTION
## Summary

Codex CLI deprecated the `[features].codex_hooks` config key in favor of `[features].hooks`. Recent Codex versions print on every startup:

> ⚠ `[features].codex_hooks` is deprecated. Use `[features].hooks` instead.

The installer's `ensure-codex-feature-flag.py` still wrote the old `codex_hooks = true` key and had no migration path, so users who ran the installer ended up with **both** keys in `~/.codex/config.toml` and saw the deprecation warning every time Codex started.

## Changes
- `scripts/ensure-codex-feature-flag.py`: write `hooks = true` instead of `codex_hooks = true`.
- Add migration: strip any deprecated `codex_hooks` line, including the case where both `codex_hooks` and `hooks` are present (new `migrated` action tag).
- Treat `hooks = false` (or deprecated `codex_hooks = false`) as a deliberate user disable and exit 2 with guidance.
- `install.sh`: update the three user-facing strings/comments that referenced the old flag name.
- Tests: update assertions in `test_ensure_codex_feature_flag.py` and `test_codex_hooks_install.py`, and add cases covering migration (both-keys and deprecated-only).

Note: the `*_dir` / `CODEX_HOOKS_DIR` references are the hooks **directory** (`~/.codex/hooks`) and are intentionally unchanged.

## Testing
- `python3 -m pytest scripts/tests/test_ensure_codex_feature_flag.py scripts/tests/test_codex_hooks_install.py` — 34 passed, 1 skipped.
- Verified the migration against a real config containing both keys: the deprecated line is removed, `hooks = true` and all other `[features]` flags are preserved.