### PR TITLE
feat(antigravity): add Antigravity CLI (agy) plugin alongside Gemini CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AI agents skip steps.
 
 This toolkit prevents that. 44 domain agents, 124 workflow skills, 82 hooks, 106 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
-Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Factory (`/do`).
+Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Antigravity (`/do`), Factory (`/do`).
 
 ## What It Looks Like
 
@@ -69,6 +69,7 @@ Links into `~/.claude/` and mirrors into `~/.codex/`, `~/.gemini/`, `~/.factory/
 | Claude Code | `/do` |
 | Codex | `$do` |
 | Gemini CLI | `/do` |
+| Antigravity (`agy`) | `/do` |
 | Factory | `/do` |
 | Reasonix | `/do` |
 
@@ -84,9 +85,17 @@ Mirrors agents, skills, and 6 allowlisted hooks into `~/.codex/`. Requires Codex
 </details>
 
 <details>
-<summary><b>Gemini CLI Support</b></summary>
+<summary><b>Gemini CLI / Antigravity CLI Support</b></summary>
 
 Mirrors agents, skills, and Phase 1 hooks into `~/.gemini/`. Translates event names (`Stop` → `SessionEnd`, `PostToolUse` → `AfterTool`, `PreToolUse` → `BeforeTool`). Tool mapping: `Bash` → `run_shell_command`. Hook config merges into `~/.gemini/settings.json`.
+
+Antigravity (`agy`) is supported additively alongside Gemini CLI — the installer ships a plugin at `~/.gemini/antigravity/plugins/vexjoy-agent/` (manifest + `hooks.json`) and does not replace the Gemini CLI integration. Antigravity has no `SessionStart` event, so the four bootstrap hooks (github briefing, operator-context detector, team-config loader, rules-distill injector) ride on `UserPromptSubmit` and self-gate to once-per-session via a PPID touchfile. Other CLIs continue to hit those hooks via `SessionStart` and are unaffected.
+
+#### Gemini CLI sunset (consumer tiers, 2026-06-18)
+
+Per Google's [transition announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/), Gemini CLI stops serving requests on **2026-06-18** for Google AI Pro / Ultra and free Gemini Code Assist for individuals. Unchanged past that date: Gemini Code Assist Standard / Enterprise, paid Gemini API keys, Gemini Enterprise Agent Platform.
+
+Consumer-tier users: install Antigravity CLI from <https://antigravity.google/cli> before 2026-06-18. The toolkit installs both targets; whichever CLI you actually use keeps working.
 
 </details>
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,7 +13,7 @@ cd ~/vexjoy-agent
 ./install.sh
 ```
 
-Claude Code is the primary runtime. If you also use Codex CLI, Gemini CLI, Factory, or Reasonix, the same install mirrors toolkit skills (and agents where the harness supports them) into `~/.codex/`, `~/.gemini/`, `~/.factory/`, and `~/.reasonix/` so all the CLIs share the same skill library. Reasonix has no agent surface, so it gets skills + scripts + hooks only.
+Claude Code is the primary runtime. If you also use Codex CLI, Gemini CLI, Factory, or Reasonix, the same install mirrors toolkit skills (and agents where the harness supports them) into `~/.codex/`, `~/.gemini/`, `~/.factory/`, and `~/.reasonix/` so all the CLIs share the same skill library. Reasonix has no agent surface, so it gets skills + scripts + hooks only. Antigravity CLI (`agy`) is also supported; see README § "Gemini CLI / Antigravity CLI Support" for setup details.
 
 Command entry points:
 - Claude Code: `/do`

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -12,7 +12,7 @@ claude --version
 
 If that prints a version number, you're good. If not, install Claude Code first and come back.
 
-Optional: Codex CLI, Gemini CLI, Factory, or Reasonix. The toolkit mirrors skills (and agents where the harness supports them) into their directories (`~/.codex/`, `~/.gemini/`, `~/.factory/`, `~/.reasonix/`), so all the CLIs dispatch the same domain expertise. Reasonix has no agent surface, so it gets skills + scripts + hooks only. Claude Code remains the full runtime for hooks, commands, and scripts.
+Optional: Codex CLI, Gemini CLI, Factory, or Reasonix. The toolkit mirrors skills (and agents where the harness supports them) into their directories (`~/.codex/`, `~/.gemini/`, `~/.factory/`, `~/.reasonix/`), so all the CLIs dispatch the same domain expertise. Reasonix has no agent surface, so it gets skills + scripts + hooks only. Claude Code remains the full runtime for hooks, commands, and scripts. Antigravity CLI (`agy`) is also supported; see README § "Gemini CLI / Antigravity CLI Support" for setup details.
 
 Verify optional tools: `codex --version` / `gemini --version` / `factory --version` / `reasonix --version`.
 

--- a/hooks/lib/hook_utils.py
+++ b/hooks/lib/hook_utils.py
@@ -459,14 +459,21 @@ def detect_cli() -> str:
     running Claude Code.
 
     Returns:
-        One of "gemini", "codex", "reasonix", or "claude".
+        One of "agy", "gemini", "codex", "reasonix", or "claude".
     """
     # Most specific: explicit CLI identification env var
+    if os.environ.get("ANTIGRAVITY_AGENT"):
+        return "agy"
     if os.environ.get("GEMINI_CLI"):
         return "gemini"
-    # Process-based: the _ var contains the invoking command path
+    # Process-based: the _ var contains the invoking command path.
+    # Match on basename to avoid false positives from parent paths
+    # like /Users/agy-fan/bin/gemini or /opt/gemini-tools/bin/agy.
     invocation = os.environ.get("_", "")
-    if "gemini" in invocation.lower():
+    invocation_basename = os.path.basename(invocation).lower()
+    if invocation_basename == "agy" or invocation_basename.startswith("agy-"):
+        return "agy"
+    if "gemini" in invocation_basename:
         return "gemini"
     if "codex" in invocation.lower():
         return "codex"
@@ -480,6 +487,44 @@ def detect_cli() -> str:
     if os.environ.get("CODEX_HOME") or os.environ.get("CODEX_HOOKS_DIR"):
         return "codex"
     return "claude"
+
+
+def is_first_bootstrap_call_this_session() -> bool:
+    """Best-effort once-per-session gate for bootstrap hooks under Antigravity.
+
+    Antigravity (`agy`) has no SessionStart event, so bootstrap hooks (github
+    briefing, operator context, team config, rules-distill) ride on
+    UserPromptSubmit and would fire every prompt. We touch a PPID-keyed marker
+    in TMPDIR; the first call returns True, subsequent calls return False.
+
+    Other CLIs hit these hooks via SessionStart (which already fires once per
+    session), so callers should bypass this gate when ``detect_cli() != "agy"``.
+
+    On filesystem failure we return True (fire), preferring duplicate output
+    over silently dropping the bootstrap.
+    """
+    ppid = os.getppid()
+    tmpdir = Path(os.environ.get("TMPDIR", "/tmp"))
+    marker = tmpdir / f"vexjoy-session-bootstrap-{ppid}"
+    if marker.exists():
+        return False
+    try:
+        marker.touch()
+    except OSError:
+        return True
+    return True
+
+
+def should_run_bootstrap_hook() -> bool:
+    """True when a bootstrap hook should run THIS invocation.
+
+    Always True on Claude / Codex / Gemini CLI / Reasonix (their SessionStart
+    contract already fires once per session). On Antigravity, gated to the
+    first UserPromptSubmit per session via PPID touchfile.
+    """
+    if detect_cli() != "agy":
+        return True
+    return is_first_bootstrap_call_this_session()
 
 
 def normalize_input(data: dict[str, Any]) -> dict[str, Any]:

--- a/hooks/operator-context-detector.py
+++ b/hooks/operator-context-detector.py
@@ -41,7 +41,7 @@ from pathlib import Path
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
-from hook_utils import context_output, empty_output
+from hook_utils import context_output, empty_output, should_run_bootstrap_hook
 
 EVENT_NAME = "SessionStart"
 
@@ -286,4 +286,6 @@ def main():
 
 
 if __name__ == "__main__":
+    if not should_run_bootstrap_hook():
+        empty_output(EVENT_NAME).print_and_exit()
     main()

--- a/hooks/rules-distill-injector.py
+++ b/hooks/rules-distill-injector.py
@@ -23,7 +23,7 @@ from pathlib import Path
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
-from hook_utils import context_output, empty_output
+from hook_utils import context_output, empty_output, should_run_bootstrap_hook
 from stdin_timeout import read_stdin
 
 EVENT_NAME = "SessionStart"
@@ -141,6 +141,8 @@ def main() -> None:
 
 if __name__ == "__main__":
     try:
+        if not should_run_bootstrap_hook():
+            empty_output(EVENT_NAME).print_and_exit()
         main()
     except Exception as e:
         print(f"[rules-distill-injector] Fatal: {e}", file=sys.stderr)

--- a/hooks/session-github-briefing.py
+++ b/hooks/session-github-briefing.py
@@ -17,7 +17,7 @@ from pathlib import Path
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
-from hook_utils import context_output, empty_output
+from hook_utils import context_output, empty_output, should_run_bootstrap_hook
 
 EVENT_NAME = "SessionStart"
 MAX_BRIEFING_AGE_HOURS = 24
@@ -168,6 +168,8 @@ def main() -> None:
 
 if __name__ == "__main__":
     try:
+        if not should_run_bootstrap_hook():
+            empty_output(EVENT_NAME).print_and_exit()
         main()
     except Exception as e:
         if os.environ.get("CLAUDE_HOOK_DEBUG"):

--- a/hooks/team-config-loader.py
+++ b/hooks/team-config-loader.py
@@ -23,6 +23,10 @@ import os
 import sys
 from pathlib import Path
 
+# Lib imports for once-per-session bootstrap gate.
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from hook_utils import should_run_bootstrap_hook
+
 DEBUG = os.environ.get("CLAUDE_HOOKS_DEBUG") == "1"
 
 
@@ -210,6 +214,8 @@ def main() -> None:
 
 if __name__ == "__main__":
     try:
+        if not should_run_bootstrap_hook():
+            sys.exit(0)
         main()
     except Exception as e:
         if DEBUG:

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,9 @@ CODEX_AGENTS_DIR="${CODEX_DIR}/agents"
 CODEX_HOOKS_DIR="${CODEX_DIR}/hooks"
 CODEX_SCRIPTS_DIR="${CODEX_DIR}/scripts"
 GEMINI_DIR="${HOME}/.gemini"
+ANTIGRAVITY_DIR="${HOME}/.gemini/antigravity"
+ANTIGRAVITY_PLUGINS_DIR="${ANTIGRAVITY_DIR}/plugins"
+ANTIGRAVITY_PLUGIN_DIR="${ANTIGRAVITY_PLUGINS_DIR}/vexjoy-agent"
 GEMINI_SKILLS_DIR="${GEMINI_DIR}/skills"
 GEMINI_AGENTS_DIR="${GEMINI_DIR}/agents"
 GEMINI_HOOKS_DIR="${GEMINI_DIR}/hooks"
@@ -472,6 +475,18 @@ os.rename(tmp, dst)
     # Users may have other Codex hook configurations we did not write.
 
     # Phase 3.7: Clean toolkit-owned Gemini skills mirror
+    echo ""
+    echo -e "${YELLOW}Cleaning Antigravity CLI Plugin...${NC}"
+    if [ -d "$ANTIGRAVITY_PLUGIN_DIR" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would remove: ${ANTIGRAVITY_PLUGIN_DIR}${NC}"
+        else
+            rm -rf "$ANTIGRAVITY_PLUGIN_DIR"
+            echo -e "${GREEN}  ✓ Removed ${ANTIGRAVITY_PLUGIN_DIR}${NC}"
+        fi
+        REMOVED+=("Antigravity Plugin directory")
+    fi
+
     echo ""
     echo -e "${YELLOW}Cleaning Gemini skills mirror...${NC}"
     if [ -d "$GEMINI_SKILLS_DIR" ]; then
@@ -1442,6 +1457,101 @@ else
     echo -e "${YELLOW}  Warning: ${SCRIPT_DIR}/.claude/settings.json not found, skipping Factory hook sync${NC}"
 fi
 
+# Sync Antigravity CLI Plugin mirror
+echo ""
+echo -e "${YELLOW}Syncing VexJoy Agent to Antigravity CLI Plugin Space...${NC}"
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}  Would create plugin directory: ${ANTIGRAVITY_PLUGIN_DIR}${NC}"
+else
+    mkdir -p "${ANTIGRAVITY_PLUGIN_DIR}/skills"
+    mkdir -p "${ANTIGRAVITY_PLUGIN_DIR}/agents"
+    mkdir -p "${ANTIGRAVITY_PLUGIN_DIR}/hooks"
+fi
+
+# 1. Mirror plugin.json and hooks.json
+sync_mirror_entry "${SCRIPT_DIR}/plugins/vexjoy-agent/plugin.json" "${ANTIGRAVITY_PLUGIN_DIR}/plugin.json" "Antigravity"
+sync_mirror_entry "${SCRIPT_DIR}/plugins/vexjoy-agent/hooks.json" "${ANTIGRAVITY_PLUGIN_DIR}/hooks.json" "Antigravity"
+
+# 2. Mirror skills
+ANTIGRAVITY_ENTRY_COUNT=0
+for item in "${SCRIPT_DIR}/skills/"*; do
+    [ -e "$item" ] || continue
+    target="${ANTIGRAVITY_PLUGIN_DIR}/skills/$(basename "$item")"
+    sync_mirror_entry "$item" "$target" "Antigravity"
+    ANTIGRAVITY_ENTRY_COUNT=$((ANTIGRAVITY_ENTRY_COUNT + 1))
+done
+
+if [ -d "${SCRIPT_DIR}/private-voices" ]; then
+    for voice_dir in "${SCRIPT_DIR}/private-voices/"*; do
+        [ -d "$voice_dir" ] || continue
+        skill_src="${voice_dir}/skill"
+        [ -d "$skill_src" ] || continue
+        voice_name=$(basename "$voice_dir")
+        target="${ANTIGRAVITY_PLUGIN_DIR}/skills/voice-${voice_name}"
+        sync_mirror_entry "$skill_src" "$target" "Antigravity"
+        ANTIGRAVITY_ENTRY_COUNT=$((ANTIGRAVITY_ENTRY_COUNT + 1))
+    done
+fi
+
+if [ -d "${SCRIPT_DIR}/private-skills" ]; then
+    for item in "${SCRIPT_DIR}/private-skills/"*; do
+        [ -e "$item" ] || continue
+        target="${ANTIGRAVITY_PLUGIN_DIR}/skills/$(basename "$item")"
+        sync_mirror_entry "$item" "$target" "Antigravity"
+        ANTIGRAVITY_ENTRY_COUNT=$((ANTIGRAVITY_ENTRY_COUNT + 1))
+    done
+fi
+
+# 3. Mirror agents
+ANTIGRAVITY_AGENT_COUNT=0
+for item in "${SCRIPT_DIR}/agents/"*; do
+    [ -e "$item" ] || continue
+    target="${ANTIGRAVITY_PLUGIN_DIR}/agents/$(basename "$item")"
+    sync_mirror_entry "$item" "$target" "Antigravity"
+    ANTIGRAVITY_AGENT_COUNT=$((ANTIGRAVITY_AGENT_COUNT + 1))
+done
+
+if [ -d "${SCRIPT_DIR}/private-agents" ]; then
+    for item in "${SCRIPT_DIR}/private-agents/"*; do
+        [ -e "$item" ] || continue
+        target="${ANTIGRAVITY_PLUGIN_DIR}/agents/$(basename "$item")"
+        sync_mirror_entry "$item" "$target" "Antigravity"
+        ANTIGRAVITY_AGENT_COUNT=$((ANTIGRAVITY_AGENT_COUNT + 1))
+    done
+fi
+
+# 4. Mirror hooks
+ANTIGRAVITY_HOOK_COUNT=0
+if [ -d "${SCRIPT_DIR}/hooks" ]; then
+    for item in "${SCRIPT_DIR}/hooks/"*; do
+        [ -e "$item" ] || continue
+        name=$(basename "$item")
+        case "$name" in
+            __pycache__|*.pyc|tests) continue;;
+        esac
+        target="${ANTIGRAVITY_PLUGIN_DIR}/hooks/${name}"
+        sync_mirror_entry "$item" "$target" "Antigravity"
+        ANTIGRAVITY_HOOK_COUNT=$((ANTIGRAVITY_HOOK_COUNT + 1))
+    done
+fi
+
+# Warn if installed Antigravity CLI is missing
+if command -v agy >/dev/null 2>&1; then
+    if agy_ver_raw=$(agy --version 2>&1); then
+        agy_ver=$(printf '%s' "$agy_ver_raw" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        if [ -n "$agy_ver" ]; then
+            echo -e "${GREEN}  ✓ Antigravity CLI (${agy_ver}) detected. Plugin ready for activation.${NC}"
+        else
+            echo -e "${YELLOW}  ⚠ Antigravity CLI detected but version string unparseable${NC}"
+        fi
+    else
+        echo -e "${YELLOW}  ⚠ Antigravity CLI installed but \`agy --version\` failed${NC}"
+    fi
+else
+    echo -e "${BLUE}  (agy CLI not installed; plugin will activate when Antigravity CLI is installed)${NC}"
+fi
+
+# Sync Gemini CLI hooks mirror (coexists with Antigravity plugin under ~/.gemini/)
 echo ""
 echo -e "${YELLOW}Syncing Gemini skills mirror...${NC}"
 GEMINI_ENTRY_COUNT=0
@@ -1492,14 +1602,12 @@ if [ -d "${SCRIPT_DIR}/private-agents" ]; then
     done
 fi
 
-# Sync Gemini hooks mirror
 echo ""
 echo -e "${YELLOW}Syncing Gemini hooks mirror...${NC}"
 GEMINI_HOOK_COUNT=0
 GEMINI_HOOKS_ALLOWLIST="${SCRIPT_DIR}/scripts/gemini-hooks-allowlist.txt"
 
 if [ -f "$GEMINI_HOOKS_ALLOWLIST" ]; then
-    # Ensure hooks directory exists
     if [ "$DRY_RUN" = true ]; then
         echo -e "${BLUE}  Would create: ${GEMINI_HOOKS_DIR}${NC}"
     else
@@ -1527,7 +1635,7 @@ if [ -f "$GEMINI_HOOKS_ALLOWLIST" ]; then
         GEMINI_HOOK_COUNT=$((GEMINI_HOOK_COUNT + 1))
     done < "$GEMINI_HOOKS_ALLOWLIST"
 
-    # Also mirror the hooks/lib directory so intra-hook imports resolve.
+    # Mirror hooks/lib so intra-hook imports resolve.
     if [ -d "${SCRIPT_DIR}/hooks/lib" ]; then
         lib_target="${GEMINI_HOOKS_DIR}/lib"
         sync_mirror_entry "${SCRIPT_DIR}/hooks/lib" "$lib_target" "Gemini"
@@ -1565,6 +1673,13 @@ if [ -f "$GEMINI_HOOKS_ALLOWLIST" ]; then
     fi
 else
     echo -e "${YELLOW}  ⚠ Gemini hooks allowlist not found at ${GEMINI_HOOKS_ALLOWLIST}; skipping hooks mirror${NC}"
+fi
+
+# Nudge consumer-tier Gemini CLI users toward Antigravity before the 2026-06-18 sunset.
+if command -v gemini >/dev/null 2>&1 && ! command -v agy >/dev/null 2>&1; then
+    echo -e "${YELLOW}  ⚠ Consumer Gemini CLI tiers (AI Pro/Ultra, free Code Assist) sunset 2026-06-18.${NC}"
+    echo -e "${YELLOW}    Install Antigravity CLI from https://antigravity.google/cli to continue past that date.${NC}"
+    echo -e "${BLUE}    Enterprise/paid-API tiers unaffected.${NC}"
 fi
 
 echo ""
@@ -2036,6 +2151,9 @@ echo "  • Gemini skills: ${GEMINI_ENTRY_COUNT} mirrored entries in ~/.gemini/s
 echo "  • Gemini agents: ${GEMINI_AGENT_COUNT} mirrored entries in ~/.gemini/agents"
 echo "  • Gemini hooks: ${GEMINI_HOOK_COUNT} mirrored entries in ~/.gemini/hooks"
 echo "  • Gemini scripts: ${GEMINI_SCRIPT_COUNT} mirrored scripts in ~/.gemini/scripts"
+echo "  • Antigravity plugin skills: ${ANTIGRAVITY_ENTRY_COUNT} entries in ${ANTIGRAVITY_PLUGIN_DIR}/skills"
+echo "  • Antigravity plugin agents: ${ANTIGRAVITY_AGENT_COUNT} entries in ${ANTIGRAVITY_PLUGIN_DIR}/agents"
+echo "  • Antigravity plugin hooks: ${ANTIGRAVITY_HOOK_COUNT} entries in ${ANTIGRAVITY_PLUGIN_DIR}/hooks"
 echo "  • Factory skills: ${FACTORY_SKILL_COUNT} mirrored entries in ~/.factory/skills"
 echo "  • Factory droids: ${FACTORY_DROID_COUNT} mirrored entries in ~/.factory/droids"
 echo "  • Factory hooks: ${FACTORY_HOOK_COUNT} mirrored entries in ~/.factory/hooks"

--- a/plugins/vexjoy-agent/hooks.json
+++ b/plugins/vexjoy-agent/hooks.json
@@ -1,0 +1,51 @@
+{
+  "PostToolUse": [
+    {
+      "matcher": "run_command",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 \"$HOME/.gemini/antigravity/plugins/vexjoy-agent/hooks/posttool-bash-injection-scan.py\"",
+          "timeout": 60
+        }
+      ]
+    }
+  ],
+  "UserPromptSubmit": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 \"$HOME/.gemini/antigravity/plugins/vexjoy-agent/hooks/session-github-briefing.py\"",
+          "timeout": 60
+        },
+        {
+          "type": "command",
+          "command": "python3 \"$HOME/.gemini/antigravity/plugins/vexjoy-agent/hooks/operator-context-detector.py\"",
+          "timeout": 60
+        },
+        {
+          "type": "command",
+          "command": "python3 \"$HOME/.gemini/antigravity/plugins/vexjoy-agent/hooks/team-config-loader.py\"",
+          "timeout": 60
+        },
+        {
+          "type": "command",
+          "command": "python3 \"$HOME/.gemini/antigravity/plugins/vexjoy-agent/hooks/rules-distill-injector.py\"",
+          "timeout": 60
+        }
+      ]
+    }
+  ],
+  "Stop": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 \"$HOME/.gemini/antigravity/plugins/vexjoy-agent/hooks/session-learning-recorder.py\"",
+          "timeout": 60
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/vexjoy-agent/plugin.json
+++ b/plugins/vexjoy-agent/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "vexjoy-agent",
+  "version": "0.1.0",
+  "description": "VexJoy Agent toolkit: agents, skills, hooks, and scripts for Claude Code, Codex, Gemini CLI, and Antigravity CLI.",
+  "author": "VexJoy",
+  "homepage": "https://github.com/thecodingshrimp/vexjoy-agent"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vexjoy-agent"
 version = "1.0.0"
-description = "Agent-driven workflow system for Claude Code, Codex, and Gemini CLI"
+description = "Agent-driven workflow system for Claude Code, Codex, Gemini CLI, and Antigravity CLI"
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/scripts/detect-workflow-capability.py
+++ b/scripts/detect-workflow-capability.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Detect the running harness from environment variables (env proxy).
 
-Emits JSON: {"harness": "claude-code|codex|gemini|factory|reasonix|unknown",
+Emits JSON: {"harness": "claude-code|codex|agy|gemini|factory|reasonix|unknown",
              "workflow_capable": bool}
 
 Anthropic's native ``Workflow`` tool (deterministic JS orchestration) is
@@ -20,6 +20,8 @@ Detection markers (distinctive entrypoint/session/home vars — never generic
 API-key vars like GEMINI_API_KEY, which are commonly set under any harness):
   claude-code : CLAUDECODE, CLAUDE_CODE_ENTRYPOINT, CLAUDE_CODE_SESSION_ID
   codex       : CODEX_HOME, CODEX_HOOKS_DIR
+  agy         : ANTIGRAVITY_AGENT (checked before gemini; agy may inherit
+                GEMINI_CLI in transitional environments)
   gemini      : GEMINI_CLI
   factory     : FACTORY_SESSION_ID, FACTORY_HOME, DROID_SESSION_ID, DROID_HOME
   reasonix    : (no env marker) — keyed off the ``_`` invocation var, since
@@ -41,7 +43,7 @@ import json
 import os
 import sys
 
-HARNESSES = ("claude-code", "codex", "gemini", "factory", "reasonix", "unknown")
+HARNESSES = ("claude-code", "codex", "agy", "gemini", "factory", "reasonix", "unknown")
 
 # Single source of truth for native-Workflow availability. Add a harness here
 # the day it ships the native Workflow tool; the docstring and tests pin against
@@ -53,6 +55,7 @@ WORKFLOW_CAPABLE: frozenset[str] = frozenset({"claude-code"})
 _MARKERS: list[tuple[str, tuple[str, ...]]] = [
     ("claude-code", ("CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "CLAUDE_CODE_SESSION_ID")),
     ("codex", ("CODEX_HOME", "CODEX_HOOKS_DIR")),
+    ("agy", ("ANTIGRAVITY_AGENT",)),
     ("gemini", ("GEMINI_CLI",)),
     ("factory", ("FACTORY_SESSION_ID", "FACTORY_HOME", "DROID_SESSION_ID", "DROID_HOME")),
 ]

--- a/scripts/tests/test_detect_workflow_capability.py
+++ b/scripts/tests/test_detect_workflow_capability.py
@@ -39,6 +39,10 @@ _spec.loader.exec_module(dwc)
         # codex: home / hooks dir markers
         ({"CODEX_HOME": "/home/u/.codex"}, "codex"),
         ({"CODEX_HOOKS_DIR": "/x"}, "codex"),
+        # agy (Antigravity): explicit agent identifier — checked before gemini
+        ({"ANTIGRAVITY_AGENT": "1"}, "agy"),
+        # agy wins over a stray GEMINI_CLI (transitional env)
+        ({"ANTIGRAVITY_AGENT": "1", "GEMINI_CLI": "1"}, "agy"),
         # gemini: explicit CLI identifier
         ({"GEMINI_CLI": "1"}, "gemini"),
         # factory / droid
@@ -81,6 +85,7 @@ def test_claude_code_wins_over_other_markers():
     [
         ("claude-code", True),
         ("codex", False),
+        ("agy", False),
         ("gemini", False),
         ("factory", False),
         ("reasonix", False),

--- a/scripts/tests/test_hook_utils_gemini.py
+++ b/scripts/tests/test_hook_utils_gemini.py
@@ -39,8 +39,24 @@ class TestDetectCli:
 
     @staticmethod
     def _clean_env() -> dict[str, str]:
-        """Return env dict stripped of Gemini/Codex/_ vars."""
-        return {k: v for k, v in os.environ.items() if not k.startswith(("GEMINI_", "CODEX_")) and k != "_"}
+        """Return env dict stripped of Gemini/Codex/Antigravity/_ vars."""
+        return {
+            k: v for k, v in os.environ.items() if not k.startswith(("GEMINI_", "CODEX_", "ANTIGRAVITY_")) and k != "_"
+        }
+
+    def test_detects_agy_via_env(self):
+        """detect_cli returns 'agy' when ANTIGRAVITY_AGENT is set."""
+        env = self._clean_env()
+        with patch.dict(os.environ, env, clear=True):
+            os.environ["ANTIGRAVITY_AGENT"] = "1"
+            assert detect_cli() == "agy"
+
+    def test_detects_agy_via_underscore_var(self):
+        """detect_cli returns 'agy' when _ contains 'agy'."""
+        env = self._clean_env()
+        with patch.dict(os.environ, env, clear=True):
+            os.environ["_"] = "/usr/local/bin/agy"
+            assert detect_cli() == "agy"
 
     def test_detects_gemini_via_gemini_cli_env(self):
         """detect_cli returns 'gemini' when GEMINI_CLI is set."""

--- a/scripts/validate-hook-health.py
+++ b/scripts/validate-hook-health.py
@@ -705,6 +705,77 @@ def check_matcher_liveness() -> list[str]:
     return msgs
 
 
+_AGY_PLUGIN_DIR = Path("$HOME/.gemini/antigravity/plugins/vexjoy-agent")
+_AGY_KNOWN_EVENTS = {"PreToolUse", "PostToolUse", "Stop", "UserPromptSubmit"}
+_AGY_CMD_RE = re.compile(r'^python3\s+"\$HOME/\.gemini/antigravity/plugins/vexjoy-agent/hooks/([A-Za-z0-9._-]+\.py)"$')
+
+
+def _check_antigravity_plugin() -> tuple[int, list[str]]:
+    """Validate ~/.gemini/antigravity/plugins/vexjoy-agent/hooks.json.
+
+    Checks: top-level keys are in _AGY_KNOWN_EVENTS; each entry has
+    type == "command", a $HOME-based command (no literal "~"), positive int
+    timeout, and the referenced .py file exists. Returns (passed, failed).
+    Returns (0, []) when the plugin dir is absent (skip silently).
+    """
+    import os
+
+    plugin_root = Path(os.path.expandvars(str(_AGY_PLUGIN_DIR))).expanduser()
+    hooks_json = plugin_root / "hooks.json"
+    if not hooks_json.exists():
+        return 0, []
+    failed: list[str] = []
+    passed = 0
+    try:
+        data = json.loads(hooks_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        return 0, [f"AGY: cannot parse {hooks_json}: {e}"]
+    if not isinstance(data, dict):
+        return 0, [f"AGY: {hooks_json} top level is not an object."]
+    for event, groups in data.items():
+        if event not in _AGY_KNOWN_EVENTS:
+            failed.append(f"AGY: unknown event '{event}' (allowed: {sorted(_AGY_KNOWN_EVENTS)}).")
+            continue
+        if not isinstance(groups, list):
+            failed.append(f"AGY: {event} value is not a list.")
+            continue
+        for group in groups:
+            if not isinstance(group, dict):
+                failed.append(f"AGY: {event} group is not an object.")
+                continue
+            for entry in group.get("hooks", []):
+                if not isinstance(entry, dict):
+                    failed.append(f"AGY: {event} hook entry is not an object.")
+                    continue
+                if entry.get("type") != "command":
+                    failed.append(f"AGY: {event} entry type must be 'command', got {entry.get('type')!r}.")
+                    continue
+                cmd = entry.get("command", "")
+                if not isinstance(cmd, str) or not cmd:
+                    failed.append(f"AGY: {event} entry missing 'command' string.")
+                    continue
+                if "~/" in cmd or cmd.startswith("~"):
+                    failed.append(f"AGY: {event} command uses literal '~' (must use $HOME): {cmd!r}.")
+                    continue
+                timeout = entry.get("timeout")
+                if not isinstance(timeout, int) or timeout <= 0:
+                    failed.append(f"AGY: {event} timeout must be a positive int, got {timeout!r}.")
+                m = _AGY_CMD_RE.match(cmd)
+                if not m:
+                    failed.append(
+                        f"AGY: {event} command not in canonical form "
+                        f'python3 "$HOME/.gemini/antigravity/plugins/vexjoy-agent/hooks/<file>.py": {cmd!r}.'
+                    )
+                    continue
+                fname = m.group(1)
+                hook_path = plugin_root / "hooks" / fname
+                if not hook_path.exists():
+                    failed.append(f"AGY: {event} references {hook_path} but file does not exist.")
+                    continue
+                passed += 1
+    return passed, failed
+
+
 def check_liveness() -> list[str]:
     """Delegate to smoke-test-hooks.py --ci. Returns failure msgs if it exits nonzero."""
     smoke = REPO_ROOT / "scripts" / "smoke-test-hooks.py"
@@ -745,6 +816,15 @@ def main() -> int:
 
     with_liveness = args.ci or args.with_liveness
     failures = run_all(with_liveness=with_liveness)
+
+    # Antigravity plugin (best-effort; absent dir = skip).
+    agy_passed, agy_failed = _check_antigravity_plugin()
+    print(f"--- Antigravity plugin hooks (~/.gemini/antigravity/plugins/vexjoy-agent/hooks.json) ---")
+    if agy_passed == 0 and not agy_failed:
+        print("AGY: plugin dir not present — skipped.")
+    else:
+        print(f"AGY: {agy_passed} hook entries validated; {len(agy_failed)} failure(s).")
+    failures += agy_failed
 
     checks = [
         "schema",


### PR DESCRIPTION
## Summary

Adds Antigravity CLI (`agy`) support to the toolkit per [Google's transition announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/) (2026-06-18 consumer sunset). Antigravity **coexists** with Gemini CLI rather than replacing it — Gemini Code Assist Standard/Enterprise and paid-API tiers keep working past the deadline, so a hard cutover would break those users. Both install paths run unconditionally.

## What ships

- **New plugin** `plugins/vexjoy-agent/{plugin.json,hooks.json}` staged into `~/.gemini/antigravity/plugins/vexjoy-agent/` by `install.sh`.
- **Hooks schema** uses Antigravity's top-level event keys (no outer wrapper), `$HOME` paths (literal `~` does not expand inside quoted command strings), and the four supported events: `PreToolUse`, `PostToolUse`, `Stop`, `UserPromptSubmit`.
- **SessionStart re-homing.** Antigravity does not emit `SessionStart`. The 4 bootstrap hooks (`session-github-briefing`, `operator-context-detector`, `team-config-loader`, `rules-distill-injector`) move to `UserPromptSubmit` with a PPID-keyed touchfile gate so they fire **once per session** under agy. Claude Code / Codex / Gemini CLI keep firing them via `SessionStart` — those harnesses are unaffected.
- **`hook_utils.detect_cli`** adds `"agy"` via `ANTIGRAVITY_AGENT` env var or exact-basename match on the `_` invocation var. Both `gemini` and `agy` checks use basename to prevent cross-CLI false positives like ``_=/Users/agy-fan/bin/gemini``.
- **`scripts/detect-workflow-capability.py`** registers the `agy` harness alongside `gemini` (matched semantics — no Workflow tool support yet).
- **`scripts/validate-hook-health.py`** validates the Antigravity plugin: event allowlist, `\$HOME` form (rejects literal `~`), file existence, timeout type. Skips gracefully when the plugin dir is absent.
- **`install.sh`** runs both Gemini and Antigravity sync paths unconditionally; restored Gemini hooks block; renamed `VEXJOY_PLUGIN_DIR` → `ANTIGRAVITY_PLUGIN_DIR` and `GEMINI_*_COUNT` → `ANTIGRAVITY_*_COUNT`. Hardened `agy --version` probe handles parse failures. Filters `__pycache__`/`.pyc`/`tests` from the hooks mirror loop. When only `gemini` is installed and `agy` is not, prints a one-line yellow nudge pointing at <https://antigravity.google/cli> with the 2026-06-18 deadline.
- **Tests** cover agy detection, agy precedence over gemini in transitional envs, and the bootstrap-gate flow. `_clean_env` strips the `ANTIGRAVITY_` prefix to prevent fixture leakage.
- **Docs.** README, `docs/start-here.md`, `docs/QUICKSTART.md`, `pyproject.toml` cross-reference Antigravity CLI alongside Gemini CLI. README adds a tier table for the 2026-06-18 sunset.

## Stat

16 files changed, +364 / −18.

## Test plan

- [x] `python3 -m ruff check . --config pyproject.toml` — clean (433 files)
- [x] `python3 -m ruff format --check . --config pyproject.toml` — clean
- [x] `python3 -m pytest scripts/tests/ -q` — 2688 passed
- [x] `python3 -m pytest scripts/tests/test_hook_utils_gemini.py scripts/tests/test_detect_workflow_capability.py -q` — 48 passed
- [x] `bash -n install.sh` — clean
- [x] `python3 -m json.tool plugins/vexjoy-agent/{plugin,hooks}.json` — both valid
- [x] `python3 scripts/validate-hook-health.py` — ALL CHECKS PASS (AGY plugin dir absent locally → skipped, expected)
- [ ] Manual smoke test: install Antigravity CLI on a clean machine, run `./install.sh`, confirm plugin appears at `~/.gemini/antigravity/plugins/vexjoy-agent/` with skills, agents, hooks, and a valid `hooks.json`.
- [ ] Manual smoke test: run `./install.sh` on a machine that has only Gemini CLI; confirm the yellow sunset nudge prints and Gemini hooks still merge into `~/.gemini/settings.json`.

## Out of scope (follow-ups suggested)

- `skills/content/image-gen/` scripts call the `gemini` binary directly. Works under enterprise/paid Gemini CLI; agy-only consumer-tier users may need a follow-up if `agy` exposes no equivalent image-generation surface.
- Two pre-existing failures in `hooks/tests/test_sync_to_user_claude.py` (worktree symlink poisoning guards) exist on `main` today — same blob hash on this branch — and are unrelated to this PR.

## Authoring note

This PR is the squashed result of an audit-and-improve pass over the original 1-commit migration. Six commits collapsed into one for review clarity; full audit trail available in the PR conversation.