### PR TITLE
feat(voice): add narrative-level AI detection from StoryScope research

### DIFF
--- a/skills/content/voice-validator/SKILL.md
+++ b/skills/content/voice-validator/SKILL.md
@@ -69,7 +69,17 @@ Check all categories against the target voice's checklist. Standard categories i
 - **Emotion**: Does emotion handling match? (e.g., explicitly named emotions, venting/ranting, moralizing)
 - **Questions**: Do question patterns match? (e.g., open-ended brainstorming, vague curiosity)
 - **Metaphors**: Do metaphor patterns match? (e.g., journey/path, biological/growth, narrative/story)
-- **Narrative** (500+ words only): Does the piece let evidence speak, or does the narrator over-explain the point? Are emotional registers mixed (named feelings + behavioral cues + sensation)? Does the piece have secondary threads that enrich the main argument? Does the piece acknowledge the reader's experience or perspective? Is temporal structure varied (callbacks, non-linear points) where appropriate? Are references specific (named people, works, sources) rather than vague?
+- **Narrative** (500+ words only; full 13-check rubric in `anti-ai-editor/references/narrative-patterns.md`):
+  - Evidence speaks for itself, or narrator over-explains the point?
+  - Emotional registers mixed (named feelings + behavioral cues + sensation)?
+  - Secondary threads present that enrich the main argument?
+  - Reader's experience acknowledged?
+  - Temporal structure varied (callbacks, non-linear points)?
+  - References specific (named people, works, sources)?
+  - Room for uncertainty and loose ends, or subject has every answer?
+  - Intensity varies (peaks and valleys), or flat throughout?
+  - Event types diverse, or every paragraph does the same thing?
+  - Ending carries forward motion, or defaults to tidy realization epilogue?
 
 **Step 2: Check pass conditions**
 
@@ -79,7 +89,7 @@ Verify the content matches the target voice's positive identity markers. Common 
 - Voice-specific patterns are present (thinking out loud, warmth, precision, etc.)
 - Could NOT be posted on LinkedIn without edits (for casual voices) — this heuristic catches ~80% of voice violations
 - Does NOT sound like AI wrote it
-- Narrative structure shows variety -- secondary threads present, temporal structure varied, ending is action or open question rather than tidy realization
+- Narrative structure shows variety — secondary threads, temporal variation, forward-motion ending
 - Mode-specific patterns are present (casual modes: no preamble, no wrap-up; formal modes: structured flow)
 
 **Step 3: Document violations**

--- a/skills/content/voice-validator/SKILL.md
+++ b/skills/content/voice-validator/SKILL.md
@@ -69,6 +69,7 @@ Check all categories against the target voice's checklist. Standard categories i
 - **Emotion**: Does emotion handling match? (e.g., explicitly named emotions, venting/ranting, moralizing)
 - **Questions**: Do question patterns match? (e.g., open-ended brainstorming, vague curiosity)
 - **Metaphors**: Do metaphor patterns match? (e.g., journey/path, biological/growth, narrative/story)
+- **Narrative** (500+ words only): Does the piece let evidence speak, or does the narrator over-explain the point? Are emotional registers mixed (named feelings + behavioral cues + sensation)? Does the piece have secondary threads that enrich the main argument? Does the piece acknowledge the reader's experience or perspective? Is temporal structure varied (callbacks, non-linear points) where appropriate? Are references specific (named people, works, sources) rather than vague?
 
 **Step 2: Check pass conditions**
 
@@ -78,12 +79,13 @@ Verify the content matches the target voice's positive identity markers. Common 
 - Voice-specific patterns are present (thinking out loud, warmth, precision, etc.)
 - Could NOT be posted on LinkedIn without edits (for casual voices) — this heuristic catches ~80% of voice violations
 - Does NOT sound like AI wrote it
+- Narrative structure shows variety -- secondary threads present, temporal structure varied, ending is action or open question rather than tidy realization
 - Mode-specific patterns are present (casual modes: no preamble, no wrap-up; formal modes: structured flow)
 
 **Step 3: Document violations**
 
 For each violation, record:
-1. Category (tone, structure, sentence, language, emotion, question, metaphor)
+1. Category (tone, structure, sentence, language, emotion, question, metaphor, narrative)
 2. Quoted text from the content
 3. Specific fix recommendation
 
@@ -156,7 +158,7 @@ User says: "Validate this draft is in the right voice"
 
 Actions:
 1. Identify target voice from context, determine mode from content style (IDENTIFY TARGET)
-2. Run full 7-category negative prompt checklist, find 2 violations (SCAN)
+2. Run full 8-category checklist (Tone, Structure, Sentences, Language, Emotion, Questions, Metaphors, Narrative), find 2 violations (SCAN)
 3. Fix "I'm excited to share" (named emotion) and "This changes everything" (dramatic short sentence) (REVISE)
 4. Rescan revised content, confirm PASS (VERIFY)
 

--- a/skills/content/voice-writer/SKILL.md
+++ b/skills/content/voice-writer/SKILL.md
@@ -174,6 +174,15 @@ Where `{voice_profile}` is the voice skill selected in Phase 1 (e.g., `voice-myp
 4. Use the voice profile's modal register (teaching, casual, investigative, etc.) as appropriate
 5. Include code examples if technical — they must be complete and tested
 6. Target word count per user request or default 1200-2000 words
+7. Apply narrative structure guidance (these counter the most durable AI fingerprints — narrative patterns survive stylistic editing):
+   - Let evidence speak — present the facts, quotes, and moments that carry the meaning. Resist the pull to state the theme explicitly.
+   - Mix emotional registers: name feelings directly sometimes, use behavioral cues, alternate between sensation and plain statement.
+   - Weave secondary threads: a tangent, counter-example, or aside that returns to enrich the main point.
+   - Reference specifically: name the person, the event, the source. Generic authority ("many experts") reads as evasion.
+   - Vary intensity: build peaks and valleys in the piece. Flat escalation is a Claude fingerprint.
+   - Acknowledge the reader: address their likely experience, ask what they have noticed, speak to them.
+   - Vary temporal structure: call back to an earlier point, open with the conclusion and explain how you got there, break chronological order where it serves the piece.
+   - Close with action or open question — resist the pull to a tidy realization epilogue.
 
 **Gate**: Complete draft exists with front matter, body, and closing. Draft is in the target voice. Proceed.
 

--- a/skills/content/voice-writer/SKILL.md
+++ b/skills/content/voice-writer/SKILL.md
@@ -175,14 +175,19 @@ Where `{voice_profile}` is the voice skill selected in Phase 1 (e.g., `voice-myp
 5. Include code examples if technical — they must be complete and tested
 6. Target word count per user request or default 1200-2000 words
 7. Apply narrative structure guidance (these counter the most durable AI fingerprints — narrative patterns survive stylistic editing):
-   - Let evidence speak — present the facts, quotes, and moments that carry the meaning. Resist the pull to state the theme explicitly.
+   - Let evidence speak — present facts, quotes, and moments that carry the meaning. Trust readers to find the point.
    - Mix emotional registers: name feelings directly sometimes, use behavioral cues, alternate between sensation and plain statement.
    - Weave secondary threads: a tangent, counter-example, or aside that returns to enrich the main point.
+   - Leave room for uncertainty: external factors, other people's decisions, and unresolved threads belong in the piece. Real situations have loose ends.
    - Reference specifically: name the person, the event, the source. Generic authority ("many experts") reads as evasion.
-   - Vary intensity: build peaks and valleys in the piece. Flat escalation is a Claude fingerprint.
+   - Vary intensity: build peaks and valleys. Flat escalation is a Claude fingerprint.
+   - Include at least one event the reader would not predict from the opening: a surprising data point, unexpected reaction, or reversal.
    - Acknowledge the reader: address their likely experience, ask what they have noticed, speak to them.
-   - Vary temporal structure: call back to an earlier point, open with the conclusion and explain how you got there, break chronological order where it serves the piece.
-   - Close with action or open question — resist the pull to a tidy realization epilogue.
+   - Vary temporal structure: call back to an earlier point, open with the conclusion, break chronological order where it serves the piece.
+   - Close with forward motion, a practical step, or an honest open question.
+   - Subvert one expectation: lead with the counter-intuitive angle, challenge a convention, take a position the reader might push back on.
+   - Use speculative departures where they serve the piece: "Imagine if..." or "What would happen if..." makes abstract points concrete.
+   - Cut the epilogue unless it adds specific new information. General future-looking paragraphs weaken the final substantive point.
 
 **Gate**: Complete draft exists with front matter, body, and closing. Draft is in the target voice. Proceed.
 


### PR DESCRIPTION
## Summary

- Add narrative-level AI detection tier to the voice toolkit, derived from StoryScope (Russell et al. 2026, arXiv:2604.03136v4)
- Surface tells get patched each model version; narrative features survive stylistic editing (93.9% F1 after LAMP rewriting)
- 8 universal patterns + 5 Claude-specific fingerprints, all Triple-Validated (Recurrence + Generative + Exclusivity ≥20pp gap)

## Changes

**Public (this PR):**
- `skills/content/voice-validator/SKILL.md` — Add 8th "Narrative" category to Phase 2 SCAN checklist
- `skills/content/voice-writer/SKILL.md` — Add narrative structure guidance (Step 7) to Phase 4 GENERATE

**Private-skills (gitignored, applied separately):**
- `anti-ai-editor/references/narrative-patterns.md` — NEW: 13-check narrative detection reference with scoring rubric
- `anti-ai-editor/references/detection-patterns.md` — Add Tier N narrative structure section
- `anti-ai-editor/references/detection-rules.md` — Add narrative quick-reference table
- `anti-ai-editor/SKILL.md` — Add narrative to reference loading, scan categories, severity weights

## Evidence

| Metric | Value |
|--------|-------|
| Narrative features alone (macro-F1) | 93.2% |
| After stylistic editing (macro-F1) | 93.9% |
| Human structural rarity (mean percentile) | 0.71 vs 0.49 AI |
| Rarity effect size (Cohen's d) | 0.83 |

## Test plan

- [ ] A/B test: generate articles with/without narrative guidance, blind-score on 13-check rubric
- [ ] Detection gap test: score AI content with old vs new anti-ai-editor
- [ ] Positive framing validation: `python3 scripts/validate_positive_instruction_docs.py`
- [ ] Codex review of changes