### PR TITLE
fix(install): coexistence per-item + auto-sync (fixes #738 review)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1080,10 +1080,10 @@ detect_conflicts() {
                 _conflict_set "$runtime_dir/$component" "symlink→$(readlink "$target")"
                 continue
             fi
-            # Count items in target not present in src
+            # Count items (files and dirs) in target not present in src
             count=0; items=""
-            for item in "$target"/*/; do
-                [ -e "$item" ] || continue
+            for item in "$target"/*; do
+                [ -e "$item" ] || [ -L "$item" ] || continue
                 name=$(basename "$item")
                 [ -e "$src/$name" ] || { count=$((count+1)); items="$items $name"; }
             done
@@ -1121,8 +1121,15 @@ install_component() {
     local source="${SCRIPT_DIR}/${name}"
     local target="${base_dir}/${target_name}"
 
-    # Per-item mode: skip targets flagged as conflicting or when CONFLICT_MODE=per-item
     local component_key="$base_dir/$target_name"
+
+    # Skip mode: leave conflicting locations untouched; install conflict-free ones normally.
+    if [ "$CONFLICT_MODE" = "skip" ] && [ "$MODE" = "symlink" ] && _conflict_has "$component_key"; then
+        echo -e "${YELLOW}  Skipping ${target} (kept existing — skip mode)${NC}"
+        return
+    fi
+
+    # Per-item mode: symlink each item (file or dir) individually; preserve external content.
     if [ "$CONFLICT_MODE" = "per-item" ] && [ "$MODE" = "symlink" ] && \
        { _conflict_has "$component_key" || [ -d "$target" ] || [ -L "$target" ]; }; then
         if [ "$DRY_RUN" = true ]; then
@@ -1130,8 +1137,8 @@ install_component() {
         else
             mkdir -p "$target"
             local item item_name
-            for item in "$source"/*/; do
-                [ -e "$item" ] || continue
+            for item in "$source"/*; do
+                [ -e "$item" ] || [ -L "$item" ] || continue
                 item_name=$(basename "$item")
                 if [ -e "$target/$item_name" ]; then
                     echo -e "${YELLOW}  WARNING: $target/$item_name already exists — skipping (kept existing)${NC}"
@@ -1195,15 +1202,15 @@ sync_mirror_entry() {
     local name
     name=$(basename "$source")
 
-    # Per-item mode: add-only symlink for each item; skip existing entries
+    # Per-item mode: add-only symlink for each item (file or dir); skip existing entries
     if [ "$CONFLICT_MODE" = "per-item" ] && [ "$MODE" = "symlink" ] && [ -d "$source" ]; then
         if [ "$DRY_RUN" = true ]; then
             echo -e "${BLUE}  Would per-item sync ${label} entry: ${source} -> ${target}/${NC}"
         else
             mkdir -p "$target"
             local item item_name
-            for item in "$source"/*/; do
-                [ -e "$item" ] || continue
+            for item in "$source"/*; do
+                [ -e "$item" ] || [ -L "$item" ] || continue
                 item_name=$(basename "$item")
                 if [ -e "$target/$item_name" ]; then
                     continue  # already present; skip silently
@@ -1254,6 +1261,11 @@ sync_codex_entry() {
 install_git_hook() {
     local hook=".git/hooks/post-merge"
     [ -d ".git" ] || return 0  # no-op outside a git repo clone
+    # Never clobber a pre-existing hook we did not write.
+    if [ -e "$hook" ] && ! grep -q "Written by vexjoy-agent" "$hook" 2>/dev/null; then
+        echo -e "${YELLOW}  Existing post-merge hook found — not overwriting: ${hook}${NC}"
+        return 0
+    fi
     if [ "$DRY_RUN" = true ]; then
         echo -e "${BLUE}  Would install post-merge hook: ${hook}${NC}"
         return 0
@@ -1271,7 +1283,8 @@ for runtime_dir in     "$HOME/.claude" "$HOME/.codex" "$HOME/.gemini"     "$HOME
     dst="$runtime_dir/$component"
     [ -d "$src" ] || continue
     [ -d "$dst" ] || continue  # only sync if component dir already installed
-    for item in "$src"/*/; do
+    for item in "$src"/*; do
+      [ -e "$item" ] || [ -L "$item" ] || continue
       name=$(basename "$item")
       [ -e "$dst/$name" ] && continue  # already present; skip
       ln -s "$item" "$dst/$name"

--- a/install.sh
+++ b/install.sh
@@ -69,6 +69,7 @@ echo ""
 MODE=""
 DRY_RUN=false
 FORCE=true  # Default to force — never prompt about existing directories
+CONFLICT_MODE=""  # per-item | replace | skip; set by --per-item/--sync or conflict prompt
 while [[ $# -gt 0 ]]; do
     case $1 in
         --symlink)
@@ -99,8 +100,18 @@ while [[ $# -gt 0 ]]; do
             FORCE=false  # Opt in to interactive prompts
             shift
             ;;
+        --per-item)
+            CONFLICT_MODE="per-item"
+            shift
+            ;;
+        --sync)
+            CONFLICT_MODE="per-item"
+            # --sync implies symlink mode when MODE is not yet set
+            [ -z "$MODE" ] && MODE="symlink"
+            shift
+            ;;
         --help|-h)
-            echo "Usage: $0 [--symlink|--copy|--uninstall|--rollback|--dry-run|--force]"
+            echo "Usage: $0 [--symlink|--copy|--uninstall|--rollback|--dry-run|--force|--per-item|--sync]"
             echo ""
             echo "Options:"
             echo "  --symlink    Create symlinks to this repo (recommended for development)"
@@ -110,6 +121,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --dry-run    Show what would happen without making changes"
             echo "  --force      Replace existing directories without prompting (default)"
             echo "  --no-force   Prompt before replacing existing directories"
+            echo "  --per-item   Symlink each item individually; preserve external content"
+            echo "  --sync       Alias for --per-item; implies --symlink mode default"
             echo ""
             echo "If no option provided, will prompt interactively."
             exit 0
@@ -1029,6 +1042,52 @@ else
 fi
 echo -e "${GREEN}✓ ${REASONIX_SKILLS_DIR} ready${NC}"
 
+# detect_conflicts — scans all runtime dirs × all component types.
+# Populates global associative array: conflicts[runtime/component]="description"
+declare -A conflicts
+detect_conflicts() {
+    local runtime_dir component target src count items item name
+    for runtime_dir in "$CLAUDE_DIR" "$CODEX_DIR" "$GEMINI_DIR"                        "$FACTORY_DIR" "$HERMES_DIR" "$REASONIX_DIR"; do
+        [ -d "$runtime_dir" ] || continue
+        for component in agents skills hooks commands scripts; do
+            target="$runtime_dir/$component"
+            src="$SCRIPT_DIR/$component"
+            [ -d "$src" ] || continue
+            [ -d "$target" ] || [ -L "$target" ] || continue
+            # Whole-dir symlink pointing elsewhere
+            if [ -L "$target" ] && [ "$(readlink "$target")" != "$src" ]; then
+                conflicts["$runtime_dir/$component"]="symlink→$(readlink "$target")"
+                continue
+            fi
+            # Count items in target not present in src
+            count=0; items=""
+            for item in "$target"/*/; do
+                [ -e "$item" ] || continue
+                name=$(basename "$item")
+                [ -e "$src/$name" ] || { count=$((count+1)); items="$items $name"; }
+            done
+            if [ "$count" -gt 0 ]; then
+                conflicts["$runtime_dir/$component"]="$count external:$items"
+            fi
+        done
+    done
+    return 0
+}
+
+print_conflict_table() {
+    echo ""
+    echo "Found existing content in the following locations:"
+    for key in "${!conflicts[@]}"; do
+        echo "  $key  (${conflicts[$key]})"
+    done
+    echo ""
+    echo "Choose install mode for all conflicting locations:"
+    echo "  [1] per-item  — symlink each vexjoy item individually; preserve external content (recommended)"
+    echo "  [2] replace   — rm -rf and replace with whole-dir symlink (destroys external content)"
+    echo "  [3] skip      — leave conflicting locations unchanged; install only conflict-free locations"
+    echo ""
+}
+
 # Install components
 echo ""
 echo -e "${YELLOW}Installing components (mode: ${MODE})...${NC}"
@@ -1039,6 +1098,28 @@ install_component() {
     local target_name=${3:-$name}
     local source="${SCRIPT_DIR}/${name}"
     local target="${base_dir}/${target_name}"
+
+    # Per-item mode: skip targets flagged as conflicting or when CONFLICT_MODE=per-item
+    local component_key="$base_dir/$target_name"
+    if [ "$CONFLICT_MODE" = "per-item" ] && [ "$MODE" = "symlink" ] &&        { [ -n "${conflicts[$component_key]+_}" ] || [ -d "$target" ] || [ -L "$target" ]; }; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would per-item symlink into: ${target}${NC}"
+        else
+            mkdir -p "$target"
+            local item item_name
+            for item in "$source"/*/; do
+                [ -e "$item" ] || continue
+                item_name=$(basename "$item")
+                if [ -e "$target/$item_name" ]; then
+                    echo -e "${YELLOW}  WARNING: $target/$item_name already exists — skipping (kept existing)${NC}"
+                    continue
+                fi
+                ln -s "$item" "$target/$item_name"
+                echo -e "${GREEN}  ✓ Per-item linked ${item_name}${NC}"
+            done
+        fi
+        return
+    fi
 
     # Check if target exists
     if [ -e "$target" ] || [ -L "$target" ]; then
@@ -1091,6 +1172,26 @@ sync_mirror_entry() {
     local name
     name=$(basename "$source")
 
+    # Per-item mode: add-only symlink for each item; skip existing entries
+    if [ "$CONFLICT_MODE" = "per-item" ] && [ "$MODE" = "symlink" ] && [ -d "$source" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${BLUE}  Would per-item sync ${label} entry: ${source} -> ${target}/${NC}"
+        else
+            mkdir -p "$target"
+            local item item_name
+            for item in "$source"/*/; do
+                [ -e "$item" ] || continue
+                item_name=$(basename "$item")
+                if [ -e "$target/$item_name" ]; then
+                    continue  # already present; skip silently
+                fi
+                ln -s "$item" "$target/$item_name"
+                echo -e "${GREEN}  ✓ ${label} per-item linked ${item_name}${NC}"
+            done
+        fi
+        return
+    fi
+
     if [ -e "$target" ] || [ -L "$target" ]; then
         if [ "$DRY_RUN" = true ]; then
             echo -e "${BLUE}  Would replace ${label} entry: ${target}${NC}"
@@ -1124,6 +1225,65 @@ sync_mirror_entry() {
 sync_codex_entry() {
     sync_mirror_entry "$1" "$2" "Codex"
 }
+
+# install_git_hook — writes .git/hooks/post-merge to auto-sync new items after git pull.
+# Add-only, never removes, never overwrites existing entries.
+install_git_hook() {
+    local hook=".git/hooks/post-merge"
+    [ -d ".git" ] || return 0  # no-op outside a git repo clone
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would install post-merge hook: ${hook}${NC}"
+        return 0
+    fi
+    mkdir -p ".git/hooks"
+    cat > "$hook" << 'HOOK'
+#!/usr/bin/env bash
+# Written by vexjoy-agent install.sh — auto-syncs new items after git pull.
+# Add-only: skips items already present; never removes or overwrites.
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+for runtime_dir in     "$HOME/.claude" "$HOME/.codex" "$HOME/.gemini"     "$HOME/.factory" "$HOME/.hermes" "$HOME/.reasonix"; do
+  [ -d "$runtime_dir" ] || continue
+  for component in agents skills hooks commands scripts; do
+    src="$REPO_DIR/$component"
+    dst="$runtime_dir/$component"
+    [ -d "$src" ] || continue
+    [ -d "$dst" ] || continue  # only sync if component dir already installed
+    for item in "$src"/*/; do
+      name=$(basename "$item")
+      [ -e "$dst/$name" ] && continue  # already present; skip
+      ln -s "$item" "$dst/$name"
+      echo "[vexjoy-agent] auto-synced: $dst/$name"
+    done
+  done
+done
+HOOK
+    chmod +x "$hook"
+    echo -e "${GREEN}  ✓ Installed post-merge hook: ${hook}${NC}"
+}
+
+# Scan for conflicts before first install_component call
+if [ "$MODE" = "symlink" ]; then
+    detect_conflicts
+    if [ ${#conflicts[@]} -gt 0 ]; then
+        if [ "$DRY_RUN" = true ]; then
+            print_conflict_table
+            _default_mode="${CONFLICT_MODE:-per-item}"
+            echo -e "${BLUE}  DRY RUN: Would prompt for conflict mode. Default would be: ${_default_mode}${NC}"
+            echo -e "${BLUE}  Would use mode: ${_default_mode}${NC}"
+            [ -z "$CONFLICT_MODE" ] && CONFLICT_MODE="per-item"
+        elif [ -z "$CONFLICT_MODE" ]; then
+            print_conflict_table
+            read -r -p "Choice [1/2/3, default=1]: " _ans
+            case "${_ans:-1}" in
+                1) CONFLICT_MODE="per-item" ;;
+                2) CONFLICT_MODE="replace"  ;;
+                3) CONFLICT_MODE="skip"     ;;
+                *) CONFLICT_MODE="per-item" ;;
+            esac
+            echo ""
+        fi
+    fi
+fi
 
 # Install main components
 for component in agents skills hooks commands scripts; do
@@ -1194,6 +1354,11 @@ if [ -d "${SCRIPT_DIR}/private-voices" ]; then
         fi
     done
 fi
+
+# Install git post-merge hook for automatic sync on git pull
+echo ""
+echo -e "${YELLOW}Installing post-merge git hook...${NC}"
+install_git_hook
 
 echo ""
 echo -e "${YELLOW}Syncing Codex skills mirror...${NC}"

--- a/install.sh
+++ b/install.sh
@@ -1043,11 +1043,32 @@ fi
 echo -e "${GREEN}✓ ${REASONIX_SKILLS_DIR} ready${NC}"
 
 # detect_conflicts — scans all runtime dirs × all component types.
-# Populates global associative array: conflicts[runtime/component]="description"
-declare -A conflicts
+# Populates parallel arrays conflict_keys[] and conflict_vals[] (bash 3.2 compatible).
+conflict_keys=()
+conflict_vals=()
+
+_conflict_set() {
+    conflict_keys+=("$1")
+    conflict_vals+=("$2")
+}
+
+_conflict_get() {
+    local _k _i
+    _k="$1"
+    for _i in "${!conflict_keys[@]}"; do
+        [ "${conflict_keys[$_i]}" = "$_k" ] && { printf '%s' "${conflict_vals[$_i]}"; return 0; }
+    done
+    return 1
+}
+
+_conflict_has() {
+    _conflict_get "$1" > /dev/null 2>&1
+}
+
 detect_conflicts() {
     local runtime_dir component target src count items item name
-    for runtime_dir in "$CLAUDE_DIR" "$CODEX_DIR" "$GEMINI_DIR"                        "$FACTORY_DIR" "$HERMES_DIR" "$REASONIX_DIR"; do
+    for runtime_dir in "$CLAUDE_DIR" "$CODEX_DIR" "$GEMINI_DIR" \
+                       "$FACTORY_DIR" "$HERMES_DIR" "$REASONIX_DIR"; do
         [ -d "$runtime_dir" ] || continue
         for component in agents skills hooks commands scripts; do
             target="$runtime_dir/$component"
@@ -1056,7 +1077,7 @@ detect_conflicts() {
             [ -d "$target" ] || [ -L "$target" ] || continue
             # Whole-dir symlink pointing elsewhere
             if [ -L "$target" ] && [ "$(readlink "$target")" != "$src" ]; then
-                conflicts["$runtime_dir/$component"]="symlink→$(readlink "$target")"
+                _conflict_set "$runtime_dir/$component" "symlink→$(readlink "$target")"
                 continue
             fi
             # Count items in target not present in src
@@ -1067,7 +1088,7 @@ detect_conflicts() {
                 [ -e "$src/$name" ] || { count=$((count+1)); items="$items $name"; }
             done
             if [ "$count" -gt 0 ]; then
-                conflicts["$runtime_dir/$component"]="$count external:$items"
+                _conflict_set "$runtime_dir/$component" "$count external:$items"
             fi
         done
     done
@@ -1075,10 +1096,11 @@ detect_conflicts() {
 }
 
 print_conflict_table() {
+    local _i
     echo ""
     echo "Found existing content in the following locations:"
-    for key in "${!conflicts[@]}"; do
-        echo "  $key  (${conflicts[$key]})"
+    for _i in "${!conflict_keys[@]}"; do
+        echo "  ${conflict_keys[$_i]}  (${conflict_vals[$_i]})"
     done
     echo ""
     echo "Choose install mode for all conflicting locations:"
@@ -1101,7 +1123,8 @@ install_component() {
 
     # Per-item mode: skip targets flagged as conflicting or when CONFLICT_MODE=per-item
     local component_key="$base_dir/$target_name"
-    if [ "$CONFLICT_MODE" = "per-item" ] && [ "$MODE" = "symlink" ] &&        { [ -n "${conflicts[$component_key]+_}" ] || [ -d "$target" ] || [ -L "$target" ]; }; then
+    if [ "$CONFLICT_MODE" = "per-item" ] && [ "$MODE" = "symlink" ] && \
+       { _conflict_has "$component_key" || [ -d "$target" ] || [ -L "$target" ]; }; then
         if [ "$DRY_RUN" = true ]; then
             echo -e "${BLUE}  Would per-item symlink into: ${target}${NC}"
         else
@@ -1264,7 +1287,7 @@ HOOK
 # Scan for conflicts before first install_component call
 if [ "$MODE" = "symlink" ]; then
     detect_conflicts
-    if [ ${#conflicts[@]} -gt 0 ]; then
+    if [ ${#conflict_keys[@]} -gt 0 ]; then
         if [ "$DRY_RUN" = true ]; then
             print_conflict_table
             _default_mode="${CONFLICT_MODE:-per-item}"


### PR DESCRIPTION
Supersedes #738 (opened from a fork; fixes pushed to a notque-owned branch so CI + merge can run).

Brings in the fork's per-item symlink mode + post-merge auto-sync, **plus** fixes for the issues found in review of #738:

- **C1/M1 (critical):** per-item, mirror, and post-merge globs were `"$src"/*/` (directories only), silently omitting all top-level files. `commands/` (0 subdirs) installed nothing; `scripts`/`hooks`/`agents` lost most content. Now `"$src"/*` links files and dirs.
- **C2 (critical):** the `skip` conflict choice was set but never read â€” it fell through to the `FORCE rm -rf` path and destroyed the external content it promised to keep. `install_component` now honors `skip` and leaves flagged locations untouched while still installing conflict-free ones.
- **M2:** `install_git_hook` overwrote any pre-existing `.git/hooks/post-merge` unconditionally; now skips when the file lacks the vexjoy marker.
- `detect_conflicts` now counts external files, not just dirs.

Verified by sandboxed runs: per-item links all 10 command files while preserving an external file; skip leaves a conflicting dir untouched and still installs conflict-free dirs; M2 guard preserves a foreign post-merge hook.
