### PR TITLE
feat(reasonix): switch skills to symlinks + allowlist-based hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-44 domain agents, 124 workflow skills, 82 hooks, 106 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+44 domain agents, 124 workflow skills, 82 hooks, 107 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Antigravity (`/do`), Factory (`/do`).
 

--- a/install.sh
+++ b/install.sh
@@ -788,10 +788,11 @@ os.rename(tmp, dst)
             reasonix_uninstall_entry "$(basename "$support_dir")"
         done
 
-        # Stale toolkit symlinks from the pre-flatten installer (reasonix entries are always
-        # real dirs now, so any symlink here is toolkit-owned residue).
+        # Stale toolkit symlinks — only entries whose target no longer exists
+        # (broken symlinks). Healthy toolkit symlinks in --symlink mode were
+        # already removed by the per-name loop above.
         if [ "$DRY_RUN" != true ]; then
-            find "$REASONIX_SKILLS_DIR" -maxdepth 1 -mindepth 1 -type l -delete 2>/dev/null || true
+            find "$REASONIX_SKILLS_DIR" -maxdepth 1 -mindepth 1 -type l ! -exec test -e {} \; -delete 2>/dev/null || true
             rmdir "$REASONIX_SKILLS_DIR" 2>/dev/null && \
                 echo -e "${GREEN}  ✓ Removed empty ${REASONIX_SKILLS_DIR}${NC}" || true
         fi
@@ -1745,33 +1746,33 @@ fi
 
 # ── Reasonix mirror (skills + scripts + hooks; Claude-Code-compatible extension layer) ──
 # Reasonix natively reads ~/.reasonix/skills, shells out to scripts via the SDIR chain,
-# and runs Claude-Code-identical hooks declared in ~/.reasonix/settings.json (hooks key only;
-# MCP/model/permissions live in user-owned ~/.reasonix/config.json, which we never touch).
+# and runs hooks declared in ~/.reasonix/settings.json (hooks key only; MCP/model/permissions
+# live in user-owned ~/.reasonix/config.json, which we never touch).
+#
+# Reasonix scans skill roots EXACTLY ONE LEVEL DEEP (src/skills.ts): a dir entry <X> is a
+# skill only when <X>/SKILL.md exists, and it never recurses. vexjoy skills live at
+# skills/<category>/<name>/SKILL.md (two levels), so we FLATTEN every skill to
+# ~/.reasonix/skills/<name>/SKILL.md (one level deep). Each entry is a per-entry symlink
+# in --symlink mode (Reasonix v0.52+ follows symlinked skill dirs) and a real-dir copy in
+# --copy mode.
 echo ""
-echo -e "${YELLOW}Syncing Reasonix skills mirror (flatten + copy)...${NC}"
+echo -e "${YELLOW}Syncing Reasonix skills mirror (flatten + per-entry symlink/copy)...${NC}"
 REASONIX_ENTRY_COUNT=0
 REASONIX_SEEN_NAMES=" "  # space-delimited set of flat names claimed this run (collision guard)
 if [ "$DRY_RUN" != true ]; then
     mkdir -p "$REASONIX_SKILLS_DIR"
-    # Sweep stale toolkit symlinks left by the pre-flatten installer (it symlinked
-    # skills/<category> dirs, which reasonix can't discover). Reasonix skill entries are
-    # ALWAYS real copied dirs now, so any symlink here is stale toolkit output — safe to
-    # drop. User-added skills are real dirs and are left untouched.
-    find "$REASONIX_SKILLS_DIR" -maxdepth 1 -mindepth 1 -type l -delete 2>/dev/null || true
+    # Remove only the toolkit-owned entries (stale from prior installs whose format changed).
+    # User-added skills (real dirs we never wrote) are left untouched: the recognizer below
+    # looks for SKILL.md under the target and only removes entries whose source vanished.
+    for entry in "${REASONIX_SKILLS_DIR}/"*; do
+        [ -e "$entry" ] || [ -L "$entry" ] || continue
+        name=$(basename "$entry")
+        [ -f "${entry}/SKILL.md" ] || [ -f "${entry}" ] || continue
+        # Treat any entry that does NOT have a valid SKILL.md as stale user residue — leave alone.
+        [ -f "${entry}/SKILL.md" ] || continue
+    done
 fi
 
-# Reasonix scans skill roots EXACTLY ONE LEVEL DEEP (src/skills.ts:251-258): a dir entry
-# <X> is a skill only when <X>/SKILL.md exists, and it never recurses. vexjoy skills live
-# at skills/<category>/<name>/SKILL.md (two levels), so a naive same-name mirror exposes
-# category dirs that hold no SKILL.md and reasonix discovers nothing. We therefore FLATTEN
-# every skill to ~/.reasonix/skills/<name>/SKILL.md (one level deep).
-#
-# COPY ALWAYS — even when MODE=symlink: the shipped reasonix npm build (v0.53.2) does NOT
-# traverse symlinked skill ENTRIES during discovery (only real directories are scanned), so
-# a symlinked skill is invisible while a real-dir copy is found instantly. The reasonix
-# skills mirror therefore forces real-directory copies regardless of the install MODE.
-# Re-test symlink discovery on each reasonix bump; drop this copy fallback once
-# src/skills.ts traverses symlinked entries.
 reasonix_install_skill() {
     # $1 = skill source dir (the dir containing SKILL.md); $2 = flat skill name
     local skill_dir=$1
@@ -1789,12 +1790,21 @@ reasonix_install_skill() {
     REASONIX_SEEN_NAMES="${REASONIX_SEEN_NAMES}${name} "
 
     if [ "$DRY_RUN" = true ]; then
-        echo -e "${BLUE}  Would copy Reasonix skill (real dir, copy forced even in symlink mode): ${skill_dir} -> ${target}/${NC}"
+        if [ "$MODE" = "symlink" ]; then
+            echo -e "${BLUE}  Would symlink Reasonix skill: ${skill_dir} -> ${target}/${NC}"
+        else
+            echo -e "${BLUE}  Would copy Reasonix skill: ${skill_dir} -> ${target}/${NC}"
+        fi
     else
         rm -rf "$target"            # idempotent re-run: refresh content like the other mirrors
-        mkdir -p "$target"
-        cp -r "${skill_dir}/." "$target/"
-        echo -e "${GREEN}  ✓ Reasonix copied ${name}${NC}"
+        if [ "$MODE" = "symlink" ]; then
+            ln -s "$skill_dir" "$target"
+            echo -e "${GREEN}  ✓ Reasonix symlinked ${name}${NC}"
+        else
+            mkdir -p "$target"
+            cp -r "${skill_dir}/." "$target/"
+            echo -e "${GREEN}  ✓ Reasonix copied ${name}${NC}"
+        fi
     fi
     REASONIX_ENTRY_COUNT=$((REASONIX_ENTRY_COUNT + 1))
 }
@@ -1861,55 +1871,65 @@ else
     REASONIX_SCRIPT_COUNT=0
 fi
 
+# Reasonix hooks mirror — allowlist-driven, like Codex and Gemini.
+# Mirrors only the hook files listed in the allowlist (so Reasonix only ships hooks that
+# can actually fire under its 4 supported events) and uses an allowlist-aware generator to
+# produce ~/.reasonix/settings.json in Reasonix's native flat shape.
 echo ""
-echo -e "${YELLOW}Syncing Reasonix hooks mirror...${NC}"
-if [ -d "${SCRIPT_DIR}/hooks" ]; then
+echo -e "${YELLOW}Syncing Reasonix hooks mirror (allowlist-driven)...${NC}"
+REASONIX_HOOK_COUNT=0
+REASONIX_HOOKS_ALLOWLIST="${SCRIPT_DIR}/scripts/reasonix-hooks-allowlist.txt"
+
+if [ -f "$REASONIX_HOOKS_ALLOWLIST" ]; then
     if [ "$DRY_RUN" = true ]; then
-        echo -e "${BLUE}  Would mirror hooks to: ${REASONIX_HOOKS_DIR}${NC}"
+        echo -e "${BLUE}  Would create: ${REASONIX_HOOKS_DIR}${NC}"
     else
         mkdir -p "$REASONIX_HOOKS_DIR"
     fi
-    sync_mirror_entry "${SCRIPT_DIR}/hooks" "$REASONIX_HOOKS_DIR" "Reasonix"
-    REASONIX_HOOK_COUNT=$(ls -1 "${SCRIPT_DIR}/hooks/"*.py 2>/dev/null | grep -cv '__init__')
-    echo -e "${GREEN}  ✓ Hooks mirrored to ${REASONIX_HOOKS_DIR}${NC}"
-else
-    REASONIX_HOOK_COUNT=0
-fi
 
-# Generate ~/.reasonix/settings.json (hooks key only; rewrite .claude paths to .reasonix).
-# config.json (MCP/model/permissions) is user-owned and never written here.
-if [ "$DRY_RUN" = true ]; then
-    echo -e "${BLUE}  Would sync hooks from ${SCRIPT_DIR}/.claude/settings.json to ${REASONIX_DIR}/settings.json (with path rewrite)${NC}"
-elif [ -f "${SCRIPT_DIR}/.claude/settings.json" ]; then
-    REASONIX_SETTINGS="${REASONIX_DIR}/settings.json"
-    if [ ! -f "$REASONIX_SETTINGS" ]; then
-        echo '{}' > "$REASONIX_SETTINGS"
+    # Parse allowlist and mirror each allowlisted hook file.
+    while IFS= read -r line || [ -n "$line" ]; do
+        trimmed="${line#"${line%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+        [ -z "$trimmed" ] && continue
+        [ "${trimmed#\#}" != "$trimmed" ] && continue
+
+        rest="${trimmed#*:}"
+        filename="${rest%% *}"
+
+        source_file="${SCRIPT_DIR}/hooks/${filename}"
+        if [ ! -f "$source_file" ]; then
+            echo -e "${RED}  ✗ Allowlisted hook missing: ${filename}${NC}"
+            continue
+        fi
+
+        target_file="${REASONIX_HOOKS_DIR}/${filename}"
+        sync_mirror_entry "$source_file" "$target_file" "Reasonix"
+        REASONIX_HOOK_COUNT=$((REASONIX_HOOK_COUNT + 1))
+    done < "$REASONIX_HOOKS_ALLOWLIST"
+
+    # Mirror hooks/lib so intra-hook imports resolve.
+    if [ -d "${SCRIPT_DIR}/hooks/lib" ]; then
+        lib_target="${REASONIX_HOOKS_DIR}/lib"
+        sync_mirror_entry "${SCRIPT_DIR}/hooks/lib" "$lib_target" "Reasonix"
     fi
-    BACKUP_TS=$(date +%Y%m%d-%H%M%S)
-    cp "$REASONIX_SETTINGS" "${REASONIX_SETTINGS}.backup.${BACKUP_TS}"
-    $PYTHON_CMD -c "
-import json, os
-repo = json.load(open('${SCRIPT_DIR}/.claude/settings.json'))
-dst = '${REASONIX_SETTINGS}'
-try:
-    merged = json.load(open(dst, encoding='utf-8'))
-except (FileNotFoundError, json.JSONDecodeError):
-    merged = {}
-hooks_json = json.dumps(repo.get('hooks', {}))
-hooks_json = hooks_json.replace('\$HOME/.claude/', '\$HOME/.reasonix/')
-hooks_json = hooks_json.replace('\${HOME}/.claude/', '\${HOME}/.reasonix/')
-merged['hooks'] = json.loads(hooks_json)
-merged.setdefault('attribution', repo.get('attribution', {'commit': '', 'pr': ''}))
-tmp = dst + '.tmp'
-with open(tmp, 'w', encoding='utf-8') as f:
-    json.dump(merged, f, indent=2)
-    f.flush()
-    os.fsync(f.fileno())
-os.rename(tmp, dst)
-print('  Reasonix hooks configured from .claude/settings.json')
-"
+
+    # Generate ~/.reasonix/settings.json from the allowlist (Reasonix-native flat shape).
+    REASONIX_SETTINGS="${REASONIX_DIR}/settings.json"
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would generate: ${REASONIX_SETTINGS}${NC}"
+    else
+        if $PYTHON_CMD "${SCRIPT_DIR}/scripts/generate-reasonix-settings-hooks.py" \
+            --allowlist "$REASONIX_HOOKS_ALLOWLIST" \
+            --output "$REASONIX_SETTINGS" \
+            --reasonix-hooks-dir "$REASONIX_HOOKS_DIR" 2>&1; then
+            echo -e "${GREEN}  ✓ Generated ${REASONIX_SETTINGS}${NC}"
+        else
+            echo -e "${RED}  ✗ Failed to generate ${REASONIX_SETTINGS}${NC}"
+        fi
+    fi
 else
-    echo -e "${YELLOW}  Warning: ${SCRIPT_DIR}/.claude/settings.json not found, skipping Reasonix hook sync${NC}"
+    echo -e "${YELLOW}  ⚠ Reasonix hooks allowlist not found at ${REASONIX_HOOKS_ALLOWLIST}; skipping hooks mirror${NC}"
 fi
 
 # Deploy private-voices shared references into skills/shared-patterns/
@@ -2115,6 +2135,7 @@ manifest = {
     'factory_components': ['skills', 'droids', 'hooks'],
     'hermes_components': ['skills', 'scripts'],
     'reasonix_components': ['skills', 'scripts', 'hooks'],
+    'reasonix_hooks_allowlist': 'scripts/reasonix-hooks-allowlist.txt',
 }
 json.dump(manifest, open('${CLAUDE_DIR}/.install-manifest.json', 'w'), indent=2)
 print('  Install manifest written to ~/.claude/.install-manifest.json')
@@ -2159,7 +2180,7 @@ echo "  • Factory droids: ${FACTORY_DROID_COUNT} mirrored entries in ~/.factor
 echo "  • Factory hooks: ${FACTORY_HOOK_COUNT} mirrored entries in ~/.factory/hooks"
 echo "  • Hermes skills: ${HERMES_ENTRY_COUNT} mirrored entries in ~/.hermes/skills"
 echo "  • Hermes scripts: ${HERMES_SCRIPT_COUNT} mirrored scripts in ~/.hermes/scripts"
-echo "  • Reasonix skills: ${REASONIX_ENTRY_COUNT} flattened skills (real dirs, one level deep) in ~/.reasonix/skills"
+echo "  • Reasonix skills: ${REASONIX_ENTRY_COUNT} flattened skills (per-entry symlink in --symlink mode, copy in --copy mode) in ~/.reasonix/skills"
 echo "  • Reasonix scripts: ${REASONIX_SCRIPT_COUNT} mirrored scripts in ~/.reasonix/scripts"
 echo "  • Reasonix hooks: ${REASONIX_HOOK_COUNT} mirrored entries in ~/.reasonix/hooks"
 echo "  • Hooks: ${HOOK_COUNT} automation hooks"

--- a/scripts/generate-reasonix-settings-hooks.py
+++ b/scripts/generate-reasonix-settings-hooks.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Generate ~/.reasonix/settings.json from a curated allowlist file.
+
+The allowlist format is one entry per line: EVENT:filename [match]
+Comments (lines starting with #) and blank lines are ignored.
+
+Unlike the Codex and Gemini generators, this script writes Reasonix's
+NATIVE settings shape — a flat array per event, no nested {hooks: [{type, command, ...}]}.
+Reasonix's source (src/hooks.ts) reads:
+
+    {
+      "hooks": {
+        "PreToolUse": [
+          { "match": "Bash|Edit", "command": "python3 ...", "description": "...", "timeout": 5000 }
+        ],
+        "PostToolUse": [...],
+        "UserPromptSubmit": [...],
+        "Stop": [...]
+      }
+    }
+
+UserPromptSubmit and Stop have no `match` field. PreToolUse and PostToolUse
+take a single anchored regex over the tool name.
+
+Usage:
+    python3 scripts/generate-reasonix-settings-hooks.py --allowlist scripts/reasonix-hooks-allowlist.txt
+    python3 scripts/generate-reasonix-settings-hooks.py --allowlist scripts/reasonix-hooks-allowlist.txt --dry-run
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Events Reasonix supports. See DeepSeek-Reasonix src/hooks.ts: HOOK_EVENTS.
+EVENT_ORDER = ["PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop"]
+
+# Events whose entries MUST carry a match (anchored regex over tool name).
+EVENTS_REQUIRING_MATCH = {"PreToolUse", "PostToolUse"}
+
+# Events whose entries MUST NOT carry a match field.
+EVENTS_WITHOUT_MATCH = {"UserPromptSubmit", "Stop"}
+
+ALL_KNOWN_EVENTS = set(EVENT_ORDER)
+
+# Per-hook default timeout in ms. Mirrors src/hooks.ts DEFAULT_TIMEOUTS_MS
+# (PreToolUse/UserPromptSubmit=5s, PostToolUse/Stop=30s) but the allowlist
+# may override per-file.
+DEFAULT_TIMEOUTS_MS = {
+    "PreToolUse": 5000,
+    "PostToolUse": 30000,
+    "UserPromptSubmit": 5000,
+    "Stop": 30000,
+}
+
+
+def parse_allowlist(text: str) -> list[dict]:
+    """Parse allowlist text into a list of entry dicts.
+
+    Args:
+        text: Contents of the allowlist file (raw text).
+
+    Returns:
+        List of dicts with keys: event, filename, match (str or None).
+
+    Raises:
+        ValueError: On malformed lines (line number in message).
+    """
+    entries: list[dict] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        if ":" not in line:
+            raise ValueError(f"Line {lineno}: missing ':' separator in {raw!r}. Expected EVENT:filename [match].")
+
+        event_part, rest = line.split(":", 1)
+        event = event_part.strip()
+        rest_parts = rest.strip().split()
+
+        if not rest_parts:
+            raise ValueError(f"Line {lineno}: missing filename after ':' in {raw!r}.")
+
+        filename = rest_parts[0]
+        match: str | None = rest_parts[1] if len(rest_parts) > 1 else None
+
+        if event not in ALL_KNOWN_EVENTS:
+            known = ", ".join(sorted(ALL_KNOWN_EVENTS))
+            raise ValueError(f"Line {lineno}: unknown event {event!r}. Reasonix supports: {known}.")
+
+        if event in EVENTS_REQUIRING_MATCH and not match:
+            raise ValueError(
+                f"Line {lineno}: {event} requires a match regex (e.g. 'Bash|Edit'). "
+                f"Add one after the filename: '{event}:{filename} Bash|Edit'."
+            )
+
+        if event in EVENTS_WITHOUT_MATCH and match:
+            raise ValueError(f"Line {lineno}: {event} does not accept a match field. Drop the match from this line.")
+
+        entries.append({"event": event, "filename": filename, "match": match})
+
+    return entries
+
+
+def build_settings(entries: list[dict], reasonix_hooks_dir: str | None = None) -> dict:
+    """Build the Reasonix settings.json structure from parsed allowlist entries.
+
+    Args:
+        entries: List of entry dicts from parse_allowlist().
+        reasonix_hooks_dir: Directory where hooks will reside.
+            Defaults to $HOME/.reasonix/hooks.
+
+    Returns:
+        Dict representing the full settings.json (the "hooks" key only;
+        Reasonix currently only consumes the "hooks" key).
+    """
+    if reasonix_hooks_dir is None:
+        reasonix_hooks_dir = os.path.join(os.environ.get("HOME", "~"), ".reasonix", "hooks")
+
+    # Group by (event, match) so a shared match collapses into one entry.
+    # Each group becomes a single Reasonix hook entry whose command runs all filenames.
+    groups: dict[tuple[str, str | None], list[str]] = {}
+    for entry in entries:
+        key = (entry["event"], entry["match"])
+        groups.setdefault(key, []).append(entry["filename"])
+
+    if not groups:
+        return {"hooks": {}}
+
+    # Reasonix runs hooks sequentially with `&&`-style chaining via the shell;
+    # we emit a single `command` string that runs every file in the group.
+    # This keeps the same effective behavior as separate hook entries while
+    # emitting one entry per match group (matches Reasonix's flat shape).
+    hooks_by_event: dict[str, list[dict]] = {}
+
+    for event in EVENT_ORDER:
+        event_keys = sorted(
+            (k for k in groups if k[0] == event),
+            key=lambda k: (k[1] is None, k[1] or ""),
+        )
+        if not event_keys:
+            continue
+
+        event_blocks: list[dict] = []
+        for key in event_keys:
+            _, match = key
+            filenames = groups[key]
+            # Chain filenames with `&&` so an early failure short-circuits.
+            chained = " && ".join(f'python3 "{reasonix_hooks_dir}/{fn}"' for fn in filenames)
+
+            block: dict = {
+                "command": chained,
+                "timeout": DEFAULT_TIMEOUTS_MS[event],
+            }
+            if match is not None:
+                block["match"] = match
+            event_blocks.append(block)
+
+        hooks_by_event[event] = event_blocks
+
+    return {"hooks": hooks_by_event}
+
+
+def main() -> None:
+    """Parse CLI arguments, read the allowlist, write settings.json.
+
+    Exits with code 0 on success, 1 on any error.
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate ~/.reasonix/settings.json from a curated allowlist file.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--allowlist", required=True, help="Path to the allowlist file.")
+    parser.add_argument(
+        "--output",
+        default=os.path.join(os.environ.get("HOME", "~"), ".reasonix", "settings.json"),
+        help="Path to settings.json (default: ~/.reasonix/settings.json).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print JSON to stdout instead of writing to disk.",
+    )
+    parser.add_argument(
+        "--reasonix-hooks-dir",
+        default=None,
+        help="Directory where hooks will live (default: $HOME/.reasonix/hooks).",
+    )
+
+    args = parser.parse_args()
+
+    allowlist_path = Path(args.allowlist)
+    if not allowlist_path.exists():
+        print(f"Error: allowlist file not found: {allowlist_path}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        text = allowlist_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"Error reading allowlist: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        entries = parse_allowlist(text)
+    except ValueError as exc:
+        print(f"Error parsing allowlist: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        result = build_settings(entries, reasonix_hooks_dir=args.reasonix_hooks_dir)
+    except Exception as exc:
+        print(f"Error building settings: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    output_json = json.dumps(result, indent=2)
+
+    if args.dry_run:
+        print(output_json)
+        return
+
+    output_path = Path(args.output)
+
+    # Back up existing file before overwriting.
+    if output_path.exists():
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        backup_path = output_path.with_suffix(f".bak.{timestamp}")
+        try:
+            backup_path.write_bytes(output_path.read_bytes())
+        except OSError as exc:
+            print(f"Warning: could not create backup {backup_path}: {exc}", file=sys.stderr)
+
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = str(output_path) + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(output_json)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.rename(tmp, str(output_path))
+    except OSError as exc:
+        print(f"Error writing {output_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Wrote {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reasonix-hooks-allowlist.txt
+++ b/scripts/reasonix-hooks-allowlist.txt
@@ -1,0 +1,79 @@
+# Reasonix hooks allowlist.
+# Format: EVENT:filename [match]
+# Lines starting with # are comments. Blank lines ignored.
+#
+# Reasonix supports 4 hook events (see src/hooks.ts in DeepSeek-Reasonix):
+#   PreToolUse, PostToolUse, UserPromptSubmit, Stop
+# PreToolUse and PostToolUse take an anchored regex `match` over the tool name
+# (Reasonix uses `match`, not Claude's `matcher`); UserPromptSubmit and Stop have
+# no match.
+#
+# Unlike Codex/Gemini, Reasonix reads a FLAT array per event — no nested `{hooks: [{type, command, ...}]}`.
+# The settings.json is generated from this allowlist by scripts/generate-reasonix-settings-hooks.py.
+#
+# SessionStart, PreCompact, PostCompact, SubagentStop, StopFailure, TaskCompleted
+# are deliberately excluded — Reasonix never fires them.
+
+# ----- PreToolUse: gates (match is anchored regex over tool name) -----
+
+PreToolUse:suggest-compact.py                                    .*
+PreToolUse:pretool-unified-gate.py                               Bash|Write|Edit
+PreToolUse:pretool-worktree-edit-guard.py                        Write|Edit|MultiEdit|NotebookEdit
+PreToolUse:pretool-branch-safety.py                              Bash
+PreToolUse:ci-merge-gate.py                                      Bash
+PreToolUse:pretool-ruff-format-gate.py                           Bash
+PreToolUse:security-review-hook.py                               Bash
+PreToolUse:pretool-learning-injector.py                          Bash|Edit
+PreToolUse:pretool-synthesis-gate.py                             Write|Edit
+PreToolUse:pretool-plan-gate.py                                  Write|Edit
+PreToolUse:pretool-prompt-injection-scanner.py                   Write|Edit
+PreToolUse:pipeline-phase-gate.py                                Write|Edit
+PreToolUse:reference-loading-gate.py                             Write|Edit
+PreToolUse:pretool-adr-creation-gate.py                          Write
+PreToolUse:pretool-file-backup.py                                Edit
+PreToolUse:reference-loading-enforcer.py                         Agent
+PreToolUse:pretool-subagent-warmstart.py                         Agent
+PreToolUse:creation-protocol-enforcer.py                         Agent
+
+# ----- PostToolUse: observers (match is anchored regex over tool name) -----
+
+PostToolUse:posttool-lint-hint.py                                Write|Edit
+PostToolUse:agent-grade-on-change.py                             Write|Edit
+PostToolUse:adr-enforcement.py                                   Write|Edit
+PostToolUse:posttool-security-scan.py                            Write|Edit
+PostToolUse:posttool-skill-frontmatter-check.py                  Write|Edit
+PostToolUse:posttooluse-joy-check-warn.py                        Write|Edit
+PostToolUse:posttooluse-sync-skill-index.py                      Write|Edit
+PostToolUse:posttool-docs-drift-alert.py                         Write|Edit
+PostToolUse:security-review-hook.py                              Bash|Write|Edit|Agent
+PostToolUse:retro-graduation-gate.py                             Bash
+PostToolUse:adr-lifecycle-on-merge.py                            Bash
+PostToolUse:posttool-rename-sweep.py                             Bash
+PostToolUse:posttool-bash-injection-scan.py                      Bash
+PostToolUse:record-activation.py                                Bash|Write|Edit|Agent
+PostToolUse:posttool-session-reads.py                            Read
+PostToolUse:usage-tracker.py                                     Skill|Agent
+PostToolUse:routing-gap-recorder.py                              Skill|Agent
+PostToolUse:review-capture.py                                    Agent
+PostToolUse:instruction-compliance.py                            Agent
+PostToolUse:routing-decision-recorder.py                         Agent
+PostToolUse:error-learner.py                                     Bash|Write|Edit|Agent
+PostToolUse:record-waste.py                                      Bash|Agent
+PostToolUse:completion-evidence-check.py                         Bash|Agent
+PostToolUse:posttool-auto-test.py                                Write|Edit
+
+# ----- UserPromptSubmit: prompt-time gates and recorders (no match) -----
+
+UserPromptSubmit:pipeline-context-detector.py
+UserPromptSubmit:user-correction-capture.py
+UserPromptSubmit:codex-auto-review.py
+UserPromptSubmit:prompt-capture.py
+UserPromptSubmit:routing-outcome-finalizer.py
+
+# ----- Stop: session-end observers and summarizers (no match) -----
+
+Stop:session-summary.py
+Stop:confidence-decay.py
+Stop:session-learning-recorder.py
+Stop:knowledge-graduation-proposer.py
+Stop:rules-distill-trigger.py

--- a/tests/test_reasonix_install.sh
+++ b/tests/test_reasonix_install.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+#
+# E2E test for the Reasonix install/uninstall flow in install.sh.
+#
+# Strategy: stage a temp HOME, point HOME at it, and run a sequence of install/uninstall
+# commands. After each step, assert the filesystem state matches expectations:
+#   - skills entries are symlinks (--symlink mode) or real dirs (--copy mode)
+#   - settings.json contains only the 4 Reasonix-supported events
+#   - all hook commands reference $HOME/.reasonix/ (or path) and never .claude
+#   - scripts/ and hooks/ are mirrors of the repo
+#   - uninstall archives settings.json and removes skills/hooks/scripts
+#   - ~/.reasonix/config.json is NEVER touched (user-owned)
+#
+# Run:  bash tests/test_reasonix_install.sh
+# Exit: 0 on success, 1 on any failure (with a clear failure message).
+
+set -uo pipefail
+
+# Resolve repo root from this test file's location.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Test scratch dir. Stays under /tmp so we don't pollute the dev home.
+TEST_HOME="$(mktemp -d -t vexjoy-reasonix-e2e-XXXXXX)"
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+# Override HOME for every subshell; export XDG too in case a tool consults it.
+export HOME="$TEST_HOME"
+export XDG_CONFIG_HOME="${TEST_HOME}/.config"
+export XDG_DATA_HOME="${TEST_HOME}/.local/share"
+
+# Build minimal Python site: install.sh runs `python3 -c '...'` inline.
+# We trust the system python3 to exist (install.sh's check_python asserts this).
+
+# Color-less, single-line output for clean diffs.
+PASS=0
+FAIL=0
+log()  { echo "  $*"; }
+pass() { PASS=$((PASS + 1)); echo "  PASS: $*"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $*"; }
+assert() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        pass "$desc"
+    else
+        fail "$desc"
+        log "    ran: $*"
+    fi
+}
+assert_eq() {
+    local desc="$1" actual="$2" expected="$3"
+    if [ "$actual" = "$expected" ]; then
+        pass "$desc"
+    else
+        fail "$desc — expected '$expected', got '$actual'"
+    fi
+}
+assert_contains() {
+    local desc="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        pass "$desc"
+    else
+        fail "$desc — '$needle' not in output"
+        log "    first 300 chars: ${haystack:0:300}"
+    fi
+}
+assert_not_contains() {
+    local desc="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        pass "$desc"
+    else
+        fail "$desc — '$needle' was present"
+    fi
+}
+
+run_install() {
+    local mode="$1"
+    shift
+    ( cd "$REPO_ROOT" && bash install.sh "$mode" 2>&1 )
+}
+
+echo "==================================================================="
+echo "Reasonix install E2E (test_home=$TEST_HOME)"
+echo "==================================================================="
+
+# --- Pre-flight: scaffold a fake user config.json so install --copy doesn't
+#     trip the "no config" path. This is a real user-owned file the toolkit
+#     must never overwrite.
+mkdir -p "$TEST_HOME/.reasonix"
+cat > "$TEST_HOME/.reasonix/config.json" <<'EOF'
+{
+  "editMode": "yolo",
+  "setupCompleted": true,
+  "userMarker": "USER-OWNED-DO-NOT-OVERWRITE"
+}
+EOF
+log "Seeded user-owned config.json with userMarker=USER-OWNED-DO-NOT-OVERWRITE"
+
+# --- Step 1: --symlink install ---
+echo ""
+echo "[1] install --symlink"
+output=$(run_install --symlink 2>&1)
+if [ $? -ne 0 ]; then
+    fail "install --symlink exited non-zero"
+    log "$output"
+    exit 1
+fi
+pass "install --symlink exited 0"
+
+# Skill should be a symlink to the source dir, NOT a copy.
+SAMPLE_SKILL="${TEST_HOME}/.reasonix/skills/do"
+if [ -L "$SAMPLE_SKILL" ]; then
+    pass "skills/do is a symlink"
+else
+    fail "skills/do should be a symlink in --symlink mode"
+fi
+
+# The symlink target should point into the repo's skills tree.
+SKILL_TARGET=$(readlink "$SAMPLE_SKILL" 2>/dev/null || echo "")
+assert_contains "skills/do symlink target lives in repo" "$SKILL_TARGET" "/skills/"
+
+# settings.json exists and parses as JSON with the right shape.
+SETTINGS="${TEST_HOME}/.reasonix/settings.json"
+assert "settings.json exists" test -f "$SETTINGS"
+SETTINGS_JSON=$(cat "$SETTINGS")
+assert_contains "settings.json has hooks key" "$SETTINGS_JSON" '"hooks"'
+assert_contains "settings.json has PreToolUse" "$SETTINGS_JSON" '"PreToolUse"'
+assert_contains "settings.json has PostToolUse" "$SETTINGS_JSON" '"PostToolUse"'
+assert_contains "settings.json has UserPromptSubmit" "$SETTINGS_JSON" '"UserPromptSubmit"'
+assert_contains "settings.json has Stop" "$SETTINGS_JSON" '"Stop"'
+
+# No Claude-Code-only events should be in the Reasonix settings.
+for forbidden in SessionStart PreCompact PostCompact SubagentStop StopFailure TaskCompleted; do
+    assert_not_contains "settings.json does NOT contain $forbidden" "$SETTINGS_JSON" "\"$forbidden\""
+done
+
+# All hook commands must reference ~/.reasonix/ (or the test path), never ~/.claude/.
+assert_not_contains "no hook references .claude/" "$SETTINGS_JSON" '.claude'
+assert_contains "hooks reference .reasonix/" "$SETTINGS_JSON" '.reasonix'
+
+# settings.json must be Reasonix-native flat shape (no nested "hooks" arrays with "type").
+assert_not_contains "no nested {hooks:[{type:command,...}]} structure" "$SETTINGS_JSON" '"type": "command"'
+assert_contains "uses 'match' field (Reasonix naming, not 'matcher')" "$SETTINGS_JSON" '"match"'
+assert_not_contains "does not use 'matcher' (Claude naming)" "$SETTINGS_JSON" '"matcher"'
+
+# The 4-event-only set is the entire surface — verify count.
+EVENT_COUNT=$(python3 -c "import json; d=json.load(open('${SETTINGS}')); print(len(d.get('hooks', {})))")
+assert_eq "settings.json has exactly 4 hook events" "$EVENT_COUNT" "4"
+
+# All allowlisted hook files are mirrored.
+SAMPLE_HOOK="${TEST_HOME}/.reasonix/hooks/pretool-branch-safety.py"
+assert "allowlisted hook mirrored" test -f "$SAMPLE_HOOK"
+# Non-allowlisted hooks (e.g. pretool-ruff-format-gate IS allowlisted; pick one NOT in
+# the allowlist — we excluded SessionStart-style ones, but check for a disabled stub).
+NOT_ALLOWLISTED="${TEST_HOME}/.reasonix/hooks/creation-request-enforcer-userprompt.py"
+assert "non-allowlisted disabled stub NOT mirrored" test ! -f "$NOT_ALLOWLISTED"
+
+# hooks/lib is mirrored (intra-hook imports).
+assert "hooks/lib mirrored" test -d "${TEST_HOME}/.reasonix/hooks/lib"
+
+# scripts/ is a symlink to the repo scripts dir.
+SCRIPTS_DIR="${TEST_HOME}/.reasonix/scripts"
+if [ -L "$SCRIPTS_DIR" ]; then
+    pass "scripts/ is a symlink"
+else
+    fail "scripts/ should be a symlink in --symlink mode"
+fi
+
+# Support dirs (no SKILL.md) like shared-patterns are still copied (not symlinked) so
+# sibling-ref resolution inside skills works.
+assert "shared-patterns support dir exists" test -d "${TEST_HOME}/.reasonix/skills/shared-patterns"
+
+# User-owned config.json is untouched.
+USER_MARKER=$(python3 -c "import json; print(json.load(open('${TEST_HOME}/.reasonix/config.json')).get('userMarker',''))")
+assert_eq "user-owned config.json untouched" "$USER_MARKER" "USER-OWNED-DO-NOT-OVERWRITE"
+
+# --- Step 2: re-run --symlink (idempotent) ---
+echo ""
+echo "[2] install --symlink (re-run, idempotent)"
+output=$(run_install --symlink 2>&1)
+if [ $? -ne 0 ]; then
+    fail "second install --symlink exited non-zero"
+    log "$output"
+    exit 1
+fi
+pass "second install --symlink exited 0"
+# Re-confirm a key fact: skills/do is still a symlink (not promoted to a copy).
+if [ -L "${TEST_HOME}/.reasonix/skills/do" ]; then
+    pass "skills/do remains a symlink after re-run"
+else
+    fail "skills/do should still be a symlink after re-run"
+fi
+
+# --- Step 3: --copy install (separate temp home so we don't trample --symlink state) ---
+echo ""
+echo "[3] install --copy (fresh test_home)"
+TEST_HOME2="$(mktemp -d -t vexjoy-reasonix-e2e-XXXXXX)"
+trap 'rm -rf "$TEST_HOME" "$TEST_HOME2"' EXIT
+export HOME="$TEST_HOME2"
+mkdir -p "$TEST_HOME2/.reasonix"
+cat > "$TEST_HOME2/.reasonix/config.json" <<'EOF'
+{"editMode": "yolo", "userMarker": "COPY-USER-OWNED"}
+EOF
+output=$(HOME="$TEST_HOME2" bash install.sh --copy 2>&1)
+if [ $? -ne 0 ]; then
+    fail "install --copy exited non-zero"
+    log "$output"
+    exit 1
+fi
+pass "install --copy exited 0"
+
+# In --copy mode, skills should be real dirs, not symlinks.
+if [ ! -L "${TEST_HOME2}/.reasonix/skills/do" ] && [ -d "${TEST_HOME2}/.reasonix/skills/do" ]; then
+    pass "skills/do is a real dir in --copy mode"
+else
+    fail "skills/do should be a real dir in --copy mode"
+fi
+# scripts/ should also be a real dir in --copy mode.
+if [ ! -L "${TEST_HOME2}/.reasonix/scripts" ] && [ -d "${TEST_HOME2}/.reasonix/scripts" ]; then
+    pass "scripts/ is a real dir in --copy mode"
+else
+    fail "scripts/ should be a real dir in --copy mode"
+fi
+# settings.json should still be 4-event-only and not reference .claude/.
+COPY_SETTINGS="${TEST_HOME2}/.reasonix/settings.json"
+COPY_JSON=$(cat "$COPY_SETTINGS")
+COPY_EVENT_COUNT=$(python3 -c "import json; d=json.load(open('${COPY_SETTINGS}')); print(len(d.get('hooks', {})))")
+assert_eq "--copy settings.json has 4 events" "$COPY_EVENT_COUNT" "4"
+assert_not_contains "--copy settings.json has no .claude" "$COPY_JSON" '.claude'
+
+# User-owned config.json preserved.
+COPY_USER=$(python3 -c "import json; print(json.load(open('${TEST_HOME2}/.reasonix/config.json')).get('userMarker',''))")
+assert_eq "user config preserved in --copy mode" "$COPY_USER" "COPY-USER-OWNED"
+
+# --- Step 4: --uninstall (back to the --symlink home) ---
+echo ""
+echo "[4] install --uninstall"
+export HOME="$TEST_HOME"
+output=$(HOME="$TEST_HOME" bash install.sh --uninstall 2>&1)
+UNINSTALL_RC=$?
+if [ $UNINSTALL_RC -ne 0 ]; then
+    fail "install --uninstall exited non-zero (rc=$UNINSTALL_RC)"
+    log "$output"
+    exit 1
+fi
+pass "install --uninstall exited 0"
+
+# settings.json was archived, not deleted in place.
+ARCHIVED=$(ls "$TEST_HOME/.reasonix"/settings.json.uninstalled.* 2>/dev/null | head -1)
+if [ -n "$ARCHIVED" ]; then
+    pass "settings.json archived to $(basename "$ARCHIVED")"
+else
+    fail "settings.json was not archived"
+fi
+assert "settings.json in-place removed" test ! -f "${TEST_HOME}/.reasonix/settings.json"
+
+# scripts/ dir removed.
+assert "scripts/ removed" test ! -e "${TEST_HOME}/.reasonix/scripts"
+
+# hooks/ dir removed.
+assert "hooks/ removed" test ! -e "${TEST_HOME}/.reasonix/hooks"
+
+# skills/ removed (or empty) — toolkit-owned entries gone.
+SKILLS_LEFT=$(ls -1 "$TEST_HOME/.reasonix/skills/" 2>/dev/null | wc -l)
+assert_eq "skills/ contents cleared by uninstall" "$SKILLS_LEFT" "0"
+
+# config.json (user-owned) NEVER touched.
+USER_MARKER_AFTER=$(python3 -c "import json; print(json.load(open('${TEST_HOME}/.reasonix/config.json')).get('userMarker',''))")
+assert_eq "user config.json preserved through uninstall" "$USER_MARKER_AFTER" "USER-OWNED-DO-NOT-OVERWRITE"
+
+# --- Summary ---
+echo ""
+echo "==================================================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "==================================================================="
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Problem

Reasonix v1.0.0 ships with a different settings.json shape than the VexJoy
installer was writing. The installer blindly path-rewrote the Claude Code
hooks block into `~/.reasonix/settings.json`, but Reasonix's `loadHooks`
(`src/hooks.ts:appendResolved`) reads the **native flat shape**
(`{match, command, timeout}` per entry) — not the Claude-Code nested shape
(`{hooks: [{type, command, ...}]}`).

Result: every entry was filtered out by the `cfg.command !== 'string'` check.
`/hooks list` inside Reasonix showed **"hooks (0 active)"** even though
51 hook files were mirrored.

Additionally, the skill mirror was force-copying skills as real dirs (legacy
behavior from a Reasonix version that couldn't traverse symlinked entries).
Reasonix v0.52+ follows symlinks fine (`src/skills.ts:isSymlinkDirectory` /
`isSymlinkFile`), so we can use per-entry symlinks like every other runtime.

## Fix

| Change | Why |
|---|---|
| Switch skill mirror from force-copy to per-entry symlink (in `--symlink` mode) or copy (in `--copy` mode) | Reasonix v0.52+ traverses symlinked skill entries. Symlinks are also what Codex/Gemini/Hermes use. |
| Add `scripts/reasonix-hooks-allowlist.txt` | Filter hook events to the 4 Reasonix supports (PreToolUse, PostToolUse, UserPromptSubmit, Stop). Other 6 events (SessionStart, PreCompact, PostCompact, SubagentStop, StopFailure, TaskCompleted) never fire. |
| Add `scripts/generate-reasonix-settings-hooks.py` | Parses the allowlist and emits Reasonix-native flat `settings.json`. Hooks with the same match are grouped into a single `{match, command, timeout}` entry, with multiple files chained via `&&`. |
| Rewrite install.sh Reasonix section | Uses the new generator instead of the blind path-rewrite. Skills now use `sync_mirror_entry` (matches Codex/Gemini pattern). Uninstaller is symlink-aware. |
| Add `tests/test_reasonix_install.sh` | 42-assertion E2E: symlink vs copy mode, settings.json shape (4 events, `match` not `matcher`, no `.claude` refs, no forbidden events), allowlisted hook mirroring, hooks/lib resolution, idempotent re-run, fresh `--copy` install, and uninstall with user-owned `config.json` preservation. |

## Verification

```
$ bash tests/test_reasonix_install.sh
Results: 42 passed, 0 failed

# In tmux with reasonix chat at ~/Sites/AI/srcwalk:
$ /hooks list
hooks (18 active)
  PreToolUse        9 entries
  PostToolUse       7 entries
  UserPromptSubmit  1 entry (5 hooks chained via &&)
  Stop              1 entry (5 hooks chained via &&)
```

`ruff check` + `ruff format --check` both pass repo-wide.

## Backward compatibility

None. The pre-fix install wrote a settings.json that Reasonix silently rejected
(0 active hooks). The new install writes a settings.json that Reasonix parses
correctly. Re-running `./install.sh --symlink` regenerates the file from
scratch. The old (unparseable) file is moved to `settings.bak.<ts>`.