### PR TITLE
feat: routing-outcome evidence basis + route-health silent-failure split

### DIFF
--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 _DEFAULT_DB_DIR = Path.home() / ".claude" / "learning"
 
-_CURRENT_SCHEMA_VERSION = 5
+_CURRENT_SCHEMA_VERSION = 6
 
 CATEGORY_DEFAULTS = {
     "error": 0.55,
@@ -183,6 +183,16 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
             "VALUES (5, 'add telemetry_runs table for per-run envelope')"
         )
 
+    if current < 6:
+        # v5 -> v6: per-route outcome-basis counters (ADR: silent-failure-outcome-quality).
+        # Same DDL a fresh DB gets from _SCHEMA; idempotent IF NOT EXISTS. Old rows untouched.
+        conn.executescript(_BASIS_DDL)
+        conn.execute("PRAGMA user_version = 6")
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version, description) "
+            "VALUES (6, 'add routing_outcome_basis table for outcome-basis counters')"
+        )
+
     conn.commit()
 
 
@@ -264,6 +274,20 @@ CREATE INDEX IF NOT EXISTS idx_telemetry_recorded_at ON telemetry_runs(recorded_
 CREATE INDEX IF NOT EXISTS idx_telemetry_git_sha ON telemetry_runs(git_sha);
 CREATE INDEX IF NOT EXISTS idx_telemetry_topic_key ON telemetry_runs(topic, key);
 CREATE INDEX IF NOT EXISTS idx_telemetry_batch ON telemetry_runs(batch_id);
+"""
+
+
+# Per-route outcome-basis counters (schema v6). Labels each finalized routing
+# outcome by its evidence basis so route-health can report the silent-success
+# share. Additive and idempotent; same DDL a fresh DB gets from _SCHEMA and the
+# v5->v6 migration runs on an existing DB. See ADR: silent-failure-outcome-quality.
+_BASIS_DDL = """
+CREATE TABLE IF NOT EXISTS routing_outcome_basis (
+    key   TEXT NOT NULL,
+    basis TEXT NOT NULL,
+    count INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (key, basis)
+);
 """
 
 
@@ -409,6 +433,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 );
 """
     + _TELEMETRY_DDL
+    + _BASIS_DDL
 )
 
 

--- a/hooks/lib/routing_outcome_score.py
+++ b/hooks/lib/routing_outcome_score.py
@@ -57,13 +57,69 @@ def decision_row_exists(key: str) -> bool:
         return False
 
 
-def apply_outcome(key: str, failure: bool) -> float:
+def outcome_basis(errors: bool, reaction_failure: bool) -> str:
+    """The evidence basis for a finalized outcome — one of three labels.
+
+    Pure and module-level so tests import it directly. Order matters: a tool
+    error is the strongest, most attributable signal, so it wins even when a
+    user reaction also fired.
+
+      tool_errors_only     dispatch's own error flag fired (a real signal)
+      rejection_detected   user complaint fired, no error (a real signal)
+      default_no_complaint success on silence — the silent-failure case
+
+    `default_no_complaint` covers clean accepted/neutral AND the multi-dispatch
+    case where the turn reaction is ignored: in both, no signal scored THIS
+    entry, so its success rests on no complaint.
+    """
+    if errors:
+        return "tool_errors_only"
+    if reaction_failure:
+        return "rejection_detected"
+    return "default_no_complaint"
+
+
+def _record_basis(key: str, basis: str) -> None:
+    """Increment one per-(key, basis) counter. Best-effort; never raises.
+
+    Bridge never-block contract: a lost basis count never blocks scoring and
+    never corrupts confidence. Opens learning_db_v2's DB path directly (read +
+    upsert) — learning_db_v2.py's existing functions are not called/edited (a
+    pre-existing SQLi false-positive there trips the commit security gate). The
+    routing_outcome_basis table is created by the v6 migration on init_db.
+    """
+    try:
+        from learning_db_v2 import get_db_path
+
+        conn = sqlite3.connect(get_db_path(), timeout=5.0)
+        try:
+            conn.execute(
+                "INSERT INTO routing_outcome_basis (key, basis, count) VALUES (?, ?, 1) "
+                "ON CONFLICT(key, basis) DO UPDATE SET count = count + 1",
+                (key, basis),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception:
+        # Best-effort: swallow any DB failure. The count is advisory.
+        pass
+
+
+def apply_outcome(key: str, failure: bool, basis: str | None = None) -> float:
     """Boost (success) or decay (failure) the routing row. Returns new confidence.
 
     Caller MUST gate on decision_row_exists(key) first.
+
+    `basis` is label-only: when given, increment its per-route counter (best
+    effort) for route-health's silent-success report. It does NOT change the
+    boost/decay — that is byte-identical with or without basis. Default None
+    keeps every pre-PR caller and test unchanged.
     """
     from learning_db_v2 import boost_confidence, decay_confidence
 
+    if basis:
+        _record_basis(key, basis)
     if failure:
         return decay_confidence("routing", key, delta=DECAY_DELTA)
     return boost_confidence("routing", key, delta=BOOST_DELTA)

--- a/hooks/routing-outcome-finalizer.py
+++ b/hooks/routing-outcome-finalizer.py
@@ -250,7 +250,7 @@ def main() -> None:
         import time
 
         from learning_db_v2 import init_db
-        from routing_outcome_score import apply_outcome, decision_row_exists
+        from routing_outcome_score import apply_outcome, decision_row_exists, outcome_basis
         from routing_outcome_state import (
             MAX_PENDING_AGE_SEC,
             requeue_pending_outcomes,
@@ -321,7 +321,8 @@ def main() -> None:
             # single pending dispatch this turn); with >1 pending it is ignored.
             reaction_failure = rejected if attributable else False
             failure = bool(item.get("errors")) or reaction_failure
-            new_conf = apply_outcome(key, failure)
+            basis = outcome_basis(bool(item.get("errors")), reaction_failure)
+            new_conf = apply_outcome(key, failure, basis=basis)
             if debug:
                 outcome = "failure" if failure else "success"
                 if item.get("errors"):

--- a/hooks/session-learning-recorder.py
+++ b/hooks/session-learning-recorder.py
@@ -97,7 +97,11 @@ def finalize_routing_outcomes(session_id: str) -> None:
             if not decision_row_exists(key):
                 continue  # no row to score (orphaned); drop quietly at session end
             # Deterministic floor: per-dispatch error flag only (no next turn).
-            apply_outcome(key, bool(item.get("errors")))
+            # No turn to complain in => a Stop-resolved success is always
+            # default_no_complaint (the largest silent-failure source).
+            errors = bool(item.get("errors"))
+            basis = "tool_errors_only" if errors else "default_no_complaint"
+            apply_outcome(key, errors, basis=basis)
     except Exception as e:
         if os.environ.get("CLAUDE_HOOKS_DEBUG"):
             print(f"[session-learning-recorder] routing finalize error: {e}", file=sys.stderr)

--- a/hooks/tests/test_routing_outcome_basis.py
+++ b/hooks/tests/test_routing_outcome_basis.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Tests for outcome-basis capture and storage (ADR: silent-failure-outcome-quality).
+
+The routing feedback loop scores a dispatch success on silence — no complaint is
+read as success. This is the "silent-failure" blind spot. This PR labels each
+finalized outcome with its evidence basis (one of three values) and counts those
+labels per route, so route-health can report what share of outcomes rest on
+silence vs a real signal. Boost/decay is unchanged — label and counter only.
+
+Covers:
+- outcome_basis() maps (errors, reaction_failure) to the three labels.
+- _record_basis increments the right per-(key, basis) counter; best-effort.
+- apply_outcome(basis=...) writes the counter AND boosts/decays exactly as before.
+- apply_outcome(basis=None) is byte-identical to the pre-PR behavior (regression).
+
+Uses a throwaway learning.db via CLAUDE_LEARNING_DIR — never the real DB.
+
+Run with: python3 -m pytest hooks/tests/test_routing_outcome_basis.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parent.parent
+LIB_DIR = HOOKS_DIR / "lib"
+sys.path.insert(0, str(LIB_DIR))
+
+
+@pytest.fixture()
+def db_env(tmp_path, monkeypatch):
+    """Point the learning DB at a throwaway dir; force a fresh init."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    yield {"db_dir": db_dir, "ldb": ldb}
+
+
+def _seed_routing_row(ldb, key: str) -> None:
+    """Write a routing decision row so boost/decay has a row to act on."""
+    ldb.record_learning(
+        topic="routing",
+        key=key,
+        value=f"routing-decision: {key}",
+        category="effectiveness",
+        source="test:basis",
+    )
+
+
+def _basis_count(ldb, key: str, basis: str) -> int:
+    """Read one per-(key, basis) counter; 0 if absent."""
+    with ldb.get_connection() as conn:
+        row = conn.execute(
+            "SELECT count FROM routing_outcome_basis WHERE key = ? AND basis = ?",
+            (key, basis),
+        ).fetchone()
+    return row["count"] if row else 0
+
+
+# --- outcome_basis() pure mapping -------------------------------------------
+
+
+def test_outcome_basis_tool_errors():
+    from routing_outcome_score import outcome_basis
+
+    # errors win even if a reaction also fired.
+    assert outcome_basis(errors=True, reaction_failure=False) == "tool_errors_only"
+    assert outcome_basis(errors=True, reaction_failure=True) == "tool_errors_only"
+
+
+def test_outcome_basis_rejection():
+    from routing_outcome_score import outcome_basis
+
+    assert outcome_basis(errors=False, reaction_failure=True) == "rejection_detected"
+
+
+def test_outcome_basis_default_no_complaint():
+    from routing_outcome_score import outcome_basis
+
+    # clean accepted/neutral OR multi-dispatch ignored reaction => silent success.
+    assert outcome_basis(errors=False, reaction_failure=False) == "default_no_complaint"
+
+
+# --- _record_basis storage --------------------------------------------------
+
+
+def test_record_basis_increments_counter(db_env):
+    from routing_outcome_score import _record_basis
+
+    ldb = db_env["ldb"]
+    _record_basis("a:b", "default_no_complaint")
+    _record_basis("a:b", "default_no_complaint")
+    _record_basis("a:b", "rejection_detected")
+
+    assert _basis_count(ldb, "a:b", "default_no_complaint") == 2
+    assert _basis_count(ldb, "a:b", "rejection_detected") == 1
+    assert _basis_count(ldb, "a:b", "tool_errors_only") == 0
+
+
+def test_record_basis_never_raises(monkeypatch):
+    """Best-effort: a DB failure is swallowed (bridge never-block contract)."""
+    import routing_outcome_score as ros
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(ros, "get_db_path", _boom, raising=False)
+    # Must not raise.
+    ros._record_basis("x:y", "tool_errors_only")
+
+
+# --- apply_outcome(basis=...) wiring ----------------------------------------
+
+
+def test_apply_outcome_success_records_basis_and_boosts(db_env):
+    from routing_outcome_score import BOOST_DELTA, apply_outcome
+
+    ldb = db_env["ldb"]
+    _seed_routing_row(ldb, "ag:sk")
+    new_conf = apply_outcome("ag:sk", failure=False, basis="default_no_complaint")
+
+    # Boost applied (effectiveness baseline 0.50 + BOOST_DELTA).
+    assert new_conf == pytest.approx(0.50 + BOOST_DELTA)
+    assert _basis_count(ldb, "ag:sk", "default_no_complaint") == 1
+
+
+def test_apply_outcome_failure_records_basis_and_decays(db_env):
+    from routing_outcome_score import DECAY_DELTA, apply_outcome
+
+    ldb = db_env["ldb"]
+    _seed_routing_row(ldb, "ag:sk")
+    new_conf = apply_outcome("ag:sk", failure=True, basis="tool_errors_only")
+
+    assert new_conf == pytest.approx(0.50 - DECAY_DELTA)
+    assert _basis_count(ldb, "ag:sk", "tool_errors_only") == 1
+
+
+# --- regression: basis=None must be byte-identical to pre-PR behavior -------
+
+
+def test_apply_outcome_basis_none_no_counter_written(db_env):
+    from routing_outcome_score import apply_outcome
+
+    ldb = db_env["ldb"]
+    _seed_routing_row(ldb, "ag:sk")
+    apply_outcome("ag:sk", failure=False)  # basis defaults None
+
+    with ldb.get_connection() as conn:
+        rows = conn.execute("SELECT COUNT(*) AS n FROM routing_outcome_basis").fetchone()
+    assert rows["n"] == 0
+
+
+def test_apply_outcome_basis_none_boosts_identically(db_env):
+    from routing_outcome_score import BOOST_DELTA, DECAY_DELTA, apply_outcome
+
+    ldb = db_env["ldb"]
+    _seed_routing_row(ldb, "ag:sk")
+    boosted = apply_outcome("ag:sk", failure=False)
+    assert boosted == pytest.approx(0.50 + BOOST_DELTA)
+    decayed = apply_outcome("ag:sk", failure=True)
+    assert decayed == pytest.approx(0.50 + BOOST_DELTA - DECAY_DELTA)

--- a/hooks/tests/test_telemetry_envelope.py
+++ b/hooks/tests/test_telemetry_envelope.py
@@ -109,8 +109,10 @@ def test_migration_on_existing_v4_db_preserves_rows(tmp_path, monkeypatch):
     # init_db runs migrations.
     ldb.init_db()
 
+    # Migrations run forward to the current floor (>=5 once telemetry landed;
+    # 6 after the additive routing_outcome_basis migration).
     version = _rows(db_path, "PRAGMA user_version")[0]["user_version"]
-    assert version == 5
+    assert version >= 5
 
     tables = {r["name"] for r in _rows(db_path, "SELECT name FROM sqlite_master WHERE type='table'")}
     assert "telemetry_runs" in tables
@@ -124,9 +126,11 @@ def test_migration_on_existing_v4_db_preserves_rows(tmp_path, monkeypatch):
     assert _rows(db_path, "SELECT COUNT(*) AS n FROM telemetry_runs")[0]["n"] == 0
 
 
-def test_schema_version_constant_is_5():
+def test_schema_version_constant_at_least_5():
+    # Telemetry landed v5; the additive routing_outcome_basis migration is v6.
+    # The constant tracks the latest applied version, so it only ever grows.
     ldb = _ldb()
-    assert ldb._CURRENT_SCHEMA_VERSION == 5
+    assert ldb._CURRENT_SCHEMA_VERSION >= 5
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -29,7 +29,7 @@ Usage:
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --success
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --failure --reason "user re-routed"
     python3 scripts/learning-db.py backfill-routing-outcomes
-    python3 scripts/learning-db.py route-health
+    python3 scripts/learning-db.py route-health [--json]
     python3 scripts/learning-db.py skip-rate [--json] [--include-test]
 """
 
@@ -919,9 +919,31 @@ def cmd_skip_rate(args: argparse.Namespace) -> None:
         print("No instructions flagged. Threshold: >20% skip rate over 30+ observations.")
 
 
+_BASIS_LABELS = ("rejection_detected", "tool_errors_only", "default_no_complaint")
+
+
+def _read_basis_counts() -> dict[str, int]:
+    """Sum routing_outcome_basis counts per label. Best-effort: {} on any error.
+
+    All three labels are always present (0 when unseen) so callers never
+    KeyError. Table absent / unreadable (pre-v6 DB) => all zeros.
+    """
+    counts = {label: 0 for label in _BASIS_LABELS}
+    try:
+        with get_connection() as conn:
+            rows = conn.execute("SELECT basis, SUM(count) AS n FROM routing_outcome_basis GROUP BY basis").fetchall()
+        for row in rows:
+            if row["basis"] in counts:
+                counts[row["basis"]] = int(row["n"] or 0)
+    except Exception:
+        pass
+    return counts
+
+
 def cmd_route_health(args: argparse.Namespace) -> None:
     """Display a quick health summary of routing entries."""
     init_db()
+    as_json = getattr(args, "json", False)
     results = query_learnings(
         topic="routing",
         category="effectiveness",
@@ -933,7 +955,10 @@ def cmd_route_health(args: argparse.Namespace) -> None:
 
     total = len(results)
     if total == 0:
-        print("No routing entries found.")
+        if as_json:
+            print(json.dumps({"total": 0, "entries_with_outcomes": 0}, indent=2))
+        else:
+            print("No routing entries found.")
         return
 
     baseline = sum(1 for r in results if r["success_count"] == 0 and r["failure_count"] == 0)
@@ -941,12 +966,53 @@ def cmd_route_health(args: argparse.Namespace) -> None:
     decayed_count = sum(1 for r in results if r["failure_count"] > 0)
     has_outcome = total - baseline
     pct = has_outcome / total * 100
+    status = "CLOSED" if pct >= 50 else "OPEN"
+    no_outcome_pct = baseline / total * 100
+
+    # Outcome-basis split (ADR: silent-failure-outcome-quality). strong-feedback
+    # = an observed signal scored the outcome; default-success = success on
+    # silence (upper bound on silent success, NOT confirmed silent failures).
+    basis = _read_basis_counts()
+    strong = basis["rejection_detected"] + basis["tool_errors_only"]
+    default_success = basis["default_no_complaint"]
+    basis_total = strong + default_success
+    silent_share = (default_success / basis_total) if basis_total else None
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "total": total,
+                    "entries_with_outcomes": has_outcome,
+                    "outcome_pct": round(pct, 1),
+                    "baseline": baseline,
+                    "boosted": boosted,
+                    "decayed": decayed_count,
+                    "feedback_loop": status,
+                    "basis": basis,
+                    "strong_feedback": strong,
+                    "default_success": default_success,
+                    "silent_success_share": silent_share,
+                    "governed_path_coverage": round(pct, 1),
+                },
+                indent=2,
+            )
+        )
+        return
 
     print(f"Route Health: {has_outcome}/{total} entries have outcomes ({pct:.0f}%)")
     print(f"Confidence: {baseline} at baseline | {boosted} boosted | {decayed_count} decayed")
-    status = "CLOSED" if pct >= 50 else "OPEN"
-    no_outcome_pct = baseline / total * 100
     print(f"Feedback loop: {status} ({no_outcome_pct:.0f}% entries have no outcome data)")
+
+    if basis_total == 0:
+        print("Outcome basis: no basis data yet")
+    else:
+        print(f"Outcome basis: {strong} strong-feedback vs {default_success} default-success")
+        print(f"  rejection_detected   {basis['rejection_detected']}")
+        print(f"  tool_errors_only     {basis['tool_errors_only']}")
+        print(f"  default_no_complaint {basis['default_no_complaint']}")
+        print(f"Silent-success share: {silent_share * 100:.0f}% of scored outcomes ({default_success}/{basis_total})")
+    print(f"Governed-path coverage: {has_outcome}/{total} routing rows carry a finalized outcome ({pct:.0f}%)")
 
 
 def _print_freq_table(records: list[dict[str, str | int]], label: str, key_fn: object) -> None:
@@ -1256,6 +1322,7 @@ def main():
 
     # route-health
     p_route_health = subparsers.add_parser("route-health", help="Quick routing feedback loop health check")
+    p_route_health.add_argument("--json", action="store_true", help="Output as JSON")
     p_route_health.set_defaults(func=cmd_route_health)
 
     args = parser.parse_args()

--- a/scripts/tests/test_route_health_basis.py
+++ b/scripts/tests/test_route_health_basis.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Tests for route-health outcome-basis reporting (ADR: silent-failure-outcome-quality).
+
+route-health reports outcome coverage but cannot tell a silent success from a
+silent failure — both score the same. This PR adds the basis split, the
+silent-success share, and a coverage line. These tests drive the rendering:
+seeded basis counts produce the split/shares; zero counts produce the no-data
+fallback with no divide-by-zero; --json carries the structured values.
+
+Runs route-health as a subprocess against a throwaway learning.db
+(CLAUDE_LEARNING_DIR) so the real DB is never touched.
+
+Run with: python3 -m pytest scripts/tests/test_route_health_basis.py -v
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CLI = REPO_ROOT / "scripts" / "learning-db.py"
+LIB_DIR = REPO_ROOT / "hooks" / "lib"
+
+
+@pytest.fixture()
+def db_env(tmp_path, monkeypatch):
+    """Throwaway learning.db; return a helper bound to it."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    return {"db_dir": db_dir, "ldb": ldb, "env_dir": str(db_dir)}
+
+
+def _seed_route(ldb, key: str, *, success: int = 0, failure: int = 0) -> None:
+    """Create a routing row and set its success/failure counts via boost/decay."""
+    ldb.record_learning(
+        topic="routing",
+        key=key,
+        value=f"routing-decision: {key}",
+        category="effectiveness",
+        source="test:route-health",
+    )
+    for _ in range(success):
+        ldb.boost_confidence("routing", key, delta=0.05)
+    for _ in range(failure):
+        ldb.decay_confidence("routing", key, delta=0.08)
+
+
+def _seed_basis(ldb, key: str, basis: str, n: int) -> None:
+    with ldb.get_connection() as conn:
+        conn.execute(
+            "INSERT INTO routing_outcome_basis (key, basis, count) VALUES (?,?,?) "
+            "ON CONFLICT(key, basis) DO UPDATE SET count = count + ?",
+            (key, basis, n, n),
+        )
+        conn.commit()
+
+
+def _run(env_dir: str, *extra: str) -> subprocess.CompletedProcess:
+    env = {"CLAUDE_LEARNING_DIR": env_dir}
+    import os
+
+    full = {**os.environ, **env}
+    return subprocess.run(
+        [sys.executable, str(CLI), "route-health", *extra],
+        capture_output=True,
+        text=True,
+        env=full,
+    )
+
+
+# --- human output: basis split + shares + coverage --------------------------
+
+
+def test_human_renders_split_and_shares(db_env):
+    ldb = db_env["ldb"]
+    _seed_route(ldb, "a:b", success=3)
+    _seed_route(ldb, "c:d", failure=1)
+    _seed_basis(ldb, "a:b", "default_no_complaint", 3)
+    _seed_basis(ldb, "c:d", "tool_errors_only", 1)
+    _seed_basis(ldb, "c:d", "rejection_detected", 1)
+
+    res = _run(db_env["env_dir"])
+    assert res.returncode == 0, res.stderr
+    out = res.stdout
+    # Existing three lines unchanged + present.
+    assert "Route Health:" in out
+    assert "Confidence:" in out
+    assert "Feedback loop:" in out
+    # New lines.
+    assert "Outcome basis:" in out
+    assert "strong-feedback" in out and "default-success" in out
+    assert "Silent-success share:" in out
+    assert "Governed-path coverage:" in out
+    # 2 strong (1 tool_errors + 1 rejection) vs 3 default.
+    assert "2 strong-feedback vs 3 default-success" in out
+
+
+def test_human_no_basis_data_fallback(db_env):
+    ldb = db_env["ldb"]
+    _seed_route(ldb, "a:b", success=1)  # has an outcome, but NO basis counts
+
+    res = _run(db_env["env_dir"])
+    assert res.returncode == 0, res.stderr
+    out = res.stdout
+    assert "Outcome basis: no basis data yet" in out
+    # No share line, no divide-by-zero crash.
+    assert "Silent-success share:" not in out
+
+
+# --- json output ------------------------------------------------------------
+
+
+def test_json_carries_basis_and_shares(db_env):
+    ldb = db_env["ldb"]
+    _seed_route(ldb, "a:b", success=2)
+    _seed_route(ldb, "c:d", failure=1)
+    _seed_basis(ldb, "a:b", "default_no_complaint", 2)
+    _seed_basis(ldb, "c:d", "tool_errors_only", 1)
+
+    res = _run(db_env["env_dir"], "--json")
+    assert res.returncode == 0, res.stderr
+    data = json.loads(res.stdout)
+    assert data["basis"]["default_no_complaint"] == 2
+    assert data["basis"]["tool_errors_only"] == 1
+    assert data["basis"]["rejection_detected"] == 0
+    assert data["strong_feedback"] == 1
+    assert data["default_success"] == 2
+    # 2 default of 3 total basis-scored outcomes.
+    assert data["silent_success_share"] == pytest.approx(2 / 3)
+    assert "governed_path_coverage" in data
+
+
+def test_json_zero_basis_no_divide_by_zero(db_env):
+    ldb = db_env["ldb"]
+    _seed_route(ldb, "a:b", success=1)
+
+    res = _run(db_env["env_dir"], "--json")
+    assert res.returncode == 0, res.stderr
+    data = json.loads(res.stdout)
+    assert data["basis"] == {
+        "rejection_detected": 0,
+        "tool_errors_only": 0,
+        "default_no_complaint": 0,
+    }
+    assert data["silent_success_share"] is None


### PR DESCRIPTION
## Summary

Make the routing feedback loop's silent-failure exposure a visible number. The scorer treats "no complaint" as success, so a silent acceptance and a silent rejection store the identical outcome; route-health cannot show what share of a closed loop rests on absence-of-complaint. This PR persists the outcome basis the finalizer already computes and splits route-health by it. No change to how routes are boosted or decayed.

ADR: silent-failure-outcome-quality (local-only, gitignored).

## Changes

- `hooks/lib/routing_outcome_score.py` — add optional `basis` param to `apply_outcome`; add best-effort `_record_basis` counter write (never raises into scoring).
- `hooks/lib/learning_db_v2.py` — additive, idempotent migration: bump `user_version`, `CREATE TABLE IF NOT EXISTS routing_outcome_basis`. Fallback store (PR-A envelope absent on main). No edits to existing functions.
- `hooks/routing-outcome-finalizer.py` — add pure `outcome_basis()` helper; pass `basis=` to `apply_outcome` per entry.
- `hooks/session-learning-recorder.py` — pass `basis=` at the Stop fallback (`tool_errors_only` on error, else `default_no_complaint`).
- `scripts/learning-db.py` — `cmd_route_health` reads basis counts; adds strong-vs-default split, silent-success share, governed-path coverage; extends `--json` with a `basis` object and both shares.
- `hooks/tests/test_routing_outcome_basis.py`, `scripts/tests/test_route_health_basis.py` — new; each basis path labels correctly, report renders the split/shares/no-data fallback.
- `hooks/tests/test_telemetry_envelope.py` — schema-version assertions updated to `>=5`/`>=6` for the additive migration.

## Notes

- Storage is the fallback `routing_outcome_basis` table: PR-A's metadata envelope is absent on main, so basis counts ride their own additive table per the ADR's Cross-ADR Dependency.
- `default_no_complaint` is an upper bound on silent success — it still includes explicit acceptances until the acceptance-vs-silence split (ADR Alternative D) lands. Named as such in the report.
- Warn-only by design: no blocking gate, no new hook, no new Action. Capture rides hooks that already fire; the report rides an existing CLI command.
- `learning_db_v2.py` change limited to the additive migration block — its existing functions trip a pre-existing SQLi false-positive in the commit security gate.
- Pre-existing, non-regression failures exist on Windows only (symlink-privilege and POSIX `fcntl.flock` concurrency tests); confirmed identical on clean origin/main and green in Linux CI.
