### PR TITLE
ci: per-PR skill-eval ablation (report-only)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,3 +134,63 @@ jobs:
           python-version: "3.12"
       - run: pip install pyyaml
       - run: python scripts/check-index-colocation.py --base origin/main --head HEAD --json || true
+
+  skill-eval-coverage:
+    # Report-only (ADR skill-eval-pr-ablation, Decision 2). Maps skills changed
+    # in this PR to their evals and posts a sticky coverage comment. It does NOT
+    # run evals -- the runner shells to the `claude` CLI, absent on GitHub
+    # runners (ADR hard constraint). continue-on-error + always-exit-0 detector
+    # mean it can never become a failing required check. PR-only, skills/** only.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml
+      - name: Skip when no skills changed
+        id: filter
+        env:
+          # Context bound to env, referenced as "$BASE"/"$HEAD" in the shell —
+          # the recommended injection-safe pattern. Values are 40-hex SHAs.
+          BASE: ${{ github.event.pull_request.base.sha }}  # security-review: ignore
+          HEAD: ${{ github.sha }}
+        run: |
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE '^skills/.+/SKILL\.md$'; then
+            echo "changed=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=0" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Build coverage comment
+        if: steps.filter.outputs.changed == '1'
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}  # security-review: ignore
+          HEAD: ${{ github.sha }}
+        run: |
+          python scripts/detect-skill-changes.py --base "$BASE" --head "$HEAD" --format json > coverage.json || echo '{}' > coverage.json
+          python scripts/render-skill-eval-comment.py coverage.json > comment.md
+      - name: Post sticky PR comment
+        if: steps.filter.outputs.changed == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Bound to env, used as "$PR"/"$REPO" in the shell (injection-safe).
+          # PR number is an integer; repo is owner/repo.
+          PR: ${{ github.event.pull_request.number }}  # security-review: ignore
+          REPO: ${{ github.repository }}
+        run: |
+          MARKER='<!-- skill-eval-coverage -->'
+          # Edit the prior bot comment if present (sticky), else create one.
+          CID=$(gh api "repos/$REPO/issues/$PR/comments" \
+            --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -n1) || true
+          if [ -n "$CID" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$CID" -f body="$(cat comment.md)" || true
+          else
+            gh pr comment "$PR" --body-file comment.md || true
+          fi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+# VexJoy Agent — make targets.
+#
+# skill-eval-ablation: local before/after eval for skills changed in a range
+# (ADR skill-eval-pr-ablation). Runs the real eval via the `claude` CLI, prints
+# the base->head delta, and (with RECORD=1) records each run to learning.db.
+# Advisory — never blocks anything.
+#
+#   make skill-eval-ablation BASE=<ref> HEAD=<ref> [SKILL=<name>] [RUNS=3] [RECORD=1]
+#   make skill-eval-install-hook    # write the opt-in pre-push hook
+
+PYTHON ?= python3
+BASE ?= HEAD~1
+HEAD ?= HEAD
+RUNS ?= 3
+SKILL ?=
+RECORD ?=
+
+ABLATION_ARGS := --base $(BASE) --head $(HEAD) --runs $(RUNS)
+ifneq ($(strip $(SKILL)),)
+ABLATION_ARGS += --skill $(SKILL)
+endif
+ifneq ($(strip $(RECORD)),)
+ABLATION_ARGS += --record
+endif
+
+.PHONY: skill-eval-ablation skill-eval-install-hook
+
+skill-eval-ablation:
+	$(PYTHON) scripts/skill-eval-ablation.py $(ABLATION_ARGS)
+
+skill-eval-install-hook:
+	$(PYTHON) scripts/skill-eval-ablation.py --install-hook

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-44 domain agents, 124 workflow skills, 83 hooks, 108 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+44 domain agents, 124 workflow skills, 83 hooks, 111 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Antigravity (`/do`), Factory (`/do`).
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -43,3 +43,65 @@ evals/
 ```
 
 See `new-skills-ab-test/` for the canonical example of a well-structured evaluation.
+
+## Per-PR Skill-Eval Ablation
+
+ADR skill-eval-pr-ablation. When a PR edits a skill, run its eval before vs.
+after the edit to measure the delta. CI cannot run evals (the runner shells to
+the `claude` CLI, absent on GitHub runners), so the real ablation runs locally.
+CI only posts a coverage map.
+
+### Mapping convention (changed skill -> eval)
+
+`scripts/detect-skill-changes.py --base <ref> --head <ref> --format json` lists
+the skills changed in a range and maps each to an eval. Resolution order, first
+hit wins:
+
+1. exact dir: `evals/<skill>/` exists.
+2. `-eval` suffix: `evals/<skill>-eval/` exists.
+3. README mention: the skill name appears as a whole word (case-insensitive) in
+   any `evals/*/README.md`.
+4. no match -> the skill is reported as **uncovered** (a gap to consider, not a
+   failure).
+
+The mapper always exits 0. Uncovered skills are data, not errors.
+
+### Running the ablation locally
+
+```bash
+make skill-eval-ablation BASE=<ref> HEAD=<ref> [SKILL=<name>] [RUNS=3] [RECORD=1]
+```
+
+For each mapped skill it runs the eval against the base content, then the head
+content, and prints the delta:
+
+```
+planning  base 58% -> head 67%  (+9, eval=evals/new-skills-ab-test, runs=3)
+```
+
+The command restores the working tree on every exit path; a crashed run leaves
+no base content checked out.
+
+`RECORD=1` writes one row per run to `learning.db` (topic `eval:<dir>`,
+`git_commit_sha` = head SHA), so eval history becomes a queryable time-series:
+
+```bash
+python3 scripts/learning-db.py query --topic "eval:evals/new-skills-ab-test"
+```
+
+If PR-A's telemetry envelope columns are absent, `--record` degrades to a no-op
+against those columns: it still writes the row (envelope packed into `value`)
+and appends one JSON line to `~/.claude/eval-ablations.log`. No run is lost; it
+never fails.
+
+### Opt-in pre-push hook
+
+Off by default — ablation spends real model calls. Install it explicitly:
+
+```bash
+make skill-eval-install-hook      # writes .git/hooks/pre-push (advisory)
+```
+
+Even installed, the hook acts only when `VEXJOY_SKILL_EVAL_PREPUSH=1`; otherwise
+it does nothing. It never blocks the push (`exit 0` always). Re-installing is
+idempotent and never clobbers a foreign pre-push hook.

--- a/scripts/detect-skill-changes.py
+++ b/scripts/detect-skill-changes.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Map skills changed in a git range to their eval directories under evals/.
+
+ADR: skill-eval-pr-ablation (Decision 1). A mapper, not a gate: it always
+exits 0. Uncovered skills are data, not errors.
+
+Usage:
+    python3 scripts/detect-skill-changes.py --base <REF> --head <REF> [--format human|json]
+
+Changed skills: `git diff --name-only <base> <head>`, keep paths matching the
+SKILL.md regex (identical to hooks/posttooluse-sync-skill-index.py), reduce each
+to its skill `name` from frontmatter.
+
+Mapping (first hit wins):
+    1. exact dir:    evals/<name>/        exists
+    2. -eval suffix: evals/<name>-eval/   exists
+    3. README:       whole-word, case-insensitive mention of <name> in any
+                     evals/*/README.md
+    4. no match -> uncovered
+
+JSON output is a single object: base, head (full hashes), changed_skills
+(sorted, deduped), mapped (list of {skill, eval_dir}, sorted by skill, no
+trailing slash), uncovered (sorted). Invariant:
+    set(changed_skills) == {m["skill"] for m in mapped} | set(uncovered)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Identical to hooks/posttooluse-sync-skill-index.py:42 (keep in sync).
+SKILL_FILE_RE = re.compile(r"skills/(?:[^/]+/)+SKILL\.md$")
+
+
+def run_git(repo: Path, *args: str) -> str:
+    """Run a git command in `repo`, return stdout (stripped). Raise on failure."""
+    res = subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return res.stdout.strip()
+
+
+def resolve_sha(repo: Path, ref: str) -> str:
+    """Resolve a ref to its full commit hash."""
+    return run_git(repo, "rev-parse", ref)
+
+
+def changed_skill_md_paths(repo: Path, base: str, head: str) -> list[str]:
+    """Repo-relative SKILL.md paths changed in base..head (POSIX separators)."""
+    out = run_git(repo, "diff", "--name-only", base, head)
+    paths = [p.strip() for p in out.splitlines() if p.strip()]
+    return [p for p in paths if SKILL_FILE_RE.search(p)]
+
+
+def skill_name_from_md(skill_md: Path) -> str | None:
+    """Read the `name:` frontmatter field from a SKILL.md file.
+
+    Falls back to the parent directory name when frontmatter has no name.
+    Returns None if the file is unreadable.
+    """
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    lines = text.splitlines()
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("name:"):
+            return stripped[len("name:") :].strip().strip('"').strip("'")
+        # Stop at the closing frontmatter delimiter (the second `---`).
+        if idx > 0 and stripped == "---":
+            break
+    # No name field: use the directory name (skills/<cat>/<name>/SKILL.md).
+    return skill_md.parent.name
+
+
+def skill_names_from_paths(paths: list[str], repo: Path) -> list[str]:
+    """Reduce changed SKILL.md paths to sorted, deduped skill names."""
+    names: set[str] = set()
+    for p in paths:
+        if not SKILL_FILE_RE.search(p):
+            continue
+        name = skill_name_from_md(repo / p)
+        if name:
+            names.add(name)
+    return sorted(names)
+
+
+def map_skill_to_eval(skill: str, repo: Path) -> str | None:
+    """Map a skill name to an eval dir (repo-relative, no trailing slash).
+
+    Resolution order, first hit wins: exact dir, -eval suffix, README mention.
+    Returns None when nothing matches (the skill is uncovered).
+    """
+    evals_root = repo / "evals"
+    if not evals_root.is_dir():
+        return None
+
+    # 1. exact dir: evals/<skill>/
+    if (evals_root / skill).is_dir():
+        return f"evals/{skill}"
+
+    # 2. -eval suffix: evals/<skill>-eval/
+    if (evals_root / f"{skill}-eval").is_dir():
+        return f"evals/{skill}-eval"
+
+    # 3. README whole-word mention (case-insensitive). Sort dirs for a stable
+    #    first hit.
+    word_re = re.compile(rf"(?<![\w-]){re.escape(skill)}(?![\w-])", re.IGNORECASE)
+    for sub in sorted(p for p in evals_root.iterdir() if p.is_dir()):
+        readme = sub / "README.md"
+        if not readme.is_file():
+            continue
+        try:
+            content = readme.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if word_re.search(content):
+            return f"evals/{sub.name}"
+
+    return None
+
+
+def build_report(repo: Path, base: str, head: str) -> dict:
+    """Build the mapping report object for the given range."""
+    base_sha = resolve_sha(repo, base)
+    head_sha = resolve_sha(repo, head)
+    paths = changed_skill_md_paths(repo, base_sha, head_sha)
+    changed = skill_names_from_paths(paths, repo)
+
+    mapped: list[dict[str, str]] = []
+    uncovered: list[str] = []
+    for skill in changed:
+        eval_dir = map_skill_to_eval(skill, repo)
+        if eval_dir:
+            mapped.append({"skill": skill, "eval_dir": eval_dir})
+        else:
+            uncovered.append(skill)
+
+    mapped.sort(key=lambda m: m["skill"])
+    uncovered.sort()
+    return {
+        "base": base_sha,
+        "head": head_sha,
+        "changed_skills": changed,
+        "mapped": mapped,
+        "uncovered": uncovered,
+    }
+
+
+def render_human(report: dict) -> str:
+    """Render the report as a human-readable coverage map."""
+    lines: list[str] = []
+    lines.append(f"Skill-eval coverage  base={report['base'][:12]}  head={report['head'][:12]}")
+    if not report["changed_skills"]:
+        lines.append("  no changed skills in range")
+        return "\n".join(lines)
+    for m in report["mapped"]:
+        lines.append(
+            f"  {m['skill']} -> eval {m['eval_dir']}. "
+            f"Run locally: make skill-eval-ablation BASE={report['base'][:12]} "
+            f"HEAD={report['head'][:12]} SKILL={m['skill']}"
+        )
+    if report["uncovered"]:
+        joined = ", ".join(report["uncovered"])
+        lines.append(f"  no eval coverage for changed skill(s): {joined}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Map changed skills to eval dirs (report-only, exit 0 always).")
+    parser.add_argument("--base", required=True, help="Base ref")
+    parser.add_argument("--head", required=True, help="Head ref")
+    parser.add_argument("--format", choices=["human", "json"], default="human")
+    parser.add_argument("--repo", default=".", help="Repo root (default: cwd)")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    try:
+        report = build_report(repo, args.base, args.head)
+    except subprocess.CalledProcessError as e:
+        # Never fail the build: report the git error to stderr, emit an empty
+        # report, exit 0.
+        print(f"[detect-skill-changes] git error: {e.stderr.strip()}", file=sys.stderr)
+        report = {"base": args.base, "head": args.head, "changed_skills": [], "mapped": [], "uncovered": []}
+
+    if args.format == "json":
+        print(json.dumps(report, indent=2))
+    else:
+        print(render_human(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -26,6 +26,7 @@ Usage:
     python3 scripts/learning-db.py roi [--json]
     python3 scripts/learning-db.py route-stats --by agent|skill|force-route|errors|override|week|day [--json]
     python3 scripts/learning-db.py route-delta --from REF --to REF [--key AGENT:SKILL] [--metric error|tokens] [--json]
+    python3 scripts/learning-db.py telemetry-query --topic eval:evals/<dir> [--git-sha SHA] [--format json]
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --success
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --failure --reason "user re-routed"
     python3 scripts/learning-db.py backfill-routing-outcomes
@@ -770,6 +771,45 @@ def cmd_route_delta(args: argparse.Namespace) -> None:
             print(f"WARNING: cohort {label} has only {n} run(s) (< MIN_N={MIN_N}); treat the delta as low-confidence.")
 
 
+def cmd_telemetry_query(args: argparse.Namespace) -> None:
+    """telemetry-query --topic T [--git-sha SHA]: read per-run rows from telemetry_runs.
+
+    PR-A's envelope (git_sha/model_id/skill_version) lives in telemetry_runs, not
+    on learnings. This reads those rows back by topic, optionally scoped to a
+    git-SHA prefix. Used to verify an ablation run landed under its head SHA.
+    Report-only; exit 0.
+    """
+    init_db()
+    # Fixed clauses only; all user values are bound as ? params.
+    clauses = ["topic = ?"]
+    params: list = [args.topic]
+    if args.git_sha:
+        clauses.append("git_sha LIKE ?")
+        params.append(args.git_sha + "%")
+    if args.key:
+        clauses.append("key = ?")
+        params.append(args.key)
+    where = " AND ".join(clauses)
+    params.append(args.limit)
+    with get_connection() as conn:
+        rows = [
+            dict(r)
+            for r in conn.execute(
+                f"SELECT * FROM telemetry_runs WHERE {where} ORDER BY recorded_at DESC LIMIT ?",  # security-review: ignore (fixed clauses; user values bound as ?)
+                params,
+            ).fetchall()
+        ]
+
+    if args.format == "json":
+        print(json.dumps(rows, indent=2, default=str))
+        return
+    if not rows:
+        print(f"No telemetry runs for topic={args.topic}.")
+        return
+    for r in rows:
+        print(f"{r['recorded_at']}  {r['topic']}/{r['key']}  git_sha={r['git_sha']}  source={r['source']}")
+
+
 def cmd_record_routing_outcome(args: argparse.Namespace) -> None:
     """Record whether a routing decision succeeded or failed."""
     init_db()
@@ -1298,6 +1338,15 @@ def main():
     )
     p_route_delta.add_argument("--json", action="store_true", help="Output as JSON")
     p_route_delta.set_defaults(func=cmd_route_delta)
+
+    # telemetry-query — read per-run envelope rows (incl. git_sha) from telemetry_runs.
+    p_tquery = subparsers.add_parser("telemetry-query", help="Query per-run telemetry_runs rows by topic")
+    p_tquery.add_argument("--topic", required=True, help="Filter by topic (e.g., eval:evals/<dir>)")
+    p_tquery.add_argument("--git-sha", dest="git_sha", help="Filter to a git-SHA prefix")
+    p_tquery.add_argument("--key", help="Filter to one key (e.g., <skill>@<head>:<arm>)")
+    p_tquery.add_argument("--limit", type=int, default=50)
+    p_tquery.add_argument("--format", choices=["human", "json"], default="human")
+    p_tquery.set_defaults(func=cmd_telemetry_query)
 
     # record-routing-outcome
     p_rro = subparsers.add_parser("record-routing-outcome", help="Record routing decision outcome")

--- a/scripts/render-skill-eval-comment.py
+++ b/scripts/render-skill-eval-comment.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Render the skill-eval-coverage PR comment from detect-skill-changes JSON.
+
+ADR: skill-eval-pr-ablation (Decision 2). Reads the detector's JSON report
+(path arg, default stdin) and writes the sticky-comment markdown to stdout.
+
+Body (per the ADR):
+  - leading marker `<!-- skill-eval-coverage -->` so CI can edit-in-place;
+  - per mapped skill: "<skill> -> eval <eval_dir>. Run locally:
+    make skill-eval-ablation BASE=<base> HEAD=<head> SKILL=<skill>";
+  - per uncovered skill: "no eval coverage for changed skill(s): <skill>" --
+    a gap to consider, not a failure.
+
+Report-only. Always exits 0; a malformed report yields a minimal comment.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+MARKER = "<!-- skill-eval-coverage -->"
+
+
+def render(report: dict) -> str:
+    """Build the comment markdown from a detector report object."""
+    base = str(report.get("base", ""))[:12]
+    head = str(report.get("head", ""))[:12]
+    mapped = report.get("mapped", []) or []
+    uncovered = report.get("uncovered", []) or []
+    changed = report.get("changed_skills", []) or []
+
+    lines: list[str] = [MARKER, "## Skill-eval coverage", ""]
+    lines.append(f"Changed skills in this PR: {len(changed)} (`{base}..{head}`).")
+    lines.append("")
+    lines.append(
+        "_Report only. CI cannot run evals (the runner needs the `claude` CLI). "
+        "Run the ablation locally to get the base->head delta._"
+    )
+    lines.append("")
+
+    if mapped:
+        lines.append("### Mapped")
+        for m in mapped:
+            skill = m.get("skill", "")
+            eval_dir = m.get("eval_dir", "")
+            lines.append(
+                f"- `{skill}` -> eval `{eval_dir}`. "
+                f"Run locally: `make skill-eval-ablation BASE={base} HEAD={head} SKILL={skill}`"
+            )
+        lines.append("")
+
+    if uncovered:
+        lines.append("### Uncovered")
+        joined = ", ".join(f"`{s}`" for s in uncovered)
+        lines.append(f"no eval coverage for changed skill(s): {joined}")
+        lines.append("_A gap to consider, not a failure._")
+        lines.append("")
+
+    if not mapped and not uncovered:
+        lines.append("_No changed skills mapped or uncovered._")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    try:
+        if len(sys.argv) > 1:
+            with open(sys.argv[1], encoding="utf-8") as fh:
+                report = json.load(fh)
+        else:
+            report = json.load(sys.stdin)
+    except (OSError, json.JSONDecodeError):
+        report = {}
+    sys.stdout.write(render(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/skill-eval-ablation.py
+++ b/scripts/skill-eval-ablation.py
@@ -14,10 +14,12 @@ detect-skill-changes.py:
 
 Uncovered skills print a no-coverage line and continue.
 
---record writes one row per run to learning.db. If PR-A's telemetry envelope
-columns are present (git_commit_sha/model_id/skill_version), the run promotes
-those fields to named columns. If absent, the run still lands in the DB (envelope
-packed into the free-text `value` column) AND appends one JSON line to
+--record writes one run per arm to learning.db. PR-A shipped the envelope as a
+dedicated telemetry_runs table (git_sha/model_id/skill_version per row) with a
+record_telemetry_run() API. When that table is present, the run's envelope goes
+to telemetry_runs and a human-queryable summary row goes to learnings. When it
+is absent (no PR-A), the run still lands in learnings (envelope packed into the
+free-text `value` column) AND appends one JSON line to
 ~/.claude/eval-ablations.log -- never dropped, never a failure.
 
 Usage:
@@ -33,6 +35,7 @@ import json
 import os
 import subprocess
 import sys
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -40,6 +43,17 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPTS_DIR.parent
 DETECTOR = SCRIPTS_DIR / "detect-skill-changes.py"
 RUN_EVAL = SCRIPTS_DIR / "skill_eval" / "run_eval.py"
+
+
+class DirtyTreeError(RuntimeError):
+    """Raised when a skill file has uncommitted edits before a base-arm checkout.
+
+    The ablation checks out base content over the working tree, then restores
+    head content. That round-trip destroys uncommitted edits. So the runner
+    refuses to ablate a skill whose file is dirty and tells the user to commit
+    or stash first.
+    """
+
 
 # Degraded-record log (pre-PR-A). Kept as a module global so tests can redirect.
 ABLATION_LOG = Path.home() / ".claude" / "eval-ablations.log"
@@ -88,11 +102,15 @@ def _import_learning_db():
 
 
 def _envelope_present(ldb) -> bool:
-    """True when learning.db has PR-A's git_commit_sha column (envelope landed)."""
+    """True when learning.db has PR-A's telemetry_runs table (envelope landed).
+
+    PR-A shipped the envelope as a dedicated telemetry_runs table, not as columns
+    on learnings. So the probe is the table's existence, not a column on learnings.
+    """
     ldb.init_db()
     with ldb.get_connection() as conn:
-        cols = {row[1] for row in conn.execute("PRAGMA table_info(learnings)")}
-    return "git_commit_sha" in cols
+        row = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'telemetry_runs'").fetchone()
+    return row is not None
 
 
 def _append_log(record: dict) -> None:
@@ -116,10 +134,11 @@ def record_run(
 ) -> int:
     """Record one ablation run to learning.db. Returns 0 always.
 
-    PR-A landed (envelope columns present): promote git_commit_sha/model_id/
-    skill_version to named columns. Otherwise: write the row with the envelope
-    packed into `value`, AND append a JSON line to ~/.claude/eval-ablations.log.
-    The record is never dropped.
+    PR-A landed (telemetry_runs table present): write the envelope (git_sha/
+    model_id/skill_version) to telemetry_runs via record_telemetry_run, and keep
+    a human-queryable summary row in learnings. Otherwise: write the summary row
+    with the envelope packed into `value`, AND append a JSON line to
+    ~/.claude/eval-ablations.log. The record is never dropped.
     """
     ldb = _import_learning_db()
     topic = f"eval:{eval_dir}"
@@ -130,8 +149,17 @@ def record_run(
     )
 
     if _envelope_present(ldb):
-        # PR-A present: write via record_learning, then promote envelope fields
-        # to the named columns on this row.
+        # PR-A present: envelope -> telemetry_runs (the real per-run table);
+        # human-queryable summary -> learnings.
+        ldb.record_telemetry_run(
+            topic=topic,
+            key=key,
+            run_id=f"{key}:{uuid.uuid4().hex}",
+            source="manual:skill-eval-ablation",
+            git_sha=head_sha,
+            model_id=model_id,
+            skill_version=skill_version,
+        )
         ldb.record_learning(
             topic=topic,
             key=key,
@@ -139,16 +167,10 @@ def record_run(
             category="effectiveness",
             source="manual:skill-eval-ablation",
         )
-        with ldb.get_connection() as conn:
-            conn.execute(
-                "UPDATE learnings SET git_commit_sha = ?, model_id = ?, skill_version = ? WHERE topic = ? AND key = ?",
-                (head_sha, model_id, skill_version, topic, key),
-            )
-            conn.commit()
         return 0
 
-    # No PR-A: write to the DB (envelope packed into value) so the run is not
-    # lost, then append the JSON line and warn.
+    # No PR-A: write the summary row to learnings (envelope packed into value) so
+    # the run is not lost, then append the JSON line and warn.
     ldb.record_learning(
         topic=topic,
         key=key,
@@ -185,6 +207,15 @@ def record_run(
 def _git(repo: Path, *args: str) -> str:
     res = subprocess.run(["git", *args], cwd=str(repo), capture_output=True, text=True, check=True)
     return res.stdout.strip()
+
+
+def _is_dirty(repo: Path, rel_path: str) -> bool:
+    """True when `rel_path` has uncommitted changes (staged or unstaged).
+
+    `git status --porcelain -- <path>` prints one line per changed path and
+    nothing for a clean path. Any output means the file is dirty.
+    """
+    return bool(_git(repo, "status", "--porcelain", "--", rel_path))
 
 
 def detect(repo: Path, base: str, head: str) -> dict:
@@ -263,10 +294,17 @@ def run_eval_for_content(repo: Path, eval_dir: str, skill: str, runs: int) -> fl
 def ablate_skill(repo: Path, skill: str, eval_dir: str, base_sha: str, head_sha: str, runs: int, record: bool) -> None:
     """Run base vs head eval for one mapped skill; print the delta; restore tree.
 
-    Stashes the working tree, checks out base content of the skill, runs the
-    eval, restores head content, runs again. The try/finally guarantees the
-    tree is restored on every exit path (a crash must not leave base checked
-    out).
+    Refuses to run when the skill file has uncommitted edits: the base-arm
+    checkout would overwrite them and the head-arm restore would not bring them
+    back, so the edits would be lost. When the file is clean, checks out base
+    content, runs the eval, restores head content, runs again. The try/finally
+    restores head content on every exit path, so a crash never leaves base
+    checked out.
+
+    Raises:
+        DirtyTreeError: the skill file has uncommitted changes. The caller
+            reports it and skips this skill; no checkout has run yet, so the
+            working tree is untouched.
     """
     skill_rel = None
     for skill_md in (repo / "skills").rglob("SKILL.md"):
@@ -276,6 +314,15 @@ def ablate_skill(repo: Path, skill: str, eval_dir: str, base_sha: str, head_sha:
     if skill_rel is None:
         print(f"[skill-eval-ablation] skill dir not found for {skill}", file=sys.stderr)
         return
+
+    # Guard BEFORE any checkout. A dirty skill file would lose its uncommitted
+    # edits to the base-arm checkout, so refuse and tell the user to commit or
+    # stash. The tree is still pristine here — nothing to restore.
+    if _is_dirty(repo, skill_rel):
+        raise DirtyTreeError(
+            f"{skill}: {skill_rel} has uncommitted changes; commit or stash them before ablating "
+            "(the base-arm checkout would overwrite them)."
+        )
 
     model_id = _model_id()
     skill_version = _skill_version(repo, skill)
@@ -395,7 +442,12 @@ def run_ablation(repo: Path, base: str, head: str, only_skill: str | None, runs:
         uncovered = [s for s in uncovered if s == only_skill]
 
     for m in mapped:
-        ablate_skill(repo, m["skill"], m["eval_dir"], base_sha, head_sha, runs, record)
+        try:
+            ablate_skill(repo, m["skill"], m["eval_dir"], base_sha, head_sha, runs, record)
+        except DirtyTreeError as exc:
+            # Advisory tool: report the dirty skill and move on. Never abort the
+            # run or touch the working tree.
+            print(f"[skill-eval-ablation] skipped {exc}", file=sys.stderr)
     if uncovered:
         print(format_uncovered(uncovered))
     return 0

--- a/scripts/skill-eval-ablation.py
+++ b/scripts/skill-eval-ablation.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Local before/after skill-eval ablation runner (the real eval).
+
+ADR: skill-eval-pr-ablation (Decision 3). This is the honest fallback: the
+actual ablation runs locally, where the `claude` CLI exists. CI cannot run
+evals (run_eval.py shells to `claude`), so CI only reports coverage.
+
+For each skill changed in base..head and mapped to an eval by
+detect-skill-changes.py:
+  1. check out the base content of the skill, run its eval, capture pass rate;
+  2. restore head content, run again, capture pass rate;
+  3. print: planning  base 58% -> head 67%  (+9, eval=evals/..., runs=3);
+  4. restore the working tree to its starting state on every exit path.
+
+Uncovered skills print a no-coverage line and continue.
+
+--record writes one row per run to learning.db. If PR-A's telemetry envelope
+columns are present (git_commit_sha/model_id/skill_version), the run promotes
+those fields to named columns. If absent, the run still lands in the DB (envelope
+packed into the free-text `value` column) AND appends one JSON line to
+~/.claude/eval-ablations.log -- never dropped, never a failure.
+
+Usage:
+    python3 scripts/skill-eval-ablation.py --base <REF> --head <REF> [--skill NAME] [--record] [--runs N]
+    python3 scripts/skill-eval-ablation.py --pre-push          # changed+mapped skills, advisory
+    python3 scripts/skill-eval-ablation.py --install-hook      # write the opt-in pre-push hook, then exit
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPTS_DIR.parent
+DETECTOR = SCRIPTS_DIR / "detect-skill-changes.py"
+RUN_EVAL = SCRIPTS_DIR / "skill_eval" / "run_eval.py"
+
+# Degraded-record log (pre-PR-A). Kept as a module global so tests can redirect.
+ABLATION_LOG = Path.home() / ".claude" / "eval-ablations.log"
+
+# Marker line written into the generated pre-push hook so a re-install detects
+# its own hook and does not clobber a foreign one.
+HOOK_MARKER = "# vexjoy-skill-eval-prepush"
+
+
+# ---------------------------------------------------------------------------
+# Formatting.
+# ---------------------------------------------------------------------------
+
+
+def _pct(rate: float) -> int:
+    """Render a 0..1 pass rate as an integer percent."""
+    return round(rate * 100)
+
+
+def format_delta(*, skill: str, base_rate: float, head_rate: float, eval_dir: str, runs: int) -> str:
+    """One-line delta: 'planning  base 58% -> head 67%  (+9, eval=..., runs=3)'."""
+    b, h = _pct(base_rate), _pct(head_rate)
+    delta = h - b
+    sign = "+" if delta >= 0 else ""
+    return f"{skill}  base {b}% -> head {h}%  ({sign}{delta}, eval={eval_dir}, runs={runs})"
+
+
+def format_uncovered(skills: list[str]) -> str:
+    """No-coverage line for changed skills with no eval."""
+    return f"no eval coverage for changed skill(s): {', '.join(skills)}"
+
+
+# ---------------------------------------------------------------------------
+# Recording (capture -> store). Probe for PR-A envelope; degrade if absent.
+# ---------------------------------------------------------------------------
+
+
+def _import_learning_db():
+    """Import the learning_db_v2 module from hooks/lib."""
+    lib = REPO_ROOT / "hooks" / "lib"
+    if str(lib) not in sys.path:
+        sys.path.insert(0, str(lib))
+    import learning_db_v2 as ldb
+
+    return ldb
+
+
+def _envelope_present(ldb) -> bool:
+    """True when learning.db has PR-A's git_commit_sha column (envelope landed)."""
+    ldb.init_db()
+    with ldb.get_connection() as conn:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(learnings)")}
+    return "git_commit_sha" in cols
+
+
+def _append_log(record: dict) -> None:
+    """Append one JSON line to the degraded-record log."""
+    ABLATION_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with ABLATION_LOG.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+
+def record_run(
+    *,
+    eval_dir: str,
+    skill: str,
+    arm: str,
+    pass_rate: float,
+    runs: int,
+    base_sha: str,
+    head_sha: str,
+    model_id: str,
+    skill_version: str,
+) -> int:
+    """Record one ablation run to learning.db. Returns 0 always.
+
+    PR-A landed (envelope columns present): promote git_commit_sha/model_id/
+    skill_version to named columns. Otherwise: write the row with the envelope
+    packed into `value`, AND append a JSON line to ~/.claude/eval-ablations.log.
+    The record is never dropped.
+    """
+    ldb = _import_learning_db()
+    topic = f"eval:{eval_dir}"
+    key = f"{skill}@{head_sha}:{arm}"
+    value = (
+        f"pass_rate={pass_rate} runs={runs} base={base_sha} head={head_sha} "
+        f"git_commit_sha={head_sha} model_id={model_id} skill_version={skill_version}"
+    )
+
+    if _envelope_present(ldb):
+        # PR-A present: write via record_learning, then promote envelope fields
+        # to the named columns on this row.
+        ldb.record_learning(
+            topic=topic,
+            key=key,
+            value=value,
+            category="effectiveness",
+            source="manual:skill-eval-ablation",
+        )
+        with ldb.get_connection() as conn:
+            conn.execute(
+                "UPDATE learnings SET git_commit_sha = ?, model_id = ?, skill_version = ? WHERE topic = ? AND key = ?",
+                (head_sha, model_id, skill_version, topic, key),
+            )
+            conn.commit()
+        return 0
+
+    # No PR-A: write to the DB (envelope packed into value) so the run is not
+    # lost, then append the JSON line and warn.
+    ldb.record_learning(
+        topic=topic,
+        key=key,
+        value=value,
+        category="effectiveness",
+        source="manual:skill-eval-ablation",
+    )
+    _append_log(
+        {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "topic": topic,
+            "key": key,
+            "eval_dir": eval_dir,
+            "skill": skill,
+            "arm": arm,
+            "pass_rate": pass_rate,
+            "runs": runs,
+            "base": base_sha,
+            "head": head_sha,
+            "git_commit_sha": head_sha,
+            "model_id": model_id,
+            "skill_version": skill_version,
+        }
+    )
+    print("WARN: telemetry envelope not present (PR-A); wrote to ~/.claude/eval-ablations.log")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Detection + git plumbing.
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> str:
+    res = subprocess.run(["git", *args], cwd=str(repo), capture_output=True, text=True, check=True)
+    return res.stdout.strip()
+
+
+def detect(repo: Path, base: str, head: str) -> dict:
+    """Run detect-skill-changes.py and return its JSON report."""
+    res = subprocess.run(
+        [sys.executable, str(DETECTOR), "--base", base, "--head", head, "--format", "json", "--repo", str(repo)],
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(res.stdout)
+
+
+def _model_id() -> str:
+    """Best-effort model id for the envelope (configured or unknown)."""
+    return os.environ.get("ANTHROPIC_MODEL") or os.environ.get("CLAUDE_MODEL") or "unknown"
+
+
+def _skill_version(repo: Path, skill: str) -> str:
+    """Read a skill's frontmatter version (best-effort)."""
+    for skill_md in (repo / "skills").rglob("SKILL.md"):
+        if skill_md.parent.name == skill:
+            for line in skill_md.read_text(encoding="utf-8").splitlines():
+                if line.strip().startswith("version:"):
+                    return line.split(":", 1)[1].strip().strip('"').strip("'")
+    return "unknown"
+
+
+def run_eval_for_content(repo: Path, eval_dir: str, skill: str, runs: int) -> float | None:
+    """Run the skill's eval against the current working-tree content.
+
+    Returns the pass rate (0..1) or None when the eval cannot run (no eval set,
+    or the `claude` CLI is unavailable). The runner shells to `claude -p`, so
+    this only works locally -- never in CI.
+    """
+    eval_set = None
+    for candidate in ("eval-set.json", "eval_set.json", "queries.json"):
+        p = repo / eval_dir / candidate
+        if p.is_file():
+            eval_set = p
+            break
+    skill_dir = None
+    for skill_md in (repo / "skills").rglob("SKILL.md"):
+        if skill_md.parent.name == skill:
+            skill_dir = skill_md.parent
+            break
+    if eval_set is None or skill_dir is None:
+        return None
+
+    res = subprocess.run(
+        [
+            sys.executable,
+            str(RUN_EVAL),
+            "--eval-set",
+            str(eval_set),
+            "--skill-path",
+            str(skill_dir),
+            "--runs-per-query",
+            str(runs),
+        ],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+    if res.returncode != 0:
+        print(f"[skill-eval-ablation] eval run failed for {skill}: {res.stderr.strip()[:200]}", file=sys.stderr)
+        return None
+    try:
+        out = json.loads(res.stdout)
+        summ = out["summary"]
+        total = summ["total"]
+        return (summ["passed"] / total) if total else 0.0
+    except (json.JSONDecodeError, KeyError, ZeroDivisionError):
+        return None
+
+
+def ablate_skill(repo: Path, skill: str, eval_dir: str, base_sha: str, head_sha: str, runs: int, record: bool) -> None:
+    """Run base vs head eval for one mapped skill; print the delta; restore tree.
+
+    Stashes the working tree, checks out base content of the skill, runs the
+    eval, restores head content, runs again. The try/finally guarantees the
+    tree is restored on every exit path (a crash must not leave base checked
+    out).
+    """
+    skill_rel = None
+    for skill_md in (repo / "skills").rglob("SKILL.md"):
+        if skill_md.parent.name == skill:
+            skill_rel = skill_md.relative_to(repo).as_posix()
+            break
+    if skill_rel is None:
+        print(f"[skill-eval-ablation] skill dir not found for {skill}", file=sys.stderr)
+        return
+
+    model_id = _model_id()
+    skill_version = _skill_version(repo, skill)
+    base_rate: float | None = None
+    head_rate: float | None = None
+
+    try:
+        # base arm: check out base content of just this skill file.
+        _git(repo, "checkout", base_sha, "--", skill_rel)
+        base_rate = run_eval_for_content(repo, eval_dir, skill, runs)
+        # head arm: restore head content.
+        _git(repo, "checkout", head_sha, "--", skill_rel)
+        head_rate = run_eval_for_content(repo, eval_dir, skill, runs)
+    finally:
+        # Restore the working tree to its starting state no matter what.
+        try:
+            _git(repo, "checkout", head_sha, "--", skill_rel)
+        except subprocess.CalledProcessError:
+            pass
+
+    if base_rate is None or head_rate is None:
+        # Not SQL — a stderr status line. security-review: ignore (false-positive
+        # sql-injection match on the f-string).
+        msg = f"{skill}: skipped — needs the claude CLI and an eval set under {eval_dir}"  # security-review: ignore
+        print(msg, file=sys.stderr)
+        return
+
+    print(format_delta(skill=skill, base_rate=base_rate, head_rate=head_rate, eval_dir=eval_dir, runs=runs))
+
+    if record:
+        record_run(
+            eval_dir=eval_dir,
+            skill=skill,
+            arm="base",
+            pass_rate=base_rate,
+            runs=runs,
+            base_sha=base_sha,
+            head_sha=head_sha,
+            model_id=model_id,
+            skill_version=skill_version,
+        )
+        record_run(
+            eval_dir=eval_dir,
+            skill=skill,
+            arm="head",
+            pass_rate=head_rate,
+            runs=runs,
+            base_sha=base_sha,
+            head_sha=head_sha,
+            model_id=model_id,
+            skill_version=skill_version,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pre-push hook installation.
+# ---------------------------------------------------------------------------
+
+
+def _hook_body() -> str:
+    """The advisory, opt-in pre-push hook script."""
+    return (
+        "#!/usr/bin/env bash\n"
+        f"{HOOK_MARKER}\n"
+        "# Advisory skill-eval ablation on push. Opt-in: acts only when\n"
+        "# VEXJOY_SKILL_EVAL_PREPUSH=1. Never blocks the push (exit 0 always).\n"
+        'if [ "${VEXJOY_SKILL_EVAL_PREPUSH:-0}" != "1" ]; then\n'
+        "  exit 0\n"
+        "fi\n"
+        'python3 "$(git rev-parse --show-toplevel)/scripts/skill-eval-ablation.py" --pre-push || true\n'
+        "exit 0\n"
+    )
+
+
+def install_hook(repo: Path) -> int:
+    """Write .git/hooks/pre-push (advisory, opt-in). Idempotent; never clobbers.
+
+    Returns 0 always. If a hook exists already: re-write only when it is our own
+    (carries HOOK_MARKER); leave a foreign hook untouched and print a notice.
+    """
+    hooks_dir = repo / ".git" / "hooks"
+    if not hooks_dir.is_dir():
+        print(f"[skill-eval-ablation] no .git/hooks/ under {repo}; not a git repo?", file=sys.stderr)
+        return 0
+    hook = hooks_dir / "pre-push"
+    if hook.exists():
+        existing = hook.read_text(encoding="utf-8")
+        if HOOK_MARKER not in existing:
+            print(
+                f"[skill-eval-ablation] {hook} exists and is not ours; left untouched. "
+                "Remove it first to install the ablation hook.",
+            )
+            return 0
+    hook.write_text(_hook_body(), encoding="utf-8")
+    os.chmod(hook, 0o755)
+    print(
+        f"[skill-eval-ablation] installed advisory pre-push hook at {hook} "
+        "(set VEXJOY_SKILL_EVAL_PREPUSH=1 to activate)"
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Orchestration.
+# ---------------------------------------------------------------------------
+
+
+def run_ablation(repo: Path, base: str, head: str, only_skill: str | None, runs: int, record: bool) -> int:
+    """Detect mapped skills and ablate each; print uncovered ones. Exit 0."""
+    report = detect(repo, base, head)
+    base_sha, head_sha = report["base"], report["head"]
+    mapped = report["mapped"]
+    uncovered = report["uncovered"]
+
+    if only_skill:
+        mapped = [m for m in mapped if m["skill"] == only_skill]
+        uncovered = [s for s in uncovered if s == only_skill]
+
+    for m in mapped:
+        ablate_skill(repo, m["skill"], m["eval_dir"], base_sha, head_sha, runs, record)
+    if uncovered:
+        print(format_uncovered(uncovered))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Local before/after skill-eval ablation (advisory, never blocks).")
+    parser.add_argument("--base", help="Base ref")
+    parser.add_argument("--head", help="Head ref")
+    parser.add_argument("--skill", help="Limit to one skill name")
+    parser.add_argument("--runs", type=int, default=3, help="Runs per query per arm (default 3)")
+    parser.add_argument("--record", action="store_true", help="Record runs to learning.db / log file")
+    parser.add_argument("--pre-push", action="store_true", help="Pre-push mode: HEAD~1..HEAD, advisory")
+    parser.add_argument("--install-hook", action="store_true", help="Write the opt-in pre-push hook, then exit")
+    parser.add_argument("--repo", default=".", help="Repo root (default: cwd)")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+
+    if args.install_hook:
+        return install_hook(repo)
+
+    if args.pre_push:
+        base, head = "HEAD~1", "HEAD"
+        return run_ablation(repo, base, head, args.skill, args.runs, record=True)
+
+    if not args.base or not args.head:
+        parser.error("--base and --head are required (unless --install-hook / --pre-push)")
+
+    return run_ablation(repo, args.base, args.head, args.skill, args.runs, args.record)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -45,7 +45,12 @@ def _skill_md(name: str, version: str = "1.0.0", body: str = "Body.") -> str:
 
 
 def _init_temp_db(db_dir: Path, monkeypatch, *, envelope: bool):
-    """Create a throwaway learning.db under db_dir; optionally add PR-A columns.
+    """Create a throwaway learning.db under db_dir from the real schema.
+
+    PR-A shipped the envelope as a dedicated `telemetry_runs` table (schema v5+),
+    not as columns on `learnings`. `init_db()` builds that table. So the
+    with-envelope DB is just the real, fully-migrated schema. The no-envelope DB
+    simulates a pre-PR-A install by dropping `telemetry_runs` after init.
 
     Returns the learning.db path. Points CLAUDE_LEARNING_DIR at db_dir and
     resets the learning_db_v2 init cache so the DB is built fresh.
@@ -60,29 +65,26 @@ def _init_temp_db(db_dir: Path, monkeypatch, *, envelope: bool):
     ldb.init_db()
     db_path = db_dir / "learning.db"
 
-    if envelope:
-        # Simulate PR-A's telemetry envelope: add the three named columns.
+    if not envelope:
+        # Simulate a pre-PR-A DB: remove the telemetry_runs table so the runner's
+        # envelope probe takes the degraded (log-file) path.
         import sqlite3
 
         with sqlite3.connect(db_path) as conn:
-            for col in ("git_commit_sha", "model_id", "skill_version"):
-                try:
-                    conn.execute(f"ALTER TABLE learnings ADD COLUMN {col} TEXT")
-                except sqlite3.OperationalError:
-                    pass
+            conn.execute("DROP TABLE IF EXISTS telemetry_runs")
             conn.commit()
     return db_path
 
 
 @pytest.fixture
 def temp_db_no_envelope(tmp_path, monkeypatch) -> Path:
-    """Throwaway learning.db with today's schema (no PR-A envelope columns)."""
+    """Throwaway learning.db simulating pre-PR-A (no telemetry_runs table)."""
     return _init_temp_db(tmp_path / "learning_noenv", monkeypatch, envelope=False)
 
 
 @pytest.fixture
 def temp_db_with_envelope(tmp_path, monkeypatch) -> Path:
-    """Throwaway learning.db with PR-A envelope columns present."""
+    """Throwaway learning.db with PR-A's telemetry_runs table (real schema)."""
     return _init_temp_db(tmp_path / "learning_env", monkeypatch, envelope=True)
 
 

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -5,12 +5,175 @@ Provides:
 - Path fixtures for the fixtures directory
 - Content fixtures for sample good/bad files
 - Expected output fixtures for golden file testing
+- Skill-eval-ablation fixtures (ADR skill-eval-pr-ablation): temp_db variants,
+  mock_skill_tree, mock_evals, git_range
 """
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
+
+# ---------------------------------------------------------------------------
+# Skill-eval-ablation fixtures (ADR: skill-eval-pr-ablation)
+#
+# Shared by test_detect_skill_changes.py and test_skill_eval_ablation.py.
+# They mirror the throwaway-DB + throwaway-git-repo patterns already used in
+# hooks/tests/test_routing_decision_recorder.py and
+# scripts/tests/test_check_index_colocation.py.
+# ---------------------------------------------------------------------------
+
+_LIB_DIR = Path(__file__).resolve().parents[2] / "hooks" / "lib"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    """Run a git command in `repo`, raising on failure."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _skill_md(name: str, version: str = "1.0.0", body: str = "Body.") -> str:
+    """Minimal valid SKILL.md frontmatter (name + version) plus a body."""
+    return f"---\nname: {name}\nversion: {version}\ndescription: {name} skill.\n---\n\n# {name}\n\n{body}\n"
+
+
+def _init_temp_db(db_dir: Path, monkeypatch, *, envelope: bool):
+    """Create a throwaway learning.db under db_dir; optionally add PR-A columns.
+
+    Returns the learning.db path. Points CLAUDE_LEARNING_DIR at db_dir and
+    resets the learning_db_v2 init cache so the DB is built fresh.
+    """
+    db_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    if str(_LIB_DIR) not in sys.path:
+        sys.path.insert(0, str(_LIB_DIR))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    db_path = db_dir / "learning.db"
+
+    if envelope:
+        # Simulate PR-A's telemetry envelope: add the three named columns.
+        import sqlite3
+
+        with sqlite3.connect(db_path) as conn:
+            for col in ("git_commit_sha", "model_id", "skill_version"):
+                try:
+                    conn.execute(f"ALTER TABLE learnings ADD COLUMN {col} TEXT")
+                except sqlite3.OperationalError:
+                    pass
+            conn.commit()
+    return db_path
+
+
+@pytest.fixture
+def temp_db_no_envelope(tmp_path, monkeypatch) -> Path:
+    """Throwaway learning.db with today's schema (no PR-A envelope columns)."""
+    return _init_temp_db(tmp_path / "learning_noenv", monkeypatch, envelope=False)
+
+
+@pytest.fixture
+def temp_db_with_envelope(tmp_path, monkeypatch) -> Path:
+    """Throwaway learning.db with PR-A envelope columns present."""
+    return _init_temp_db(tmp_path / "learning_env", monkeypatch, envelope=True)
+
+
+@pytest.fixture
+def mock_skill_tree(tmp_path) -> Path:
+    """A skills/ tree: skills/<cat>/<name>/SKILL.md with minimal frontmatter.
+
+    Returns the root holding skills/. Names chosen to exercise the mapper.
+    """
+    root = tmp_path / "tree"
+    layout = {
+        ("process", "planning"): "planning",
+        ("process", "quick"): "quick",
+        ("meta", "skill-creator"): "skill-creator",
+    }
+    for (cat, dirname), name in layout.items():
+        d = root / "skills" / cat / dirname
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(_skill_md(name), encoding="utf-8")
+    return root
+
+
+@pytest.fixture
+def mock_evals(tmp_path) -> Path:
+    """An evals/ tree exercising all three resolution rules.
+
+    - evals/planning/            -> exact-dir match for skill "planning"
+    - evals/quick-eval/          -> "-eval" suffix match for skill "quick"
+    - evals/grouped/README.md    -> README whole-word mention of "skill-creator"
+    Returns the root holding evals/.
+    """
+    root = tmp_path / "evalsroot"
+    (root / "evals" / "planning").mkdir(parents=True)
+    (root / "evals" / "planning" / "README.md").write_text("# planning eval\n", encoding="utf-8")
+    (root / "evals" / "quick-eval").mkdir(parents=True)
+    (root / "evals" / "quick-eval" / "README.md").write_text("# quick eval\n", encoding="utf-8")
+    (root / "evals" / "grouped").mkdir(parents=True)
+    (root / "evals" / "grouped" / "README.md").write_text(
+        "# grouped\n\nTests the skill-creator skill against baseline.\n", encoding="utf-8"
+    )
+    return root
+
+
+@pytest.fixture
+def git_range(tmp_path):
+    """A git repo with a base commit and a head commit that edits three skills.
+
+    Builds skills/ and evals/ trees, commits the base, edits three skills
+    (two map to evals, one is uncovered), commits the head. Returns a dict:
+    {repo, base, head} where base/head are full SHAs.
+    """
+    repo = tmp_path / "repo"
+    (repo / "skills").mkdir(parents=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t.test")
+    _git(repo, "config", "user.name", "t")
+
+    # Three skills; planning + quick map to evals, orphan is uncovered.
+    skills = {
+        ("process", "planning"): "planning",
+        ("process", "quick"): "quick",
+        ("process", "orphan"): "orphan",
+    }
+    for (cat, dirname), name in skills.items():
+        d = repo / "skills" / cat / dirname
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(_skill_md(name, body="Base body."), encoding="utf-8")
+
+    # Evals: exact-dir for planning, -eval suffix for quick. No eval for orphan.
+    (repo / "evals" / "planning").mkdir(parents=True)
+    (repo / "evals" / "planning" / "README.md").write_text("# planning\n", encoding="utf-8")
+    (repo / "evals" / "quick-eval").mkdir(parents=True)
+    (repo / "evals" / "quick-eval" / "README.md").write_text("# quick\n", encoding="utf-8")
+
+    # A non-SKILL.md file that also changes (must be ignored by the mapper).
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+    base = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    # Head: edit all three SKILL.md bodies + the non-skill file.
+    for (cat, dirname), name in skills.items():
+        f = repo / "skills" / cat / dirname / "SKILL.md"
+        f.write_text(_skill_md(name, version="1.1.0", body="Head body changed."), encoding="utf-8")
+    (repo / "README.md").write_text("head\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "head")
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    return {"repo": repo, "base": base, "head": head}
 
 
 @pytest.fixture

--- a/scripts/tests/test_detect_skill_changes.py
+++ b/scripts/tests/test_detect_skill_changes.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Tests for scripts/detect-skill-changes.py (changed-skill -> eval mapping).
+
+ADR: skill-eval-pr-ablation, Decision section 1 + Test Plan.
+
+Covers the mapping resolution order (first hit wins):
+  1. exact dir match: evals/<name>/
+  2. -eval suffix:    evals/<name>-eval/
+  3. README mention:  whole-word, case-insensitive, in any evals/*/README.md
+  4. no match -> uncovered
+Plus: non-SKILL.md changes ignored, exit 0 always, JSON schema + invariant,
+and the required 3-skill integration test on a real git range.
+
+Run with: python3 -m pytest scripts/tests/test_detect_skill_changes.py -v
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "detect-skill-changes.py"
+
+
+def _load_module():
+    """Import detect-skill-changes.py as a module to unit-test its helpers."""
+    spec = importlib.util.spec_from_file_location("detect_skill_changes", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run(repo: Path, base: str, head: str, fmt: str = "json") -> subprocess.CompletedProcess:
+    """Run the script as a subprocess inside `repo`."""
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", base, "--head", head, "--format", fmt],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: the mapping function against a mock evals/ tree.
+# ---------------------------------------------------------------------------
+
+
+def test_map_exact_dir(mock_evals):
+    mod = _load_module()
+    assert mod.map_skill_to_eval("planning", mock_evals) == "evals/planning"
+
+
+def test_map_eval_suffix(mock_evals):
+    mod = _load_module()
+    assert mod.map_skill_to_eval("quick", mock_evals) == "evals/quick-eval"
+
+
+def test_map_readme_mention(mock_evals):
+    mod = _load_module()
+    assert mod.map_skill_to_eval("skill-creator", mock_evals) == "evals/grouped"
+
+
+def test_map_uncovered_returns_none(mock_evals):
+    mod = _load_module()
+    assert mod.map_skill_to_eval("nonexistent-skill", mock_evals) is None
+
+
+def test_map_readme_whole_word_only(mock_evals):
+    """A substring of a longer word in README must NOT match (whole-word rule)."""
+    mod = _load_module()
+    # "plan" is a substring of "planning" mentioned in evals/planning/README.md,
+    # but "plan" is not a whole word there -> no README match, and no dir
+    # evals/plan or evals/plan-eval -> uncovered.
+    assert mod.map_skill_to_eval("plan", mock_evals) is None
+
+
+def test_map_exact_dir_precedes_readme(tmp_path):
+    """Resolution order: exact dir wins over a README mention elsewhere."""
+    mod = _load_module()
+    root = tmp_path / "r"
+    (root / "evals" / "planning").mkdir(parents=True)
+    (root / "evals" / "planning" / "README.md").write_text("# planning\n", encoding="utf-8")
+    (root / "evals" / "other").mkdir(parents=True)
+    (root / "evals" / "other" / "README.md").write_text("mentions planning here\n", encoding="utf-8")
+    assert mod.map_skill_to_eval("planning", root) == "evals/planning"
+
+
+# ---------------------------------------------------------------------------
+# Changed-skill extraction: only skills/**/SKILL.md paths count.
+# ---------------------------------------------------------------------------
+
+
+def test_changed_skills_ignores_non_skill_md(mock_skill_tree):
+    mod = _load_module()
+    paths = [
+        "skills/process/planning/SKILL.md",
+        "skills/process/planning/references/foo.md",  # not SKILL.md -> ignore
+        "README.md",  # not under skills/ -> ignore
+        "scripts/x.py",  # ignore
+    ]
+    names = mod.skill_names_from_paths(paths, mock_skill_tree)
+    assert names == ["planning"]
+
+
+def test_changed_skills_sorted_deduped(mock_skill_tree):
+    mod = _load_module()
+    paths = [
+        "skills/meta/skill-creator/SKILL.md",
+        "skills/process/planning/SKILL.md",
+        "skills/process/planning/SKILL.md",  # dup
+    ]
+    names = mod.skill_names_from_paths(paths, mock_skill_tree)
+    assert names == ["planning", "skill-creator"]
+
+
+# ---------------------------------------------------------------------------
+# Integration: real git range, JSON output, schema + invariant. (REQUIRED)
+# ---------------------------------------------------------------------------
+
+
+def test_integration_three_skills(git_range):
+    repo, base, head = git_range["repo"], git_range["base"], git_range["head"]
+    res = _run(repo, base, head, "json")
+
+    assert res.returncode == 0, res.stderr
+    data = json.loads(res.stdout)
+
+    # Schema keys + types.
+    assert isinstance(data["base"], str)
+    assert isinstance(data["head"], str)
+    assert isinstance(data["changed_skills"], list)
+    assert isinstance(data["mapped"], list)
+    assert isinstance(data["uncovered"], list)
+
+    # base/head resolved to full hashes.
+    assert data["base"] == base
+    assert data["head"] == head
+
+    # 3 changed skills, sorted ascending.
+    assert data["changed_skills"] == ["orphan", "planning", "quick"]
+
+    # 2 mapped, sorted by skill, correct eval_dir, no trailing slash.
+    mapped = data["mapped"]
+    assert len(mapped) == 2
+    by_skill = {m["skill"]: m["eval_dir"] for m in mapped}
+    assert by_skill == {"planning": "evals/planning", "quick": "evals/quick-eval"}
+    for m in mapped:
+        assert not m["eval_dir"].endswith("/")
+    assert [m["skill"] for m in mapped] == sorted(m["skill"] for m in mapped)
+
+    # 1 uncovered.
+    assert data["uncovered"] == ["orphan"]
+
+    # Invariant: every changed skill is mapped XOR uncovered.
+    assert set(data["changed_skills"]) == {m["skill"] for m in mapped} | set(data["uncovered"])
+
+
+def test_exit_code_always_zero_even_all_uncovered(tmp_path):
+    """A range whose changed skills have no eval still exits 0 (mapper, not gate)."""
+    repo = tmp_path / "repo"
+    (repo / "skills" / "x" / "lonely").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    skill = repo / "skills" / "x" / "lonely" / "SKILL.md"
+    skill.write_text("---\nname: lonely\nversion: 1.0.0\n---\n\nbody\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, check=True)
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    skill.write_text("---\nname: lonely\nversion: 1.1.0\n---\n\nbody2\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "head"], cwd=repo, check=True)
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    res = _run(repo, base, head, "json")
+    assert res.returncode == 0
+    data = json.loads(res.stdout)
+    assert data["changed_skills"] == ["lonely"]
+    assert data["mapped"] == []
+    assert data["uncovered"] == ["lonely"]
+
+
+def test_human_format_runs_and_exits_zero(git_range):
+    res = _run(git_range["repo"], git_range["base"], git_range["head"], "human")
+    assert res.returncode == 0
+    assert "planning" in res.stdout
+
+
+@pytest.mark.parametrize("fmt", ["json", "human"])
+def test_no_changed_skills_is_clean(tmp_path, fmt):
+    """Range with no skill changes: empty lists, exit 0."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    (repo / "README.md").write_text("a\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, check=True)
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    (repo / "README.md").write_text("b\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "head"], cwd=repo, check=True)
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    res = _run(repo, base, head, fmt)
+    assert res.returncode == 0
+    if fmt == "json":
+        data = json.loads(res.stdout)
+        assert data["changed_skills"] == []
+        assert data["mapped"] == []
+        assert data["uncovered"] == []

--- a/scripts/tests/test_skill_eval_ablation.py
+++ b/scripts/tests/test_skill_eval_ablation.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+Tests for scripts/skill-eval-ablation.py (local before/after eval runner).
+
+ADR: skill-eval-pr-ablation, Decision section 3 + Validation Requirements 3-5.
+
+Covers the parts that do NOT need the `claude` CLI:
+- delta line formatting (base% -> head% (+delta));
+- --record degradation when the PR-A envelope is absent: WARN string + one
+  JSON line appended to the log file, exit 0, no DB row dropped;
+- --record promotion when the envelope is present: named columns written,
+  readable back by learning-db query (git_commit_sha == head);
+- the CI workflow YAML guarantees the coverage job can never become a failing
+  required check (continue-on-error: true, no required: true);
+- --install-hook writes an idempotent, advisory .git/hooks/pre-push.
+
+Run with: python3 -m pytest scripts/tests/test_skill_eval_ablation.py -v
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "skill-eval-ablation.py"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEARNING_DB_CLI = REPO_ROOT / "scripts" / "learning-db.py"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "test.yml"
+LIB_DIR = REPO_ROOT / "hooks" / "lib"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("skill_eval_ablation", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Delta formatting.
+# ---------------------------------------------------------------------------
+
+
+def test_format_delta_line():
+    mod = _load_module()
+    line = mod.format_delta(
+        skill="planning", base_rate=0.58, head_rate=0.67, eval_dir="evals/new-skills-ab-test", runs=3
+    )
+    assert "planning" in line
+    assert "58%" in line
+    assert "67%" in line
+    assert "+9" in line
+    assert "eval=evals/new-skills-ab-test" in line
+    assert "runs=3" in line
+
+
+def test_format_delta_negative():
+    mod = _load_module()
+    line = mod.format_delta(skill="x", base_rate=0.70, head_rate=0.60, eval_dir="evals/x", runs=2)
+    assert "70%" in line
+    assert "60%" in line
+    assert "-10" in line
+
+
+def test_format_uncovered_line():
+    mod = _load_module()
+    line = mod.format_uncovered(["a", "b"])
+    assert "no eval coverage for changed skill(s)" in line
+    assert "a" in line
+    assert "b" in line
+
+
+# ---------------------------------------------------------------------------
+# --record degradation (no PR-A envelope) -- Validation Requirement 3.
+# ---------------------------------------------------------------------------
+
+
+def test_record_no_envelope_degrades_to_log(temp_db_no_envelope, tmp_path, capsys, monkeypatch):
+    mod = _load_module()
+    log = tmp_path / "eval-ablations.log"
+    monkeypatch.setattr(mod, "ABLATION_LOG", log, raising=False)
+
+    rc = mod.record_run(
+        eval_dir="evals/new-skills-ab-test",
+        skill="planning",
+        arm="head",
+        pass_rate=0.67,
+        runs=3,
+        base_sha="b" * 40,
+        head_sha="h" * 40,
+        model_id="claude-x",
+        skill_version="1.1.0",
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "WARN: telemetry envelope not present (PR-A); wrote to ~/.claude/eval-ablations.log" in out
+
+    # One JSON line appended, with the envelope schema + a UTC timestamp.
+    lines = [ln for ln in log.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["eval_dir"] == "evals/new-skills-ab-test"
+    assert rec["skill"] == "planning"
+    assert rec["arm"] == "head"
+    assert rec["pass_rate"] == 0.67
+    assert rec["git_commit_sha"] == "h" * 40
+    assert rec["model_id"] == "claude-x"
+    assert rec["skill_version"] == "1.1.0"
+    assert "timestamp" in rec
+
+
+def test_record_no_envelope_still_writes_db_row(temp_db_no_envelope, tmp_path, monkeypatch):
+    """Degraded record is NOT dropped: it lands in the DB via the value column."""
+    mod = _load_module()
+    monkeypatch.setattr(mod, "ABLATION_LOG", tmp_path / "log.jsonl", raising=False)
+    mod.record_run(
+        eval_dir="evals/x",
+        skill="quick",
+        arm="base",
+        pass_rate=0.5,
+        runs=2,
+        base_sha="b" * 40,
+        head_sha="h" * 40,
+        model_id="m",
+        skill_version="1.0.0",
+    )
+    sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    rows = ldb.query_learnings(topic="eval:evals/x", exclude_test_sources=False)
+    assert len(rows) == 1
+    # Envelope packed into value (no named columns pre-PR-A).
+    assert "git_commit_sha=" + "h" * 40 in rows[0]["value"]
+
+
+# ---------------------------------------------------------------------------
+# --record promotion (PR-A envelope present) -- Validation Requirement 5.
+# ---------------------------------------------------------------------------
+
+
+def test_record_with_envelope_writes_named_columns(temp_db_with_envelope, tmp_path, monkeypatch):
+    mod = _load_module()
+    monkeypatch.setattr(mod, "ABLATION_LOG", tmp_path / "log.jsonl", raising=False)
+    head = "a" * 40
+    rc = mod.record_run(
+        eval_dir="evals/new-skills-ab-test",
+        skill="planning",
+        arm="head",
+        pass_rate=0.67,
+        runs=3,
+        base_sha="b" * 40,
+        head_sha=head,
+        model_id="claude-x",
+        skill_version="1.1.0",
+    )
+    assert rc == 0
+
+    # Read it back via the learning-db CLI query (Validation Requirement 5).
+    res = subprocess.run(
+        [
+            sys.executable,
+            str(LEARNING_DB_CLI),
+            "query",
+            "--topic",
+            "eval:evals/new-skills-ab-test",
+            "--format",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        env={**_clean_env(), "CLAUDE_LEARNING_DIR": str(temp_db_with_envelope.parent)},
+    )
+    assert res.returncode == 0, res.stderr
+    rows = json.loads(res.stdout)
+    assert rows, "expected at least one row"
+    assert any(r.get("git_commit_sha") == head for r in rows)
+
+
+def _clean_env() -> dict:
+    import os
+
+    return {k: v for k, v in os.environ.items()}
+
+
+# ---------------------------------------------------------------------------
+# CI workflow guarantee -- Validation Requirement 4.
+# ---------------------------------------------------------------------------
+
+
+def test_ci_job_is_report_only():
+    """skill-eval-coverage job: continue-on-error true, never a required check."""
+    import yaml
+
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    jobs = data["jobs"]
+    assert "skill-eval-coverage" in jobs, "skill-eval-coverage job missing"
+    job = jobs["skill-eval-coverage"]
+    assert job.get("continue-on-error") is True
+    # No 'required: true' anywhere in the job definition.
+    assert "required: true" not in yaml.safe_dump(job)
+
+
+# ---------------------------------------------------------------------------
+# --install-hook: writes an idempotent, advisory pre-push hook.
+# ---------------------------------------------------------------------------
+
+
+def test_install_hook_writes_advisory_idempotent(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / ".git" / "hooks").mkdir(parents=True)
+    res1 = subprocess.run(
+        [sys.executable, str(SCRIPT), "--install-hook"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+    assert res1.returncode == 0, res1.stderr
+    hook = repo / ".git" / "hooks" / "pre-push"
+    assert hook.exists()
+    body = hook.read_text(encoding="utf-8")
+    assert "# vexjoy-skill-eval-prepush" in body
+    assert "VEXJOY_SKILL_EVAL_PREPUSH" in body
+    assert "exit 0" in body
+
+    # Re-run: idempotent, does not duplicate the marker.
+    res2 = subprocess.run(
+        [sys.executable, str(SCRIPT), "--install-hook"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+    assert res2.returncode == 0
+    body2 = hook.read_text(encoding="utf-8")
+    assert body2.count("# vexjoy-skill-eval-prepush") == 1
+
+
+def test_install_hook_preserves_foreign_hook(tmp_path):
+    """A pre-existing non-vexjoy hook is not clobbered."""
+    repo = tmp_path / "repo"
+    (repo / ".git" / "hooks").mkdir(parents=True)
+    hook = repo / ".git" / "hooks" / "pre-push"
+    hook.write_text("#!/usr/bin/env bash\necho foreign\nexit 0\n", encoding="utf-8")
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), "--install-hook"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+    # Refuses to clobber a foreign hook; exits 0, prints a notice.
+    assert res.returncode == 0
+    assert "foreign" in hook.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("arm", ["base", "head"])
+def test_record_arm_keying(temp_db_no_envelope, tmp_path, monkeypatch, arm):
+    """base and head arms write distinct keys (skill@head:arm)."""
+    mod = _load_module()
+    monkeypatch.setattr(mod, "ABLATION_LOG", tmp_path / f"log-{arm}.jsonl", raising=False)
+    head = "c" * 40
+    mod.record_run(
+        eval_dir="evals/k",
+        skill="planning",
+        arm=arm,
+        pass_rate=0.5,
+        runs=1,
+        base_sha="b" * 40,
+        head_sha=head,
+        model_id="m",
+        skill_version="1.0.0",
+    )
+    sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    rows = ldb.query_learnings(topic="eval:evals/k", exclude_test_sources=False)
+    assert any(r["key"] == f"planning@{head}:{arm}" for r in rows)

--- a/scripts/tests/test_skill_eval_ablation.py
+++ b/scripts/tests/test_skill_eval_ablation.py
@@ -6,10 +6,11 @@ ADR: skill-eval-pr-ablation, Decision section 3 + Validation Requirements 3-5.
 
 Covers the parts that do NOT need the `claude` CLI:
 - delta line formatting (base% -> head% (+delta));
-- --record degradation when the PR-A envelope is absent: WARN string + one
-  JSON line appended to the log file, exit 0, no DB row dropped;
-- --record promotion when the envelope is present: named columns written,
-  readable back by learning-db query (git_commit_sha == head);
+- --record degradation when PR-A's telemetry_runs table is absent: WARN string +
+  one JSON line appended to the log file, exit 0, no DB row dropped;
+- --record promotion when telemetry_runs is present: envelope written to
+  telemetry_runs, read back by `learning-db telemetry-query` (git_sha == head);
+- a dirty (uncommitted) edit to a mapped skill survives an ablation run;
 - the CI workflow YAML guarantees the coverage job can never become a failing
   required check (continue-on-error: true, no required: true);
 - --install-hook writes an idempotent, advisory .git/hooks/pre-push.
@@ -139,10 +140,14 @@ def test_record_no_envelope_still_writes_db_row(temp_db_no_envelope, tmp_path, m
 
 # ---------------------------------------------------------------------------
 # --record promotion (PR-A envelope present) -- Validation Requirement 5.
+#
+# PR-A's envelope lives in the telemetry_runs table (git_sha column), not on
+# learnings. The run's envelope must read back from telemetry_runs by
+# git_sha == head via the real learning-db CLI.
 # ---------------------------------------------------------------------------
 
 
-def test_record_with_envelope_writes_named_columns(temp_db_with_envelope, tmp_path, monkeypatch):
+def test_record_with_envelope_writes_telemetry_run(temp_db_with_envelope, tmp_path, monkeypatch):
     mod = _load_module()
     monkeypatch.setattr(mod, "ABLATION_LOG", tmp_path / "log.jsonl", raising=False)
     head = "a" * 40
@@ -159,8 +164,30 @@ def test_record_with_envelope_writes_named_columns(temp_db_with_envelope, tmp_pa
     )
     assert rc == 0
 
-    # Read it back via the learning-db CLI query (Validation Requirement 5).
+    # Read back from telemetry_runs by git_sha via the real CLI (Validation Req 5).
     res = subprocess.run(
+        [
+            sys.executable,
+            str(LEARNING_DB_CLI),
+            "telemetry-query",
+            "--topic",
+            "eval:evals/new-skills-ab-test",
+            "--git-sha",
+            head,
+            "--format",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        env={**_clean_env(), "CLAUDE_LEARNING_DIR": str(temp_db_with_envelope.parent)},
+    )
+    assert res.returncode == 0, res.stderr
+    rows = json.loads(res.stdout)
+    assert rows, "expected at least one telemetry_runs row"
+    assert any(r.get("git_sha") == head for r in rows)
+    assert all(r.get("git_sha") == head for r in rows)
+    # The human summary row still lands in learnings for queryability.
+    res2 = subprocess.run(
         [
             sys.executable,
             str(LEARNING_DB_CLI),
@@ -174,10 +201,28 @@ def test_record_with_envelope_writes_named_columns(temp_db_with_envelope, tmp_pa
         text=True,
         env={**_clean_env(), "CLAUDE_LEARNING_DIR": str(temp_db_with_envelope.parent)},
     )
-    assert res.returncode == 0, res.stderr
-    rows = json.loads(res.stdout)
-    assert rows, "expected at least one row"
-    assert any(r.get("git_commit_sha") == head for r in rows)
+    assert res2.returncode == 0, res2.stderr
+    learn_rows = json.loads(res2.stdout)
+    assert any(f"git_commit_sha={head}" in r.get("value", "") for r in learn_rows)
+
+
+def test_record_with_envelope_no_log_written(temp_db_with_envelope, tmp_path, monkeypatch):
+    """When PR-A is present the degraded log file is NOT written."""
+    mod = _load_module()
+    log = tmp_path / "should-not-exist.jsonl"
+    monkeypatch.setattr(mod, "ABLATION_LOG", log, raising=False)
+    mod.record_run(
+        eval_dir="evals/x",
+        skill="planning",
+        arm="head",
+        pass_rate=0.5,
+        runs=1,
+        base_sha="b" * 40,
+        head_sha="a" * 40,
+        model_id="m",
+        skill_version="1.0.0",
+    )
+    assert not log.exists()
 
 
 def _clean_env() -> dict:
@@ -253,6 +298,78 @@ def test_install_hook_preserves_foreign_hook(tmp_path):
     # Refuses to clobber a foreign hook; exits 0, prints a notice.
     assert res.returncode == 0
     assert "foreign" in hook.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Dirty-tree safety -- uncommitted edits to a changed skill must survive.
+# ---------------------------------------------------------------------------
+
+
+def _planning_md(repo: Path) -> Path:
+    return repo / "skills" / "process" / "planning" / "SKILL.md"
+
+
+def test_ablate_refuses_dirty_skill_and_preserves_edit(git_range, monkeypatch):
+    """An uncommitted edit to a mapped skill survives an ablation run.
+
+    The runner must NOT check out base content over a dirty file. It raises
+    DirtyTreeError before any checkout, so the working-tree edit is intact.
+    """
+    mod = _load_module()
+    repo = git_range["repo"]
+    base, head = git_range["base"], git_range["head"]
+
+    # Append an uncommitted line to the changed skill.
+    md = _planning_md(repo)
+    sentinel = "UNCOMMITTED-WORK-DO-NOT-LOSE\n"
+    md.write_text(md.read_text(encoding="utf-8") + sentinel, encoding="utf-8")
+
+    # Direct ablate_skill raises rather than clobbering.
+    with pytest.raises(mod.DirtyTreeError):
+        mod.ablate_skill(repo, "planning", "evals/planning", base, head, runs=1, record=False)
+
+    # The uncommitted line is still there -- not destroyed.
+    assert sentinel in md.read_text(encoding="utf-8")
+
+
+def test_run_ablation_skips_dirty_skill_continues_clean(git_range, capsys):
+    """run_ablation reports the dirty skill, skips it, exits 0, leaves the edit."""
+    mod = _load_module()
+    repo = git_range["repo"]
+    base, head = git_range["base"], git_range["head"]
+
+    md = _planning_md(repo)
+    sentinel = "STILL-HERE\n"
+    md.write_text(md.read_text(encoding="utf-8") + sentinel, encoding="utf-8")
+
+    rc = mod.run_ablation(repo, base, head, only_skill=None, runs=1, record=False)
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "skipped" in err and "planning" in err
+    # Edit survived; no checkout touched the file.
+    assert sentinel in md.read_text(encoding="utf-8")
+
+
+def test_ablate_clean_skill_restores_head_content(git_range, monkeypatch):
+    """On a clean tree the run restores head content (restore fidelity).
+
+    The eval cannot run here (no claude CLI), so run_eval_for_content returns
+    None. We only assert the checkout round-trip leaves head content in place.
+    """
+    mod = _load_module()
+    repo = git_range["repo"]
+    base, head = git_range["base"], git_range["head"]
+
+    md = _planning_md(repo)
+    head_content = md.read_text(encoding="utf-8")
+    assert "Head body changed." in head_content  # sanity: starts on head
+
+    mod.ablate_skill(repo, "planning", "evals/planning", base, head, runs=1, record=False)
+
+    # After the run the file holds head content again, not base.
+    after = md.read_text(encoding="utf-8")
+    assert "Head body changed." in after
+    assert "Base body." not in after
 
 
 @pytest.mark.parametrize("arm", ["base", "head"])


### PR DESCRIPTION
## Summary

Per-PR skill-eval ablation, report-only — neither surface blocks a merge.
ADR: skill-eval-pr-ablation (local-only, gitignored).

A skill change ships today with no measured eval delta. Evals cannot run in GitHub Actions: the runner shells to the `claude` CLI, absent on hosted runners. So CI reports coverage; a local command runs the real before/after ablation.

Key decisions (ADR):
- CI reports coverage only; it never runs an eval and never sets a failing check (rejected the never-green gate).
- Coverage gaps surface as a PR comment, not a block (rejected mandatory coverage).
- Local `make skill-eval-ablation` runs the real delta; `--record` rides PR-A's telemetry envelope.
- No PR-A yet: `--record` degrades to a no-op against the DB columns and appends each run to `~/.claude/eval-ablations.log` — never fails.

## Changes

- `scripts/detect-skill-changes.py` — map changed skills (base..head) to `evals/` dirs; JSON/human output; exit 0 always.
- `scripts/skill-eval-ablation.py` — local base-vs-head runner; prints delta; `--record`, `--pre-push`, `--install-hook`.
- `scripts/render-skill-eval-comment.py` — render the sticky coverage PR comment.
- `scripts/learning-db.py` — query support for recorded ablation runs.
- `.github/workflows/test.yml` — add report-only `skill-eval-coverage` job (paths-filter `skills/**`, `continue-on-error`, sticky comment).
- `Makefile` — add `skill-eval-ablation` target.
- `evals/README.md` — document the ablation command, mapping convention, and opt-in pre-push hook.
- `scripts/tests/{conftest.py,test_detect_skill_changes.py,test_skill_eval_ablation.py}` — fixtures plus 24 tests: mapping rules, 3-skill integration, `--record` degradation/promotion, CI-config invariant, `--install-hook` idempotence.

## Notes

- Not covered by CI — the real ablation spends model calls and runs only locally (no `claude` CLI on hosted runners). CI shows coverage; the delta comes from `make skill-eval-ablation`.
- `--record` against the learning.db envelope columns is exercised only when PR-A has landed; before then it writes the log fallback. The DB-promotion path is verified locally against a simulated PR-A schema.
- Pre-push hook is opt-in twice over: installed via `--install-hook`, and acts only when `VEXJOY_SKILL_EVAL_PREPUSH=1`. It always exits 0 (advisory, never blocks).
