### PR TITLE
feat: review-tier ROI instrumentation + review-roi query

### DIFF
--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -592,6 +592,128 @@ def record_learning(
         }
 
 
+# ─── Rightsizing ROI accumulation (ADR: review-tier-roi) ──────
+#
+# The rightsizing:tier{N} row must yield a TRUE per-tier mean, not the last
+# review's sample. record_learning's upsert keeps only the longest `value` and
+# discards per-review numbers, so it cannot store a running mean. This function
+# read-modify-writes running sums in the value envelope under one connection, so
+# review-roi divides true sums by true counts. Findings-bearing and cost counts
+# are tracked separately: a legacy (no-findings) review bumps `reviews` only,
+# never the findings sums or denominator; a review with tokens "-" never enters
+# the token sum. Atomic: SELECT + UPSERT share one connection and commit.
+
+# Order is the stored value's field order; review-roi parses by name, not order.
+_RIGHTSIZING_SUM_FIELDS = (
+    "reviews",  # all banners at this tier (= observation_count)
+    "sum_critical",
+    "sum_high",
+    "sum_medium",
+    "n_findings",  # banners that carried findings= (findings denominator)
+    "sum_tokens",
+    "n_tokens",  # banners with a numeric tokens= (token denominator)
+    "sum_wall_clock_s",
+    "n_wall",  # banners with a numeric wall_clock_s=
+)
+
+
+def _parse_rightsizing_sums(value: str) -> dict[str, int]:
+    """Read the running-sum envelope into ints; missing/non-numeric fields = 0."""
+    sums = dict.fromkeys(_RIGHTSIZING_SUM_FIELDS, 0)
+    for pair in (value or "").split(" | "):
+        if ": " not in pair:
+            continue
+        k, v = pair.split(": ", 1)
+        k = k.strip()
+        if k in sums:
+            try:
+                sums[k] = int(float(v.strip()))
+            except (ValueError, TypeError):
+                pass
+    return sums
+
+
+def accumulate_rightsizing(
+    tier: int,
+    *,
+    critical: int | None = None,
+    high: int | None = None,
+    medium: int | None = None,
+    tokens: int | None = None,
+    wall_clock_s: int | None = None,
+    source: str = "hook:routing-decision-recorder",
+    session_id: str | None = None,
+    confidence: float | None = None,
+) -> dict:
+    """Add one rightsizing review to the tier's running sums. Atomic upsert.
+
+    Pass None for an absent banner field. `critical/high/medium` are all-or-none:
+    when all three are given it counts as a findings-bearing review (bumps
+    n_findings and the severity sums); when all three are None it is a legacy
+    composition-only review (bumps `reviews` alone). `tokens` / `wall_clock_s`
+    each enter their own sum and denominator only when numeric.
+
+    The stored `value` always reflects the new sums (written directly, not via
+    record_learning's longest-value merge). observation_count = reviews at tier.
+    """
+    init_db()
+    now = datetime.now().isoformat()
+    if confidence is None:
+        confidence = CATEGORY_DEFAULTS.get("effectiveness", 0.5)
+
+    key = f"rightsizing:tier{int(tier)}"
+    has_findings = critical is not None and high is not None and medium is not None
+    has_tokens = tokens is not None
+    has_wall = wall_clock_s is not None
+
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT value FROM learnings WHERE topic = 'routing' AND key = ?",
+            (key,),
+        ).fetchone()
+        sums = _parse_rightsizing_sums(row["value"]) if row else dict.fromkeys(_RIGHTSIZING_SUM_FIELDS, 0)
+
+        sums["reviews"] += 1
+        if has_findings:
+            sums["sum_critical"] += int(critical)
+            sums["sum_high"] += int(high)
+            sums["sum_medium"] += int(medium)
+            sums["n_findings"] += 1
+        if has_tokens:
+            sums["sum_tokens"] += int(tokens)
+            sums["n_tokens"] += 1
+        if has_wall:
+            sums["sum_wall_clock_s"] += int(wall_clock_s)
+            sums["n_wall"] += 1
+
+        value = f"tier: {int(tier)} | " + " | ".join(f"{f}: {sums[f]}" for f in _RIGHTSIZING_SUM_FIELDS)
+        tags_str = ",".join(["routing", "rightsizing", f"tier{int(tier)}"])
+
+        conn.execute(
+            """
+            INSERT INTO learnings
+                (topic, key, value, category, confidence, tags,
+                 source, session_id, first_seen, last_seen)
+            VALUES ('routing', ?, ?, 'effectiveness', ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(topic, key) DO UPDATE SET
+                value = excluded.value,
+                confidence = max(confidence, excluded.confidence),
+                observation_count = observation_count + 1,
+                last_seen = excluded.last_seen,
+                source = excluded.source,
+                tags = COALESCE(excluded.tags, tags)
+            """,
+            (key, value, confidence, tags_str, source, session_id, now, now),
+        )
+        conn.commit()
+
+        out = conn.execute(
+            "SELECT value, observation_count FROM learnings WHERE topic = 'routing' AND key = ?",
+            (key,),
+        ).fetchone()
+        return {"key": key, "value": out["value"], "observation_count": out["observation_count"]}
+
+
 def record_telemetry_run(
     *,
     topic: str,

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -134,37 +134,33 @@ def detect_errors(event: dict) -> bool:
 
 
 def record_rightsizing(output: str, session_id: str | None = None) -> None:
-    """(C) Record a rightsizing row when the output carries the banner. Silent otherwise.
+    """(C) Add one rightsizing review to the tier's running sums. Silent when no banner.
 
-    Stores the full review envelope as a pipe-delimited `k: v` value so
-    `learning-db.py review-roi` (and route-stats) can parse it with the shared
-    split loop. findings= and the cost fields are optional; absent fields store
-    as "-" and average out as n/a downstream (ADR: review-tier-roi).
+    Per-review findings and cost are accumulated into running sums in the
+    rightsizing:tier{N} row (`accumulate_rightsizing`) so `learning-db.py
+    review-roi` reports a TRUE per-tier mean (sum / count), not the last
+    review's sample. findings= and the cost fields are optional: a legacy
+    banner (no findings=) bumps the review count only; a "-" cost never enters
+    its sum (ADR: review-tier-roi).
     """
     if not output or "rightsizing:" not in output.lower():
         return
     m = _RIGHTSIZING_RE.search(output)
     if not m:
         return
-    tier, files, packages, agents = m.group(1), m.group(2), m.group(3), m.group(4)
-    crit = m.group(5) or "-"
-    high = m.group(6) or "-"
-    med = m.group(7) or "-"
-    tokens = m.group(8) or "-"
-    wall = m.group(9) or "-"
-    from learning_db_v2 import record_learning
 
-    record_learning(
-        topic="routing",
-        key=f"rightsizing:tier{tier}",
-        value=(
-            f"tier: {tier} | files: {files} | packages: {packages} | "
-            f"agents_dispatched: {agents} | findings_critical: {crit} | "
-            f"findings_high: {high} | findings_medium: {med} | "
-            f"tokens: {tokens} | wall_clock_s: {wall}"
-        ),
-        category="effectiveness",
-        tags=["routing", "rightsizing", f"tier{tier}"],
+    def _int_or_none(s: str | None) -> int | None:
+        return int(s) if s is not None and s != "" else None
+
+    from learning_db_v2 import accumulate_rightsizing
+
+    accumulate_rightsizing(
+        int(m.group(1)),
+        critical=_int_or_none(m.group(5)),
+        high=_int_or_none(m.group(6)),
+        medium=_int_or_none(m.group(7)),
+        tokens=_int_or_none(m.group(8)),
+        wall_clock_s=_int_or_none(m.group(9)),
         source="hook:routing-decision-recorder",
         session_id=session_id or None,
     )

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -74,9 +74,15 @@ _DO_ROUTE_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
-# Right-sizing banner, e.g. "rightsizing: tier=2 files=8 packages=3 agents_dispatched=12"
+# Right-sizing banner. The first four fields are required; findings= and the
+# cost fields (tokens=, wall_clock_s=) are optional, additive extensions
+# (ADR: review-tier-roi). Legacy four-field banners still match.
+#   rightsizing: tier=3 files=15 packages=4 agents_dispatched=17 findings=2C/3H/5M tokens=84000 wall_clock_s=312
 _RIGHTSIZING_RE = re.compile(
-    r"rightsizing:\s*tier=(\d+)\s+files=(\d+)\s+packages=(\d+)\s+agents_dispatched=(\d+)",
+    r"rightsizing:\s*tier=(\d+)\s+files=(\d+)\s+packages=(\d+)\s+agents_dispatched=(\d+)"
+    r"(?:\s+findings=(\d+)C/(\d+)H/(\d+)M)?"
+    r"(?:\s+tokens=(\d+))?"
+    r"(?:\s+wall_clock_s=(\d+))?",
     re.IGNORECASE,
 )
 
@@ -127,23 +133,40 @@ def detect_errors(event: dict) -> bool:
         return False
 
 
-def record_rightsizing(output: str) -> None:
-    """(C) Record a rightsizing row when the output carries the banner. Silent otherwise."""
+def record_rightsizing(output: str, session_id: str | None = None) -> None:
+    """(C) Record a rightsizing row when the output carries the banner. Silent otherwise.
+
+    Stores the full review envelope as a pipe-delimited `k: v` value so
+    `learning-db.py review-roi` (and route-stats) can parse it with the shared
+    split loop. findings= and the cost fields are optional; absent fields store
+    as "-" and average out as n/a downstream (ADR: review-tier-roi).
+    """
     if not output or "rightsizing:" not in output.lower():
         return
     m = _RIGHTSIZING_RE.search(output)
     if not m:
         return
     tier, files, packages, agents = m.group(1), m.group(2), m.group(3), m.group(4)
+    crit = m.group(5) or "-"
+    high = m.group(6) or "-"
+    med = m.group(7) or "-"
+    tokens = m.group(8) or "-"
+    wall = m.group(9) or "-"
     from learning_db_v2 import record_learning
 
     record_learning(
         topic="routing",
         key=f"rightsizing:tier{tier}",
-        value=f"rightsizing: tier={tier} files={files} packages={packages} agents_dispatched={agents}",
+        value=(
+            f"tier: {tier} | files: {files} | packages: {packages} | "
+            f"agents_dispatched: {agents} | findings_critical: {crit} | "
+            f"findings_high: {high} | findings_medium: {med} | "
+            f"tokens: {tokens} | wall_clock_s: {wall}"
+        ),
         category="effectiveness",
-        tags=["routing", "rightsizing"],
+        tags=["routing", "rightsizing", f"tier{tier}"],
         source="hook:routing-decision-recorder",
+        session_id=session_id or None,
     )
 
 
@@ -231,7 +254,7 @@ def main() -> None:
 
         output = get_tool_output(get_tool_result(event))
         if isinstance(output, str):
-            record_rightsizing(output)
+            record_rightsizing(output, session_id)
 
         # Bridge to the SubagentStop outcome hook (action B). The dispatch was
         # already claimed (marked seen) atomically above, so no separate mark.

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -217,6 +217,57 @@ class TestDecisionRecorder:
         keys = {r["key"] for r in _query_routing(db_env)}
         assert not any(k.startswith("rightsizing:") for k in keys)
 
+    def test_rightsizing_row_records_findings(self, db_env, monkeypatch):
+        # ADR review-tier-roi test 1: a banner carrying findings= records the
+        # per-severity counts in the rightsizing:tier{N} row value.
+        a = _load(A_PATH, "rdr_findings")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        event = _agent_event(
+            skill="systematic-code-review",
+            output="done. rightsizing: tier=3 files=15 packages=4 agents_dispatched=17 findings=2C/3H/5M",
+        )
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        row = next(r for r in _query_routing(db_env) if r["key"] == "rightsizing:tier3")
+        assert "findings_critical: 2" in row["value"]
+        assert "findings_high: 3" in row["value"]
+        assert "findings_medium: 5" in row["value"]
+
+    def test_rightsizing_row_records_cost_fields(self, db_env, monkeypatch):
+        # ADR review-tier-roi: optional tokens= and wall_clock_s= are stored.
+        a = _load(A_PATH, "rdr_cost")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        event = _agent_event(
+            skill="systematic-code-review",
+            output=(
+                "done. rightsizing: tier=2 files=8 packages=2 agents_dispatched=12 "
+                "findings=0C/1H/2M tokens=52000 wall_clock_s=180"
+            ),
+        )
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        row = next(r for r in _query_routing(db_env) if r["key"] == "rightsizing:tier2")
+        assert "tokens: 52000" in row["value"]
+        assert "wall_clock_s: 180" in row["value"]
+
+    def test_legacy_rightsizing_banner_still_records(self, db_env, monkeypatch):
+        # ADR review-tier-roi test 2: a four-field legacy banner (no findings=)
+        # still records the tier row; findings/cost fields stored as "-".
+        a = _load(A_PATH, "rdr_legacy")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        event = _agent_event(
+            skill="systematic-code-review",
+            output="done. rightsizing: tier=1 files=3 packages=1 agents_dispatched=3",
+        )
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        row = next(r for r in _query_routing(db_env) if r["key"] == "rightsizing:tier1")
+        assert "findings_critical: -" in row["value"]
+        assert "tokens: -" in row["value"]
+
     def test_idempotent_same_dispatch_recorded_once(self, db_env):
         # Use the real bridge state (redirected to tmp) so dedup engages.
         a = _load(A_PATH, "rdr_a6")

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -218,8 +218,8 @@ class TestDecisionRecorder:
         assert not any(k.startswith("rightsizing:") for k in keys)
 
     def test_rightsizing_row_records_findings(self, db_env, monkeypatch):
-        # ADR review-tier-roi test 1: a banner carrying findings= records the
-        # per-severity counts in the rightsizing:tier{N} row value.
+        # ADR review-tier-roi test 1: a banner carrying findings= adds the
+        # severity counts to the tier's running sums (one findings-bearing review).
         a = _load(A_PATH, "rdr_findings")
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
         monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
@@ -230,12 +230,32 @@ class TestDecisionRecorder:
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             a.main()
         row = next(r for r in _query_routing(db_env) if r["key"] == "rightsizing:tier3")
-        assert "findings_critical: 2" in row["value"]
-        assert "findings_high: 3" in row["value"]
-        assert "findings_medium: 5" in row["value"]
+        assert "sum_critical: 2" in row["value"]
+        assert "sum_high: 3" in row["value"]
+        assert "sum_medium: 5" in row["value"]
+        assert "n_findings: 1" in row["value"]
+
+    def test_rightsizing_sums_accumulate_a_true_mean(self, db_env, monkeypatch):
+        # The fix's core: two findings-bearing reviews at one tier accumulate
+        # into running sums (2+5 critical over n_findings=2 => mean 3.5), NOT
+        # the last sample. Two banners must not overwrite each other.
+        a = _load(A_PATH, "rdr_mean")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        for out, sess in (
+            ("rightsizing: tier=3 files=15 packages=4 agents_dispatched=17 findings=2C/1H/0M", "s1"),
+            ("rightsizing: tier=3 files=15 packages=4 agents_dispatched=17 findings=5C/3H/4M", "s2"),
+        ):
+            event = _agent_event(skill="systematic-code-review", output=f"done. {out}", session=sess)
+            with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+                a.main()
+        row = next(r for r in _query_routing(db_env) if r["key"] == "rightsizing:tier3")
+        assert "sum_critical: 7" in row["value"]  # 2 + 5
+        assert "sum_high: 4" in row["value"]  # 1 + 3
+        assert "n_findings: 2" in row["value"]
 
     def test_rightsizing_row_records_cost_fields(self, db_env, monkeypatch):
-        # ADR review-tier-roi: optional tokens= and wall_clock_s= are stored.
+        # ADR review-tier-roi: optional tokens= and wall_clock_s= enter the sums.
         a = _load(A_PATH, "rdr_cost")
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
         monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
@@ -249,12 +269,13 @@ class TestDecisionRecorder:
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             a.main()
         row = next(r for r in _query_routing(db_env) if r["key"] == "rightsizing:tier2")
-        assert "tokens: 52000" in row["value"]
-        assert "wall_clock_s: 180" in row["value"]
+        assert "sum_tokens: 52000" in row["value"]
+        assert "n_tokens: 1" in row["value"]
+        assert "sum_wall_clock_s: 180" in row["value"]
 
     def test_legacy_rightsizing_banner_still_records(self, db_env, monkeypatch):
         # ADR review-tier-roi test 2: a four-field legacy banner (no findings=)
-        # still records the tier row; findings/cost fields stored as "-".
+        # still records the tier row; it bumps `reviews` but no findings sum.
         a = _load(A_PATH, "rdr_legacy")
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
         monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
@@ -265,8 +286,29 @@ class TestDecisionRecorder:
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             a.main()
         row = next(r for r in _query_routing(db_env) if r["key"] == "rightsizing:tier1")
-        assert "findings_critical: -" in row["value"]
-        assert "tokens: -" in row["value"]
+        assert "reviews: 1" in row["value"]
+        assert "n_findings: 0" in row["value"]
+        assert "sum_critical: 0" in row["value"]
+        assert "n_tokens: 0" in row["value"]
+
+    def test_legacy_review_does_not_pollute_findings_mean(self, db_env, monkeypatch):
+        # A legacy (no-findings) review at a tier that also has a findings-bearing
+        # review must NOT count into the findings denominator: n_findings stays 1
+        # while `reviews` is 2. (The old single-row model lost this distinction.)
+        a = _load(A_PATH, "rdr_mix")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        for out, sess in (
+            ("rightsizing: tier=2 files=8 packages=2 agents_dispatched=12 findings=4C/2H/1M", "s1"),
+            ("rightsizing: tier=2 files=8 packages=2 agents_dispatched=12", "s2"),  # legacy
+        ):
+            event = _agent_event(skill="systematic-code-review", output=f"done. {out}", session=sess)
+            with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+                a.main()
+        row = next(r for r in _query_routing(db_env) if r["key"] == "rightsizing:tier2")
+        assert "reviews: 2" in row["value"]
+        assert "n_findings: 1" in row["value"]
+        assert "sum_critical: 4" in row["value"]  # only the findings-bearing review
 
     def test_idempotent_same_dispatch_recorded_once(self, db_env):
         # Use the real bridge state (redirected to tmp) so dedup engages.

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -25,6 +25,7 @@ Usage:
     python3 scripts/learning-db.py record-session --session SESSION_ID --had-retro --failures 2 --waste-tokens 3000
     python3 scripts/learning-db.py roi [--json]
     python3 scripts/learning-db.py route-stats --by agent|skill|force-route|errors|override|week|day [--json]
+    python3 scripts/learning-db.py review-roi [--json]
     python3 scripts/learning-db.py route-delta --from REF --to REF [--key AGENT:SKILL] [--metric error|tokens] [--json]
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --success
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --failure --reason "user re-routed"
@@ -35,6 +36,7 @@ Usage:
 
 import argparse
 import json
+import re
 import sqlite3
 import sys
 from datetime import datetime, timedelta
@@ -708,6 +710,129 @@ def _cohort_tokens(conn, where: str, params: list[str]) -> dict:
     return {"runs": row["runs"], "n": n, "avg_tokens": avg}
 
 
+# Below this many findings-bearing reviews the ROI table refuses to assert a
+# "best" tier — a humility gate, not a merge gate (ADR: review-tier-roi).
+ROI_MIN_REVIEWS = 20
+
+# Severity fields whose per-tier average is always reported.
+_ROI_FINDINGS_FIELDS = ("findings_critical", "findings_high", "findings_medium")
+# Cost fields that are nullable: a "-" value is skipped, never counted as 0.
+_ROI_COST_FIELDS = ("tokens", "wall_clock_s")
+_RIGHTSIZING_KEY_RE = re.compile(r"^rightsizing:tier(\d+)$")
+
+
+def _parse_pipe_value(value: str) -> dict[str, str]:
+    """Parse a pipe-delimited `k: v | k: v` value into a dict (route-stats format)."""
+    parsed: dict[str, str] = {}
+    for pair in value.split(" | "):
+        if ": " in pair:
+            k, v = pair.split(": ", 1)
+            parsed[k.strip()] = v.strip()
+    return parsed
+
+
+def _avg(total: float, count: int) -> float | None:
+    """Average, or None when there is no contributing row (n/a, not 0)."""
+    return round(total / count, 2) if count else None
+
+
+def _compute_review_roi() -> list[dict]:
+    """Aggregate rightsizing:tier{N} rows into per-tier ROI dicts, tier ascending.
+
+    reviews = observation_count (reviews recorded at that tier). Findings are
+    averaged over reviews. Cost fields average only over rows with a numeric
+    value; an all-"-" tier reports null (n/a). Tiers with zero findings-bearing
+    reviews are excluded (a composition-only banner carries no findings)."""
+    rows = query_learnings(
+        topic="routing",
+        category="effectiveness",
+        limit=10000,
+        exclude_graduated=False,
+        exclude_test_sources=False,
+    )
+    # Per tier: review count + running sums for findings (per-review) and cost.
+    agg: dict[int, dict] = {}
+    for r in rows:
+        m = _RIGHTSIZING_KEY_RE.match(r["key"])
+        if not m:
+            continue
+        fields = _parse_pipe_value(r["value"])
+        # A findings-bearing review has numeric severity counts (not "-").
+        if any(fields.get(f, "-") == "-" for f in _ROI_FINDINGS_FIELDS):
+            continue
+        tier = int(m.group(1))
+        reviews = int(r.get("observation_count", 1) or 1)
+        a = agg.setdefault(
+            tier,
+            {
+                "reviews": 0,
+                "findings": dict.fromkeys(_ROI_FINDINGS_FIELDS, 0.0),
+                "cost": {c: [0.0, 0] for c in _ROI_COST_FIELDS},
+            },
+        )
+        a["reviews"] += reviews
+        for f in _ROI_FINDINGS_FIELDS:
+            a["findings"][f] += float(fields[f]) * reviews
+        for c in _ROI_COST_FIELDS:
+            raw = fields.get(c, "-")
+            if raw != "-":
+                a["cost"][c][0] += float(raw) * reviews
+                a["cost"][c][1] += reviews
+
+    total_reviews = sum(a["reviews"] for a in agg.values())
+    insufficient = total_reviews < ROI_MIN_REVIEWS
+    out = []
+    for tier in sorted(agg):
+        a = agg[tier]
+        n = a["reviews"]
+        out.append(
+            {
+                "tier": tier,
+                "reviews": n,
+                "avg_critical": _avg(a["findings"]["findings_critical"], n),
+                "avg_high": _avg(a["findings"]["findings_high"], n),
+                "avg_medium": _avg(a["findings"]["findings_medium"], n),
+                "avg_tokens": _avg(*a["cost"]["tokens"]),
+                "avg_wall_clock_s": _avg(*a["cost"]["wall_clock_s"]),
+                "insufficient_data": insufficient,
+            }
+        )
+    return out
+
+
+def cmd_review_roi(args: argparse.Namespace) -> None:
+    """review-roi: per-tier review cost/findings ROI (report-only, never blocks)."""
+    init_db()
+    data = _compute_review_roi()
+    total_reviews = sum(r["reviews"] for r in data)
+
+    if args.json:
+        print(json.dumps(data, indent=2, default=str))
+        return
+
+    if not data:
+        print("No review-ROI data. Run reviews that emit findings= in the rightsizing banner.")
+        return
+
+    def _cell(v: float | None) -> str:
+        return "n/a" if v is None else f"{v:g}"
+
+    print(f"Review-Tier ROI  ({total_reviews} reviews)")
+    print(
+        f"{'Tier':<5} {'Reviews':>8} {'Avg Crit':>9} {'Avg High':>9} {'Avg Med':>8} {'Avg Tokens':>11} {'Avg Wall(s)':>12}"
+    )
+    for r in data:
+        print(
+            f"{r['tier']:<5} {r['reviews']:>8} {_cell(r['avg_critical']):>9} {_cell(r['avg_high']):>9} "
+            f"{_cell(r['avg_medium']):>8} {_cell(r['avg_tokens']):>11} {_cell(r['avg_wall_clock_s']):>12}"
+        )
+    if data and data[0]["insufficient_data"]:
+        print(
+            f"INSUFFICIENT DATA: {total_reviews} reviews (<{ROI_MIN_REVIEWS}). "
+            "Numbers shown for inspection; do not act on them."
+        )
+
+
 def cmd_route_delta(args: argparse.Namespace) -> None:
     """route-delta --from REF --to REF: 'did that change help?' cohort comparison.
 
@@ -1287,6 +1412,11 @@ def main():
     )
     p_route_stats.add_argument("--json", action="store_true", help="Also output raw JSON")
     p_route_stats.set_defaults(func=cmd_route_stats)
+
+    # review-roi — per-tier review cost/findings ROI (report-only).
+    p_review_roi = subparsers.add_parser("review-roi", help="Per-tier review cost/findings ROI")
+    p_review_roi.add_argument("--json", action="store_true", help="Output as JSON")
+    p_review_roi.set_defaults(func=cmd_review_roi)
 
     # route-delta — "did that change help?" cohort comparison over telemetry_runs.
     p_route_delta = subparsers.add_parser("route-delta", help="Compare two cohorts (git-SHA or date) of telemetry runs")

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -714,11 +714,20 @@ def _cohort_tokens(conn, where: str, params: list[str]) -> dict:
 # "best" tier — a humility gate, not a merge gate (ADR: review-tier-roi).
 ROI_MIN_REVIEWS = 20
 
-# Severity fields whose per-tier average is always reported.
-_ROI_FINDINGS_FIELDS = ("findings_critical", "findings_high", "findings_medium")
-# Cost fields that are nullable: a "-" value is skipped, never counted as 0.
-_ROI_COST_FIELDS = ("tokens", "wall_clock_s")
 _RIGHTSIZING_KEY_RE = re.compile(r"^rightsizing:tier(\d+)$")
+# Running-sum fields stored by accumulate_rightsizing (learning_db_v2). review-roi
+# divides these true sums by their true counts — no per-review sample survives.
+_RIGHTSIZING_SUM_KEYS = (
+    "reviews",
+    "sum_critical",
+    "sum_high",
+    "sum_medium",
+    "n_findings",
+    "sum_tokens",
+    "n_tokens",
+    "sum_wall_clock_s",
+    "n_wall",
+)
 
 
 def _parse_pipe_value(value: str) -> dict[str, str]:
@@ -731,6 +740,14 @@ def _parse_pipe_value(value: str) -> dict[str, str]:
     return parsed
 
 
+def _to_int(s: str | None) -> int:
+    """Read a stored sum/count field to int; non-numeric or missing => 0."""
+    try:
+        return int(float(s))
+    except (ValueError, TypeError):
+        return 0
+
+
 def _avg(total: float, count: int) -> float | None:
     """Average, or None when there is no contributing row (n/a, not 0)."""
     return round(total / count, 2) if count else None
@@ -739,10 +756,16 @@ def _avg(total: float, count: int) -> float | None:
 def _compute_review_roi() -> list[dict]:
     """Aggregate rightsizing:tier{N} rows into per-tier ROI dicts, tier ascending.
 
-    reviews = observation_count (reviews recorded at that tier). Findings are
-    averaged over reviews. Cost fields average only over rows with a numeric
-    value; an all-"-" tier reports null (n/a). Tiers with zero findings-bearing
-    reviews are excluded (a composition-only banner carries no findings)."""
+    Each row stores RUNNING SUMS, not one sample, so averages are true means
+    (ADR: review-tier-roi). Findings averages divide sum_critical/high/medium by
+    n_findings (findings-bearing reviews only) — legacy no-findings reviews are
+    counted in `reviews` but never inflate the findings denominator. Cost
+    averages divide sum_tokens by n_tokens (and wall by n_wall); an all-"-" tier
+    has n_tokens 0 and reports null (n/a, not 0). A tier with zero
+    findings-bearing reviews (n_findings 0) is excluded from the table.
+
+    `reviews` displayed = n_findings (the reviews the findings averages rest on),
+    so the count and the averages describe the same sample."""
     rows = query_learnings(
         topic="routing",
         category="effectiveness",
@@ -750,50 +773,36 @@ def _compute_review_roi() -> list[dict]:
         exclude_graduated=False,
         exclude_test_sources=False,
     )
-    # Per tier: review count + running sums for findings (per-review) and cost.
-    agg: dict[int, dict] = {}
+    # One row per tier carries the running sums; merge defensively if duplicated.
+    agg: dict[int, dict[str, int]] = {}
     for r in rows:
         m = _RIGHTSIZING_KEY_RE.match(r["key"])
         if not m:
             continue
-        fields = _parse_pipe_value(r["value"])
-        # A findings-bearing review has numeric severity counts (not "-").
-        if any(fields.get(f, "-") == "-" for f in _ROI_FINDINGS_FIELDS):
-            continue
+        f = _parse_pipe_value(r["value"])
         tier = int(m.group(1))
-        reviews = int(r.get("observation_count", 1) or 1)
-        a = agg.setdefault(
-            tier,
-            {
-                "reviews": 0,
-                "findings": dict.fromkeys(_ROI_FINDINGS_FIELDS, 0.0),
-                "cost": {c: [0.0, 0] for c in _ROI_COST_FIELDS},
-            },
-        )
-        a["reviews"] += reviews
-        for f in _ROI_FINDINGS_FIELDS:
-            a["findings"][f] += float(fields[f]) * reviews
-        for c in _ROI_COST_FIELDS:
-            raw = fields.get(c, "-")
-            if raw != "-":
-                a["cost"][c][0] += float(raw) * reviews
-                a["cost"][c][1] += reviews
+        a = agg.setdefault(tier, dict.fromkeys(_RIGHTSIZING_SUM_KEYS, 0))
+        for k in _RIGHTSIZING_SUM_KEYS:
+            a[k] += _to_int(f.get(k))
 
-    total_reviews = sum(a["reviews"] for a in agg.values())
+    # Reviews underpinning the findings averages, summed across findings-bearing tiers.
+    total_reviews = sum(a["n_findings"] for a in agg.values() if a["n_findings"])
     insufficient = total_reviews < ROI_MIN_REVIEWS
     out = []
     for tier in sorted(agg):
         a = agg[tier]
-        n = a["reviews"]
+        nf = a["n_findings"]
+        if nf <= 0:
+            continue  # composition-only tier: no findings to average
         out.append(
             {
                 "tier": tier,
-                "reviews": n,
-                "avg_critical": _avg(a["findings"]["findings_critical"], n),
-                "avg_high": _avg(a["findings"]["findings_high"], n),
-                "avg_medium": _avg(a["findings"]["findings_medium"], n),
-                "avg_tokens": _avg(*a["cost"]["tokens"]),
-                "avg_wall_clock_s": _avg(*a["cost"]["wall_clock_s"]),
+                "reviews": nf,
+                "avg_critical": _avg(a["sum_critical"], nf),
+                "avg_high": _avg(a["sum_high"], nf),
+                "avg_medium": _avg(a["sum_medium"], nf),
+                "avg_tokens": _avg(a["sum_tokens"], a["n_tokens"]),
+                "avg_wall_clock_s": _avg(a["sum_wall_clock_s"], a["n_wall"]),
                 "insufficient_data": insufficient,
             }
         )

--- a/scripts/right-size-review.py
+++ b/scripts/right-size-review.py
@@ -25,8 +25,12 @@ Exit 0 always (a sizing signal never blocks a review).
 
 import argparse
 import json
+import re
 import subprocess
 import sys
+
+# Validates the --findings value: NC/NH/NM (critical/high/medium counts).
+_FINDINGS_RE = re.compile(r"^(\d+)C/(\d+)H/(\d+)M$", re.IGNORECASE)
 
 
 def _tier_from_value(value: int, bounds: list[int]) -> int:
@@ -108,6 +112,10 @@ def main() -> int:
     parser.add_argument("--packages", type=int, help="package (directory) count")
     parser.add_argument("--base", help="git base ref (computes scope from range)")
     parser.add_argument("--head", default="HEAD", help="git head ref (default: HEAD)")
+    parser.add_argument(
+        "--findings",
+        help="aggregated review findings NC/NH/NM; emits the rightsizing capture banner",
+    )
     args = parser.parse_args()
 
     if args.files is not None:
@@ -118,6 +126,20 @@ def main() -> int:
 
     tier = compute_tier(file_count, package_count)
     comp = composition_for_tier(tier)
+
+    # With --findings, emit the rightsizing banner the routing-decision-recorder
+    # parses (ADR: review-tier-roi). Without it, JSON-only — existing callers
+    # that json.loads(stdout) are unaffected. Malformed findings => warn, skip.
+    if args.findings:
+        fm = _FINDINGS_RE.match(args.findings.strip())
+        if fm:
+            print(
+                f"rightsizing: tier={tier} files={file_count} packages={package_count} "
+                f"agents_dispatched={comp['agent_estimate']} "
+                f"findings={fm.group(1)}C/{fm.group(2)}H/{fm.group(3)}M"
+            )
+        else:
+            print(f"warning: --findings must be NC/NH/NM, got {args.findings!r}", file=sys.stderr)
 
     result = {
         "tier": tier,

--- a/scripts/tests/test_review_roi.py
+++ b/scripts/tests/test_review_roi.py
@@ -1,0 +1,172 @@
+"""Tests for the `review-roi` subcommand in learning-db.py (ADR: review-tier-roi).
+
+Covers:
+- Per-tier averaging math over rightsizing:tier{N} rows (findings + cost).
+- The <20 insufficient-data guard: below threshold => insufficient_data true and
+  no tier labeled "best"; at/above => false.
+- Cost nullability: rows with tokens "-" are skipped; an all-"-" tier reports
+  avg_tokens null (n/a), not 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import io
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+# Force the repo hooks/lib copy of learning_db_v2 ahead of any ~/.claude copy,
+# mirroring test_learning_roi.py.
+_repo_root = Path(__file__).resolve().parent.parent.parent
+_repo_hooks_lib = str(_repo_root / "hooks" / "lib")
+
+sys_path_entry = str(Path(__file__).resolve().parent.parent)
+sys.path.insert(0, sys_path_entry)
+learning_db = importlib.import_module("learning-db")
+sys.path.pop(0)
+
+sys.path.insert(0, _repo_hooks_lib)
+if "learning_db_v2" in sys.modules:
+    del sys.modules["learning_db_v2"]
+import learning_db_v2 as _ld2_repo
+
+for attr_name in dir(_ld2_repo):
+    if hasattr(learning_db, attr_name) and not attr_name.startswith("__"):
+        try:
+            setattr(learning_db, attr_name, getattr(_ld2_repo, attr_name))
+        except (AttributeError, TypeError):
+            pass
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    import learning_db_v2
+
+    monkeypatch.setattr(learning_db_v2, "_initialized", False)
+    learning_db_v2.init_db()
+    return db_dir
+
+
+def _seed_tier(tier, *, critical, high, medium, tokens="-", wall="-", reviews=1):
+    """Seed a rightsizing:tier{N} row, bumping observation_count to `reviews`.
+
+    Value uses the pipe-delimited `k: v` envelope cmd_review_roi parses.
+    """
+    value = (
+        f"tier: {tier} | files: 10 | packages: 2 | agents_dispatched: 12 | "
+        f"findings_critical: {critical} | findings_high: {high} | "
+        f"findings_medium: {medium} | tokens: {tokens} | wall_clock_s: {wall}"
+    )
+    for _ in range(reviews):
+        _ld2_repo.record_learning(
+            topic="routing",
+            key=f"rightsizing:tier{tier}",
+            value=value,
+            category="effectiveness",
+            tags=["routing", "rightsizing", f"tier{tier}"],
+            source="hook:routing-decision-recorder",
+        )
+
+
+def _run_json():
+    """Invoke cmd_review_roi --json, return the parsed JSON list."""
+    import json as _json
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        learning_db.cmd_review_roi(argparse.Namespace(json=True))
+    return _json.loads(buf.getvalue())
+
+
+def _run_human():
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        learning_db.cmd_review_roi(argparse.Namespace(json=False))
+    return buf.getvalue()
+
+
+# --- ROI averaging math (test 3) -------------------------------------------
+
+
+class TestRoiMath:
+    def test_per_tier_averages(self, isolated_db):
+        # Two tiers, each seeded so observation_count = reviews.
+        _seed_tier(1, critical=0, high=2, medium=4, reviews=14)
+        _seed_tier(3, critical=1, high=3, medium=6, tokens="84000", wall="310", reviews=8)
+        rows = {r["tier"]: r for r in _run_json()}
+
+        assert rows[1]["reviews"] == 14
+        assert rows[1]["avg_critical"] == 0.0
+        assert rows[1]["avg_high"] == 2.0
+        assert rows[1]["avg_medium"] == 4.0
+
+        assert rows[3]["reviews"] == 8
+        assert rows[3]["avg_critical"] == 1.0
+        assert rows[3]["avg_tokens"] == 84000.0
+        assert rows[3]["avg_wall_clock_s"] == 310.0
+
+    def test_tiers_sorted_ascending(self, isolated_db):
+        _seed_tier(4, critical=1, high=1, medium=1, reviews=11)
+        _seed_tier(2, critical=0, high=1, medium=2, reviews=11)
+        tiers = [r["tier"] for r in _run_json()]
+        assert tiers == sorted(tiers)
+
+
+# --- Insufficient-data guard (test 4) --------------------------------------
+
+
+class TestInsufficientDataGuard:
+    def test_below_threshold_flags_insufficient(self, isolated_db):
+        # 5 + 4 = 9 findings-bearing reviews, under ROI_MIN_REVIEWS (20).
+        _seed_tier(1, critical=0, high=1, medium=2, reviews=5)
+        _seed_tier(2, critical=0, high=2, medium=3, reviews=4)
+        rows = _run_json()
+        assert all(r["insufficient_data"] is True for r in rows)
+        # No tier is labeled "best" below threshold.
+        assert not any(r.get("best") for r in rows)
+
+    def test_below_threshold_human_banner(self, isolated_db):
+        _seed_tier(1, critical=0, high=1, medium=2, reviews=9)
+        out = _run_human()
+        assert "INSUFFICIENT DATA" in out
+        assert "do not act on them" in out
+
+    def test_at_threshold_is_sufficient(self, isolated_db):
+        # 20 total findings-bearing reviews meets the threshold (>= 20).
+        _seed_tier(1, critical=0, high=1, medium=2, reviews=10)
+        _seed_tier(3, critical=1, high=2, medium=3, reviews=10)
+        rows = _run_json()
+        assert all(r["insufficient_data"] is False for r in rows)
+
+    def test_min_reviews_constant_is_20(self):
+        assert learning_db.ROI_MIN_REVIEWS == 20
+
+
+# --- Cost nullability (test 5) ---------------------------------------------
+
+
+class TestCostNullability:
+    def test_all_dash_tokens_report_null(self, isolated_db):
+        # A tier whose rows all carry tokens "-" reports avg_tokens null, not 0.
+        _seed_tier(1, critical=0, high=1, medium=2, reviews=21)
+        row = next(r for r in _run_json() if r["tier"] == 1)
+        assert row["avg_tokens"] is None
+        assert row["avg_wall_clock_s"] is None
+
+    def test_human_shows_na_for_null_cost(self, isolated_db):
+        _seed_tier(1, critical=0, high=1, medium=2, reviews=21)
+        out = _run_human()
+        assert "n/a" in out
+
+    def test_empty_db_reports_no_data(self, isolated_db):
+        rows = _run_json()
+        assert rows == []
+        out = _run_human()
+        assert out.strip() != ""

--- a/scripts/tests/test_review_roi.py
+++ b/scripts/tests/test_review_roi.py
@@ -54,25 +54,33 @@ def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return db_dir
 
 
-def _seed_tier(tier, *, critical, high, medium, tokens="-", wall="-", reviews=1):
-    """Seed a rightsizing:tier{N} row, bumping observation_count to `reviews`.
+def _seed_tier(tier, *, critical, high, medium, tokens=None, wall=None, reviews=1):
+    """Seed `reviews` identical findings-bearing reviews at a tier.
 
-    Value uses the pipe-delimited `k: v` envelope cmd_review_roi parses.
+    Each call accumulates into the tier's running sums via the same path the
+    hook uses (accumulate_rightsizing). tokens/wall None => no cost recorded.
     """
-    value = (
-        f"tier: {tier} | files: 10 | packages: 2 | agents_dispatched: 12 | "
-        f"findings_critical: {critical} | findings_high: {high} | "
-        f"findings_medium: {medium} | tokens: {tokens} | wall_clock_s: {wall}"
-    )
     for _ in range(reviews):
-        _ld2_repo.record_learning(
-            topic="routing",
-            key=f"rightsizing:tier{tier}",
-            value=value,
-            category="effectiveness",
-            tags=["routing", "rightsizing", f"tier{tier}"],
-            source="hook:routing-decision-recorder",
+        _ld2_repo.accumulate_rightsizing(
+            tier,
+            critical=critical,
+            high=high,
+            medium=medium,
+            tokens=tokens,
+            wall_clock_s=wall,
         )
+
+
+def _seed_review(tier, *, critical=None, high=None, medium=None, tokens=None, wall=None):
+    """Seed ONE review at a tier. critical/high/medium None => legacy (no findings)."""
+    _ld2_repo.accumulate_rightsizing(
+        tier,
+        critical=critical,
+        high=high,
+        medium=medium,
+        tokens=tokens,
+        wall_clock_s=wall,
+    )
 
 
 def _run_json():
@@ -97,9 +105,9 @@ def _run_human():
 
 class TestRoiMath:
     def test_per_tier_averages(self, isolated_db):
-        # Two tiers, each seeded so observation_count = reviews.
+        # Two tiers, each seeded with `reviews` identical findings-bearing reviews.
         _seed_tier(1, critical=0, high=2, medium=4, reviews=14)
-        _seed_tier(3, critical=1, high=3, medium=6, tokens="84000", wall="310", reviews=8)
+        _seed_tier(3, critical=1, high=3, medium=6, tokens=84000, wall=310, reviews=8)
         rows = {r["tier"]: r for r in _run_json()}
 
         assert rows[1]["reviews"] == 14
@@ -111,6 +119,39 @@ class TestRoiMath:
         assert rows[3]["avg_critical"] == 1.0
         assert rows[3]["avg_tokens"] == 84000.0
         assert rows[3]["avg_wall_clock_s"] == 310.0
+
+    def test_differing_per_review_findings_yield_true_mean(self, isolated_db):
+        # The bug this fix exists for: per-review findings 2,5,0 must average to
+        # 2.33 (7/3), not a single stored sample. The old single-row model
+        # reported 2.0 (one arbitrary row's value).
+        for c, h, m in ((2, 1, 0), (5, 2, 3), (0, 0, 1)):
+            _seed_review(3, critical=c, high=h, medium=m)
+        row = next(r for r in _run_json() if r["tier"] == 3)
+        assert row["reviews"] == 3
+        assert row["avg_critical"] == 2.33  # 7 / 3
+        assert row["avg_high"] == 1.0  # 3 / 3
+        assert row["avg_medium"] == 1.33  # 4 / 3
+
+    def test_tokens_mean_skips_dash_review(self, isolated_db):
+        # tokens 50000, 80000, and one review with no tokens => mean 65000 over
+        # n=2, attributed to the two reviews that actually carried tokens.
+        _seed_review(3, critical=1, high=1, medium=1, tokens=50000, wall=100)
+        _seed_review(3, critical=1, high=1, medium=1, tokens=80000, wall=200)
+        _seed_review(3, critical=1, high=1, medium=1)  # no cost
+        row = next(r for r in _run_json() if r["tier"] == 3)
+        assert row["reviews"] == 3  # three findings-bearing reviews
+        assert row["avg_tokens"] == 65000.0  # (50000 + 80000) / 2
+        assert row["avg_wall_clock_s"] == 150.0  # (100 + 200) / 2
+
+    def test_legacy_review_excluded_from_findings_mean(self, isolated_db):
+        # A tier mixing findings-bearing and legacy (no-findings) reviews: the
+        # legacy review counts in neither the findings denominator nor the sums.
+        _seed_review(2, critical=4, high=2, medium=2)  # findings-bearing
+        _seed_review(2, critical=2, high=0, medium=0)  # findings-bearing
+        _seed_review(2)  # legacy, no findings
+        row = next(r for r in _run_json() if r["tier"] == 2)
+        assert row["reviews"] == 2  # only findings-bearing reviews
+        assert row["avg_critical"] == 3.0  # (4 + 2) / 2, legacy not in denominator
 
     def test_tiers_sorted_ascending(self, isolated_db):
         _seed_tier(4, critical=1, high=1, medium=1, reviews=11)

--- a/scripts/tests/test_right_size_review.py
+++ b/scripts/tests/test_right_size_review.py
@@ -259,3 +259,43 @@ def test_cli_includes_recommended_and_field_scope_tier():
     assert data["tier"] == 2
     assert "recommended" in data
     assert data["FILE_SCOPE_TIER"] == 2
+
+
+# --- Findings banner emission (ADR: review-tier-roi) ------------------------
+
+
+def _banner_line(stdout):
+    """Return the rightsizing banner line from mixed stdout, or None."""
+    for line in stdout.splitlines():
+        if line.startswith("rightsizing:"):
+            return line
+    return None
+
+
+def test_findings_flag_emits_banner_line():
+    # --findings makes the script print the capture banner the recorder parses.
+    proc = _run("--files", "15", "--packages", "4", "--findings", "2C/3H/5M")
+    assert proc.returncode == 0
+    banner = _banner_line(proc.stdout)
+    assert banner is not None
+    assert "tier=3" in banner
+    assert "files=15" in banner
+    assert "packages=4" in banner
+    assert "agents_dispatched=17" in banner
+    assert "findings=2C/3H/5M" in banner
+
+
+def test_findings_flag_keeps_json_parseable():
+    # The JSON contract still holds: a JSON line is present alongside the banner.
+    proc = _run("--files", "15", "--packages", "4", "--findings", "2C/3H/5M")
+    json_line = next(line for line in proc.stdout.splitlines() if line.startswith("{"))
+    data = json.loads(json_line)
+    assert data["tier"] == 3
+    assert data["agent_estimate"] == 17
+
+
+def test_no_banner_without_findings_flag():
+    # Default (no --findings): JSON only, no banner — preserves existing callers.
+    proc = _run("--files", "15", "--packages", "4")
+    assert _banner_line(proc.stdout) is None
+    assert json.loads(proc.stdout)["tier"] == 3

--- a/skills/workflow/references/comprehensive-review.md
+++ b/skills/workflow/references/comprehensive-review.md
@@ -441,6 +441,17 @@ echo "Saved final report: $(wc -l < "$REVIEW_DIR/final-report.md") lines"
 ls -la "$REVIEW_DIR/"
 ```
 
+**Step 5b: Emit the rightsizing capture banner** — closes the review-tier-ROI loop (ADR: review-tier-roi). Count final CRITICAL/HIGH/MEDIUM and re-run the sizer with `--findings` so `routing-decision-recorder` captures the per-tier yield. Without this line, `review-roi` reports insufficient data forever.
+
+```bash
+C=$(grep -c -i "CRITICAL" "$REVIEW_DIR/final-report.md" || echo 0)
+H=$(grep -c -i "HIGH" "$REVIEW_DIR/final-report.md" || echo 0)
+M=$(grep -c -i "MEDIUM" "$REVIEW_DIR/final-report.md" || echo 0)
+python3 scripts/right-size-review.py --files "$FILES" --packages "$PKGS" --findings "${C}C/${H}H/${M}M"
+```
+
+The printed `rightsizing: ... findings=NC/NH/NM` line is the capture banner. Append `tokens=` / `wall_clock_s=` to it from PR-A's telemetry envelope when those values are known; absent, they store as n/a.
+
 **Step 6**: Show the matrix, agreement summary, and CONTESTED findings BEFORE proceeding to fixes. If `--review-only`, stop here.
 
 For CONTESTED findings: "Wave 3 challenges these N findings. Fix them anyway, skip them, or decide individually?"

--- a/skills/workflow/references/comprehensive-review.md
+++ b/skills/workflow/references/comprehensive-review.md
@@ -441,12 +441,22 @@ echo "Saved final report: $(wc -l < "$REVIEW_DIR/final-report.md") lines"
 ls -la "$REVIEW_DIR/"
 ```
 
-**Step 5b: Emit the rightsizing capture banner** — closes the review-tier-ROI loop (ADR: review-tier-roi). Count final CRITICAL/HIGH/MEDIUM and re-run the sizer with `--findings` so `routing-decision-recorder` captures the per-tier yield. Without this line, `review-roi` reports insufficient data forever.
+**Step 5a: Write the machine-readable finding counts** — the post-Wave-3 TOTAL row of the summary matrix you just built. These are the ROI inputs; Step 5b reads them. Use the deduplicated final counts, NOT grep over the report.
 
 ```bash
-C=$(grep -c -i "CRITICAL" "$REVIEW_DIR/final-report.md" || echo 0)
-H=$(grep -c -i "HIGH" "$REVIEW_DIR/final-report.md" || echo 0)
-M=$(grep -c -i "MEDIUM" "$REVIEW_DIR/final-report.md" || echo 0)
+# Replace the three values with the TOTAL (post-Wave 3) CRITICAL/HIGH/MEDIUM
+# finding counts from the matrix above (e.g. 2 3 5). Integers only,
+# space-separated, one line.
+printf '%s %s %s\n' "$CRITICAL_TOTAL" "$HIGH_TOTAL" "$MEDIUM_TOTAL" > "$REVIEW_DIR/findings-count.txt"
+```
+
+**Step 5b: Emit the rightsizing capture banner** — closes the review-tier-ROI loop (ADR: review-tier-roi). Read the deduplicated finding counts from Step 5a and re-run the sizer with `--findings` so `routing-decision-recorder` captures the per-tier yield. Without this line, `review-roi` reports insufficient data forever.
+
+Read the counts from `findings-count.txt` — the TOTAL row, real findings. Do NOT `grep -c` the report: `grep -c` counts LINES containing the word, so the severity legend, matrix rows, and prose like "highly"/"medium-sized" all inflate the count.
+
+```bash
+# findings-count.txt holds three integers: CRITICAL HIGH MEDIUM (from Step 5a).
+read -r C H M < "$REVIEW_DIR/findings-count.txt"
 python3 scripts/right-size-review.py --files "$FILES" --packages "$PKGS" --findings "${C}C/${H}H/${M}M"
 ```
 


### PR DESCRIPTION
## Summary

Closes the capture→store→query→display loop so the review-tier recommendation becomes measurable. `right-size-review.py` maps change scope to a tier (1-4) and an agent composition, then stops — it never records whether a heavier tier earns its cost. This PR extends the existing rightsizing banner and its capture to carry findings-by-severity and optional cost, stores one aggregate row per tier, and adds a `review-roi` query that prints per-tier averages with an insufficient-data guard.

ADR: review-tier-roi (local-only, gitignored).

## Changes

- `hooks/routing-decision-recorder.py` — extend `_RIGHTSIZING_RE` and `record_rightsizing` to parse and store optional `findings=NC/NH/NM`, `tokens=`, `wall_clock_s=`; carry `session_id`.
- `scripts/learning-db.py` — add `cmd_review_roi` and the `review-roi` subparser; add `ROI_MIN_REVIEWS = 20`.
- `scripts/right-size-review.py` — add `--findings NC/NH/NM`; include `findings=` in the printed banner when given.
- `skills/workflow/references/comprehensive-review.md` — emit the extended banner with `findings=` (plus cost fields when present) after aggregating wave findings.
- `hooks/lib/learning_db_v2.py` — supporting store path for the extended row value.
- `hooks/tests/test_routing_decision_recorder.py`, `scripts/tests/test_review_roi.py`, `scripts/tests/test_right_size_review.py` — cover findings capture, legacy four-field backward compatibility, ROI averaging math, cost nullability, and the `<20` guard.

## Key decisions

- Extend the existing capture, not a new hook — `routing-decision-recorder.py` already parses the banner; a second hook on the same event doubles parsing and risks double-counting.
- Derive stats from `routing` rows via `record_learning`'s per-key upsert and `observation_count`, not a new SQL table — matches the `route-stats`/`route-health` precedent. Trade-off: per-review history is not retained; the metric is per-tier averages.
- Findings-by-severity is an explicit proxy for accuracy. True false-positive labeling needs a ground truth the toolkit does not collect.
- Cost fields are optional and nullable — hook payloads carry no token or duration data, so cost arrives only from the telemetry envelope or reads `n/a`.

## Notes

- New surface is report-only. `review-roi` prints; it never blocks a merge. The `<20` guard makes the tool refuse to overclaim, not refuse to run.
- Banner change is additive and backward-compatible — legacy four-field banners still parse and record.
- Hook cost is an extended regex, no new I/O; measured well under the 50ms budget.
- Two `test_routing_outcome.py` concurrency tests (`test_parallel_thread_appends_no_lost_outcomes`, `test_parallel_process_appends_no_lost_outcomes`) fail on this Windows host — it lacks `fcntl`, so flock-based append serialization degrades. Pre-existing: they fail identically on pristine `origin/main`, touch no code in this PR, and pass on the Linux CI runner.
