### PR TITLE
feat: stale-skill scan + correction-harvest digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ A game built entirely by Claude Code using these agents, skills, and pipelines:
 
 Full design philosophy: **[PHILOSOPHY.md](docs/PHILOSOPHY.md)**
 
+## Maintenance
+
+Two report-only scripts surface upkeep work; both print a digest and never edit, delete, or block.
+
+- `python3 scripts/harvest-corrections.py` — clusters captured user corrections by routed domain and suggests one-line doc fixes. Run weekly by habit, or schedule it via `/schedule`.
+- `python3 scripts/stale-skill-scan.py --top 20` — ranks stale skills/agents as pruning candidates. Run quarterly; see [docs/deprecation-template.md](docs/deprecation-template.md).
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-44 domain agents, 124 workflow skills, 83 hooks, 111 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+44 domain agents, 124 workflow skills, 83 hooks, 113 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Antigravity (`/do`), Factory (`/do`).
 

--- a/docs/deprecation-template.md
+++ b/docs/deprecation-template.md
@@ -1,0 +1,41 @@
+# Deprecation Template
+
+A short record a human copies when retiring a skill or agent. The
+`stale-skill-scan.py` report proposes candidates; a person owns the retirement
+decision and writes this record.
+
+## Record form
+
+Copy this block, fill it in, and keep it with the change that removes the
+component.
+
+```markdown
+# Deprecation: <component-name>
+
+- **Kind:** skill | agent
+- **Date:** YYYY-MM-DD
+- **Reason:** <one line — model improved, redundant with X, never routed>
+- **Replacement:** <skill/agent name, or "none — capability dropped">
+- **Evidence:** stale-skill-scan score N (age Xd, routes Y) on YYYY-MM-DD
+- **Action taken:** removed file + INDEX entry | marked redundant | merged into X
+```
+
+## Quarterly run
+
+Run once per quarter, review the output, deprecate by hand:
+
+```bash
+python3 scripts/stale-skill-scan.py --top 20
+```
+
+The scan is report-only. It ranks skills and agents by a staleness score built
+from git mtime, routing-row frequency, and orphaned INDEX entries. It never
+edits, deletes, or blocks — every line is a candidate for review, not a
+deletion.
+
+## Automating the cadence (opt-in)
+
+The quarterly run is human-initiated by design — a person reads the report
+before anything is retired. To automate it later, point the existing
+`/schedule` skill (cron-backed remote routine) at the command above. That is the
+opt-in escalation path; no cron is created here.

--- a/scripts/harvest-corrections.py
+++ b/scripts/harvest-corrections.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Harvest user corrections from learning.db into a review digest.
+
+ADR: correction-harvesting. Capture already exists
+(`hooks/user-correction-capture.py` writes `topic="user-correction"` rows on
+every UserPromptSubmit). Nothing read them back. This script closes the loop:
+read correction rows + routing rows, cluster corrections by the domain inferred
+from the routing row sharing the correction's session, and print a digest with
+a suggested doc target and a one-line fix hint per cluster.
+
+Report-only. It opens no PR and writes no DB column — the operator reads the
+digest and applies the one-liner by hand (human-owns-definitions). Exit 0 when
+the DB is readable; an empty digest is a valid result, not an error.
+
+Cadence: run on demand, weekly by habit. To automate, point `/schedule` at:
+    python3 scripts/harvest-corrections.py
+with prompt "summarize clusters, suggest one-liners".
+
+Usage:
+    python3 scripts/harvest-corrections.py [--since-hours N] [--min-confidence C]
+        [--format human|json] [--limit-examples K] [--db PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+# Insert repo hooks/lib so learning_db_v2 imports (sibling pattern,
+# learning-db.py:42-51). Home lib first (lower priority), repo lib at pos 0.
+_HOME_LIB = Path.home() / ".claude" / "hooks" / "lib"
+if _HOME_LIB.is_dir():
+    sys.path.insert(0, str(_HOME_LIB))
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "hooks" / "lib"))
+
+from learning_db_v2 import get_db_path, query_learnings
+
+UNATTRIBUTED = "unattributed"
+
+# Fixed one-line fix hints per target type (not LLM-generated — the human writes
+# the actual edit; this only points the way).
+_FIX_HINT_SKILL = "tighten not_for / description so routing stops misfiring"
+_FIX_HINT_AGENT = "tighten the agent scope boundary so routing stops misfiring"
+_FIX_HINT_NONE = "no doc target — review manually"
+
+
+def _parse_last_seen(value: str | None) -> datetime | None:
+    """Parse a `last_seen` string (datetime('now') format) to a datetime."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _skill_file_from_index(skill: str, repo_root: Path) -> str | None:
+    """Resolve a skill's doc path via skills/INDEX.json `file` field.
+
+    Returns the INDEX `file` (normalized to forward slashes) or None when the
+    INDEX is absent/unparseable or the skill has no entry. Caller falls back to
+    a literal path when this returns None.
+    """
+    index = repo_root / "skills" / "INDEX.json"
+    try:
+        data = json.loads(index.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    entry = data.get("skills", {}).get(skill)
+    if not isinstance(entry, dict):
+        return None
+    file_field = entry.get("file")
+    if not file_field:
+        return None
+    return str(file_field).replace("\\", "/")
+
+
+def _suggested(domain: str, repo_root: Path) -> tuple[str | None, str]:
+    """Map a domain to (suggested_target, fix_hint).
+
+    domain is "skill:<name>", "agent:<name>", or "unattributed".
+    """
+    if domain == UNATTRIBUTED:
+        return None, _FIX_HINT_NONE
+    kind, _, name = domain.partition(":")
+    if kind == "skill" and name:
+        target = _skill_file_from_index(name, repo_root) or f"skills/**/{name}/SKILL.md"
+        return target, _FIX_HINT_SKILL
+    if kind == "agent" and name:
+        return f"agents/{name}.md", _FIX_HINT_AGENT
+    return None, _FIX_HINT_NONE
+
+
+def _domain_for_route(key: str) -> str:
+    """Map a routing key 'agent:skill' to a digest domain.
+
+    Skill present -> 'skill:<skill>' (the doc most likely to need the fix).
+    Skill empty (agent-only route) -> 'agent:<agent>'.
+    """
+    agent, _, skill = key.partition(":")
+    skill = skill.strip()
+    if skill and skill != "-":
+        return f"skill:{skill}"
+    return f"agent:{agent}"
+
+
+def build_digest(
+    *,
+    since_hours: int = 168,
+    min_confidence: float = 0.65,
+    limit_examples: int = 3,
+    repo_root: Path | None = None,
+) -> dict:
+    """Read corrections + routes, cluster by session-joined domain, return digest.
+
+    Pure read. Returns a dict with `generated`, `window_hours`, `min_confidence`,
+    `total_corrections`, and `clusters` (sorted by count desc). Each cluster:
+    `domain`, `count`, `suggested_target`, `suggested_fix`, `examples` (latest K
+    correction snippets, newest first).
+    """
+    repo_root = repo_root or _REPO_ROOT
+    cutoff = datetime.now() - timedelta(hours=since_hours)
+
+    corrections = query_learnings(
+        topic="user-correction",
+        category="correction",
+        min_confidence=min_confidence,
+        limit=10000,
+        exclude_graduated=False,
+        exclude_test_sources=True,
+    )
+    routes = query_learnings(
+        topic="routing",
+        category="effectiveness",
+        limit=10000,
+        exclude_graduated=False,
+        exclude_test_sources=True,
+    )
+
+    # Window filter on last_seen (in Python — the read API has no time filter).
+    in_window = []
+    for c in corrections:
+        ts = _parse_last_seen(c.get("last_seen"))
+        if ts is None or ts >= cutoff:
+            in_window.append(c)
+
+    # Latest route per session by last_seen.
+    session_to_domain: dict[str, str] = {}
+    session_route_ts: dict[str, datetime] = {}
+    for r in routes:
+        sid = r.get("session_id")
+        if not sid:
+            continue
+        ts = _parse_last_seen(r.get("last_seen")) or datetime.min
+        if sid not in session_route_ts or ts >= session_route_ts[sid]:
+            session_route_ts[sid] = ts
+            session_to_domain[sid] = _domain_for_route(r["key"])
+
+    # Group corrections by inferred domain.
+    grouped: dict[str, list[dict]] = {}
+    for c in in_window:
+        domain = session_to_domain.get(c.get("session_id"), UNATTRIBUTED)
+        grouped.setdefault(domain, []).append(c)
+
+    clusters = []
+    for domain, rows in grouped.items():
+        rows_sorted = sorted(
+            rows,
+            key=lambda r: _parse_last_seen(r.get("last_seen")) or datetime.min,
+            reverse=True,
+        )
+        examples = [r["value"] for r in rows_sorted[:limit_examples]]
+        target, fix_hint = _suggested(domain, repo_root)
+        clusters.append(
+            {
+                "domain": domain,
+                "count": len(rows),
+                "suggested_target": target,
+                "suggested_fix": fix_hint,
+                "examples": examples,
+            }
+        )
+
+    # Sort by count desc, then domain for stable ordering.
+    clusters.sort(key=lambda c: (-c["count"], c["domain"]))
+
+    return {
+        "generated": datetime.now().isoformat(timespec="seconds"),
+        "window_hours": since_hours,
+        "min_confidence": min_confidence,
+        "total_corrections": len(in_window),
+        "clusters": clusters,
+    }
+
+
+def _print_human(digest: dict) -> None:
+    """Print the digest as a human-readable report."""
+    if digest["total_corrections"] == 0:
+        print(f"No corrections in window (last {digest['window_hours']}h).")
+        return
+
+    print(
+        f"Correction digest — {digest['total_corrections']} corrections, "
+        f"last {digest['window_hours']}h, {digest['generated']}"
+    )
+    print("-" * 60)
+    for c in digest["clusters"]:
+        kind, _, name = c["domain"].partition(":")
+        label = f"{kind} {name}" if name else c["domain"]
+        target = c["suggested_target"] or "(no doc target — review manually)"
+        print(f"{label} drew {c['count']} correction(s) — target: {target}")
+        print(f"  suggested fix: {c['suggested_fix']}")
+        if c["examples"]:
+            print("  latest:")
+            for ex in c["examples"]:
+                print(f'    - "{ex}"')
+    print("-" * 60)
+    print("These are clusters, not patches. Review each, then apply the one-liner by hand.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry. Returns an exit code (0 always when the DB is readable)."""
+    parser = argparse.ArgumentParser(description="Harvest user corrections into a review digest.")
+    parser.add_argument("--since-hours", type=int, default=168, help="Window in hours (default 168 = 7d).")
+    parser.add_argument("--min-confidence", type=float, default=0.65, help="Minimum correction confidence.")
+    parser.add_argument("--format", choices=["human", "json"], default="human", help="Output format.")
+    parser.add_argument("--limit-examples", type=int, default=3, help="Example snippets per cluster.")
+    parser.add_argument("--db", default=None, help="learning.db path (default ~/.claude/learning/learning.db).")
+    args = parser.parse_args(argv)
+
+    if args.db:
+        # Route the read API at an explicit DB by pointing its dir env at it.
+        import os
+
+        os.environ["CLAUDE_LEARNING_DIR"] = str(Path(args.db).expanduser().resolve().parent)
+    else:
+        # Touch get_db_path() so a missing dir surfaces here, not deep in a query.
+        try:
+            get_db_path()
+        except OSError as exc:
+            print(f"ERROR: cannot open learning.db: {exc}", file=sys.stderr)
+            return 1
+
+    try:
+        digest = build_digest(
+            since_hours=args.since_hours,
+            min_confidence=args.min_confidence,
+            limit_examples=args.limit_examples,
+        )
+    except Exception as exc:  # unreadable DB / bad args -> exit 1 per ADR
+        print(f"ERROR: harvest failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.format == "json":
+        print(json.dumps(digest, indent=2, default=str))
+    else:
+        _print_human(digest)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -1018,6 +1018,23 @@ def cmd_route_health(args: argparse.Namespace) -> None:
     basis_total = strong + default_success
     silent_share = (default_success / basis_total) if basis_total else None
 
+    # Correction rate (ADR: correction-harvesting). Share of routed sessions that
+    # drew correction language, plus corrections with no concurrent /do route.
+    # Read-only: adds informational lines, changes no boost/decay, no schema.
+    corrections = query_learnings(
+        topic="user-correction",
+        category="correction",
+        min_confidence=0.65,
+        limit=10000,
+        exclude_graduated=False,
+        exclude_test_sources=True,
+    )
+    corr_sessions = {c["session_id"] for c in corrections if c.get("session_id")}
+    routed_sessions = {r["session_id"] for r in results if r.get("session_id")}
+    routed_with_corr = len(corr_sessions & routed_sessions)
+    pct_corr = (routed_with_corr / len(routed_sessions) * 100) if routed_sessions else 0.0
+    unattributed_corr = len(corr_sessions - routed_sessions)
+
     if as_json:
         print(
             json.dumps(
@@ -1034,6 +1051,10 @@ def cmd_route_health(args: argparse.Namespace) -> None:
                     "default_success": default_success,
                     "silent_success_share": silent_share,
                     "governed_path_coverage": round(pct, 1),
+                    "correction_rate_pct": round(pct_corr, 1),
+                    "routed_sessions_with_correction": routed_with_corr,
+                    "routed_sessions": len(routed_sessions),
+                    "unattributed_corrections": unattributed_corr,
                 },
                 indent=2,
             )
@@ -1053,6 +1074,11 @@ def cmd_route_health(args: argparse.Namespace) -> None:
         print(f"  default_no_complaint {basis['default_no_complaint']}")
         print(f"Silent-success share: {silent_share * 100:.0f}% of scored outcomes ({default_success}/{basis_total})")
     print(f"Governed-path coverage: {has_outcome}/{total} routing rows carry a finalized outcome ({pct:.0f}%)")
+    print(
+        f"Correction rate: {routed_with_corr}/{len(routed_sessions)} "
+        f"routed sessions drew correction language ({pct_corr:.0f}%)"
+    )
+    print(f"Unattributed corrections: {unattributed_corr} (correction with no concurrent /do route)")
 
 
 def _print_freq_table(records: list[dict[str, str | int]], label: str, key_fn: object) -> None:

--- a/scripts/stale-skill-scan.py
+++ b/scripts/stale-skill-scan.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Rank stale skill/agent scaffolding as pruning candidates. Report-only.
+
+ADR: skill-scaffold-pruning. The toolkit creates skills and agents but never
+retires them. Three staleness signals are already computable today with no new
+capture:
+
+  1. git mtime — last-touched epoch per component file.
+  2. routing frequency — `topic="routing"` rows in learning.db, aggregated by
+     the skill/agent segment of `key="agent:skill"`.
+  3. orphaned INDEX entry — an INDEX `file` that no longer exists on disk.
+
+This script joins all three, scores each component, and prints the top N
+candidates with the reason for each. It never edits, deletes, or blocks; exit is
+always 0. The script proposes; the human prunes (record in
+docs/deprecation-template.md).
+
+Quarterly run (documented, human-initiated — no cron created here):
+    python3 scripts/stale-skill-scan.py --top 20
+
+Usage:
+    python3 scripts/stale-skill-scan.py [--top N] [--kind skills|agents|all]
+        [--min-age-days 180] [--json] [--repo-root PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Insert repo hooks/lib so learning_db_v2 imports (sibling pattern,
+# learning-db.py:42-51).
+_HOME_LIB = Path.home() / ".claude" / "hooks" / "lib"
+if _HOME_LIB.is_dir():
+    sys.path.insert(0, str(_HOME_LIB))
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "hooks" / "lib"))
+
+from learning_db_v2 import query_learnings
+
+DAY = 86400
+
+
+def git_mtime(path: str) -> int | None:
+    """Last git-commit epoch for `path`, or None when untracked/unknown.
+
+    `git log -1 --format=%ct -- <path>`. Empty output (new/untracked file) ->
+    None; the caller treats that as "now" (age 0, never a candidate).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%ct", "--", path],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    out = result.stdout.strip()
+    if not out:
+        return None
+    try:
+        return int(out)
+    except ValueError:
+        return None
+
+
+def _route_counts() -> tuple[dict[str, int], dict[str, int]]:
+    """Aggregate routing observation_count by skill segment and agent segment.
+
+    key="agent:skill". Skill counts keyed by the last segment; agent counts by
+    the first. Returns (skill_counts, agent_counts).
+    """
+    rows = query_learnings(
+        topic="routing",
+        category="effectiveness",
+        limit=10000,
+        exclude_graduated=False,
+        exclude_test_sources=False,
+    )
+    skill_counts: dict[str, int] = {}
+    agent_counts: dict[str, int] = {}
+    for r in rows:
+        key = r.get("key", "")
+        if ":" not in key:
+            continue
+        agent, _, skill = key.partition(":")
+        n = int(r.get("observation_count", 1) or 1)
+        agent = agent.strip()
+        skill = skill.strip()
+        if agent:
+            agent_counts[agent] = agent_counts.get(agent, 0) + n
+        if skill and skill != "-":
+            skill_counts[skill] = skill_counts.get(skill, 0) + n
+    return skill_counts, agent_counts
+
+
+def _load_index(repo_root: Path, kind: str) -> dict[str, dict]:
+    """Load skills or agents INDEX.json entries dict ({} when absent/bad)."""
+    fname = "skills" if kind == "skill" else "agents"
+    inner = "skills" if kind == "skill" else "agents"
+    path = repo_root / fname / "INDEX.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    entries = data.get(inner, {})
+    return {n: e for n, e in entries.items() if isinstance(e, dict)}
+
+
+def _score_component(
+    *,
+    kind: str,
+    name: str,
+    file_field: str,
+    repo_root: Path,
+    routes: int,
+    min_age_days: int,
+    now_epoch: int,
+    mtime_fn,
+) -> dict | None:
+    """Score one component. Returns a result row, or None when healthy (score 0).
+
+    Scoring (deterministic, per ADR):
+      orphaned (INDEX file missing) -> +100
+      age >= min_age_days           -> +min(age_months, 24), +1 per stale month
+      routes == 0                   -> +20  (never routed)
+      routes <= 2                   -> +10  (rarely routed)
+    """
+    # Normalize mixed separators (skills/business\\csuite/SKILL.md on Windows).
+    norm = file_field.replace("\\", "/") if file_field else ""
+    abs_path = (repo_root / norm) if norm else None
+    orphaned = not (abs_path and abs_path.is_file())
+
+    mtime = None if orphaned or abs_path is None else mtime_fn(str(abs_path))
+    if mtime is None:
+        # Orphan has no file mtime; untracked file treated as now (age 0).
+        age_days = 0
+    else:
+        age_days = max(0, (now_epoch - mtime) // DAY)
+
+    score = 0
+    reasons: list[str] = []
+
+    if orphaned:
+        score += 100
+        reasons.append("orphaned: INDEX file missing on disk")
+
+    if age_days >= min_age_days:
+        age_points = min(age_days // 30, 24)
+        score += int(age_points)
+        reasons.append(f"untouched {int(age_days)}d")
+
+    if routes == 0:
+        score += 20
+        reasons.append("never routed")
+    elif routes <= 2:
+        score += 10
+        reasons.append(f"rarely routed ({routes})")
+
+    if score == 0:
+        return None
+
+    return {
+        "kind": kind,
+        "name": name,
+        "file": norm,
+        "age_days": int(age_days),
+        "routes": routes,
+        "orphaned": orphaned,
+        "score": int(score),
+        "reasons": reasons,
+    }
+
+
+def scan(
+    *,
+    repo_root: Path,
+    top: int = 15,
+    kind: str = "all",
+    min_age_days: int = 180,
+    now_epoch: int | None = None,
+    mtime_fn=git_mtime,
+) -> list[dict]:
+    """Rank pruning candidates. Pure read; never edits or blocks.
+
+    now_epoch and mtime_fn are injectable for deterministic tests.
+    Returns result rows sorted by score desc, truncated to `top`.
+    """
+    now_epoch = now_epoch if now_epoch is not None else int(time.time())
+    skill_counts, agent_counts = _route_counts()
+
+    kinds = []
+    if kind in ("skills", "all"):
+        kinds.append("skill")
+    if kind in ("agents", "all"):
+        kinds.append("agent")
+
+    results: list[dict] = []
+    for component_kind in kinds:
+        index = _load_index(repo_root, component_kind)
+        counts = skill_counts if component_kind == "skill" else agent_counts
+        for name, entry in index.items():
+            row = _score_component(
+                kind=component_kind,
+                name=name,
+                file_field=entry.get("file", ""),
+                repo_root=repo_root,
+                routes=counts.get(name, 0),
+                min_age_days=min_age_days,
+                now_epoch=now_epoch,
+                mtime_fn=mtime_fn,
+            )
+            if row is not None:
+                results.append(row)
+
+    # Sort by score desc, then name for stable order.
+    results.sort(key=lambda r: (-r["score"], r["name"]))
+    return results[:top]
+
+
+def _print_human(results: list[dict], top: int) -> None:
+    """Print the ranked candidate table."""
+    import datetime
+
+    today = datetime.date.today().isoformat()
+    print(f"Stale-skill scan — {len(results)} candidates (top {top}), {today}")
+    print("-" * 60)
+    print(f"{'SCORE':>5}  {'KIND':<6} {'NAME':<28} {'AGE':>6}  {'ROUTES':>6}  REASONS")
+    for r in results:
+        print(
+            f"{r['score']:>5}  {r['kind']:<6} {r['name']:<28} "
+            f"{r['age_days']:>5}d  {r['routes']:>6}  {'; '.join(r['reasons'])}"
+        )
+    print("-" * 60)
+    print("These are candidates, not deletions. Review each before deprecating.")
+    print("Next step: docs/deprecation-template.md, then remove the component or mark it redundant.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry. Always returns 0 — report-only never fails a pipeline."""
+    parser = argparse.ArgumentParser(description="Rank stale skill/agent scaffolding. Report-only.")
+    parser.add_argument("--top", type=int, default=15, help="Cap candidates printed (default 15).")
+    parser.add_argument("--kind", choices=["skills", "agents", "all"], default="all", help="Scope (default all).")
+    parser.add_argument("--min-age-days", type=int, default=180, help="Below this git-mtime age, never a candidate.")
+    parser.add_argument("--json", action="store_true", help="Machine-readable output.")
+    parser.add_argument("--repo-root", default=None, help="Override repo root (tests point at a fixture tree).")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else _REPO_ROOT
+
+    results = scan(
+        repo_root=repo_root,
+        top=args.top,
+        kind=args.kind,
+        min_age_days=args.min_age_days,
+    )
+
+    if args.json:
+        print(json.dumps(results, indent=2, default=str))
+    else:
+        _print_human(results, args.top)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_harvest_corrections.py
+++ b/scripts/tests/test_harvest_corrections.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Tests for scripts/harvest-corrections.py and the route-health correction rate.
+
+ADR: correction-harvesting. The harvester reads user-correction rows and
+routing rows from learning.db, clusters corrections by session-joined domain,
+and emits a digest (human / json). It opens no PR and writes no DB column —
+report-only. route-health gains two informational lines (correction rate +
+unattributed count); read-only, never gates.
+
+Throwaway DB via CLAUDE_LEARNING_DIR; rows seeded with record_learning.
+
+Run with: python3 -m pytest scripts/tests/test_harvest_corrections.py -v
+"""
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = SCRIPTS_DIR.parent
+LIB_DIR = REPO_ROOT / "hooks" / "lib"
+HARVEST_PATH = SCRIPTS_DIR / "harvest-corrections.py"
+LEARNING_DB_PATH = SCRIPTS_DIR / "learning-db.py"
+
+
+@pytest.fixture()
+def db_env(tmp_path, monkeypatch):
+    """Point learning.db at a throwaway dir and reset the init cache."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    if str(LIB_DIR) not in sys.path:
+        sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    yield {"db_dir": db_dir, "ldb": ldb}
+
+
+def _load(path: Path, name: str):
+    """Load a hyphen-named script as an importable module."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _seed_correction(ldb, *, session_id, value, confidence=0.70, key=None, last_seen=None):
+    """Seed one user-correction row; optionally back-date last_seen."""
+    key = key or f"corr-{session_id}-{abs(hash(value)) % 100000}"
+    ldb.record_learning(
+        topic="user-correction",
+        key=key,
+        value=value,
+        category="correction",
+        confidence=confidence,
+        source="hook:user-correction-capture",
+        session_id=session_id,
+    )
+    if last_seen is not None:
+        with ldb.get_connection() as conn:
+            conn.execute(
+                "UPDATE learnings SET last_seen = ? WHERE topic = ? AND key = ?",
+                (last_seen, "user-correction", key),
+            )
+            conn.commit()
+
+
+def _seed_route(ldb, *, session_id, agent, skill, last_seen=None):
+    """Seed one routing row keyed agent:skill in a session."""
+    key = f"{agent}:{skill}"
+    ldb.record_learning(
+        topic="routing",
+        key=key,
+        value=f"routing-decision: agent={agent} skill={skill} request: do work",
+        category="effectiveness",
+        source="hook:routing-decision-recorder",
+        session_id=session_id,
+    )
+    if last_seen is not None:
+        with ldb.get_connection() as conn:
+            conn.execute(
+                "UPDATE learnings SET last_seen = ? WHERE topic = ? AND key = ?",
+                (last_seen, "routing", key),
+            )
+            conn.commit()
+
+
+def _iso_hours_ago(hours: float) -> str:
+    return (datetime.now() - timedelta(hours=hours)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# harvest-corrections.py — clustering + digest
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_by_joined_domain(db_env):
+    """3 corrections in s1 + a planning route in s1 -> one skill:planning cluster."""
+    ldb = db_env["ldb"]
+    for i in range(3):
+        _seed_correction(ldb, session_id="s1", value=f"no, planning is for software {i}", key=f"c{i}")
+    _seed_route(ldb, session_id="s1", agent="planning-agent", skill="planning")
+
+    mod = _load(HARVEST_PATH, "harvest_corrections")
+    digest = mod.build_digest(since_hours=168, min_confidence=0.65, limit_examples=3)
+
+    clusters = digest["clusters"]
+    assert len(clusters) == 1
+    c = clusters[0]
+    assert c["domain"] == "skill:planning"
+    assert c["count"] == 3
+    assert c["suggested_target"].endswith("planning/SKILL.md")
+
+
+def test_unattributed_path(db_env):
+    """A correction with no routing row in its session lands unattributed, null target."""
+    ldb = db_env["ldb"]
+    _seed_correction(ldb, session_id="sX", value="that is wrong", key="cx")
+
+    mod = _load(HARVEST_PATH, "harvest_corrections")
+    digest = mod.build_digest(since_hours=168, min_confidence=0.65, limit_examples=3)
+
+    c = next(c for c in digest["clusters"] if c["domain"] == "unattributed")
+    assert c["count"] == 1
+    assert c["suggested_target"] is None
+
+
+def test_since_hours_filter(db_env):
+    """One 200h-old, one 10h-old correction; --since-hours 168 keeps only the recent."""
+    ldb = db_env["ldb"]
+    _seed_correction(ldb, session_id="s1", value="old correction", key="old", last_seen=_iso_hours_ago(200))
+    _seed_correction(ldb, session_id="s1", value="new correction", key="new", last_seen=_iso_hours_ago(10))
+
+    mod = _load(HARVEST_PATH, "harvest_corrections")
+    digest = mod.build_digest(since_hours=168, min_confidence=0.65, limit_examples=3)
+
+    assert digest["total_corrections"] == 1
+
+
+def test_min_confidence_filter(db_env):
+    """0.50 correction excluded at --min-confidence 0.65; 0.70 included."""
+    ldb = db_env["ldb"]
+    _seed_correction(ldb, session_id="s1", value="low conf", key="lo", confidence=0.50)
+    _seed_correction(ldb, session_id="s1", value="high conf", key="hi", confidence=0.70)
+
+    mod = _load(HARVEST_PATH, "harvest_corrections")
+    digest = mod.build_digest(since_hours=168, min_confidence=0.65, limit_examples=3)
+
+    assert digest["total_corrections"] == 1
+
+
+def test_limit_examples_newest_first(db_env):
+    """5 corrections in one cluster, --limit-examples 2 -> 2 snippets, newest first."""
+    ldb = db_env["ldb"]
+    for i in range(5):
+        _seed_correction(
+            ldb,
+            session_id="s1",
+            value=f"correction number {i}",
+            key=f"c{i}",
+            last_seen=_iso_hours_ago(50 - i),  # higher i => more recent
+        )
+
+    mod = _load(HARVEST_PATH, "harvest_corrections")
+    digest = mod.build_digest(since_hours=168, min_confidence=0.65, limit_examples=2)
+
+    c = digest["clusters"][0]
+    assert len(c["examples"]) == 2
+    assert c["examples"][0] == "correction number 4"
+    assert c["examples"][1] == "correction number 3"
+
+
+def test_json_shape(db_env, capsys):
+    """--format json parses and carries the documented top-level + cluster keys."""
+    ldb = db_env["ldb"]
+    _seed_correction(ldb, session_id="s1", value="a correction", key="c1")
+    _seed_route(ldb, session_id="s1", agent="planning-agent", skill="planning")
+
+    mod = _load(HARVEST_PATH, "harvest_corrections")
+    rc = mod.main(["--format", "json"])
+    assert rc == 0
+
+    out = json.loads(capsys.readouterr().out)
+    for key in ("generated", "window_hours", "min_confidence", "total_corrections", "clusters"):
+        assert key in out
+    for ckey in ("domain", "count", "suggested_target", "examples"):
+        assert ckey in out["clusters"][0]
+
+
+def test_empty_db(db_env, capsys):
+    """No corrections: exit 0, human says no corrections, json clusters empty."""
+    mod = _load(HARVEST_PATH, "harvest_corrections")
+
+    rc = mod.main([])
+    assert rc == 0
+    assert "no corrections in window" in capsys.readouterr().out.lower()
+
+    rc = mod.main(["--format", "json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["clusters"] == []
+    assert out["total_corrections"] == 0
+
+
+def test_agent_only_target(db_env):
+    """An agent-only route (skill empty) targets agents/<agent>.md."""
+    ldb = db_env["ldb"]
+    _seed_correction(ldb, session_id="s2", value="agent scoping is wrong", key="ca")
+    _seed_route(ldb, session_id="s2", agent="security-engineer", skill="")
+
+    mod = _load(HARVEST_PATH, "harvest_corrections")
+    digest = mod.build_digest(since_hours=168, min_confidence=0.65, limit_examples=3)
+
+    c = next(c for c in digest["clusters"] if c["domain"].startswith("agent:"))
+    assert c["suggested_target"] == "agents/security-engineer.md"
+
+
+# ---------------------------------------------------------------------------
+# route-health — correction-rate lines
+# ---------------------------------------------------------------------------
+
+
+def test_route_health_correction_rate(db_env, capsys):
+    """route-health prints correction rate over routed sessions + unattributed count."""
+    ldb = db_env["ldb"]
+    # Routed sessions s1, s2, s3; a correction in s1 only.
+    _seed_route(ldb, session_id="s1", agent="a", skill="x")
+    _seed_route(ldb, session_id="s2", agent="a", skill="y")
+    _seed_route(ldb, session_id="s3", agent="b", skill="z")
+    _seed_correction(ldb, session_id="s1", value="you got this wrong", key="c1")
+
+    mod = _load(LEARNING_DB_PATH, "learning_db_cli")
+    import argparse
+
+    mod.cmd_route_health(argparse.Namespace(json=False))
+    out = capsys.readouterr().out
+    assert "Correction rate: 1/3" in out
+    assert "33%" in out
+    assert "Unattributed corrections:" in out

--- a/scripts/tests/test_stale_skill_scan.py
+++ b/scripts/tests/test_stale_skill_scan.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Tests for scripts/stale-skill-scan.py — ranked pruning-candidate report.
+
+ADR: skill-scaffold-pruning. The scanner ranks skills/agents by a staleness
+score built from three signals already in the toolkit: git mtime, routing-row
+frequency, and orphaned INDEX entries. Report-only: it never edits, deletes, or
+blocks; exit is always 0.
+
+Fixtures: a temp repo-root tree with skills/INDEX.json + agents/INDEX.json and
+SKILL.md / agent .md files. Routing rows seeded in a throwaway learning.db via
+CLAUDE_LEARNING_DIR. git mtime mocked by monkeypatching the scanner's mtime
+function, so tests need no real git history.
+
+Run with: python3 -m pytest scripts/tests/test_stale_skill_scan.py -v
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = SCRIPTS_DIR.parent
+LIB_DIR = REPO_ROOT / "hooks" / "lib"
+SCAN_PATH = SCRIPTS_DIR / "stale-skill-scan.py"
+
+NOW = 1_700_000_000  # fixed epoch for determinism
+DAY = 86400
+
+
+@pytest.fixture()
+def db_env(tmp_path, monkeypatch):
+    """Throwaway learning.db; reset init cache."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    if str(LIB_DIR) not in sys.path:
+        sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    yield ldb
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _seed_route(ldb, *, agent, skill, count=1):
+    """Seed a routing row keyed agent:skill with observation_count=count.
+
+    record_learning upserts observation_count += 1 per call, so call `count`
+    times to reach the target count.
+    """
+    key = f"{agent}:{skill}"
+    for _ in range(count):
+        ldb.record_learning(
+            topic="routing",
+            key=key,
+            value=f"routing-decision: agent={agent} skill={skill} request: do work",
+            category="effectiveness",
+            source="hook:routing-decision-recorder",
+            session_id="s1",
+        )
+
+
+def _make_tree(root: Path, *, skills=None, agents=None, on_disk=None):
+    """Build a fixture repo-root with INDEX.json files + component files.
+
+    skills/agents: {name: file_field}. on_disk: set of names whose file is
+    actually written (others are orphaned INDEX entries).
+    """
+    skills = skills or {}
+    agents = agents or {}
+    on_disk = on_disk if on_disk is not None else set(skills) | set(agents)
+
+    (root / "skills").mkdir(parents=True, exist_ok=True)
+    (root / "agents").mkdir(parents=True, exist_ok=True)
+
+    skills_index = {"version": "2.0", "skills": {n: {"file": f} for n, f in skills.items()}}
+    agents_index = {"version": "1.0", "agents": {n: {"file": f} for n, f in agents.items()}}
+    (root / "skills" / "INDEX.json").write_text(json.dumps(skills_index), encoding="utf-8")
+    (root / "agents" / "INDEX.json").write_text(json.dumps(agents_index), encoding="utf-8")
+
+    for name, file_field in {**skills, **agents}.items():
+        if name in on_disk:
+            p = root / file_field
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("body\n", encoding="utf-8")
+    return root
+
+
+def _scan(mod, root, *, mtimes, top=15, kind="all", min_age_days=180):
+    """Run the scanner with a fixed now and mocked per-file git mtimes."""
+    return mod.scan(
+        repo_root=root,
+        top=top,
+        kind=kind,
+        min_age_days=min_age_days,
+        now_epoch=NOW,
+        mtime_fn=lambda path: mtimes.get(Path(path).name, NOW),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_ranks_first(db_env):
+    """An INDEX entry whose file is missing scores +100 and ranks first."""
+    mod = _load(SCAN_PATH, "stale_skill_scan")
+    root = _make_tree(
+        Path(db_env.get_db_path()).parent.parent / "tree_orphan",
+        skills={"legacy-foo": "skills/legacy/legacy-foo/SKILL.md", "fresh": "skills/x/fresh/SKILL.md"},
+        on_disk={"fresh"},  # legacy-foo file absent -> orphan
+    )
+    _seed_route(db_env, agent="a", skill="fresh", count=20)
+    results = _scan(mod, root, mtimes={"SKILL.md": NOW}, kind="skills")
+
+    top = results[0]
+    assert top["name"] == "legacy-foo"
+    assert top["orphaned"] is True
+    assert top["score"] >= 100
+    assert any("orphan" in r.lower() for r in top["reasons"])
+
+
+def test_never_routed(db_env):
+    """An old, on-disk skill with zero routing rows scores +20, reason 'never routed'."""
+    mod = _load(SCAN_PATH, "stale_skill_scan")
+    root = _make_tree(
+        Path(db_env.get_db_path()).parent.parent / "tree_never",
+        skills={"lonely": "skills/x/lonely/SKILL.md"},
+    )
+    # no routing rows at all
+    mtimes = {"SKILL.md": NOW - 400 * DAY}
+    results = _scan(mod, root, mtimes=mtimes, kind="skills")
+
+    lonely = next(r for r in results if r["name"] == "lonely")
+    assert lonely["routes"] == 0
+    assert any("never routed" in r.lower() for r in lonely["reasons"])
+    assert lonely["score"] >= 20
+
+
+def test_rarely_routed(db_env):
+    """Routing observation_count summing to <=2 scores +10 with the count in the reason."""
+    mod = _load(SCAN_PATH, "stale_skill_scan")
+    root = _make_tree(
+        Path(db_env.get_db_path()).parent.parent / "tree_rare",
+        skills={"design": "skills/x/design/SKILL.md"},
+    )
+    _seed_route(db_env, agent="ui", skill="design", count=2)
+    mtimes = {"SKILL.md": NOW - 400 * DAY}
+    results = _scan(mod, root, mtimes=mtimes, kind="skills")
+
+    design = next(r for r in results if r["name"] == "design")
+    assert design["routes"] == 2
+    assert any("rarely routed (2)" in r.lower() for r in design["reasons"])
+
+
+def test_age_threshold_excludes_young(db_env):
+    """A young, well-routed skill accrues no age points and is omitted (score 0)."""
+    mod = _load(SCAN_PATH, "stale_skill_scan")
+    root = _make_tree(
+        Path(db_env.get_db_path()).parent.parent / "tree_young",
+        skills={"newish": "skills/x/newish/SKILL.md"},
+    )
+    _seed_route(db_env, agent="a", skill="newish", count=10)
+    mtimes = {"SKILL.md": NOW - 30 * DAY}  # 30d < min_age_days 180
+    results = _scan(mod, root, mtimes=mtimes, kind="skills", min_age_days=180)
+
+    assert all(r["name"] != "newish" for r in results)
+
+
+def test_age_points_capped(db_env):
+    """An old never-routed skill accrues +1 per stale month, capped at 24."""
+    mod = _load(SCAN_PATH, "stale_skill_scan")
+    root = _make_tree(
+        Path(db_env.get_db_path()).parent.parent / "tree_capped",
+        skills={"ancient": "skills/x/ancient/SKILL.md"},
+    )
+    # 3000 days -> 100 months, capped at 24; plus 20 for never-routed = 44.
+    mtimes = {"SKILL.md": NOW - 3000 * DAY}
+    results = _scan(mod, root, mtimes=mtimes, kind="skills")
+
+    ancient = next(r for r in results if r["name"] == "ancient")
+    assert ancient["score"] == 24 + 20
+
+
+def test_healthy_omitted(db_env):
+    """A recent, well-routed, on-disk skill scores 0 and never appears."""
+    mod = _load(SCAN_PATH, "stale_skill_scan")
+    root = _make_tree(
+        Path(db_env.get_db_path()).parent.parent / "tree_healthy",
+        skills={"healthy": "skills/x/healthy/SKILL.md"},
+    )
+    _seed_route(db_env, agent="a", skill="healthy", count=15)
+    mtimes = {"SKILL.md": NOW - 10 * DAY}
+    results = _scan(mod, root, mtimes=mtimes, kind="skills")
+
+    assert results == []
+
+
+def test_rank_order_and_top(db_env):
+    """Mixed candidates sort by score desc; --top truncates."""
+    mod = _load(SCAN_PATH, "stale_skill_scan")
+    root = _make_tree(
+        Path(db_env.get_db_path()).parent.parent / "tree_rank",
+        skills={
+            "orphaned-one": "skills/x/orphaned-one/SKILL.md",
+            "old-unrouted": "skills/x/old-unrouted/SKILL.md",
+            "old-rare": "skills/x/old-rare/SKILL.md",
+        },
+        on_disk={"old-unrouted", "old-rare"},  # orphaned-one missing
+    )
+    _seed_route(db_env, agent="a", skill="old-rare", count=2)
+    mtimes = {"SKILL.md": NOW - 400 * DAY}
+    results = _scan(mod, root, mtimes=mtimes, kind="skills")
+
+    scores = [r["score"] for r in results]
+    assert scores == sorted(scores, reverse=True)
+    assert results[0]["name"] == "orphaned-one"  # +100 orphan dominates
+
+    truncated = _scan(mod, root, mtimes=mtimes, kind="skills", top=1)
+    assert len(truncated) == 1
+
+
+def test_json_schema_keys(db_env):
+    """Each result row carries the documented keys."""
+    mod = _load(SCAN_PATH, "stale_skill_scan")
+    root = _make_tree(
+        Path(db_env.get_db_path()).parent.parent / "tree_keys",
+        skills={"lonely": "skills/x/lonely/SKILL.md"},
+    )
+    mtimes = {"SKILL.md": NOW - 400 * DAY}
+    results = _scan(mod, root, mtimes=mtimes, kind="skills")
+
+    row = results[0]
+    for key in ("kind", "name", "file", "age_days", "routes", "orphaned", "score", "reasons"):
+        assert key in row
+
+
+def test_determinism(db_env):
+    """Same fixtures + mocked now/mtime -> identical output across runs."""
+    mod = _load(SCAN_PATH, "stale_skill_scan")
+    root = _make_tree(
+        Path(db_env.get_db_path()).parent.parent / "tree_det",
+        skills={"a-skill": "skills/x/a-skill/SKILL.md", "b-skill": "skills/x/b-skill/SKILL.md"},
+    )
+    _seed_route(db_env, agent="a", skill="a-skill", count=1)
+    mtimes = {"SKILL.md": NOW - 300 * DAY}
+    r1 = _scan(mod, root, mtimes=mtimes, kind="skills")
+    r2 = _scan(mod, root, mtimes=mtimes, kind="skills")
+    assert r1 == r2
+
+
+def test_agents_scanned(db_env):
+    """--kind agents scores agent components by the agent segment of routing keys."""
+    mod = _load(SCAN_PATH, "stale_skill_scan")
+    root = _make_tree(
+        Path(db_env.get_db_path()).parent.parent / "tree_agents",
+        agents={"old-bar-engineer": "agents/old-bar-engineer.md"},
+    )
+    _seed_route(db_env, agent="old-bar-engineer", skill="something", count=1)
+    mtimes = {"old-bar-engineer.md": NOW - 300 * DAY}
+    results = _scan(mod, root, mtimes=mtimes, kind="agents")
+
+    bar = next(r for r in results if r["name"] == "old-bar-engineer")
+    assert bar["kind"] == "agent"
+    assert bar["routes"] == 1
+    assert any("rarely routed (1)" in r.lower() for r in bar["reasons"])


### PR DESCRIPTION
## Summary

Two maintenance signals already in `learning.db` go unread; this adds report-only readers for both. No new capture, no schema change, no merge gate.

- Stale scaffolding is never flagged: skills/agents written for old model failures keep routing work and bloating the router manifest.
- User corrections land in `learning.db` but nothing groups them or points at the doc to fix; the same misroute recurs.

ADR: skill-scaffold-pruning, correction-harvesting (local-only, gitignored).

## Changes

- `scripts/stale-skill-scan.py` — ranked pruning-candidate report from three free signals: git mtime, routing-row frequency, orphaned INDEX entry. Report-only, always exit 0.
- `scripts/harvest-corrections.py` — clusters correction rows by session-joined domain, emits human/json digest with target doc + one-line fix hint. Empty window is a valid result, exit 0.
- `scripts/learning-db.py` — append correction-rate and unattributed-count lines to `route-health`; read-only, additive.
- `docs/deprecation-template.md` — retirement record form + quarterly-run + `/schedule` escalation note.
- `scripts/tests/` — 19 tests: 9 harvest (incl. route-health correction rate), 10 stale-scan.
- `README.md` — maintenance commands: how to run harvest + suggested `/schedule` cadence.

## Notes

- Correction domain joins on `session_id`; a correction with no concurrent /do route clusters under `unattributed` — honest, not a bug.
- Both scripts surface candidates only; the human decides retirement and writes the one-liner (human-ownership constraint). Suggested fixes are fixed strings, not LLM-drafted.
- The optional `correction-digest` CI job is documented as OFF-by-default — CI has no access to the local-only learning.db.
