### PR TITLE
fix: capture review-ROI banner from live Agent content-block payload

### DIFF
--- a/docs/what-didnt-work.md
+++ b/docs/what-didnt-work.md
@@ -46,6 +46,13 @@ Query it: read this file, run `grep -c '^## 2026' docs/what-didnt-work.md`, or r
 
 Operational dead-ends from the implementation program. Reverted approaches and runtime quirks, not experiment hypotheses, so they sit below the dated seed entries. Same six fields, lighter heading.
 
+### 2026-06-05 Installed .git/hooks/* update on generator-change merge
+
+- **Expectation**: merging an `install.sh` generator change (e.g. a new staleness notice in the installed git hook) updates the already-installed `.git/hooks/*` for that repo.
+- **What happened**: installed `.git/hooks/*` are install-time artifacts written by `install_git_hook`; they do NOT regenerate on a code merge. PR #751's staleness notice was absent live after PR #740's merge because the installed hook predated #751 and was never rewritten.
+- **Evidence**: PR #751; PR #740; `install.sh` `install_git_hook`; program negative-notes log, 2026-06-05.
+- **Decision**: rejected. After merging `install.sh` generator changes, rerun `install.sh` (or `install_git_hook`) to rewrite the installed `.git/hooks/*`; merging the generator alone does not update them.
+
 ### 2026-06-05 Post-merge git pull as live hook deployment
 
 - **Expectation**: pulling main after a merge puts the changed hooks live in `~/.claude` immediately via the post-merge sync hook.

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -133,6 +133,48 @@ def detect_errors(event: dict) -> bool:
         return False
 
 
+def extract_output_text(result: object) -> str:
+    """Flatten a PostToolUse tool_result/tool_response into searchable text.
+
+    The shipped tests simulate the Bash-style ``{"output": "..."}`` shape, but a
+    LIVE Agent (Task) dispatch returns its final message as the Anthropic
+    message-content shape: a LIST of content blocks
+    ``[{"type": "text", "text": "...banner..."}]`` (or a dict carrying that list
+    under ``content``). ``get_tool_output`` only reads the ``output``/``stdout``
+    string keys, so it returned "" for the live shape and the rightsizing banner
+    was never seen (decision + telemetry rows still recorded — they don't read
+    output). This handles every shape and keeps the plain-string path:
+
+      - str                              -> itself
+      - {"output"/"stdout": str}         -> that string (via get_tool_output)
+      - {"text": str}                    -> that string
+      - {"content": <blocks or str>}     -> recurse into content
+      - [block, ...] / content blocks    -> concat each block's text
+    """
+    if result is None:
+        return ""
+    if isinstance(result, str):
+        return result
+    if isinstance(result, list):
+        # A list of content blocks (or nested lists). Concat each block's text.
+        return "\n".join(extract_output_text(block) for block in result)
+    if isinstance(result, dict):
+        # Bash-style output/stdout first (preserves the existing path).
+        from hook_utils import get_tool_output
+
+        out = get_tool_output(result)
+        if out:
+            return out
+        # Content-block dict: {"type": "text", "text": "..."} or {"content": ...}.
+        text = result.get("text")
+        if isinstance(text, str) and text:
+            return text
+        if "content" in result:
+            return extract_output_text(result["content"])
+        return ""
+    return ""
+
+
 def record_rightsizing(output: str, session_id: str | None = None) -> None:
     """(C) Add one rightsizing review to the tier's running sums. Silent when no banner.
 
@@ -245,11 +287,14 @@ def main() -> None:
             tool_errors=has_errors,
         )
 
-        # (C) right-sizing feedback, parse-only.
-        from hook_utils import get_tool_output, get_tool_result
+        # (C) right-sizing feedback, parse-only. extract_output_text flattens
+        # the LIVE Agent content-block shape (list of {"type","text"} blocks)
+        # as well as the Bash-style {"output": "..."} the tests simulate, so the
+        # banner is found regardless of payload shape.
+        from hook_utils import get_tool_result
 
-        output = get_tool_output(get_tool_result(event))
-        if isinstance(output, str):
+        output = extract_output_text(get_tool_result(event))
+        if output:
             record_rightsizing(output, session_id)
 
         # Bridge to the SubagentStop outcome hook (action B). The dispatch was

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -207,6 +207,34 @@ class TestDecisionRecorder:
         keys = {r["key"] for r in _query_routing(db_env)}
         assert "rightsizing:tier3" in keys
 
+    def test_rightsizing_row_recorded_from_live_content_block_shape(self, db_env, monkeypatch):
+        # LIVE PAYLOAD REGRESSION: a real Agent (Task) dispatch returns its final
+        # message as the Anthropic content-block shape — a LIST of
+        # {"type":"text","text":...} blocks — NOT the Bash-style {"output": str}
+        # the other tests simulate. The old get_tool_output read only output/stdout
+        # string keys, so it returned "" for this shape and the banner was missed
+        # (decision + telemetry rows still recorded). This drives the fix.
+        a = _load(A_PATH, "rdr_live_blocks")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        banner = (
+            "rightsizing: tier=3 files=5 packages=3 agents_dispatched=17 "
+            "findings=1C/13H/24M tokens=1984536 wall_clock_s=1667"
+        )
+        event = _agent_event(skill="systematic-code-review")
+        # Replace the Bash-style result with the LIVE content-block list shape
+        # under tool_response (the key live Agent dispatches populate).
+        event["tool_response"] = [{"type": "text", "text": f"summary...\n{banner}"}]
+        event.pop("tool_result", None)
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        row = next(r for r in _query_routing(db_env) if r["key"] == "rightsizing:tier3")
+        assert "sum_critical: 1" in row["value"]
+        assert "sum_high: 13" in row["value"]
+        assert "sum_medium: 24" in row["value"]
+        assert "sum_tokens: 1984536" in row["value"]
+        assert "sum_wall_clock_s: 1667" in row["value"]
+
     def test_no_rightsizing_row_when_banner_absent(self, db_env, monkeypatch):
         a = _load(A_PATH, "rdr_a5")
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)


### PR DESCRIPTION
## Root cause

The review-ROI banner capture worked in test simulations but not live. A live `PostToolUse:Agent` dispatch returns the subagent's final message as the Anthropic **content-block** shape — a LIST of `{"type":"text","text":...}` blocks (under `tool_response`) — not the Bash-style `{"output": str}` the shipped tests simulate. `record_rightsizing` read output through `hook_utils.get_tool_output`, which only handles the `output`/`stdout` string keys and returns `""` for a list, so the `rightsizing:` banner was never parsed.

This matches the live evidence exactly: the `telemetry_runs` row and routing-decision row both recorded (neither reads the output), while `learning-db.py review-roi` stayed empty because `record_rightsizing` never accumulated.

## Fix

Add `extract_output_text(result)` in `routing-decision-recorder.py`. It flattens any `tool_result`/`tool_response` shape into searchable text:

- `str` -> itself
- `{"output"/"stdout": str}` -> that string (existing path, preserved)
- `{"text": str}` -> that string
- `{"content": <blocks or str>}` -> recurse
- `[block, ...]` content blocks -> concat each block's text

The call site now extracts from the full `get_tool_result(event)` via this helper instead of the narrow `get_tool_output`, so the banner is found regardless of payload shape. The regex itself was never the problem — it matches the live banner; the text just never reached it.

## Test evidence (TDD)

- New `test_rightsizing_row_recorded_from_live_content_block_shape` feeds the LIVE content-block list shape carrying the exact dogfood banner (`findings=1C/13H/24M tokens=1984536 wall_clock_s=1667`).
- Confirmed **red before / green after**: with the old narrow extraction the test raises `StopIteration` (no `rightsizing:tier3` row); with the fix it passes.
- Full file: `54 passed` (`pytest hooks/tests/test_routing_decision_recorder.py`).
- Live-adjacent proof: piping a synthetic live-shape event through the hook against a temp DB (`CLAUDE_LEARNING_DIR`) accumulates `rightsizing:tier3 | sum_critical: 1 | sum_high: 13 | sum_medium: 24 | sum_tokens: 1984536 | sum_wall_clock_s: 1667`.
- `ruff check` clean; `ruff format --check` clean on touched files. Hook exits 0 on empty/malformed input. New code path costs 0.003ms/call; warm per-event `main()` ~30ms (<50ms budget).

## Also

Appends a `docs/what-didnt-work.md` program note: installed `.git/hooks/*` are install-time artifacts — merging `install.sh` generator changes does not update them; rerun `install.sh` (or `install_git_hook`). Evidence: PR #751's staleness notice was absent after PR #740's merge because the installed hook predated #751.
