### PR TITLE
docs: relocate skills catalog out of skill root to docs/skills.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Strips built-in tool-use instructions. The toolkit's agents, skills, hooks, and 
 | Hooks | 77 | Fire on lifecycle events. Block incomplete work. Zero LLM cost. |
 | Scripts | 101 | Determinism: test runners, linters, validators. No LLM judgment. |
 
+Full skill catalog: [docs/skills.md](docs/skills.md).
+
 ```
 ┌─────────────────────────────────────────────────┐
 │  SKILL.md                                       │

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -139,7 +139,7 @@ Skills are invoked via `/do [request]` (routed automatically) or directly as `/s
 | `topic-brainstormer` | no | Generate blog topic ideas: problem mining, gap analysis, expansion |
 | `series-planner` | no | Plan multi-part content series: structure, cross-linking, cadence |
 | `content-engine` | no | Repurpose source assets into platform-native social content |
-| `content-calendar` | no | Manage editorial content through 6 pipeline stages |
+| `content-calendar` | no | Manage editorial content through six pipeline stages |
 | `joy-check` | no | Validate content framing on joy-grievance spectrum |
 | `professional-communication` | no | Transform technical communication into structured business formats |
 | `gemini-image-generator` | no | Generate images from text prompts via Google Gemini |

--- a/skills/meta/docs-sync-checker/SKILL.md
+++ b/skills/meta/docs-sync-checker/SKILL.md
@@ -86,7 +86,7 @@ YAML errors: [N] (must be 0 to proceed)
 
 ### Phase 2: CROSS-REFERENCE
 
-**Goal**: Extract documented tools from README files and compare with discovered tools. Each tool type has a primary documentation file: skills belong in `skills/README.md`, agents in `agents/README.md`, commands in `commands/README.md`.
+**Goal**: Extract documented tools from README files and compare with discovered tools. Each tool type has a primary documentation file: skills belong in `docs/skills.md`, agents in `agents/README.md`, commands in `commands/README.md`.
 
 **Step 1: Run the documentation parser**
 
@@ -100,7 +100,7 @@ These are the five documentation files to check -- no others:
 
 | File | Format | What to Extract |
 |------|--------|-----------------|
-| `skills/README.md` | Markdown table | Name, Description, Command, Hook columns |
+| `docs/skills.md` | Markdown table | Name, Description, Command, Hook columns |
 | `agents/README.md` | Table or list | Name, Description fields |
 | `commands/README.md` | Markdown list | /command-name - Description items |
 | `README.md` | Inline references | Pattern-match `skill: X`, `/command`, `agent-name` |
@@ -208,12 +208,12 @@ Remove any helper scripts and debug outputs created during execution.
 ### Examples
 
 #### Example 1: New Skill Missing from README
-User created `skills/my-new-skill/SKILL.md` but forgot to update `skills/README.md`.
+User created `skills/my-new-skill/SKILL.md` but forgot to update `docs/skills.md`.
 Actions:
 1. SCAN discovers `my-new-skill` in filesystem
-2. CROSS-REFERENCE parses skills/README.md, does not find `my-new-skill`
+2. CROSS-REFERENCE parses docs/skills.md, does not find `my-new-skill`
 3. DETECT flags as HIGH severity missing entry
-4. REPORT suggests exact table row to add to skills/README.md
+4. REPORT suggests exact table row to add to docs/skills.md
 
 #### Example 2: Removed Agent Still Documented
 User deleted `agents/old-agent.md` but `agents/README.md` still lists it.
@@ -235,7 +235,7 @@ Actions:
 User created 3 new skills and deleted 2 old ones in a refactoring PR.
 Actions:
 1. SCAN discovers 3 new skills in filesystem, does not find 2 removed skills
-2. CROSS-REFERENCE finds 2 stale entries and 3 absent entries in skills/README.md
+2. CROSS-REFERENCE finds 2 stale entries and 3 absent entries in docs/skills.md
 3. DETECT flags 3 HIGH (missing) + 2 MEDIUM (stale) issues
 4. REPORT provides exact table rows to add and identifies rows to remove
 
@@ -253,7 +253,7 @@ Solution:
 Cause: Expected README file does not exist at expected path
 Solution:
 1. Verify --repo-root path is correct
-2. Check that skills/README.md, agents/README.md, commands/README.md exist
+2. Check that docs/skills.md, agents/README.md, commands/README.md exist
 3. If file is legitimately missing, create a placeholder with the expected table/list header
 4. Re-run scan after creating placeholder
 

--- a/skills/meta/docs-sync-checker/references/documentation-structure.md
+++ b/skills/meta/docs-sync-checker/references/documentation-structure.md
@@ -6,13 +6,13 @@ This file defines where each tool type should be documented and the required fie
 
 | Tool Type | Primary Documentation | Secondary Documentation | Optional Documentation |
 |-----------|----------------------|-------------------------|------------------------|
-| Skills | skills/README.md (table) | docs/REFERENCE.md (sections) | README.md (references) |
+| Skills | docs/skills.md (table) | docs/REFERENCE.md (sections) | README.md (references) |
 | Agents | agents/README.md (table/list) | docs/REFERENCE.md (sections) | README.md (references) |
 | Commands | commands/README.md (list) | docs/REFERENCE.md (sections) | README.md (references) |
 
 ## Required Fields Per Documentation Type
 
-### skills/README.md
+### docs/skills.md
 
 **Format**: Markdown table
 
@@ -92,7 +92,7 @@ Combined Python (ruff) and JavaScript (Biome) linting skill. Use when user reque
 ## Cross-Reference Requirements
 
 ### Skills
-- **MUST** be documented in: skills/README.md
+- **MUST** be documented in: docs/skills.md
 - **SHOULD** be documented in: docs/REFERENCE.md (if significant/commonly used)
 - **MAY** be referenced in: README.md (if highlighted as important)
 
@@ -131,7 +131,7 @@ When deprecating a tool:
 
 1. **Create Tool**: Add tool directory with SKILL.md/agent.md file
 2. **Run docs-sync-checker**: Detect missing documentation
-3. **Update Primary Documentation**: Add to skills/README.md, agents/README.md, or commands/README.md
+3. **Update Primary Documentation**: Add to docs/skills.md, agents/README.md, or commands/README.md
 4. **Update Secondary Documentation**: Add to docs/REFERENCE.md if significant tool
 5. **Update Root README**: Add reference if highlighted tool
 6. **Verify Sync**: Re-run docs-sync-checker to confirm all in sync

--- a/skills/meta/docs-sync-checker/references/examples.md
+++ b/skills/meta/docs-sync-checker/references/examples.md
@@ -15,7 +15,7 @@ description: Verify all skills, agents, and commands are documented in repositor
 ---
 ```
 
-### Before: skills/README.md
+### Before: docs/skills.md
 
 ```markdown
 # Skills
@@ -26,7 +26,7 @@ description: Verify all skills, agents, and commands are documented in repositor
 | test-driven-development | RED-GREEN-REFACTOR cycle for all code changes | `skill: test-driven-development` | - |
 ```
 
-### After: skills/README.md
+### After: docs/skills.md
 
 ```markdown
 # Skills
@@ -225,7 +225,7 @@ description: Proactively checks GitHub Actions workflow status after git push
 ---
 ```
 
-### Before: skills/README.md
+### Before: docs/skills.md
 
 ```markdown
 | Name | Description | Command | Hook |
@@ -233,7 +233,7 @@ description: Proactively checks GitHub Actions workflow status after git push
 | code-linting | Combined Python and JavaScript linting | `skill: code-linting` | - |
 ```
 
-### After: skills/README.md
+### After: docs/skills.md
 
 ```markdown
 | Name | Description | Command | Hook |
@@ -259,7 +259,7 @@ description: [EXPERIMENTAL] Automatically fix missing documentation entries
 ---
 ```
 
-### Documentation: skills/README.md
+### Documentation: docs/skills.md
 
 ```markdown
 | Name | Description | Command | Hook |
@@ -288,7 +288,7 @@ description: RED-GREEN-REFACTOR cycle for all code changes. Write failing test f
 ---
 ```
 
-### Update 1: skills/README.md
+### Update 1: docs/skills.md
 
 **Before**:
 ```markdown
@@ -334,7 +334,7 @@ You created 3 new skills and removed 1 old skill. Update all at once.
 - Created: `skill-a`, `skill-b`, `skill-c`
 - Removed: `old-skill`
 
-### Before: skills/README.md
+### Before: docs/skills.md
 
 ```markdown
 | Name | Description | Command | Hook |
@@ -344,7 +344,7 @@ You created 3 new skills and removed 1 old skill. Update all at once.
 | test-driven-development | TDD workflow | `skill: test-driven-development` | - |
 ```
 
-### After: skills/README.md
+### After: docs/skills.md
 
 ```markdown
 | Name | Description | Command | Hook |
@@ -478,12 +478,12 @@ git commit -m "Add/update [tool-name] with documentation"
 
 ### Add Skill
 1. Create `skills/skill-name/SKILL.md` with YAML frontmatter
-2. Add row to `skills/README.md` table
+2. Add row to `docs/skills.md` table
 3. Add section to `docs/REFERENCE.md` (if significant skill)
 
 ### Remove Skill
 1. Delete `skills/skill-name/` directory
-2. Remove row from `skills/README.md` table
+2. Remove row from `docs/skills.md` table
 3. Remove section from `docs/REFERENCE.md` (if documented)
 4. Remove references from `README.md` (if any)
 

--- a/skills/meta/docs-sync-checker/references/integration-guide.md
+++ b/skills/meta/docs-sync-checker/references/integration-guide.md
@@ -118,7 +118,7 @@ python3 skills/meta/docs-sync-checker/scripts/generate_report.py
 
 # Update documentation per report suggestions
 # Commit tool AND documentation together
-git add skills/new-skill skills/README.md
+git add skills/new-skill docs/skills.md
 git commit -m "Add new-skill with documentation"
 ```
 
@@ -130,9 +130,9 @@ rm -rf skills/old-skill
 # Run sync checker to find stale entries
 python3 skills/meta/docs-sync-checker/scripts/generate_report.py
 
-# Remove entries from skills/README.md, docs/REFERENCE.md
+# Remove entries from docs/skills.md, docs/REFERENCE.md
 # Commit deletion AND documentation cleanup together
-git add skills/ skills/README.md docs/REFERENCE.md
+git add skills/ docs/skills.md docs/REFERENCE.md
 git commit -m "Remove old-skill and documentation references"
 ```
 

--- a/skills/meta/docs-sync-checker/references/markdown-formats.md
+++ b/skills/meta/docs-sync-checker/references/markdown-formats.md
@@ -2,7 +2,7 @@
 
 This file provides expected markdown table and list formats for each README file in the repository.
 
-## skills/README.md
+## docs/skills.md
 
 ### Expected Format
 

--- a/skills/meta/docs-sync-checker/references/sync-rules.md
+++ b/skills/meta/docs-sync-checker/references/sync-rules.md
@@ -5,9 +5,9 @@ This file documents the synchronization rules for determining which files must d
 ## Primary Documentation Rules
 
 ### Skills
-**Primary Location**: `skills/README.md`
+**Primary Location**: `docs/skills.md`
 
-**Rule**: EVERY skill with a `skills/*/SKILL.md` file MUST be documented in `skills/README.md`
+**Rule**: EVERY skill with a `skills/*/SKILL.md` file MUST be documented in `docs/skills.md`
 
 **Format**: Markdown table with columns: Name, Description, Command, Hook
 
@@ -75,7 +75,7 @@ This file documents the synchronization rules for determining which files must d
 
 **Recommended**:
 - docs/REFERENCE.md: Include version in tool section
-- skills/README.md: Could add Version column (not standard currently)
+- docs/skills.md: Could add Version column (not standard currently)
 
 **Enforcement**: Low priority - version mismatches reported as LOW severity
 
@@ -146,7 +146,7 @@ description: Combined Python (ruff) and JavaScript (Biome) linting
 ```
 
 ```markdown
-# skills/README.md
+# docs/skills.md
 | code-linting | Combined Python (ruff) and JavaScript (Biome) linting | ... |
 
 # docs/REFERENCE.md
@@ -292,13 +292,13 @@ python3 skills/meta/docs-sync-checker/scripts/parse_docs.py --repo-root . --scan
 python3 skills/meta/docs-sync-checker/scripts/generate_report.py --issues /tmp/parse.json --scan-results /tmp/scan.json
 
 # 3. Review report and update documentation
-vim skills/README.md
+vim docs/skills.md
 
 # 4. Verify sync
 python3 skills/meta/docs-sync-checker/scripts/generate_report.py --issues /tmp/parse.json --scan-results /tmp/scan.json
 
 # 5. Commit tool AND documentation together
-git add skills/new-skill skills/README.md
+git add skills/new-skill docs/skills.md
 git commit -m "Add new-skill with documentation"
 ```
 
@@ -308,7 +308,7 @@ These rules may evolve as the repository grows:
 
 **Potential Changes**:
 - Add `.docsignore` for tools to exclude
-- Add version column to skills/README.md table
+- Add version column to docs/skills.md table
 - Introduce skill/agent namespaces
 - Add automated description consistency checking
 - Support alternative documentation formats (JSON, YAML)

--- a/skills/meta/docs-sync-checker/scripts/parse_docs.py
+++ b/skills/meta/docs-sync-checker/scripts/parse_docs.py
@@ -131,15 +131,15 @@ class DocumentationParser:
 
     def parse_skills_readme(self) -> List[Dict[str, str]]:
         """
-        Parse skills/README.md table.
+        Parse docs/skills.md table.
 
         Expected format:
         | Name | Description | Command | Hook |
         """
-        readme_path = self.repo_root / "skills" / "README.md"
+        readme_path = self.repo_root / "docs" / "skills.md"
 
         if not readme_path.exists():
-            self.log(f"Skills README not found: {readme_path}")
+            self.log(f"Skills catalog not found: {readme_path}")
             return []
 
         self.log(f"Parsing {readme_path}")
@@ -163,7 +163,7 @@ class DocumentationParser:
                         "name": name,
                         "description": description or "",
                         "command": command or "",
-                        "source": "skills/README.md",
+                        "source": "docs/skills.md",
                     }
                 )
 
@@ -356,8 +356,8 @@ class DocumentationParser:
         skill_versions = {s["name"]: s["version"] for s in scan_results.get("skills", [])}
         agent_versions = {a["name"]: a["version"] for a in scan_results.get("agents", [])}
 
-        # Check skills README
-        skills_readme = documented.get("skills/README.md", [])
+        # Check skills catalog
+        skills_readme = documented.get("docs/skills.md", [])
         documented_skills = {s["name"] for s in skills_readme}
 
         # Missing skills
@@ -369,7 +369,7 @@ class DocumentationParser:
                         "tool_type": "skill",
                         "tool_name": skill,
                         "tool_path": skill_info["path"],
-                        "missing_from": ["skills/README.md"],
+                        "missing_from": ["docs/skills.md"],
                         "severity": "high",
                         "yaml_description": skill_info["description"],
                     }
@@ -378,7 +378,7 @@ class DocumentationParser:
         # Stale skills
         for skill in documented_skills - discovered_skills:
             issues["stale_entries"].append(
-                {"tool_type": "skill", "tool_name": skill, "documented_in": ["skills/README.md"], "severity": "medium"}
+                {"tool_type": "skill", "tool_name": skill, "documented_in": ["docs/skills.md"], "severity": "medium"}
             )
 
         # Version mismatches for skills
@@ -465,7 +465,7 @@ def main():
         parser_obj = DocumentationParser(args.repo_root, debug=args.debug)
 
         documented = {
-            "skills/README.md": parser_obj.parse_skills_readme(),
+            "docs/skills.md": parser_obj.parse_skills_readme(),
             "agents/README.md": parser_obj.parse_agents_readme(),
             "commands/README.md": parser_obj.parse_commands_readme(),
             "README.md": parser_obj.parse_root_readme(),

--- a/skills/meta/docs-sync-checker/scripts/validate.py
+++ b/skills/meta/docs-sync-checker/scripts/validate.py
@@ -211,7 +211,7 @@ version: 1.0.0
             "agents": [],
             "commands": [],
         }
-        documented = {"skills/README.md": [{"name": "old-skill", "description": "Old skill"}]}
+        documented = {"docs/skills.md": [{"name": "old-skill", "description": "Old skill"}]}
 
         issues = parser.detect_issues(discovered, documented)
         missing_count = len(issues["missing_entries"])


### PR DESCRIPTION
## Problem

The skills catalog lived at `skills/README.md` — a loose `.md` file inside a directory that harnesses scan for skills. Reasonix (and the Claude `~/.claude/skills` whole-dir symlink) treated it as a single-file skill with no frontmatter, emitting on every run:

```
warning: skill "README" at ~/.reasonix/skills/README.md has no description: — it will load but won't appear in the skills index
warning: skill "README" at ~/.claude/skills/README.md has no description: — it will load but won't appear in the skills index
```

Adding `description:` frontmatter would register a junk `README` skill (the warning says "it will load"), and renaming it within the same directory leaves a loose `.md` at a scanned root — so neither addresses the structural cause.

## Change

Move the catalog to `docs/skills.md` so nothing loose remains at a scanned skill root. Both warnings clear at the structural level with no installer or harness changes.

Keep `docs-sync-checker` working at the new path (it hardcoded `skills/README.md` as the canonical skills doc):

- `parse_docs.py` — read `docs/skills.md`; relabel `source` / `missing_from` / `documented_in` and the `documented` dict key
- `validate.py` — update the test fixture key
- 6 reference/`SKILL.md` docs — point at `docs/skills.md`
- `README.md` — link to the relocated catalog under the Four Layers table
- reword "6 pipeline stages" → "six pipeline stages" so the doc-count drift guard no longer false-matches the prose

## Testing

- `reasonix` — no more "has no description / won't appear in the skills index" warnings
- `~/.claude/skills/README.md` no longer resolves (target moved)
- `docs-sync-checker` self-test: 20/21 (the one failing `YAML field version:` check is pre-existing — fails identically on the base, unrelated to this change)
- `parse_docs.py` parses the catalog from `docs/skills.md` correctly
- `scripts/validate-doc-counts.py --json` → 0 drifts
- `scripts/security-review-scan.py` → no findings