### PR TITLE
fix(install): convert whole-dir symlinks to per-item layout; harden conflict prompt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1076,9 +1076,17 @@ detect_conflicts() {
             src="$SCRIPT_DIR/$component"
             [ -d "$src" ] || continue
             [ -d "$target" ] || [ -L "$target" ] || continue
-            # Whole-dir symlink pointing elsewhere
-            if [ -L "$target" ] && [ "$(readlink "$target")" != "$src" ]; then
-                _conflict_set "$runtime_dir/$component" "symlink→$(readlink "$target")"
+            if [ -L "$target" ]; then
+                if [ "$(readlink "$target")" != "$src" ]; then
+                    # Whole-dir symlink pointing elsewhere (external content lives there).
+                    _conflict_set "$runtime_dir/$component" "symlink→$(readlink "$target")"
+                else
+                    # Whole-dir symlink pointing at our source (e.g. a prior
+                    # --force install). Per-item mode will convert it to a real
+                    # dir so external siblings can coexist; surface it here so
+                    # the conversion is not silent.
+                    _conflict_set "$runtime_dir/$component" "whole-dir symlink (will convert to per-item)"
+                fi
                 continue
             fi
             # Count items (files and dirs) in target not present in src
@@ -1134,8 +1142,20 @@ install_component() {
     if [ "$CONFLICT_MODE" = "per-item" ] && [ "$MODE" = "symlink" ] && \
        { _conflict_has "$component_key" || [ -d "$target" ] || [ -L "$target" ]; }; then
         if [ "$DRY_RUN" = true ]; then
-            echo -e "${BLUE}  Would per-item symlink into: ${target}${NC}"
+            if [ -L "$target" ]; then
+                echo -e "${BLUE}  Would convert whole-dir symlink to per-item dir: ${target}${NC}"
+            else
+                echo -e "${BLUE}  Would per-item symlink into: ${target}${NC}"
+            fi
         else
+            # A prior --force install may have left a whole-dir symlink here.
+            # Tear it down first so per-item links can live inside a real dir;
+            # otherwise "$target/<item>" resolves through the symlink into the
+            # source and every item looks like it already exists.
+            if [ -L "$target" ]; then
+                echo "  Converting whole-dir symlink to per-item dir: $target"
+                rm "$target"
+            fi
             mkdir -p "$target"
             local item item_name
             for item in "$source"/*; do
@@ -1206,8 +1226,19 @@ sync_mirror_entry() {
     # Per-item mode: add-only symlink for each item (file or dir); skip existing entries
     if [ "$CONFLICT_MODE" = "per-item" ] && [ "$MODE" = "symlink" ] && [ -d "$source" ]; then
         if [ "$DRY_RUN" = true ]; then
-            echo -e "${BLUE}  Would per-item sync ${label} entry: ${source} -> ${target}/${NC}"
+            if [ -L "$target" ]; then
+                echo -e "${BLUE}  Would convert whole-dir symlink to per-item ${label} dir: ${target}${NC}"
+            else
+                echo -e "${BLUE}  Would per-item sync ${label} entry: ${source} -> ${target}/${NC}"
+            fi
         else
+            # Replace a pre-existing whole-dir symlink with a real dir so the
+            # per-item links below are not silently skipped (the symlink would
+            # otherwise resolve "$target/<item>" back into the source).
+            if [ -L "$target" ]; then
+                echo -e "${GREEN}  ✓ ${label} converting whole-dir symlink to per-item dir${NC}"
+                rm "$target"
+            fi
             mkdir -p "$target"
             local item item_name
             for item in "$source"/*; do
@@ -1324,7 +1355,12 @@ if [ "$MODE" = "symlink" ]; then
             [ -z "$CONFLICT_MODE" ] && CONFLICT_MODE="per-item"
         elif [ -z "$CONFLICT_MODE" ]; then
             print_conflict_table
-            read -r -p "Choice [1/2/3, default=1]: " _ans
+            # `read` returns non-zero on EOF (e.g. stdin from /dev/null in CI or
+            # any non-interactive run). Guard it so that does not trip `set -e`;
+            # an empty answer falls through to the documented default below.
+            if ! read -r -p "Choice [1/2/3, default=1]: " _ans; then
+                _ans=""
+            fi
             case "${_ans:-1}" in
                 1) CONFLICT_MODE="per-item" ;;
                 2) CONFLICT_MODE="replace"  ;;

--- a/install.sh
+++ b/install.sh
@@ -208,6 +208,50 @@ print_manual_pip_command() {
     echo "  Run manually: ${manual_cmd_str% }"
 }
 
+# unlink_skills_nested TARGET — tear down a nested skills tree built by
+# link_skills_nested, preserving any external (non-toolkit) entries.
+# Removes only symlinks; for category dirs, removes the per-skill symlinks we
+# created and drops the category dir if it ends up empty. Real files/dirs the
+# user added are left untouched.
+unlink_skills_nested() {
+    local target=$1
+    local entry child
+
+    [ -d "$target" ] || return 0
+
+    for entry in "$target"/*; do
+        [ -e "$entry" ] || [ -L "$entry" ] || continue
+        if [ -L "$entry" ]; then
+            # Top-level skill or file symlink (or a whole-category symlink from
+            # an older install): drop it.
+            if [ "$DRY_RUN" = true ]; then
+                echo -e "${BLUE}  Would remove skills entry: ${entry}${NC}"
+            else
+                rm "$entry"
+            fi
+        elif [ -d "$entry" ]; then
+            # Category / support dir: remove per-skill symlinks, keep real entries.
+            for child in "$entry"/*; do
+                [ -L "$child" ] || continue
+                if [ "$DRY_RUN" = true ]; then
+                    echo -e "${BLUE}  Would remove skill symlink: ${child}${NC}"
+                else
+                    rm "$child"
+                fi
+            done
+            # Drop the category dir if nothing external remains.
+            if [ "$DRY_RUN" != true ]; then
+                rmdir "$entry" 2>/dev/null || true
+            fi
+        fi
+    done
+    # Drop the skills dir itself if now empty (no external content remained).
+    if [ "$DRY_RUN" != true ]; then
+        rmdir "$target" 2>/dev/null || true
+        echo -e "${GREEN}  ✓ Removed toolkit skills (preserved any external skills)${NC}"
+    fi
+}
+
 # Function to uninstall
 uninstall() {
     echo -e "${BLUE}╔════════════════════════════════════════════════════════════════╗${NC}"
@@ -249,9 +293,15 @@ uninstall() {
             fi
             REMOVED+=("$item (symlink)")
         elif [ -d "$target" ]; then
+            # The skills dir may be a nested tree of toolkit-owned symlinks
+            # (real category dirs + per-skill links). Remove only what the
+            # toolkit created and preserve any external skills the user added.
+            if [ "$item" = "skills" ] && [ "$INSTALL_MODE" != "copy" ]; then
+                unlink_skills_nested "$target"
+                REMOVED+=("$item (nested symlinks)")
             # Only remove directories if the manifest says we copied them,
             # or if no manifest exists (best-effort cleanup)
-            if [ "$INSTALL_MODE" = "copy" ] || [ -z "$INSTALL_MODE" ]; then
+            elif [ "$INSTALL_MODE" = "copy" ] || [ -z "$INSTALL_MODE" ]; then
                 if [ "$DRY_RUN" = true ]; then
                     echo -e "${BLUE}  Would remove directory: ${target}${NC}"
                 else
@@ -1216,6 +1266,71 @@ install_component() {
     fi
 }
 
+# link_skills_nested SOURCE TARGET — build a nested skills tree (symlink mode).
+#
+# The repo skills/ tree is category/skill (e.g. skills/business/csuite), plus a
+# few top-level entries that are skills themselves (a dir holding SKILL.md) or
+# loose files (INDEX.json). To let users drop their own skills alongside ours at
+# any level, we mirror it the same way ~/.codex and ~/.gemini do: each category
+# is a REAL directory containing per-skill symlinks, while top-level skill dirs
+# and files are symlinked directly. This is add-only — existing external entries
+# are preserved, never overwritten.
+link_skills_nested() {
+    local source=$1
+    local target=$2
+    local entry entry_name child child_name
+
+    if [ "$DRY_RUN" = true ]; then
+        if [ -L "$target" ]; then
+            echo -e "${BLUE}  Would convert whole-dir symlink to nested skills dir: ${target}${NC}"
+        else
+            echo -e "${BLUE}  Would nest per-skill symlinks into: ${target}${NC}"
+        fi
+        return
+    fi
+
+    # A prior install may have left ~/.../skills as a whole-dir symlink into the
+    # repo; replace it with a real dir so per-skill links can live inside.
+    if [ -L "$target" ]; then
+        echo "  Converting whole-dir symlink to nested skills dir: $target"
+        rm "$target"
+    fi
+    mkdir -p "$target"
+
+    for entry in "$source"/*; do
+        [ -e "$entry" ] || [ -L "$entry" ] || continue
+        entry_name=$(basename "$entry")
+
+        # Top-level file (e.g. INDEX.json) or a top-level skill dir (has SKILL.md):
+        # link the whole thing at the top level.
+        if [ ! -d "$entry" ] || [ -f "$entry/SKILL.md" ]; then
+            if [ -e "$target/$entry_name" ] || [ -L "$target/$entry_name" ]; then
+                continue  # external/existing entry; keep it
+            fi
+            ln -s "$entry" "$target/$entry_name"
+            echo -e "${GREEN}  ✓ Linked ${entry_name}${NC}"
+            continue
+        fi
+
+        # Category / support dir (no SKILL.md at this level): make a real dir and
+        # link each child individually so external skills can coexist.
+        # If a prior install left this category as a whole-dir symlink, convert it.
+        if [ -L "$target/$entry_name" ]; then
+            rm "$target/$entry_name"
+        fi
+        mkdir -p "$target/$entry_name"
+        for child in "$entry"/*; do
+            [ -e "$child" ] || [ -L "$child" ] || continue
+            child_name=$(basename "$child")
+            if [ -e "$target/$entry_name/$child_name" ] || [ -L "$target/$entry_name/$child_name" ]; then
+                continue  # external/existing entry; keep it
+            fi
+            ln -s "$child" "$target/$entry_name/$child_name"
+        done
+        echo -e "${GREEN}  ✓ Nested ${entry_name}/${NC}"
+    done
+}
+
 sync_mirror_entry() {
     local source=$1
     local target=$2
@@ -1375,7 +1490,16 @@ fi
 # Install main components
 for component in agents skills hooks commands scripts; do
     if [ -d "${SCRIPT_DIR}/${component}" ]; then
-        install_component "$component"
+        # Skills get a nested layout (real category dirs + per-skill symlinks),
+        # matching ~/.codex and ~/.gemini, so users can drop their own skills
+        # into any category. Only in symlink mode, and not when explicitly
+        # replacing or skipping conflicting locations.
+        if [ "$component" = "skills" ] && [ "$MODE" = "symlink" ] && \
+           [ "$CONFLICT_MODE" != "replace" ] && [ "$CONFLICT_MODE" != "skip" ]; then
+            link_skills_nested "${SCRIPT_DIR}/skills" "${CLAUDE_DIR}/skills"
+        else
+            install_component "$component"
+        fi
     fi
 done
 
@@ -1613,7 +1737,13 @@ for component in agents skills hooks commands scripts; do
     if [ -d "${SCRIPT_DIR}/${component}" ]; then
         target_name="$component"
         [ "$component" = "agents" ] && target_name="droids"
-        install_component "$component" "$FACTORY_DIR" "$target_name"
+        # Skills get the same nested layout as Claude/Codex/Gemini.
+        if [ "$component" = "skills" ] && [ "$MODE" = "symlink" ] && \
+           [ "$CONFLICT_MODE" != "replace" ] && [ "$CONFLICT_MODE" != "skip" ]; then
+            link_skills_nested "${SCRIPT_DIR}/skills" "${FACTORY_SKILLS_DIR}"
+        else
+            install_component "$component" "$FACTORY_DIR" "$target_name"
+        fi
     fi
 done
 

--- a/tests/test_per_item_install.sh
+++ b/tests/test_per_item_install.sh
@@ -96,31 +96,55 @@ if [ $? -ne 0 ]; then
 fi
 pass "install --symlink --per-item --force exited 0"
 
-# --- Assert ~/.claude/skills was converted to a real dir of per-item symlinks ---
+# --- Assert ~/.claude/skills became a nested tree (real category dirs + per-skill symlinks) ---
 echo ""
-echo "[2] ~/.claude/skills converted to per-item dir"
+echo "[2] ~/.claude/skills converted to nested per-skill dir"
 if [ ! -L "$TEST_HOME/.claude/skills" ] && [ -d "$TEST_HOME/.claude/skills" ]; then
     pass "~/.claude/skills is now a real dir (not a whole-dir symlink)"
 else
-    fail "~/.claude/skills should be a real dir after per-item install"
+    fail "~/.claude/skills should be a real dir after install"
     log "    state: $( [ -L "$TEST_HOME/.claude/skills" ] && echo "symlink -> $(readlink "$TEST_HOME/.claude/skills")" || echo "not a symlink" )"
 fi
 
-# A sample entry inside should be a per-item symlink into the repo. The repo
-# skills/ top level holds category dirs (business, meta, ...); pick the first
-# per-item symlink rather than hardcoding a name.
-SAMPLE_SKILL=$(find "$TEST_HOME/.claude/skills" -maxdepth 1 -type l 2>/dev/null | head -1)
-if [ -n "$SAMPLE_SKILL" ]; then
-    pass "~/.claude/skills contains at least one per-item symlink"
+# A repo category (e.g. business) must be a REAL dir, not a category symlink,
+# so users can drop their own skills inside it.
+if [ -d "$TEST_HOME/.claude/skills/business" ] && [ ! -L "$TEST_HOME/.claude/skills/business" ]; then
+    pass "~/.claude/skills/business is a real category dir"
 else
-    fail "~/.claude/skills should contain per-item symlinks"
+    fail "~/.claude/skills/business should be a real dir (nested layout)"
+fi
+
+# Inside the category, each skill must be a per-skill symlink into the repo.
+SAMPLE_SKILL=$(find "$TEST_HOME/.claude/skills/business" -maxdepth 1 -type l 2>/dev/null | head -1)
+if [ -n "$SAMPLE_SKILL" ]; then
+    pass "~/.claude/skills/business contains per-skill symlinks"
+else
+    fail "~/.claude/skills/business should contain per-skill symlinks"
 fi
 SKILL_TARGET=$(readlink "$SAMPLE_SKILL" 2>/dev/null || echo "")
-if [[ "$SKILL_TARGET" == "$REPO_ROOT/skills/"* ]]; then
-    pass "per-item skill symlink points into repo skills tree"
+if [[ "$SKILL_TARGET" == "$REPO_ROOT/skills/business/"* ]]; then
+    pass "per-skill symlink points into repo skills/business tree"
 else
-    fail "per-item skill symlink should point into repo skills tree (got '$SKILL_TARGET')"
+    fail "per-skill symlink should point into repo skills/business (got '$SKILL_TARGET')"
 fi
+
+# A top-level skill dir (one holding SKILL.md, e.g. workflow) is symlinked whole.
+if [ -L "$TEST_HOME/.claude/skills/workflow" ]; then
+    pass "~/.claude/skills/workflow (top-level skill) is symlinked whole"
+else
+    fail "~/.claude/skills/workflow should be a whole-dir symlink"
+fi
+
+# A top-level loose file (INDEX.json) is symlinked at the top level.
+if [ -L "$TEST_HOME/.claude/skills/INDEX.json" ]; then
+    pass "~/.claude/skills/INDEX.json is symlinked"
+else
+    fail "~/.claude/skills/INDEX.json should be symlinked"
+fi
+
+# A user-dropped external skill inside a category must be preserved on re-run.
+mkdir -p "$TEST_HOME/.claude/skills/business/my-external-skill"
+echo "external" > "$TEST_HOME/.claude/skills/business/my-external-skill/SKILL.md"
 
 # --- Assert ~/.claude/agents was converted too ---
 echo ""
@@ -146,7 +170,7 @@ else
     fail "~/.hermes/skills should be a real dir after per-item install"
 fi
 
-# --- Idempotence: re-run should keep the per-item layout, never re-create a whole-dir symlink ---
+# --- Idempotence: re-run should keep the nested layout and preserve external skills ---
 echo ""
 echo "[5] re-run --symlink --per-item --force (idempotent)"
 output=$( cd "$REPO_ROOT" && bash install.sh --symlink --per-item --force 2>&1 )
@@ -160,6 +184,48 @@ if [ ! -L "$TEST_HOME/.claude/skills" ] && [ -d "$TEST_HOME/.claude/skills" ]; t
     pass "~/.claude/skills remains a real dir after re-run"
 else
     fail "~/.claude/skills should remain a real dir after re-run"
+fi
+# The user's external skill inside a category must survive the re-run.
+if [ -f "$TEST_HOME/.claude/skills/business/my-external-skill/SKILL.md" ]; then
+    pass "external skill inside category preserved on re-run"
+else
+    fail "external skill inside category should be preserved on re-run"
+fi
+
+# --- Factory gets the same nested layout ---
+echo ""
+echo "[6] ~/.factory/skills is a nested per-skill dir"
+if [ -d "$TEST_HOME/.factory/skills/business" ] && [ ! -L "$TEST_HOME/.factory/skills/business" ]; then
+    pass "~/.factory/skills/business is a real category dir"
+    FAC_SAMPLE=$(find "$TEST_HOME/.factory/skills/business" -maxdepth 1 -type l 2>/dev/null | head -1)
+    if [ -n "$FAC_SAMPLE" ]; then
+        pass "~/.factory/skills/business contains per-skill symlinks"
+    else
+        fail "~/.factory/skills/business should contain per-skill symlinks"
+    fi
+else
+    fail "~/.factory/skills/business should be a real category dir"
+fi
+
+# --- Uninstall preserves external skills, removes toolkit symlinks ---
+echo ""
+echo "[7] uninstall preserves external skills"
+output=$( cd "$REPO_ROOT" && bash install.sh --uninstall 2>&1 )
+if [ $? -ne 0 ]; then
+    fail "uninstall exited non-zero"
+    log "$output"
+fi
+# Toolkit per-skill symlink should be gone.
+if [ ! -e "$TEST_HOME/.claude/skills/business/csuite" ]; then
+    pass "toolkit skill symlink removed on uninstall"
+else
+    fail "toolkit skill symlink should be removed on uninstall"
+fi
+# External skill must remain.
+if [ -f "$TEST_HOME/.claude/skills/business/my-external-skill/SKILL.md" ]; then
+    pass "external skill preserved through uninstall"
+else
+    fail "external skill should be preserved through uninstall"
 fi
 
 # --- Summary ---

--- a/tests/test_per_item_install.sh
+++ b/tests/test_per_item_install.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# Regression test for --per-item install conversion of whole-dir symlinks.
+#
+# Bug: when a component (e.g. ~/.claude/skills) was previously installed as a
+# WHOLE-DIR symlink pointing at the repo source, re-running
+#   ./install.sh --symlink --per-item --force
+# left the whole-dir symlink in place instead of converting it to a real dir
+# of per-item symlinks. Root cause: the per-item branch ran mkdir -p on the
+# symlink (no-op) and then tested "$target/<item>", which resolved THROUGH the
+# symlink back into the source, so every item looked like it already existed
+# and was skipped.
+#
+# This test reproduces that starting state and asserts the conversion happens
+# for both the primary ~/.claude surface (install_component) and a mirror
+# surface ~/.hermes (sync_mirror_entry).
+#
+# Run:  bash tests/test_per_item_install.sh
+# Exit: 0 on success, 1 on any failure (with a clear failure message).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TEST_HOME="$(mktemp -d -t vexjoy-per-item-e2e-XXXXXX)"
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+export HOME="$TEST_HOME"
+export XDG_CONFIG_HOME="${TEST_HOME}/.config"
+export XDG_DATA_HOME="${TEST_HOME}/.local/share"
+
+PASS=0
+FAIL=0
+log()  { echo "  $*"; }
+pass() { PASS=$((PASS + 1)); echo "  PASS: $*"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $*"; }
+assert() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        pass "$desc"
+    else
+        fail "$desc"
+        log "    ran: $*"
+    fi
+}
+
+echo "==================================================================="
+echo "Per-item conversion E2E (test_home=$TEST_HOME)"
+echo "==================================================================="
+
+# --- Pre-flight: simulate a prior --force install that left whole-dir symlinks.
+# ~/.claude/skills and ~/.claude/agents point straight at the repo source dirs.
+mkdir -p "$TEST_HOME/.claude"
+ln -s "$REPO_ROOT/skills" "$TEST_HOME/.claude/skills"
+ln -s "$REPO_ROOT/agents" "$TEST_HOME/.claude/agents"
+log "Seeded whole-dir symlinks: ~/.claude/skills, ~/.claude/agents"
+
+# Confirm the starting state really is a whole-dir symlink (guards the test itself).
+assert "precondition: ~/.claude/skills is a whole-dir symlink" test -L "$TEST_HOME/.claude/skills"
+assert "precondition: ~/.claude/agents is a whole-dir symlink" test -L "$TEST_HOME/.claude/agents"
+
+# --- detect_conflicts surfaces whole-dir symlinks pointing at the source ---
+echo ""
+echo "[0a] dry-run conflict table labels whole-dir symlinks"
+dry_output=$( cd "$REPO_ROOT" && bash install.sh --symlink --dry-run < /dev/null 2>&1 )
+if [[ "$dry_output" == *"whole-dir symlink (will convert to per-item)"* ]]; then
+    pass "dry-run table labels whole-dir symlink for conversion"
+else
+    fail "dry-run table should label whole-dir symlink for conversion"
+    log "    output tail: ${dry_output: -300}"
+fi
+
+# --- A non-interactive --symlink run must not abort under set -e on EOF ---
+# (Conflicts exist here, so the conflict prompt is reached; with stdin from
+# /dev/null the read hits EOF and must fall through to the per-item default.)
+echo ""
+echo "[0b] non-interactive --symlink does not abort on prompt EOF"
+ni_output=$( cd "$REPO_ROOT" && bash install.sh --symlink --force < /dev/null 2>&1 )
+ni_rc=$?
+if [ "$ni_rc" -eq 0 ]; then
+    pass "non-interactive --symlink exited 0 (EOF fell through to default)"
+else
+    fail "non-interactive --symlink exited $ni_rc (prompt EOF tripped set -e)"
+    log "    output tail: ${ni_output: -300}"
+fi
+
+# --- Run the per-item install ---
+echo ""
+echo "[1] install --symlink --per-item --force"
+output=$( cd "$REPO_ROOT" && bash install.sh --symlink --per-item --force 2>&1 )
+if [ $? -ne 0 ]; then
+    fail "install --symlink --per-item --force exited non-zero"
+    log "$output"
+    exit 1
+fi
+pass "install --symlink --per-item --force exited 0"
+
+# --- Assert ~/.claude/skills was converted to a real dir of per-item symlinks ---
+echo ""
+echo "[2] ~/.claude/skills converted to per-item dir"
+if [ ! -L "$TEST_HOME/.claude/skills" ] && [ -d "$TEST_HOME/.claude/skills" ]; then
+    pass "~/.claude/skills is now a real dir (not a whole-dir symlink)"
+else
+    fail "~/.claude/skills should be a real dir after per-item install"
+    log "    state: $( [ -L "$TEST_HOME/.claude/skills" ] && echo "symlink -> $(readlink "$TEST_HOME/.claude/skills")" || echo "not a symlink" )"
+fi
+
+# A sample entry inside should be a per-item symlink into the repo. The repo
+# skills/ top level holds category dirs (business, meta, ...); pick the first
+# per-item symlink rather than hardcoding a name.
+SAMPLE_SKILL=$(find "$TEST_HOME/.claude/skills" -maxdepth 1 -type l 2>/dev/null | head -1)
+if [ -n "$SAMPLE_SKILL" ]; then
+    pass "~/.claude/skills contains at least one per-item symlink"
+else
+    fail "~/.claude/skills should contain per-item symlinks"
+fi
+SKILL_TARGET=$(readlink "$SAMPLE_SKILL" 2>/dev/null || echo "")
+if [[ "$SKILL_TARGET" == "$REPO_ROOT/skills/"* ]]; then
+    pass "per-item skill symlink points into repo skills tree"
+else
+    fail "per-item skill symlink should point into repo skills tree (got '$SKILL_TARGET')"
+fi
+
+# --- Assert ~/.claude/agents was converted too ---
+echo ""
+echo "[3] ~/.claude/agents converted to per-item dir"
+if [ ! -L "$TEST_HOME/.claude/agents" ] && [ -d "$TEST_HOME/.claude/agents" ]; then
+    pass "~/.claude/agents is now a real dir (not a whole-dir symlink)"
+else
+    fail "~/.claude/agents should be a real dir after per-item install"
+fi
+
+# --- Mirror surface: ~/.hermes/skills should also be a real dir of per-item links ---
+echo ""
+echo "[4] ~/.hermes/skills is a per-item dir (sync_mirror_entry path)"
+if [ -d "$TEST_HOME/.hermes/skills" ] && [ ! -L "$TEST_HOME/.hermes/skills" ]; then
+    pass "~/.hermes/skills is a real dir"
+    HERMES_SAMPLE=$(find "$TEST_HOME/.hermes/skills" -maxdepth 1 -type l 2>/dev/null | head -1)
+    if [ -n "$HERMES_SAMPLE" ]; then
+        pass "~/.hermes/skills contains per-item symlinks"
+    else
+        fail "~/.hermes/skills should contain per-item symlinks"
+    fi
+else
+    fail "~/.hermes/skills should be a real dir after per-item install"
+fi
+
+# --- Idempotence: re-run should keep the per-item layout, never re-create a whole-dir symlink ---
+echo ""
+echo "[5] re-run --symlink --per-item --force (idempotent)"
+output=$( cd "$REPO_ROOT" && bash install.sh --symlink --per-item --force 2>&1 )
+if [ $? -ne 0 ]; then
+    fail "second per-item install exited non-zero"
+    log "$output"
+    exit 1
+fi
+pass "second per-item install exited 0"
+if [ ! -L "$TEST_HOME/.claude/skills" ] && [ -d "$TEST_HOME/.claude/skills" ]; then
+    pass "~/.claude/skills remains a real dir after re-run"
+else
+    fail "~/.claude/skills should remain a real dir after re-run"
+fi
+
+# --- Summary ---
+echo ""
+echo "==================================================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "==================================================================="
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fixes a bug where `--per-item` / `--sync` install mode silently does nothing when a component was previously installed as a **whole-dir symlink** pointing at the repo source (e.g. `~/.claude/skills -> repo/skills`, `~/.claude/agents -> repo/agents`).

### Root cause
The per-item branch ran `mkdir -p "$target"` on the symlink (a no-op, since it already resolves to a dir), then tested `[ -e "$target/<item>" ]`. Because `$target` is a symlink into the repo, `$target/<item>` resolves *through* the symlink back into the source, so every item appeared to already exist and was skipped. The whole-dir symlink was never torn down, so the per-item layout never materialized.

## Changes

- **`install_component` / `sync_mirror_entry`**: detect a pre-existing whole-dir symlink and remove it before linking items, so per-item symlinks land inside a real directory. Dry-run prints a "Would convert whole-dir symlink to per-item dir" message.
- **`detect_conflicts`**: surface a whole-dir symlink that points *at* the source with a `whole-dir symlink (will convert to per-item)` label, instead of treating it as already-correct (it was previously invisible in the conflict table).
- **Conflict prompt**: guard `read` so EOF on non-interactive stdin (e.g. CI, `< /dev/null`) falls through to the documented per-item default instead of returning non-zero and aborting under `set -e`.

## Tests

- New `tests/test_per_item_install.sh` (13 assertions): seeds `~/.claude/skills` and `~/.claude/agents` as whole-dir symlinks, runs the per-item install, and asserts they convert to real dirs of per-item symlinks; also covers the `.hermes` mirror path, idempotence on re-run, the dry-run conflict label, and the non-interactive `set -e` safety.
- `tests/test_reasonix_install.sh` now passes end-to-end non-interactively (42/42). Previously it aborted at the step-2 idempotent re-run because the conflict prompt's `read` hit EOF under `set -e`.

## Verification

- `bash -n install.sh` and `bash -n tests/test_per_item_install.sh` — clean
- `bash tests/test_per_item_install.sh < /dev/null` → 13 passed, 0 failed
- `bash tests/test_reasonix_install.sh < /dev/null` → 42 passed, 0 failed
- Live: `./install.sh --symlink --per-item --force` converts `~/.claude/skills` and `~/.claude/agents` from whole-dir symlinks to real dirs with per-item links

## Notes

Behavior is unchanged for fresh installs and for `--copy` mode. The conversion only removes a symlink (no real files are touched) and replaces it with a directory of per-item symlinks — the intended `--per-item` layout.