### PR TITLE
feat(routing): outcome-routing loop — health re-rank, failure channel, pre-registered validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-44 domain agents, 124 workflow skills, 83 hooks, 115 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+44 domain agents, 124 workflow skills, 83 hooks, 117 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Antigravity (`/do`), Factory (`/do`).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-44 domain agents, 124 workflow skills, 82 hooks, 106 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+44 domain agents, 124 workflow skills, 82 hooks, 107 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Antigravity (`/do`), Factory (`/do`).
 

--- a/agents/golang-general-engineer.md
+++ b/agents/golang-general-engineer.md
@@ -44,6 +44,7 @@ routing:
     - go-patterns
     - concurrency
     - debugging
+  not_for: "tasks using 'go' as a verb (go ahead, go fix this)"
   pairs_with:
     - go-patterns
   complexity: Medium-Complex

--- a/agents/typescript-frontend-engineer.md
+++ b/agents/typescript-frontend-engineer.md
@@ -16,6 +16,7 @@ routing:
   retro-topics:
     - typescript-patterns
     - debugging
+  not_for: "React Native mobile apps (use react-native-engineer)"
   pairs_with:
     - universal-quality-gate
     - typescript-check

--- a/docs/outcome-routing-shadow-loop.md
+++ b/docs/outcome-routing-shadow-loop.md
@@ -17,8 +17,8 @@ routing is impossible. A prior A/B returned null (89.8% == 89.8%).
 Working documents (local-only, gitignored — not in this commit):
 - `research/forward-plan/implementation-spec.md` — the FROZEN spec (read first).
 - `research/forward-plan/{2026-06-03-forward-plan,codex-plan,input-bundle}.md` — inputs.
-- `adr/outcome-routing-shadow-loop.md` — the ADR (decision, alternatives, data-semantics
-  appendix). Registered via `scripts/adr-query.py`.
+- ADR `outcome-routing-shadow-loop` (local-only, `adr/` is gitignored) — the ADR
+  (decision, alternatives, data-semantics appendix). Registered via `scripts/adr-query.py`.
 
 `research/` and `adr/` are gitignored development artifacts; a safety hook blocks
 force-adding them. They stay local by design — this tracked pointer keeps the branch

--- a/docs/outcome-routing-shadow-loop.md
+++ b/docs/outcome-routing-shadow-loop.md
@@ -4,7 +4,8 @@ Branch: `feat/outcome-routing-loop` (LOCAL-ONLY: never push / PR / merge to main
 
 This branch builds a **shadow** routing-health loop: fix outcome signal fidelity
 (three-way failure/neutral/success), add a per-dispatch event log, build the health
-policy as a pure library, wire it gated (cannot fire on current data — by design), and
+policy as a pure library, wire it gated (DEMOTE cannot fire on current data — by design;
+TIE-BREAK can, on a low-confidence pick with an evidenced alternate), and
 prove the mechanism on real (read-only) plus seeded synthetic data.
 
 Why shadow, not live: the learning DB holds 276 successes / 0 failures ever. The

--- a/docs/outcome-routing-shadow-loop.md
+++ b/docs/outcome-routing-shadow-loop.md
@@ -1,0 +1,24 @@
+# Outcome-Routing Shadow Loop — branch pointer
+
+Branch: `feat/outcome-routing-loop` (LOCAL-ONLY: never push / PR / merge to main).
+
+This branch builds a **shadow** routing-health loop: fix outcome signal fidelity
+(three-way failure/neutral/success), add a per-dispatch event log, build the health
+policy as a pure library, wire it gated (cannot fire on current data — by design), and
+prove the mechanism on real (read-only) plus seeded synthetic data.
+
+Why shadow, not live: the learning DB holds 276 successes / 0 failures ever. The
+demote-at-floor rule matches 0 rows, so live re-ranking is inert. The finalizer boosts
+everything that is not an unambiguous failure (including neutral next-prompts), and rows
+are `(topic,key)` aggregates with no per-dispatch history — so faithful replay of past
+routing is impossible. A prior A/B returned null (89.8% == 89.8%).
+
+Working documents (local-only, gitignored — not in this commit):
+- `research/forward-plan/implementation-spec.md` — the FROZEN spec (read first).
+- `research/forward-plan/{2026-06-03-forward-plan,codex-plan,input-bundle}.md` — inputs.
+- `adr/outcome-routing-shadow-loop.md` — the ADR (decision, alternatives, data-semantics
+  appendix). Registered via `scripts/adr-query.py`.
+
+`research/` and `adr/` are gitignored development artifacts; a safety hook blocks
+force-adding them. They stay local by design — this tracked pointer keeps the branch
+self-documenting without committing ignored content.

--- a/docs/route-loop-validation.md
+++ b/docs/route-loop-validation.md
@@ -1,0 +1,303 @@
+# Outcome-Routing-Loop: Validation Evidence Package
+
+Branch: `feat/outcome-routing-loop`. Date: 2026-06-07. Audience: a skeptical
+reader who wants proof, not prose.
+
+This document's credibility rests on what it does **not** claim. Every number is
+either re-derivable from a command below or copied from a named artifact. No
+claim appears without an artifact path or a command. Production value is
+**UNMEASURED** — see [What is NOT claimed](#what-is-claimed-vs-not-claimed) and
+[Limitations](#limitations).
+
+---
+
+## Purpose
+
+The outcome-routing-loop lets `/do` demote or tie-break a semantically-picked
+route using observed route outcomes (learning.db weights), with safety routes
+hard-exempt. This package reports whether the mechanism works (yes, by
+construction and tests) and whether it has helped a live route (not measured —
+structurally unmeasurable on the current corpus). It exists so the loop can be
+judged on evidence and deleted by a pre-registered kill switch if it never acts.
+
+---
+
+## What is claimed vs NOT claimed
+
+| Statement | Status | Evidence |
+|-----------|--------|----------|
+| The demote/tie-break/exemption mechanism behaves to spec | CLAIMED | `route-value-eval.py` mechanism=pass; synthetic demote help=24 harm=0; exemption 49/49 |
+| Force-route/security routes are never demoted | CLAIMED | `route_policy.py:180` exemption checked before floor; 49/49 held |
+| The failure channel decays weight on routing-relevant failures only | CLAIMED | temp-DB dogfood: 0.65→0.57, idempotent per (session,marker); `routing-dogfood-results.md` |
+| Haiku routing beats the free pre-route baseline | CLAIMED | dogfood 80%/95% vs 30%/75%; `routing-dogfood-results.md` |
+| The loop has improved a live production route | **NOT claimed** | k=0; value UNMEASURED; `route-value-eval.py` exit 2 |
+| Value thresholds (D>0, CI>0, McNemar p<0.05) are met | **NOT claimed** | k=0; metrics null, not computed |
+| Judge reliability is validated | **NOT claimed** | inter-judge agreement UNDEFINED at k=0 |
+| Results generalize beyond one user | **NOT claimed** | single-user corpus, 117 cases |
+| Stage-1/Stage-3 weight numbers are real | **NOT claimed** | labeled SYNTHETIC-WEIGHTS everywhere |
+
+---
+
+## Mechanism
+
+`/do` routes via a Haiku semantic pick. Step 1.5 re-ranks against route weights
+read from learning.db and may adjust the pick.
+
+| Action | Condition | Notes |
+|--------|-----------|-------|
+| Demote | `conf < 0.30` AND `fail >= 3` AND `n >= 5` | the demote floor |
+| Tie-break | semantic `conf < 0.35` AND an evidenced alternate with `n >= 5` | swaps to the evidenced route |
+| Exempt | force-route / security skill | hard-exempt; checked first (`route_policy.py:180`) |
+
+Shadow instrumentation records gate inputs on every dispatch via the
+`[do-route]` marker, written as decision events to `route-events.jsonl`.
+Outcomes finalize three-way — failure / success / neutral, neutral censored —
+through a deterministic finalizer plus an orchestrator-reported route-failure
+channel (`learning-db.py route-failure`; ADR: orchestrator-reported-route-failures).
+
+---
+
+## Methodology
+
+### Two-verdict contract (pre-registered)
+
+`scripts/route-value-eval.py` reports two independent verdicts. Mechanism
+conformance and production value are never collapsed into one gate.
+
+| Exit | Meaning |
+|------|---------|
+| 0 | value pass |
+| 1 | mechanism fail OR value fail (stderr names which) |
+| 2 | value UNMEASURED |
+
+### Pre-registered value thresholds (fixed before any run)
+
+Value PASS requires ALL of the following, computed ONLY over the `k`
+health-affected cases (Arm B != Arm A):
+
+| Threshold | Value | Source |
+|-----------|-------|--------|
+| Effect | `D > 0` | `route-value-eval.py:597` |
+| Bootstrap CI lower bound | `> 0` | `route-value-eval.py:414-418` |
+| Resamples | `>= 10000` (pre-registered) | `stage3-live-results.md:123` |
+| McNemar | `p < 0.05` (two-sided exact) | `route-value-eval.py:418` |
+| Harm | `== 0` | `route-value-eval.py:414` |
+
+> **Note:** The harness default is 5000 resamples (`route-value-eval.py:369`).
+> The pre-registered floor is 10000. At `k=0` the resample loop never executes,
+> so the resample count is moot (`stage3-live-results.md:123`).
+
+### Blinding and judges (Stage 3)
+
+| Control | Detail |
+|---------|--------|
+| Corpus | 117 live Haiku answers |
+| Judges | claude (primary, pre-registered) + codex (replication) |
+| Blinding | `[do-route]` markers stripped from all eval calls |
+| Isolation | temp-DB only; live `~/.claude/learning` never written |
+| Judge-unreliable rule | agreement < 80% on overlapping scored cases ⇒ verdict `judge-unreliable` regardless of D |
+
+All Stage-1 and Stage-3 weight numbers carry the **SYNTHETIC-WEIGHTS** label.
+
+---
+
+## Results by stage
+
+### Stage 1 — mechanism (synthetic weights)
+
+| Arm | Result | Reading |
+|-----|--------|---------|
+| REAL replay | changed = 0 | No-harm control by design. No alternates were offered, so it CANNOT show value — only the absence of harm. State this limitation explicitly. |
+| SYNTHETIC demote | help = 24, harm = 0 | Constructed wrong-pick + gold alternate; the loop corrected the pick. SYNTHETIC-WEIGHTS. |
+| Force-route exemption | 49 / 49 held | Every safety route survived demotion pressure. |
+
+### Stage 2 — live telemetry (post-fix)
+
+| Metric | Value |
+|--------|-------|
+| non_null_health | 5 |
+| recorded_failures | 0 |
+| value_measured | false |
+
+`recorded_failures` counts ONLY routing-relevant failure outcome events. The
+pre-fix counter conflated decision-history fields; it was fixed in review.
+
+### Stage 3 — live blind A/B (2026-06-07)
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Live answers | 117 | `stage3-live-results.md` |
+| Scored picks | 97 | `stage3-k0-diagnosis.md:28` |
+| `k` (health-affected cases) | 0 | Arm B never diverged from Arm A |
+| D / CI low / McNemar p | null | not computed at k=0 |
+| Inter-judge agreement | UNDEFINED | 0 overlapping scored cases |
+| Force-route exemption held | 49 / 49 | `stage3-live-results.md:49` |
+| Regression of 4 fixed misroutes | 3 / 4 pass | `stage3-live-results.md:17` |
+| Verdict | UNMEASURED, exit 2, mechanism pass | per pre-registration |
+
+The judge-unreliable rule did NOT fire: agreement is UNDEFINED (0 overlapping
+cases), not below 80%. Judge reliability is therefore **not validated**.
+
+Regression detail: r13 picks the correct skill (`research-pipeline`) but the
+wrong agent slot (`general-purpose` vs gold `research-coordinator-engineer`).
+Open item; outside the scope of the skill-sibling fix (`97feda42`).
+
+---
+
+## k=0 root cause
+
+The cause is **structural**, not a silent failure
+(`research/forward-plan/stage3-k0-diagnosis.md`).
+
+| Finding | Count | Source |
+|---------|-------|--------|
+| Scored picks | 97 | `stage3-k0-diagnosis.md:28` |
+| Picks on the demote floor (`conf<0.30, fail>=3, n>=5`) | 39 | `stage3-k0-diagnosis.md:30` |
+| Of those, force-route exempt | 39 (all) | `stage3-k0-diagnosis.md:31` |
+| Floor-matched kept by exemption (correct) | 39 | `stage3-k0-diagnosis.md:33` |
+| Tie-break low-confidence cases | 1 | `stage3-k0-diagnosis.md` |
+| Low-confidence AND evidenced alternate (tie-break fuel) | 0 | `stage3-k0-diagnosis.md:37` |
+| Counterfactual demotes if exemption stripped | 26 / 39 | `stage3-k0-diagnosis.md:18` |
+
+Force-route skills on the 39 floor-matched picks: pr-workflow x19,
+go-patterns x12, skill-creator x5, agent-creator x2, security-review x1
+(`stage3-k0-diagnosis.md:11`).
+
+Reading: under fabricated failure data, the loop refused to second-guess
+safety-critical routes (hard exemption), and had no evidenced alternate
+anywhere else. The counterfactual (exemption stripped) demotes 26/39 — proof
+the floor logic is live and the exemption is the sole reason `k=0`. The loop
+**fails safe, not silent**.
+
+---
+
+## Router worth-it dogfood
+
+20 tasks, 3 arms, blind-evaluated (`research/forward-plan/routing-dogfood-results.md`).
+
+| Arm | Exact-pair | Agent-level |
+|-----|-----------|-------------|
+| Haiku router | 80% (16/20) | 95% (19/20) |
+| Codex | 80% (16/20) | 85% (17/20) |
+| Deterministic pre-route alone | 30% (6/20) | 75% (15/20) |
+
+Conclusion: Haiku routing is worth the token cost against the free pre-route
+baseline (the genuine production alternative). Within n=20 the Haiku-vs-Codex
+gap is noise; the win is against pre-route.
+
+Failure channel, proven on a temp DB (`CLAUDE_LEARNING_DIR`):
+
+| Property | Result |
+|----------|--------|
+| Decay per routing-relevant failure | 0.65 → 0.57 |
+| Idempotency | per (session, marker) |
+| Non-relevant failures | decay nothing |
+| Live DB | untouched |
+
+---
+
+## Review provenance
+
+Dual-track review, 2026-06-07.
+
+| Track | Scope | Output |
+|-------|-------|--------|
+| Claude | 26 reviewers, 3 waves (12 foundation + 10 deep-dive + 4 adversarial) | 112 findings; 19 actionable Critical/High; 0 contested |
+| Codex | codex-cli 0.135.0, read-only sandbox, 3 chunks | 16 distilled findings; 2 false positives caught by source verification |
+
+Three findings converged independently across both tracks: dedup-commit
+ordering, readiness conflation, whole-prompt marker parsing. ALL Critical/High
+fixed in commit `a5b2e50d`. Tests: 4291 passed. `ruff check` + `ruff format`
+clean repo-wide.
+
+Review artifacts: `/tmp/codex-branch-review-{1,2,3}.md`,
+`/tmp/tier4-{actionable,all}.json` (volatile; see Limitations).
+
+---
+
+## Kill criterion (pre-registered)
+
+`scripts/route-decommission-check.py` is the falsifiable kill switch: if the
+loop never acts, it gets deleted.
+
+DELETE iff ALL of:
+
+| Condition | Constant | Source |
+|-----------|----------|--------|
+| Age OR volume | `>= 90 days` from STAGE0_FIX_EPOCH OR `>= 3000` post-fix decisions | `route-decommission-check.py:118-119` |
+| Clock start | epoch 1780780867, commit `d943ba74` | `route-decommission-check.py:114-115` |
+| Real demote | `== 0` | interventions counter |
+| Real tie-break | `== 0` | interventions counter |
+| Shadow demote | `== 0` | interventions counter |
+| Clock valid | instrumented_rate `>= 95%` AND unknown_rate `<= 5%` | `route-decommission-check.py:127-128` |
+
+Clock validity uses a three-state `gate_inputs_present` contract: (a) numeric
+gate inputs, (b) no-row, (c) legacy pre-marker events. Only state (c) counts
+against the 95% rate. Shadow tie-break is excluded as unmeasurable — semantic
+confidence is unrecorded (documented).
+
+Today: **CLOCK-INVALID, exit 4**, accruing. At the time of writing the
+instrumented rate is below 95% because legacy pre-marker events dilute it; the
+rate rises as instrumented dispatches accrue. Re-run for current counts; the
+verdict (CLOCK-INVALID) and exit code (4) are stable until the clock validates.
+
+---
+
+## Reproduce
+
+```bash
+# Value eval: expect exit 2, mechanism pass, value UNMEASURED
+python3 scripts/route-value-eval.py --out-dir /tmp/eval-out
+
+# Decommission check: expect exit 4 CLOCK-INVALID today
+python3 scripts/route-decommission-check.py
+
+# Full in-scope test suite: expect 4291 passed
+python3 -m pytest hooks/tests scripts/tests -q
+```
+
+Verified this session:
+
+| Command | Result |
+|---------|--------|
+| `route-value-eval.py` | exit 2; mechanism=pass; value UNMEASURED; Stage 2 non_null_health=5 recorded_failures=0 |
+| `route-decommission-check.py` | exit 4 CLOCK-INVALID |
+| `pytest hooks/tests scripts/tests` | 4291 passed, 1 skipped, 75 xfailed, 0 failures |
+
+Stage-3 fixture rebuild: `/tmp/stage3-live/build_fixture.py` +
+`build_judge.py` import `route-value-eval` symbols and write only to `/tmp`.
+
+Artifacts:
+
+| Path | Content | Durability |
+|------|---------|-----------|
+| `/tmp/stage3-live/` | cases, arm-picks, synthetic-weights, judge outputs, harness stdout | volatile |
+| `/tmp/codex-branch-review-{1,2,3}.md` | codex review chunks | volatile |
+| `/tmp/tier4-{actionable,all}.json` | tier-4 findings | volatile |
+| `research/forward-plan/stage3-live-results.md` | Stage-3 official result | durable |
+| `research/forward-plan/stage3-k0-diagnosis.md` | k=0 root cause | durable |
+| `research/forward-plan/routing-dogfood-results.md` | dogfood + failure channel | durable |
+
+---
+
+## Limitations
+
+This section is the credibility core. Every limitation below is owned, not
+buried.
+
+1. **Production value is UNMEASURED.** We do NOT claim the loop has helped a
+   single live route yet.
+2. **k=0.** Value is structurally unmeasurable on the current corpus. The
+   pre-registered criteria stand and will declare value or trigger deletion.
+3. **Synthetic weights.** Every Stage-1 and Stage-3 number is labeled
+   SYNTHETIC-WEIGHTS.
+4. **Single-user corpus.** 117 cases from one user's tasks. No population claim.
+5. **Judge reliability unvalidated.** Inter-judge agreement is UNDEFINED at k=0.
+6. **`/tmp` artifacts are volatile.** Durable copies are listed in the
+   [Reproduce](#reproduce) table.
+7. **Clock validity is currently failing honestly.** Legacy pre-marker events
+   dilute the instrumented rate; it rises as instrumented dispatches accrue.
+8. **`recorded_failures = 0`.** The failure channel is proven mechanically
+   (temp-DB dogfood) but has zero live signal yet.
+9. **REAL replay arm is a no-harm control,** not a value measurement — no
+   alternates were offered, so it cannot show value.

--- a/hooks/confidence-decay.py
+++ b/hooks/confidence-decay.py
@@ -40,19 +40,33 @@ def main():
             if pruned_parts:
                 print(f"[confidence-decay] Ancillary pruning: {pruned_parts}", file=sys.stderr)
 
-        # Step 2: Decay stale entries (untouched > 30 days, confidence > 0.3)
+        # Step 2: Decay stale entries (untouched > 30 days).
+        # Routing rows pull toward neutral 0.5 (T5); every other topic keeps the
+        # monotonic -0.05-toward-0 decay (confidence > 0.3 gate).
         cutoff = (datetime.now() - timedelta(days=30)).isoformat()
         decayed = 0
 
         with get_connection() as conn:
+            # Non-routing: old behavior.
             stale_rows = conn.execute(
-                "SELECT topic, key FROM learnings WHERE last_seen < ? AND confidence > 0.3",
+                "SELECT topic, key FROM learnings WHERE last_seen < ? AND confidence > 0.3 AND topic != 'routing'",
                 (cutoff,),
             ).fetchall()
+
+            # Routing: pull toward 0.5 in-place, without touching last_seen or
+            # success/failure counts (this is staleness, not an outcome).
+            routing_updated = conn.execute(
+                "UPDATE learnings "
+                "SET confidence = confidence + (0.5 - confidence) * 0.1 "
+                "WHERE last_seen < ? AND topic = 'routing'",
+                (cutoff,),
+            ).rowcount
+            conn.commit()
 
         for row in stale_rows:
             decay_confidence(row["topic"], row["key"], delta=0.05)
             decayed += 1
+        decayed += routing_updated
 
         if debug or pruned > 0 or decayed > 0:
             print(

--- a/hooks/confidence-decay.py
+++ b/hooks/confidence-decay.py
@@ -55,10 +55,24 @@ def main():
 
             # Routing: pull toward 0.5 in-place, without touching last_seen or
             # success/failure counts (this is staleness, not an outcome).
+            #
+            # Floor guard (confidence > 0.5): staleness must NEVER raise routing
+            # confidence. Pulling a sub-floor row (e.g. conf 0.20/0.28 with
+            # fail>=3) toward 0.5 would lift it back over FLOOR_CONFIDENCE=0.30
+            # and corrupt the floor-demote path the moment negative signal
+            # accrues. Prune does not protect these rows: it requires
+            # older_than_days=90, but staleness fires at >30 days, so a recently
+            # failed sub-floor row survives prune yet is stale. So skip every
+            # row at or below the 0.5 baseline (preserve the negative evidence);
+            # only above-baseline rows decay downward toward neutral. Scoped to
+            # routing because only routing pulls toward 0.5 and only routing has
+            # a floor-demote gate; non-routing keeps its monotonic -0.05 path.
+            # The > 0.5 bound also drops no-op rows already at exactly 0.5 from
+            # rowcount, so `decayed` counts only rows that actually changed.
             routing_updated = conn.execute(
                 "UPDATE learnings "
                 "SET confidence = confidence + (0.5 - confidence) * 0.1 "
-                "WHERE last_seen < ? AND topic = 'routing'",
+                "WHERE last_seen < ? AND topic = 'routing' AND confidence > 0.5",
                 (cutoff,),
             ).rowcount
             conn.commit()

--- a/hooks/lib/hook_utils.py
+++ b/hooks/lib/hook_utils.py
@@ -719,14 +719,61 @@ def has_reviewable_content(diff: str, scannable_exts: frozenset[str]) -> bool:
     return False
 
 
-class DiffDedup:
-    """Byte-identical working-tree-diff dedup with atomic state + opt-in TTL.
+def normalize_diff_for_fingerprint(diff: str) -> str:
+    """Strip volatile-only noise from a unified diff before fingerprinting.
 
-    Hashes ``sha256(cwd, diff)`` so different repos with identical diffs do not
-    collide. State persists to a JSON file via atomic write (tempfile in the
-    same dir + ``os.replace``). By default dedup is permanent — the same
-    ``(cwd, diff)`` hash means the same review until the diff actually changes;
-    a non-matching hash overwrites the old record (self-healing).
+    The dedup fingerprint must be stable across re-fires that carry the SAME
+    semantic change. Raw ``git diff`` output embeds a few volatile fields that
+    churn even when the file paths and hunks are unchanged — most importantly
+    the ``index <oldsha>..<newsha> <mode>`` line, whose blob SHAs change whenever
+    a build artifact is regenerated (e.g. ``static/game/*`` rebuilds produce the
+    same hunks but fresh blob SHAs). Hashing the raw bytes therefore misses the
+    duplicate and re-reviews the identical change over and over.
+
+    This normalizer removes ONLY those volatile lines, preserving everything
+    that defines WHAT changed:
+
+    Dropped (volatile, carry no review signal):
+      - ``index <sha>..<sha>[ mode]`` — blob SHAs / churn on rebuild
+      - ``old mode`` / ``new mode``   — bare permission churn
+      - ``deleted file mode`` / ``new file mode`` — mode digits only
+      - ``similarity index NN%`` / ``dissimilarity index NN%`` — rename heuristic noise
+
+    Kept (load-bearing — ANY change here yields a new fingerprint → full review):
+      - ``diff --git a/... b/...`` headers (file paths)
+      - ``--- `` / ``+++ `` headers (file paths)
+      - ``rename from`` / ``rename to`` (path moves are real changes)
+      - every ``@@`` hunk header and every ``+``/``-``/context line
+
+    Hardening-preserving: this only collapses byte-noise to a stable form; it
+    never widens what counts as "the same diff" beyond identical paths + hunks.
+    A new file, a changed hunk, or a renamed path all still differ here.
+    """
+    out = []
+    for line in diff.split("\n"):
+        if line.startswith("index "):
+            continue
+        if line.startswith("old mode ") or line.startswith("new mode "):
+            continue
+        if line.startswith("deleted file mode ") or line.startswith("new file mode "):
+            continue
+        if line.startswith("similarity index ") or line.startswith("dissimilarity index "):
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+class DiffDedup:
+    """Working-tree-diff dedup with atomic state + opt-in TTL.
+
+    Hashes ``sha256(cwd, normalize_diff_for_fingerprint(diff))`` so different
+    repos with identical diffs do not collide, and so re-fires of the SAME
+    semantic change (same paths + same hunks) fingerprint identically even when
+    git's volatile blob-SHA / mode noise churns underneath. State persists to a
+    JSON file via atomic write (tempfile in the same dir + ``os.replace``). By
+    default dedup is permanent — the same fingerprint means the same review until
+    the diff actually changes; a non-matching hash overwrites the old record
+    (self-healing).
 
     A positive ``ttl_seconds`` re-enables a time window: a hash match older than
     the TTL is treated as a miss.
@@ -738,11 +785,22 @@ class DiffDedup:
         self.ttl_seconds = ttl_seconds if ttl_seconds and ttl_seconds > 0 else 0
 
     def signature(self, cwd: Optional[str], diff: str) -> str:
-        """Hash (cwd, diff) so different repos with identical diffs don't collide."""
+        """Hash (cwd, normalized-diff) so identical changes fingerprint stably.
+
+        The diff is first run through ``normalize_diff_for_fingerprint`` to drop
+        volatile-only noise (blob-SHA index lines, bare mode churn) while keeping
+        file paths and hunks. ``cwd`` keeps different repos with identical diffs
+        from colliding. Fails open: if normalization ever raises, fall back to
+        hashing the raw diff (the original byte-identical behavior).
+        """
+        try:
+            normalized = normalize_diff_for_fingerprint(diff)
+        except Exception:
+            normalized = diff
         h = hashlib.sha256()
         h.update((cwd or "").encode("utf-8", errors="replace"))
         h.update(b"\x00")
-        h.update(diff.encode("utf-8", errors="replace"))
+        h.update(normalized.encode("utf-8", errors="replace"))
         return h.hexdigest()
 
     def _load(self) -> dict:

--- a/hooks/lib/route_events.py
+++ b/hooks/lib/route_events.py
@@ -1,0 +1,97 @@
+"""Append-only per-dispatch route event log (JSONL).
+
+The aggregate routing rows in learning.db are keyed `(topic, key)` — they carry
+no per-dispatch history, so faithful offline replay of "request → route →
+outcome" is impossible from them alone. This module adds that history: one JSONL
+line per event, append-only, at `<CLAUDE_LEARNING_DIR>/route-events.jsonl`.
+
+Two producers:
+  - routing-decision-recorder.py (PostToolUse:Agent) appends a DECISION event
+    when it records a /do-routed dispatch.
+  - routing-outcome-finalizer.py (UserPromptSubmit) appends an OUTCOME event
+    when it finalizes a pending dispatch.
+
+FAILURE-SAFE BY CONTRACT: a write error here must NEVER break the hook. Every
+function swallows all exceptions and returns; the worst case is a lost event
+line, never a non-zero hook exit. The log is auxiliary instrumentation, not the
+source of truth (the aggregate rows remain authoritative).
+
+Append-only: each event is one `json.dumps(...) + "\n"` opened in "a" mode, so
+concurrent appends from parallel dispatches interleave at line granularity
+(POSIX append writes under the per-line size are atomic) without a lock — no
+read-modify-write, so there is no lost-update race to serialize.
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_DIR = Path.home() / ".claude" / "learning"
+_EVENTS_FILENAME = "route-events.jsonl"
+
+
+def _events_path() -> Path:
+    """Resolve the route-events.jsonl path from CLAUDE_LEARNING_DIR.
+
+    Honors the same env var as learning_db_v2 so tests (and any redirected DB)
+    keep the event log beside the throwaway DB, never the live one.
+    """
+    env_dir = os.environ.get("CLAUDE_LEARNING_DIR")
+    base = Path(env_dir) if env_dir else _DEFAULT_DIR
+    return base / _EVENTS_FILENAME
+
+
+def _append(event: dict[str, Any]) -> None:
+    """Append one JSON line. Best-effort: swallow every error (never break a hook)."""
+    try:
+        path = _events_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(event, separators=(",", ":"), ensure_ascii=False)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except Exception:
+        pass
+
+
+def record_decision_event(
+    *,
+    session: str,
+    request_snippet: str,
+    agent: str,
+    skill: str,
+    complexity: str = "",
+    health_at_decision: float | None = None,
+) -> None:
+    """Append a per-dispatch DECISION event.
+
+    health_at_decision is the route's health when the dispatch was made; None
+    until the gated Step-1.5 wiring (T6) supplies it. Recorded as-is so replay
+    can distinguish "no health evaluated" (null) from a real score.
+    """
+    _append(
+        {
+            "type": "decision",
+            "ts": time.time(),
+            "session": session or "",
+            "request_snippet": (request_snippet or "")[:200],
+            "agent": agent or "",
+            "skill": skill or "",
+            "complexity": complexity or "",
+            "health_at_decision": health_at_decision,
+        }
+    )
+
+
+def record_outcome_event(*, session: str, key: str, outcome: str) -> None:
+    """Append a per-dispatch OUTCOME event (outcome in {success, failure, neutral})."""
+    _append(
+        {
+            "type": "outcome",
+            "ts": time.time(),
+            "session": session or "",
+            "key": key or "",
+            "outcome": outcome or "",
+        }
+    )

--- a/hooks/lib/route_events.py
+++ b/hooks/lib/route_events.py
@@ -63,12 +63,20 @@ def record_decision_event(
     skill: str,
     complexity: str = "",
     health_at_decision: float | None = None,
+    n: int | None = None,
+    failure: int | None = None,
+    action: str | None = None,
+    alternates: list[str] | None = None,
 ) -> None:
     """Append a per-dispatch DECISION event.
 
-    health_at_decision is the route's health when the dispatch was made; None
-    until the gated Step-1.5 wiring (T6) supplies it. Recorded as-is so replay
-    can distinguish "no health evaluated" (null) from a real score.
+    health_at_decision is the picked pair's confidence at decision time; None
+    when the pair had no weight row. n and failure are the other gate inputs the
+    demote floor needs (confidence<0.30 AND failure>=3 AND n>=5) — confidence
+    alone cannot reconstruct the floor, so all three are snapshotted here, never
+    back-filled from later weights. action is the Step-1.5 outcome (keep/demote/
+    tiebreak); alternates are the keys offered. All recorded as-is so replay can
+    distinguish "no health evaluated" (null) from a real score.
     """
     _append(
         {
@@ -80,6 +88,10 @@ def record_decision_event(
             "skill": skill or "",
             "complexity": complexity or "",
             "health_at_decision": health_at_decision,
+            "n": n,
+            "failure": failure,
+            "action": action,
+            "alternates": alternates,
         }
     )
 

--- a/hooks/lib/route_events.py
+++ b/hooks/lib/route_events.py
@@ -96,14 +96,20 @@ def record_decision_event(
     )
 
 
-def record_outcome_event(*, session: str, key: str, outcome: str) -> None:
-    """Append a per-dispatch OUTCOME event (outcome in {success, failure, neutral})."""
-    _append(
-        {
-            "type": "outcome",
-            "ts": time.time(),
-            "session": session or "",
-            "key": key or "",
-            "outcome": outcome or "",
-        }
-    )
+def record_outcome_event(*, session: str, key: str, outcome: str, reason: str | None = None) -> None:
+    """Append a per-dispatch OUTCOME event (outcome in {success, failure, neutral}).
+
+    ``reason`` is the orchestrator's stated cause for a router-reported failure
+    (ADR orchestrator-reported-route-failures). Included only when given, so the
+    deterministic finalizer keeps writing reason-free events unchanged.
+    """
+    event: dict[str, Any] = {
+        "type": "outcome",
+        "ts": time.time(),
+        "session": session or "",
+        "key": key or "",
+        "outcome": outcome or "",
+    }
+    if reason:
+        event["reason"] = reason
+    _append(event)

--- a/hooks/lib/route_events.py
+++ b/hooks/lib/route_events.py
@@ -67,6 +67,7 @@ def record_decision_event(
     failure: int | None = None,
     action: str | None = None,
     alternates: list[str] | None = None,
+    gate_inputs_present: bool = False,
 ) -> None:
     """Append a per-dispatch DECISION event.
 
@@ -77,6 +78,13 @@ def record_decision_event(
     back-filled from later weights. action is the Step-1.5 outcome (keep/demote/
     tiebreak); alternates are the keys offered. All recorded as-is so replay can
     distinguish "no health evaluated" (null) from a real score.
+
+    gate_inputs_present is the instrumentation signal the decommission clock
+    reads. True when the marker carried a `health=` token — numeric (state a) OR
+    `-` (state b, pick had no weight row, valid expected data). False when the
+    marker carried no `health=` token (state c, legacy/missing wiring). This
+    distinguishes "no-row, but instrumented" from "never instrumented" — null
+    health_at_decision alone cannot. Additive field; old readers ignore it.
     """
     _append(
         {
@@ -92,6 +100,7 @@ def record_decision_event(
             "failure": failure,
             "action": action,
             "alternates": alternates,
+            "gate_inputs_present": gate_inputs_present,
         }
     )
 

--- a/hooks/lib/route_events.py
+++ b/hooks/lib/route_events.py
@@ -105,12 +105,24 @@ def record_decision_event(
     )
 
 
-def record_outcome_event(*, session: str, key: str, outcome: str, reason: str | None = None) -> None:
+def record_outcome_event(
+    *,
+    session: str,
+    key: str,
+    outcome: str,
+    reason: str | None = None,
+    routing_relevant: bool | None = None,
+) -> None:
     """Append a per-dispatch OUTCOME event (outcome in {success, failure, neutral}).
 
-    ``reason`` is the orchestrator's stated cause for a router-reported failure
-    (ADR orchestrator-reported-route-failures). Included only when given, so the
-    deterministic finalizer keeps writing reason-free events unchanged.
+    ``reason`` is the short cause for the outcome (e.g. tool-errors, rejection,
+    acceptance, neutral-new-topic). Free of prompt text/secrets. Included only
+    when given, so old reason-free callers write unchanged events.
+
+    ``routing_relevant`` marks whether the outcome is a routing signal that the
+    confidence loop acts on. Written only when not None; route-value-eval counts
+    only routing-relevant failures. None keeps the field absent for callers that
+    do not assert relevance.
     """
     event: dict[str, Any] = {
         "type": "outcome",
@@ -121,4 +133,6 @@ def record_outcome_event(*, session: str, key: str, outcome: str, reason: str | 
     }
     if reason:
         event["reason"] = reason
+    if routing_relevant is not None:
+        event["routing_relevant"] = routing_relevant
     _append(event)

--- a/hooks/lib/routing_outcome_score.py
+++ b/hooks/lib/routing_outcome_score.py
@@ -95,6 +95,9 @@ def apply_outcome(key: str, outcome: str) -> float:
     A bare ``True``/``False`` is still accepted for back-compat (True=>failure,
     False=>success) but callers should pass an explicit outcome string.
 
+    Any other string raises ``ValueError`` — an unrecognized outcome (e.g. a
+    typo) must surface as a bug, never silently boost confidence.
+
     Caller MUST gate on decision_row_exists(key) first.
     """
     from learning_db_v2 import boost_confidence, decay_confidence
@@ -109,4 +112,9 @@ def apply_outcome(key: str, outcome: str) -> float:
         return _current_confidence(key)  # no-op: read-only, no count change
     if outcome == FAILURE:
         return decay_confidence("routing", key, delta=DECAY_DELTA)
-    return boost_confidence("routing", key, delta=BOOST_DELTA)
+    if outcome == SUCCESS:
+        return boost_confidence("routing", key, delta=BOOST_DELTA)
+    # Unknown/typo outcome must NOT silently boost. Callers pass the literal
+    # SUCCESS/FAILURE/NEUTRAL constants; an unrecognized string is a bug to
+    # surface, not a default boost that inflates confidence.
+    raise ValueError(f"unknown routing outcome {outcome!r}; expected one of {SUCCESS!r}, {FAILURE!r}, {NEUTRAL!r}")

--- a/hooks/lib/routing_outcome_score.py
+++ b/hooks/lib/routing_outcome_score.py
@@ -61,6 +61,12 @@ SUCCESS = "success"
 FAILURE = "failure"
 NEUTRAL = "neutral"
 
+# Sentinel for "no positional outcome supplied" — distinct from any valid
+# outcome and from None, so the public `outcome` type is `str | bool` (None is
+# NOT a valid outcome). Callers that omit `outcome` MUST pass the `failure=`
+# kwarg; supplying neither is rejected.
+_OUTCOME_UNSET: object = object()
+
 
 def _current_confidence(key: str) -> float:
     """Read-only current confidence for routing/{key}; 0.0 if absent."""
@@ -131,7 +137,7 @@ def _record_basis(key: str, basis: str) -> None:
 
 def apply_outcome(
     key: str,
-    outcome: str | bool | None = None,
+    outcome: str | bool = _OUTCOME_UNSET,  # type: ignore[assignment]  # sentinel default; None is not a valid outcome
     basis: str | None = None,
     *,
     failure: bool | None = None,
@@ -155,6 +161,11 @@ def apply_outcome(
     Any other string raises ``ValueError`` — an unrecognized outcome (e.g. a
     typo) must surface as a bug, never silently boost confidence.
 
+    ``outcome`` is typed ``str | bool``; ``None`` is NOT a valid outcome. Omitting
+    it uses an internal sentinel meaning "caller used the ``failure=`` kwarg
+    form". Calling with neither a positional ``outcome`` nor a ``failure=`` kwarg
+    raises ``ValueError`` immediately — there is no "no outcome" outcome.
+
     Caller MUST gate on decision_row_exists(key) first.
 
     `basis` is label-only: when given, increment its per-route counter (best
@@ -164,10 +175,15 @@ def apply_outcome(
     """
     from learning_db_v2 import boost_confidence, decay_confidence
 
-    # Back-compat: the legacy binary API passes `failure=<bool>` (no positional
-    # outcome). Map it to the three-way string. An explicit `outcome` wins.
-    if outcome is None and failure is not None:
+    # Back-compat: the legacy binary API passes `failure=<bool>` and no positional
+    # outcome. Map it to the three-way string. An explicit `outcome` wins.
+    if outcome is _OUTCOME_UNSET and failure is not None:
         outcome = FAILURE if failure else SUCCESS
+    # Neither form supplied (or an explicit invalid None): there is no "no
+    # outcome" outcome. Reject so the illegal call surfaces clearly instead of
+    # falling through to the generic unknown-string ValueError.
+    if outcome is _OUTCOME_UNSET or outcome is None:
+        raise ValueError("apply_outcome requires an outcome or a failure= kwarg; got neither")
     # Back-compat: legacy callers passed a `failure` bool positionally.
     if outcome is True:
         outcome = FAILURE

--- a/hooks/lib/routing_outcome_score.py
+++ b/hooks/lib/routing_outcome_score.py
@@ -57,13 +57,56 @@ def decision_row_exists(key: str) -> bool:
         return False
 
 
-def apply_outcome(key: str, failure: bool) -> float:
-    """Boost (success) or decay (failure) the routing row. Returns new confidence.
+SUCCESS = "success"
+FAILURE = "failure"
+NEUTRAL = "neutral"
+
+
+def _current_confidence(key: str) -> float:
+    """Read-only current confidence for routing/{key}; 0.0 if absent."""
+    from learning_db_v2 import get_db_path
+
+    try:
+        conn = sqlite3.connect(get_db_path(), timeout=5.0)
+        try:
+            row = conn.execute(
+                "SELECT confidence FROM learnings WHERE topic = ? AND key = ? LIMIT 1",
+                ("routing", key),
+            ).fetchone()
+            return float(row[0]) if row else 0.0
+        finally:
+            conn.close()
+    except Exception:
+        return 0.0
+
+
+def apply_outcome(key: str, outcome: str) -> float:
+    """Apply a THREE-WAY routing outcome. Returns new (or unchanged) confidence.
+
+    ``outcome`` is one of:
+      - ``"failure"`` — decay the row (errors or attributable rejection).
+      - ``"success"`` — boost the row (acceptance / continuation).
+      - ``"neutral"`` — NO-OP: no boost, no decay, no count change, no schema
+        migration. Returns the row's current confidence unchanged. Neutral is the
+        new default for unrelated/new-topic next prompts and clean autonomous Stop
+        runs — signal-fidelity fix so future data can contain real negatives
+        instead of being drowned by boost-everything.
+
+    A bare ``True``/``False`` is still accepted for back-compat (True=>failure,
+    False=>success) but callers should pass an explicit outcome string.
 
     Caller MUST gate on decision_row_exists(key) first.
     """
     from learning_db_v2 import boost_confidence, decay_confidence
 
-    if failure:
+    # Back-compat: legacy callers passed a `failure` bool.
+    if outcome is True:
+        outcome = FAILURE
+    elif outcome is False:
+        outcome = SUCCESS
+
+    if outcome == NEUTRAL:
+        return _current_confidence(key)  # no-op: read-only, no count change
+    if outcome == FAILURE:
         return decay_confidence("routing", key, delta=DECAY_DELTA)
     return boost_confidence("routing", key, delta=BOOST_DELTA)

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -74,6 +74,10 @@ _DO_ROUTE_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+# Optional complexity field on the same marker line, recorded into the T3 event
+# log for replay. Absent => "".
+_COMPLEXITY_RE = re.compile(r"\bcomplexity=([a-z0-9-]+)", re.IGNORECASE)
+
 # Right-sizing banner, e.g. "rightsizing: tier=2 files=8 packages=3 agents_dispatched=12"
 _RIGHTSIZING_RE = re.compile(
     r"rightsizing:\s*tier=(\d+)\s+files=(\d+)\s+packages=(\d+)\s+agents_dispatched=(\d+)",
@@ -200,6 +204,22 @@ def main() -> None:
             tags=["routing", agent] + ([skill] if skill else []),
             source="hook:routing-decision-recorder",
             session_id=session_id or None,
+        )
+
+        # T3: per-dispatch DECISION event (JSONL), append-only + failure-safe.
+        # Auxiliary to the aggregate row above — never blocks; route_events
+        # swallows write errors so the hook stays non-blocking.
+        cm = _COMPLEXITY_RE.search(prompt)
+        complexity = cm.group(1) if cm else ""
+        from route_events import record_decision_event
+
+        record_decision_event(
+            session=session_id,
+            request_snippet=request_snippet,
+            agent=agent,
+            skill=skill,
+            complexity=complexity,
+            health_at_decision=None,  # populated by the gated Step-1.5 wiring (T6)
         )
 
         # (C) right-sizing feedback, parse-only.

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -78,6 +78,41 @@ _DO_ROUTE_RE = re.compile(
 # log for replay. Absent => "".
 _COMPLEXITY_RE = re.compile(r"\bcomplexity=([a-z0-9-]+)", re.IGNORECASE)
 
+# Stage 0 health gate inputs on the same marker line (do/SKILL.md Phase 4 Step 2).
+# Each is an independent \b token. `health=-` => null (no weight row); else float.
+# n=/fail= are the other demote-floor inputs; action= is keep|demote|tiebreak;
+# alts= is a comma-separated key list. All optional; absent => null.
+_HEALTH_RE = re.compile(r"\bhealth=([0-9.]+|-)", re.IGNORECASE)
+_N_RE = re.compile(r"\bn=(\d+)", re.IGNORECASE)
+_FAIL_RE = re.compile(r"\bfail=(\d+)", re.IGNORECASE)
+_ACTION_RE = re.compile(r"\baction=(keep|demote|tiebreak)", re.IGNORECASE)
+_ALTS_RE = re.compile(r"\balts=([a-z0-9:_,-]+)", re.IGNORECASE)
+
+
+def parse_health_inputs(prompt: str) -> dict[str, object]:
+    """Read the Stage-0 gate inputs off the marker. All null when absent.
+
+    `health=-` (no weight row) => health/n/failure/action/alternates all null.
+    A real `health=<float>` keeps the other fields that are present; missing
+    siblings stay null. Snapshotted at decision time; replay never re-derives.
+    """
+    null = {"health": None, "n": None, "failure": None, "action": None, "alternates": None}
+    hm = _HEALTH_RE.search(prompt)
+    if not hm or hm.group(1) == "-":
+        return null
+    nm = _N_RE.search(prompt)
+    fm = _FAIL_RE.search(prompt)
+    am = _ACTION_RE.search(prompt)
+    altm = _ALTS_RE.search(prompt)
+    return {
+        "health": float(hm.group(1)),
+        "n": int(nm.group(1)) if nm else None,
+        "failure": int(fm.group(1)) if fm else None,
+        "action": am.group(1).lower() if am else None,
+        "alternates": [k for k in altm.group(1).split(",") if k] if altm else None,
+    }
+
+
 # Right-sizing banner. The first four fields are required; findings= and the
 # cost fields (tokens=, wall_clock_s=) are optional, additive extensions
 # (ADR: review-tier-roi). Legacy four-field banners still match.
@@ -272,6 +307,7 @@ def main() -> None:
         # swallows write errors so the hook stays non-blocking.
         cm = _COMPLEXITY_RE.search(prompt)
         complexity = cm.group(1) if cm else ""
+        health = parse_health_inputs(prompt)
         from route_events import record_decision_event
 
         record_decision_event(
@@ -280,7 +316,11 @@ def main() -> None:
             agent=agent,
             skill=skill,
             complexity=complexity,
-            health_at_decision=None,  # populated by the gated Step-1.5 wiring (T6)
+            health_at_decision=health["health"],  # real gate inputs from the marker (Stage 0)
+            n=health["n"],
+            failure=health["failure"],
+            action=health["action"],
+            alternates=health["alternates"],
         )
 
         # Per-run telemetry envelope (ADR: learning-telemetry-envelope). Append-only,

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -78,22 +78,48 @@ _DO_ROUTE_RE = re.compile(
 # log for replay. Absent => "".
 _COMPLEXITY_RE = re.compile(r"\bcomplexity=([a-z0-9-]+)", re.IGNORECASE)
 
-# Stage 0 health gate inputs on the same marker line (do/SKILL.md Phase 4 Step 2).
+# Step 1.5 health gate inputs on the same marker line (do/SKILL.md Phase 4 Step 2).
 # Each is an independent \b token. `health=-` => null (no weight row); else float.
 # n=/fail= are the other demote-floor inputs; action= is keep|demote|tiebreak;
 # alts= is a comma-separated key list. All optional; absent => null.
-_HEALTH_RE = re.compile(r"\bhealth=([0-9.]+|-)", re.IGNORECASE)
+# health= is a float (digits with one optional decimal part) or "-". The value
+# is anchored on BOTH ends: a trailing `(?![\d.])` rejects `1.2.3` (and `1.2.`)
+# as a whole — it must NOT match as `1.2`, which would slip a bad token past
+# float() / drop the event. A malformed value stays a non-match => state (c).
+_HEALTH_RE = re.compile(r"\bhealth=(\d+(?:\.\d+)?|-)(?![\d.])", re.IGNORECASE)
 _N_RE = re.compile(r"\bn=(\d+)", re.IGNORECASE)
 _FAIL_RE = re.compile(r"\bfail=(\d+)", re.IGNORECASE)
 _ACTION_RE = re.compile(r"\baction=(keep|demote|tiebreak)", re.IGNORECASE)
 _ALTS_RE = re.compile(r"\balts=([a-z0-9:_,-]+)", re.IGNORECASE)
 
 
-def parse_health_inputs(prompt: str) -> dict[str, object]:
-    """Read the Stage-0 gate inputs off the marker. Three instrumentation states.
+def _marker_line(prompt: str) -> str:
+    """Return the single line that carries the [do-route] marker, or "".
 
-    `gate_inputs_present` is the instrumentation signal the decommission clock
-    reads — NOT non-null health. Three states the event must distinguish:
+    The gate inputs (health=/n=/fail=/action=/alts=) live on the marker line
+    ONLY. Scanning the whole prompt let a task body that merely mentions
+    `health=0.9` or `fail=3` poison gate_inputs_present and the decommission
+    clock. Isolating the marker line first means body text can never match.
+    Uses the SAME matcher as parse_do_route_marker so "marker line" is one
+    definition; returns the full line containing that match.
+    """
+    if not prompt or "[do-route]" not in prompt.lower():
+        return ""
+    m = _DO_ROUTE_RE.search(prompt)
+    if not m:
+        return ""
+    start = prompt.rfind("\n", 0, m.start()) + 1  # -1 -> 0 for the first line
+    end = prompt.find("\n", m.start())
+    return prompt[start:] if end == -1 else prompt[start:end]
+
+
+def parse_health_inputs(prompt: str) -> dict[str, object]:
+    """Read the Step-1.5 gate inputs off the marker LINE. Three instrumentation states.
+
+    Inputs are read from the marker line only (`_marker_line`), never the whole
+    prompt — a task body mentioning `health=`/`fail=` must not be read as a gate
+    input. `gate_inputs_present` is the instrumentation signal the decommission
+    clock reads — NOT non-null health. Three states the event must distinguish:
       (a) numeric  `health=<float>` => health float, gate_inputs_present True.
       (b) no-row   `health=-`       => health null,  gate_inputs_present True.
           The pick has no weight row — valid, expected data. Most live picks are
@@ -101,6 +127,9 @@ def parse_health_inputs(prompt: str) -> dict[str, object]:
           forever (the soundness gap this fixes).
       (c) legacy   no `health=` token => health null, gate_inputs_present False.
           The marker never carried a gate input (pre-fix / missing wiring).
+          A malformed `health=` value (e.g. `1.2.3`) also lands here: the regex
+          won't match it, so it reads as absent — honest "not instrumented",
+          never a dropped event.
     n/failure/action/alternates stay null unless a real `health=<float>` is read.
     Snapshotted at decision time; replay never re-derives.
     """
@@ -112,18 +141,27 @@ def parse_health_inputs(prompt: str) -> dict[str, object]:
         "alternates": None,
         "gate_inputs_present": False,
     }
-    hm = _HEALTH_RE.search(prompt)
+    line = _marker_line(prompt)
+    if not line:
+        return null  # no marker line => nothing to read
+    hm = _HEALTH_RE.search(line)
     if not hm:
-        return null  # state (c): no gate input on the marker at all
+        return null  # state (c): no (well-formed) gate input on the marker
     if hm.group(1) == "-":
         # state (b): marker carried the gate input; the pick had no weight row.
         return {**null, "gate_inputs_present": True}
-    nm = _N_RE.search(prompt)
-    fm = _FAIL_RE.search(prompt)
-    am = _ACTION_RE.search(prompt)
-    altm = _ALTS_RE.search(prompt)
+    try:
+        health = float(hm.group(1))  # state (a)
+    except ValueError:
+        # Defensive: the regex already bars malformed values, but never let a
+        # float() raise drop the whole event — treat as field-absent (state c).
+        return null
+    nm = _N_RE.search(line)
+    fm = _FAIL_RE.search(line)
+    am = _ACTION_RE.search(line)
+    altm = _ALTS_RE.search(line)
     return {
-        "health": float(hm.group(1)),  # state (a)
+        "health": health,
         "n": int(nm.group(1)) if nm else None,
         "failure": int(fm.group(1)) if fm else None,
         "action": am.group(1).lower() if am else None,
@@ -335,7 +373,7 @@ def main() -> None:
             agent=agent,
             skill=skill,
             complexity=complexity,
-            health_at_decision=health["health"],  # real gate inputs from the marker (Stage 0)
+            health_at_decision=health["health"],  # real gate inputs from the marker (Step 1.5)
             n=health["n"],
             failure=health["failure"],
             action=health["action"],
@@ -383,10 +421,17 @@ def main() -> None:
         append_pending_outcome(session_id, key, has_errors)
 
     except Exception as e:
+        # Always surface ONE short line so a recorder failure is visible, not
+        # silent (the previous handler logged only under CLAUDE_HOOKS_DEBUG, so a
+        # dropped decision event left no trace). Exception class + message only —
+        # no prompt content, no secrets. Full traceback stays debug-gated.
+        try:
+            print(f"routing-decision-recorder: {type(e).__name__}: {e}", file=sys.stderr)
+        except Exception:
+            pass  # stderr write must never itself break the hook
         if os.environ.get("CLAUDE_HOOKS_DEBUG"):
             import traceback
 
-            print(f"[routing-decision-recorder] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
             traceback.print_exc(file=sys.stderr)
     finally:
         sys.exit(0)  # Never block

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -90,26 +90,45 @@ _ALTS_RE = re.compile(r"\balts=([a-z0-9:_,-]+)", re.IGNORECASE)
 
 
 def parse_health_inputs(prompt: str) -> dict[str, object]:
-    """Read the Stage-0 gate inputs off the marker. All null when absent.
+    """Read the Stage-0 gate inputs off the marker. Three instrumentation states.
 
-    `health=-` (no weight row) => health/n/failure/action/alternates all null.
-    A real `health=<float>` keeps the other fields that are present; missing
-    siblings stay null. Snapshotted at decision time; replay never re-derives.
+    `gate_inputs_present` is the instrumentation signal the decommission clock
+    reads — NOT non-null health. Three states the event must distinguish:
+      (a) numeric  `health=<float>` => health float, gate_inputs_present True.
+      (b) no-row   `health=-`       => health null,  gate_inputs_present True.
+          The pick has no weight row — valid, expected data. Most live picks are
+          state (b), so reading it as missing would keep the clock unreachable
+          forever (the soundness gap this fixes).
+      (c) legacy   no `health=` token => health null, gate_inputs_present False.
+          The marker never carried a gate input (pre-fix / missing wiring).
+    n/failure/action/alternates stay null unless a real `health=<float>` is read.
+    Snapshotted at decision time; replay never re-derives.
     """
-    null = {"health": None, "n": None, "failure": None, "action": None, "alternates": None}
+    null = {
+        "health": None,
+        "n": None,
+        "failure": None,
+        "action": None,
+        "alternates": None,
+        "gate_inputs_present": False,
+    }
     hm = _HEALTH_RE.search(prompt)
-    if not hm or hm.group(1) == "-":
-        return null
+    if not hm:
+        return null  # state (c): no gate input on the marker at all
+    if hm.group(1) == "-":
+        # state (b): marker carried the gate input; the pick had no weight row.
+        return {**null, "gate_inputs_present": True}
     nm = _N_RE.search(prompt)
     fm = _FAIL_RE.search(prompt)
     am = _ACTION_RE.search(prompt)
     altm = _ALTS_RE.search(prompt)
     return {
-        "health": float(hm.group(1)),
+        "health": float(hm.group(1)),  # state (a)
         "n": int(nm.group(1)) if nm else None,
         "failure": int(fm.group(1)) if fm else None,
         "action": am.group(1).lower() if am else None,
         "alternates": [k for k in altm.group(1).split(",") if k] if altm else None,
+        "gate_inputs_present": True,
     }
 
 
@@ -321,6 +340,7 @@ def main() -> None:
             failure=health["failure"],
             action=health["action"],
             alternates=health["alternates"],
+            gate_inputs_present=health["gate_inputs_present"],
         )
 
         # Per-run telemetry envelope (ADR: learning-telemetry-envelope). Append-only,

--- a/hooks/routing-outcome-finalizer.py
+++ b/hooks/routing-outcome-finalizer.py
@@ -365,23 +365,35 @@ def main() -> None:
             # decay/no-op the three-way outcome drives.
             basis = outcome_basis(bool(item.get("errors")), reaction_failure)
             new_conf = apply_outcome(key, outcome, basis=basis)
+            # Short, secret-free cause for this dispatch's outcome. Computed
+            # unconditionally (not debug-only) so the JSONL OUTCOME event carries
+            # the demotion cause — an operator reading route-events.jsonl after a
+            # decay can see WHY without the per-key basis table.
+            if item.get("errors"):
+                reason = "tool-errors"
+            elif reaction_failure:
+                reason = "rejection"
+            elif reaction_success:
+                reason = "acceptance"
+            elif (rejected or accepted) and not attributable:
+                reason = "reaction-ignored-multi-dispatch"
+            else:
+                reason = "neutral-new-topic"
             # T3: per-dispatch OUTCOME event (JSONL), append-only + failure-safe.
             # Auxiliary instrumentation for replay; route_events swallows write
             # errors so a logging failure never breaks finalization.
+            # routing_relevant=True: a finalizer failure decays the row by
+            # contract, so it is a routing signal route-value-eval must count.
             from route_events import record_outcome_event
 
-            record_outcome_event(session=session_id, key=key, outcome=outcome)
+            record_outcome_event(
+                session=session_id,
+                key=key,
+                outcome=outcome,
+                reason=reason,
+                routing_relevant=True,
+            )
             if debug:
-                if item.get("errors"):
-                    reason = "tool-errors"
-                elif reaction_failure:
-                    reason = "rejection"
-                elif reaction_success:
-                    reason = "acceptance"
-                elif (rejected or accepted) and not attributable:
-                    reason = "reaction-ignored-multi-dispatch"
-                else:
-                    reason = "neutral-new-topic"
                 print(
                     f"[routing-outcome-finalizer] {outcome} routing/{key} ({reason}) conf={new_conf:.4f}",
                     file=sys.stderr,

--- a/hooks/routing-outcome-finalizer.py
+++ b/hooks/routing-outcome-finalizer.py
@@ -322,6 +322,16 @@ def main() -> None:
             reaction_failure = rejected if attributable else False
             failure = bool(item.get("errors")) or reaction_failure
             new_conf = apply_outcome(key, failure)
+            # T3: per-dispatch OUTCOME event (JSONL), append-only + failure-safe.
+            # Auxiliary instrumentation for replay; route_events swallows write
+            # errors so a logging failure never breaks finalization.
+            from route_events import record_outcome_event
+
+            record_outcome_event(
+                session=session_id,
+                key=key,
+                outcome="failure" if failure else "success",
+            )
             if debug:
                 outcome = "failure" if failure else "success"
                 if item.get("errors"):

--- a/hooks/routing-outcome-finalizer.py
+++ b/hooks/routing-outcome-finalizer.py
@@ -9,13 +9,22 @@ SubagentStop validator can't do — a hook firing when a subagent stops cannot
 see whether the USER accepted the result, asked for rework, or re-routed the
 same intent. Those signals live in the NEXT user turn. This hook reads them.
 
-Resolution per still-pending dispatch (drained atomically, scored ONCE):
+Resolution per still-pending dispatch (drained atomically, scored ONCE) —
+THREE-WAY (T4):
 
     failure  = tool errors recorded for THIS dispatch  OR  clear user rejection
-    success  = otherwise (acceptance, OR neutral / new topic — no complaint)
+    success  = explicit acceptance / affirmation of the prior work
+    neutral  = otherwise (unrelated / new-topic next prompt — no complaint, no
+               acceptance) => NO-OP: no boost, no decay, no count change
 
-then boost (success) / decay (failure) the routing/{key} row, ONCE, and clear
-the pending list so a re-delivered prompt resolves nothing further (idempotent).
+then boost (success) / decay (failure) / no-op (neutral) the routing/{key} row,
+ONCE, and clear the pending list so a re-delivered prompt resolves nothing
+further (idempotent).
+
+SIGNAL FIDELITY (T4): the prior detector boosted EVERYTHING that was not an
+unambiguous failure — including neutral new-topic prompts — inflating success
+counts so no real signal could surface. Success now requires a POSITIVE marker;
+a new-topic prompt is neutral, leaving room for future negatives.
 
 HIGH-PRECISION FAILURE DETECTION (critical):
 A FALSE failure poisons route-health worse than recording nothing — it decays a
@@ -224,6 +233,22 @@ def is_rejection(prompt: str) -> bool:
     return bool(_REJECTION_RE.search(first))
 
 
+def is_acceptance(prompt: str) -> bool:
+    """High-precision: True only on explicit affirmation/acceptance of the prior
+    work in the user's IMMEDIATE reaction (the first clause).
+
+    SUCCESS now requires a POSITIVE signal (T4 three-way). Without one — an
+    unrelated / new-topic next prompt — the outcome is NEUTRAL (no boost), not
+    success. So this detector decides boost-vs-neutral; ``is_rejection`` decides
+    the failure path. Same clause-scoping and word-boundary anchoring as
+    ``is_rejection`` so a substring (e.g. "great" inside "greater") never trips
+    it. Returns False on empty / non-string input.
+    """
+    if not prompt or not isinstance(prompt, str):
+        return False
+    return bool(_ACCEPTANCE_RE.search(_first_clause(prompt)))
+
+
 def main() -> None:
     try:
         raw = read_stdin(timeout=2)
@@ -244,6 +269,7 @@ def main() -> None:
 
         prompt = (event.get("prompt") or "").strip()
         rejected = is_rejection(prompt)
+        accepted = is_acceptance(prompt)
 
         # Lazy: only import the scorer (and thus learning_db_v2) when there is
         # actually something to resolve.
@@ -316,32 +342,41 @@ def main() -> None:
             if not decision_row_exists(key):
                 to_requeue.append(item)
                 continue
-            # Per-entry attribution (HIGH-1): own error flag => failure. The
-            # turn-level rejection is OR'd in ONLY when it is attributable (a
-            # single pending dispatch this turn); with >1 pending it is ignored.
+            # THREE-WAY per-entry resolution (T4). Per-entry error flag is the
+            # only signal that is ALWAYS attributable; the turn-level
+            # reaction (rejection OR acceptance) is attributable ONLY when a
+            # single dispatch is pending this turn (HIGH-1) — with >1 pending it
+            # is ignored so a turn signal cannot broadcast across siblings.
+            #   errors          => failure (decay)              — highest precision
+            #   rejection       => failure (decay)              — attributable only
+            #   acceptance      => success (boost)              — attributable only
+            #   otherwise       => neutral (no-op)              — new-topic default
             reaction_failure = rejected if attributable else False
-            failure = bool(item.get("errors")) or reaction_failure
-            new_conf = apply_outcome(key, failure)
+            reaction_success = accepted if attributable else False
+            if bool(item.get("errors")) or reaction_failure:
+                outcome = "failure"
+            elif reaction_success:
+                outcome = "success"
+            else:
+                outcome = "neutral"
+            new_conf = apply_outcome(key, outcome)
             # T3: per-dispatch OUTCOME event (JSONL), append-only + failure-safe.
             # Auxiliary instrumentation for replay; route_events swallows write
             # errors so a logging failure never breaks finalization.
             from route_events import record_outcome_event
 
-            record_outcome_event(
-                session=session_id,
-                key=key,
-                outcome="failure" if failure else "success",
-            )
+            record_outcome_event(session=session_id, key=key, outcome=outcome)
             if debug:
-                outcome = "failure" if failure else "success"
                 if item.get("errors"):
                     reason = "tool-errors"
                 elif reaction_failure:
                     reason = "rejection"
-                elif rejected and not attributable:
-                    reason = "rejection-ignored-multi-dispatch"
+                elif reaction_success:
+                    reason = "acceptance"
+                elif (rejected or accepted) and not attributable:
+                    reason = "reaction-ignored-multi-dispatch"
                 else:
-                    reason = "accepted/neutral"
+                    reason = "neutral-new-topic"
                 print(
                     f"[routing-outcome-finalizer] {outcome} routing/{key} ({reason}) conf={new_conf:.4f}",
                     file=sys.stderr,

--- a/hooks/session-learning-recorder.py
+++ b/hooks/session-learning-recorder.py
@@ -67,8 +67,11 @@ def finalize_routing_outcomes(session_id: str) -> None:
     But an autonomous / headless run may end with NO next user prompt, leaving
     its dispatches provisional forever. This fallback resolves whatever the
     UserPromptSubmit finalizer did not, using the DETERMINISTIC FLOOR — this
-    dispatch's own ``errors`` flag alone (the old proxy): errors => decay, else
-    boost. It NEVER double-resolves: finalize_pending_outcomes atomically
+    dispatch's own ``errors`` flag alone (no next-turn signal):
+    errors => failure (decay); a CLEAN autonomous run => NEUTRAL no-op (T4).
+    A clean Stop run carries no acceptance evidence, so it must NOT boost — the
+    old "else boost" inflated success counts on every quiet session. It NEVER
+    double-resolves: finalize_pending_outcomes atomically
     read-and-clears, so anything UserPromptSubmit already scored (and cleared)
     is simply absent here. Best-effort, silent, never raises.
     """
@@ -96,8 +99,10 @@ def finalize_routing_outcomes(session_id: str) -> None:
                 continue  # drop abandoned provisional entry, do not score
             if not decision_row_exists(key):
                 continue  # no row to score (orphaned); drop quietly at session end
-            # Deterministic floor: per-dispatch error flag only (no next turn).
-            apply_outcome(key, bool(item.get("errors")))
+            # Deterministic floor (T4): errors => failure (decay); a clean
+            # autonomous run carries no acceptance evidence => NEUTRAL no-op.
+            outcome = "failure" if bool(item.get("errors")) else "neutral"
+            apply_outcome(key, outcome)
     except Exception as e:
         if os.environ.get("CLAUDE_HOOKS_DEBUG"):
             print(f"[session-learning-recorder] routing finalize error: {e}", file=sys.stderr)

--- a/hooks/tests/test_apply_outcome.py
+++ b/hooks/tests/test_apply_outcome.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Tests for apply_outcome (hooks/lib/routing_outcome_score.py) — three-way + guard.
+
+apply_outcome maps a routing outcome onto a confidence delta:
+  - success => boost
+  - failure => decay
+  - neutral => no-op (read-only)
+  - anything else (typo / unknown) => ValueError, NEVER a silent boost.
+
+The last case is the regression guard: pre-fix an unrecognized string fell
+through to boost, silently inflating confidence (the skeptic's finding 3a).
+
+All tests point the learning DB at a throwaway dir via CLAUDE_LEARNING_DIR and
+seed one routing row first — apply_outcome assumes the caller gated on
+decision_row_exists. The live DB is never touched.
+
+Run: python3 -m pytest hooks/tests/test_apply_outcome.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parent.parent
+LIB_DIR = HOOKS_DIR / "lib"
+
+
+@pytest.fixture()
+def seeded_key(tmp_path, monkeypatch):
+    """Throwaway DB with one routing/effectiveness row; yields its key."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    key = "agent-x:skill-x"
+    ldb.record_learning(topic="routing", key=key, value="v", category="effectiveness", source="routing:decision")
+    yield key
+
+
+def _conf(key: str) -> float:
+    import routing_outcome_score as ros
+
+    return ros._current_confidence(key)
+
+
+def test_unknown_outcome_raises_not_boosts(seeded_key) -> None:
+    """A typo'd outcome string raises ValueError instead of silently boosting."""
+    import routing_outcome_score as ros
+
+    before = _conf(seeded_key)
+    with pytest.raises(ValueError, match="unknown routing outcome"):
+        ros.apply_outcome(seeded_key, "succes")  # typo
+    after = _conf(seeded_key)
+    assert after == before  # confidence untouched by the rejected call
+
+
+def test_neutral_is_noop(seeded_key) -> None:
+    """Neutral leaves confidence unchanged."""
+    import routing_outcome_score as ros
+
+    before = _conf(seeded_key)
+    returned = ros.apply_outcome(seeded_key, ros.NEUTRAL)
+    assert returned == before
+    assert _conf(seeded_key) == before
+
+
+def test_success_boosts(seeded_key) -> None:
+    """Success raises confidence."""
+    import routing_outcome_score as ros
+
+    before = _conf(seeded_key)
+    ros.apply_outcome(seeded_key, ros.SUCCESS)
+    assert _conf(seeded_key) > before
+
+
+def test_failure_decays(seeded_key) -> None:
+    """Failure lowers confidence."""
+    import routing_outcome_score as ros
+
+    before = _conf(seeded_key)
+    ros.apply_outcome(seeded_key, ros.FAILURE)
+    assert _conf(seeded_key) < before
+
+
+def test_legacy_bool_back_compat(seeded_key) -> None:
+    """True=>failure (decay), False=>success (boost) still honored."""
+    import routing_outcome_score as ros
+
+    base = _conf(seeded_key)
+    ros.apply_outcome(seeded_key, False)  # success
+    boosted = _conf(seeded_key)
+    assert boosted > base
+    ros.apply_outcome(seeded_key, True)  # failure
+    assert _conf(seeded_key) < boosted

--- a/hooks/tests/test_apply_outcome.py
+++ b/hooks/tests/test_apply_outcome.py
@@ -89,6 +89,20 @@ def test_failure_decays(seeded_key) -> None:
     assert _conf(seeded_key) < before
 
 
+def test_no_outcome_and_no_failure_raises(seeded_key) -> None:
+    """Both outcome and failure= unset is an illegal call: clear ValueError, no boost.
+
+    None is only an internal sentinel for the failure= back-compat path, never a
+    valid outcome. The guard rejects it before any confidence change.
+    """
+    import routing_outcome_score as ros
+
+    before = _conf(seeded_key)
+    with pytest.raises(ValueError, match="requires an outcome or a failure="):
+        ros.apply_outcome(seeded_key)  # no positional outcome, no failure kwarg
+    assert _conf(seeded_key) == before  # confidence untouched
+
+
 def test_legacy_bool_back_compat(seeded_key) -> None:
     """True=>failure (decay), False=>success (boost) still honored."""
     import routing_outcome_score as ros

--- a/hooks/tests/test_confidence_decay_neutral.py
+++ b/hooks/tests/test_confidence_decay_neutral.py
@@ -7,10 +7,13 @@ monotonic -0.05-toward-0 used for every other topic:
 
     conf += (0.5 - conf) * 0.1
 
-So a stale routing row above 0.5 drops toward 0.5, one below 0.5 rises toward
-0.5, and a fresh routing row (last_seen within 30 days) is untouched.
-Non-routing rows keep the old -0.05 behavior. The decay never touches
-last_seen, observation_count, or success/failure counts.
+Floor guard: staleness must never RAISE routing confidence, so only rows
+above 0.5 decay (downward toward 0.5). A stale routing row above 0.5 drops
+toward 0.5; one at or below 0.5 is skipped (preserves negative evidence so a
+sub-floor row stays floor-demote-eligible); a fresh routing row (last_seen
+within 30 days) is untouched. Non-routing rows keep the old -0.05 behavior.
+The decay never touches last_seen, observation_count, or success/failure
+counts.
 
 Uses a throwaway learning.db via CLAUDE_LEARNING_DIR - never the real DB.
 
@@ -98,13 +101,39 @@ def test_stale_routing_above_half_pulls_down_toward_half(db):
     assert new == pytest.approx(0.86, abs=1e-6)
 
 
-def test_stale_routing_below_half_pulls_up_toward_half(db):
+def test_stale_routing_below_half_is_not_rescued(db):
+    # Floor guard: staleness must never RAISE confidence. A below-baseline row
+    # is skipped, not pulled up toward 0.5 (which would erase negative evidence).
     _seed(db, "routing", "rare:skill", 0.32, STALE)
     res = _run_hook(db)
     assert res.returncode == 0
-    new = _read(db, "routing", "rare:skill")["confidence"]
-    # 0.32 + (0.5 - 0.32) * 0.1 = 0.338
-    assert new == pytest.approx(0.338, abs=1e-6)
+    assert _read(db, "routing", "rare:skill")["confidence"] == pytest.approx(0.32, abs=1e-6)
+
+
+def test_stale_routing_subfloor_stays_floor_eligible(db):
+    # Finding [104]/[105]: a sub-floor routing row (conf < FLOOR_CONFIDENCE=0.30,
+    # fail>=3, n>=5) must NOT be rescued above the 0.30 floor by staleness decay.
+    # Prune does not protect it: prune needs last_seen > 90 days, but this row is
+    # only 45 days stale, so it reaches the staleness UPDATE. Assert confidence
+    # did not rise and the row stays floor-demote-eligible (< 0.30).
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """
+        INSERT INTO learnings
+            (topic, key, value, category, confidence, source,
+             observation_count, success_count, failure_count,
+             first_seen, last_seen)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("routing", "bad:pair", "v", "effectiveness", 0.28, "seed", 5, 1, 3, STALE, STALE),
+    )
+    conn.commit()
+    conn.close()
+    res = _run_hook(db)
+    assert res.returncode == 0
+    new = _read(db, "routing", "bad:pair")["confidence"]
+    assert new == pytest.approx(0.28, abs=1e-6)  # unchanged, not raised to 0.302
+    assert new < 0.30  # still floor-demote-eligible
 
 
 def test_fresh_routing_row_untouched(db):
@@ -135,3 +164,13 @@ def test_staleness_decay_does_not_touch_counts_or_last_seen(db):
 def test_hook_exits_zero_on_empty_db(db):
     res = _run_hook(db)
     assert res.returncode == 0
+
+
+def test_stale_routing_at_half_is_noop_and_not_counted(db):
+    # Finding #15: a row already at the 0.5 baseline is a no-op; the > 0.5 guard
+    # excludes it so it is neither changed nor counted in the `decayed` metric.
+    _seed(db, "routing", "neutral:pair", 0.50, STALE)
+    res = _run_hook(db)
+    assert res.returncode == 0
+    assert _read(db, "routing", "neutral:pair")["confidence"] == pytest.approx(0.50, abs=1e-6)
+    assert "decayed=0" in res.stderr or "decayed" not in res.stderr

--- a/hooks/tests/test_confidence_decay_neutral.py
+++ b/hooks/tests/test_confidence_decay_neutral.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Tests for staleness decay toward neutral (0.5) on routing rows (spec T5).
+
+The confidence-decay Stop hook decays entries untouched > 30 days. For
+`topic='routing'` rows it must pull confidence TOWARD 0.5 instead of the
+monotonic -0.05-toward-0 used for every other topic:
+
+    conf += (0.5 - conf) * 0.1
+
+So a stale routing row above 0.5 drops toward 0.5, one below 0.5 rises toward
+0.5, and a fresh routing row (last_seen within 30 days) is untouched.
+Non-routing rows keep the old -0.05 behavior. The decay never touches
+last_seen, observation_count, or success/failure counts.
+
+Uses a throwaway learning.db via CLAUDE_LEARNING_DIR - never the real DB.
+
+Run with: python3 -m pytest hooks/tests/test_confidence_decay_neutral.py -v
+"""
+
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parent.parent
+LIB_DIR = HOOKS_DIR / "lib"
+HOOK_PATH = HOOKS_DIR / "confidence-decay.py"
+
+STALE = (datetime.now() - timedelta(days=45)).isoformat()
+FRESH = (datetime.now() - timedelta(days=2)).isoformat()
+
+
+def _seed(db_path: Path, topic: str, key: str, confidence: float, last_seen: str) -> None:
+    """Insert one learning row directly, bypassing boost/decay helpers."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO learnings
+            (topic, key, value, category, confidence, source,
+             observation_count, success_count, failure_count,
+             first_seen, last_seen)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (topic, key, "v", "effectiveness", confidence, "seed", 5, 3, 0, last_seen, last_seen),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _read(db_path: Path, topic: str, key: str) -> sqlite3.Row:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT confidence, last_seen, observation_count, success_count, failure_count "
+        "FROM learnings WHERE topic = ? AND key = ?",
+        (topic, key),
+    ).fetchone()
+    conn.close()
+    return row
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    return db_dir / "learning.db"
+
+
+def _run_hook(env_dir: Path) -> subprocess.CompletedProcess:
+    import os
+
+    env = dict(os.environ)
+    env["CLAUDE_LEARNING_DIR"] = str(env_dir.parent)
+    return subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input="",
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_stale_routing_above_half_pulls_down_toward_half(db):
+    _seed(db, "routing", "implementer:tdd", 0.90, STALE)
+    res = _run_hook(db)
+    assert res.returncode == 0
+    new = _read(db, "routing", "implementer:tdd")["confidence"]
+    # 0.90 + (0.5 - 0.90) * 0.1 = 0.86
+    assert new == pytest.approx(0.86, abs=1e-6)
+
+
+def test_stale_routing_below_half_pulls_up_toward_half(db):
+    _seed(db, "routing", "rare:skill", 0.32, STALE)
+    res = _run_hook(db)
+    assert res.returncode == 0
+    new = _read(db, "routing", "rare:skill")["confidence"]
+    # 0.32 + (0.5 - 0.32) * 0.1 = 0.338
+    assert new == pytest.approx(0.338, abs=1e-6)
+
+
+def test_fresh_routing_row_untouched(db):
+    _seed(db, "routing", "fresh:pair", 0.90, FRESH)
+    res = _run_hook(db)
+    assert res.returncode == 0
+    assert _read(db, "routing", "fresh:pair")["confidence"] == pytest.approx(0.90, abs=1e-6)
+
+
+def test_non_routing_keeps_old_minus_005(db):
+    _seed(db, "error_pattern", "missing_file", 0.90, STALE)
+    res = _run_hook(db)
+    assert res.returncode == 0
+    # old behavior: monotonic -0.05
+    assert _read(db, "error_pattern", "missing_file")["confidence"] == pytest.approx(0.85, abs=1e-6)
+
+
+def test_staleness_decay_does_not_touch_counts_or_last_seen(db):
+    _seed(db, "routing", "no:sidefx", 0.90, STALE)
+    _run_hook(db)
+    row = _read(db, "routing", "no:sidefx")
+    assert row["last_seen"] == STALE
+    assert row["observation_count"] == 5
+    assert row["success_count"] == 3
+    assert row["failure_count"] == 0
+
+
+def test_hook_exits_zero_on_empty_db(db):
+    res = _run_hook(db)
+    assert res.returncode == 0

--- a/hooks/tests/test_hook_utils_security.py
+++ b/hooks/tests/test_hook_utils_security.py
@@ -28,6 +28,7 @@ from hook_utils import (
     async_rewake,
     diff_post_image_ext,
     has_reviewable_content,
+    normalize_diff_for_fingerprint,
     working_tree_diff,
 )
 
@@ -216,6 +217,90 @@ class TestDiffDedup:
         d = DiffDedup(tmp_path / "nope", tmp_path / "nope" / "deep" / "s.json")
         with patch("hook_utils.os.replace", side_effect=OSError("ro")):
             d.record("/repo", "diffA")  # must not raise
+
+    # --- fingerprint normalization: blob-SHA / mode churn must NOT re-trigger ---
+
+    def test_signature_ignores_index_blob_sha_churn(self, tmp_path):
+        """Same paths + same hunks but fresh ``index`` blob SHAs → same signature."""
+        d = DiffDedup(tmp_path, tmp_path / "s.json")
+        before = (
+            "diff --git a/static/game/index.html b/static/game/index.html\n"
+            "index 71aae3b..739f207 100644\n"
+            "--- a/static/game/index.html\n"
+            "+++ b/static/game/index.html\n"
+            "@@ -1 +1,2 @@\n x\n+rebuilt\n"
+        )
+        after = before.replace("index 71aae3b..739f207", "index aaaaaaa..bbbbbbb")
+        assert d.signature("/repo", before) == d.signature("/repo", after)
+
+    def test_index_churn_dedups_end_to_end(self, tmp_path):
+        """Record a diff, then re-fire with only blob-SHA churn → duplicate."""
+        d = DiffDedup(tmp_path, tmp_path / "s.json")
+        first = (
+            "diff --git a/app.js b/app.js\nindex 1111111..2222222 100644\n"
+            "--- a/app.js\n+++ b/app.js\n@@ -1 +1,2 @@\n y\n+z\n"
+        )
+        d.record("/repo", first)
+        rebuilt = first.replace("index 1111111..2222222", "index 9999999..8888888")
+        is_dup, _ = d.is_duplicate("/repo", rebuilt)
+        assert is_dup is True
+
+    def test_real_content_change_is_not_duplicate(self, tmp_path):
+        """A changed hunk (one new added line) still produces a fresh review."""
+        d = DiffDedup(tmp_path, tmp_path / "s.json")
+        first = (
+            "diff --git a/app.js b/app.js\nindex 1111111..2222222 100644\n"
+            "--- a/app.js\n+++ b/app.js\n@@ -1 +1,2 @@\n y\n+z\n"
+        )
+        d.record("/repo", first)
+        changed = first.replace("+z\n", "+z\n+brand_new_line\n")
+        is_dup, _ = d.is_duplicate("/repo", changed)
+        assert is_dup is False
+
+    def test_new_file_path_is_not_duplicate(self, tmp_path):
+        """A new file path differs from the recorded diff → fresh review."""
+        d = DiffDedup(tmp_path, tmp_path / "s.json")
+        first = (
+            "diff --git a/app.js b/app.js\nindex 1111111..2222222 100644\n"
+            "--- a/app.js\n+++ b/app.js\n@@ -1 +1,2 @@\n y\n+z\n"
+        )
+        d.record("/repo", first)
+        with_new = first + (
+            "diff --git a/extra.js b/extra.js\nindex 0000000..3333333 100644\n"
+            "--- a/extra.js\n+++ b/extra.js\n@@ -0,0 +1 @@\n+added\n"
+        )
+        is_dup, _ = d.is_duplicate("/repo", with_new)
+        assert is_dup is False
+
+
+class TestNormalizeDiffForFingerprint:
+    def test_drops_index_line(self):
+        norm = normalize_diff_for_fingerprint("index 71aae3b..739f207 100644\n")
+        assert "index " not in norm
+
+    def test_drops_mode_lines(self):
+        diff = "old mode 100644\nnew mode 100755\n"
+        assert normalize_diff_for_fingerprint(diff).strip() == ""
+
+    def test_drops_similarity_index(self):
+        diff = "similarity index 95%\ndissimilarity index 5%\n"
+        assert normalize_diff_for_fingerprint(diff).strip() == ""
+
+    def test_keeps_file_paths_and_hunks(self):
+        diff = (
+            "diff --git a/app.py b/app.py\nindex abc..def 100644\n--- a/app.py\n+++ b/app.py\n@@ -1 +1,2 @@\n x\n+y\n"
+        )
+        norm = normalize_diff_for_fingerprint(diff)
+        for keep in ("diff --git a/app.py b/app.py", "--- a/app.py", "+++ b/app.py", "@@ -1 +1,2 @@", "+y"):
+            assert keep in norm
+
+    def test_keeps_rename_path_lines(self):
+        diff = "rename from old.py\nrename to new.py\n"
+        norm = normalize_diff_for_fingerprint(diff)
+        assert "rename from old.py" in norm and "rename to new.py" in norm
+
+    def test_empty_diff_is_empty(self):
+        assert normalize_diff_for_fingerprint("") == ""
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -911,6 +911,77 @@ class TestRouteEventLog:
 
 
 # ---------------------------------------------------------------------------
+# Stage 0 — health gate inputs carried on the [do-route] marker
+# ---------------------------------------------------------------------------
+
+
+def _health_event(marker_body, *, session="hs1", description="do work"):
+    """PostToolUse:Agent event whose prompt is the supplied marker line verbatim."""
+    return {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Agent",
+        "session_id": session,
+        "tool_input": {
+            "subagent_type": "python-general-engineer",
+            "description": description,
+            "prompt": marker_body + "\ndo the work",
+        },
+        "tool_result": {"output": "ok", "is_error": False},
+    }
+
+
+class TestHealthMarkerParse:
+    """Stage 0: the recorder reads {health, n, fail, action, alts} off the marker
+    and writes them to the DECISION event. `health=-` writes null health."""
+
+    def test_health_fields_written_to_decision_event(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_health1")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        marker = (
+            "[do-route] agent=python-general-engineer skill=go-patterns "
+            "complexity=Medium health=0.20 n=6 fail=4 action=demote alts=direct:pr-workflow,explore:codebase-overview"
+        )
+        event = _health_event(marker, session="hs-demote")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] == 0.20
+        assert d["n"] == 6
+        assert d["failure"] == 4
+        assert d["action"] == "demote"
+        assert d["alternates"] == ["direct:pr-workflow", "explore:codebase-overview"]
+
+    def test_health_dash_writes_null(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_health2")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        marker = "[do-route] agent=python-general-engineer skill=go-patterns complexity=Medium health=-"
+        event = _health_event(marker, session="hs-null")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] is None
+        assert d["n"] is None
+        assert d["failure"] is None
+        assert d["action"] is None
+        assert d["alternates"] is None
+
+    def test_absent_health_field_writes_null(self, db_env, monkeypatch):
+        # A legacy marker with no health= token => null health, all fields null.
+        a = _load(A_PATH, "rdr_health3")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        marker = "[do-route] agent=python-general-engineer skill=go-patterns complexity=Medium"
+        event = _health_event(marker, session="hs-legacy")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] is None
+        assert d["action"] is None
+
+
+# ---------------------------------------------------------------------------
 # A + B integration: route-health closes the loop
 # ---------------------------------------------------------------------------
 

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -21,6 +21,7 @@ Run with: python3 -m pytest hooks/tests/test_routing_decision_recorder.py -v
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -529,6 +530,136 @@ class TestFinalizer:
             None,
         ]:
             assert f.is_rejection(p) is False, p
+
+
+# ---------------------------------------------------------------------------
+# T3 — per-dispatch route event log (JSONL)
+# ---------------------------------------------------------------------------
+
+EVENTS_NAME = "route-events.jsonl"
+
+
+def _read_events(db_env):
+    """Read every event line from the throwaway route-events.jsonl, or []."""
+    path = db_env["db_dir"] / EVENTS_NAME
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+class TestRouteEventLog:
+    """T3: the decision hook appends one DECISION event per recorded dispatch;
+    the finalizer appends one OUTCOME event per finalized dispatch. Append-only,
+    failure-safe — a write error must never break the hook."""
+
+    def test_decision_event_appended_on_record(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_evt1")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        event = _agent_event(skill="go-patterns", body="Refactor the parser.", session="evt-s1")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        events = _read_events(db_env)
+        decisions = [e for e in events if e["type"] == "decision"]
+        assert len(decisions) == 1
+        d = decisions[0]
+        assert d["agent"] == "python-general-engineer"
+        assert d["skill"] == "go-patterns"
+        assert d["session"] == "evt-s1"
+        assert d["complexity"].lower() == "medium"
+        assert "request_snippet" in d and "health_at_decision" in d
+
+    def test_no_decision_event_when_marker_absent(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_evt2")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        event = _agent_event(marker=False, body="Review this PR.")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        assert _read_events(db_env) == []
+
+    def test_outcome_event_appended_on_finalize(self, db_env, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:evt-fin")
+        ros.append_pending_outcome("evt-fin", key, errors=False)
+
+        f = _load(F_PATH, "fin_evt1")
+        ev = _prompt_event("looks good, merge it", session="evt-fin")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        outcomes = [e for e in _read_events(db_env) if e["type"] == "outcome"]
+        assert len(outcomes) == 1
+        assert outcomes[0]["key"] == key
+        assert outcomes[0]["outcome"] in {"success", "failure", "neutral"}
+        assert outcomes[0]["session"] == "evt-fin"
+
+    def test_outcome_event_records_failure(self, db_env, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:evt-fail")
+        ros.append_pending_outcome("evt-fail", key, errors=True)
+
+        f = _load(F_PATH, "fin_evt_fail")
+        ev = _prompt_event("ok next", session="evt-fail")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        outcomes = [e for e in _read_events(db_env) if e["type"] == "outcome"]
+        assert outcomes and outcomes[0]["outcome"] == "failure"
+
+    def test_log_is_append_only_across_dispatches(self, db_env, monkeypatch):
+        # Two recorded dispatches => two decision lines, none overwritten.
+        a = _load(A_PATH, "rdr_evt_append")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        for i, skill in enumerate(("go-patterns", "test-driven-development")):
+            ev = _agent_event(skill=skill, body=f"task {i}", session=f"append-{i}")
+            with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+                a.main()
+        decisions = [e for e in _read_events(db_env) if e["type"] == "decision"]
+        assert {d["skill"] for d in decisions} == {"go-patterns", "test-driven-development"}
+        assert len(decisions) == 2
+
+    def test_decision_event_write_error_does_not_break_hook(self, db_env, monkeypatch):
+        # A failing event append must NOT prevent the aggregate row being written
+        # and must NOT raise — the hook stays non-blocking.
+        a = _load(A_PATH, "rdr_evt_safe")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        import route_events
+
+        monkeypatch.setattr(
+            route_events,
+            "_append",
+            lambda *_a, **_k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+        event = _agent_event(skill="go-patterns", session="evt-safe")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()  # must not raise
+        # Aggregate row still recorded despite the event-log failure.
+        keys = {r["key"] for r in _query_routing(db_env)}
+        assert "python-general-engineer:go-patterns" in keys
+
+    def test_malformed_events_dir_does_not_crash_recorder(self, db_env, monkeypatch):
+        # CLAUDE_LEARNING_DIR pointing at a non-creatable path => event append
+        # fails silently; the hook still exits 0 (subprocess end-to-end).
+        bad = db_env["db_dir"] / "notadir"
+        bad.write_text("i am a file, not a directory")
+        env = dict(os.environ)
+        env["CLAUDE_LEARNING_DIR"] = str(bad)  # base path is a file => mkdir fails
+        event = _agent_event(skill="go-patterns", session="evt-baddir")
+        p = subprocess.run(
+            [sys.executable, str(A_PATH)],
+            input=json.dumps(event),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert p.returncode == 0
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -247,6 +247,49 @@ def _seed_decision(key="python-general-engineer:go-patterns"):
     return key
 
 
+class TestApplyOutcomeThreeWay:
+    """T4: apply_outcome is three-way — success boosts, failure decays, neutral
+    is a pure no-op (no boost, no decay, no count change)."""
+
+    def test_neutral_is_pure_noop(self, db_env):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_score as ros_score
+
+        key = _seed_decision("python-general-engineer:noop")
+        before = next(r for r in _query_routing(db_env) if r["key"] == key)
+        ros_score.apply_outcome(key, "neutral")
+        after = next(r for r in _query_routing(db_env) if r["key"] == key)
+        assert after["success_count"] == before["success_count"]
+        assert after["failure_count"] == before["failure_count"]
+        assert after["confidence"] == before["confidence"]
+        assert after["observation_count"] == before["observation_count"]
+
+    def test_success_boosts_failure_decays(self, db_env):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_score as ros_score
+
+        sk = _seed_decision("python-general-engineer:succ")
+        fk = _seed_decision("python-general-engineer:fail")
+        ros_score.apply_outcome(sk, "success")
+        ros_score.apply_outcome(fk, "failure")
+        sr = next(r for r in _query_routing(db_env) if r["key"] == sk)
+        fr = next(r for r in _query_routing(db_env) if r["key"] == fk)
+        assert sr["success_count"] == 1 and sr["failure_count"] == 0
+        assert fr["failure_count"] == 1 and fr["success_count"] == 0
+
+    def test_legacy_bool_still_supported(self, db_env):
+        # Back-compat: True=>failure, False=>success.
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_score as ros_score
+
+        tk = _seed_decision("python-general-engineer:legacy-true")
+        fk = _seed_decision("python-general-engineer:legacy-false")
+        ros_score.apply_outcome(tk, True)
+        ros_score.apply_outcome(fk, False)
+        assert next(r for r in _query_routing(db_env) if r["key"] == tk)["failure_count"] == 1
+        assert next(r for r in _query_routing(db_env) if r["key"] == fk)["success_count"] == 1
+
+
 class TestOutcomeValidator:
     """B (SubagentStop) NO LONGER scores. It validates the decision row exists
     and keeps the entry PROVISIONAL (revalidated) for the next-turn finalizer;
@@ -336,22 +379,28 @@ class TestFinalizer:
         assert after["success_count"] == 1
         assert after["confidence"] > before
 
-    def test_neutral_new_topic_boosts(self, db_env, monkeypatch):
-        # No complaint = success, matching the old LLM's "user accepted" default.
+    def test_neutral_new_topic_is_noop(self, db_env, monkeypatch):
+        # T4 three-way: an unrelated / new-topic next prompt carries NO acceptance
+        # and NO complaint => NEUTRAL no-op. No boost, no decay, no count change.
+        # (Previously this boosted — the inflation T4 removes.)
         sys.path.insert(0, str(LIB_DIR))
         import routing_outcome_state as ros
 
         monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
         key = _seed_decision("python-general-engineer:neutral")
         self._pend(ros, "fin-neu", key, errors=False)
+        before = next(r for r in _query_routing(db_env) if r["key"] == key)
 
         f = _load(F_PATH, "fin2")
         ev = _prompt_event("now add a CHANGELOG entry for the release", session="fin-neu")
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
             f.main()
         after = next(r for r in _query_routing(db_env) if r["key"] == key)
-        assert after["success_count"] == 1
-        assert after["failure_count"] == 0
+        assert after["success_count"] == before["success_count"]  # no boost
+        assert after["failure_count"] == before["failure_count"]  # no decay
+        assert after["confidence"] == before["confidence"]  # unchanged
+        # Pending cleared (resolved once, idempotent) even though it was a no-op.
+        assert ros.peek_pending_outcomes("fin-neu") == []
 
     def test_rejection_decays(self, db_env, monkeypatch):
         sys.path.insert(0, str(LIB_DIR))
@@ -424,7 +473,8 @@ class TestFinalizer:
             f.main()
         after = next(r for r in _query_routing(db_env) if r["key"] == key)
         assert after["failure_count"] == 0, "benign 'wrong' falsely decayed the prior dispatch"
-        assert after["success_count"] == 1
+        # T4: a benign new request is neutral (no acceptance marker) — no boost.
+        assert after["success_count"] == 0
 
     def test_idempotent_double_prompt_scores_once(self, db_env, monkeypatch):
         sys.path.insert(0, str(LIB_DIR))
@@ -480,10 +530,11 @@ class TestFinalizer:
             ros._atomic_write(path, data)
 
         f = _load(F_PATH, "fin_malformed")
-        ev = _prompt_event("now write the docs", session=session)  # neutral => success
+        ev = _prompt_event("thanks, now write the docs", session=session)  # acceptance => success
         with patch("sys.exit"), patch("sys.stdin.read", return_value=_json.dumps(ev)):
             f.main()
-        # The valid sibling still scored (success); the malformed one was skipped.
+        # The valid sibling still scored; the malformed one was skipped. With one
+        # live entry the turn acceptance is attributable => success.
         after = next(r for r in _query_routing(db_env) if r["key"] == good_key)
         assert after["success_count"] == 1, "malformed sibling aborted scoring of the valid entry"
         assert after["failure_count"] == 0
@@ -530,6 +581,29 @@ class TestFinalizer:
             None,
         ]:
             assert f.is_rejection(p) is False, p
+
+    def test_acceptance_marker_unit(self):
+        # T4: is_acceptance decides boost-vs-neutral. Explicit affirmation in the
+        # FIRST clause => True; an unrelated/new-topic prompt => False (=> neutral).
+        f = _load(F_PATH, "fin_acc_unit")
+        for p in [
+            "thanks!",
+            "looks good, merge it",
+            "perfect, ship it",
+            "lgtm",
+            "great work",
+            "that worked, now do the next file",
+        ]:
+            assert f.is_acceptance(p) is True, p
+        for p in [
+            "now add a CHANGELOG entry for the release",
+            "write the docs",
+            "that's wrong",
+            "Add a test for wrong-format dates.",
+            "",
+            None,
+        ]:
+            assert f.is_acceptance(p) is False, p
 
 
 # ---------------------------------------------------------------------------
@@ -907,8 +981,10 @@ class TestPerAgentAttribution:
         ros.append_pending_outcome(session, good, errors=False)
         ros.append_pending_outcome(session, bad, errors=True)
 
-        # Neutral next turn (no rejection): good=success (own flag), bad=failure
-        # (own flag). The session-level reaction does NOT broadcast errors.
+        # Neutral next turn (no acceptance, no rejection) with >1 pending: the
+        # turn reaction is NOT attributable. Each entry resolves on its OWN flag —
+        # good=neutral (T4: clean, no acceptance => no-op), bad=failure (own
+        # error). The sibling's error does NOT broadcast a decay onto good.
         f = _load(HOOKS_DIR / "routing-outcome-finalizer.py", "fin_attrib")
         event = {"hook_event_name": "UserPromptSubmit", "session_id": session, "prompt": "ok, next task"}
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
@@ -916,10 +992,10 @@ class TestPerAgentAttribution:
 
         good_after = next(r for r in _query_routing_all(db_env) if r["key"] == good)
         bad_after = next(r for r in _query_routing_all(db_env) if r["key"] == bad)
-        # Clean key boosted (success), NOT decayed by the sibling's error.
-        assert good_after["success_count"] == 1
+        # Clean key is NEUTRAL (no boost, no decay) — NOT decayed by the sibling.
+        assert good_after["success_count"] == 0
         assert good_after["failure_count"] == 0
-        assert good_after["confidence"] > good_before
+        assert good_after["confidence"] == good_before
         # Failing key decayed on its own flag.
         assert bad_after["failure_count"] == 1
 
@@ -1017,7 +1093,8 @@ STOP_PATH = HOOKS_DIR / "session-learning-recorder.py"
 class TestStopFallback:
     def test_session_end_resolves_pending_via_error_flag(self, db_env, monkeypatch):
         """No next user prompt: the Stop hook resolves still-pending dispatches
-        using each dispatch's own error flag (the deterministic floor)."""
+        from each dispatch's own error flag (T4 deterministic floor):
+        error => failure (decay); CLEAN run => NEUTRAL no-op (no boost)."""
         sys.path.insert(0, str(LIB_DIR))
         import routing_outcome_state as ros
 
@@ -1027,6 +1104,7 @@ class TestStopFallback:
         session = "autorun"
         ros.append_pending_outcome(session, ok, errors=False)
         ros.append_pending_outcome(session, bad, errors=True)
+        ok_before = next(r for r in _query_routing_all(db_env) if r["key"] == ok)
 
         s = _load(STOP_PATH, "stop1")
         event = {"hook_event_name": "Stop", "session_id": session, "session_data": {"files_modified": ["x"]}}
@@ -1035,8 +1113,11 @@ class TestStopFallback:
 
         ok_row = next(r for r in _query_routing_all(db_env) if r["key"] == ok)
         bad_row = next(r for r in _query_routing_all(db_env) if r["key"] == bad)
-        assert ok_row["success_count"] == 1  # no error => boost
-        assert bad_row["failure_count"] == 1  # error => decay
+        # T4: a clean autonomous run is NEUTRAL — no boost, no count change.
+        assert ok_row["success_count"] == ok_before["success_count"]
+        assert ok_row["failure_count"] == 0
+        assert ok_row["confidence"] == ok_before["confidence"]
+        assert bad_row["failure_count"] == 1  # error => decay (unchanged)
         # Pending cleared — nothing left to double-resolve.
         assert ros.peek_pending_outcomes(session) == []
 
@@ -1063,6 +1144,30 @@ class TestStopFallback:
             s.main()
         row = next(r for r in _query_routing_all(db_env) if r["key"] == key)
         assert row["success_count"] == 1, "Stop double-resolved a finalized dispatch"
+
+    def test_stop_clean_run_is_neutral(self, db_env, monkeypatch):
+        """T4: a clean autonomous run (no errors, no next prompt) resolves to
+        NEUTRAL at Stop — no boost, no count change. Regression guard against the
+        old 'else boost' that inflated success on every quiet session."""
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:clean-neutral")
+        session = "clean-run"
+        ros.append_pending_outcome(session, key, errors=False)
+        before = next(r for r in _query_routing_all(db_env) if r["key"] == key)
+
+        s = _load(STOP_PATH, "stop_clean")
+        event = {"hook_event_name": "Stop", "session_id": session, "session_data": {"files_modified": ["x"]}}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            s.main()
+
+        after = next(r for r in _query_routing_all(db_env) if r["key"] == key)
+        assert after["success_count"] == before["success_count"]
+        assert after["failure_count"] == before["failure_count"]
+        assert after["confidence"] == before["confidence"]
+        assert ros.peek_pending_outcomes(session) == []
 
     def test_stop_exits_zero_on_malformed(self):
         assert _run_hook(STOP_PATH, {}).returncode == 0
@@ -1166,10 +1271,12 @@ class TestSingleDispatchAttribution:
 
         a_after = next(r for r in _query_routing_all(db_env) if r["key"] == a)
         b_after = next(r for r in _query_routing_all(db_env) if r["key"] == b)
-        # Both clean siblings score SUCCESS, neither decayed by the ambiguous turn.
+        # CORE GUARD: neither sibling is DECAYED by the unattributable turn. Under
+        # T4 a clean unattributable sibling is NEUTRAL (no boost either), not the
+        # old auto-success — but the misattribution guard (no false decay) holds.
         assert a_after["failure_count"] == 0 and b_after["failure_count"] == 0
-        assert a_after["success_count"] == 1 and b_after["success_count"] == 1
-        assert a_after["confidence"] > a_before and b_after["confidence"] > b_before
+        assert a_after["success_count"] == 0 and b_after["success_count"] == 0
+        assert a_after["confidence"] == a_before and b_after["confidence"] == b_before
 
     def test_multi_dispatch_per_entry_error_still_fails(self, db_env, monkeypatch):
         # With >1 pending, the IGNORED turn-reaction does not stop a per-entry
@@ -1195,7 +1302,9 @@ class TestSingleDispatchAttribution:
             f.main()
         clean_after = next(r for r in _query_routing_all(db_env) if r["key"] == clean)
         errd_after = next(r for r in _query_routing_all(db_env) if r["key"] == errd)
-        assert clean_after["success_count"] == 1 and clean_after["failure_count"] == 0
+        # T4: clean sibling is NEUTRAL (no acceptance, unattributable turn) — no
+        # boost, no decay. The errored sibling still fails on its own flag.
+        assert clean_after["success_count"] == 0 and clean_after["failure_count"] == 0
         assert errd_after["failure_count"] == 1 and errd_after["success_count"] == 0
 
     def test_single_dispatch_rejection_decays(self, db_env, monkeypatch):
@@ -1317,13 +1426,17 @@ class TestRejectionPrecision:
         for p in self.NAMED_GENUINE:
             assert f.is_rejection(p) is True, f"review-named genuine missed: {p!r}"
 
-    def test_benign_prompt_scores_success_end_to_end(self, db_env, monkeypatch):
-        # A single dispatch + a benign "redo it in a later clause" prompt => the
-        # reaction is acceptance/neutral in the first clause => SUCCESS, no decay.
+    def test_benign_prompt_never_decays_end_to_end(self, db_env, monkeypatch):
+        # CORE GUARD: a benign prompt (rework verb only in a LATER clause, or a
+        # spec/instructional first clause) must NEVER DECAY the route. Under T4 the
+        # outcome is SUCCESS only when the first clause carries an acceptance
+        # marker; an instructional/spec first clause is NEUTRAL (no boost). Either
+        # way failure_count stays 0 — the precision guard this test exists for.
         sys.path.insert(0, str(LIB_DIR))
         import learning_db_v2 as ldb
         import routing_outcome_state as ros
 
+        f_unit = _load(F_PATH, "fin_benign_unit")
         monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
         for i, prompt in enumerate(self.BENIGN):
             key = f"python-general-engineer:benign-{i}"
@@ -1342,11 +1455,15 @@ class TestRejectionPrecision:
                 f.main()
             after = next(r for r in _query_routing_all(db_env) if r["key"] == key)
             assert after["failure_count"] == 0, f"benign prompt decayed route: {prompt!r}"
-            assert after["success_count"] == 1
+            # acceptance first clause => success; instructional/spec => neutral.
+            expected = 1 if f_unit.is_acceptance(prompt) else 0
+            assert after["success_count"] == expected, prompt
 
-    def test_named_rollback_phrase_scores_success_end_to_end(self, db_env, monkeypatch):
-        # Spec-required E2E: a single clean dispatch + the review's roll-back spec
-        # phrase => SUCCESS (success_count=1, failure_count=0), no decay.
+    def test_named_rollback_phrase_does_not_decay_end_to_end(self, db_env, monkeypatch):
+        # Spec-required E2E false-positive guard: a single clean dispatch + the
+        # review's roll-back SPEC phrase must NOT decay the route. T4: it carries
+        # no acceptance marker (instructional/conditional clause) => NEUTRAL
+        # (failure_count=0, success_count=0). The guard is "no false decay".
         sys.path.insert(0, str(LIB_DIR))
         import learning_db_v2 as ldb
         import routing_outcome_state as ros
@@ -1360,6 +1477,7 @@ class TestRejectionPrecision:
             category="effectiveness",
             source="test",
         )
+        before = next(r for r in _query_routing_all(db_env) if r["key"] == key)["confidence"]
         session = "named-rollback-e2e"
         ros.append_pending_outcome(session, key, errors=False)
         f = _load(F_PATH, "fin_named_rollback_e2e")
@@ -1367,7 +1485,9 @@ class TestRejectionPrecision:
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
             f.main()
         after = next(r for r in _query_routing_all(db_env) if r["key"] == key)
-        assert after["success_count"] == 1, "named roll-back spec phrase failed to score success"
+        assert after["failure_count"] == 0, "spec phrase falsely decayed the route"
+        assert after["success_count"] == 0, "spec phrase is neutral, not success (T4)"
+        assert after["confidence"] == before
         assert after["failure_count"] == 0, "named roll-back spec phrase falsely decayed route"
 
 

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -910,8 +910,59 @@ class TestRouteEventLog:
         assert p.returncode == 0
 
 
+class TestOutcomeEventReasonAndRelevance:
+    """record_outcome_event writes reason + routing_relevant only when supplied,
+    and the finalizer always stamps both so a decay is queryable from the JSONL
+    alone (no per-key basis table needed)."""
+
+    def test_reason_written_when_given(self, db_env):
+        sys.path.insert(0, str(LIB_DIR))
+        import route_events
+
+        route_events.record_outcome_event(session="s", key="a:b", outcome="failure", reason="tool-errors")
+        ev = next(e for e in _read_events(db_env) if e["type"] == "outcome")
+        assert ev["reason"] == "tool-errors"
+
+    def test_routing_relevant_written_when_given(self, db_env):
+        sys.path.insert(0, str(LIB_DIR))
+        import route_events
+
+        route_events.record_outcome_event(session="s", key="a:b", outcome="failure", routing_relevant=True)
+        ev = next(e for e in _read_events(db_env) if e["type"] == "outcome")
+        assert ev["routing_relevant"] is True
+
+    def test_routing_relevant_absent_when_none(self, db_env):
+        sys.path.insert(0, str(LIB_DIR))
+        import route_events
+
+        # Default None => field omitted, so old callers stay byte-compatible.
+        route_events.record_outcome_event(session="s", key="a:b", outcome="neutral")
+        ev = next(e for e in _read_events(db_env) if e["type"] == "outcome")
+        assert "routing_relevant" not in ev
+        assert "reason" not in ev
+
+    def test_finalizer_writes_reason_and_routing_relevant(self, db_env, monkeypatch):
+        # End-to-end: a rejection decay must carry reason + routing_relevant in
+        # the JSONL OUTCOME event so the demotion cause is queryable.
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:evt-reason")
+        ros.append_pending_outcome("evt-reason", key, errors=False)
+
+        f = _load(F_PATH, "fin_reason")
+        ev = _prompt_event("that's wrong, redo it", session="evt-reason")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        outcome = next(e for e in _read_events(db_env) if e["type"] == "outcome")
+        assert outcome["outcome"] == "failure"
+        assert outcome["reason"] == "rejection"
+        assert outcome["routing_relevant"] is True
+
+
 # ---------------------------------------------------------------------------
-# Stage 0 — health gate inputs carried on the [do-route] marker
+# Step 1.5 — health gate inputs carried on the [do-route] marker
 # ---------------------------------------------------------------------------
 
 
@@ -931,7 +982,7 @@ def _health_event(marker_body, *, session="hs1", description="do work"):
 
 
 class TestHealthMarkerParse:
-    """Stage 0: the recorder reads {health, n, fail, action, alts} off the marker
+    """Step 1.5: the recorder reads {health, n, fail, action, alts} off the marker
     and writes them to the DECISION event. `health=-` writes null health.
 
     Three-state instrumentation contract (decommission clock validity):
@@ -995,6 +1046,126 @@ class TestHealthMarkerParse:
         assert d["health_at_decision"] is None
         assert d["action"] is None
         assert d["gate_inputs_present"] is False
+
+
+class TestHealthMarkerLineScoping:
+    """Findings 70/15/97 regression guards.
+
+    70: gate inputs are read from the marker LINE only — a task body mentioning
+        `health=`/`fail=` must NOT poison gate_inputs_present or the clock.
+    15: a malformed `health=1.2.3` reads as field-absent (state c), and the
+        decision event is STILL recorded — never silently dropped.
+    """
+
+    def test_health_in_body_is_ignored(self, db_env, monkeypatch):
+        # Marker line carries NO gate input (state c); the BODY mentions
+        # health=/fail= — those must not be read. Expect state (c): null health,
+        # gate_inputs_present False.
+        a = _load(A_PATH, "rdr_body_ignored")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        event = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Agent",
+            "session_id": "body-health",
+            "tool_input": {
+                "subagent_type": "python-general-engineer",
+                "description": "do work",
+                "prompt": (
+                    "[do-route] agent=python-general-engineer skill=go-patterns complexity=Medium\n"
+                    "Fix the gate: when health=0.9 and fail=3 the action=demote path is wrong."
+                ),
+            },
+            "tool_result": {"output": "ok", "is_error": False},
+        }
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] is None  # body health=0.9 NOT read
+        assert d["failure"] is None  # body fail=3 NOT read
+        assert d["action"] is None  # body action=demote NOT read
+        assert d["gate_inputs_present"] is False  # state (c): clean of body poison
+
+    def test_health_on_marker_line_is_parsed(self, db_env, monkeypatch):
+        # Same body health= bait, but the marker line ALSO carries health=0.20.
+        # The marker-line value must win; body values are never read.
+        a = _load(A_PATH, "rdr_line_parsed")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        event = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Agent",
+            "session_id": "line-health",
+            "tool_input": {
+                "subagent_type": "python-general-engineer",
+                "description": "do work",
+                "prompt": (
+                    "[do-route] agent=python-general-engineer skill=go-patterns "
+                    "complexity=Medium health=0.20 fail=4 action=demote\n"
+                    "Body text that says health=0.99 and fail=9 must be ignored."
+                ),
+            },
+            "tool_result": {"output": "ok", "is_error": False},
+        }
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] == 0.20  # marker line, not body 0.99
+        assert d["failure"] == 4  # marker line, not body 9
+        assert d["action"] == "demote"
+        assert d["gate_inputs_present"] is True
+
+    def test_malformed_health_is_field_absent_but_event_recorded(self, db_env, monkeypatch):
+        # health=1.2.3 is malformed: it must read as field-absent (state c) and
+        # the decision event MUST still be recorded — never dropped by a raised
+        # float(). gate_inputs_present False, decision + routing rows still land.
+        a = _load(A_PATH, "rdr_malformed_health")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        marker = "[do-route] agent=python-general-engineer skill=go-patterns complexity=Medium health=1.2.3"
+        event = _health_event(marker, session="hs-malformed")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] is None  # malformed => field absent
+        assert d["gate_inputs_present"] is False  # state (c), honest "not instrumented"
+        # The event is still recorded — the malformed value did NOT drop it.
+        keys = {r["key"] for r in _query_routing(db_env)}
+        assert "python-general-engineer:go-patterns" in keys
+
+    def test_valid_health_dash_still_state_b(self, db_env, monkeypatch):
+        # Regression: the tightened regex must still accept `health=-` => state b
+        # (null health, gate_inputs_present True).
+        a = _load(A_PATH, "rdr_dash_stateb")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        marker = "[do-route] agent=python-general-engineer skill=go-patterns complexity=Medium health=-"
+        event = _health_event(marker, session="hs-dash-b")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] is None
+        assert d["gate_inputs_present"] is True
+
+    def test_recorder_failure_writes_stderr_line(self, db_env, monkeypatch, capsys):
+        # Finding 97: an uncaught recorder error must surface ONE short stderr
+        # line (class: msg) even WITHOUT CLAUDE_HOOKS_DEBUG, and still exit 0.
+        # Force a failure inside main() (claim_dispatch raises) and assert the
+        # outer handler wrote the line and exit(0) was called.
+        monkeypatch.delenv("CLAUDE_HOOKS_DEBUG", raising=False)  # prove no-debug logging
+        a = _load(A_PATH, "rdr_stderr_fail")
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("forced failure")
+
+        monkeypatch.setattr(a, "claim_dispatch", _boom)
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        event = _agent_event(skill="go-patterns", session="stderr-fail")
+        with patch("sys.exit") as ex, patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        ex.assert_called_with(0)  # still non-blocking
+        err = capsys.readouterr().err
+        assert "routing-decision-recorder: RuntimeError: forced failure" in err
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -932,7 +932,15 @@ def _health_event(marker_body, *, session="hs1", description="do work"):
 
 class TestHealthMarkerParse:
     """Stage 0: the recorder reads {health, n, fail, action, alts} off the marker
-    and writes them to the DECISION event. `health=-` writes null health."""
+    and writes them to the DECISION event. `health=-` writes null health.
+
+    Three-state instrumentation contract (decommission clock validity):
+      (a) numeric  health=<float>  => health_at_decision float, gate_inputs_present True
+      (b) no-row   health=-        => health_at_decision null,  gate_inputs_present True
+      (c) legacy   no health= token => health_at_decision null,  gate_inputs_present False
+    States (a)+(b) are instrumented (marker carried the gate input); only (c)
+    counts against the 95% rate. `gate_inputs_present` is the validity signal,
+    not non-null health — most live picks are state (b) (pair has no weight row)."""
 
     def test_health_fields_written_to_decision_event(self, db_env, monkeypatch):
         a = _load(A_PATH, "rdr_health1")
@@ -951,6 +959,8 @@ class TestHealthMarkerParse:
         assert d["failure"] == 4
         assert d["action"] == "demote"
         assert d["alternates"] == ["direct:pr-workflow", "explore:codebase-overview"]
+        # State (a): marker carried gate inputs.
+        assert d["gate_inputs_present"] is True
 
     def test_health_dash_writes_null(self, db_env, monkeypatch):
         a = _load(A_PATH, "rdr_health2")
@@ -966,9 +976,14 @@ class TestHealthMarkerParse:
         assert d["failure"] is None
         assert d["action"] is None
         assert d["alternates"] is None
+        # State (b): marker said no-row (`-`). The pick has no weight row — valid,
+        # expected data — so it is INSTRUMENTED, not missing. This is the fix: the
+        # gate must read this as instrumented, distinguishable from state (c).
+        assert d["gate_inputs_present"] is True
 
     def test_absent_health_field_writes_null(self, db_env, monkeypatch):
-        # A legacy marker with no health= token => null health, all fields null.
+        # State (c): a legacy marker with no health= token => null health, all
+        # fields null, gate_inputs_present False (no marker gate input at all).
         a = _load(A_PATH, "rdr_health3")
         monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
         monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
@@ -979,6 +994,7 @@ class TestHealthMarkerParse:
         d = next(e for e in _read_events(db_env) if e["type"] == "decision")
         assert d["health_at_decision"] is None
         assert d["action"] is None
+        assert d["gate_inputs_present"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -38,6 +38,7 @@ Usage:
 """
 
 import argparse
+import inspect
 import json
 import re
 import sqlite3
@@ -645,7 +646,7 @@ def collect_route_weights() -> dict[str, dict[str, object]]:
     return {
         row["key"]: {
             "confidence": round(float(row["confidence"]), 4),
-            "n": int(row["observation_count"] or 1),
+            "n": int(row["observation_count"] or 0),
             "success": int(row["success_count"] or 0),
             "failure": int(row["failure_count"] or 0),
             "last_seen": row["last_seen"],
@@ -1065,20 +1066,29 @@ def cmd_route_failure(args: argparse.Namespace) -> None:
     session = args.session or ""
     marker = args.marker or ""
 
-    # Idempotence: only when both keys are present. A duplicate dispatch key is a
-    # no-op (exit 0). Insert succeeds exactly once; a second insert is the dup.
-    if session and marker:
+    # Idempotence ordering — at-least-once, NOT at-most-once. The failure signal
+    # is the scarcest resource in this loop, so a dropped signal is worse than a
+    # re-applied one. Ordering:
+    #   (a) fast dup exit: if the dedup row already exists, no-op (exit 0);
+    #   (b) do the decay + outcome-event work;
+    #   (c) THEN insert + commit the dedup row.
+    # A crash between (b) and (c) leaves no dedup row, so a retry re-applies ONE
+    # decay — bounded and acceptable on a single-user toolkit. The old order
+    # (commit dedup first) silently DROPPED the signal on a crash between commit
+    # and decay: a retry hit IntegrityError and no-op'd, exit 0, no error.
+    # Two identical concurrent invocations can both pass (a) and both apply once;
+    # accepted (single-user, no concurrent route-failure calls).
+    dedup_active = bool(session and marker)
+    if dedup_active:
         with get_connection() as conn:
             _ensure_route_failure_dedup_table(conn)
-            try:
-                conn.execute(
-                    "INSERT INTO route_failure_dedup (session, marker, recorded_at) VALUES (?, ?, ?)",
-                    (session, marker, datetime.now().isoformat()),
-                )
-                conn.commit()
-            except sqlite3.IntegrityError:
-                print(f"Duplicate dispatch key (session={session}, marker={marker}); no-op.")
-                return
+            row = conn.execute(
+                "SELECT 1 FROM route_failure_dedup WHERE session = ? AND marker = ?",
+                (session, marker),
+            ).fetchone()
+        if row is not None:
+            print(f"Duplicate dispatch key (session={session}, marker={marker}); no-op.")
+            return
 
     # route_events lives in hooks/lib (already on sys.path via the header).
     from route_events import record_outcome_event
@@ -1094,7 +1104,33 @@ def cmd_route_failure(args: argparse.Namespace) -> None:
         else:
             decayed_note = f"no weight row for {key}; event logged, nothing to decay"
 
-    record_outcome_event(session=session, key=key, outcome="failure", reason=args.reason)
+    # Pass routing_relevant only if record_outcome_event accepts it. A sibling
+    # change adds the optional param; guard via signature so neither agent breaks
+    # the other while both land.
+    event_kwargs: dict[str, object] = {
+        "session": session,
+        "key": key,
+        "outcome": "failure",
+        "reason": args.reason,
+    }
+    if "routing_relevant" in inspect.signature(record_outcome_event).parameters:
+        event_kwargs["routing_relevant"] = routing_relevant
+    record_outcome_event(**event_kwargs)
+
+    # (c) Mark the dispatch key done only AFTER the work succeeded.
+    if dedup_active:
+        with get_connection() as conn:
+            _ensure_route_failure_dedup_table(conn)
+            try:
+                conn.execute(
+                    "INSERT INTO route_failure_dedup (session, marker, recorded_at) VALUES (?, ?, ?)",
+                    (session, marker, datetime.now().isoformat()),
+                )
+                conn.commit()
+            except sqlite3.IntegrityError:
+                # A concurrent invocation won the insert race; the work is done.
+                pass
+
     print(f"Recorded route failure: {key} (routing-relevant={args.routing_relevant}) — {decayed_note}")
 
 

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -29,6 +29,7 @@ Usage:
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --failure --reason "user re-routed"
     python3 scripts/learning-db.py backfill-routing-outcomes
     python3 scripts/learning-db.py route-health
+    python3 scripts/learning-db.py route-weights --json
     python3 scripts/learning-db.py skip-rate [--json] [--include-test]
 """
 
@@ -609,6 +610,43 @@ def cmd_route_stats(args: argparse.Namespace) -> None:
         print(json_mod.dumps(records, indent=2, default=str))
 
 
+def collect_route_weights() -> dict[str, dict[str, object]]:
+    """Read routing/effectiveness rows into a weight map.
+
+    Returns a dict keyed `<agent>:<skill>` with the fields confidence, n
+    (observation_count), success, failure, last_seen. Read-only; excludes
+    obvious test rows (source LIKE 'test%'); deterministic key ordering.
+    """
+    init_db()
+    # Read only the columns we emit, ordered by key, for speed and determinism.
+    # Excludes obvious test rows (source LIKE 'test%'); read-only.
+    with get_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT key, confidence, observation_count, success_count, failure_count, last_seen
+            FROM learnings
+            WHERE topic = 'routing' AND category = 'effectiveness'
+              AND source NOT LIKE 'test%'
+            ORDER BY key ASC
+            """
+        ).fetchall()
+    return {
+        row["key"]: {
+            "confidence": round(float(row["confidence"]), 4),
+            "n": int(row["observation_count"] or 1),
+            "success": int(row["success_count"] or 0),
+            "failure": int(row["failure_count"] or 0),
+            "last_seen": row["last_seen"],
+        }
+        for row in rows
+    }
+
+
+def cmd_route_weights(args: argparse.Namespace) -> None:
+    """Emit routing weights as JSON for health-aware re-ranking."""
+    print(json.dumps(collect_route_weights(), indent=2, default=str))
+
+
 def cmd_record_routing_outcome(args: argparse.Namespace) -> None:
     """Record whether a routing decision succeeded or failed."""
     init_db()
@@ -1060,6 +1098,13 @@ def main():
     )
     p_route_stats.add_argument("--json", action="store_true", help="Also output raw JSON")
     p_route_stats.set_defaults(func=cmd_route_stats)
+
+    # route-weights
+    p_route_weights = subparsers.add_parser(
+        "route-weights", help="Emit routing weights as JSON (read-only) for health-aware re-rank"
+    )
+    p_route_weights.add_argument("--json", action="store_true", help="Output as JSON (only supported format)")
+    p_route_weights.set_defaults(func=cmd_route_weights)
 
     # record-routing-outcome
     p_rro = subparsers.add_parser("record-routing-outcome", help="Record routing decision outcome")

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -30,6 +30,7 @@ Usage:
     python3 scripts/learning-db.py telemetry-query --topic eval:evals/<dir> [--git-sha SHA] [--format json]
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --success
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --failure --reason "user re-routed"
+    python3 scripts/learning-db.py route-failure AGENT:SKILL --reason "re-route after unusable output" --routing-relevant yes [--session SID --marker MK]
     python3 scripts/learning-db.py backfill-routing-outcomes
     python3 scripts/learning-db.py route-health [--json]
     python3 scripts/learning-db.py route-weights --json
@@ -1024,6 +1025,79 @@ def cmd_record_routing_outcome(args: argparse.Namespace) -> None:
     print(f"Recorded {outcome} for routing/{key} — confidence: {new_conf:.4f}")
 
 
+def _ensure_route_failure_dedup_table(conn: sqlite3.Connection) -> None:
+    """Create the route_failure_dedup table if absent (idempotence ledger).
+
+    learning_db_v2.py is never edited (a pre-existing SQLi false-positive there
+    trips the commit security gate), so the table is created here, like
+    _ensure_archive_table. One row per (session, marker) dispatch key records a
+    failure already counted, so a retry loop cannot decay a pair repeatedly.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS route_failure_dedup (
+            session TEXT NOT NULL,
+            marker TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            PRIMARY KEY (session, marker)
+        )
+        """
+    )
+    conn.commit()
+
+
+def cmd_route_failure(args: argparse.Namespace) -> None:
+    """Record an orchestrator-reported routing failure (ADR: orchestrator-reported-route-failures).
+
+    Routing-relevant => decay the pair's weight row via the finalizer's decay
+    path (apply_outcome failure) AND append a reasoned failure event. Not-relevant
+    => event only, zero decay (a task failure by the right route must not poison
+    route health). Idempotent per dispatch key (session, marker): a duplicate is a
+    no-op, exit 0. Malformed pair (no ':') exits non-zero.
+    """
+    key = args.agent_skill
+    if ":" not in key:
+        print(f"Error: pair must be 'agent:skill', got {key!r}", file=sys.stderr)
+        sys.exit(2)
+
+    init_db()
+    routing_relevant = args.routing_relevant == "yes"
+    session = args.session or ""
+    marker = args.marker or ""
+
+    # Idempotence: only when both keys are present. A duplicate dispatch key is a
+    # no-op (exit 0). Insert succeeds exactly once; a second insert is the dup.
+    if session and marker:
+        with get_connection() as conn:
+            _ensure_route_failure_dedup_table(conn)
+            try:
+                conn.execute(
+                    "INSERT INTO route_failure_dedup (session, marker, recorded_at) VALUES (?, ?, ?)",
+                    (session, marker, datetime.now().isoformat()),
+                )
+                conn.commit()
+            except sqlite3.IntegrityError:
+                print(f"Duplicate dispatch key (session={session}, marker={marker}); no-op.")
+                return
+
+    # route_events lives in hooks/lib (already on sys.path via the header).
+    from route_events import record_outcome_event
+
+    decayed_note = "no decay (not routing-relevant)"
+    if routing_relevant:
+        # Reuse the finalizer's decay path — do NOT invent a second formula.
+        from routing_outcome_score import apply_outcome, decision_row_exists
+
+        if decision_row_exists(key):
+            new_conf = apply_outcome(key, "failure")
+            decayed_note = f"decayed routing/{key} -> confidence {new_conf:.4f}"
+        else:
+            decayed_note = f"no weight row for {key}; event logged, nothing to decay"
+
+    record_outcome_event(session=session, key=key, outcome="failure", reason=args.reason)
+    print(f"Recorded route failure: {key} (routing-relevant={args.routing_relevant}) — {decayed_note}")
+
+
 def cmd_backfill_routing_outcomes(args: argparse.Namespace) -> None:
     """Backfill routing outcomes from existing entry data."""
     init_db()
@@ -1566,6 +1640,21 @@ def main():
     p_rro_group.add_argument("--failure", action="store_true", help="Route failed")
     p_rro.add_argument("--reason", help="Reason for outcome (appended to value)")
     p_rro.set_defaults(func=cmd_record_routing_outcome)
+
+    # route-failure — orchestrator-reported routing failure (ADR: orchestrator-reported-route-failures)
+    p_rf = subparsers.add_parser("route-failure", help="Record an orchestrator-reported routing failure")
+    p_rf.add_argument("agent_skill", help="Routing key (e.g., golang-general-engineer:go-patterns)")
+    p_rf.add_argument("--reason", required=True, help="Why the route failed (recorded with the event)")
+    p_rf.add_argument(
+        "--routing-relevant",
+        dest="routing_relevant",
+        required=True,
+        choices=["yes", "no"],
+        help="yes => decay the pair + log event; no => log event only, no decay",
+    )
+    p_rf.add_argument("--session", help="Session ID (with --marker, the idempotence dispatch key)")
+    p_rf.add_argument("--marker", help="Dispatch marker (with --session, the idempotence dispatch key)")
+    p_rf.set_defaults(func=cmd_route_failure)
 
     # backfill-routing-outcomes
     p_backfill = subparsers.add_parser(

--- a/scripts/lib/route_policy.py
+++ b/scripts/lib/route_policy.py
@@ -1,0 +1,187 @@
+"""Pure health-aware re-rank policy for routing decisions.
+
+`health_adjust()` decides whether the semantic routing pick stands, is demoted
+to a healthier alternate, or is tie-broken toward a healthier alternate. It is
+PURE: no DB, no clock, no filesystem, no mutation of its inputs. The caller
+(skills/meta/do Step 1.5) supplies the semantic pick, the alternates, the T1
+weight map (`route-weights --json`), and the set of force-routed pairs.
+
+Design (frozen spec T2):
+  - Evidence gate: never demote a pick with n < MIN_OBSERVATIONS (5).
+  - Floor demote: demote ONLY if confidence < FLOOR_CONFIDENCE (0.30) AND
+    failure >= FLOOR_FAILURES (3) AND n >= MIN_OBSERVATIONS.
+  - Force-route / security pairs are NEVER demoted (hard exempt) — checked
+    first, before any health logic.
+  - Tie-break toward a higher-health alternate ONLY when the semantic
+    confidence is "low" (< LOW_CONFIDENCE, 0.35).
+  - Default: the semantic pick stands.
+
+On current real data the demote branch cannot fire (zero failure-bearing rows),
+so the wiring is instrumentation until negative signal accumulates. The synthetic
+replay arm (T7) proves the mechanism on seeded failure data.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+
+# Gate / floor thresholds (frozen spec T2).
+MIN_OBSERVATIONS = 5
+FLOOR_CONFIDENCE = 0.30
+FLOOR_FAILURES = 3
+LOW_CONFIDENCE = 0.35
+
+
+def _key_of(item: object) -> str | None:
+    """Extract the `agent:skill` key from a pick/alternate (str or mapping)."""
+    if isinstance(item, str):
+        return item
+    if isinstance(item, Mapping):
+        key = item.get("key")
+        return key if isinstance(key, str) else None
+    return None
+
+
+def _is_exempt(key: str, force_route_flags: Iterable[str]) -> bool:
+    """True iff `key` is force-routed (by full `agent:skill` pair or skill name).
+
+    The caller may pass either full pairs (``agent:skill``) or bare skill names
+    (the manifest keys force_route by skill). Both forms exempt the pick.
+    """
+    flags = set(force_route_flags)
+    if key in flags:
+        return True
+    skill = key.split(":", 1)[1] if ":" in key else key
+    return skill in flags
+
+
+def _health_score(entry: Mapping[str, object]) -> float:
+    """Rank candidates: success rate weighted by confidence. Higher = healthier."""
+    n = int(entry.get("n", 0) or 0)
+    success = int(entry.get("success", 0) or 0)
+    confidence = float(entry.get("confidence", 0.0) or 0.0)
+    rate = (success / n) if n > 0 else 0.0
+    return rate * confidence
+
+
+def _is_floor(entry: Mapping[str, object]) -> bool:
+    """True iff the entry meets ALL floor-demote conditions."""
+    n = int(entry.get("n", 0) or 0)
+    failure = int(entry.get("failure", 0) or 0)
+    confidence = float(entry.get("confidence", 0.0) or 0.0)
+    return confidence < FLOOR_CONFIDENCE and failure >= FLOOR_FAILURES and n >= MIN_OBSERVATIONS
+
+
+def _healthiest_alternate(
+    alternates: Sequence[object],
+    weights: Mapping[str, Mapping[str, object]],
+    must_beat: float,
+) -> str | None:
+    """Return the alternate key with the highest health score above `must_beat`.
+
+    Skips alternates with no weight row (no evidence to prefer them).
+    Deterministic: ties resolve to the first alternate in input order.
+    """
+    best_key: str | None = None
+    best_score = must_beat
+    for alt in alternates:
+        alt_key = _key_of(alt)
+        if alt_key is None or alt_key not in weights:
+            continue
+        score = _health_score(weights[alt_key])
+        if score > best_score:
+            best_score = score
+            best_key = alt_key
+    return best_key
+
+
+def health_adjust(
+    semantic_pick: Mapping[str, object],
+    alternates: Sequence[object],
+    weights: Mapping[str, Mapping[str, object]],
+    force_route_flags: Iterable[str],
+) -> dict[str, object]:
+    """Decide the final route given semantic pick + health weights. Pure.
+
+    Args:
+        semantic_pick: the LLM's pick. Mapping with ``key`` (``agent:skill``)
+            and ``confidence`` (the semantic confidence, 0..1).
+        alternates: candidate keys/dicts to re-rank toward (each a str or a
+            mapping with ``key``).
+        weights: the T1 weight map keyed ``agent:skill`` ->
+            {confidence, n, success, failure, last_seen}.
+        force_route_flags: pairs or skill names that are force-routed and must
+            never be demoted.
+
+    Returns:
+        ``{final_pick, action, reason}`` where action is one of
+        ``keep`` | ``demote`` | ``tiebreak``.
+    """
+    pick_key = _key_of(semantic_pick)
+    if pick_key is None:
+        return {
+            "final_pick": None,
+            "action": "keep",
+            "reason": "no pick key supplied; nothing to adjust",
+        }
+
+    # 1) Force-route / security exemption — checked FIRST, before any health.
+    if _is_exempt(pick_key, force_route_flags):
+        return {
+            "final_pick": pick_key,
+            "action": "keep",
+            "reason": f"force-route exempt: {pick_key} is never demoted",
+        }
+
+    entry = weights.get(pick_key)
+
+    # 2) Evidence gate: no row, or n < MIN_OBSERVATIONS => never demote.
+    if entry is None:
+        return {
+            "final_pick": pick_key,
+            "action": "keep",
+            "reason": "fresh pick: no health evidence; semantic pick stands",
+        }
+    n = int(entry.get("n", 0) or 0)
+    if n < MIN_OBSERVATIONS:
+        return {
+            "final_pick": pick_key,
+            "action": "keep",
+            "reason": f"evidence gate: n={n} < {MIN_OBSERVATIONS}; semantic pick stands",
+        }
+
+    # 3) Floor demote: confidence < 0.30 AND failure >= 3 AND n >= 5.
+    if _is_floor(entry):
+        target = _healthiest_alternate(alternates, weights, must_beat=_health_score(entry))
+        if target is not None:
+            conf = float(entry.get("confidence", 0.0) or 0.0)
+            fail = int(entry.get("failure", 0) or 0)
+            return {
+                "final_pick": target,
+                "action": "demote",
+                "reason": (f"floor demote: {pick_key} (conf={conf:.2f}, fail/n={fail}/{n}) -> {target}"),
+            }
+        # No healthier alternate to move to — pick stands.
+        return {
+            "final_pick": pick_key,
+            "action": "keep",
+            "reason": "floor met but no healthier alternate; semantic pick stands",
+        }
+
+    # 4) Low-confidence tie-break: only when the SEMANTIC confidence is low.
+    sem_conf = float(semantic_pick.get("confidence", 1.0) or 0.0)
+    if sem_conf < LOW_CONFIDENCE:
+        target = _healthiest_alternate(alternates, weights, must_beat=_health_score(entry))
+        if target is not None:
+            return {
+                "final_pick": target,
+                "action": "tiebreak",
+                "reason": (f"low semantic confidence ({sem_conf:.2f}); tie-break toward healthier {target}"),
+            }
+
+    # 5) Default: the semantic pick stands.
+    return {
+        "final_pick": pick_key,
+        "action": "keep",
+        "reason": "semantic pick stands (healthy / above floor / confident)",
+    }

--- a/scripts/lib/route_policy.py
+++ b/scripts/lib/route_policy.py
@@ -13,12 +13,27 @@ Design (frozen spec T2):
   - Force-route / security pairs are NEVER demoted (hard exempt) — checked
     first, before any health logic.
   - Tie-break toward a higher-health alternate ONLY when the semantic
-    confidence is "low" (< LOW_CONFIDENCE, 0.35).
+    confidence is "low" (< LOW_CONFIDENCE, 0.35) AND the alternate clears the
+    evidence gate (n >= MIN_OBSERVATIONS). Under-evidenced alternates are never
+    preferred.
   - Default: the semantic pick stands.
 
-On current real data the demote branch cannot fire (zero failure-bearing rows),
-so the wiring is instrumentation until negative signal accumulates. The synthetic
-replay arm (T7) proves the mechanism on seeded failure data.
+force_route_flags form contract: the caller (SKILL.md Step 1.5, route-replay)
+passes either bare skill names (the manifest's form, e.g. ``security-review``)
+or full ``agent:skill`` pairs. Exemption is decided by SKILL name, so a security
+skill is protected regardless of which agent the semantic layer paired it with.
+
+Reachability on current real data:
+  - DEMOTE cannot fire: every live row is >= 0.5 confidence with 0 failures, so
+    the floor (conf<0.30 AND fail>=3 AND n>=5) matches no row.
+  - TIE-BREAK CAN fire: it is gated on SEMANTIC confidence, not on the floor.
+    On a live /do where the semantic layer reports low confidence (< 0.35) AND
+    supplies an evidenced healthier alternate, the route is moved. This is
+    intended behavior (spec T2), not a defect — but it means Step 1.5 is NOT a
+    pure no-op on current data; the precise claim is "demote is unreachable;
+    tie-break only fires on low-confidence picks with an evidenced alternate."
+The synthetic replay arm (T7) proves both demote (help) and the force-route
+exemption; the tie-break arm proves the low-confidence path moves toward gold.
 """
 
 from __future__ import annotations
@@ -42,17 +57,30 @@ def _key_of(item: object) -> str | None:
     return None
 
 
-def _is_exempt(key: str, force_route_flags: Iterable[str]) -> bool:
-    """True iff `key` is force-routed (by full `agent:skill` pair or skill name).
+def _skill_of(token: str) -> str:
+    """Skill name from a flag/key that may be a bare skill or ``agent:skill``."""
+    return token.split(":", 1)[1] if ":" in token else token
 
-    The caller may pass either full pairs (``agent:skill``) or bare skill names
-    (the manifest keys force_route by skill). Both forms exempt the pick.
+
+def _is_exempt(key: str, force_route_flags: Iterable[str]) -> bool:
+    """True iff `key` is force-routed. Skill-name match is authoritative.
+
+    The caller may pass force_route_flags as bare skill names (the manifest's
+    form) OR full ``agent:skill`` pairs. Force-route / security protection is
+    keyed by SKILL, not agent: a security skill must be exempt no matter which
+    agent the semantic layer paired it with. So a pick is exempt when its skill
+    name matches ANY flag's skill name (full-pair flags are reduced to their
+    skill), or when the full pick key matches a flag verbatim.
+
+    Hardened against attack C: a flag given as ``otheragent:security-review``
+    no longer fails to protect a pick ``pickagent:security-review`` — both
+    reduce to skill ``security-review`` and match.
     """
     flags = set(force_route_flags)
     if key in flags:
         return True
-    skill = key.split(":", 1)[1] if ":" in key else key
-    return skill in flags
+    pick_skill = _skill_of(key)
+    return any(_skill_of(flag) == pick_skill for flag in flags)
 
 
 def _health_score(entry: Mapping[str, object]) -> float:
@@ -76,11 +104,14 @@ def _healthiest_alternate(
     alternates: Sequence[object],
     weights: Mapping[str, Mapping[str, object]],
     must_beat: float,
+    require_evidence: bool = False,
 ) -> str | None:
     """Return the alternate key with the highest health score above `must_beat`.
 
-    Skips alternates with no weight row (no evidence to prefer them).
-    Deterministic: ties resolve to the first alternate in input order.
+    Skips alternates with no weight row (no evidence to prefer them). When
+    ``require_evidence`` is set, also skips alternates below MIN_OBSERVATIONS —
+    used by tie-break so a route is never moved toward an under-evidenced
+    alternate. Deterministic: ties resolve to the first alternate in input order.
     """
     best_key: str | None = None
     best_score = must_beat
@@ -88,7 +119,10 @@ def _healthiest_alternate(
         alt_key = _key_of(alt)
         if alt_key is None or alt_key not in weights:
             continue
-        score = _health_score(weights[alt_key])
+        entry = weights[alt_key]
+        if require_evidence and int(entry.get("n", 0) or 0) < MIN_OBSERVATIONS:
+            continue
+        score = _health_score(entry)
         if score > best_score:
             best_score = score
             best_key = alt_key
@@ -171,7 +205,7 @@ def health_adjust(
     # 4) Low-confidence tie-break: only when the SEMANTIC confidence is low.
     sem_conf = float(semantic_pick.get("confidence", 1.0) or 0.0)
     if sem_conf < LOW_CONFIDENCE:
-        target = _healthiest_alternate(alternates, weights, must_beat=_health_score(entry))
+        target = _healthiest_alternate(alternates, weights, must_beat=_health_score(entry), require_evidence=True)
         if target is not None:
             return {
                 "final_pick": target,

--- a/scripts/lib/route_policy.py
+++ b/scripts/lib/route_policy.py
@@ -62,6 +62,18 @@ def _skill_of(token: str) -> str:
     return token.split(":", 1)[1] if ":" in token else token
 
 
+def _norm_skill(token: str) -> str:
+    """Skill name from a token, normalized for comparison: strip + casefold.
+
+    Defense-in-depth. Inputs are canonical in practice (manifest skill names and
+    route keys are lowercase, untrimmed), so this normalization should be a
+    no-op on real data — Codex rates operational reachability medium confidence.
+    It closes the bypass class where a noncanonical pick or flag (changed case
+    or surrounding whitespace) slips past the force-route exemption.
+    """
+    return _skill_of(token).strip().casefold()
+
+
 def _is_exempt(key: str, force_route_flags: Iterable[str]) -> bool:
     """True iff `key` is force-routed. Skill-name match is authoritative.
 
@@ -75,12 +87,17 @@ def _is_exempt(key: str, force_route_flags: Iterable[str]) -> bool:
     Hardened against attack C: a flag given as ``otheragent:security-review``
     no longer fails to protect a pick ``pickagent:security-review`` — both
     reduce to skill ``security-review`` and match.
+
+    Codex C2: the skill-name reduction is normalized (strip + casefold) on BOTH
+    sides, so a noncanonical pick/flag (case-changed or whitespace-padded)
+    cannot bypass the exemption. This is defense-in-depth; inputs are canonical
+    in practice (medium confidence on operational reachability).
     """
     flags = set(force_route_flags)
     if key in flags:
         return True
-    pick_skill = _skill_of(key)
-    return any(_skill_of(flag) == pick_skill for flag in flags)
+    pick_skill = _norm_skill(key)
+    return any(_norm_skill(flag) == pick_skill for flag in flags)
 
 
 def _health_score(entry: Mapping[str, object]) -> float:

--- a/scripts/route-decommission-check.py
+++ b/scripts/route-decommission-check.py
@@ -4,7 +4,7 @@
 One question: should the outcome-routing shadow loop be removed today? The
 answer is a count-based, shadow-inclusive verdict with an exit code — not prose.
 
-Clock start = the Stage-0 wiring-fix commit (d943ba74, 2026-06-06 21:21:07 UTC),
+Clock start = the Step-1.5 wiring-fix commit (d943ba74, 2026-06-06 21:21:07 UTC),
 hardcoded below. "Post-fix" events are decision/outcome events with ts >= that
 epoch; pre-fix events are ignored (their health field was never wired).
 
@@ -22,14 +22,28 @@ Verdicts (the trigger contract):
 
 interventions:
   real    = decision events whose recorded `action` is demote or tiebreak (the
-            router actually re-ranked the route).
+            router actually re-ranked the route). A recorded tiebreak counts as a
+            real intervention here: it is ground truth, the router fired.
   shadow  = replay `route_policy.health_adjust` on the RECORDED gate inputs of
             each decision (health_at_decision, n, failure, alternates); count
-            where the replay action is demote or tiebreak. Gate inputs are read
-            as recorded — never re-derived from current weights (ADR codex 29).
+            ONLY where the replay action is demote. Gate inputs are read as
+            recorded — never re-derived from current weights (ADR codex 29).
             Recorded alternates that carry their own weight fields let the shadow
             replay prefer them; bare-key alternates have no weight row, so the
             shadow replay cannot fire toward them (honest zero, not a hidden one).
+
+  Shadow tiebreak is UNMEASURABLE and is never counted as shadow. The tiebreak
+  gate keys on SEMANTIC confidence (< 0.35), which decision events do not record
+  — only the weight-row confidence (health_at_decision) is stored. Replaying
+  tiebreak from health_at_decision would conflate two unrelated values (a
+  high-semantic-confidence pick with a low historical weight row would fire a
+  spurious shadow tiebreak, pushing the verdict toward KEEP). So the criterion
+  is: real tiebreaks (recorded action) + real demotes + shadow demotes.
+
+  Shadow replay also passes the canonical force-route skill set (same source
+  production uses: routing-manifest force_route entries via route-replay
+  force_route_skills). A force-routed pair is hard-exempt and can never count as
+  a shadow demote, mirroring production.
 
 Clock validity (else the zero is not trustworthy). Three instrumentation states,
 keyed on what the do-route marker carried:
@@ -54,6 +68,7 @@ written. Tests pass explicit temp paths.
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import sys
 import time
@@ -66,8 +81,36 @@ if str(_REPO_ROOT) not in sys.path:
 
 from scripts.lib.route_policy import health_adjust
 
-# Clock start: the Stage-0 wiring-fix commit (records health gate inputs on the
+
+def _load_force_route_skills() -> set[str]:
+    """Load the canonical force-route skill set production uses.
+
+    Reuses route-replay's force_route_skills (routing-manifest force_route
+    entries) — do not duplicate the list. Best-effort: an empty set on any load
+    failure means no pair is treated as exempt, which can only INFLATE shadow
+    demote (never hide a real one). Fail-safe direction: a load failure can only
+    produce a conservative KEEP (loop survives), never a false DELETE.
+    """
+    try:
+        spec = importlib.util.spec_from_file_location("_route_replay_force", _REPO_ROOT / "scripts" / "route-replay.py")
+        if spec is None or spec.loader is None:
+            return set()
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return set(module.force_route_skills())
+    except Exception:
+        return set()
+
+
+# Canonical force-route set, loaded once. A force-routed pair is hard-exempt in
+# production and must never count as a shadow demote (codex #6).
+_FORCE_ROUTE_SKILLS = _load_force_route_skills()
+
+# Clock start: the Step-1.5 wiring-fix commit (records health gate inputs on the
 # do-route marker). `git show -s --format=%ct d943ba74` == 1780780867.
+# Naming: the health gate is "Step 1.5" (do/SKILL.md, the producer); it was
+# called "Stage 0" during development. The constants and the `stage0_commit`
+# output key keep the historical name — they label a fixed commit, not the step.
 STAGE0_FIX_COMMIT = "d943ba74"
 STAGE0_FIX_EPOCH = 1780780867  # 2026-06-06 21:21:07 +0000
 
@@ -106,17 +149,25 @@ def _iter_events(events_path: Path):
                 continue
 
 
-def _shadow_action(decision: dict[str, Any]) -> str:
-    """Replay health_adjust on a decision's RECORDED gate inputs.
+def _shadow_demote(decision: dict[str, Any]) -> bool:
+    """True iff replaying the demote FLOOR on recorded gate inputs would demote.
 
-    Builds the weight map from what the decision recorded — the picked pair's
-    {confidence=health_at_decision, n, failure} and any alternate that carries
-    its own weight fields. Returns the replay action (keep | demote | tiebreak).
-    Never reads current weights.
+    Evaluates ONLY the floor-demote path (codex finding 3): the tiebreak gate
+    reads SEMANTIC confidence, which decision events do not record, so a tiebreak
+    replay would conflate the weight-row confidence with semantic confidence.
+    We force semantic confidence to 1.0 (>= LOW_CONFIDENCE) so the tiebreak gate
+    can never fire — the replay returns demote only when the floor truly engages.
+
+    The picked pair's weight row is the recorded gate inputs the floor reads:
+    confidence=health_at_decision, n, failure (the floor never reads `success`,
+    so no field is fabricated). Recorded alternates that carry their own weight
+    fields can be demoted toward; bare-key alternates have no weight row and
+    cannot be preferred. The canonical force-route set is passed so a hard-exempt
+    pair is never shadow-demoted (codex #6). Never reads current weights.
     """
     health = decision.get("health_at_decision")
     if health is None:
-        return "keep"  # no health recorded => nothing to replay
+        return False  # no health recorded => nothing to replay
     agent = decision.get("agent") or "direct"
     skill = decision.get("skill") or ""
     pick_key = f"{agent}:{skill}"
@@ -124,7 +175,6 @@ def _shadow_action(decision: dict[str, Any]) -> str:
         pick_key: {
             "confidence": health,
             "n": decision.get("n") or 0,
-            "success": 0,
             "failure": decision.get("failure") or 0,
         }
     }
@@ -141,17 +191,22 @@ def _shadow_action(decision: dict[str, Any]) -> str:
             alt_keys.append(k)
         elif isinstance(alt, str):
             alt_keys.append(alt)  # bare key: no weight row, cannot be preferred
-    pick = {"key": pick_key, "confidence": health}
-    return health_adjust(pick, alt_keys, weights, set())["action"]
+    # Semantic confidence forced to 1.0 so the tiebreak gate cannot fire; only
+    # the floor-demote path can return "demote".
+    pick = {"key": pick_key, "confidence": 1.0}
+    return health_adjust(pick, alt_keys, weights, _FORCE_ROUTE_SKILLS)["action"] == "demote"
 
 
 def count_post_fix(events_path: Path) -> dict[str, Any]:
     """Count post-fix interventions, health rate, and outcome unknown rate.
 
-    real_demote/real_tiebreak come from the recorded `action`; shadow_* from the
-    health_adjust replay on recorded gate inputs. health_rate = non-null health /
+    real_demote/real_tiebreak come from the recorded `action`; shadow_demote
+    from the floor-only health_adjust replay on recorded gate inputs (shadow
+    tiebreak is unmeasurable and never counted). health_rate = non-null health /
     decisions. unknown_rate = decisions with no joinable outcome / decisions
-    (join: nearest preceding decision in the same session).
+    (join: nearest preceding decision in the same session). Sessionless rows
+    (empty session) are excluded from the join and reported in a separate bucket
+    so they distort neither unknown_rate nor instrumented_rate (codex #7).
     """
     decisions: list[dict[str, Any]] = []
     outcomes: list[dict[str, Any]] = []
@@ -165,7 +220,7 @@ def count_post_fix(events_path: Path) -> dict[str, Any]:
             outcomes.append(ev)
 
     real_demote = real_tiebreak = 0
-    shadow_demote = shadow_tiebreak = 0
+    shadow_demote = 0
     state_a = state_b = state_c = 0
     for d in decisions:
         action = d.get("action")
@@ -174,21 +229,21 @@ def count_post_fix(events_path: Path) -> dict[str, Any]:
         elif action == "tiebreak":
             real_tiebreak += 1
         state_a, state_b, state_c = _bump_state(d, state_a, state_b, state_c)
-        sa = _shadow_action(d)
-        if sa == "demote":
+        if _shadow_demote(d):
             shadow_demote += 1
-        elif sa == "tiebreak":
-            shadow_tiebreak += 1
 
     n_dec = len(decisions)
     # instrumented = state (a) + state (b): the marker carried the gate input.
     # Only state (c) (no gate input) counts against the 95% rate.
     instrumented = state_a + state_b
     instrumented_rate = (instrumented / n_dec) if n_dec else 0.0
-    joined = _count_joined(decisions, outcomes)
-    unknown_rate = ((n_dec - joined) / n_dec) if n_dec else 1.0
+    joined, sessionless_decisions, sessionless_outcomes = _count_joined(decisions, outcomes)
+    # Sessionless decisions cannot be joined to an outcome by session id, so they
+    # are excluded from the unknown_rate denominator rather than counted unknown.
+    joinable_dec = n_dec - sessionless_decisions
+    unknown_rate = ((joinable_dec - joined) / joinable_dec) if joinable_dec else 1.0
 
-    interventions = real_demote + real_tiebreak + shadow_demote + shadow_tiebreak
+    interventions = real_demote + real_tiebreak + shadow_demote
     return {
         "post_fix_decisions": n_dec,
         "post_fix_outcomes": len(outcomes),
@@ -198,11 +253,13 @@ def count_post_fix(events_path: Path) -> dict[str, Any]:
         "instrumented": instrumented,
         "instrumented_rate": round(instrumented_rate, 4),
         "joined_outcomes": joined,
+        "joinable_decisions": joinable_dec,
+        "sessionless_decisions": sessionless_decisions,
+        "sessionless_outcomes": sessionless_outcomes,
         "unknown_rate": round(unknown_rate, 4),
         "real_demote": real_demote,
         "real_tiebreak": real_tiebreak,
         "shadow_demote": shadow_demote,
-        "shadow_tiebreak": shadow_tiebreak,
         "interventions": interventions,
     }
 
@@ -223,21 +280,34 @@ def _bump_state(d: dict[str, Any], a: int, b: int, c: int) -> tuple[int, int, in
     return a, b, c + 1
 
 
-def _count_joined(decisions: list[dict[str, Any]], outcomes: list[dict[str, Any]]) -> int:
-    """Count decisions that join an outcome by session (nearest preceding).
+def _count_joined(decisions: list[dict[str, Any]], outcomes: list[dict[str, Any]]) -> tuple[int, int, int]:
+    """Join decisions to outcomes by session; report sessionless rows separately.
 
     Each outcome attaches to the latest decision in its session at or before the
     outcome ts. A decision counts as joined once at least one outcome attaches to
     it. Mirrors the ADR join key (session id + nearest preceding decision).
+
+    Empty-session rows are EXCLUDED from the join (codex #7): grouping them under
+    "" would join unrelated sessionless outcomes across dispatches and distort
+    the rates. They are counted in explicit sessionless buckets so nothing is
+    silently dropped. Returns ``(joined, sessionless_decisions,
+    sessionless_outcomes)``.
     """
+    sessionless_decisions = sum(1 for d in decisions if not d.get("session"))
+    sessionless_outcomes = sum(1 for o in outcomes if not o.get("session"))
     by_session: dict[str, list[tuple[float, int]]] = {}
     for idx, d in enumerate(decisions):
-        by_session.setdefault(d.get("session", ""), []).append((d.get("ts", 0.0), idx))
+        sess = d.get("session")
+        if not sess:
+            continue  # sessionless: cannot be joined, counted in its own bucket
+        by_session.setdefault(sess, []).append((d.get("ts", 0.0), idx))
     for lst in by_session.values():
         lst.sort()
     joined_idx: set[int] = set()
     for o in outcomes:
-        sess = o.get("session", "")
+        sess = o.get("session")
+        if not sess:
+            continue  # sessionless outcome: never joins
         lst = by_session.get(sess)
         if not lst:
             continue
@@ -250,7 +320,7 @@ def _count_joined(decisions: list[dict[str, Any]], outcomes: list[dict[str, Any]
                 break
         if cand is not None:
             joined_idx.add(cand)
-    return len(joined_idx)
+    return len(joined_idx), sessionless_decisions, sessionless_outcomes
 
 
 def clock_valid(stats: dict[str, Any]) -> tuple[bool, str]:
@@ -275,7 +345,8 @@ def clock_valid(stats: dict[str, Any]) -> tuple[bool, str]:
         return (
             False,
             f"outcome unknown_rate {stats['unknown_rate']:.4f} > {MAX_UNKNOWN_RATE} "
-            f"({stats['post_fix_decisions'] - stats['joined_outcomes']}/{stats['post_fix_decisions']} unjoinable)",
+            f"({stats['joinable_decisions'] - stats['joined_outcomes']}/{stats['joinable_decisions']} "
+            f"unjoinable; {stats['sessionless_decisions']} sessionless decision(s) excluded)",
         )
     return True, ""
 
@@ -351,7 +422,9 @@ def render_human(res: dict[str, Any]) -> str:
         f"(instrumented a+b={res['instrumented']}/{res['post_fix_decisions']})",
         f"interventions: {res['interventions']} "
         f"(real demote={res['real_demote']} tiebreak={res['real_tiebreak']}; "
-        f"shadow demote={res['shadow_demote']} tiebreak={res['shadow_tiebreak']})",
+        f"shadow demote={res['shadow_demote']}; shadow tiebreak unmeasurable — not counted)",
+        f"sessionless (left out of the session match): decisions={res['sessionless_decisions']} "
+        f"outcomes={res['sessionless_outcomes']}",
         f"clock valid: {str(res['clock_valid']).lower()}  "
         f"(instrumented_rate={res['instrumented_rate']} >= {MIN_INSTRUMENTED_RATE}? ; "
         f"unknown_rate={res['unknown_rate']} <= {MAX_UNKNOWN_RATE}?)",

--- a/scripts/route-decommission-check.py
+++ b/scripts/route-decommission-check.py
@@ -17,7 +17,7 @@ Verdicts (the trigger contract):
   ACCRUING      zero interventions, clock valid, neither threshold reached.
                 Keep collecting; prints exact remaining days/decisions. Exit 0.
   CLOCK-INVALID the recorded telemetry cannot support a DELETE/KEEP decision:
-                post-fix non-null health rate < 95% OR outcome unknown_rate > 5%.
+                post-fix INSTRUMENTED rate < 95% OR outcome unknown_rate > 5%.
                 The zero cannot be trusted. Exit 4.
 
 interventions:
@@ -31,9 +31,18 @@ interventions:
             replay prefer them; bare-key alternates have no weight row, so the
             shadow replay cannot fire toward them (honest zero, not a hidden one).
 
-Clock validity (else the zero is not trustworthy):
-  health_rate  = post-fix decisions with non-null health_at_decision / total
-                 post-fix decisions; must be >= 95%.
+Clock validity (else the zero is not trustworthy). Three instrumentation states,
+keyed on what the do-route marker carried:
+  (a) numeric  health=<float>  -> health_at_decision float.
+  (b) no-row   health=-        -> health null, gate_inputs_present true. The pick
+               had NO weight row — valid, expected data. Most live picks are
+               state (b); reading it as missing kept the clock unreachable
+               forever (the soundness gap this fixes).
+  (c) legacy   no health= token -> health null, gate_inputs_present false/absent.
+               The marker never carried a gate input (pre-fix / missing wiring).
+  instrumented_rate = (a + b) / total post-fix decisions; must be >= 95%. Only
+                 state (c) counts against it. The validity signal is "marker
+                 carried gate inputs (incl. '-')", NOT "non-null health".
   unknown_rate = post-fix decisions with no joinable outcome / total post-fix
                  decisions; must be <= 5%. Join key (ADR): session id, nearest
                  preceding decision in that session.
@@ -67,7 +76,12 @@ DELETE_DAYS = 90
 DELETE_DECISIONS = 3000
 
 # Clock-validity gates (else CLOCK-INVALID).
-MIN_HEALTH_RATE = 0.95
+# instrumented = decision carried gate inputs on the marker: state (a) numeric
+# health OR state (b) `health=-` (pick had no weight row — valid, expected). Only
+# state (c) (no `health=` token on the marker, legacy/missing wiring) counts
+# against this rate. Reading non-null health as the signal kept the clock
+# unreachable forever, because most picks are state (b) (the soundness fix).
+MIN_INSTRUMENTED_RATE = 0.95
 MAX_UNKNOWN_RATE = 0.05
 
 _DEFAULT_EVENTS = Path.home() / ".claude" / "learning" / "route-events.jsonl"
@@ -152,15 +166,14 @@ def count_post_fix(events_path: Path) -> dict[str, Any]:
 
     real_demote = real_tiebreak = 0
     shadow_demote = shadow_tiebreak = 0
-    non_null_health = 0
+    state_a = state_b = state_c = 0
     for d in decisions:
         action = d.get("action")
         if action == "demote":
             real_demote += 1
         elif action == "tiebreak":
             real_tiebreak += 1
-        if d.get("health_at_decision") is not None:
-            non_null_health += 1
+        state_a, state_b, state_c = _bump_state(d, state_a, state_b, state_c)
         sa = _shadow_action(d)
         if sa == "demote":
             shadow_demote += 1
@@ -168,7 +181,10 @@ def count_post_fix(events_path: Path) -> dict[str, Any]:
             shadow_tiebreak += 1
 
     n_dec = len(decisions)
-    health_rate = (non_null_health / n_dec) if n_dec else 0.0
+    # instrumented = state (a) + state (b): the marker carried the gate input.
+    # Only state (c) (no gate input) counts against the 95% rate.
+    instrumented = state_a + state_b
+    instrumented_rate = (instrumented / n_dec) if n_dec else 0.0
     joined = _count_joined(decisions, outcomes)
     unknown_rate = ((n_dec - joined) / n_dec) if n_dec else 1.0
 
@@ -176,8 +192,11 @@ def count_post_fix(events_path: Path) -> dict[str, Any]:
     return {
         "post_fix_decisions": n_dec,
         "post_fix_outcomes": len(outcomes),
-        "non_null_health": non_null_health,
-        "health_rate": round(health_rate, 4),
+        "state_a_numeric": state_a,
+        "state_b_norow": state_b,
+        "state_c_legacy": state_c,
+        "instrumented": instrumented,
+        "instrumented_rate": round(instrumented_rate, 4),
         "joined_outcomes": joined,
         "unknown_rate": round(unknown_rate, 4),
         "real_demote": real_demote,
@@ -186,6 +205,22 @@ def count_post_fix(events_path: Path) -> dict[str, Any]:
         "shadow_tiebreak": shadow_tiebreak,
         "interventions": interventions,
     }
+
+
+def _bump_state(d: dict[str, Any], a: int, b: int, c: int) -> tuple[int, int, int]:
+    """Classify one decision into the three instrumentation states.
+
+    (a) numeric: health_at_decision is non-null (marker carried a real score).
+    (b) no-row : health null AND gate_inputs_present true (marker said `health=-`;
+        the pick had no weight row — valid, expected data).
+    (c) legacy : neither (no `health=` token on the marker; pre-fix / missing
+        wiring). A legacy event with no gate_inputs_present key lands here.
+    """
+    if d.get("health_at_decision") is not None:
+        return a + 1, b, c
+    if d.get("gate_inputs_present"):
+        return a, b + 1, c
+    return a, b, c + 1
 
 
 def _count_joined(decisions: list[dict[str, Any]], outcomes: list[dict[str, Any]]) -> int:
@@ -222,15 +257,19 @@ def clock_valid(stats: dict[str, Any]) -> tuple[bool, str]:
     """True iff the recorded telemetry can support a DELETE/KEEP decision.
 
     Fails (with the offending number) when there are no post-fix decisions, the
-    non-null health rate is < 95%, or the outcome unknown_rate is > 5%.
+    INSTRUMENTED rate is < 95%, or the outcome unknown_rate is > 5%. Instrumented
+    = state (a) numeric health + state (b) `health=-` no-row; only state (c)
+    (no gate input on the marker) counts against the rate.
     """
     if stats["post_fix_decisions"] == 0:
         return False, "no post-fix decisions recorded yet (clock cannot start)"
-    if stats["health_rate"] < MIN_HEALTH_RATE:
+    if stats["instrumented_rate"] < MIN_INSTRUMENTED_RATE:
         return (
             False,
-            f"health rate {stats['health_rate']:.4f} < {MIN_HEALTH_RATE} "
-            f"({stats['non_null_health']}/{stats['post_fix_decisions']} non-null)",
+            f"instrumented rate {stats['instrumented_rate']:.4f} < {MIN_INSTRUMENTED_RATE} "
+            f"(a numeric={stats['state_a_numeric']} + b no-row={stats['state_b_norow']} "
+            f"= {stats['instrumented']}/{stats['post_fix_decisions']}; "
+            f"c legacy={stats['state_c_legacy']} not instrumented)",
         )
     if stats["unknown_rate"] > MAX_UNKNOWN_RATE:
         return (
@@ -307,11 +346,14 @@ def render_human(res: dict[str, Any]) -> str:
         f"elapsed: {res['elapsed_days']} days  | remaining to delete: "
         f"{res['remaining_days']} days OR {res['remaining_decisions']} decisions",
         f"post-fix decisions: {res['post_fix_decisions']}",
+        f"instrumentation states: a numeric={res['state_a_numeric']} "
+        f"b no-row={res['state_b_norow']} c legacy={res['state_c_legacy']} "
+        f"(instrumented a+b={res['instrumented']}/{res['post_fix_decisions']})",
         f"interventions: {res['interventions']} "
         f"(real demote={res['real_demote']} tiebreak={res['real_tiebreak']}; "
         f"shadow demote={res['shadow_demote']} tiebreak={res['shadow_tiebreak']})",
         f"clock valid: {str(res['clock_valid']).lower()}  "
-        f"(health_rate={res['health_rate']} >= {MIN_HEALTH_RATE}? ; "
+        f"(instrumented_rate={res['instrumented_rate']} >= {MIN_INSTRUMENTED_RATE}? ; "
         f"unknown_rate={res['unknown_rate']} <= {MAX_UNKNOWN_RATE}?)",
     ]
     if not res["clock_valid"]:

--- a/scripts/route-decommission-check.py
+++ b/scripts/route-decommission-check.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Routing-loop decommission check (ADR: routing-loop-value-eval).
+
+One question: should the outcome-routing shadow loop be removed today? The
+answer is a count-based, shadow-inclusive verdict with an exit code — not prose.
+
+Clock start = the Stage-0 wiring-fix commit (d943ba74, 2026-06-06 21:21:07 UTC),
+hardcoded below. "Post-fix" events are decision/outcome events with ts >= that
+epoch; pre-fix events are ignored (their health field was never wired).
+
+Verdicts (the trigger contract):
+  KEEP          interventions > 0 (real OR shadow). The loop demonstrably fires;
+                keep it. Exit 0.
+  DELETE        zero interventions AND the clock is valid AND
+                (elapsed >= 90 days OR post-fix decisions >= 3000). The negative
+                result is trustworthy: remove the loop. Exit 3.
+  ACCRUING      zero interventions, clock valid, neither threshold reached.
+                Keep collecting; prints exact remaining days/decisions. Exit 0.
+  CLOCK-INVALID the recorded telemetry cannot support a DELETE/KEEP decision:
+                post-fix non-null health rate < 95% OR outcome unknown_rate > 5%.
+                The zero cannot be trusted. Exit 4.
+
+interventions:
+  real    = decision events whose recorded `action` is demote or tiebreak (the
+            router actually re-ranked the route).
+  shadow  = replay `route_policy.health_adjust` on the RECORDED gate inputs of
+            each decision (health_at_decision, n, failure, alternates); count
+            where the replay action is demote or tiebreak. Gate inputs are read
+            as recorded — never re-derived from current weights (ADR codex 29).
+            Recorded alternates that carry their own weight fields let the shadow
+            replay prefer them; bare-key alternates have no weight row, so the
+            shadow replay cannot fire toward them (honest zero, not a hidden one).
+
+Clock validity (else the zero is not trustworthy):
+  health_rate  = post-fix decisions with non-null health_at_decision / total
+                 post-fix decisions; must be >= 95%.
+  unknown_rate = post-fix decisions with no joinable outcome / total post-fix
+                 decisions; must be <= 5%. Join key (ADR): session id, nearest
+                 preceding decision in that session.
+
+Read-only: the default events path is the live route-events.jsonl; it is never
+written. Tests pass explicit temp paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.lib.route_policy import health_adjust
+
+# Clock start: the Stage-0 wiring-fix commit (records health gate inputs on the
+# do-route marker). `git show -s --format=%ct d943ba74` == 1780780867.
+STAGE0_FIX_COMMIT = "d943ba74"
+STAGE0_FIX_EPOCH = 1780780867  # 2026-06-06 21:21:07 +0000
+
+# DELETE thresholds (pre-registered, fixed before any run).
+DELETE_DAYS = 90
+DELETE_DECISIONS = 3000
+
+# Clock-validity gates (else CLOCK-INVALID).
+MIN_HEALTH_RATE = 0.95
+MAX_UNKNOWN_RATE = 0.05
+
+_DEFAULT_EVENTS = Path.home() / ".claude" / "learning" / "route-events.jsonl"
+_SECONDS_PER_DAY = 86400
+
+
+def _iter_events(events_path: Path):
+    """Yield parsed events from a JSONL file. Skips blank/corrupt lines.
+
+    Read-only: opens for reading, never writes. Missing file yields nothing.
+    """
+    if not events_path.exists():
+        return
+    with open(events_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def _shadow_action(decision: dict[str, Any]) -> str:
+    """Replay health_adjust on a decision's RECORDED gate inputs.
+
+    Builds the weight map from what the decision recorded — the picked pair's
+    {confidence=health_at_decision, n, failure} and any alternate that carries
+    its own weight fields. Returns the replay action (keep | demote | tiebreak).
+    Never reads current weights.
+    """
+    health = decision.get("health_at_decision")
+    if health is None:
+        return "keep"  # no health recorded => nothing to replay
+    agent = decision.get("agent") or "direct"
+    skill = decision.get("skill") or ""
+    pick_key = f"{agent}:{skill}"
+    weights: dict[str, dict[str, Any]] = {
+        pick_key: {
+            "confidence": health,
+            "n": decision.get("n") or 0,
+            "success": 0,
+            "failure": decision.get("failure") or 0,
+        }
+    }
+    alt_keys: list[str] = []
+    for alt in decision.get("alternates") or []:
+        if isinstance(alt, dict) and "key" in alt:
+            k = alt["key"]
+            weights[k] = {
+                "confidence": alt.get("confidence", 0.0),
+                "n": alt.get("n", 0),
+                "success": alt.get("success", 0),
+                "failure": alt.get("failure", 0),
+            }
+            alt_keys.append(k)
+        elif isinstance(alt, str):
+            alt_keys.append(alt)  # bare key: no weight row, cannot be preferred
+    pick = {"key": pick_key, "confidence": health}
+    return health_adjust(pick, alt_keys, weights, set())["action"]
+
+
+def count_post_fix(events_path: Path) -> dict[str, Any]:
+    """Count post-fix interventions, health rate, and outcome unknown rate.
+
+    real_demote/real_tiebreak come from the recorded `action`; shadow_* from the
+    health_adjust replay on recorded gate inputs. health_rate = non-null health /
+    decisions. unknown_rate = decisions with no joinable outcome / decisions
+    (join: nearest preceding decision in the same session).
+    """
+    decisions: list[dict[str, Any]] = []
+    outcomes: list[dict[str, Any]] = []
+    for ev in _iter_events(events_path):
+        if ev.get("ts", 0) < STAGE0_FIX_EPOCH:
+            continue
+        t = ev.get("type")
+        if t == "decision":
+            decisions.append(ev)
+        elif t == "outcome":
+            outcomes.append(ev)
+
+    real_demote = real_tiebreak = 0
+    shadow_demote = shadow_tiebreak = 0
+    non_null_health = 0
+    for d in decisions:
+        action = d.get("action")
+        if action == "demote":
+            real_demote += 1
+        elif action == "tiebreak":
+            real_tiebreak += 1
+        if d.get("health_at_decision") is not None:
+            non_null_health += 1
+        sa = _shadow_action(d)
+        if sa == "demote":
+            shadow_demote += 1
+        elif sa == "tiebreak":
+            shadow_tiebreak += 1
+
+    n_dec = len(decisions)
+    health_rate = (non_null_health / n_dec) if n_dec else 0.0
+    joined = _count_joined(decisions, outcomes)
+    unknown_rate = ((n_dec - joined) / n_dec) if n_dec else 1.0
+
+    interventions = real_demote + real_tiebreak + shadow_demote + shadow_tiebreak
+    return {
+        "post_fix_decisions": n_dec,
+        "post_fix_outcomes": len(outcomes),
+        "non_null_health": non_null_health,
+        "health_rate": round(health_rate, 4),
+        "joined_outcomes": joined,
+        "unknown_rate": round(unknown_rate, 4),
+        "real_demote": real_demote,
+        "real_tiebreak": real_tiebreak,
+        "shadow_demote": shadow_demote,
+        "shadow_tiebreak": shadow_tiebreak,
+        "interventions": interventions,
+    }
+
+
+def _count_joined(decisions: list[dict[str, Any]], outcomes: list[dict[str, Any]]) -> int:
+    """Count decisions that join an outcome by session (nearest preceding).
+
+    Each outcome attaches to the latest decision in its session at or before the
+    outcome ts. A decision counts as joined once at least one outcome attaches to
+    it. Mirrors the ADR join key (session id + nearest preceding decision).
+    """
+    by_session: dict[str, list[tuple[float, int]]] = {}
+    for idx, d in enumerate(decisions):
+        by_session.setdefault(d.get("session", ""), []).append((d.get("ts", 0.0), idx))
+    for lst in by_session.values():
+        lst.sort()
+    joined_idx: set[int] = set()
+    for o in outcomes:
+        sess = o.get("session", "")
+        lst = by_session.get(sess)
+        if not lst:
+            continue
+        o_ts = o.get("ts", 0.0)
+        cand = None
+        for ts, idx in lst:
+            if ts <= o_ts:
+                cand = idx
+            else:
+                break
+        if cand is not None:
+            joined_idx.add(cand)
+    return len(joined_idx)
+
+
+def clock_valid(stats: dict[str, Any]) -> tuple[bool, str]:
+    """True iff the recorded telemetry can support a DELETE/KEEP decision.
+
+    Fails (with the offending number) when there are no post-fix decisions, the
+    non-null health rate is < 95%, or the outcome unknown_rate is > 5%.
+    """
+    if stats["post_fix_decisions"] == 0:
+        return False, "no post-fix decisions recorded yet (clock cannot start)"
+    if stats["health_rate"] < MIN_HEALTH_RATE:
+        return (
+            False,
+            f"health rate {stats['health_rate']:.4f} < {MIN_HEALTH_RATE} "
+            f"({stats['non_null_health']}/{stats['post_fix_decisions']} non-null)",
+        )
+    if stats["unknown_rate"] > MAX_UNKNOWN_RATE:
+        return (
+            False,
+            f"outcome unknown_rate {stats['unknown_rate']:.4f} > {MAX_UNKNOWN_RATE} "
+            f"({stats['post_fix_decisions'] - stats['joined_outcomes']}/{stats['post_fix_decisions']} unjoinable)",
+        )
+    return True, ""
+
+
+def decide(events_path: Path, now: float | None = None) -> dict[str, Any]:
+    """Compute the decommission verdict + exit code.
+
+    Precedence: KEEP (interventions > 0) wins first — a firing loop is kept
+    regardless of clock validity. Else the clock must be valid; an invalid clock
+    yields CLOCK-INVALID (the zero is untrustworthy). With a valid clock and zero
+    interventions: DELETE when a threshold is met, else ACCRUING with exact
+    remaining.
+    """
+    now = time.time() if now is None else now
+    stats = count_post_fix(events_path)
+    elapsed_days = (now - STAGE0_FIX_EPOCH) / _SECONDS_PER_DAY
+    remaining_days = max(0, DELETE_DAYS - int(elapsed_days))
+    remaining_decisions = max(0, DELETE_DECISIONS - stats["post_fix_decisions"])
+    valid, clock_reason = clock_valid(stats)
+
+    res: dict[str, Any] = {
+        **stats,
+        "stage0_commit": STAGE0_FIX_COMMIT,
+        "elapsed_days": round(elapsed_days, 3),
+        "remaining_days": remaining_days,
+        "remaining_decisions": remaining_decisions,
+        "clock_valid": valid,
+        "clock_reason": clock_reason,
+    }
+
+    if stats["interventions"] > 0:
+        res["verdict"] = "KEEP"
+        res["exit_code"] = 0
+        res["reason"] = f"{stats['interventions']} intervention(s): the loop fires; keep it"
+        return res
+
+    if not valid:
+        res["verdict"] = "CLOCK-INVALID"
+        res["exit_code"] = 4
+        res["reason"] = clock_reason
+        return res
+
+    time_met = elapsed_days >= DELETE_DAYS
+    count_met = stats["post_fix_decisions"] >= DELETE_DECISIONS
+    if time_met or count_met:
+        res["verdict"] = "DELETE"
+        res["exit_code"] = 3
+        trig = "time" if time_met else "count"
+        res["reason"] = f"0 interventions, valid clock, {trig} threshold met: remove the loop"
+        return res
+
+    res["verdict"] = "ACCRUING"
+    res["exit_code"] = 0
+    res["reason"] = (
+        f"0 interventions, valid clock, neither threshold reached: "
+        f"{remaining_days} day(s) OR {remaining_decisions} decision(s) remaining"
+    )
+    return res
+
+
+def render_human(res: dict[str, Any]) -> str:
+    """Render the verdict as a Dense-Complete human summary."""
+    lines = [
+        f"VERDICT: {res['verdict']} (exit {res['exit_code']})",
+        f"  {res['reason']}",
+        "",
+        f"clock start: commit {res['stage0_commit']} (epoch {STAGE0_FIX_EPOCH})",
+        f"elapsed: {res['elapsed_days']} days  | remaining to delete: "
+        f"{res['remaining_days']} days OR {res['remaining_decisions']} decisions",
+        f"post-fix decisions: {res['post_fix_decisions']}",
+        f"interventions: {res['interventions']} "
+        f"(real demote={res['real_demote']} tiebreak={res['real_tiebreak']}; "
+        f"shadow demote={res['shadow_demote']} tiebreak={res['shadow_tiebreak']})",
+        f"clock valid: {str(res['clock_valid']).lower()}  "
+        f"(health_rate={res['health_rate']} >= {MIN_HEALTH_RATE}? ; "
+        f"unknown_rate={res['unknown_rate']} <= {MAX_UNKNOWN_RATE}?)",
+    ]
+    if not res["clock_valid"]:
+        lines.append(f"clock_reason: {res['clock_reason']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Routing-loop decommission check (ADR routing-loop-value-eval).")
+    parser.add_argument("--events", type=Path, default=_DEFAULT_EVENTS, help="route-events.jsonl path (read-only).")
+    parser.add_argument("--json", action="store_true", help="emit JSON only.")
+    args = parser.parse_args(argv)
+
+    res = decide(events_path=args.events)
+    if args.json:
+        print(json.dumps(res, indent=2))
+    else:
+        print(render_human(res))
+        print()
+        print(json.dumps(res, separators=(",", ":")))
+    return res["exit_code"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/route-replay.py
+++ b/scripts/route-replay.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Shadow replay of the health-aware re-rank policy over the routing corpora.
+
+Runs `health_adjust()` (scripts/lib/route_policy.py) against every case in
+`routing-ab-corpus.json` (49) and `routing-benchmark.json` (68) in two arms:
+
+  ARM A — REAL: the live DB weights (read-only) from
+    `learning-db.py route-weights --json`. The semantic pick is the gold route
+    for each case; no alternates are offered (faithful shadow: today there is no
+    per-dispatch alternate history). Prediction: 0 routes changed, because every
+    real row is >=0.5 confidence with 0 failures, so the floor never fires.
+
+  ARM B — SYNTHETIC: a seeded temp DB built so the gates actually engage.
+    For each non-force-route case the semantic pick is a deliberately WRONG
+    route seeded into the demote floor (conf<0.30, fail>=3, n>=5) and the gold
+    route is offered as a healthy alternate. health_adjust must demote the
+    failing wrong pick toward the healthy gold alternate (help). For force-route
+    cases the semantic pick is the gold force-route pair seeded with the SAME
+    failure load; the exemption must keep it (proving force-route is never
+    demoted even under negative signal).
+
+Per arm we report: routes changed, help (moved toward gold), harm (moved away
+from gold), unchanged. Deterministic, offline, zero model calls. The real arm
+never writes the DB; the synthetic arm writes ONLY to a temp dir.
+
+Outputs `research/forward-plan/replay-results.md` and `.json` with the real
+numbers. If the real arm changes 0 routes, that is the predicted honest finding
+and is reported plainly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.lib.route_policy import health_adjust
+
+_SCRIPTS = _REPO_ROOT / "scripts"
+_LEARNING_DB_CLI = _SCRIPTS / "learning-db.py"
+_AB_CORPUS = _SCRIPTS / "routing-ab-corpus.json"
+_BENCHMARK = _SCRIPTS / "routing-benchmark.json"
+
+# A wrong route used as the failing synthetic pick. Never a real gold route.
+_WRONG_KEY = "wrong-agent:wrong-skill"
+
+
+def _gold_key(case: dict[str, Any]) -> str | None:
+    """Build the `agent:skill` gold key for a case, or None if it has no skill."""
+    skill = case.get("expected_skill")
+    if not skill:
+        return None
+    agent = case.get("expected_agent") or "direct"
+    return f"{agent}:{skill}"
+
+
+def load_corpus(path: Path) -> list[dict[str, Any]]:
+    """Load the `test_cases` list from a corpus file."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    cases = data.get("test_cases", [])
+    if not isinstance(cases, list):
+        raise ValueError(f"{path}: test_cases is not a list")
+    return cases
+
+
+def force_route_skills() -> set[str]:
+    """Read force-route skill names from the manifest (read-only import)."""
+    spec = importlib.util.spec_from_file_location("_routing_manifest", _SCRIPTS / "routing-manifest.py")
+    if spec is None or spec.loader is None:
+        return set()
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return {e["name"] for e in module.load_entries() if e.get("force_route")}
+
+
+def read_real_weights() -> dict[str, dict[str, Any]]:
+    """Run `learning-db.py route-weights --json` against the live DB (read-only)."""
+    proc = subprocess.run(
+        [sys.executable, str(_LEARNING_DB_CLI), "route-weights", "--json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def replay_real(
+    cases: list[dict[str, Any]],
+    weights: dict[str, dict[str, Any]],
+    force_flags: set[str],
+) -> dict[str, Any]:
+    """ARM A: gold pick, no alternates, real weights. Predicted: 0 changes."""
+    changed = help_ = harm = unchanged = evaluated = 0
+    changes: list[dict[str, Any]] = []
+    for case in cases:
+        gold = _gold_key(case)
+        if gold is None:
+            continue
+        evaluated += 1
+        pick = {"key": gold, "confidence": 0.9}
+        result = health_adjust(pick, [], weights, force_flags)
+        final = result["final_pick"]
+        if final == gold:
+            unchanged += 1
+            continue
+        # Semantic pick == gold, so any change moves AWAY from gold = harm.
+        changed += 1
+        harm += 1
+        changes.append({"request": case.get("request"), "from": gold, "to": final, "reason": result["reason"]})
+    return {
+        "arm": "real",
+        "evaluated": evaluated,
+        "changed": changed,
+        "help": help_,
+        "harm": harm,
+        "unchanged": unchanged,
+        "changes": changes,
+    }
+
+
+def _seed_floor(env: dict[str, str], key: str, observations: int = 5, failures: int = 3) -> None:
+    """Seed a routing row into the demote floor (low conf, high failure, n>=5)."""
+    _seed_calls(env, key, observations, boosts=0, decays=failures)
+
+
+def _seed_healthy(env: dict[str, str], key: str, observations: int = 6, successes: int = 6) -> None:
+    """Seed a routing row with high success and confidence (a healthy alternate)."""
+    _seed_calls(env, key, observations, boosts=successes, decays=0)
+
+
+def _seed_calls(env: dict[str, str], key: str, observations: int, boosts: int, decays: int) -> None:
+    """Drive record_learning / boost / decay in a subprocess against the temp DB."""
+    script = (
+        "import sys; sys.path.insert(0, r'{lib}')\n"
+        "import learning_db_v2 as L\n"
+        "for _ in range({obs}):\n"
+        "    L.record_learning(topic='routing', key='{key}', value='x', category='effectiveness', source='routing:decision')\n"
+        "for _ in range({boosts}):\n"
+        "    L.boost_confidence('routing', '{key}')\n"
+        "for _ in range({decays}):\n"
+        "    L.decay_confidence('routing', '{key}')\n"
+    ).format(lib=str(_REPO_ROOT / "hooks" / "lib"), obs=observations, key=key, boosts=boosts, decays=decays)
+    subprocess.run([sys.executable, "-c", script], env=env, check=True, capture_output=True, text=True)
+
+
+def replay_synthetic(
+    cases: list[dict[str, Any]],
+    force_flags: set[str],
+    db_dir: Path,
+) -> dict[str, Any]:
+    """ARM B: seeded failure DB proves demote (help) and force-route exemption.
+
+    Non-force-route case: pick = a failing wrong route, gold offered as healthy
+    alternate -> demote toward gold = help.
+    Force-route case: pick = gold force-route pair seeded with the same failure
+    load -> exemption keeps it (no demote, counted unchanged + exempt).
+    """
+    env = dict(os.environ)
+    env["CLAUDE_LEARNING_DIR"] = str(db_dir)
+
+    # Seed the shared failing wrong pick once.
+    _seed_floor(env, _WRONG_KEY)
+
+    # Seed each distinct gold route as a healthy alternate, and each distinct
+    # force-route gold into the floor (to prove exemption holds under failure).
+    healthy_seeded: set[str] = set()
+    floor_seeded: set[str] = set()
+    for case in cases:
+        gold = _gold_key(case)
+        if gold is None:
+            continue
+        skill = gold.split(":", 1)[1]
+        if skill in force_flags:
+            if gold not in floor_seeded:
+                _seed_floor(env, gold)
+                floor_seeded.add(gold)
+        elif gold not in healthy_seeded:
+            _seed_healthy(env, gold)
+            healthy_seeded.add(gold)
+
+    weights = _read_weights(env)
+
+    changed = help_ = harm = unchanged = evaluated = exempt_held = 0
+    changes: list[dict[str, Any]] = []
+    for case in cases:
+        gold = _gold_key(case)
+        if gold is None:
+            continue
+        evaluated += 1
+        skill = gold.split(":", 1)[1]
+        if skill in force_flags:
+            # Force-route: pick the gold force-route pair itself (in the floor).
+            pick = {"key": gold, "confidence": 0.9}
+            alternates = [_WRONG_KEY]  # a tempting (also-failing) alternate
+            result = health_adjust(pick, alternates, weights, force_flags)
+            if result["final_pick"] == gold:
+                unchanged += 1
+                exempt_held += 1
+            else:
+                changed += 1
+                harm += 1
+                changes.append(
+                    {
+                        "request": case.get("request"),
+                        "from": gold,
+                        "to": result["final_pick"],
+                        "reason": result["reason"],
+                    }
+                )
+            continue
+        # Non-force-route: failing wrong pick, gold as healthy alternate.
+        pick = {"key": _WRONG_KEY, "confidence": 0.9}
+        result = health_adjust(pick, [gold], weights, force_flags)
+        final = result["final_pick"]
+        if final == _WRONG_KEY:
+            unchanged += 1
+        elif final == gold:
+            changed += 1
+            help_ += 1
+        else:
+            changed += 1
+            harm += 1
+            changes.append(
+                {"request": case.get("request"), "from": _WRONG_KEY, "to": final, "reason": result["reason"]}
+            )
+    return {
+        "arm": "synthetic",
+        "evaluated": evaluated,
+        "changed": changed,
+        "help": help_,
+        "harm": harm,
+        "unchanged": unchanged,
+        "force_route_held": exempt_held,
+        "changes": changes,
+    }
+
+
+def _read_weights(env: dict[str, str]) -> dict[str, dict[str, Any]]:
+    """Read route-weights from the DB pointed at by env (subprocess)."""
+    proc = subprocess.run(
+        [sys.executable, str(_LEARNING_DB_CLI), "route-weights", "--json"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def run_replay(
+    ab_path: Path = _AB_CORPUS,
+    benchmark_path: Path = _BENCHMARK,
+    db_dir: Path | None = None,
+    real_weights: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Run both arms over both corpora and return the combined result dict.
+
+    `db_dir` is the temp dir for the synthetic arm (created if None). When
+    `real_weights` is supplied the real arm uses it instead of the live DB
+    (used by tests with a fixture DB).
+    """
+    cases = load_corpus(ab_path) + load_corpus(benchmark_path)
+    force_flags = force_route_skills()
+
+    weights = real_weights if real_weights is not None else read_real_weights()
+    real = replay_real(cases, weights, force_flags)
+
+    if db_dir is None:
+        tmp = tempfile.TemporaryDirectory()
+        db_dir = Path(tmp.name) / "learning"
+        db_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        db_dir.mkdir(parents=True, exist_ok=True)
+    synthetic = replay_synthetic(cases, force_flags, db_dir)
+
+    return {
+        "corpora": {"ab": ab_path.name, "benchmark": benchmark_path.name},
+        "total_cases": len(cases),
+        "real": real,
+        "synthetic": synthetic,
+    }
+
+
+def _md_arm(arm: dict[str, Any]) -> str:
+    """Render one arm as a markdown table row block."""
+    extra = ""
+    if "force_route_held" in arm:
+        extra = f"\n- force-route held (exemption): **{arm['force_route_held']}**"
+    return (
+        f"- evaluated: {arm['evaluated']}\n"
+        f"- changed: {arm['changed']}\n"
+        f"- help (toward gold): **{arm['help']}**\n"
+        f"- harm (away from gold): **{arm['harm']}**\n"
+        f"- unchanged: {arm['unchanged']}{extra}"
+    )
+
+
+def render_markdown(result: dict[str, Any]) -> str:
+    """Render the full results as Dense-Complete markdown."""
+    real = result["real"]
+    syn = result["synthetic"]
+    real_finding = (
+        "Predicted and confirmed: the real-DB arm changes **0** routes. Every live row is "
+        ">=0.5 confidence with 0 failures, so the demote floor (conf<0.30 AND fail>=3 AND n>=5) "
+        "cannot fire. Health re-ranking is inert on current data — pure shadow instrumentation."
+        if real["changed"] == 0
+        else f"The real-DB arm changed {real['changed']} routes (help={real['help']}, harm={real['harm']}). See changes below."
+    )
+    return f"""# Shadow Replay Results — Health-Aware Re-Rank (T7)
+
+Deterministic offline replay of `health_adjust()` over {result["total_cases"]} cases
+({result["corpora"]["ab"]} + {result["corpora"]["benchmark"]}). Zero model calls.
+
+## Arm A — REAL live DB weights (read-only)
+
+{_md_arm(real)}
+
+{real_finding}
+
+## Arm B — SEEDED synthetic failure DB
+
+{_md_arm(syn)}
+
+The synthetic arm seeds failure-bearing rows so the gates engage: non-force-route
+picks are seeded into the demote floor with the gold route as a healthy
+alternate (health_adjust demotes toward gold = help); force-route picks carry
+the same failure load and must be kept (exemption). Result: help>0, harm=0,
+and every force-route pair held.
+
+## Verdict
+
+- Mechanism is SOUND: synthetic arm shows help={syn["help"]}, harm={syn["harm"]},
+  force-route held={syn["force_route_held"]}.
+- Live value TODAY: {"NONE — 0 routes change on real data (honest finding)." if real["changed"] == 0 else f"{real['changed']} routes change."}
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: run the replay and write results md + json."""
+    parser = argparse.ArgumentParser(description="Shadow replay of the health-aware re-rank policy.")
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=_REPO_ROOT / "research" / "forward-plan",
+        help="Directory for replay-results.md and replay-results.json",
+    )
+    args = parser.parse_args(argv)
+
+    result = run_replay()
+
+    out_dir: Path = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "replay-results.json").write_text(json.dumps(result, indent=2), encoding="utf-8")
+    (out_dir / "replay-results.md").write_text(render_markdown(result), encoding="utf-8")
+
+    real = result["real"]
+    syn = result["synthetic"]
+    print(f"REAL arm: changed={real['changed']} help={real['help']} harm={real['harm']} unchanged={real['unchanged']}")
+    print(
+        f"SYNTHETIC arm: changed={syn['changed']} help={syn['help']} harm={syn['harm']} "
+        f"unchanged={syn['unchanged']} force_route_held={syn['force_route_held']}"
+    )
+    print(f"Wrote {out_dir / 'replay-results.md'} and replay-results.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/route-replay.py
+++ b/scripts/route-replay.py
@@ -245,6 +245,89 @@ def replay_synthetic(
     }
 
 
+def replay_tiebreak(
+    cases: list[dict[str, Any]],
+    force_flags: set[str],
+    db_dir: Path,
+) -> dict[str, Any]:
+    """ARM C: low-confidence semantic pick + an evidenced healthy gold alternate.
+
+    Tie-break keys on SEMANTIC confidence, not the demote floor, so it can fire
+    on healthy data. This arm proves the path honestly: a wrong pick offered at
+    low semantic confidence (0.1) with the gold route as an evidenced healthy
+    alternate must be tie-broken toward gold (help). Force-route picks are kept
+    even at low confidence (exemption applies to tie-break too).
+    """
+    env = dict(os.environ)
+    env["CLAUDE_LEARNING_DIR"] = str(db_dir)
+
+    # The wrong pick needs a (healthy) weight row so it clears the evidence gate
+    # but is still beaten by the gold alternate's score.
+    _seed_healthy(env, _WRONG_KEY, observations=6, successes=4)
+    healthy_seeded: set[str] = set()
+    for case in cases:
+        gold = _gold_key(case)
+        if gold is None:
+            continue
+        if gold not in healthy_seeded:
+            _seed_healthy(env, gold)
+            healthy_seeded.add(gold)
+
+    weights = _read_weights(env)
+
+    changed = help_ = harm = unchanged = evaluated = exempt_held = 0
+    changes: list[dict[str, Any]] = []
+    for case in cases:
+        gold = _gold_key(case)
+        if gold is None:
+            continue
+        evaluated += 1
+        skill = gold.split(":", 1)[1]
+        # Low semantic confidence triggers the tie-break path.
+        if skill in force_flags:
+            pick = {"key": gold, "confidence": 0.1}
+            result = health_adjust(pick, [_WRONG_KEY], weights, force_flags)
+            if result["final_pick"] == gold:
+                unchanged += 1
+                exempt_held += 1
+            else:
+                changed += 1
+                harm += 1
+                changes.append(
+                    {
+                        "request": case.get("request"),
+                        "from": gold,
+                        "to": result["final_pick"],
+                        "reason": result["reason"],
+                    }
+                )
+            continue
+        pick = {"key": _WRONG_KEY, "confidence": 0.1}
+        result = health_adjust(pick, [gold], weights, force_flags)
+        final = result["final_pick"]
+        if final == _WRONG_KEY:
+            unchanged += 1
+        elif final == gold:
+            changed += 1
+            help_ += 1
+        else:
+            changed += 1
+            harm += 1
+            changes.append(
+                {"request": case.get("request"), "from": _WRONG_KEY, "to": final, "reason": result["reason"]}
+            )
+    return {
+        "arm": "tiebreak",
+        "evaluated": evaluated,
+        "changed": changed,
+        "help": help_,
+        "harm": harm,
+        "unchanged": unchanged,
+        "force_route_held": exempt_held,
+        "changes": changes,
+    }
+
+
 def _read_weights(env: dict[str, str]) -> dict[str, dict[str, Any]]:
     """Read route-weights from the DB pointed at by env (subprocess)."""
     proc = subprocess.run(
@@ -281,13 +364,19 @@ def run_replay(
         db_dir.mkdir(parents=True, exist_ok=True)
     else:
         db_dir.mkdir(parents=True, exist_ok=True)
-    synthetic = replay_synthetic(cases, force_flags, db_dir)
+    syn_dir = db_dir / "synthetic"
+    tb_dir = db_dir / "tiebreak"
+    syn_dir.mkdir(parents=True, exist_ok=True)
+    tb_dir.mkdir(parents=True, exist_ok=True)
+    synthetic = replay_synthetic(cases, force_flags, syn_dir)
+    tiebreak = replay_tiebreak(cases, force_flags, tb_dir)
 
     return {
         "corpora": {"ab": ab_path.name, "benchmark": benchmark_path.name},
         "total_cases": len(cases),
         "real": real,
         "synthetic": synthetic,
+        "tiebreak": tiebreak,
     }
 
 
@@ -309,6 +398,7 @@ def render_markdown(result: dict[str, Any]) -> str:
     """Render the full results as Dense-Complete markdown."""
     real = result["real"]
     syn = result["synthetic"]
+    tb = result["tiebreak"]
     real_finding = (
         "Predicted and confirmed: the real-DB arm changes **0** routes. Every live row is "
         ">=0.5 confidence with 0 failures, so the demote floor (conf<0.30 AND fail>=3 AND n>=5) "
@@ -337,11 +427,25 @@ alternate (health_adjust demotes toward gold = help); force-route picks carry
 the same failure load and must be kept (exemption). Result: help>0, harm=0,
 and every force-route pair held.
 
+## Arm C — TIE-BREAK on healthy data (low semantic confidence)
+
+{_md_arm(tb)}
+
+Tie-break keys on SEMANTIC confidence, NOT the demote floor — so it CAN move a
+route on healthy data (zero failures). This arm offers a low-confidence (0.1)
+wrong pick plus the gold route as an evidenced healthy alternate: health_adjust
+tie-breaks toward gold (help). Force-route picks are kept even at low confidence
+(exemption covers tie-break too). This is the honest counter to "Step 1.5 cannot
+change any live route": demote cannot, but tie-break can when a low-confidence
+pick is handed an evidenced alternate.
+
 ## Verdict
 
 - Mechanism is SOUND: synthetic arm shows help={syn["help"]}, harm={syn["harm"]},
-  force-route held={syn["force_route_held"]}.
-- Live value TODAY: {"NONE — 0 routes change on real data (honest finding)." if real["changed"] == 0 else f"{real['changed']} routes change."}
+  force-route held={syn["force_route_held"]}; tie-break arm shows help={tb["help"]},
+  harm={tb["harm"]}, force-route held={tb["force_route_held"]}.
+- Live value TODAY: {"DEMOTE: NONE — 0 routes change on real data (honest finding)." if real["changed"] == 0 else f"{real['changed']} routes change."}
+  TIE-BREAK can fire on low-confidence dispatches with an evidenced alternate.
 """
 
 
@@ -365,10 +469,15 @@ def main(argv: list[str] | None = None) -> int:
 
     real = result["real"]
     syn = result["synthetic"]
+    tb = result["tiebreak"]
     print(f"REAL arm: changed={real['changed']} help={real['help']} harm={real['harm']} unchanged={real['unchanged']}")
     print(
         f"SYNTHETIC arm: changed={syn['changed']} help={syn['help']} harm={syn['harm']} "
         f"unchanged={syn['unchanged']} force_route_held={syn['force_route_held']}"
+    )
+    print(
+        f"TIEBREAK arm: changed={tb['changed']} help={tb['help']} harm={tb['harm']} "
+        f"unchanged={tb['unchanged']} force_route_held={tb['force_route_held']}"
     )
     print(f"Wrote {out_dir / 'replay-results.md'} and replay-results.json")
     return 0

--- a/scripts/route-replay.py
+++ b/scripts/route-replay.py
@@ -138,19 +138,45 @@ def _seed_healthy(env: dict[str, str], key: str, observations: int = 6, successe
     _seed_calls(env, key, observations, boosts=successes, decays=0)
 
 
+# Fixed child program: reads lib path, key, and counts from argv so no caller
+# data is ever interpolated into source (codex #5). The program is constant; only
+# data crosses the boundary, as argv, where it cannot be parsed as code.
+_SEED_CHILD = (
+    "import sys\n"
+    "lib, key, obs, boosts, decays = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4]), int(sys.argv[5])\n"
+    "sys.path.insert(0, lib)\n"
+    "import learning_db_v2 as L\n"
+    "for _ in range(obs):\n"
+    "    L.record_learning(topic='routing', key=key, value='x', category='effectiveness', source='routing:decision')\n"
+    "for _ in range(boosts):\n"
+    "    L.boost_confidence('routing', key)\n"
+    "for _ in range(decays):\n"
+    "    L.decay_confidence('routing', key)\n"
+)
+
+
 def _seed_calls(env: dict[str, str], key: str, observations: int, boosts: int, decays: int) -> None:
-    """Drive record_learning / boost / decay in a subprocess against the temp DB."""
-    script = (
-        "import sys; sys.path.insert(0, r'{lib}')\n"
-        "import learning_db_v2 as L\n"
-        "for _ in range({obs}):\n"
-        "    L.record_learning(topic='routing', key='{key}', value='x', category='effectiveness', source='routing:decision')\n"
-        "for _ in range({boosts}):\n"
-        "    L.boost_confidence('routing', '{key}')\n"
-        "for _ in range({decays}):\n"
-        "    L.decay_confidence('routing', '{key}')\n"
-    ).format(lib=str(_REPO_ROOT / "hooks" / "lib"), obs=observations, key=key, boosts=boosts, decays=decays)
-    subprocess.run([sys.executable, "-c", script], env=env, check=True, capture_output=True, text=True)
+    """Drive record_learning / boost / decay in a subprocess against the temp DB.
+
+    key and the counts are passed as argv (not interpolated into source), so a
+    key containing quotes or newlines cannot inject code into the child.
+    """
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _SEED_CHILD,
+            str(_REPO_ROOT / "hooks" / "lib"),
+            key,
+            str(observations),
+            str(boosts),
+            str(decays),
+        ],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
 
 def replay_synthetic(
@@ -389,7 +415,7 @@ def _md_arm(arm: dict[str, Any]) -> str:
         f"- evaluated: {arm['evaluated']}\n"
         f"- changed: {arm['changed']}\n"
         f"- help (toward gold): **{arm['help']}**\n"
-        f"- harm (away from gold): **{arm['harm']}**\n"
+        f"- harm (moved off gold): **{arm['harm']}**\n"
         f"- unchanged: {arm['unchanged']}{extra}"
     )
 

--- a/scripts/route-value-eval.py
+++ b/scripts/route-value-eval.py
@@ -15,9 +15,10 @@ Two SEPARATE verdicts, never one gate:
     — never PASS, never FAIL.
 
 Stage 2 (no model) is a measurement-availability check: it counts recorded
-decisions/outcomes/non-null-health/failures in a read-only copy of
-route-events.jsonl and decides whether faithful replay can run. Today it prints
-non_null_health=0 recorded_failures=0 and sets value_measured=false.
+decisions/outcomes/non-null-health and recorded_failures (routing-relevant
+outcome=="failure" events only) in a read-only copy of route-events.jsonl and
+decides whether faithful replay can run. Today it prints non_null_health=0
+recorded_failures=0 and sets value_measured=false.
 
 Exit codes (no consumer can mistake mechanism for value):
   0 = MECHANISM PASS AND value_measured AND VALUE PASS
@@ -141,13 +142,21 @@ def run_stage2(events_path: Path | None = None) -> dict[str, Any]:
     """Read-only copy of route-events.jsonl; count and gate faithful replay.
 
     Counts decisions, outcomes, non-null health_at_decision, and recorded
-    failures (action=demote OR a linked failure outcome). Faithful replay runs
-    only when non_null_health >= MIN_NON_NULL_HEALTH AND failures > 0. Today it is
-    skipped; the exact blocking numbers are returned. Neutral outcomes are
-    censored (counted separately, excluded from value).
+    failures. A recorded failure is ONLY a routing-relevant outcome event with
+    ``outcome=="failure"``: a real dispatch that ended in failure. Decision
+    events contribute no failures — a decision's ``failure`` field is the weight
+    row's historical failure_count snapshotted at decision time, not this
+    dispatch's result, so counting it conflates history with outcome (finding
+    [51]). Legacy outcome events without ``routing_relevant`` count as relevant;
+    events explicitly ``routing_relevant: false`` are excluded.
+
+    Faithful replay runs only when non_null_health >= MIN_NON_NULL_HEALTH AND
+    recorded_failures > 0. Today it is skipped; the exact blocking numbers are
+    returned. Neutral outcomes are censored (counted separately, excluded from
+    value).
     """
     src = events_path if events_path is not None else _DEFAULT_EVENTS
-    decisions = outcomes = non_null_health = failures = neutral = 0
+    decisions = outcomes = non_null_health = recorded_failures = neutral = 0
     if src.exists():
         with tempfile.TemporaryDirectory() as td:
             copy = Path(td) / "route-events.jsonl"
@@ -165,24 +174,24 @@ def run_stage2(events_path: Path | None = None) -> dict[str, Any]:
                     decisions += 1
                     if ev.get("health_at_decision") is not None:
                         non_null_health += 1
-                    if ev.get("action") == "demote" or (ev.get("failure") or 0) > 0:
-                        failures += 1
                 elif t == "outcome":
                     outcomes += 1
                     oc = ev.get("outcome")
-                    if oc == "failure":
-                        failures += 1
+                    # routing_relevant defaults True for legacy events; only an
+                    # explicit False excludes the failure from the count.
+                    if oc == "failure" and ev.get("routing_relevant", True):
+                        recorded_failures += 1
                     elif oc == "neutral":
                         neutral += 1
 
-    can_replay = non_null_health >= MIN_NON_NULL_HEALTH and failures > 0
+    can_replay = non_null_health >= MIN_NON_NULL_HEALTH and recorded_failures > 0
     return {
         "events_path": str(src),
         "events_present": src.exists(),
         "decisions": decisions,
         "outcomes": outcomes,
         "non_null_health": non_null_health,
-        "recorded_failures": failures,
+        "recorded_failures": recorded_failures,
         "neutral_censored": neutral,
         "min_non_null_health": MIN_NON_NULL_HEALTH,
         "faithful_replay_ran": can_replay,
@@ -190,7 +199,7 @@ def run_stage2(events_path: Path | None = None) -> dict[str, Any]:
             ""
             if can_replay
             else f"non_null_health={non_null_health} (<{MIN_NON_NULL_HEALTH}) "
-            f"AND/OR recorded_failures={failures} (need >0)"
+            f"AND/OR recorded_failures={recorded_failures} (need >0)"
         ),
         # Stage 2 contributes NO value evidence; it is availability only.
         "value_measured": False,
@@ -199,6 +208,14 @@ def run_stage2(events_path: Path | None = None) -> dict[str, Any]:
 
 # --------------------------------------------------------------------------- #
 # Stage 3 — blind A/B arms + alternate builder (Arm A vs health_adjust Arm B)
+#
+# build_alternates, compute_health_arms, build_judge_rows and
+# _JUDGE_FORBIDDEN_FIELDS are the offline Stage-3 fixture-rebuild pipeline. They
+# have no argparse CLI entry by design: live Stage 3 needs Haiku calls, so the
+# fixture is built out-of-band by the rebuild scripts (build_fixture.py +
+# build_judge.py), which import this module and call these symbols, then feed the
+# resulting scoreboard back through --stage3-stub. They are NOT dead code; each
+# is exercised by the rebuild tooling and unit-tested.
 # --------------------------------------------------------------------------- #
 def _gold_key(case: dict[str, Any]) -> str | None:
     skill = case.get("expected_skill")
@@ -584,7 +601,7 @@ def render_markdown(res: dict[str, Any]) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Routing-loop value eval (two verdicts).")
+    parser = argparse.ArgumentParser(description="Routing-loop value evaluation (two verdicts).")
     parser.add_argument("--out-dir", type=Path, default=_OUT_DIR)
     parser.add_argument("--events", type=Path, default=None, help="route-events.jsonl path (read-only).")
     parser.add_argument(
@@ -619,8 +636,13 @@ def main(argv: list[str] | None = None) -> int:
         f"Stage 2: non_null_health={s2['non_null_health']} recorded_failures={s2['recorded_failures']} "
         f"value_measured={str(res['value_measured']).lower()}"
     )
+    # Exit 1 has two distinct causes; name which one on stderr so an automated
+    # consumer can tell them apart without parsing the JSON output (finding [81]).
     if res["mechanism_verdict"] == "fail":
         print(f"MECHANISM FAIL: {res['stage1']['mechanism']['failing_clauses']}", file=sys.stderr)
+    elif res["value_measured"] and res["value_verdict"] == "fail":
+        ci_low, ci_high = res.get("D_ci_low"), res.get("D_ci_high")
+        print(f"VALUE FAIL: D={res.get('D')} CI=[{ci_low},{ci_high}] mcnemar_p={res.get('mcnemar_p')}", file=sys.stderr)
     print(f"exit_code={res['exit_code']}")
     print(f"Wrote {out_dir / 'route-value-eval-results.md'} and .json")
     return res["exit_code"]

--- a/scripts/route-value-eval.py
+++ b/scripts/route-value-eval.py
@@ -1,0 +1,630 @@
+#!/usr/bin/env python3
+"""Routing-loop value eval orchestrator (ADR: routing-loop-value-eval).
+
+Two SEPARATE verdicts, never one gate:
+
+  MECHANISM (Stage 1, deterministic, no model) — does the health re-rank policy
+    fire correctly on constructed cases? REAL arm must change 0 routes (honest
+    zero on live data); SYNTHETIC and TIEBREAK arms must show help>0, harm==0,
+    force-route held. This is conformance, NOT value.
+
+  VALUE (Stage 3, blind A/B) — does health re-rank beat pure semantic routing on
+    the k health-affected cases? value_measured is true only when k>0 AND
+    non-null health telemetry exists AND live health interventions exist. Today
+    all three are false, so value_measured=false and the verdict is "unmeasured"
+    — never PASS, never FAIL.
+
+Stage 2 (no model) is a measurement-availability check: it counts recorded
+decisions/outcomes/non-null-health/failures in a read-only copy of
+route-events.jsonl and decides whether faithful replay can run. Today it prints
+non_null_health=0 recorded_failures=0 and sets value_measured=false.
+
+Exit codes (no consumer can mistake mechanism for value):
+  0 = MECHANISM PASS AND value_measured AND VALUE PASS
+  2 = MECHANISM PASS AND value_measured=false (today's expected outcome)
+  1 = any MECHANISM clause fails, OR VALUE FAIL when measured
+
+Writes research/forward-plan/route-value-eval-results.{md,json} (gitignored
+working dir). Stage 3 needs live Haiku calls to produce real picks; --stage3-stub
+runs the full stats path over a supplied scoreboard so the pipeline is verifiable
+offline. Without a scoreboard, Stage 3 reports value_measured=false.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import random
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+_SCRIPTS = _REPO_ROOT / "scripts"
+_OUT_DIR = _REPO_ROOT / "research" / "forward-plan"
+_DEFAULT_EVENTS = Path.home() / ".claude" / "learning" / "route-events.jsonl"
+
+# Stage-2 gate: faithful per-decision replay runs only with enough non-null
+# health AND at least one recorded failure. Pre-registered, fixed before any run.
+MIN_NON_NULL_HEALTH = 20
+
+
+def _load_module(name: str, filename: str):
+    """Import a hyphenated script as a module (the test_health_replay shim)."""
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------- #
+# Stage 1 — deterministic mechanism gate (reuses route-replay.run_replay)
+# --------------------------------------------------------------------------- #
+def run_stage1(
+    ab_path: Path | None = None,
+    benchmark_path: Path | None = None,
+    db_dir: Path | None = None,
+    real_weights: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Run the three-arm replay and apply the MECHANISM thresholds.
+
+    Returns the replay result plus a `mechanism` block with per-clause pass flags
+    and the overall mechanism_pass. REAL must change 0 routes; SYNTHETIC and
+    TIEBREAK must each show help>0, harm==0, force-route held == force count.
+    """
+    rr = _load_module("route_replay", "route-replay.py")
+    kwargs: dict[str, Any] = {}
+    ab = ab_path if ab_path is not None else rr._AB_CORPUS
+    bm = benchmark_path if benchmark_path is not None else rr._BENCHMARK
+    kwargs["ab_path"] = ab
+    kwargs["benchmark_path"] = bm
+    if db_dir is not None:
+        kwargs["db_dir"] = db_dir
+    if real_weights is not None:
+        kwargs["real_weights"] = real_weights
+    result = rr.run_replay(**kwargs)
+
+    # Force-route case count, counted independently from the corpora + manifest
+    # flags — so the held clause is a real equality, not a tautology against the
+    # arm's own held tally.
+    force_total = _force_case_count(rr, ab, bm)
+
+    real, syn, tb = result["real"], result["synthetic"], result["tiebreak"]
+    clauses = {
+        "real_changed_zero": real["changed"] == 0,
+        "synthetic_help_positive": syn["help"] > 0,
+        "synthetic_harm_zero": syn["harm"] == 0,
+        "synthetic_force_route_held": syn["force_route_held"] == force_total,
+        "tiebreak_help_positive": tb["help"] > 0,
+        "tiebreak_harm_zero": tb["harm"] == 0,
+        "tiebreak_force_route_held": tb["force_route_held"] == force_total,
+    }
+    result["force_case_count"] = force_total
+    result["mechanism"] = {
+        "clauses": clauses,
+        "mechanism_pass": all(clauses.values()),
+        "failing_clauses": [k for k, v in clauses.items() if not v],
+    }
+    return result
+
+
+def _force_case_count(rr, ab_path: Path, benchmark_path: Path) -> int:
+    """Count gold-bearing corpus cases whose skill is force-routed (manifest flags).
+
+    Independent of the replay's held tally, so the held==force_total clause is a
+    genuine equality check, not held==held.
+    """
+    cases = rr.load_corpus(ab_path) + rr.load_corpus(benchmark_path)
+    flags = rr.force_route_skills()
+    count = 0
+    for case in cases:
+        gold = _gold_key(case)
+        if gold is None:
+            continue
+        if gold.split(":", 1)[1] in flags:
+            count += 1
+    return count
+
+
+# --------------------------------------------------------------------------- #
+# Stage 2 — recorded-events measurement-availability check (no model)
+# --------------------------------------------------------------------------- #
+def run_stage2(events_path: Path | None = None) -> dict[str, Any]:
+    """Read-only copy of route-events.jsonl; count and gate faithful replay.
+
+    Counts decisions, outcomes, non-null health_at_decision, and recorded
+    failures (action=demote OR a linked failure outcome). Faithful replay runs
+    only when non_null_health >= MIN_NON_NULL_HEALTH AND failures > 0. Today it is
+    skipped; the exact blocking numbers are returned. Neutral outcomes are
+    censored (counted separately, excluded from value).
+    """
+    src = events_path if events_path is not None else _DEFAULT_EVENTS
+    decisions = outcomes = non_null_health = failures = neutral = 0
+    if src.exists():
+        with tempfile.TemporaryDirectory() as td:
+            copy = Path(td) / "route-events.jsonl"
+            shutil.copyfile(src, copy)  # read-only: never touch the live file
+            for line in copy.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                t = ev.get("type")
+                if t == "decision":
+                    decisions += 1
+                    if ev.get("health_at_decision") is not None:
+                        non_null_health += 1
+                    if ev.get("action") == "demote" or (ev.get("failure") or 0) > 0:
+                        failures += 1
+                elif t == "outcome":
+                    outcomes += 1
+                    oc = ev.get("outcome")
+                    if oc == "failure":
+                        failures += 1
+                    elif oc == "neutral":
+                        neutral += 1
+
+    can_replay = non_null_health >= MIN_NON_NULL_HEALTH and failures > 0
+    return {
+        "events_path": str(src),
+        "events_present": src.exists(),
+        "decisions": decisions,
+        "outcomes": outcomes,
+        "non_null_health": non_null_health,
+        "recorded_failures": failures,
+        "neutral_censored": neutral,
+        "min_non_null_health": MIN_NON_NULL_HEALTH,
+        "faithful_replay_ran": can_replay,
+        "skip_reason": (
+            ""
+            if can_replay
+            else f"non_null_health={non_null_health} (<{MIN_NON_NULL_HEALTH}) "
+            f"AND/OR recorded_failures={failures} (need >0)"
+        ),
+        # Stage 2 contributes NO value evidence; it is availability only.
+        "value_measured": False,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Stage 3 — blind A/B arms + alternate builder (Arm A vs health_adjust Arm B)
+# --------------------------------------------------------------------------- #
+def _gold_key(case: dict[str, Any]) -> str | None:
+    skill = case.get("expected_skill")
+    if not skill:
+        return None
+    agent = case.get("expected_agent") or "direct"
+    return f"{agent}:{skill}"
+
+
+def build_alternates(cases: list[dict[str, Any]], seed: int = 20260527) -> dict[int, list[str]]:
+    """Per case, build a mixed alternate pool: gold-sibling routes (same bucket)
+    AND at least one plausibly-WRONG route (gold for a different bucket). Mixing a
+    wrong route in makes harm a real risk, so harm==0 is meaningful, not built-in.
+    Deterministic given the seed. Keyed by case index.
+    """
+    rng = random.Random(seed)
+    bucket_golds: dict[str, list[str]] = {}
+    all_golds: list[str] = []
+    for case in cases:
+        gold = _gold_key(case)
+        if gold is None:
+            continue
+        bucket = case.get("bucket") or case.get("category") or "default"
+        bucket_golds.setdefault(bucket, [])
+        if gold not in bucket_golds[bucket]:
+            bucket_golds[bucket].append(gold)
+        if gold not in all_golds:
+            all_golds.append(gold)
+
+    out: dict[int, list[str]] = {}
+    for i, case in enumerate(cases):
+        gold = _gold_key(case)
+        if gold is None:
+            continue
+        bucket = case.get("bucket") or case.get("category") or "default"
+        siblings = [k for k in bucket_golds.get(bucket, []) if k != gold]
+        wrong_pool = [k for k in all_golds if k not in siblings and k != gold]
+        alts: list[str] = list(siblings[:2])
+        if wrong_pool:
+            alts.append(rng.choice(wrong_pool))  # at least one plausibly-wrong route
+        out[i] = alts
+    return out
+
+
+# Fields the judge prompt MUST NOT carry (codex 1/2/3/5). The judge sees ONLY
+# the request and two candidate route picks; it never sees which arm produced a
+# pick, the seed kind, weights, alternates, confidence, n, failure, or health.
+_JUDGE_FORBIDDEN_FIELDS = frozenset(
+    {
+        "arm",
+        "arm_label",
+        "seed_kind",
+        "weights",
+        "synthetic_weights",
+        "alternates",
+        "confidence",
+        "n",
+        "failure",
+        "health",
+        "health_at_decision",
+        "action",
+        "bucket",
+        "provenance",
+    }
+)
+
+
+def compute_health_arms(
+    semantic_picks: dict[int, dict[str, Any]],
+    cases: list[dict[str, Any]],
+    weights: dict[str, dict[str, Any]],
+    force_flags: set[str],
+    alternates: dict[int, list[str]] | None = None,
+) -> dict[str, Any]:
+    """Stage-3 live arm computation. Arm A = semantic pick; Arm B = health_adjust.
+
+    semantic_picks: case index -> {"key": "agent:skill", "confidence": float} (the
+    one Haiku decision per case, reused across both arms — the ADR's reuse rule).
+    Arm B applies health_adjust(pick, mixed-alternates, synthetic-weights,
+    force_flags) to Arm A's pick. Returns the per-case A/B picks and the indices of
+    the k health-affected cases (Arm B pick != Arm A pick) — only those are scored.
+    """
+    from scripts.lib.route_policy import health_adjust
+
+    alts = alternates if alternates is not None else build_alternates(cases)
+    per_case: list[dict[str, Any]] = []
+    health_affected: list[int] = []
+    for i, _case in enumerate(cases):
+        pick = semantic_picks.get(i)
+        if pick is None:
+            continue
+        a_key = pick.get("key")
+        adjusted = health_adjust(pick, alts.get(i, []), weights, force_flags)
+        b_key = adjusted["final_pick"]
+        affected = b_key != a_key
+        if affected:
+            health_affected.append(i)
+        per_case.append(
+            {
+                "case_index": i,
+                "a_pick": a_key,
+                "b_pick": b_key,
+                "action": adjusted["action"],
+                "health_affected": affected,
+            }
+        )
+    return {
+        "per_case": per_case,
+        "k_health_affected": len(health_affected),
+        "health_affected_indices": health_affected,
+    }
+
+
+def build_judge_rows(
+    arm_picks: dict[str, Any],
+    cases: list[dict[str, Any]],
+    seed: int = 20260527,
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
+    """Build arm-stripped, shuffled judge rows + a private uid->arm map.
+
+    Only the k health-affected cases are scored. Each arm's pick becomes its own
+    row carrying request text + the candidate pick ONLY — none of the forbidden
+    fields. The uid-map (which the judge never sees) records the arm for rejoin.
+    Mirrors routing-ab-test --build-judge (fixed-seed interleave).
+    """
+    rows: list[dict[str, Any]] = []
+    uid_map: dict[str, dict[str, Any]] = {}
+    uid = 0
+    for rec in arm_picks["per_case"]:
+        if not rec["health_affected"]:
+            continue
+        i = rec["case_index"]
+        request = cases[i].get("request", "")
+        for arm, pick_key in (("A", rec["a_pick"]), ("B", rec["b_pick"])):
+            uid_str = f"u{uid:03d}"
+            uid += 1
+            agent, _, skill = (pick_key or "").partition(":")
+            row = {"uid": uid_str, "query": request, "predicted_agent": agent or None, "predicted_skill": skill or None}
+            assert _JUDGE_FORBIDDEN_FIELDS.isdisjoint(row.keys()), "judge row leaks a forbidden field"
+            rows.append(row)
+            uid_map[uid_str] = {"case_index": i, "arm": arm}
+    rng = random.Random(seed)
+    rng.shuffle(rows)
+    return rows, uid_map
+
+
+def compute_value_stats(
+    per_case: list[dict[str, Any]],
+    baseline_runs: list[list[bool]] | None = None,
+    seed: int = 20260527,
+    bootstrap_iters: int = 5000,
+) -> dict[str, Any]:
+    """Compute the VALUE verdict from per-case A/B correctness on the k cases.
+
+    per_case: list of {"a_correct": bool, "b_correct": bool} for the k
+    health-affected cases (Arm B pick != Arm A pick). Returns D, the 95% paired
+    bootstrap CI, the McNemar p-value, harm count, and value_pass.
+    """
+    k = len(per_case)
+    a = [bool(c["a_correct"]) for c in per_case]
+    b = [bool(c["b_correct"]) for c in per_case]
+    a_strict = sum(a)
+    b_strict = sum(b)
+    d = (b_strict - a_strict) / k if k else 0.0
+
+    # Per-case harm: B wrong where A was right. Hard one-sided gate.
+    harm = sum(1 for ai, bi in zip(a, b, strict=True) if ai and not bi)
+    help_ = sum(1 for ai, bi in zip(a, b, strict=True) if (not ai) and bi)
+
+    # Paired bootstrap CI on D (resample the k cases with replacement).
+    ci_low = ci_high = 0.0
+    if k:
+        rng = random.Random(seed)
+        deltas = []
+        diffs = [int(bi) - int(ai) for ai, bi in zip(a, b, strict=True)]
+        for _ in range(bootstrap_iters):
+            sample = [diffs[rng.randrange(k)] for _ in range(k)]
+            deltas.append(sum(sample) / k)
+        deltas.sort()
+        ci_low = deltas[int(0.025 * bootstrap_iters)]
+        ci_high = deltas[min(int(0.975 * bootstrap_iters), bootstrap_iters - 1)]
+
+    # McNemar exact (paired): discordant pairs b01 (A wrong, B right) vs b10.
+    b01 = help_  # A wrong, B right
+    b10 = harm  # A right, B wrong
+    mcnemar_p = _mcnemar_exact_p(b01, b10)
+
+    # Baseline variance: self-disagreement between two semantic-only runs.
+    baseline_variance = None
+    if baseline_runs and len(baseline_runs) >= 2 and k:
+        r1, r2 = baseline_runs[0], baseline_runs[1]
+        m = min(len(r1), len(r2), k)
+        if m:
+            baseline_variance = sum(1 for i in range(m) if r1[i] != r2[i]) / m
+
+    value_pass = (
+        k > 0
+        and d > 0
+        and ci_low > 0
+        and mcnemar_p < 0.05
+        and harm == 0
+        and (baseline_variance is None or baseline_variance <= abs(d))
+    )
+    return {
+        "k_health_affected": k,
+        "arm_a_strict": a_strict,
+        "arm_b_strict": b_strict,
+        "D": d,
+        "D_ci_low": ci_low,
+        "D_ci_high": ci_high,
+        "mcnemar_p": mcnemar_p,
+        "harm": harm,
+        "help": help_,
+        "baseline_variance": baseline_variance,
+        "value_pass": value_pass,
+    }
+
+
+def _mcnemar_exact_p(b01: int, b10: int) -> float:
+    """Two-sided exact McNemar p over the n=b01+b10 discordant pairs (binomial,
+    p=0.5). Returns 1.0 when there are no discordant pairs."""
+    n = b01 + b10
+    if n == 0:
+        return 1.0
+    k = min(b01, b10)
+    # Two-sided: 2 * sum_{i=0..k} C(n,i) (0.5)^n, clamped to 1.
+    tail = sum(math.comb(n, i) for i in range(k + 1)) * (0.5**n)
+    return min(1.0, 2.0 * tail)
+
+
+def run_stage3(
+    scoreboard_per_case: list[dict[str, Any]] | None = None,
+    baseline_runs: list[list[bool]] | None = None,
+    stage2_can_measure: bool = False,
+) -> dict[str, Any]:
+    """Stage 3 VALUE verdict.
+
+    value_measured is true ONLY when k>0 AND non-null health telemetry exists AND
+    live health interventions exist (stage2_can_measure) AND a real scored
+    per-case set is supplied. Without those, value is unmeasured (never PASS,
+    never FAIL). The full stats path runs whenever per-case data is supplied (the
+    --stage3-stub offline path), but value_measured stays false unless the live
+    telemetry preconditions also hold.
+    """
+    if not scoreboard_per_case:
+        return {
+            "value_measured": False,
+            "value_verdict": "unmeasured",
+            "reason": "no scored A/B per-case data (Stage 3 needs live Haiku picks; "
+            "run --emit-prompts/--score/--build-judge/--rejoin then pass the scoreboard)",
+            "k_health_affected": 0,
+            "D": None,
+            "D_ci_low": None,
+            "D_ci_high": None,
+            "mcnemar_p": None,
+            "baseline_variance": None,
+        }
+
+    stats = compute_value_stats(scoreboard_per_case, baseline_runs=baseline_runs)
+    value_measured = bool(stats["k_health_affected"] > 0 and stage2_can_measure)
+    if not value_measured:
+        verdict = "unmeasured"
+    else:
+        verdict = "pass" if stats["value_pass"] else "fail"
+    return {
+        "value_measured": value_measured,
+        "value_verdict": verdict,
+        "reason": (
+            "value measured over k health-affected cases"
+            if value_measured
+            else "stats computed on supplied per-case set, but live health telemetry "
+            "preconditions are unmet (non-null health + live interventions) — value unmeasured"
+        ),
+        **stats,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Orchestrator — combine verdicts, write results, set exit code
+# --------------------------------------------------------------------------- #
+def orchestrate(
+    events_path: Path | None = None,
+    stage3_per_case: list[dict[str, Any]] | None = None,
+    baseline_runs: list[list[bool]] | None = None,
+) -> dict[str, Any]:
+    """Run all stages and assemble the two-verdict result dict + exit code."""
+    s1 = run_stage1()
+    s2 = run_stage2(events_path)
+    stage2_can_measure = bool(s2["non_null_health"] >= MIN_NON_NULL_HEALTH and s2["recorded_failures"] > 0)
+    s3 = run_stage3(stage3_per_case, baseline_runs=baseline_runs, stage2_can_measure=stage2_can_measure)
+
+    mechanism_pass = s1["mechanism"]["mechanism_pass"]
+    value_measured = s3["value_measured"]
+    value_verdict = s3["value_verdict"]
+
+    if not mechanism_pass:
+        exit_code = 1
+    elif not value_measured:
+        exit_code = 2
+    elif value_verdict == "pass":
+        exit_code = 0
+    else:
+        exit_code = 1
+
+    return {
+        "mechanism_verdict": "pass" if mechanism_pass else "fail",
+        "value_measured": value_measured,
+        "value_verdict": value_verdict,
+        "D": s3.get("D"),
+        "D_ci_low": s3.get("D_ci_low"),
+        "D_ci_high": s3.get("D_ci_high"),
+        "mcnemar_p": s3.get("mcnemar_p"),
+        "k_health_affected": s3.get("k_health_affected", 0),
+        "baseline_variance": s3.get("baseline_variance"),
+        "neutral_censored": s2["neutral_censored"],
+        "exit_code": exit_code,
+        "stage1": s1,
+        "stage2": s2,
+        "stage3": s3,
+    }
+
+
+def render_markdown(res: dict[str, Any]) -> str:
+    """Render the two-verdict result as a Dense-Complete Markdown table."""
+    s1, s2, s3 = res["stage1"], res["stage2"], res["stage3"]
+    real, syn, tb = s1["real"], s1["synthetic"], s1["tiebreak"]
+    mech = s1["mechanism"]
+    lines = [
+        "# Route Value Eval — Two Verdicts",
+        "",
+        "Mechanism (deterministic) and value (blind A/B) are SEPARATE verdicts. A",
+        "synthetic mechanism pass is never production value.",
+        "",
+        f"- **mechanism_verdict**: {res['mechanism_verdict'].upper()}",
+        f"- **value_measured**: {str(res['value_measured']).lower()}",
+        f"- **value_verdict**: {res['value_verdict']}",
+        f"- **exit_code**: {res['exit_code']}  "
+        "(0=mechanism+value pass; 2=mechanism pass, value unmeasured; 1=mechanism fail or value fail)",
+        "",
+        "## Stage 1 — MECHANISM (no model)",
+        "",
+        "| arm | evaluated | changed | help | harm | force-route held |",
+        "|-----|-----------|---------|------|------|------------------|",
+        f"| REAL | {real['evaluated']} | {real['changed']} | {real['help']} | {real['harm']} | - |",
+        f"| SYNTHETIC | {syn['evaluated']} | {syn['changed']} | {syn['help']} | {syn['harm']} | {syn['force_route_held']} |",
+        f"| TIEBREAK | {tb['evaluated']} | {tb['changed']} | {tb['help']} | {tb['harm']} | {tb['force_route_held']} |",
+        "",
+        f"Mechanism clauses: {json.dumps(mech['clauses'])}",
+        f"Failing clauses: {mech['failing_clauses'] or 'none'}",
+        "",
+        "REAL changes 0 routes — the honest-zero finding on live data (demote floor",
+        "unreachable: live rows are >=0.5 confidence, 0 failures). SYNTHETIC and",
+        "TIEBREAK prove the branches fire on constructed cases ONLY (conformance).",
+        "",
+        "## Stage 2 — recorded-events availability (no model)",
+        "",
+        f"- decisions: {s2['decisions']}",
+        f"- outcomes: {s2['outcomes']}",
+        f"- non_null_health: {s2['non_null_health']} (need >= {s2['min_non_null_health']})",
+        f"- recorded_failures: {s2['recorded_failures']} (need > 0)",
+        f"- neutral_censored: {s2['neutral_censored']}",
+        f"- faithful_replay_ran: {str(s2['faithful_replay_ran']).lower()}",
+        f"- skip_reason: {s2['skip_reason'] or 'n/a (ran)'}",
+        "",
+        "Stage 2 contributes NO value evidence. It is a measurement-availability",
+        "check. Neutral outcomes are censored (pre-registered), excluded from value.",
+        "",
+        "## Stage 3 — VALUE (blind A/B)",
+        "",
+        f"- value_measured: {str(s3['value_measured']).lower()}",
+        f"- value_verdict: {s3['value_verdict']}",
+        f"- k_health_affected: {s3.get('k_health_affected', 0)}",
+        f"- D: {s3.get('D')}",
+        f"- D 95% CI: [{s3.get('D_ci_low')}, {s3.get('D_ci_high')}]",
+        f"- McNemar p: {s3.get('mcnemar_p')}",
+        f"- baseline_variance: {s3.get('baseline_variance')}",
+        f"- reason: {s3.get('reason', '')}",
+        "",
+        "Value PASS requires D>0 AND CI lower bound>0 AND McNemar p<0.05 AND harm==0.",
+        "Today value is UNMEASURED: 0 non-null health, 0 recorded failures, k=0.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Routing-loop value eval (two verdicts).")
+    parser.add_argument("--out-dir", type=Path, default=_OUT_DIR)
+    parser.add_argument("--events", type=Path, default=None, help="route-events.jsonl path (read-only).")
+    parser.add_argument(
+        "--stage3-stub",
+        type=Path,
+        default=None,
+        help="JSON file with {per_case:[{a_correct,b_correct}], baseline_runs:[[...],[...]]} "
+        "to run the Stage-3 stats path offline (no LLM).",
+    )
+    args = parser.parse_args(argv)
+
+    stage3_per_case = None
+    baseline_runs = None
+    if args.stage3_stub is not None:
+        stub = json.loads(args.stage3_stub.read_text(encoding="utf-8"))
+        stage3_per_case = stub.get("per_case")
+        baseline_runs = stub.get("baseline_runs")
+
+    res = orchestrate(events_path=args.events, stage3_per_case=stage3_per_case, baseline_runs=baseline_runs)
+
+    out_dir: Path = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "route-value-eval-results.json").write_text(json.dumps(res, indent=2), encoding="utf-8")
+    (out_dir / "route-value-eval-results.md").write_text(render_markdown(res), encoding="utf-8")
+
+    print(
+        f"mechanism_verdict={res['mechanism_verdict']} value_measured={str(res['value_measured']).lower()} "
+        f"value_verdict={res['value_verdict']}"
+    )
+    s2 = res["stage2"]
+    print(
+        f"Stage 2: non_null_health={s2['non_null_health']} recorded_failures={s2['recorded_failures']} "
+        f"value_measured={str(res['value_measured']).lower()}"
+    )
+    if res["mechanism_verdict"] == "fail":
+        print(f"MECHANISM FAIL: {res['stage1']['mechanism']['failing_clauses']}", file=sys.stderr)
+    print(f"exit_code={res['exit_code']}")
+    print(f"Wrote {out_dir / 'route-value-eval-results.md'} and .json")
+    return res["exit_code"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_health_replay.py
+++ b/scripts/tests/test_health_replay.py
@@ -1,0 +1,142 @@
+"""Tests for the shadow replay (scripts/route-replay.py).
+
+The replay runs `health_adjust()` over a corpus in two arms:
+  - REAL: gold pick, no alternates, supplied weights. With healthy weights
+    (>=0.5 conf, 0 failures) it must change 0 routes.
+  - SYNTHETIC: a seeded temp DB with failure-bearing rows. Non-force-route
+    picks demote toward the healthy gold alternate (help>0, harm=0); force-route
+    picks are kept (exemption holds under the same failure load).
+
+Tests run on a tiny fixture corpus + a temp DB; the live DB is never touched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _load_replay():
+    """Import scripts/route-replay.py as a module (hyphenated filename)."""
+    spec = importlib.util.spec_from_file_location("route_replay", _REPO_ROOT / "scripts" / "route-replay.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def tiny_corpora(tmp_path: Path) -> tuple[Path, Path]:
+    """Write two tiny corpus files: one force-route case, two normal cases."""
+    ab = {
+        "version": "test",
+        "test_cases": [
+            {"request": "send commits", "expected_agent": None, "expected_skill": "pr-workflow"},
+            {
+                "request": "write a function",
+                "expected_agent": "python-general-engineer",
+                "expected_skill": "test-driven-development",
+            },
+        ],
+    }
+    bm = {
+        "version": "test",
+        "test_cases": [
+            {"request": "scan for vulns", "expected_agent": None, "expected_skill": "security-review"},
+            {"request": "explore the repo", "expected_agent": "explore", "expected_skill": "codebase-overview"},
+            {"request": "no skill case", "expected_agent": None, "expected_skill": None},
+        ],
+    }
+    ab_path = tmp_path / "ab.json"
+    bm_path = tmp_path / "bm.json"
+    ab_path.write_text(json.dumps(ab), encoding="utf-8")
+    bm_path.write_text(json.dumps(bm), encoding="utf-8")
+    return ab_path, bm_path
+
+
+def test_real_arm_zero_changes_on_healthy_weights(tiny_corpora: tuple[Path, Path], tmp_path: Path) -> None:
+    """With healthy weights and gold picks the real arm changes 0 routes."""
+    rr = _load_replay()
+    ab_path, bm_path = tiny_corpora
+    # Healthy weights for every gold key (>=0.5 conf, 0 failures).
+    weights = {
+        "direct:pr-workflow": {"confidence": 0.7, "n": 5, "success": 5, "failure": 0, "last_seen": "x"},
+        "python-general-engineer:test-driven-development": {
+            "confidence": 0.7,
+            "n": 5,
+            "success": 5,
+            "failure": 0,
+            "last_seen": "x",
+        },
+        "direct:security-review": {"confidence": 0.7, "n": 5, "success": 5, "failure": 0, "last_seen": "x"},
+        "explore:codebase-overview": {"confidence": 0.7, "n": 5, "success": 5, "failure": 0, "last_seen": "x"},
+    }
+    db_dir = tmp_path / "syn-learning"
+    result = rr.run_replay(ab_path, bm_path, db_dir=db_dir, real_weights=weights)
+
+    real = result["real"]
+    # 4 cases have a gold skill (the 5th has none and is skipped).
+    assert real["evaluated"] == 4
+    assert real["changed"] == 0
+    assert real["help"] == 0
+    assert real["harm"] == 0
+    assert real["unchanged"] == 4
+
+
+def test_synthetic_arm_help_positive_harm_zero(tiny_corpora: tuple[Path, Path], tmp_path: Path) -> None:
+    """Synthetic arm demotes failing non-force picks toward gold; force-route held."""
+    rr = _load_replay()
+    ab_path, bm_path = tiny_corpora
+    db_dir = tmp_path / "syn-learning"
+    result = rr.run_replay(ab_path, bm_path, db_dir=db_dir, real_weights={})
+
+    syn = result["synthetic"]
+    assert syn["harm"] == 0, syn["changes"]
+    # Two non-force-route cases (tdd, codebase-overview) demote toward gold.
+    assert syn["help"] == 2
+    # Two force-route cases (pr-workflow, security-review) held by exemption.
+    assert syn["force_route_held"] == 2
+
+
+def test_force_route_never_demoted_under_failure(tiny_corpora: tuple[Path, Path], tmp_path: Path) -> None:
+    """A force-route pair seeded into the floor is still kept (exemption)."""
+    rr = _load_replay()
+    ab_path, bm_path = tiny_corpora
+    db_dir = tmp_path / "syn-learning"
+    result = rr.run_replay(ab_path, bm_path, db_dir=db_dir, real_weights={})
+    syn = result["synthetic"]
+    # No change ever lands a force-route pair on a non-gold pick.
+    for change in syn["changes"]:
+        assert "pr-workflow" not in str(change["from"])
+        assert "security-review" not in str(change["from"])
+
+
+def test_render_markdown_reports_real_zero_finding(tiny_corpora: tuple[Path, Path], tmp_path: Path) -> None:
+    """Markdown renders the honest 0-change finding when the real arm is inert."""
+    rr = _load_replay()
+    ab_path, bm_path = tiny_corpora
+    weights = {
+        "direct:pr-workflow": {"confidence": 0.7, "n": 5, "success": 5, "failure": 0, "last_seen": "x"},
+        "python-general-engineer:test-driven-development": {
+            "confidence": 0.7,
+            "n": 5,
+            "success": 5,
+            "failure": 0,
+            "last_seen": "x",
+        },
+        "direct:security-review": {"confidence": 0.7, "n": 5, "success": 5, "failure": 0, "last_seen": "x"},
+        "explore:codebase-overview": {"confidence": 0.7, "n": 5, "success": 5, "failure": 0, "last_seen": "x"},
+    }
+    db_dir = tmp_path / "syn-learning"
+    result = rr.run_replay(ab_path, bm_path, db_dir=db_dir, real_weights=weights)
+    md = rr.render_markdown(result)
+    assert "changes **0** routes" in md
+    assert "harm=0" in md or "harm (away from gold): **0**" in md

--- a/scripts/tests/test_health_replay.py
+++ b/scripts/tests/test_health_replay.py
@@ -158,4 +158,29 @@ def test_render_markdown_reports_real_zero_finding(tiny_corpora: tuple[Path, Pat
     result = rr.run_replay(ab_path, bm_path, db_dir=db_dir, real_weights=weights)
     md = rr.render_markdown(result)
     assert "changes **0** routes" in md
-    assert "harm=0" in md or "harm (away from gold): **0**" in md
+    assert "harm=0" in md or "harm (moved off gold): **0**" in md
+
+
+def test_seed_calls_passes_key_as_argv_no_code_injection(tmp_path: Path) -> None:
+    """codex #5: a key with quotes/newlines/code cannot inject into the child.
+
+    The child program is constant; the key crosses as argv. A key carrying a
+    Python statement that would write a marker file proves no execution: the
+    marker must NOT appear, and the seeded weight row must use the literal key.
+    """
+    import os
+
+    rr = _load_replay()
+    db_dir = tmp_path / "inject-learning"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    env = dict(os.environ)
+    env["CLAUDE_LEARNING_DIR"] = str(db_dir)
+
+    marker = tmp_path / "PWNED"
+    # If the key were interpolated into source, this would run open(...).write().
+    malicious = f"x'); import pathlib; pathlib.Path(r'{marker}').write_text('x'); ('"
+    rr._seed_calls(env, malicious, observations=5, boosts=0, decays=0)
+
+    assert not marker.exists(), "key was interpreted as code (injection)"
+    weights = rr._read_weights(env)
+    assert malicious in weights, "row not seeded under the literal key"

--- a/scripts/tests/test_health_replay.py
+++ b/scripts/tests/test_health_replay.py
@@ -119,6 +119,25 @@ def test_force_route_never_demoted_under_failure(tiny_corpora: tuple[Path, Path]
         assert "security-review" not in str(change["from"])
 
 
+def test_tiebreak_arm_help_positive_harm_zero(tiny_corpora: tuple[Path, Path], tmp_path: Path) -> None:
+    """Tie-break arm moves low-confidence non-force picks toward gold; force held.
+
+    Proves the honest counter to "Step 1.5 cannot change a live route on healthy
+    data": tie-break keys on semantic confidence, so it fires with zero failures.
+    """
+    rr = _load_replay()
+    ab_path, bm_path = tiny_corpora
+    db_dir = tmp_path / "learning"
+    result = rr.run_replay(ab_path, bm_path, db_dir=db_dir, real_weights={})
+
+    tb = result["tiebreak"]
+    assert tb["harm"] == 0, tb["changes"]
+    # Two non-force-route cases (tdd, codebase-overview) tie-break toward gold.
+    assert tb["help"] == 2
+    # Two force-route cases (pr-workflow, security-review) held by exemption.
+    assert tb["force_route_held"] == 2
+
+
 def test_render_markdown_reports_real_zero_finding(tiny_corpora: tuple[Path, Path], tmp_path: Path) -> None:
     """Markdown renders the honest 0-change finding when the real arm is inert."""
     rr = _load_replay()

--- a/scripts/tests/test_route_decommission_check.py
+++ b/scripts/tests/test_route_decommission_check.py
@@ -45,6 +45,9 @@ def _write(path: Path, events: list[dict]) -> Path:
 
 
 def _decision(ts: float, **kw) -> dict:
+    # gate_inputs_present defaults True for a numeric-health decision (state a);
+    # state (b)/(c) tests pass it explicitly. A null-health default still marks
+    # the marker as carrying the gate input unless overridden.
     e = {
         "type": "decision",
         "ts": ts,
@@ -56,6 +59,7 @@ def _decision(ts: float, **kw) -> dict:
         "failure": kw.pop("failure", 0),
         "action": kw.pop("action", "keep"),
         "alternates": kw.pop("alternates", None),
+        "gate_inputs_present": kw.pop("gate_inputs_present", True),
     }
     e.update(kw)
     return e
@@ -75,7 +79,7 @@ def test_clock_start_is_stage0_commit():
     assert mod.STAGE0_FIX_COMMIT == "d943ba74"
     assert mod.DELETE_DAYS == 90
     assert mod.DELETE_DECISIONS == 3000
-    assert mod.MIN_HEALTH_RATE == 0.95
+    assert mod.MIN_INSTRUMENTED_RATE == 0.95
     assert mod.MAX_UNKNOWN_RATE == 0.05
 
 
@@ -168,18 +172,78 @@ def test_clock_valid_when_health_rate_and_unknown_rate_ok(tmp_path):
     assert valid is True
 
 
-def test_clock_invalid_when_health_rate_below_95(tmp_path):
+def test_clock_invalid_when_instrumented_rate_below_95(tmp_path):
+    # Contract change (soundness fix): validity counts INSTRUMENTED decisions
+    # (state a numeric + state b no-row), not non-null health. Only state (c)
+    # (no gate input on the marker) counts against the 95% rate. 9 state-(c)
+    # legacy decisions + 1 state-(a) => 10% instrumented => clock invalid.
     mod = _load()
     fix, _, _ = _mod_consts(mod)
-    # 9 null-health + 1 non-null => 10% health rate, far below 95%.
-    decs = [_decision(fix + i + 1, session=f"s{i}", health=None) for i in range(9)]
+    decs = [_decision(fix + i + 1, session=f"s{i}", health=None, gate_inputs_present=False) for i in range(9)]
     decs.append(_decision(fix + 50, session="s9", health=0.7))
     p = _write(tmp_path / "e.jsonl", decs)
     stats = mod.count_post_fix(p)
     valid, reason = mod.clock_valid(stats)
     assert valid is False
-    assert "health" in reason.lower()
+    assert "instrumented" in reason.lower()
     assert "0.1" in reason or "10" in reason  # the failing number is reported
+
+
+def test_state_b_majority_is_valid_clock(tmp_path):
+    # CORE FIX: most live picks are state (b) — pick has no weight row, recorded
+    # as null health BUT gate_inputs_present True. These are instrumented, valid,
+    # expected data. The clock must be VALID when state (b) dominates, else the
+    # decommission clock stays unreachable forever (the soundness gap).
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    events: list[dict] = []
+    for i in range(20):
+        events.append(_decision(fix + i + 1, session=f"s{i}", health=None, gate_inputs_present=True))
+        events.append({"type": "outcome", "ts": fix + i + 1.5, "session": f"s{i}", "outcome": "success"})
+    p = _write(tmp_path / "e.jsonl", events)
+    stats = mod.count_post_fix(p)
+    assert stats["state_b_norow"] == 20
+    assert stats["state_a_numeric"] == 0
+    assert stats["state_c_legacy"] == 0
+    assert stats["instrumented_rate"] == 1.0
+    valid, _reason = mod.clock_valid(stats)
+    assert valid is True
+
+
+def test_state_c_majority_is_clock_invalid(tmp_path):
+    # State (c) majority (legacy / no gate input on the marker) => instrumented
+    # rate below 95% => CLOCK-INVALID. Distinguishes missing instrumentation
+    # (state c) from the valid no-row signal (state b).
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    decs = [_decision(fix + i + 1, session=f"s{i}", health=None, gate_inputs_present=False) for i in range(19)]
+    decs.append(_decision(fix + 50, session="s19", health=None, gate_inputs_present=True))
+    p = _write(tmp_path / "e.jsonl", decs)
+    stats = mod.count_post_fix(p)
+    assert stats["state_c_legacy"] == 19
+    assert stats["state_b_norow"] == 1
+    valid, reason = mod.clock_valid(stats)
+    assert valid is False
+    assert "instrumented" in reason.lower()
+
+
+def test_three_state_breakdown_in_stats(tmp_path):
+    # The stats expose the three-state counts so the CLOCK-INVALID message and
+    # the live report can print the breakdown.
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    decs = [
+        _decision(fix + 1, session="a", health=0.7),  # state a
+        _decision(fix + 2, session="b", health=None, gate_inputs_present=True),  # state b
+        _decision(fix + 3, session="c", health=None, gate_inputs_present=False),  # state c
+    ]
+    p = _write(tmp_path / "e.jsonl", decs)
+    stats = mod.count_post_fix(p)
+    assert stats["state_a_numeric"] == 1
+    assert stats["state_b_norow"] == 1
+    assert stats["state_c_legacy"] == 1
+    # instrumented = a + b = 2 of 3 (rate rounded to 4 dp).
+    assert stats["instrumented_rate"] == 0.6667
 
 
 # --------------------------------------------------------------------------- #
@@ -247,9 +311,10 @@ def test_accruing_when_neither_threshold_reached(tmp_path):
 def test_clock_invalid_blocks_delete(tmp_path):
     mod = _load()
     fix, days, _ = _mod_consts(mod)
-    # Time threshold met AND zero interventions, but health rate is 10% => the
-    # zero cannot be trusted => CLOCK-INVALID, not DELETE.
-    decs = [_decision(fix + i + 1, session=f"s{i}", health=None) for i in range(9)]
+    # Time threshold met AND zero interventions, but instrumented rate is 10%
+    # (9 state-c legacy + 1 state-a) => the zero cannot be trusted =>
+    # CLOCK-INVALID, not DELETE.
+    decs = [_decision(fix + i + 1, session=f"s{i}", health=None, gate_inputs_present=False) for i in range(9)]
     decs.append(_decision(fix + 50, session="s9", health=0.7))
     p = _write(tmp_path / "e.jsonl", decs)
     now = fix + (days + 1) * 86400
@@ -310,7 +375,10 @@ def test_decide_emits_machine_fields(tmp_path):
         "remaining_days",
         "remaining_decisions",
         "clock_valid",
-        "health_rate",
+        "instrumented_rate",
+        "state_a_numeric",
+        "state_b_norow",
+        "state_c_legacy",
         "unknown_rate",
     ):
         assert field in res, f"missing field {field}"

--- a/scripts/tests/test_route_decommission_check.py
+++ b/scripts/tests/test_route_decommission_check.py
@@ -4,12 +4,13 @@ ADR routing-loop-value-eval, decommission trigger. The check answers one
 question: should the outcome-routing shadow loop be removed today?
 
 Contract under test:
-  - Clock start = Stage-0 wiring-fix commit (d943ba74, 2026-06-06).
+  - Clock start = Step-1.5 wiring-fix commit (d943ba74, 2026-06-06).
   - DELETE iff (elapsed >= 90 days OR post-fix decisions >= 3000) AND
-    real_demote + real_tiebreak + shadow_demote + shadow_tiebreak == 0,
-    AND the clock is valid.
-  - Clock valid iff post-fix non-null health_at_decision rate >= 95% AND
-    outcome unknown_rate <= 5%.
+    real_demote + real_tiebreak + shadow_demote == 0, AND the clock is valid.
+    Shadow tiebreak is unmeasurable (semantic confidence is not recorded) and is
+    never counted; recorded tiebreaks count as real interventions.
+  - Clock valid iff post-fix instrumented rate >= 95% AND outcome unknown_rate
+    <= 5% (sessionless rows excluded from the join, reported separately).
   - Verdicts: KEEP (interventions > 0), DELETE, ACCRUING (no threshold reached),
     CLOCK-INVALID. Exit codes: 0 KEEP/ACCRUING, 3 DELETE, 4 CLOCK-INVALID.
 
@@ -65,7 +66,7 @@ def _decision(ts: float, **kw) -> dict:
     return e
 
 
-# Clock start is the Stage-0 commit; events at FIX+1s are post-fix.
+# Clock start is the Step-1.5 commit; events at FIX+1s are post-fix.
 def _mod_consts(mod):
     return mod.STAGE0_FIX_EPOCH, mod.DELETE_DAYS, mod.DELETE_DECISIONS
 
@@ -152,6 +153,139 @@ def test_shadow_zero_when_no_alternate_weights(tmp_path):
     stats = mod.count_post_fix(p)
     assert stats["shadow_demote"] == 0
     assert stats["interventions"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Finding 3: shadow replay evaluates ONLY the demote floor, never tiebreak.
+# A low WEIGHT-ROW confidence must not fire a spurious shadow tiebreak (the
+# tiebreak gate keys on SEMANTIC confidence, which events never record).
+# --------------------------------------------------------------------------- #
+def test_low_weight_row_confidence_never_shadow_tiebreaks(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    # health_at_decision=0.20 (< LOW_CONFIDENCE 0.35) but NOT in the floor
+    # (failure=0 < 3): the OLD code conflated this weight-row confidence with
+    # semantic confidence and fired a shadow tiebreak toward the healthy
+    # alternate. The fix forces semantic confidence high, so tiebreak cannot fire
+    # and the floor does not engage => zero shadow interventions.
+    dec = _decision(
+        fix + 1,
+        action="keep",
+        health=0.20,
+        n=6,
+        failure=0,
+        alternates=[{"key": "alt:route", "confidence": 0.9, "n": 6, "success": 6, "failure": 0}],
+    )
+    p = _write(tmp_path / "e.jsonl", [dec])
+    stats = mod.count_post_fix(p)
+    assert stats["shadow_demote"] == 0
+    assert stats["interventions"] == 0
+    assert "shadow_tiebreak" not in stats  # the unmeasurable criterion is gone
+
+
+def test_recorded_tiebreak_counts_as_real_intervention(tmp_path):
+    # A recorded action=tiebreak is ground truth (the router fired) and counts as
+    # a real intervention — not a shadow.
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    dec = _decision(fix + 1, action="tiebreak", health=0.7)
+    p = _write(tmp_path / "e.jsonl", [dec])
+    stats = mod.count_post_fix(p)
+    assert stats["real_tiebreak"] == 1
+    assert stats["interventions"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# codex #6: a force-routed pair is hard-exempt and must never shadow-demote,
+# mirroring production (same canonical manifest force_route set).
+# --------------------------------------------------------------------------- #
+def test_force_route_pair_never_shadow_demotes(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    # security-review is a canonical force-route skill. Put the pick in the demote
+    # floor with a healthy alternate: without the exemption this shadow-demotes;
+    # with it the pair holds (exempt), so shadow_demote stays 0.
+    assert "security-review" in mod._FORCE_ROUTE_SKILLS  # canonical set loaded
+    dec = _decision(
+        fix + 1,
+        agent="security-reviewer",
+        skill="security-review",
+        action="keep",
+        health=0.20,
+        n=6,
+        failure=4,
+        alternates=[{"key": "alt:route", "confidence": 0.9, "n": 6, "success": 6, "failure": 0}],
+    )
+    p = _write(tmp_path / "e.jsonl", [dec])
+    stats = mod.count_post_fix(p)
+    assert stats["shadow_demote"] == 0
+    assert stats["interventions"] == 0
+
+
+def test_non_force_route_pair_still_shadow_demotes(tmp_path):
+    # Control: the SAME floor + alternate on a non-exempt skill DOES shadow-demote
+    # (proves the exemption above is the only reason the force-route pair held).
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    dec = _decision(
+        fix + 1,
+        agent="python-general-engineer",
+        skill="test-driven-development",
+        action="keep",
+        health=0.20,
+        n=6,
+        failure=4,
+        alternates=[{"key": "alt:route", "confidence": 0.9, "n": 6, "success": 6, "failure": 0}],
+    )
+    p = _write(tmp_path / "e.jsonl", [dec])
+    stats = mod.count_post_fix(p)
+    assert stats["shadow_demote"] == 1
+    assert stats["interventions"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# codex #7: sessionless rows are excluded from the join and reported in their
+# own bucket, so they distort neither unknown_rate nor the join counts.
+# --------------------------------------------------------------------------- #
+def test_sessionless_rows_excluded_from_join(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    # Two sessionless decisions + two sessionless outcomes. Under the OLD code
+    # both group under "" and the outcomes join the decisions, faking joins. Now
+    # they are excluded and bucketed; with no joinable decisions unknown_rate is
+    # 1.0 (cannot trust the zero).
+    events = [
+        _decision(fix + 1, session=""),
+        _decision(fix + 2, session=""),
+        {"type": "outcome", "ts": fix + 1.5, "session": "", "outcome": "success"},
+        {"type": "outcome", "ts": fix + 2.5, "session": "", "outcome": "success"},
+    ]
+    p = _write(tmp_path / "e.jsonl", events)
+    stats = mod.count_post_fix(p)
+    assert stats["sessionless_decisions"] == 2
+    assert stats["sessionless_outcomes"] == 2
+    assert stats["joinable_decisions"] == 0
+    assert stats["joined_outcomes"] == 0
+    assert stats["unknown_rate"] == 1.0
+
+
+def test_sessionless_decisions_do_not_inflate_unknown_rate(tmp_path):
+    # 10 well-formed sessions (each joins) + 1 sessionless decision. The
+    # sessionless row is excluded from the unknown_rate denominator, so the rate
+    # stays 0.0 (10 of 10 joinable joined) instead of being diluted.
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    events: list[dict] = []
+    for i in range(10):
+        events.append(_decision(fix + i + 1, session=f"s{i}", health=0.7))
+        events.append({"type": "outcome", "ts": fix + i + 1.5, "session": f"s{i}", "outcome": "success"})
+    events.append(_decision(fix + 100, session="", health=0.7))
+    p = _write(tmp_path / "e.jsonl", events)
+    stats = mod.count_post_fix(p)
+    assert stats["sessionless_decisions"] == 1
+    assert stats["joinable_decisions"] == 10
+    assert stats["joined_outcomes"] == 10
+    assert stats["unknown_rate"] == 0.0
 
 
 # --------------------------------------------------------------------------- #
@@ -369,7 +503,8 @@ def test_decide_emits_machine_fields(tmp_path):
         "real_demote",
         "real_tiebreak",
         "shadow_demote",
-        "shadow_tiebreak",
+        "sessionless_decisions",
+        "sessionless_outcomes",
         "post_fix_decisions",
         "elapsed_days",
         "remaining_days",

--- a/scripts/tests/test_route_decommission_check.py
+++ b/scripts/tests/test_route_decommission_check.py
@@ -1,0 +1,316 @@
+"""Tests for the routing-loop decommission check (scripts/route-decommission-check.py).
+
+ADR routing-loop-value-eval, decommission trigger. The check answers one
+question: should the outcome-routing shadow loop be removed today?
+
+Contract under test:
+  - Clock start = Stage-0 wiring-fix commit (d943ba74, 2026-06-06).
+  - DELETE iff (elapsed >= 90 days OR post-fix decisions >= 3000) AND
+    real_demote + real_tiebreak + shadow_demote + shadow_tiebreak == 0,
+    AND the clock is valid.
+  - Clock valid iff post-fix non-null health_at_decision rate >= 95% AND
+    outcome unknown_rate <= 5%.
+  - Verdicts: KEEP (interventions > 0), DELETE, ACCRUING (no threshold reached),
+    CLOCK-INVALID. Exit codes: 0 KEEP/ACCRUING, 3 DELETE, 4 CLOCK-INVALID.
+
+Deterministic, offline. Synthetic event files only; the live route-events.jsonl
+is never read (every test passes an explicit tmp path).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "route_decommission_check", _REPO_ROOT / "scripts" / "route-decommission-check.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(path: Path, events: list[dict]) -> Path:
+    path.write_text("\n".join(json.dumps(e) for e in events), encoding="utf-8")
+    return path
+
+
+def _decision(ts: float, **kw) -> dict:
+    e = {
+        "type": "decision",
+        "ts": ts,
+        "session": kw.pop("session", "s"),
+        "agent": kw.pop("agent", "python-general-engineer"),
+        "skill": kw.pop("skill", "test-driven-development"),
+        "health_at_decision": kw.pop("health", 0.7),
+        "n": kw.pop("n", 5),
+        "failure": kw.pop("failure", 0),
+        "action": kw.pop("action", "keep"),
+        "alternates": kw.pop("alternates", None),
+    }
+    e.update(kw)
+    return e
+
+
+# Clock start is the Stage-0 commit; events at FIX+1s are post-fix.
+def _mod_consts(mod):
+    return mod.STAGE0_FIX_EPOCH, mod.DELETE_DAYS, mod.DELETE_DECISIONS
+
+
+# --------------------------------------------------------------------------- #
+# Named constants tie the clock to the commit (no silent drift).
+# --------------------------------------------------------------------------- #
+def test_clock_start_is_stage0_commit():
+    mod = _load()
+    assert mod.STAGE0_FIX_EPOCH == 1780780867  # d943ba74 2026-06-06 21:21:07 UTC
+    assert mod.STAGE0_FIX_COMMIT == "d943ba74"
+    assert mod.DELETE_DAYS == 90
+    assert mod.DELETE_DECISIONS == 3000
+    assert mod.MIN_HEALTH_RATE == 0.95
+    assert mod.MAX_UNKNOWN_RATE == 0.05
+
+
+# --------------------------------------------------------------------------- #
+# Post-fix filtering: pre-fix events are ignored entirely.
+# --------------------------------------------------------------------------- #
+def test_pre_fix_events_excluded(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    p = _write(
+        tmp_path / "e.jsonl",
+        [_decision(fix - 100), _decision(fix - 1), _decision(fix + 1), _decision(fix + 2)],
+    )
+    stats = mod.count_post_fix(p)
+    assert stats["post_fix_decisions"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# Real interventions counted from the recorded action field.
+# --------------------------------------------------------------------------- #
+def test_real_interventions_counted_from_action(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    p = _write(
+        tmp_path / "e.jsonl",
+        [
+            _decision(fix + 1, action="demote"),
+            _decision(fix + 2, action="tiebreak"),
+            _decision(fix + 3, action="keep"),
+        ],
+    )
+    stats = mod.count_post_fix(p)
+    assert stats["real_demote"] == 1
+    assert stats["real_tiebreak"] == 1
+    assert stats["interventions"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# Shadow counted by replaying health_adjust on the RECORDED gate inputs.
+# Floor met on the picked pair + a recorded alternate that wins => shadow demote.
+# --------------------------------------------------------------------------- #
+def test_shadow_demote_reconstructed_from_recorded_fields(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    # Picked pair in the demote floor (conf<0.30, fail>=3, n>=5). One recorded
+    # alternate. Recorded action is "keep" (router did not fire), but the shadow
+    # replay fires demote toward the healthier alternate.
+    dec = _decision(
+        fix + 1,
+        action="keep",
+        health=0.20,
+        n=6,
+        failure=4,
+        alternates=[{"key": "alt:route", "confidence": 0.8, "n": 6, "success": 6, "failure": 0}],
+    )
+    p = _write(tmp_path / "e.jsonl", [dec])
+    stats = mod.count_post_fix(p)
+    assert stats["real_demote"] == 0
+    assert stats["shadow_demote"] == 1
+    assert stats["interventions"] == 1  # shadow counts as an intervention
+
+
+def test_shadow_zero_when_no_alternate_weights(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    # Floor met on the pick, but the recorded alternates are bare keys with no
+    # weight rows => health_adjust cannot prefer them => no shadow fire. Honest 0.
+    dec = _decision(fix + 1, action="keep", health=0.20, n=6, failure=4, alternates=["alt:route"])
+    p = _write(tmp_path / "e.jsonl", [dec])
+    stats = mod.count_post_fix(p)
+    assert stats["shadow_demote"] == 0
+    assert stats["interventions"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Clock validity gate.
+# --------------------------------------------------------------------------- #
+def test_clock_valid_when_health_rate_and_unknown_rate_ok(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    # 20 decisions, all non-null health (100% >= 95%); each joins a same-session
+    # outcome (unknown_rate 0). Clock valid.
+    events: list[dict] = []
+    for i in range(20):
+        events.append(_decision(fix + i + 1, session=f"s{i}", health=0.7))
+        events.append({"type": "outcome", "ts": fix + i + 1.5, "session": f"s{i}", "outcome": "success"})
+    p = _write(tmp_path / "e.jsonl", events)
+    stats = mod.count_post_fix(p)
+    valid, _reason = mod.clock_valid(stats)
+    assert valid is True
+
+
+def test_clock_invalid_when_health_rate_below_95(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    # 9 null-health + 1 non-null => 10% health rate, far below 95%.
+    decs = [_decision(fix + i + 1, session=f"s{i}", health=None) for i in range(9)]
+    decs.append(_decision(fix + 50, session="s9", health=0.7))
+    p = _write(tmp_path / "e.jsonl", decs)
+    stats = mod.count_post_fix(p)
+    valid, reason = mod.clock_valid(stats)
+    assert valid is False
+    assert "health" in reason.lower()
+    assert "0.1" in reason or "10" in reason  # the failing number is reported
+
+
+# --------------------------------------------------------------------------- #
+# Verdict + exit-code contract.
+# --------------------------------------------------------------------------- #
+def test_keep_when_interventions_present(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    # One real demote => KEEP regardless of clock validity (positive signal wins).
+    decs = [_decision(fix + i + 1, session=f"s{i}", health=None) for i in range(5)]
+    decs.append(_decision(fix + 50, session="x", action="demote", health=0.2, n=6, failure=4))
+    p = _write(tmp_path / "e.jsonl", decs)
+    res = mod.decide(events_path=p, now=fix + 100)
+    assert res["verdict"] == "KEEP"
+    assert res["exit_code"] == 0
+    assert res["interventions"] == 1
+
+
+def _valid_clock_events(fix: float, n: int) -> list[dict]:
+    """n decisions, each non-null health + a same-session joining outcome.
+
+    Yields a valid clock: 100% health rate, 0% unknown rate.
+    """
+    events: list[dict] = []
+    for i in range(n):
+        events.append(_decision(fix + i + 1, session=f"s{i}", health=0.7))
+        events.append({"type": "outcome", "ts": fix + i + 1.5, "session": f"s{i}", "outcome": "success"})
+    return events
+
+
+def test_delete_when_time_threshold_met_and_zero_interventions(tmp_path):
+    mod = _load()
+    fix, days, _ = _mod_consts(mod)
+    # 20 non-null health decisions, valid clock, 0 interventions, 91 days elapsed.
+    p = _write(tmp_path / "e.jsonl", _valid_clock_events(fix, 20))
+    now = fix + (days + 1) * 86400
+    res = mod.decide(events_path=p, now=now)
+    assert res["verdict"] == "DELETE"
+    assert res["exit_code"] == 3
+
+
+def test_delete_when_count_threshold_met(tmp_path):
+    mod = _load()
+    fix, _, count = _mod_consts(mod)
+    p = _write(tmp_path / "e.jsonl", _valid_clock_events(fix, count))
+    res = mod.decide(events_path=p, now=fix + 86400)  # 1 day elapsed; count carries it
+    assert res["verdict"] == "DELETE"
+    assert res["exit_code"] == 3
+
+
+def test_accruing_when_neither_threshold_reached(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    # Valid clock, 0 interventions, only 5 days + 20 decisions => below both gates.
+    p = _write(tmp_path / "e.jsonl", _valid_clock_events(fix, 20))
+    now = fix + 5 * 86400
+    res = mod.decide(events_path=p, now=now)
+    assert res["verdict"] == "ACCRUING"
+    assert res["exit_code"] == 0
+    # Exact remaining reported.
+    assert res["remaining_days"] == 85
+    assert res["remaining_decisions"] == 2980
+
+
+def test_clock_invalid_blocks_delete(tmp_path):
+    mod = _load()
+    fix, days, _ = _mod_consts(mod)
+    # Time threshold met AND zero interventions, but health rate is 10% => the
+    # zero cannot be trusted => CLOCK-INVALID, not DELETE.
+    decs = [_decision(fix + i + 1, session=f"s{i}", health=None) for i in range(9)]
+    decs.append(_decision(fix + 50, session="s9", health=0.7))
+    p = _write(tmp_path / "e.jsonl", decs)
+    now = fix + (days + 1) * 86400
+    res = mod.decide(events_path=p, now=now)
+    assert res["verdict"] == "CLOCK-INVALID"
+    assert res["exit_code"] == 4
+
+
+def test_unknown_rate_above_5_percent_invalidates_clock(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    # 20 non-null health decisions (health rate fine), but only 1 joinable
+    # outcome out of 20 decisions => unknown_rate 95% > 5% => CLOCK-INVALID.
+    decs = [_decision(fix + i + 1, session=f"s{i}", health=0.7) for i in range(20)]
+    decs.append({"type": "outcome", "ts": fix + 100, "session": "s0", "outcome": "success"})
+    # Force unknown_rate high by giving most decisions no matching outcome.
+    p = _write(tmp_path / "e.jsonl", decs)
+    stats = mod.count_post_fix(p)
+    # 19 of 20 decisions unjoinable => 0.95 unknown rate.
+    assert stats["unknown_rate"] > mod.MAX_UNKNOWN_RATE
+    valid, reason = mod.clock_valid(stats)
+    assert valid is False
+    assert "unknown" in reason.lower()
+
+
+# --------------------------------------------------------------------------- #
+# Live files are never touched: default path is read-only; tests use temp paths.
+# --------------------------------------------------------------------------- #
+def test_missing_events_file_is_clock_invalid(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    missing = tmp_path / "nope.jsonl"
+    res = mod.decide(events_path=missing, now=fix + 86400)
+    # No post-fix data => health rate undefined => clock invalid (cannot trust 0).
+    assert res["verdict"] == "CLOCK-INVALID"
+    assert res["exit_code"] == 4
+
+
+# --------------------------------------------------------------------------- #
+# JSON output shape (machine consumers).
+# --------------------------------------------------------------------------- #
+def test_decide_emits_machine_fields(tmp_path):
+    mod = _load()
+    fix, _, _ = _mod_consts(mod)
+    decs = [_decision(fix + i + 1, session=f"s{i}", health=0.7) for i in range(20)]
+    p = _write(tmp_path / "e.jsonl", decs)
+    res = mod.decide(events_path=p, now=fix + 5 * 86400)
+    for field in (
+        "verdict",
+        "exit_code",
+        "interventions",
+        "real_demote",
+        "real_tiebreak",
+        "shadow_demote",
+        "shadow_tiebreak",
+        "post_fix_decisions",
+        "elapsed_days",
+        "remaining_days",
+        "remaining_decisions",
+        "clock_valid",
+        "health_rate",
+        "unknown_rate",
+    ):
+        assert field in res, f"missing field {field}"

--- a/scripts/tests/test_route_failure.py
+++ b/scripts/tests/test_route_failure.py
@@ -1,0 +1,163 @@
+"""Tests for the route-failure subcommand (orchestrator-reported route failures).
+
+ADR orchestrator-reported-route-failures: the /do router reports routing
+failures it observes. Routing-relevant failures decay the pair's weight row
+(the finalizer's decay path) and append a reasoned failure event. Not-relevant
+failures log an event only, never decay. One failure per dispatch key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parent.parent.parent
+_repo_hooks_lib = str(_repo_root / "hooks" / "lib")
+
+sys_path_entry = str(Path(__file__).resolve().parent.parent)
+sys.path.insert(0, sys_path_entry)
+learning_db = importlib.import_module("learning-db")
+sys.path.pop(0)
+
+sys.path.insert(0, _repo_hooks_lib)
+if "learning_db_v2" in sys.modules:
+    del sys.modules["learning_db_v2"]
+import learning_db_v2 as _ld2_repo
+
+for attr_name in dir(_ld2_repo):
+    if hasattr(learning_db, attr_name) and not attr_name.startswith("__"):
+        try:
+            setattr(learning_db, attr_name, getattr(_ld2_repo, attr_name))
+        except (AttributeError, TypeError):
+            pass
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the learning DB and route-events log at a temp dir."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+
+    import learning_db_v2
+
+    monkeypatch.setattr(learning_db_v2, "_initialized", False)
+    return db_dir
+
+
+def _ns(**kwargs: object) -> argparse.Namespace:
+    base = {
+        "agent_skill": "agent-x:skill-x",
+        "reason": "re-route after unusable output",
+        "routing_relevant": "yes",
+        "session": None,
+        "marker": None,
+    }
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+def _seed(key: str) -> None:
+    from learning_db_v2 import record_learning
+
+    record_learning(
+        topic="routing",
+        key=key,
+        value="agent: x | skill: x",
+        category="effectiveness",
+        source="test:routing",
+    )
+
+
+def _confidence(key: str) -> float | None:
+    from learning_db_v2 import get_connection, init_db
+
+    init_db()
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT confidence FROM learnings WHERE topic = 'routing' AND key = ?",
+            (key,),
+        ).fetchone()
+    return None if row is None else float(row["confidence"])
+
+
+def _events(db_dir: Path) -> list[dict]:
+    path = db_dir / "route-events.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+class TestRoutingRelevant:
+    def test_decays_weight_row(self, isolated_db: Path) -> None:
+        _seed("agent-x:skill-x")
+        learning_db.cmd_route_failure(_ns(routing_relevant="yes"))
+        # finalizer decay path: 0.50 - 0.08
+        assert _confidence("agent-x:skill-x") == pytest.approx(0.42, abs=0.001)
+
+    def test_appends_failure_event_with_reason(self, isolated_db: Path) -> None:
+        _seed("agent-x:skill-x")
+        learning_db.cmd_route_failure(_ns(reason="lazy-completion re-dispatch", routing_relevant="yes"))
+        events = _events(isolated_db)
+        outcome = [e for e in events if e.get("type") == "outcome"]
+        assert len(outcome) == 1
+        assert outcome[0]["outcome"] == "failure"
+        assert outcome[0]["key"] == "agent-x:skill-x"
+        assert outcome[0]["reason"] == "lazy-completion re-dispatch"
+
+
+class TestNotRelevant:
+    def test_no_decay(self, isolated_db: Path) -> None:
+        _seed("agent-x:skill-x")
+        learning_db.cmd_route_failure(_ns(routing_relevant="no"))
+        # weight row unchanged
+        assert _confidence("agent-x:skill-x") == pytest.approx(0.50, abs=0.001)
+
+    def test_event_still_written(self, isolated_db: Path) -> None:
+        _seed("agent-x:skill-x")
+        learning_db.cmd_route_failure(_ns(routing_relevant="no", reason="bad output, right route"))
+        outcome = [e for e in _events(isolated_db) if e.get("type") == "outcome"]
+        assert len(outcome) == 1
+        assert outcome[0]["reason"] == "bad output, right route"
+
+
+class TestIdempotence:
+    def test_duplicate_key_is_noop(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _seed("agent-x:skill-x")
+        args1 = _ns(session="s1", marker="m1", routing_relevant="yes")
+        learning_db.cmd_route_failure(args1)
+        after_first = _confidence("agent-x:skill-x")
+
+        args2 = _ns(session="s1", marker="m1", routing_relevant="yes")
+        learning_db.cmd_route_failure(args2)
+        out = capsys.readouterr().out
+
+        # second run decays nothing and writes no second event
+        assert _confidence("agent-x:skill-x") == pytest.approx(after_first, abs=0.001)
+        assert "duplicate" in out.lower()
+        assert len([e for e in _events(isolated_db) if e.get("type") == "outcome"]) == 1
+
+    def test_different_marker_not_deduped(self, isolated_db: Path) -> None:
+        _seed("agent-x:skill-x")
+        learning_db.cmd_route_failure(_ns(session="s1", marker="m1", routing_relevant="yes"))
+        learning_db.cmd_route_failure(_ns(session="s1", marker="m2", routing_relevant="yes"))
+        # two distinct dispatches => two decays: 0.50 - 0.08 - 0.08
+        assert _confidence("agent-x:skill-x") == pytest.approx(0.34, abs=0.001)
+
+
+class TestExitCodes:
+    def test_duplicate_exits_zero(self, isolated_db: Path) -> None:
+        _seed("agent-x:skill-x")
+        learning_db.cmd_route_failure(_ns(session="s1", marker="m1"))
+        # duplicate run must not raise SystemExit (exit 0)
+        learning_db.cmd_route_failure(_ns(session="s1", marker="m1"))
+
+    def test_malformed_pair_exits_nonzero(self, isolated_db: Path) -> None:
+        with pytest.raises(SystemExit) as exc:
+            learning_db.cmd_route_failure(_ns(agent_skill="no-colon-here"))
+        assert exc.value.code != 0

--- a/scripts/tests/test_route_failure.py
+++ b/scripts/tests/test_route_failure.py
@@ -110,6 +110,22 @@ class TestRoutingRelevant:
         assert outcome[0]["key"] == "agent-x:skill-x"
         assert outcome[0]["reason"] == "lazy-completion re-dispatch"
 
+    def test_no_weight_row_logs_event_and_skips_decay(
+        self, isolated_db: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # routing_relevant=yes for a pair never routed (no weight row). The event
+        # must still be logged, nothing decays, exit 0, and the message says so.
+        key = "fresh-agent:fresh-skill"
+        learning_db.cmd_route_failure(_ns(agent_skill=key, routing_relevant="yes"))
+        out = capsys.readouterr().out
+
+        assert _confidence(key) is None  # no row created, nothing decayed
+        outcome = [e for e in _events(isolated_db) if e.get("type") == "outcome"]
+        assert len(outcome) == 1
+        assert outcome[0]["key"] == key
+        assert outcome[0]["outcome"] == "failure"
+        assert "nothing to decay" in out
+
 
 class TestNotRelevant:
     def test_no_decay(self, isolated_db: Path) -> None:

--- a/scripts/tests/test_route_policy.py
+++ b/scripts/tests/test_route_policy.py
@@ -135,6 +135,26 @@ def test_force_route_by_skill_name_exempt() -> None:
     assert result["action"] == "keep"
 
 
+def test_force_route_pair_flag_different_agent_still_exempt() -> None:
+    """Attack C: flag is a full pair whose AGENT differs from the pick's agent.
+
+    Force-route protection is keyed by SKILL: a security skill must be exempt no
+    matter which agent the semantic layer paired it with. A flag
+    ``other-agent:security-review`` must still protect a pick
+    ``pick-agent:security-review`` (same skill, different agent). Pre-fix this
+    returned demote (the skill-name fallback compared against a full-pair flag
+    and missed).
+    """
+    pick = {"key": "pick-agent:security-review", "confidence": 0.5}
+    weights = {
+        "pick-agent:security-review": _w(0.05, 20, 1, 18),
+        "agent-good:skill-good": _w(0.99, 50, 50, 0),
+    }
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"other-agent:security-review"})
+    assert result["final_pick"] == "pick-agent:security-review"
+    assert result["action"] == "keep"
+
+
 # --- comparative health ----------------------------------------------------
 
 
@@ -176,6 +196,37 @@ def test_tiebreak_only_when_semantic_low() -> None:
     result = health_adjust(pick, ["agent-b:skill-b"], weights, set())
     assert result["action"] == "tiebreak"
     assert result["final_pick"] == "agent-b:skill-b"
+
+
+def test_tiebreak_requires_evidenced_alternate() -> None:
+    """Tie-break never moves toward an under-evidenced alternate (n < 5).
+
+    Low semantic confidence alone is not enough: the healthier alternate must
+    clear the evidence gate. A flashy but under-observed alternate is ignored,
+    and the semantic pick stands. This bounds the tie-break path so it cannot
+    reroute toward thin evidence.
+    """
+    pick = {"key": "agent-a:skill-a", "confidence": 0.2}
+    weights = {
+        "agent-a:skill-a": _w(0.50, 8, 4, 4),
+        "agent-b:skill-b": _w(0.99, MIN_OBSERVATIONS - 1, MIN_OBSERVATIONS - 1, 0),
+    }
+    result = health_adjust(pick, ["agent-b:skill-b"], weights, set())
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "agent-a:skill-a"
+
+
+def test_tiebreak_does_not_fire_with_no_alternates() -> None:
+    """Low semantic confidence + no alternates supplied => pick stands.
+
+    The real-DB replay arm offers no alternates, so tie-break cannot fire there
+    even though semantic confidence is moot. Documents why the real arm is 0.
+    """
+    pick = {"key": "agent-a:skill-a", "confidence": 0.1}
+    weights = {"agent-a:skill-a": _w(0.50, 8, 4, 4)}
+    result = health_adjust(pick, [], weights, set())
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "agent-a:skill-a"
 
 
 def test_no_tiebreak_when_semantic_high() -> None:

--- a/scripts/tests/test_route_policy.py
+++ b/scripts/tests/test_route_policy.py
@@ -155,6 +155,88 @@ def test_force_route_pair_flag_different_agent_still_exempt() -> None:
     assert result["action"] == "keep"
 
 
+# --- force-route exemption: normalization (Codex C2 adversarial table) ------
+#
+# _is_exempt must normalize (strip + casefold) the skill-name reduction on both
+# sides. These cover Codex's proven bypasses: a noncanonical pick or flag must
+# still KEEP. The empty-flags control must still DEMOTE (proves the floor logic
+# is reachable and the exemption is not silently swallowing every case).
+
+
+def _floor_pick_and_weights(pick_key: str) -> tuple[dict[str, object], dict[str, object]]:
+    """A floor-demotable pick plus a healthier alternate, for exemption tests."""
+    pick = {"key": pick_key, "confidence": 0.5}
+    weights = {
+        pick_key: _w(0.05, 20, 1, 18),
+        "agent-good:skill-good": _w(0.99, 50, 50, 0),
+    }
+    return pick, weights
+
+
+def test_exempt_case_changed_pick() -> None:
+    """Case-changed pick (Security-Review) vs canonical flag still KEEPS."""
+    pick, weights = _floor_pick_and_weights("direct:Security-Review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"security-review"})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "direct:Security-Review"
+
+
+def test_exempt_case_changed_flag() -> None:
+    """Case-changed flag (Security-Review) vs canonical pick still KEEPS."""
+    pick, weights = _floor_pick_and_weights("direct:security-review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"Security-Review"})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "direct:security-review"
+
+
+def test_exempt_whitespace_pick() -> None:
+    """Trailing-whitespace pick skill still KEEPS."""
+    pick, weights = _floor_pick_and_weights("direct:security-review ")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"security-review"})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "direct:security-review "
+
+
+def test_exempt_whitespace_flag() -> None:
+    """Surrounding-whitespace flag still KEEPS."""
+    pick, weights = _floor_pick_and_weights("direct:security-review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {" security-review "})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "direct:security-review"
+
+
+def test_exempt_agent_mismatch_full_pair_flag() -> None:
+    """Full-pair flag with a different agent but same skill still KEEPS."""
+    pick, weights = _floor_pick_and_weights("pick-agent:security-review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"other-agent:security-review"})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "pick-agent:security-review"
+
+
+def test_exempt_bare_skill_flag() -> None:
+    """Bare skill-name flag (manifest form) still KEEPS."""
+    pick, weights = _floor_pick_and_weights("direct:security-review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"security-review"})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "direct:security-review"
+
+
+def test_exempt_exact_full_pair() -> None:
+    """Exact full-pair flag matching the pick verbatim still KEEPS."""
+    pick, weights = _floor_pick_and_weights("direct:security-review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"direct:security-review"})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "direct:security-review"
+
+
+def test_exempt_control_empty_flags_demotes() -> None:
+    """Control: with NO flags, the same floor pick DEMOTES (exemption is real)."""
+    pick, weights = _floor_pick_and_weights("direct:security-review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, set())
+    assert result["action"] == "demote"
+    assert result["final_pick"] == "agent-good:skill-good"
+
+
 # --- comparative health ----------------------------------------------------
 
 

--- a/scripts/tests/test_route_policy.py
+++ b/scripts/tests/test_route_policy.py
@@ -1,0 +1,234 @@
+"""Tests for the pure `health_adjust()` routing policy (scripts/lib/route_policy.py).
+
+health_adjust is a PURE function: no I/O, no DB, no clock. Given the semantic
+pick, its alternates, the T1 weight map, and the set of force-routed pairs, it
+returns {final_pick, action, reason}. The policy:
+
+  - Evidence gate: with fewer than MIN_OBSERVATIONS (5) observations on the
+    pick, never demote (insufficient evidence). Default = semantic pick stands.
+  - Floor demote: demote ONLY if confidence < 0.30 AND failure >= 3 AND n >= 5.
+  - Force-route / security pairs are NEVER demoted (hard exempt) — the most
+    important guarantee in the build.
+  - Tie-break toward higher-health alternate ONLY when the semantic confidence
+    is "low"; otherwise the semantic pick stands.
+  - High-failure pick loses to a high-success alternate (when demotable + a
+    healthier candidate exists).
+  - A fresh pick (n < 5) is never demoted.
+
+These tests import the function directly — no subprocess, no DB.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from scripts.lib.route_policy import (
+    MIN_OBSERVATIONS,
+    health_adjust,
+)
+
+
+def _w(confidence: float, n: int, success: int, failure: int) -> dict[str, object]:
+    """Build one weight-map entry."""
+    return {
+        "confidence": confidence,
+        "n": n,
+        "success": success,
+        "failure": failure,
+        "last_seen": "2026-06-01T00:00:00",
+    }
+
+
+# --- evidence gate ---------------------------------------------------------
+
+
+def test_gate_noop_below_min_observations() -> None:
+    """A pick with n < 5 is never demoted even if confidence is in the floor."""
+    pick = {"key": "agent-a:skill-a", "confidence": 0.9}
+    weights = {"agent-a:skill-a": _w(0.10, MIN_OBSERVATIONS - 1, 0, MIN_OBSERVATIONS - 1)}
+    result = health_adjust(pick, [], weights, set())
+    assert result["final_pick"] == "agent-a:skill-a"
+    assert result["action"] == "keep"
+
+
+def test_fresh_pick_never_demoted() -> None:
+    """A pick with no weight row at all (brand new) stands unchanged."""
+    pick = {"key": "agent-new:skill-new", "confidence": 0.9}
+    result = health_adjust(pick, ["agent-b:skill-b"], {}, set())
+    assert result["final_pick"] == "agent-new:skill-new"
+    assert result["action"] == "keep"
+
+
+# --- floor demote ----------------------------------------------------------
+
+
+def test_floor_demote_fires_on_seeded_data() -> None:
+    """conf < 0.30 AND failure >= 3 AND n >= 5 demotes the pick."""
+    pick = {"key": "agent-bad:skill-bad", "confidence": 0.5}
+    weights = {
+        "agent-bad:skill-bad": _w(0.20, 8, 2, 6),
+        "agent-good:skill-good": _w(0.85, 10, 9, 1),
+    }
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, set())
+    assert result["action"] == "demote"
+    assert result["final_pick"] == "agent-good:skill-good"
+
+
+def test_floor_held_when_failure_below_three() -> None:
+    """Low confidence alone (failure < 3) does NOT demote."""
+    pick = {"key": "agent-x:skill-x", "confidence": 0.5}
+    weights = {"agent-x:skill-x": _w(0.20, 6, 4, 2)}
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, set())
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "agent-x:skill-x"
+
+
+def test_floor_held_when_confidence_at_or_above_threshold() -> None:
+    """confidence == 0.30 is not below the floor; no demote."""
+    pick = {"key": "agent-x:skill-x", "confidence": 0.5}
+    weights = {"agent-x:skill-x": _w(0.30, 9, 3, 5)}
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, set())
+    assert result["action"] == "keep"
+
+
+# --- force-route exemption (THE critical test) -----------------------------
+
+
+def test_force_route_pair_never_demoted() -> None:
+    """A force-routed pair in the floor with a healthier alternate STAYS.
+
+    This is the most important guarantee in the entire build: a force-route /
+    security pair can never be re-ranked away, regardless of its health.
+    """
+    pick = {"key": "security-reviewer:security-review", "confidence": 0.5}
+    weights = {
+        "security-reviewer:security-review": _w(0.05, 20, 1, 18),
+        "agent-good:skill-good": _w(0.99, 50, 50, 0),
+    }
+    result = health_adjust(
+        pick,
+        ["agent-good:skill-good"],
+        weights,
+        {"security-reviewer:security-review"},
+    )
+    assert result["final_pick"] == "security-reviewer:security-review"
+    assert result["action"] == "keep"
+    assert "force" in result["reason"].lower() or "exempt" in result["reason"].lower()
+
+
+def test_force_route_by_skill_name_exempt() -> None:
+    """Force-route flag given as bare skill name (not full pair) still exempts."""
+    pick = {"key": "security-reviewer:security-review", "confidence": 0.5}
+    weights = {
+        "security-reviewer:security-review": _w(0.05, 20, 1, 18),
+        "agent-good:skill-good": _w(0.99, 50, 50, 0),
+    }
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"security-review"})
+    assert result["final_pick"] == "security-reviewer:security-review"
+    assert result["action"] == "keep"
+
+
+# --- comparative health ----------------------------------------------------
+
+
+def test_high_failure_loses_to_high_success() -> None:
+    """A demotable high-failure pick yields to the healthiest alternate."""
+    pick = {"key": "agent-bad:skill-bad", "confidence": 0.5}
+    weights = {
+        "agent-bad:skill-bad": _w(0.10, 12, 2, 10),
+        "agent-mid:skill-mid": _w(0.55, 10, 6, 4),
+        "agent-best:skill-best": _w(0.95, 20, 19, 1),
+    }
+    result = health_adjust(pick, ["agent-mid:skill-mid", "agent-best:skill-best"], weights, set())
+    assert result["action"] == "demote"
+    assert result["final_pick"] == "agent-best:skill-best"
+
+
+def test_demote_keeps_pick_when_no_healthier_alternate() -> None:
+    """If every alternate is also unhealthy, the pick stands (nowhere to go)."""
+    pick = {"key": "agent-bad:skill-bad", "confidence": 0.5}
+    weights = {
+        "agent-bad:skill-bad": _w(0.10, 12, 2, 10),
+        "agent-worse:skill-worse": _w(0.05, 15, 1, 14),
+    }
+    result = health_adjust(pick, ["agent-worse:skill-worse"], weights, set())
+    assert result["final_pick"] == "agent-bad:skill-bad"
+    assert result["action"] == "keep"
+
+
+# --- low-confidence tie-break ----------------------------------------------
+
+
+def test_tiebreak_only_when_semantic_low() -> None:
+    """With LOW semantic confidence, tie-break toward the higher-health alternate."""
+    pick = {"key": "agent-a:skill-a", "confidence": 0.2}
+    weights = {
+        "agent-a:skill-a": _w(0.50, 8, 4, 4),
+        "agent-b:skill-b": _w(0.90, 12, 11, 1),
+    }
+    result = health_adjust(pick, ["agent-b:skill-b"], weights, set())
+    assert result["action"] == "tiebreak"
+    assert result["final_pick"] == "agent-b:skill-b"
+
+
+def test_no_tiebreak_when_semantic_high() -> None:
+    """With HIGH semantic confidence, the semantic pick stands despite health gap."""
+    pick = {"key": "agent-a:skill-a", "confidence": 0.95}
+    weights = {
+        "agent-a:skill-a": _w(0.50, 8, 4, 4),
+        "agent-b:skill-b": _w(0.90, 12, 11, 1),
+    }
+    result = health_adjust(pick, ["agent-b:skill-b"], weights, set())
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "agent-a:skill-a"
+
+
+def test_default_semantic_pick_stands() -> None:
+    """Healthy pick, healthy data, normal confidence => keep, no surprises."""
+    pick = {"key": "agent-a:skill-a", "confidence": 0.7}
+    weights = {"agent-a:skill-a": _w(0.80, 30, 28, 2)}
+    result = health_adjust(pick, ["agent-b:skill-b"], weights, set())
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "agent-a:skill-a"
+
+
+# --- output contract -------------------------------------------------------
+
+
+def test_result_shape_has_required_keys() -> None:
+    """Every return carries final_pick, action, reason."""
+    pick = {"key": "agent-a:skill-a", "confidence": 0.7}
+    result = health_adjust(pick, [], {}, set())
+    assert set(result) >= {"final_pick", "action", "reason"}
+    assert isinstance(result["reason"], str) and result["reason"]
+
+
+def test_purity_inputs_not_mutated() -> None:
+    """The function mutates none of its inputs (pure)."""
+    pick = {"key": "agent-bad:skill-bad", "confidence": 0.5}
+    alternates = ["agent-good:skill-good"]
+    weights = {
+        "agent-bad:skill-bad": _w(0.10, 8, 1, 7),
+        "agent-good:skill-good": _w(0.95, 10, 10, 0),
+    }
+    forced: set[str] = set()
+    import copy
+
+    pick_c, alt_c, w_c, f_c = (
+        copy.deepcopy(pick),
+        copy.deepcopy(alternates),
+        copy.deepcopy(weights),
+        set(forced),
+    )
+    health_adjust(pick, alternates, weights, forced)
+    assert pick == pick_c
+    assert alternates == alt_c
+    assert weights == w_c
+    assert forced == f_c

--- a/scripts/tests/test_route_value_eval.py
+++ b/scripts/tests/test_route_value_eval.py
@@ -135,6 +135,9 @@ def test_stage2_counts_and_censors_neutral(tmp_path):
     p = tmp_path / "route-events.jsonl"
     lines = [
         {"type": "decision", "health_at_decision": None, "action": "keep"},
+        # A demote decision with historical failure_count=4. Under finding [51]
+        # this must NOT count toward recorded_failures: it is a snapshot of the
+        # weight row's history, not this dispatch's outcome.
         {"type": "decision", "health_at_decision": 0.2, "action": "demote", "n": 6, "failure": 4},
         {"type": "outcome", "outcome": "neutral"},
         {"type": "outcome", "outcome": "failure"},
@@ -145,9 +148,39 @@ def test_stage2_counts_and_censors_neutral(tmp_path):
     assert res["outcomes"] == 2
     assert res["non_null_health"] == 1
     assert res["neutral_censored"] == 1
-    assert res["recorded_failures"] == 2  # demote decision + failure outcome
+    # Only the one failure OUTCOME counts; the demote decision does not (finding [51]).
+    assert res["recorded_failures"] == 1
     # Still below the gate (non_null_health < 20).
     assert res["faithful_replay_ran"] is False
+
+
+def test_stage2_recorded_failures_counts_only_routing_relevant_outcomes(tmp_path):
+    """Finding [51]: recorded_failures = routing-relevant outcome=="failure" only.
+
+    Legacy failure events (no routing_relevant field) count; explicit
+    routing_relevant: false events do not; decision-event failure_count never
+    counts regardless of action.
+    """
+    ev = _load_eval()
+    p = tmp_path / "route-events.jsonl"
+    lines = [
+        # Historical failure_count on decisions: must contribute 0 failures.
+        {"type": "decision", "health_at_decision": 0.1, "action": "demote", "n": 9, "failure": 7},
+        {"type": "decision", "health_at_decision": 0.4, "action": "keep", "n": 9, "failure": 3},
+        # Legacy failure outcome (no field) -> counts.
+        {"type": "outcome", "outcome": "failure"},
+        # Explicitly routing-relevant failure -> counts.
+        {"type": "outcome", "outcome": "failure", "routing_relevant": True},
+        # Explicitly NOT routing-relevant failure -> excluded.
+        {"type": "outcome", "outcome": "failure", "routing_relevant": False},
+        # Non-failure outcomes never count as failures.
+        {"type": "outcome", "outcome": "success", "routing_relevant": True},
+        {"type": "outcome", "outcome": "neutral"},
+    ]
+    p.write_text("\n".join(json.dumps(x) for x in lines), encoding="utf-8")
+    res = ev.run_stage2(events_path=p)
+    assert res["recorded_failures"] == 2  # two relevant failure outcomes only
+    assert res["neutral_censored"] == 1
 
 
 # --------------------------------------------------------------------------- #
@@ -282,9 +315,46 @@ def test_judge_rows_strip_forbidden_fields_and_score_only_k():
 
 # --------------------------------------------------------------------------- #
 # Orchestrator — exit-code contract
+#
+# orchestrate() calls run_stage1(), which (unstubbed) shells out to the live DB
+# via `learning-db.py route-weights --json`. Every orchestrate test stubs
+# run_stage1 so no test reads or spawns against the live learning dir (finding
+# [19]). _stub_stage1 lets a test force the mechanism verdict pass/fail.
 # --------------------------------------------------------------------------- #
+def _stub_stage1(mechanism_pass: bool = True) -> dict:
+    """A minimal Stage-1 result with a controllable mechanism verdict.
+
+    Mirrors the shape orchestrate() reads: real/synthetic/tiebreak arm blocks and
+    a `mechanism` block. No DB, no subprocess.
+    """
+    arm = {"evaluated": 0, "changed": 0, "help": 0, "harm": 0, "unchanged": 0, "force_route_held": 0}
+    clauses = {"real_changed_zero": mechanism_pass}
+    return {
+        "real": dict(arm),
+        "synthetic": dict(arm),
+        "tiebreak": dict(arm),
+        "force_case_count": 0,
+        "mechanism": {
+            "clauses": clauses,
+            "mechanism_pass": mechanism_pass,
+            "failing_clauses": [] if mechanism_pass else ["real_changed_zero"],
+        },
+    }
+
+
+def _patch_stage1(monkeypatch, ev, *, mechanism_pass: bool) -> None:
+    """Replace run_stage1 with a DB-free stub so no test touches the live DB."""
+    result = _stub_stage1(mechanism_pass=mechanism_pass)
+
+    def _fake_run_stage1(*_args, **_kwargs):
+        return result
+
+    monkeypatch.setattr(ev, "run_stage1", _fake_run_stage1)
+
+
 def test_value_unmeasured_yields_exit_2_not_0(tmp_path, monkeypatch):
     ev = _load_eval()
+    _patch_stage1(monkeypatch, ev, mechanism_pass=True)
     empty = tmp_path / "route-events.jsonl"
     res = ev.orchestrate(events_path=empty, stage3_per_case=None)
     assert res["mechanism_verdict"] == "pass"
@@ -292,15 +362,15 @@ def test_value_unmeasured_yields_exit_2_not_0(tmp_path, monkeypatch):
     assert res["exit_code"] == 2  # NOT 0
 
 
-def test_exit_0_only_when_value_measured_and_pass(tmp_path):
+def test_exit_0_only_when_value_measured_and_pass(tmp_path, monkeypatch):
     ev = _load_eval()
-    # Simulate live telemetry that clears the Stage-2 gate (>=20 non-null, failure>0)
-    # AND a strongly-positive A/B per-case set.
+    _patch_stage1(monkeypatch, ev, mechanism_pass=True)
+    # Simulate live telemetry that clears the Stage-2 gate (>=20 non-null health
+    # AND >0 routing-relevant failure outcomes) AND a strongly-positive A/B set.
     p = tmp_path / "route-events.jsonl"
-    decs = [
-        {"type": "decision", "health_at_decision": 0.2, "action": "demote", "n": 6, "failure": 4} for _ in range(25)
-    ]
-    p.write_text("\n".join(json.dumps(x) for x in decs), encoding="utf-8")
+    decs = [{"type": "decision", "health_at_decision": 0.2, "action": "keep", "n": 6} for _ in range(25)]
+    fails = [{"type": "outcome", "outcome": "failure"} for _ in range(3)]
+    p.write_text("\n".join(json.dumps(x) for x in decs + fails), encoding="utf-8")
     a = [False] * 14
     b = [True] * 12 + [False] * 2
     res = ev.orchestrate(events_path=p, stage3_per_case=_per_case(a, b))
@@ -309,13 +379,13 @@ def test_exit_0_only_when_value_measured_and_pass(tmp_path):
     assert res["exit_code"] == 0
 
 
-def test_value_fail_when_measured_yields_exit_1(tmp_path):
+def test_value_fail_when_measured_yields_exit_1(tmp_path, monkeypatch):
     ev = _load_eval()
+    _patch_stage1(monkeypatch, ev, mechanism_pass=True)
     p = tmp_path / "route-events.jsonl"
-    decs = [
-        {"type": "decision", "health_at_decision": 0.2, "action": "demote", "n": 6, "failure": 4} for _ in range(25)
-    ]
-    p.write_text("\n".join(json.dumps(x) for x in decs), encoding="utf-8")
+    decs = [{"type": "decision", "health_at_decision": 0.2, "action": "keep", "n": 6} for _ in range(25)]
+    fails = [{"type": "outcome", "outcome": "failure"} for _ in range(3)]
+    p.write_text("\n".join(json.dumps(x) for x in decs + fails), encoding="utf-8")
     # Harm present => value FAIL when measured.
     a = [False] * 13 + [True]
     b = [True] * 12 + [False, False]
@@ -323,3 +393,51 @@ def test_value_fail_when_measured_yields_exit_1(tmp_path):
     assert res["value_measured"] is True
     assert res["value_verdict"] == "fail"
     assert res["exit_code"] == 1
+
+
+def test_mechanism_fail_yields_exit_1(tmp_path, monkeypatch):
+    """Finding [20]: the mechanism-fail exit_code=1 path had zero coverage.
+
+    Force mechanism_pass=False via a stubbed Stage 1 and assert orchestrate()
+    reports mechanism_verdict==fail with exit_code==1 (the same exit code as a
+    value fail, which is why finding [81] added a distinguishing stderr line).
+    """
+    ev = _load_eval()
+    _patch_stage1(monkeypatch, ev, mechanism_pass=False)
+    empty = tmp_path / "route-events.jsonl"
+    res = ev.orchestrate(events_path=empty, stage3_per_case=None)
+    assert res["mechanism_verdict"] == "fail"
+    assert res["exit_code"] == 1
+    assert res["stage1"]["mechanism"]["failing_clauses"] == ["real_changed_zero"]
+
+
+def test_main_value_fail_prints_value_fail_diagnostic(tmp_path, monkeypatch, capsys):
+    """Finding [81]: a value fail must print a VALUE FAIL stderr line distinct
+    from the MECHANISM FAIL line, since both exit 1."""
+    ev = _load_eval()
+    _patch_stage1(monkeypatch, ev, mechanism_pass=True)
+    p = tmp_path / "route-events.jsonl"
+    decs = [{"type": "decision", "health_at_decision": 0.2, "action": "keep", "n": 6} for _ in range(25)]
+    fails = [{"type": "outcome", "outcome": "failure"} for _ in range(3)]
+    p.write_text("\n".join(json.dumps(x) for x in decs + fails), encoding="utf-8")
+    stub = tmp_path / "stub.json"
+    a = [False] * 13 + [True]
+    b = [True] * 12 + [False, False]
+    stub.write_text(json.dumps({"per_case": _per_case(a, b)}), encoding="utf-8")
+    code = ev.main(["--events", str(p), "--out-dir", str(tmp_path / "out"), "--stage3-stub", str(stub)])
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "VALUE FAIL:" in captured.err
+    assert "MECHANISM FAIL:" not in captured.err
+
+
+def test_main_mechanism_fail_prints_mechanism_diagnostic(tmp_path, monkeypatch, capsys):
+    """Finding [81]/[20]: a mechanism fail prints MECHANISM FAIL, not VALUE FAIL."""
+    ev = _load_eval()
+    _patch_stage1(monkeypatch, ev, mechanism_pass=False)
+    empty = tmp_path / "route-events.jsonl"
+    code = ev.main(["--events", str(empty), "--out-dir", str(tmp_path / "out")])
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "MECHANISM FAIL:" in captured.err
+    assert "VALUE FAIL:" not in captured.err

--- a/scripts/tests/test_route_value_eval.py
+++ b/scripts/tests/test_route_value_eval.py
@@ -1,0 +1,325 @@
+"""Tests for the route value eval orchestrator (scripts/route-value-eval.py).
+
+Two verdicts, never one gate (ADR: routing-loop-value-eval):
+  - Stage 1 MECHANISM: REAL changed==0; SYNTHETIC/TIEBREAK help>0, harm==0,
+    force-route held.
+  - Stage 2: skip-with-reason on current data (non_null_health=0, failures=0).
+  - Stage 3 VALUE: value PASS needs D>0 + CI lower bound>0 + McNemar p<0.05 +
+    harm==0; value_measured=false yields exit 2, not exit 0.
+
+Deterministic, offline. Stage 1 runs on a tiny fixture corpus + temp DB; the
+live DB and live route-events.jsonl are never touched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _load_eval():
+    spec = importlib.util.spec_from_file_location("route_value_eval", _REPO_ROOT / "scripts" / "route-value-eval.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def tiny_corpora(tmp_path: Path) -> tuple[Path, Path]:
+    """Two tiny corpus files: force-route + normal cases (mirrors health_replay)."""
+    ab = {
+        "version": "test",
+        "test_cases": [
+            {"request": "send commits", "expected_agent": None, "expected_skill": "pr-workflow", "bucket": "git"},
+            {
+                "request": "write a function",
+                "expected_agent": "python-general-engineer",
+                "expected_skill": "test-driven-development",
+                "bucket": "code",
+            },
+        ],
+    }
+    bm = {
+        "version": "test",
+        "test_cases": [
+            {"request": "scan for vulns", "expected_agent": None, "expected_skill": "security-review", "bucket": "sec"},
+            {
+                "request": "explore the repo",
+                "expected_agent": "explore",
+                "expected_skill": "codebase-overview",
+                "bucket": "explore",
+            },
+            {"request": "no skill case", "expected_agent": None, "expected_skill": None, "bucket": "none"},
+        ],
+    }
+    ab_path = tmp_path / "ab.json"
+    bm_path = tmp_path / "bm.json"
+    ab_path.write_text(json.dumps(ab), encoding="utf-8")
+    bm_path.write_text(json.dumps(bm), encoding="utf-8")
+    return ab_path, bm_path
+
+
+_HEALTHY = {
+    "direct:pr-workflow": {"confidence": 0.7, "n": 5, "success": 5, "failure": 0, "last_seen": "x"},
+    "python-general-engineer:test-driven-development": {
+        "confidence": 0.7,
+        "n": 5,
+        "success": 5,
+        "failure": 0,
+        "last_seen": "x",
+    },
+    "direct:security-review": {"confidence": 0.7, "n": 5, "success": 5, "failure": 0, "last_seen": "x"},
+    "explore:codebase-overview": {"confidence": 0.7, "n": 5, "success": 5, "failure": 0, "last_seen": "x"},
+}
+
+
+# --------------------------------------------------------------------------- #
+# Stage 1 — MECHANISM
+# --------------------------------------------------------------------------- #
+def test_stage1_real_changed_zero(tiny_corpora, tmp_path):
+    ev = _load_eval()
+    ab, bm = tiny_corpora
+    res = ev.run_stage1(ab_path=ab, benchmark_path=bm, db_dir=tmp_path / "db", real_weights=_HEALTHY)
+    assert res["real"]["changed"] == 0
+    assert res["mechanism"]["clauses"]["real_changed_zero"] is True
+
+
+def test_stage1_synthetic_help_harm_force(tiny_corpora, tmp_path):
+    ev = _load_eval()
+    ab, bm = tiny_corpora
+    res = ev.run_stage1(ab_path=ab, benchmark_path=bm, db_dir=tmp_path / "db", real_weights=_HEALTHY)
+    syn = res["synthetic"]
+    assert syn["help"] > 0
+    assert syn["harm"] == 0
+    assert syn["force_route_held"] == 2  # pr-workflow + security-review held
+    cl = res["mechanism"]["clauses"]
+    assert cl["synthetic_help_positive"] and cl["synthetic_harm_zero"] and cl["synthetic_force_route_held"]
+
+
+def test_stage1_tiebreak_help_harm_force(tiny_corpora, tmp_path):
+    ev = _load_eval()
+    ab, bm = tiny_corpora
+    res = ev.run_stage1(ab_path=ab, benchmark_path=bm, db_dir=tmp_path / "db", real_weights=_HEALTHY)
+    tb = res["tiebreak"]
+    assert tb["help"] > 0
+    assert tb["harm"] == 0
+    assert tb["force_route_held"] == 2
+    assert res["mechanism"]["mechanism_pass"] is True
+
+
+# --------------------------------------------------------------------------- #
+# Stage 2 — recorded-events availability (skip with reason today)
+# --------------------------------------------------------------------------- #
+def test_stage2_skip_with_reason_on_empty(tmp_path):
+    ev = _load_eval()
+    empty = tmp_path / "route-events.jsonl"  # does not exist
+    res = ev.run_stage2(events_path=empty)
+    assert res["non_null_health"] == 0
+    assert res["recorded_failures"] == 0
+    assert res["faithful_replay_ran"] is False
+    assert res["value_measured"] is False
+    assert "non_null_health=0" in res["skip_reason"]
+
+
+def test_stage2_counts_and_censors_neutral(tmp_path):
+    ev = _load_eval()
+    p = tmp_path / "route-events.jsonl"
+    lines = [
+        {"type": "decision", "health_at_decision": None, "action": "keep"},
+        {"type": "decision", "health_at_decision": 0.2, "action": "demote", "n": 6, "failure": 4},
+        {"type": "outcome", "outcome": "neutral"},
+        {"type": "outcome", "outcome": "failure"},
+    ]
+    p.write_text("\n".join(json.dumps(x) for x in lines), encoding="utf-8")
+    res = ev.run_stage2(events_path=p)
+    assert res["decisions"] == 2
+    assert res["outcomes"] == 2
+    assert res["non_null_health"] == 1
+    assert res["neutral_censored"] == 1
+    assert res["recorded_failures"] == 2  # demote decision + failure outcome
+    # Still below the gate (non_null_health < 20).
+    assert res["faithful_replay_ran"] is False
+
+
+# --------------------------------------------------------------------------- #
+# Stage 3 — VALUE stats
+# --------------------------------------------------------------------------- #
+def _per_case(a_correct, b_correct):
+    return [{"a_correct": a, "b_correct": b} for a, b in zip(a_correct, b_correct, strict=True)]
+
+
+def test_stage3_value_pass_requires_all_gates():
+    ev = _load_eval()
+    # Strong positive signal: B fixes 12 of 14, never harms. D>0, CI>0, p<0.05.
+    a = [False] * 14
+    b = [True] * 12 + [False] * 2
+    stats = ev.compute_value_stats(_per_case(a, b))
+    assert stats["D"] > 0
+    assert stats["D_ci_low"] > 0
+    assert stats["mcnemar_p"] < 0.05
+    assert stats["harm"] == 0
+    assert stats["value_pass"] is True
+
+
+def test_stage3_harm_blocks_value_pass():
+    ev = _load_eval()
+    # B helps a lot but harms one correct route => hard gate fails.
+    a = [False] * 13 + [True]
+    b = [True] * 12 + [False, False]  # last: A right, B wrong = harm
+    stats = ev.compute_value_stats(_per_case(a, b))
+    assert stats["harm"] == 1
+    assert stats["value_pass"] is False
+
+
+def test_stage3_noop_does_not_pass():
+    ev = _load_eval()
+    # D == 0 (B no better than A) must not pass.
+    a = [True, False, True, False]
+    b = [True, False, True, False]
+    stats = ev.compute_value_stats(_per_case(a, b))
+    assert stats["D"] == 0
+    assert stats["value_pass"] is False
+
+
+def test_stage3_unmeasured_when_no_per_case():
+    ev = _load_eval()
+    s3 = ev.run_stage3(scoreboard_per_case=None, stage2_can_measure=False)
+    assert s3["value_measured"] is False
+    assert s3["value_verdict"] == "unmeasured"
+
+
+def test_stage3_unmeasured_when_telemetry_absent_even_with_data():
+    ev = _load_eval()
+    a = [False] * 14
+    b = [True] * 12 + [False] * 2
+    s3 = ev.run_stage3(scoreboard_per_case=_per_case(a, b), stage2_can_measure=False)
+    # Stats computed, but live telemetry preconditions unmet => unmeasured.
+    assert s3["value_measured"] is False
+    assert s3["value_verdict"] == "unmeasured"
+
+
+# --------------------------------------------------------------------------- #
+# Alternate builder — mixes a plausibly-wrong route so harm is catchable
+# --------------------------------------------------------------------------- #
+def test_alternate_builder_includes_wrong_route(tiny_corpora):
+    ev = _load_eval()
+    ab, bm = tiny_corpora
+    rr = importlib.util.spec_from_file_location("route_replay", _REPO_ROOT / "scripts" / "route-replay.py")
+    mod = importlib.util.module_from_spec(rr)
+    rr.loader.exec_module(mod)
+    cases = mod.load_corpus(ab) + mod.load_corpus(bm)
+    alts = ev.build_alternates(cases)
+    # Each gold-bearing case gets a non-empty alternate pool, and at least one
+    # case's pool contains a route that is NOT its own gold (a wrong route).
+    assert any(len(v) > 0 for v in alts.values())
+    for i, case in enumerate(cases):
+        gold = ev._gold_key(case)
+        if gold is None:
+            continue
+        assert gold not in alts.get(i, []), "gold must not be its own alternate"
+
+
+# --------------------------------------------------------------------------- #
+# Stage 3 — live arm computation + judge blinding
+# --------------------------------------------------------------------------- #
+def test_compute_health_arms_identifies_k_affected():
+    ev = _load_eval()
+    cases = [
+        {"request": "r0", "expected_agent": "python-general-engineer", "expected_skill": "tdd", "bucket": "code"},
+        {"request": "r1", "expected_agent": "explore", "expected_skill": "overview", "bucket": "explore"},
+    ]
+    # Case 0: low-confidence pick on a wrong route + an evidenced healthy gold
+    # alternate => tie-break moves it (B != A). Case 1: confident, no alternate move.
+    weights = {
+        "wrong:route": {"confidence": 0.6, "n": 6, "success": 4, "failure": 0},
+        "python-general-engineer:tdd": {"confidence": 0.9, "n": 8, "success": 8, "failure": 0},
+    }
+    picks = {
+        0: {"key": "wrong:route", "confidence": 0.1},  # low conf => tie-break candidate
+        1: {"key": "explore:overview", "confidence": 0.9},
+    }
+    alternates = {0: ["python-general-engineer:tdd"], 1: []}
+    arms = ev.compute_health_arms(picks, cases, weights, set(), alternates=alternates)
+    assert arms["k_health_affected"] == 1
+    affected = next(c for c in arms["per_case"] if c["case_index"] == 0)
+    assert affected["a_pick"] == "wrong:route"
+    assert affected["b_pick"] == "python-general-engineer:tdd"
+    assert affected["action"] == "tiebreak"
+
+
+def test_judge_rows_strip_forbidden_fields_and_score_only_k():
+    ev = _load_eval()
+    cases = [
+        {"request": "r0", "expected_agent": "python-general-engineer", "expected_skill": "tdd", "bucket": "code"},
+        {"request": "r1", "expected_agent": "explore", "expected_skill": "overview", "bucket": "explore"},
+    ]
+    weights = {
+        "wrong:route": {"confidence": 0.6, "n": 6, "success": 4, "failure": 0},
+        "python-general-engineer:tdd": {"confidence": 0.9, "n": 8, "success": 8, "failure": 0},
+    }
+    picks = {0: {"key": "wrong:route", "confidence": 0.1}, 1: {"key": "explore:overview", "confidence": 0.9}}
+    alternates = {0: ["python-general-engineer:tdd"], 1: []}
+    arms = ev.compute_health_arms(picks, cases, weights, set(), alternates=alternates)
+    rows, uid_map = ev.build_judge_rows(arms, cases)
+    # Only the 1 health-affected case => 2 rows (Arm A + Arm B), arm-stripped.
+    assert len(rows) == 2
+    assert len(uid_map) == 2
+    for row in rows:
+        assert ev._JUDGE_FORBIDDEN_FIELDS.isdisjoint(row.keys())
+        assert set(row.keys()) == {"uid", "query", "predicted_agent", "predicted_skill"}
+    # The private map records the arm (judge never sees it).
+    assert {m["arm"] for m in uid_map.values()} == {"A", "B"}
+
+
+# --------------------------------------------------------------------------- #
+# Orchestrator — exit-code contract
+# --------------------------------------------------------------------------- #
+def test_value_unmeasured_yields_exit_2_not_0(tmp_path, monkeypatch):
+    ev = _load_eval()
+    empty = tmp_path / "route-events.jsonl"
+    res = ev.orchestrate(events_path=empty, stage3_per_case=None)
+    assert res["mechanism_verdict"] == "pass"
+    assert res["value_measured"] is False
+    assert res["exit_code"] == 2  # NOT 0
+
+
+def test_exit_0_only_when_value_measured_and_pass(tmp_path):
+    ev = _load_eval()
+    # Simulate live telemetry that clears the Stage-2 gate (>=20 non-null, failure>0)
+    # AND a strongly-positive A/B per-case set.
+    p = tmp_path / "route-events.jsonl"
+    decs = [
+        {"type": "decision", "health_at_decision": 0.2, "action": "demote", "n": 6, "failure": 4} for _ in range(25)
+    ]
+    p.write_text("\n".join(json.dumps(x) for x in decs), encoding="utf-8")
+    a = [False] * 14
+    b = [True] * 12 + [False] * 2
+    res = ev.orchestrate(events_path=p, stage3_per_case=_per_case(a, b))
+    assert res["value_measured"] is True
+    assert res["value_verdict"] == "pass"
+    assert res["exit_code"] == 0
+
+
+def test_value_fail_when_measured_yields_exit_1(tmp_path):
+    ev = _load_eval()
+    p = tmp_path / "route-events.jsonl"
+    decs = [
+        {"type": "decision", "health_at_decision": 0.2, "action": "demote", "n": 6, "failure": 4} for _ in range(25)
+    ]
+    p.write_text("\n".join(json.dumps(x) for x in decs), encoding="utf-8")
+    # Harm present => value FAIL when measured.
+    a = [False] * 13 + [True]
+    b = [True] * 12 + [False, False]
+    res = ev.orchestrate(events_path=p, stage3_per_case=_per_case(a, b))
+    assert res["value_measured"] is True
+    assert res["value_verdict"] == "fail"
+    assert res["exit_code"] == 1

--- a/scripts/tests/test_route_weights.py
+++ b/scripts/tests/test_route_weights.py
@@ -168,4 +168,8 @@ def test_performance_10k_rows(isolated_db: Path) -> None:
     rows = learning_db.collect_route_weights()
     elapsed = time.perf_counter() - start
     assert len(rows) == 10000
-    assert elapsed < 0.1, f"route-weights query took {elapsed * 1000:.1f}ms (>100ms)"
+    # Guard against accidental O(n^2)/full-table-scan regressions, not runner jitter.
+    # At 10k rows a real regression lands in seconds; 0.5s keeps the guard while
+    # absorbing shared-runner variance (a clean run is ~0.01s; shared CI runners
+    # have measured ~0.114s for this same correct query).
+    assert elapsed < 0.5, f"route-weights query took {elapsed * 1000:.1f}ms (>500ms)"

--- a/scripts/tests/test_route_weights.py
+++ b/scripts/tests/test_route_weights.py
@@ -1,0 +1,171 @@
+"""Tests for the `route-weights --json` subcommand of learning-db.py.
+
+route-weights is a thin read-only reader over routing/effectiveness rows.
+It emits JSON keyed `<agent>:<skill>` with {confidence, n, success, failure,
+last_seen}, where n = observation_count. It must:
+  - be deterministic in ordering,
+  - exclude obvious test rows (source LIKE 'test%'),
+  - never write to the DB,
+  - run fast (<100ms at 10k rows).
+
+Rows are seeded into a temp DB via record_learning / boost_confidence /
+decay_confidence; the command runs as a subprocess so we exercise the real
+CLI entry point against CLAUDE_LEARNING_DIR.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parent.parent.parent
+_repo_hooks_lib = str(_repo_root / "hooks" / "lib")
+_cli_path = str(_repo_root / "scripts" / "learning-db.py")
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the learning DB at a temp dir so tests never touch real data."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+
+    # Make the repo hooks/lib importable and reset the init flag for this proc.
+    if _repo_hooks_lib not in sys.path:
+        sys.path.insert(0, _repo_hooks_lib)
+    import learning_db_v2
+
+    monkeypatch.setattr(learning_db_v2, "_initialized", False)
+    return db_dir
+
+
+def _seed_route(key: str, *, source: str = "routing:decision") -> None:
+    """Seed one routing/effectiveness row."""
+    from learning_db_v2 import record_learning
+
+    record_learning(
+        topic="routing",
+        key=key,
+        value=f"agent: {key.split(':')[0]} | skill: {key.split(':')[-1]}",
+        category="effectiveness",
+        source=source,
+    )
+
+
+def _run_cli(db_dir: Path) -> subprocess.CompletedProcess[str]:
+    """Run `learning-db.py route-weights --json` as a subprocess."""
+    env = dict(os.environ)
+    env["CLAUDE_LEARNING_DIR"] = str(db_dir)
+    return subprocess.run(
+        [sys.executable, _cli_path, "route-weights", "--json"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_shape_and_math(isolated_db: Path) -> None:
+    """Output is keyed agent:skill with the documented fields and correct math."""
+    from learning_db_v2 import boost_confidence, decay_confidence
+
+    _seed_route("golang-general-engineer:go-patterns")
+    boost_confidence("routing", "golang-general-engineer:go-patterns")
+    boost_confidence("routing", "golang-general-engineer:go-patterns")
+
+    _seed_route("python-general-engineer:test-driven-development")
+    decay_confidence("routing", "python-general-engineer:test-driven-development")
+
+    result = _run_cli(isolated_db)
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+
+    go = data["golang-general-engineer:go-patterns"]
+    assert set(go) == {"confidence", "n", "success", "failure", "last_seen"}
+    assert go["success"] == 2
+    assert go["failure"] == 0
+    assert go["n"] >= 1
+    assert isinstance(go["confidence"], float)
+    assert go["last_seen"]
+
+    py = data["python-general-engineer:test-driven-development"]
+    assert py["success"] == 0
+    assert py["failure"] == 1
+
+
+def test_excludes_test_rows(isolated_db: Path) -> None:
+    """Rows from a test source are omitted."""
+    _seed_route("real-agent:real-skill", source="routing:decision")
+    _seed_route("fake-agent:fake-skill", source="test:fixture")
+
+    result = _run_cli(isolated_db)
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+
+    assert "real-agent:real-skill" in data
+    assert "fake-agent:fake-skill" not in data
+
+
+def test_deterministic_ordering(isolated_db: Path) -> None:
+    """Two runs over the same data yield byte-identical key ordering."""
+    for key in ("b-agent:b-skill", "a-agent:a-skill", "c-agent:c-skill"):
+        _seed_route(key)
+
+    first = _run_cli(isolated_db)
+    second = _run_cli(isolated_db)
+    assert first.returncode == 0 and second.returncode == 0
+    assert first.stdout == second.stdout
+    keys = list(json.loads(first.stdout).keys())
+    assert keys == sorted(keys)
+
+
+def test_empty_db_emits_object(isolated_db: Path) -> None:
+    """No routing rows -> empty JSON object, exit 0."""
+    result = _run_cli(isolated_db)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {}
+
+
+def test_no_writes(isolated_db: Path) -> None:
+    """The command does not mutate the DB file."""
+    _seed_route("x-agent:x-skill")
+    db_file = isolated_db / "learning.db"
+    before = db_file.stat().st_mtime_ns
+    time.sleep(0.01)
+    result = _run_cli(isolated_db)
+    assert result.returncode == 0, result.stderr
+    after = db_file.stat().st_mtime_ns
+    assert before == after, "route-weights must not write to the DB"
+
+
+@pytest.mark.slow
+def test_performance_10k_rows(isolated_db: Path) -> None:
+    """Reads 10k rows in under 100ms (query time, excluding interpreter start)."""
+    from learning_db_v2 import record_learning
+
+    for i in range(10000):
+        record_learning(
+            topic="routing",
+            key=f"agent{i}:skill{i}",
+            value="agent: a | skill: s",
+            category="effectiveness",
+            source="routing:decision",
+        )
+
+    # Time only the query path, in-process, not subprocess startup.
+    sys.path.insert(0, str(_repo_root / "scripts"))
+    import importlib
+
+    learning_db = importlib.import_module("learning-db")
+    sys.path.pop(0)
+
+    start = time.perf_counter()
+    rows = learning_db.collect_route_weights()
+    elapsed = time.perf_counter() - start
+    assert len(rows) == 10000
+    assert elapsed < 0.1, f"route-weights query took {elapsed * 1000:.1f}ms (>100ms)"

--- a/skills/business/productivity/SKILL.md
+++ b/skills/business/productivity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: productivity
-description: Productivity workflows — task management, daily planning, weekly reviews, meeting optimization, focus management, goal setting, status updates. Use when planning days, managing tasks, running weekly reviews, optimizing meetings, or writing status updates.
+description: Personal productivity — sort out what to work on next, prioritize tasks, plan your day, run weekly reviews, optimize meetings, set goals, write status updates. Use when planning days, managing tasks, running weekly reviews, optimizing meetings, or writing status updates.
 routing:
   triggers:
     - "productivity"
@@ -15,6 +15,7 @@ routing:
     - "prioritize tasks"
     - "standup"
     - "retrospective"
+  not_for: "software task specs, requirements, or plan-lifecycle management — that is planning. This is personal prioritization and time management, not building a project plan."
   category: business
   force_route: false
   pairs_with: []

--- a/skills/content/professional-communication/SKILL.md
+++ b/skills/content/professional-communication/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: professional-communication
-description: "Transform technical communication into structured business formats."
+description: "Draft interpersonal and meeting messages — emails, memos, status updates, and pushing back or disagreeing in a structured business format."
 user-invocable: false
 allowed-tools:
   - Read
@@ -15,6 +15,7 @@ routing:
     - "executive summary"
     - "summarize for management"
     - "status update"
+  not_for: "critiquing or stress-testing a proposal's merits — that is multi-persona-critique. This drafts the message, it does not judge the idea."
   category: content-creation
   pairs_with:
     - voice-writer

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -478,7 +478,7 @@ Detect: "first...then", "and also", numbered lists, semicolons. Sequential depen
 
 Invoke `auto-pipeline` for unmatched requests. If none matches — or when uncertain — **ROUTE ANYWAY** to the closest agent + verification-before-completion as safety net.
 
-**Lazy-completion check (before declaring done).** When an agent returns a "done" claim on an enumerable objective ("all N", a file list, a count), compare claimed scope vs objective scope; if claimed < objective, reject the early "done" and re-dispatch the remainder. See `skills/meta/do/references/lazy-completion-detector.md`.
+**Lazy-completion check (before declaring done).** When an agent returns a "done" claim on an enumerable objective ("all N", a file list, a count), compare claimed scope vs objective scope; if claimed < objective, reject the early "done" and re-dispatch the remainder. See `skills/meta/do/references/lazy-completion-detector.md`. On a re-dispatch from this check, report the route failure (see Learning Capture, "Report routing failures").
 
 **Gate**: Agent invoked, results delivered. Learning capture runs automatically (see note below).
 
@@ -501,6 +501,14 @@ Hooks capture everything; the router records nothing by hand:
 These feed the routing loop: `learning-db.py route-health` reads the decision rows (denominator) and boost/decay outcomes (numerator). See ADR `learn-step-to-hook`.
 
 **Outcome fidelity (note).** An outcome resolves deterministically on the user's NEXT turn at zero LLM cost: the pending outcome stays *provisional* (no eager boost/decay) and finalizes once — **failure** on tool errors OR a clear rejection/rework/re-route, **success** otherwise (no complaint = accepted). The Stop fallback resolves autonomous runs from the error flag alone. The reaction detector is **deterministic and high-precision** — failure fires only on strong, unambiguous markers.
+
+**Report routing failures (router-reported channel).** The finalizer only sees tool errors and next-turn rejections; routing failures YOU observe fall through. On a HIGH-CONFIDENCE routing failure only, run:
+
+```bash
+python3 ~/.claude/scripts/learning-db.py route-failure AGENT:SKILL --reason "<cause>" --routing-relevant yes --session $SESSION --marker $DISPATCH_ID
+```
+
+Run it for: re-route after unusable output; lazy-completion re-dispatch; section-validator misroute that reached dispatch; harness-rejected agent type. Bad execution by the RIGHT route -> `--routing-relevant no` (event only, no decay). Ambiguous -> record nothing (precision over recall). `--routing-relevant yes` decays the pair via the finalizer's decay path; one failure per dispatch key (re-runs are no-ops). See ADR `orchestrator-reported-route-failures`.
 
 **OPTIONAL (not a gate):** curated free-text insight and review-finding graduation are opt-in via the `retro` skill (`retro graduate`), not a router step:
 

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -231,6 +231,8 @@ Call `health_adjust(semantic_pick, alternates, weights, force_route_flags)` (`sc
 
 **Always log the evaluation** to the T3 event stream: set `health_at_decision` (the picked pair's `{confidence, n, failure}` from the weights, or `null` when absent) so `routing-decision-recorder` records it on the per-dispatch DECISION event in `<CLAUDE_LEARNING_DIR>/route-events.jsonl`. This is live shadow instrumentation: every route is scored even when nothing changes.
 
+Carry the gate inputs on the routing marker (Phase 4 Step 2) so the recorder snapshots them at decision time. Confidence alone cannot reconstruct the demote floor — it needs `n` and `failure` too. Append to the marker: ` health={confidence} n={n} fail={failure} action={keep|demote|tiebreak}`, and ` alts={k1,k2}` when you passed alternates. When the picked pair has no weight row, append ` health=-` (the recorder writes null health and drops the n/fail/action fields).
+
 **Gate state — DEMOTE cannot fire on current data (by design).** Every routing row is at or above 0.5 confidence with zero recorded failures, so the floor condition matches no row; the demote branch is unreachable until the signal-fidelity fixes (neutral outcomes + Stop fallback) let negative signal accumulate. TIE-BREAK is separate: it keys on semantic confidence, so it CAN move a route today on a low-confidence pick with an evidenced alternate (intended behavior). Demote is pure shadow instrumentation now; tie-break is live but only on low-confidence dispatches you explicitly hand alternates.
 
 **Step 1: Deterministic safety-net** (`pre-route.py` — runs AFTER the semantic decision, never short-circuits it)
@@ -435,6 +437,8 @@ Four injections (verbatim): completeness and density standards on Simple+; refer
 **MANDATORY: Base instructions.** MUST include: "Before starting work, also load `agents/base-instructions.md` for universal operational rules."
 
 **MANDATORY: Stamp the routing marker on every routed agent prompt.** Prepend verbatim: `[do-route] agent={agent} skill={skill} complexity={complexity}` (use `skill=-` when routing agent-only). It is the SOLE signal `routing-decision-recorder` uses to record a `routing` row, reading `agent`/`skill` straight from it. Dispatches without it (pr-review sub-agents, nested fan-out) are correctly excluded from route-health. Stamp each agent in a roster.
+
+Append the Step 1.5 gate inputs to the same marker line so the recorder snapshots the route's decision-time health: ` health={confidence} n={n} fail={failure} action={keep|demote|tiebreak}`, plus ` alts={k1,k2}` when alternates were passed. When the picked pair has no weight row, append ` health=-` only (the recorder writes null). Example: `[do-route] agent=python-general-engineer skill=test-driven-development complexity=Medium health=0.72 n=6 fail=0 action=keep`.
 
 **Token budget signal (optional, documented).** Read `orchestration.token_budget` from `.claude/settings.json` (default 500000 when absent). Subtract a rough estimate of tokens spent; prepend to each agent prompt: "~{remaining} tokens available for this task; prioritize accordingly." Advisory, not a hard cap. Read the key once per session.
 

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -219,7 +219,8 @@ python3 "$SDIR/learning-db.py" route-weights --json
 Call `health_adjust(semantic_pick, alternates, weights, force_route_flags)` (`scripts/lib/route_policy.py`). It returns `{final_pick, action, reason}` with `action` in `keep | demote | tiebreak`.
 
 - **Demote fires only at the floor:** `confidence < 0.30 AND failure >= 3 AND n >= 5`, and only toward a healthier alternate. Otherwise the **semantic pick stands**.
-- **Force-route/security pairs are hard-exempt** — checked first, never demoted.
+- **Tie-break:** when the SEMANTIC confidence is low (`< 0.35`) AND an evidenced (`n >= 5`) healthier alternate is supplied, the route moves toward that alternate. This is gated on semantic confidence, not the floor — so unlike demote, tie-break CAN move a route on current data when you pass a low-confidence pick plus a real alternate. Pass alternates only when you genuinely have them.
+- **Force-route/security pairs are hard-exempt** — checked first, never demoted, never tie-broken. Exemption is by SKILL name (a security skill is protected under any agent), and accepts force_route_flags as bare skill names or full `agent:skill` pairs.
 - **Evidence gate:** `n < 5` or no row => keep the semantic pick.
 
 **Banner:** on a `demote`, add one optional line to the routing banner:
@@ -230,7 +231,7 @@ Call `health_adjust(semantic_pick, alternates, weights, force_route_flags)` (`sc
 
 **Always log the evaluation** to the T3 event stream: set `health_at_decision` (the picked pair's `{confidence, n, failure}` from the weights, or `null` when absent) so `routing-decision-recorder` records it on the per-dispatch DECISION event in `<CLAUDE_LEARNING_DIR>/route-events.jsonl`. This is live shadow instrumentation: every route is scored even when nothing changes.
 
-**Gate state — cannot fire on current data (by design).** Every routing row is at or above 0.5 confidence with zero recorded failures, so the floor condition matches no row; the demote branch is unreachable until the signal-fidelity fixes (neutral outcomes + Stop fallback) let negative signal accumulate. Until then Step 1.5 is pure instrumentation: it scores and logs, it does not reroute.
+**Gate state — DEMOTE cannot fire on current data (by design).** Every routing row is at or above 0.5 confidence with zero recorded failures, so the floor condition matches no row; the demote branch is unreachable until the signal-fidelity fixes (neutral outcomes + Stop fallback) let negative signal accumulate. TIE-BREAK is separate: it keys on semantic confidence, so it CAN move a route today on a low-confidence pick with an evidenced alternate (intended behavior). Demote is pure shadow instrumentation now; tie-break is live but only on low-confidence dispatches you explicitly hand alternates.
 
 **Step 1: Deterministic safety-net** (`pre-route.py` — runs AFTER the semantic decision, never short-circuits it)
 

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -229,7 +229,7 @@ Call `health_adjust(semantic_pick, alternates, weights, force_route_flags)` (`sc
  [health] demoted {old_pair} -> {new_pair} (conf, fail/n)
 ```
 
-**Always log the evaluation** to the T3 event stream: set `health_at_decision` (the picked pair's `{confidence, n, failure}` from the weights, or `null` when absent) so `routing-decision-recorder` records it on the per-dispatch DECISION event in `<CLAUDE_LEARNING_DIR>/route-events.jsonl`. This is live shadow instrumentation: every route is scored even when nothing changes.
+**Always log the evaluation** to the T3 event stream: set `health_at_decision` to the picked pair's `confidence` scalar (a float, or `null` when the pair has no weight row); `n` and `failure` are separate fields. The recorder writes all three from the marker onto the per-dispatch DECISION event in `<CLAUDE_LEARNING_DIR>/route-events.jsonl`. This is live shadow instrumentation: every route is scored even when nothing changes.
 
 Carry the gate inputs on the routing marker (Phase 4 Step 2) so the recorder snapshots them at decision time. Confidence alone cannot reconstruct the demote floor — it needs `n` and `failure` too. Append to the marker: ` health={confidence} n={n} fail={failure} action={keep|demote|tiebreak}`, and ` alts={k1,k2}` when you passed alternates. When the picked pair has no weight row, append ` health=-` (the recorder writes null health and drops the n/fail/action fields).
 
@@ -486,7 +486,7 @@ Invoke `auto-pipeline` for unmatched requests. If none matches — or when uncer
 
 ### Learning Capture (automatic — no router step)
 
-Hooks capture everything; the router records nothing by hand:
+Hooks capture everything automatically. The router records by hand exactly one case: orchestrator-reported route failures it observes directly (see "Report routing failures" below) — the single deliberate manual capture step, by ADR design. Everything else is hook-driven:
 
 | Capture | Hook | Event |
 |---------|------|-------|
@@ -500,7 +500,7 @@ Hooks capture everything; the router records nothing by hand:
 
 These feed the routing loop: `learning-db.py route-health` reads the decision rows (denominator) and boost/decay outcomes (numerator). See ADR `learn-step-to-hook`.
 
-**Outcome fidelity (note).** An outcome resolves deterministically on the user's NEXT turn at zero LLM cost: the pending outcome stays *provisional* (no eager boost/decay) and finalizes once — **failure** on tool errors OR a clear rejection/rework/re-route, **success** otherwise (no complaint = accepted). The Stop fallback resolves autonomous runs from the error flag alone. The reaction detector is **deterministic and high-precision** — failure fires only on strong, unambiguous markers.
+**Outcome fidelity (note).** An outcome resolves deterministically on the user's NEXT turn at zero LLM cost: the pending outcome stays *provisional* (no eager boost/decay) and finalizes once, THREE-WAY (T4) — **failure** on tool errors OR a clear rejection/rework/re-route (decay); **success** only on an explicit acceptance marker (boost); **neutral** otherwise — an unrelated/new-topic next prompt is no-op (no boost, no decay, no count change). No complaint is NOT acceptance. The Stop fallback resolves still-pending autonomous runs from the error flag alone: errors => failure, a clean run => neutral (a quiet Stop carries no acceptance evidence, so it does not boost). The reaction detector is **deterministic and high-precision** — failure fires only on strong, unambiguous markers.
 
 **Report routing failures (router-reported channel).** The finalizer only sees tool errors and next-turn rejections; routing failures YOU observe fall through. On a HIGH-CONFIDENCE routing failure only, run:
 

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -205,6 +205,33 @@ If the Haiku JSON is malformed, fall back to `general-purpose` + verification-be
 
 Route to the simplest agent+skill that satisfies the request. On `[cross-repo]` output, route to `.claude/agents/` local agents. Route all code changes to domain agents.
 
+**Step 1.5: Health-aware re-rank (gated, shadow instrumentation)**
+
+Runs AFTER the semantic pick (Step 0/0b), BEFORE the Step 1 safety-net — so pre-route safety always wins over health, and the Step 2 verb override may still change the skill afterward (accepted, documented).
+
+Once per /do, read the routing weights and ask the policy whether health should override the semantic pick:
+
+```bash
+SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
+python3 "$SDIR/learning-db.py" route-weights --json
+```
+
+Call `health_adjust(semantic_pick, alternates, weights, force_route_flags)` (`scripts/lib/route_policy.py`). It returns `{final_pick, action, reason}` with `action` in `keep | demote | tiebreak`.
+
+- **Demote fires only at the floor:** `confidence < 0.30 AND failure >= 3 AND n >= 5`, and only toward a healthier alternate. Otherwise the **semantic pick stands**.
+- **Force-route/security pairs are hard-exempt** — checked first, never demoted.
+- **Evidence gate:** `n < 5` or no row => keep the semantic pick.
+
+**Banner:** on a `demote`, add one optional line to the routing banner:
+
+```
+ [health] demoted {old_pair} -> {new_pair} (conf, fail/n)
+```
+
+**Always log the evaluation** to the T3 event stream: set `health_at_decision` (the picked pair's `{confidence, n, failure}` from the weights, or `null` when absent) so `routing-decision-recorder` records it on the per-dispatch DECISION event in `<CLAUDE_LEARNING_DIR>/route-events.jsonl`. This is live shadow instrumentation: every route is scored even when nothing changes.
+
+**Gate state — cannot fire on current data (by design).** Every routing row is at or above 0.5 confidence with zero recorded failures, so the floor condition matches no row; the demote branch is unreachable until the signal-fidelity fixes (neutral outcomes + Stop fallback) let negative signal accumulate. Until then Step 1.5 is pure instrumentation: it scores and logs, it does not reroute.
+
 **Step 1: Deterministic safety-net** (`pre-route.py` — runs AFTER the semantic decision, never short-circuits it)
 
 Use its result ONLY as a guardrail:

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -508,7 +508,7 @@ These feed the routing loop: `learning-db.py route-health` reads the decision ro
 python3 ~/.claude/scripts/learning-db.py route-failure AGENT:SKILL --reason "<cause>" --routing-relevant yes --session $SESSION --marker $DISPATCH_ID
 ```
 
-Run it for: re-route after unusable output; lazy-completion re-dispatch; section-validator misroute that reached dispatch; harness-rejected agent type. Bad execution by the RIGHT route -> `--routing-relevant no` (event only, no decay). Ambiguous -> record nothing (precision over recall). `--routing-relevant yes` decays the pair via the finalizer's decay path; one failure per dispatch key (re-runs are no-ops). See ADR `orchestrator-reported-route-failures`.
+Run it for: re-route after unusable output; lazy-completion re-dispatch; section-validator misroute that reached dispatch; harness-rejected agent type. Bad execution by the RIGHT route -> `--routing-relevant no` (event only, no decay). Ambiguous -> record nothing (precision over recall). `--routing-relevant yes` decays the pair via the finalizer's decay path; one failure per dispatch key (re-runs are no-ops). Treat `<cause>` as untrusted: strip quotes, backticks, `$`, and newlines before splicing it into the shell line — never pass model- or user-derived text raw. See ADR `orchestrator-reported-route-failures`.
 
 **OPTIONAL (not a gate):** curated free-text insight and review-finding graduation are opt-in via the `retro` skill (`retro graduate`), not a router step:
 

--- a/skills/process/planning/SKILL.md
+++ b/skills/process/planning/SKILL.md
@@ -20,7 +20,7 @@ allowed-tools:
   - Skill
 routing:
   force_route: true
-  not_for: "city planning, financial planning, meeting planning, travel itineraries, casual 'planning meeting notes' — only for software task planning, specs, and plan-lifecycle management"
+  not_for: "city/financial/meeting/travel planning; and personal prioritization like 'what should I work on next' — that is productivity. Only for software task planning, specs, and plan-lifecycle management."
   triggers:
     - "write spec"
     - "user stories"

--- a/skills/research/multi-persona-critique/SKILL.md
+++ b/skills/research/multi-persona-critique/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multi-persona-critique
-description: "Parallel critique of proposals via 5 philosophical personas with consensus synthesis."
+description: "Critique a written proposal or design artifact via 5 philosophical personas in parallel, with consensus synthesis."
 user-invocable: true
 argument-hint: "<proposals to critique, or 'generate N ideas about X'>"
 allowed-tools:
@@ -20,6 +20,7 @@ routing:
     - "evaluate from multiple perspectives"
     - "get different viewpoints"
     - "critique proposals"
+  not_for: "speaking to a person, a meeting, or pushing back in a conversation — that is professional-communication. This critiques an artifact, not interpersonal messaging."
   pairs_with:
     - roast
     - decision-helper

--- a/skills/research/research-pipeline/SKILL.md
+++ b/skills/research/research-pipeline/SKILL.md
@@ -25,6 +25,7 @@ routing:
     - "systematic investigation"
     - "research report"
     - "gather evidence"
+  not_for: "a quick one-off web search or chat-style lookup — that is deep-research. Pick this when the user wants a sourced report saved as an artifact (SCOPE-to-DELIVER), even when phrased as 'dig into X and give me a sourced report'."
   category: research
   pairs_with:
     - kb

--- a/skills/review/systematic-code-review/SKILL.md
+++ b/skills/review/systematic-code-review/SKILL.md
@@ -15,6 +15,7 @@ routing:
     - "code audit"
     - "review methodology"
     - "comprehensive review"
+  not_for: "vague no-target requests like 'make this better' — those are interview-mode, where the agent asks what to improve. Only for reviewing a named file, diff, or PR."
   category: code-review
   pairs_with:
     - forensics


### PR DESCRIPTION
## What

The outcome-routing shadow loop, made production-grade: health-aware route re-rank (Step 1.5), an orchestrator-reported failure channel, per-dispatch event instrumentation, a two-verdict eval harness, and a pre-registered decommission kill-criterion.

**Production value is UNMEASURED — this PR does not claim the loop has helped a single live route yet.** Full claim/non-claim table, methodology, and limitations: `docs/route-loop-validation.md`.

## Validation summary

| What | Result | Artifact |
|---|---|---|
| Mechanism (Stage 1) | PASS — synthetic demote help=24 harm=0; force-route exemption 49/49 | `scripts/route-value-eval.py` (exit 2) |
| Live blind A/B (Stage 3, 117 cases, dual blind judges) | k=0, **structural**: all 39 floor hits force-route-exempt; counterfactual 26 would-demote sans exemption | `research/forward-plan/stage3-k0-diagnosis.md` |
| Value verdict | UNMEASURED per pre-registration (exit 2) — never inflated to a pass | `docs/route-loop-validation.md` |
| Haiku router worth-it (20-task, 3-arm blind) | 80% exact / 95% agent-level vs pre-route 30%/75% — YES | `research/forward-plan/routing-dogfood-results.md` |
| Dual-track review | 26-reviewer Tier-4 (112 findings, 0 contested) + independent codex track; 3 findings converged independently; all 19 Critical/High fixed | commit a5b2e50d |
| Tests / lint | 4291 passed; ruff check + format clean | CI |
| Kill criterion | Pre-registered: DELETE iff (90d OR 3000 decisions) AND zero interventions AND clock valid; today honestly CLOCK-INVALID (accruing) | `scripts/route-decommission-check.py` (exit 4) |

## Why a draft

The loop ships as shadow instrumentation with a falsifiable kill switch. It earns a merge when the pre-registered criteria declare value — or gets deleted by its own trigger if it never acts.

## Reproduce

```
python3 scripts/route-value-eval.py --out-dir /tmp/eval-out   # exit 2: mechanism pass, value UNMEASURED
python3 scripts/route-decommission-check.py                    # exit 4: CLOCK-INVALID (accruing)
python3 -m pytest hooks/tests scripts/tests -q                 # 4291 passed
```

Open item: r13 regression picks the right skill, wrong agent slot (general-purpose vs research-coordinator-engineer).