### PR TITLE
fix(codex): migrate deprecated hooks feature flag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1527,10 +1527,13 @@ if [ -f "$CODEX_HOOKS_ALLOWLIST" ]; then
     if [ "$DRY_RUN" = true ]; then
         echo -e "${BLUE}  Would ensure ${CODEX_CONFIG} has [features] hooks = true${NC}"
     else
-        if $PYTHON_CMD "${SCRIPT_DIR}/scripts/ensure-codex-feature-flag.py" \
-            --config "$CODEX_CONFIG" 2>&1; then
-            :
+        codex_flag_action=$($PYTHON_CMD "${SCRIPT_DIR}/scripts/ensure-codex-feature-flag.py" \
+            --config "$CODEX_CONFIG" 2>&1)
+        codex_flag_status=$?
+        if [ "$codex_flag_status" -eq 0 ]; then
+            echo -e "${GREEN}  ✓ Codex config feature flag: ${codex_flag_action}${NC}"
         else
+            echo "$codex_flag_action"
             echo -e "${YELLOW}  ⚠ Could not update ${CODEX_CONFIG} (see error above). Codex hooks may not activate.${NC}"
         fi
     fi

--- a/scripts/ensure-codex-feature-flag.py
+++ b/scripts/ensure-codex-feature-flag.py
@@ -102,8 +102,10 @@ def _analyse_content(content: str) -> tuple[bool, str]:
         return False, "already-present"
 
     # No new key. A deprecated codex_hooks = false is a deliberate disable.
-    if dep_match and dep_match.group(1) == "false":
-        _exit_on_disabled()
+    if dep_match:
+        if dep_match.group(1) == "false":
+            _exit_on_disabled()
+        return True, "migrated"
 
     has_features_section = bool(_SECTION_PATTERN.search(content))
     if has_features_section:
@@ -170,8 +172,11 @@ def apply_update(content: str) -> str:
         return content
 
     if action == "migrated":
-        # hooks = true is already present; just drop the deprecated key.
-        return _strip_deprecated(content)
+        # Drop the deprecated key. If hooks = true was not already present,
+        # insert the current key below [features].
+        content = _strip_deprecated(content)
+        if _KEY_PATTERN.search(content):
+            return content
 
     if action in ("created-file", "added-section"):
         # Append a new [features] block. Ensure a trailing newline before it
@@ -183,8 +188,8 @@ def apply_update(content: str) -> str:
         content += "[features]\nhooks = true\n"
         return content
 
-    # action == "added-key": strip any deprecated key, then insert hooks after
-    # the [features] header.
+    # action == "added-key" or migrated-without-hooks: strip any deprecated key,
+    # then insert hooks after the [features] header.
     content = _strip_deprecated(content)
     lines = content.splitlines(keepends=True)
     result: list[str] = []

--- a/scripts/tests/test_codex_hooks_install.py
+++ b/scripts/tests/test_codex_hooks_install.py
@@ -231,6 +231,30 @@ def test_install_sh_preserves_existing_config_toml_sections(fake_home: Path) -> 
     assert config["features"].get("hooks") is True
 
 
+@requires_tomllib
+def test_install_sh_migrates_deprecated_codex_hooks_flag(fake_home: Path) -> None:
+    """install.sh removes deprecated codex_hooks and reports the migration action."""
+    codex_dir = fake_home / ".codex"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+
+    config_path = codex_dir / "config.toml"
+    config_path.write_text("[features]\ncodex_hooks = true\ngoals = true\n", encoding="utf-8")
+
+    result = _run_install(fake_home, ["--copy", "--force"])
+
+    assert result.returncode == 0, f"install.sh failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    text = config_path.read_text(encoding="utf-8")
+    assert "codex_hooks" not in text
+    assert "Codex config feature flag: migrated" in result.stdout
+
+    with open(config_path, "rb") as fh:
+        config = tomllib.load(fh)
+
+    assert config["features"]["hooks"] is True
+    assert config["features"]["goals"] is True
+    assert "codex_hooks" not in config["features"]
+
+
 def test_install_sh_dry_run_does_not_touch_filesystem(fake_home: Path) -> None:
     """install.sh --dry-run leaves ~/.codex untouched."""
     result = _run_install(fake_home, ["--dry-run", "--symlink"])

--- a/scripts/tests/test_ensure_codex_feature_flag.py
+++ b/scripts/tests/test_ensure_codex_feature_flag.py
@@ -101,12 +101,12 @@ class TestNeedsUpdate:
         assert write_needed is True
         assert action == "migrated"
 
-    def test_only_deprecated_key_returns_added_key(self) -> None:
-        """Deprecated codex_hooks alone (no hooks) maps to added-key."""
+    def test_only_deprecated_key_returns_migrated(self) -> None:
+        """Deprecated codex_hooks alone (no hooks) maps to migrated."""
         content = "[features]\ncodex_hooks = true\n"
         write_needed, action = needs_update(content)
         assert write_needed is True
-        assert action == "added-key"
+        assert action == "migrated"
 
     def test_deprecated_key_false_exits_2(self) -> None:
         """Deprecated codex_hooks = false (no hooks) must exit with code 2."""
@@ -282,6 +282,20 @@ class TestCLI:
         assert "codex_hooks" not in text
         parsed = tomllib.loads(text)
         assert parsed["features"]["hooks"] is True
+
+    @requires_tomllib
+    def test_only_deprecated_key_reports_migrated(self, tmp_path: Path) -> None:
+        """A config with only codex_hooks is migrated; stdout reports migrated."""
+        cfg = tmp_path / "config.toml"
+        cfg.write_text("[features]\ncodex_hooks = true\ngoals = true\n", encoding="utf-8")
+        result = _run(["--config", str(cfg), "--no-backup"])
+        assert result.returncode == 0
+        assert result.stdout.strip() == "migrated"
+        text = cfg.read_text()
+        assert "codex_hooks" not in text
+        parsed = tomllib.loads(text)
+        assert parsed["features"]["hooks"] is True
+        assert parsed["features"]["goals"] is True
 
     def test_already_present_is_noop(self, tmp_path: Path) -> None:
         """Pre-existing flag produces no file change and reports already-present."""


### PR DESCRIPTION
## Summary
Migrate Codex hook config handling from deprecated `[features].codex_hooks` to `[features].hooks`.
Surface the installer action so users can see when the deprecated flag was removed.

## Changes
- `scripts/ensure-codex-feature-flag.py` — classify deprecated-only configs as `migrated` and insert `hooks = true` after removing `codex_hooks`.
- `install.sh` — print the Codex feature-flag action instead of suppressing helper output.
- `scripts/tests/test_ensure_codex_feature_flag.py` — cover deprecated-only migration with preserved sibling feature flags.
- `scripts/tests/test_codex_hooks_install.py` — cover installer migration from `codex_hooks = true` to `hooks = true`.

## Notes
- Verified against the current Codex docs: hooks use `[features].hooks` or `codex --enable hooks`.
- Local live config was migrated: `~/.codex/config.toml` now contains `hooks = true` and no `codex_hooks`.