### PR TITLE
feat(routing): outcome sensor — event log, three-way outcomes, failure channel (shadow-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.
 
-44 domain agents, 124 workflow skills, 83 hooks, 114 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
+44 domain agents, 124 workflow skills, 83 hooks, 115 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism. The pipeline has gates. Gates require evidence. Evidence means exit codes, not assertions.
 
 Works across Claude Code (`/do`), Codex (`$do`), Gemini CLI (`/do`), Antigravity (`/do`), Factory (`/do`).
 

--- a/docs/outcome-routing-shadow-loop.md
+++ b/docs/outcome-routing-shadow-loop.md
@@ -1,0 +1,25 @@
+# Outcome-Routing Shadow Loop — branch pointer
+
+Branch: `feat/outcome-routing-loop` (LOCAL-ONLY: never push / PR / merge to main).
+
+This branch builds a **shadow** routing-health loop: fix outcome signal fidelity
+(three-way failure/neutral/success), add a per-dispatch event log, build the health
+policy as a pure library, wire it gated (DEMOTE cannot fire on current data — by design;
+TIE-BREAK can, on a low-confidence pick with an evidenced alternate), and
+prove the mechanism on real (read-only) plus seeded synthetic data.
+
+Why shadow, not live: the learning DB holds 276 successes / 0 failures ever. The
+demote-at-floor rule matches 0 rows, so live re-ranking is inert. The finalizer boosts
+everything that is not an unambiguous failure (including neutral next-prompts), and rows
+are `(topic,key)` aggregates with no per-dispatch history — so faithful replay of past
+routing is impossible. A prior A/B returned null (89.8% == 89.8%).
+
+Working documents (local-only, gitignored — not in this commit):
+- `research/forward-plan/implementation-spec.md` — the FROZEN spec (read first).
+- `research/forward-plan/{2026-06-03-forward-plan,codex-plan,input-bundle}.md` — inputs.
+- ADR `outcome-routing-shadow-loop` (local-only, `adr/` is gitignored) — the ADR
+  (decision, alternatives, data-semantics appendix). Registered via `scripts/adr-query.py`.
+
+`research/` and `adr/` are gitignored development artifacts; a safety hook blocks
+force-adding them. They stay local by design — this tracked pointer keeps the branch
+self-documenting without committing ignored content.

--- a/docs/route-loop-validation.md
+++ b/docs/route-loop-validation.md
@@ -1,0 +1,170 @@
+# Route Loop Validation: Sensor Kept, Actuator Dropped
+
+Branch: `feat/route-sensor`. Date: 2026-06-10. Audience: a skeptical reader
+who wants proof, not prose.
+
+---
+
+## Decision
+
+The outcome-routing loop was split. The **sensor** merges; the **actuator**
+was closed with PR #755.
+
+**Kept (sensor, ~600 LOC):** route event log (`route-events.jsonl`), three-way
+outcome finalization (failure / success / neutral), the orchestrator-reported
+route-failure channel (`learning-db.py route-failure`), the pure policy lib
+(`scripts/lib/route_policy.py`), and shadow instrumentation on every `/do`
+dispatch. Step 1.5 is **shadow-only**: the policy's would-action is computed
+and logged; the route is never altered.
+
+**Dropped (actuator + oversized measurement):** active Step 1.5 re-rank,
+`route-value-eval.py` (652 LOC), `route-decommission-check.py` (454 LOC),
+`route-replay.py`, and their tests.
+
+### Why
+
+| Evidence | Finding |
+|----------|---------|
+| unknown_rate 0.98 | Only 2 of 101 recorded decisions ever joined an outcome. The decommission clock's validity gate (`unknown_rate <= 5%`) can never pass on this data; the kill switch was dead on arrival. |
+| Demote floor unreachable | 133 routes in the weights table, minimum confidence 0.5, zero recorded failures ever. The floor (`conf < 0.30 AND fail >= 3 AND n >= 5`) matches no row and cannot until negative signal exists. |
+| k=0 STRUCTURAL | In the live blind A/B, all 39 floor hits were force-route-exempt (39/39); the health arm never diverged. Value was structurally unmeasurable, not pending. |
+
+An actuator whose trigger cannot fire and whose kill switch cannot validate is
+dead weight. The sensor stays because it is the only path to the negative
+signal that would justify re-proposing the actuator.
+
+### Re-propose condition
+
+Re-propose the actuator when `scripts/route-signal-check.py` exits 3 — that
+is, on the **first routing-relevant failure event** OR the **first non-neutral
+would-action** (would-demote or would-tiebreak) recorded on a decision. Exit 0
+means no signal yet; keep waiting.
+
+```bash
+python3 scripts/route-signal-check.py   # exit 0 = no signal; exit 3 = re-propose
+```
+
+---
+
+## Sensor mechanism
+
+Every `/do` dispatch is scored, never altered:
+
+1. The router reads route weights (`learning-db.py route-weights`) and calls
+   `health_adjust(semantic_pick, alternates, weights, force_route_flags)`
+   (`scripts/lib/route_policy.py`). The returned `action`
+   (`keep | demote | tiebreak`) is the policy's would-action only.
+2. Gate inputs ride the `[do-route]` marker
+   (` health={confidence} n={n} fail={failure} action={...}`; ` health=-`
+   when no weight row; ` alts=` when alternates were passed).
+3. `routing-decision-recorder` snapshots them onto the per-dispatch DECISION
+   event in `<CLAUDE_LEARNING_DIR>/route-events.jsonl`.
+4. Outcomes finalize three-way: **failure** on tool errors or clear
+   rejection/rework/re-route (decay); **success** only on an explicit
+   acceptance marker (boost); **neutral** otherwise (no-op). No complaint is
+   NOT acceptance.
+5. The orchestrator reports routing failures it observes directly via
+   `learning-db.py route-failure` (ADR orchestrator-reported-route-failures,
+   local working document). `--routing-relevant yes` decays the pair;
+   idempotent per (session, marker).
+
+Force-route/security pairs are hard-exempt in the policy — checked first,
+always `keep`. Exemption is by skill name and accepts bare skill names or full
+`agent:skill` pairs.
+
+---
+
+## Evidence retained from the actuator evaluation
+
+These results justified the split and are kept for the record. The harness
+that produced them is dropped; the numbers are final, not reproducible here.
+
+### Live blind A/B (2026-06-07, k=0 root cause)
+
+97 scored picks over 117 live answers. The cause of k=0 is structural, not a
+silent failure:
+
+| Finding | Count |
+|---------|-------|
+| Picks on the demote floor (`conf<0.30, fail>=3, n>=5`, synthetic weights) | 39 |
+| Of those, force-route exempt | 39 (all) |
+| Low-confidence picks with an evidenced alternate (tie-break fuel) | 0 |
+| Counterfactual demotes if exemption stripped | 26 / 39 |
+
+Under fabricated failure data the loop refused to second-guess safety-critical
+routes and had no evidenced alternate anywhere else. It fails safe, not
+silent — but it also never acts, which is why the actuator is dropped.
+
+### Live telemetry (post-fix)
+
+| Metric | Value |
+|--------|-------|
+| non_null_health decisions | 5 |
+| recorded routing-relevant failures | 0 |
+| decisions joined to an outcome | 2 / 101 (unknown_rate 0.98) |
+
+### Failure channel (temp-DB dogfood)
+
+Proven mechanically; zero live signal yet. This code is kept.
+
+| Property | Result |
+|----------|--------|
+| Decay per routing-relevant failure | 0.65 → 0.57 |
+| Idempotency | per (session, marker) |
+| Non-relevant failures | decay nothing |
+| Live DB | untouched (`CLAUDE_LEARNING_DIR` temp dir) |
+
+### Router worth-it dogfood
+
+20 tasks, 3 arms, blind-evaluated. Justifies the Haiku router itself, not the
+actuator.
+
+| Arm | Exact-pair | Agent-level |
+|-----|-----------|-------------|
+| Haiku router | 80% (16/20) | 95% (19/20) |
+| Codex | 80% (16/20) | 85% (17/20) |
+| Deterministic pre-route alone | 30% (6/20) | 75% (15/20) |
+
+---
+
+## Review provenance
+
+Dual-track review, 2026-06-07, covered the full branch including all sensor
+code kept here.
+
+| Track | Scope | Output |
+|-------|-------|--------|
+| Claude | 26 reviewers, 3 waves | 112 findings; 19 actionable Critical/High; 0 contested |
+| Codex | codex-cli 0.135.0, read-only sandbox, 3 chunks | 16 distilled findings; 2 false positives caught by source verification |
+
+All Critical/High findings were fixed on the original branch before the split.
+
+---
+
+## Reproduce (sensor)
+
+```bash
+# Signal check: expect exit 0 (NO-SIGNAL) today
+python3 scripts/route-signal-check.py
+
+# Test suite
+python3 -m pytest hooks/tests scripts/tests -q
+```
+
+The sensor is read-instrumented only: tests isolate via `CLAUDE_LEARNING_DIR`;
+the live learning directory is never written by the checks above.
+
+---
+
+## Limitations
+
+1. **Production value is UNMEASURED and no longer being measured.** The eval
+   harness is dropped; measurement resumes only if the actuator is
+   re-proposed.
+2. **Zero live negative signal.** The failure channel is proven mechanically
+   but has recorded nothing live. The re-propose condition keys on this.
+3. **Single-user corpus.** All retained evidence comes from one user's tasks.
+4. **Synthetic weights.** The A/B floor-hit numbers were produced under
+   fabricated failure data, labeled SYNTHETIC-WEIGHTS in the original runs.
+5. **Outcome join rate was 0.02.** Until the three-way finalizer raises it,
+   any future clock or value measurement inherits the same problem.

--- a/hooks/confidence-decay.py
+++ b/hooks/confidence-decay.py
@@ -40,19 +40,47 @@ def main():
             if pruned_parts:
                 print(f"[confidence-decay] Ancillary pruning: {pruned_parts}", file=sys.stderr)
 
-        # Step 2: Decay stale entries (untouched > 30 days, confidence > 0.3)
+        # Step 2: Decay stale entries (untouched > 30 days).
+        # Routing rows pull toward neutral 0.5 (T5); every other topic keeps the
+        # monotonic -0.05-toward-0 decay (confidence > 0.3 gate).
         cutoff = (datetime.now() - timedelta(days=30)).isoformat()
         decayed = 0
 
         with get_connection() as conn:
+            # Non-routing: old behavior.
             stale_rows = conn.execute(
-                "SELECT topic, key FROM learnings WHERE last_seen < ? AND confidence > 0.3",
+                "SELECT topic, key FROM learnings WHERE last_seen < ? AND confidence > 0.3 AND topic != 'routing'",
                 (cutoff,),
             ).fetchall()
+
+            # Routing: pull toward 0.5 in-place, without touching last_seen or
+            # success/failure counts (this is staleness, not an outcome).
+            #
+            # Floor guard (confidence > 0.5): staleness must NEVER raise routing
+            # confidence. Pulling a sub-floor row (e.g. conf 0.20/0.28 with
+            # fail>=3) toward 0.5 would lift it back over FLOOR_CONFIDENCE=0.30
+            # and corrupt the floor-demote path the moment negative signal
+            # accrues. Prune does not protect these rows: it requires
+            # older_than_days=90, but staleness fires at >30 days, so a recently
+            # failed sub-floor row survives prune yet is stale. So skip every
+            # row at or below the 0.5 baseline (preserve the negative evidence);
+            # only above-baseline rows decay downward toward neutral. Scoped to
+            # routing because only routing pulls toward 0.5 and only routing has
+            # a floor-demote gate; non-routing keeps its monotonic -0.05 path.
+            # The > 0.5 bound also drops no-op rows already at exactly 0.5 from
+            # rowcount, so `decayed` counts only rows that actually changed.
+            routing_updated = conn.execute(
+                "UPDATE learnings "
+                "SET confidence = confidence + (0.5 - confidence) * 0.1 "
+                "WHERE last_seen < ? AND topic = 'routing' AND confidence > 0.5",
+                (cutoff,),
+            ).rowcount
+            conn.commit()
 
         for row in stale_rows:
             decay_confidence(row["topic"], row["key"], delta=0.05)
             decayed += 1
+        decayed += routing_updated
 
         if debug or pruned > 0 or decayed > 0:
             print(

--- a/hooks/lib/route_events.py
+++ b/hooks/lib/route_events.py
@@ -1,0 +1,138 @@
+"""Append-only per-dispatch route event log (JSONL).
+
+The aggregate routing rows in learning.db are keyed `(topic, key)` — they carry
+no per-dispatch history, so faithful offline replay of "request → route →
+outcome" is impossible from them alone. This module adds that history: one JSONL
+line per event, append-only, at `<CLAUDE_LEARNING_DIR>/route-events.jsonl`.
+
+Two producers:
+  - routing-decision-recorder.py (PostToolUse:Agent) appends a DECISION event
+    when it records a /do-routed dispatch.
+  - routing-outcome-finalizer.py (UserPromptSubmit) appends an OUTCOME event
+    when it finalizes a pending dispatch.
+
+FAILURE-SAFE BY CONTRACT: a write error here must NEVER break the hook. Every
+function swallows all exceptions and returns; the worst case is a lost event
+line, never a non-zero hook exit. The log is auxiliary instrumentation, not the
+source of truth (the aggregate rows remain authoritative).
+
+Append-only: each event is one `json.dumps(...) + "\n"` opened in "a" mode, so
+concurrent appends from parallel dispatches interleave at line granularity
+(POSIX append writes under the per-line size are atomic) without a lock — no
+read-modify-write, so there is no lost-update race to serialize.
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_DIR = Path.home() / ".claude" / "learning"
+_EVENTS_FILENAME = "route-events.jsonl"
+
+
+def _events_path() -> Path:
+    """Resolve the route-events.jsonl path from CLAUDE_LEARNING_DIR.
+
+    Honors the same env var as learning_db_v2 so tests (and any redirected DB)
+    keep the event log beside the throwaway DB, never the live one.
+    """
+    env_dir = os.environ.get("CLAUDE_LEARNING_DIR")
+    base = Path(env_dir) if env_dir else _DEFAULT_DIR
+    return base / _EVENTS_FILENAME
+
+
+def _append(event: dict[str, Any]) -> None:
+    """Append one JSON line. Best-effort: swallow every error (never break a hook)."""
+    try:
+        path = _events_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(event, separators=(",", ":"), ensure_ascii=False)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except Exception:
+        pass
+
+
+def record_decision_event(
+    *,
+    session: str,
+    request_snippet: str,
+    agent: str,
+    skill: str,
+    complexity: str = "",
+    health_at_decision: float | None = None,
+    n: int | None = None,
+    failure: int | None = None,
+    action: str | None = None,
+    alternates: list[str] | None = None,
+    gate_inputs_present: bool = False,
+) -> None:
+    """Append a per-dispatch DECISION event.
+
+    health_at_decision is the picked pair's confidence at decision time; None
+    when the pair had no weight row. n and failure are the other gate inputs the
+    demote floor needs (confidence<0.30 AND failure>=3 AND n>=5) — confidence
+    alone cannot reconstruct the floor, so all three are snapshotted here, never
+    back-filled from later weights. action is the Step-1.5 outcome (keep/demote/
+    tiebreak); alternates are the keys offered. All recorded as-is so replay can
+    distinguish "no health evaluated" (null) from a real score.
+
+    gate_inputs_present is the instrumentation signal the decommission clock
+    reads. True when the marker carried a `health=` token — numeric (state a) OR
+    `-` (state b, pick had no weight row, valid expected data). False when the
+    marker carried no `health=` token (state c, legacy/missing wiring). This
+    distinguishes "no-row, but instrumented" from "never instrumented" — null
+    health_at_decision alone cannot. Additive field; old readers ignore it.
+    """
+    _append(
+        {
+            "type": "decision",
+            "ts": time.time(),
+            "session": session or "",
+            "request_snippet": (request_snippet or "")[:200],
+            "agent": agent or "",
+            "skill": skill or "",
+            "complexity": complexity or "",
+            "health_at_decision": health_at_decision,
+            "n": n,
+            "failure": failure,
+            "action": action,
+            "alternates": alternates,
+            "gate_inputs_present": gate_inputs_present,
+        }
+    )
+
+
+def record_outcome_event(
+    *,
+    session: str,
+    key: str,
+    outcome: str,
+    reason: str | None = None,
+    routing_relevant: bool | None = None,
+) -> None:
+    """Append a per-dispatch OUTCOME event (outcome in {success, failure, neutral}).
+
+    ``reason`` is the short cause for the outcome (e.g. tool-errors, rejection,
+    acceptance, neutral-new-topic). Free of prompt text/secrets. Included only
+    when given, so old reason-free callers write unchanged events.
+
+    ``routing_relevant`` marks whether the outcome is a routing signal that the
+    confidence loop acts on. Written only when not None; route-value-eval counts
+    only routing-relevant failures. None keeps the field absent for callers that
+    do not assert relevance.
+    """
+    event: dict[str, Any] = {
+        "type": "outcome",
+        "ts": time.time(),
+        "session": session or "",
+        "key": key or "",
+        "outcome": outcome or "",
+    }
+    if reason:
+        event["reason"] = reason
+    if routing_relevant is not None:
+        event["routing_relevant"] = routing_relevant
+    _append(event)

--- a/hooks/lib/routing_outcome_score.py
+++ b/hooks/lib/routing_outcome_score.py
@@ -57,6 +57,35 @@ def decision_row_exists(key: str) -> bool:
         return False
 
 
+SUCCESS = "success"
+FAILURE = "failure"
+NEUTRAL = "neutral"
+
+# Sentinel for "no positional outcome supplied" — distinct from any valid
+# outcome and from None, so the public `outcome` type is `str | bool` (None is
+# NOT a valid outcome). Callers that omit `outcome` MUST pass the `failure=`
+# kwarg; supplying neither is rejected.
+_OUTCOME_UNSET: object = object()
+
+
+def _current_confidence(key: str) -> float:
+    """Read-only current confidence for routing/{key}; 0.0 if absent."""
+    from learning_db_v2 import get_db_path
+
+    try:
+        conn = sqlite3.connect(get_db_path(), timeout=5.0)
+        try:
+            row = conn.execute(
+                "SELECT confidence FROM learnings WHERE topic = ? AND key = ? LIMIT 1",
+                ("routing", key),
+            ).fetchone()
+            return float(row[0]) if row else 0.0
+        finally:
+            conn.close()
+    except Exception:
+        return 0.0
+
+
 def outcome_basis(errors: bool, reaction_failure: bool) -> str:
     """The evidence basis for a finalized outcome — one of three labels.
 
@@ -106,20 +135,71 @@ def _record_basis(key: str, basis: str) -> None:
         pass
 
 
-def apply_outcome(key: str, failure: bool, basis: str | None = None) -> float:
-    """Boost (success) or decay (failure) the routing row. Returns new confidence.
+def apply_outcome(
+    key: str,
+    outcome: str | bool = _OUTCOME_UNSET,  # type: ignore[assignment]  # sentinel default; None is not a valid outcome
+    basis: str | None = None,
+    *,
+    failure: bool | None = None,
+) -> float:
+    """Apply a THREE-WAY routing outcome. Returns new (or unchanged) confidence.
+
+    ``outcome`` is one of:
+      - ``"failure"`` — decay the row (errors or attributable rejection).
+      - ``"success"`` — boost the row (acceptance / continuation).
+      - ``"neutral"`` — NO-OP: no boost, no decay, no count change, no schema
+        migration. Returns the row's current confidence unchanged. Neutral is the
+        new default for unrelated/new-topic next prompts and clean autonomous Stop
+        runs — signal-fidelity fix so future data can contain real negatives
+        instead of being drowned by boost-everything.
+
+    Back-compat (two-way binary callers): pass a bare ``True``/``False`` as
+    ``outcome`` OR the keyword ``failure=<bool>`` (True=>failure, False=>success).
+    The ``failure=`` keyword is the legacy binary API the basis tests still use;
+    it maps to FAILURE/SUCCESS and never reaches NEUTRAL.
+
+    Any other string raises ``ValueError`` — an unrecognized outcome (e.g. a
+    typo) must surface as a bug, never silently boost confidence.
+
+    ``outcome`` is typed ``str | bool``; ``None`` is NOT a valid outcome. Omitting
+    it uses an internal sentinel meaning "caller used the ``failure=`` kwarg
+    form". Calling with neither a positional ``outcome`` nor a ``failure=`` kwarg
+    raises ``ValueError`` immediately — there is no "no outcome" outcome.
 
     Caller MUST gate on decision_row_exists(key) first.
 
     `basis` is label-only: when given, increment its per-route counter (best
     effort) for route-health's silent-success report. It does NOT change the
-    boost/decay — that is byte-identical with or without basis. Default None
+    boost/decay/no-op — that is byte-identical with or without basis. Default None
     keeps every pre-PR caller and test unchanged.
     """
     from learning_db_v2 import boost_confidence, decay_confidence
 
+    # Back-compat: the legacy binary API passes `failure=<bool>` and no positional
+    # outcome. Map it to the three-way string. An explicit `outcome` wins.
+    if outcome is _OUTCOME_UNSET and failure is not None:
+        outcome = FAILURE if failure else SUCCESS
+    # Neither form supplied (or an explicit invalid None): there is no "no
+    # outcome" outcome. Reject so the illegal call surfaces clearly instead of
+    # falling through to the generic unknown-string ValueError.
+    if outcome is _OUTCOME_UNSET or outcome is None:
+        raise ValueError("apply_outcome requires an outcome or a failure= kwarg; got neither")
+    # Back-compat: legacy callers passed a `failure` bool positionally.
+    if outcome is True:
+        outcome = FAILURE
+    elif outcome is False:
+        outcome = SUCCESS
+
     if basis:
         _record_basis(key, basis)
-    if failure:
+
+    if outcome == NEUTRAL:
+        return _current_confidence(key)  # no-op: read-only, no count change
+    if outcome == FAILURE:
         return decay_confidence("routing", key, delta=DECAY_DELTA)
-    return boost_confidence("routing", key, delta=BOOST_DELTA)
+    if outcome == SUCCESS:
+        return boost_confidence("routing", key, delta=BOOST_DELTA)
+    # Unknown/typo outcome must NOT silently boost. Callers pass the literal
+    # SUCCESS/FAILURE/NEUTRAL constants; an unrecognized string is a bug to
+    # surface, not a default boost that inflates confidence.
+    raise ValueError(f"unknown routing outcome {outcome!r}; expected one of {SUCCESS!r}, {FAILURE!r}, {NEUTRAL!r}")

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -74,6 +74,102 @@ _DO_ROUTE_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+# Optional complexity field on the same marker line, recorded into the T3 event
+# log for replay. Absent => "".
+_COMPLEXITY_RE = re.compile(r"\bcomplexity=([a-z0-9-]+)", re.IGNORECASE)
+
+# Step 1.5 health gate inputs on the same marker line (do/SKILL.md Phase 4 Step 2).
+# Each is an independent \b token. `health=-` => null (no weight row); else float.
+# n=/fail= are the other demote-floor inputs; action= is keep|demote|tiebreak;
+# alts= is a comma-separated key list. All optional; absent => null.
+# health= is a float (digits with one optional decimal part) or "-". The value
+# is anchored on BOTH ends: a trailing `(?![\d.])` rejects `1.2.3` (and `1.2.`)
+# as a whole — it must NOT match as `1.2`, which would slip a bad token past
+# float() / drop the event. A malformed value stays a non-match => state (c).
+_HEALTH_RE = re.compile(r"\bhealth=(\d+(?:\.\d+)?|-)(?![\d.])", re.IGNORECASE)
+_N_RE = re.compile(r"\bn=(\d+)", re.IGNORECASE)
+_FAIL_RE = re.compile(r"\bfail=(\d+)", re.IGNORECASE)
+_ACTION_RE = re.compile(r"\baction=(keep|demote|tiebreak)", re.IGNORECASE)
+_ALTS_RE = re.compile(r"\balts=([a-z0-9:_,-]+)", re.IGNORECASE)
+
+
+def _marker_line(prompt: str) -> str:
+    """Return the single line that carries the [do-route] marker, or "".
+
+    The gate inputs (health=/n=/fail=/action=/alts=) live on the marker line
+    ONLY. Scanning the whole prompt let a task body that merely mentions
+    `health=0.9` or `fail=3` poison gate_inputs_present and the decommission
+    clock. Isolating the marker line first means body text can never match.
+    Uses the SAME matcher as parse_do_route_marker so "marker line" is one
+    definition; returns the full line containing that match.
+    """
+    if not prompt or "[do-route]" not in prompt.lower():
+        return ""
+    m = _DO_ROUTE_RE.search(prompt)
+    if not m:
+        return ""
+    start = prompt.rfind("\n", 0, m.start()) + 1  # -1 -> 0 for the first line
+    end = prompt.find("\n", m.start())
+    return prompt[start:] if end == -1 else prompt[start:end]
+
+
+def parse_health_inputs(prompt: str) -> dict[str, object]:
+    """Read the Step-1.5 gate inputs off the marker LINE. Three instrumentation states.
+
+    Inputs are read from the marker line only (`_marker_line`), never the whole
+    prompt — a task body mentioning `health=`/`fail=` must not be read as a gate
+    input. `gate_inputs_present` is the instrumentation signal the decommission
+    clock reads — NOT non-null health. Three states the event must distinguish:
+      (a) numeric  `health=<float>` => health float, gate_inputs_present True.
+      (b) no-row   `health=-`       => health null,  gate_inputs_present True.
+          The pick has no weight row — valid, expected data. Most live picks are
+          state (b), so reading it as missing would keep the clock unreachable
+          forever (the soundness gap this fixes).
+      (c) legacy   no `health=` token => health null, gate_inputs_present False.
+          The marker never carried a gate input (pre-fix / missing wiring).
+          A malformed `health=` value (e.g. `1.2.3`) also lands here: the regex
+          won't match it, so it reads as absent — honest "not instrumented",
+          never a dropped event.
+    n/failure/action/alternates stay null unless a real `health=<float>` is read.
+    Snapshotted at decision time; replay never re-derives.
+    """
+    null = {
+        "health": None,
+        "n": None,
+        "failure": None,
+        "action": None,
+        "alternates": None,
+        "gate_inputs_present": False,
+    }
+    line = _marker_line(prompt)
+    if not line:
+        return null  # no marker line => nothing to read
+    hm = _HEALTH_RE.search(line)
+    if not hm:
+        return null  # state (c): no (well-formed) gate input on the marker
+    if hm.group(1) == "-":
+        # state (b): marker carried the gate input; the pick had no weight row.
+        return {**null, "gate_inputs_present": True}
+    try:
+        health = float(hm.group(1))  # state (a)
+    except ValueError:
+        # Defensive: the regex already bars malformed values, but never let a
+        # float() raise drop the whole event — treat as field-absent (state c).
+        return null
+    nm = _N_RE.search(line)
+    fm = _FAIL_RE.search(line)
+    am = _ACTION_RE.search(line)
+    altm = _ALTS_RE.search(line)
+    return {
+        "health": health,
+        "n": int(nm.group(1)) if nm else None,
+        "failure": int(fm.group(1)) if fm else None,
+        "action": am.group(1).lower() if am else None,
+        "alternates": [k for k in altm.group(1).split(",") if k] if altm else None,
+        "gate_inputs_present": True,
+    }
+
+
 # Right-sizing banner. The first four fields are required; findings= and the
 # cost fields (tokens=, wall_clock_s=) are optional, additive extensions
 # (ADR: review-tier-roi). Legacy four-field banners still match.
@@ -263,6 +359,28 @@ def main() -> None:
             session_id=session_id or None,
         )
 
+        # T3: per-dispatch DECISION event (JSONL), append-only + failure-safe.
+        # Auxiliary to the aggregate row above — never blocks; route_events
+        # swallows write errors so the hook stays non-blocking.
+        cm = _COMPLEXITY_RE.search(prompt)
+        complexity = cm.group(1) if cm else ""
+        health = parse_health_inputs(prompt)
+        from route_events import record_decision_event
+
+        record_decision_event(
+            session=session_id,
+            request_snippet=request_snippet,
+            agent=agent,
+            skill=skill,
+            complexity=complexity,
+            health_at_decision=health["health"],  # real gate inputs from the marker (Step 1.5)
+            n=health["n"],
+            failure=health["failure"],
+            action=health["action"],
+            alternates=health["alternates"],
+            gate_inputs_present=health["gate_inputs_present"],
+        )
+
         # Per-run telemetry envelope (ADR: learning-telemetry-envelope). Append-only,
         # one row per dispatch, AFTER the decision row so both share (topic, key).
         # git_sha + session_id + run_id are always derivable, so this row is non-empty
@@ -303,10 +421,17 @@ def main() -> None:
         append_pending_outcome(session_id, key, has_errors)
 
     except Exception as e:
+        # Always surface ONE short line so a recorder failure is visible, not
+        # silent (the previous handler logged only under CLAUDE_HOOKS_DEBUG, so a
+        # dropped decision event left no trace). Exception class + message only —
+        # no prompt content, no secrets. Full traceback stays debug-gated.
+        try:
+            print(f"routing-decision-recorder: {type(e).__name__}: {e}", file=sys.stderr)
+        except Exception:
+            pass  # stderr write must never itself break the hook
         if os.environ.get("CLAUDE_HOOKS_DEBUG"):
             import traceback
 
-            print(f"[routing-decision-recorder] HOOK-ERROR: {type(e).__name__}: {e}", file=sys.stderr)
             traceback.print_exc(file=sys.stderr)
     finally:
         sys.exit(0)  # Never block

--- a/hooks/routing-outcome-finalizer.py
+++ b/hooks/routing-outcome-finalizer.py
@@ -9,13 +9,22 @@ SubagentStop validator can't do — a hook firing when a subagent stops cannot
 see whether the USER accepted the result, asked for rework, or re-routed the
 same intent. Those signals live in the NEXT user turn. This hook reads them.
 
-Resolution per still-pending dispatch (drained atomically, scored ONCE):
+Resolution per still-pending dispatch (drained atomically, scored ONCE) —
+THREE-WAY (T4):
 
     failure  = tool errors recorded for THIS dispatch  OR  clear user rejection
-    success  = otherwise (acceptance, OR neutral / new topic — no complaint)
+    success  = explicit acceptance / affirmation of the prior work
+    neutral  = otherwise (unrelated / new-topic next prompt — no complaint, no
+               acceptance) => NO-OP: no boost, no decay, no count change
 
-then boost (success) / decay (failure) the routing/{key} row, ONCE, and clear
-the pending list so a re-delivered prompt resolves nothing further (idempotent).
+then boost (success) / decay (failure) / no-op (neutral) the routing/{key} row,
+ONCE, and clear the pending list so a re-delivered prompt resolves nothing
+further (idempotent).
+
+SIGNAL FIDELITY (T4): the prior detector boosted EVERYTHING that was not an
+unambiguous failure — including neutral new-topic prompts — inflating success
+counts so no real signal could surface. Success now requires a POSITIVE marker;
+a new-topic prompt is neutral, leaving room for future negatives.
 
 HIGH-PRECISION FAILURE DETECTION (critical):
 A FALSE failure poisons route-health worse than recording nothing — it decays a
@@ -224,6 +233,22 @@ def is_rejection(prompt: str) -> bool:
     return bool(_REJECTION_RE.search(first))
 
 
+def is_acceptance(prompt: str) -> bool:
+    """High-precision: True only on explicit affirmation/acceptance of the prior
+    work in the user's IMMEDIATE reaction (the first clause).
+
+    SUCCESS now requires a POSITIVE signal (T4 three-way). Without one — an
+    unrelated / new-topic next prompt — the outcome is NEUTRAL (no boost), not
+    success. So this detector decides boost-vs-neutral; ``is_rejection`` decides
+    the failure path. Same clause-scoping and word-boundary anchoring as
+    ``is_rejection`` so a substring (e.g. "great" inside "greater") never trips
+    it. Returns False on empty / non-string input.
+    """
+    if not prompt or not isinstance(prompt, str):
+        return False
+    return bool(_ACCEPTANCE_RE.search(_first_clause(prompt)))
+
+
 def main() -> None:
     try:
         raw = read_stdin(timeout=2)
@@ -244,6 +269,7 @@ def main() -> None:
 
         prompt = (event.get("prompt") or "").strip()
         rejected = is_rejection(prompt)
+        accepted = is_acceptance(prompt)
 
         # Lazy: only import the scorer (and thus learning_db_v2) when there is
         # actually something to resolve.
@@ -316,23 +342,58 @@ def main() -> None:
             if not decision_row_exists(key):
                 to_requeue.append(item)
                 continue
-            # Per-entry attribution (HIGH-1): own error flag => failure. The
-            # turn-level rejection is OR'd in ONLY when it is attributable (a
-            # single pending dispatch this turn); with >1 pending it is ignored.
+            # THREE-WAY per-entry resolution (T4). Per-entry error flag is the
+            # only signal that is ALWAYS attributable; the turn-level
+            # reaction (rejection OR acceptance) is attributable ONLY when a
+            # single dispatch is pending this turn (HIGH-1) — with >1 pending it
+            # is ignored so a turn signal cannot broadcast across siblings.
+            #   errors          => failure (decay)              — highest precision
+            #   rejection       => failure (decay)              — attributable only
+            #   acceptance      => success (boost)              — attributable only
+            #   otherwise       => neutral (no-op)              — new-topic default
             reaction_failure = rejected if attributable else False
-            failure = bool(item.get("errors")) or reaction_failure
+            reaction_success = accepted if attributable else False
+            if bool(item.get("errors")) or reaction_failure:
+                outcome = "failure"
+            elif reaction_success:
+                outcome = "success"
+            else:
+                outcome = "neutral"
+            # Basis is the failure-axis evidence label (errors > rejection >
+            # no-complaint), recorded as a per-route counter for route-health's
+            # silent-success report. Label-only: it never changes the boost/
+            # decay/no-op the three-way outcome drives.
             basis = outcome_basis(bool(item.get("errors")), reaction_failure)
-            new_conf = apply_outcome(key, failure, basis=basis)
+            new_conf = apply_outcome(key, outcome, basis=basis)
+            # Short, secret-free cause for this dispatch's outcome. Computed
+            # unconditionally (not debug-only) so the JSONL OUTCOME event carries
+            # the demotion cause — an operator reading route-events.jsonl after a
+            # decay can see WHY without the per-key basis table.
+            if item.get("errors"):
+                reason = "tool-errors"
+            elif reaction_failure:
+                reason = "rejection"
+            elif reaction_success:
+                reason = "acceptance"
+            elif (rejected or accepted) and not attributable:
+                reason = "reaction-ignored-multi-dispatch"
+            else:
+                reason = "neutral-new-topic"
+            # T3: per-dispatch OUTCOME event (JSONL), append-only + failure-safe.
+            # Auxiliary instrumentation for replay; route_events swallows write
+            # errors so a logging failure never breaks finalization.
+            # routing_relevant=True: a finalizer failure decays the row by
+            # contract, so it is a routing signal route-value-eval must count.
+            from route_events import record_outcome_event
+
+            record_outcome_event(
+                session=session_id,
+                key=key,
+                outcome=outcome,
+                reason=reason,
+                routing_relevant=True,
+            )
             if debug:
-                outcome = "failure" if failure else "success"
-                if item.get("errors"):
-                    reason = "tool-errors"
-                elif reaction_failure:
-                    reason = "rejection"
-                elif rejected and not attributable:
-                    reason = "rejection-ignored-multi-dispatch"
-                else:
-                    reason = "accepted/neutral"
                 print(
                     f"[routing-outcome-finalizer] {outcome} routing/{key} ({reason}) conf={new_conf:.4f}",
                     file=sys.stderr,

--- a/hooks/session-learning-recorder.py
+++ b/hooks/session-learning-recorder.py
@@ -67,8 +67,11 @@ def finalize_routing_outcomes(session_id: str) -> None:
     But an autonomous / headless run may end with NO next user prompt, leaving
     its dispatches provisional forever. This fallback resolves whatever the
     UserPromptSubmit finalizer did not, using the DETERMINISTIC FLOOR — this
-    dispatch's own ``errors`` flag alone (the old proxy): errors => decay, else
-    boost. It NEVER double-resolves: finalize_pending_outcomes atomically
+    dispatch's own ``errors`` flag alone (no next-turn signal):
+    errors => failure (decay); a CLEAN autonomous run => NEUTRAL no-op (T4).
+    A clean Stop run carries no acceptance evidence, so it must NOT boost — the
+    old "else boost" inflated success counts on every quiet session. It NEVER
+    double-resolves: finalize_pending_outcomes atomically
     read-and-clears, so anything UserPromptSubmit already scored (and cleared)
     is simply absent here. Best-effort, silent, never raises.
     """
@@ -96,12 +99,16 @@ def finalize_routing_outcomes(session_id: str) -> None:
                 continue  # drop abandoned provisional entry, do not score
             if not decision_row_exists(key):
                 continue  # no row to score (orphaned); drop quietly at session end
-            # Deterministic floor: per-dispatch error flag only (no next turn).
-            # No turn to complain in => a Stop-resolved success is always
-            # default_no_complaint (the largest silent-failure source).
+            # Deterministic floor (T4): errors => failure (decay); a clean
+            # autonomous run carries no acceptance evidence => NEUTRAL no-op.
+            # Basis is the failure-axis label only (no next turn => a non-error
+            # entry is default_no_complaint), recorded for route-health's
+            # silent-success report. It never changes the boost/decay/no-op.
             errors = bool(item.get("errors"))
+            outcome = "failure" if errors else "neutral"
             basis = "tool_errors_only" if errors else "default_no_complaint"
-            apply_outcome(key, errors, basis=basis)
+            apply_outcome(key, outcome, basis=basis)
+
     except Exception as e:
         if os.environ.get("CLAUDE_HOOKS_DEBUG"):
             print(f"[session-learning-recorder] routing finalize error: {e}", file=sys.stderr)

--- a/hooks/tests/test_apply_outcome.py
+++ b/hooks/tests/test_apply_outcome.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Tests for apply_outcome (hooks/lib/routing_outcome_score.py) — three-way + guard.
+
+apply_outcome maps a routing outcome onto a confidence delta:
+  - success => boost
+  - failure => decay
+  - neutral => no-op (read-only)
+  - anything else (typo / unknown) => ValueError, NEVER a silent boost.
+
+The last case is the regression guard: pre-fix an unrecognized string fell
+through to boost, silently inflating confidence (the skeptic's finding 3a).
+
+All tests point the learning DB at a throwaway dir via CLAUDE_LEARNING_DIR and
+seed one routing row first — apply_outcome assumes the caller gated on
+decision_row_exists. The live DB is never touched.
+
+Run: python3 -m pytest hooks/tests/test_apply_outcome.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parent.parent
+LIB_DIR = HOOKS_DIR / "lib"
+
+
+@pytest.fixture()
+def seeded_key(tmp_path, monkeypatch):
+    """Throwaway DB with one routing/effectiveness row; yields its key."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    key = "agent-x:skill-x"
+    ldb.record_learning(topic="routing", key=key, value="v", category="effectiveness", source="routing:decision")
+    yield key
+
+
+def _conf(key: str) -> float:
+    import routing_outcome_score as ros
+
+    return ros._current_confidence(key)
+
+
+def test_unknown_outcome_raises_not_boosts(seeded_key) -> None:
+    """A typo'd outcome string raises ValueError instead of silently boosting."""
+    import routing_outcome_score as ros
+
+    before = _conf(seeded_key)
+    with pytest.raises(ValueError, match="unknown routing outcome"):
+        ros.apply_outcome(seeded_key, "succes")  # typo
+    after = _conf(seeded_key)
+    assert after == before  # confidence untouched by the rejected call
+
+
+def test_neutral_is_noop(seeded_key) -> None:
+    """Neutral leaves confidence unchanged."""
+    import routing_outcome_score as ros
+
+    before = _conf(seeded_key)
+    returned = ros.apply_outcome(seeded_key, ros.NEUTRAL)
+    assert returned == before
+    assert _conf(seeded_key) == before
+
+
+def test_success_boosts(seeded_key) -> None:
+    """Success raises confidence."""
+    import routing_outcome_score as ros
+
+    before = _conf(seeded_key)
+    ros.apply_outcome(seeded_key, ros.SUCCESS)
+    assert _conf(seeded_key) > before
+
+
+def test_failure_decays(seeded_key) -> None:
+    """Failure lowers confidence."""
+    import routing_outcome_score as ros
+
+    before = _conf(seeded_key)
+    ros.apply_outcome(seeded_key, ros.FAILURE)
+    assert _conf(seeded_key) < before
+
+
+def test_no_outcome_and_no_failure_raises(seeded_key) -> None:
+    """Both outcome and failure= unset is an illegal call: clear ValueError, no boost.
+
+    None is only an internal sentinel for the failure= back-compat path, never a
+    valid outcome. The guard rejects it before any confidence change.
+    """
+    import routing_outcome_score as ros
+
+    before = _conf(seeded_key)
+    with pytest.raises(ValueError, match="requires an outcome or a failure="):
+        ros.apply_outcome(seeded_key)  # no positional outcome, no failure kwarg
+    assert _conf(seeded_key) == before  # confidence untouched
+
+
+def test_legacy_bool_back_compat(seeded_key) -> None:
+    """True=>failure (decay), False=>success (boost) still honored."""
+    import routing_outcome_score as ros
+
+    base = _conf(seeded_key)
+    ros.apply_outcome(seeded_key, False)  # success
+    boosted = _conf(seeded_key)
+    assert boosted > base
+    ros.apply_outcome(seeded_key, True)  # failure
+    assert _conf(seeded_key) < boosted

--- a/hooks/tests/test_confidence_decay_neutral.py
+++ b/hooks/tests/test_confidence_decay_neutral.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Tests for staleness decay toward neutral (0.5) on routing rows (spec T5).
+
+The confidence-decay Stop hook decays entries untouched > 30 days. For
+`topic='routing'` rows it must pull confidence TOWARD 0.5 instead of the
+monotonic -0.05-toward-0 used for every other topic:
+
+    conf += (0.5 - conf) * 0.1
+
+Floor guard: staleness must never RAISE routing confidence, so only rows
+above 0.5 decay (downward toward 0.5). A stale routing row above 0.5 drops
+toward 0.5; one at or below 0.5 is skipped (preserves negative evidence so a
+sub-floor row stays floor-demote-eligible); a fresh routing row (last_seen
+within 30 days) is untouched. Non-routing rows keep the old -0.05 behavior.
+The decay never touches last_seen, observation_count, or success/failure
+counts.
+
+Uses a throwaway learning.db via CLAUDE_LEARNING_DIR - never the real DB.
+
+Run with: python3 -m pytest hooks/tests/test_confidence_decay_neutral.py -v
+"""
+
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parent.parent
+LIB_DIR = HOOKS_DIR / "lib"
+HOOK_PATH = HOOKS_DIR / "confidence-decay.py"
+
+STALE = (datetime.now() - timedelta(days=45)).isoformat()
+FRESH = (datetime.now() - timedelta(days=2)).isoformat()
+
+
+def _seed(db_path: Path, topic: str, key: str, confidence: float, last_seen: str) -> None:
+    """Insert one learning row directly, bypassing boost/decay helpers."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO learnings
+            (topic, key, value, category, confidence, source,
+             observation_count, success_count, failure_count,
+             first_seen, last_seen)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (topic, key, "v", "effectiveness", confidence, "seed", 5, 3, 0, last_seen, last_seen),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _read(db_path: Path, topic: str, key: str) -> sqlite3.Row:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT confidence, last_seen, observation_count, success_count, failure_count "
+        "FROM learnings WHERE topic = ? AND key = ?",
+        (topic, key),
+    ).fetchone()
+    conn.close()
+    return row
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    sys.path.insert(0, str(LIB_DIR))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    return db_dir / "learning.db"
+
+
+def _run_hook(env_dir: Path) -> subprocess.CompletedProcess:
+    import os
+
+    env = dict(os.environ)
+    env["CLAUDE_LEARNING_DIR"] = str(env_dir.parent)
+    return subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input="",
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_stale_routing_above_half_pulls_down_toward_half(db):
+    _seed(db, "routing", "implementer:tdd", 0.90, STALE)
+    res = _run_hook(db)
+    assert res.returncode == 0
+    new = _read(db, "routing", "implementer:tdd")["confidence"]
+    # 0.90 + (0.5 - 0.90) * 0.1 = 0.86
+    assert new == pytest.approx(0.86, abs=1e-6)
+
+
+def test_stale_routing_below_half_is_not_rescued(db):
+    # Floor guard: staleness must never RAISE confidence. A below-baseline row
+    # is skipped, not pulled up toward 0.5 (which would erase negative evidence).
+    _seed(db, "routing", "rare:skill", 0.32, STALE)
+    res = _run_hook(db)
+    assert res.returncode == 0
+    assert _read(db, "routing", "rare:skill")["confidence"] == pytest.approx(0.32, abs=1e-6)
+
+
+def test_stale_routing_subfloor_stays_floor_eligible(db):
+    # Finding [104]/[105]: a sub-floor routing row (conf < FLOOR_CONFIDENCE=0.30,
+    # fail>=3, n>=5) must NOT be rescued above the 0.30 floor by staleness decay.
+    # Prune does not protect it: prune needs last_seen > 90 days, but this row is
+    # only 45 days stale, so it reaches the staleness UPDATE. Assert confidence
+    # did not rise and the row stays floor-demote-eligible (< 0.30).
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """
+        INSERT INTO learnings
+            (topic, key, value, category, confidence, source,
+             observation_count, success_count, failure_count,
+             first_seen, last_seen)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("routing", "bad:pair", "v", "effectiveness", 0.28, "seed", 5, 1, 3, STALE, STALE),
+    )
+    conn.commit()
+    conn.close()
+    res = _run_hook(db)
+    assert res.returncode == 0
+    new = _read(db, "routing", "bad:pair")["confidence"]
+    assert new == pytest.approx(0.28, abs=1e-6)  # unchanged, not raised to 0.302
+    assert new < 0.30  # still floor-demote-eligible
+
+
+def test_fresh_routing_row_untouched(db):
+    _seed(db, "routing", "fresh:pair", 0.90, FRESH)
+    res = _run_hook(db)
+    assert res.returncode == 0
+    assert _read(db, "routing", "fresh:pair")["confidence"] == pytest.approx(0.90, abs=1e-6)
+
+
+def test_non_routing_keeps_old_minus_005(db):
+    _seed(db, "error_pattern", "missing_file", 0.90, STALE)
+    res = _run_hook(db)
+    assert res.returncode == 0
+    # old behavior: monotonic -0.05
+    assert _read(db, "error_pattern", "missing_file")["confidence"] == pytest.approx(0.85, abs=1e-6)
+
+
+def test_staleness_decay_does_not_touch_counts_or_last_seen(db):
+    _seed(db, "routing", "no:sidefx", 0.90, STALE)
+    _run_hook(db)
+    row = _read(db, "routing", "no:sidefx")
+    assert row["last_seen"] == STALE
+    assert row["observation_count"] == 5
+    assert row["success_count"] == 3
+    assert row["failure_count"] == 0
+
+
+def test_hook_exits_zero_on_empty_db(db):
+    res = _run_hook(db)
+    assert res.returncode == 0
+
+
+def test_stale_routing_at_half_is_noop_and_not_counted(db):
+    # Finding #15: a row already at the 0.5 baseline is a no-op; the > 0.5 guard
+    # excludes it so it is neither changed nor counted in the `decayed` metric.
+    _seed(db, "routing", "neutral:pair", 0.50, STALE)
+    res = _run_hook(db)
+    assert res.returncode == 0
+    assert _read(db, "routing", "neutral:pair")["confidence"] == pytest.approx(0.50, abs=1e-6)
+    assert "decayed=0" in res.stderr or "decayed" not in res.stderr

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -21,6 +21,7 @@ Run with: python3 -m pytest hooks/tests/test_routing_decision_recorder.py -v
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -420,6 +421,49 @@ def _seed_decision(key="python-general-engineer:go-patterns"):
     return key
 
 
+class TestApplyOutcomeThreeWay:
+    """T4: apply_outcome is three-way — success boosts, failure decays, neutral
+    is a pure no-op (no boost, no decay, no count change)."""
+
+    def test_neutral_is_pure_noop(self, db_env):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_score as ros_score
+
+        key = _seed_decision("python-general-engineer:noop")
+        before = next(r for r in _query_routing(db_env) if r["key"] == key)
+        ros_score.apply_outcome(key, "neutral")
+        after = next(r for r in _query_routing(db_env) if r["key"] == key)
+        assert after["success_count"] == before["success_count"]
+        assert after["failure_count"] == before["failure_count"]
+        assert after["confidence"] == before["confidence"]
+        assert after["observation_count"] == before["observation_count"]
+
+    def test_success_boosts_failure_decays(self, db_env):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_score as ros_score
+
+        sk = _seed_decision("python-general-engineer:succ")
+        fk = _seed_decision("python-general-engineer:fail")
+        ros_score.apply_outcome(sk, "success")
+        ros_score.apply_outcome(fk, "failure")
+        sr = next(r for r in _query_routing(db_env) if r["key"] == sk)
+        fr = next(r for r in _query_routing(db_env) if r["key"] == fk)
+        assert sr["success_count"] == 1 and sr["failure_count"] == 0
+        assert fr["failure_count"] == 1 and fr["success_count"] == 0
+
+    def test_legacy_bool_still_supported(self, db_env):
+        # Back-compat: True=>failure, False=>success.
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_score as ros_score
+
+        tk = _seed_decision("python-general-engineer:legacy-true")
+        fk = _seed_decision("python-general-engineer:legacy-false")
+        ros_score.apply_outcome(tk, True)
+        ros_score.apply_outcome(fk, False)
+        assert next(r for r in _query_routing(db_env) if r["key"] == tk)["failure_count"] == 1
+        assert next(r for r in _query_routing(db_env) if r["key"] == fk)["success_count"] == 1
+
+
 class TestOutcomeValidator:
     """B (SubagentStop) NO LONGER scores. It validates the decision row exists
     and keeps the entry PROVISIONAL (revalidated) for the next-turn finalizer;
@@ -509,22 +553,28 @@ class TestFinalizer:
         assert after["success_count"] == 1
         assert after["confidence"] > before
 
-    def test_neutral_new_topic_boosts(self, db_env, monkeypatch):
-        # No complaint = success, matching the old LLM's "user accepted" default.
+    def test_neutral_new_topic_is_noop(self, db_env, monkeypatch):
+        # T4 three-way: an unrelated / new-topic next prompt carries NO acceptance
+        # and NO complaint => NEUTRAL no-op. No boost, no decay, no count change.
+        # (Previously this boosted — the inflation T4 removes.)
         sys.path.insert(0, str(LIB_DIR))
         import routing_outcome_state as ros
 
         monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
         key = _seed_decision("python-general-engineer:neutral")
         self._pend(ros, "fin-neu", key, errors=False)
+        before = next(r for r in _query_routing(db_env) if r["key"] == key)
 
         f = _load(F_PATH, "fin2")
         ev = _prompt_event("now add a CHANGELOG entry for the release", session="fin-neu")
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
             f.main()
         after = next(r for r in _query_routing(db_env) if r["key"] == key)
-        assert after["success_count"] == 1
-        assert after["failure_count"] == 0
+        assert after["success_count"] == before["success_count"]  # no boost
+        assert after["failure_count"] == before["failure_count"]  # no decay
+        assert after["confidence"] == before["confidence"]  # unchanged
+        # Pending cleared (resolved once, idempotent) even though it was a no-op.
+        assert ros.peek_pending_outcomes("fin-neu") == []
 
     def test_rejection_decays(self, db_env, monkeypatch):
         sys.path.insert(0, str(LIB_DIR))
@@ -597,7 +647,8 @@ class TestFinalizer:
             f.main()
         after = next(r for r in _query_routing(db_env) if r["key"] == key)
         assert after["failure_count"] == 0, "benign 'wrong' falsely decayed the prior dispatch"
-        assert after["success_count"] == 1
+        # T4: a benign new request is neutral (no acceptance marker) — no boost.
+        assert after["success_count"] == 0
 
     def test_idempotent_double_prompt_scores_once(self, db_env, monkeypatch):
         sys.path.insert(0, str(LIB_DIR))
@@ -653,10 +704,11 @@ class TestFinalizer:
             ros._atomic_write(path, data)
 
         f = _load(F_PATH, "fin_malformed")
-        ev = _prompt_event("now write the docs", session=session)  # neutral => success
+        ev = _prompt_event("thanks, now write the docs", session=session)  # acceptance => success
         with patch("sys.exit"), patch("sys.stdin.read", return_value=_json.dumps(ev)):
             f.main()
-        # The valid sibling still scored (success); the malformed one was skipped.
+        # The valid sibling still scored; the malformed one was skipped. With one
+        # live entry the turn acceptance is attributable => success.
         after = next(r for r in _query_routing(db_env) if r["key"] == good_key)
         assert after["success_count"] == 1, "malformed sibling aborted scoring of the valid entry"
         assert after["failure_count"] == 0
@@ -703,6 +755,417 @@ class TestFinalizer:
             None,
         ]:
             assert f.is_rejection(p) is False, p
+
+    def test_acceptance_marker_unit(self):
+        # T4: is_acceptance decides boost-vs-neutral. Explicit affirmation in the
+        # FIRST clause => True; an unrelated/new-topic prompt => False (=> neutral).
+        f = _load(F_PATH, "fin_acc_unit")
+        for p in [
+            "thanks!",
+            "looks good, merge it",
+            "perfect, ship it",
+            "lgtm",
+            "great work",
+            "that worked, now do the next file",
+        ]:
+            assert f.is_acceptance(p) is True, p
+        for p in [
+            "now add a CHANGELOG entry for the release",
+            "write the docs",
+            "that's wrong",
+            "Add a test for wrong-format dates.",
+            "",
+            None,
+        ]:
+            assert f.is_acceptance(p) is False, p
+
+
+# ---------------------------------------------------------------------------
+# T3 — per-dispatch route event log (JSONL)
+# ---------------------------------------------------------------------------
+
+EVENTS_NAME = "route-events.jsonl"
+
+
+def _read_events(db_env):
+    """Read every event line from the throwaway route-events.jsonl, or []."""
+    path = db_env["db_dir"] / EVENTS_NAME
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+class TestRouteEventLog:
+    """T3: the decision hook appends one DECISION event per recorded dispatch;
+    the finalizer appends one OUTCOME event per finalized dispatch. Append-only,
+    failure-safe — a write error must never break the hook."""
+
+    def test_decision_event_appended_on_record(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_evt1")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        event = _agent_event(skill="go-patterns", body="Refactor the parser.", session="evt-s1")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        events = _read_events(db_env)
+        decisions = [e for e in events if e["type"] == "decision"]
+        assert len(decisions) == 1
+        d = decisions[0]
+        assert d["agent"] == "python-general-engineer"
+        assert d["skill"] == "go-patterns"
+        assert d["session"] == "evt-s1"
+        assert d["complexity"].lower() == "medium"
+        assert "request_snippet" in d and "health_at_decision" in d
+
+    def test_no_decision_event_when_marker_absent(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_evt2")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        event = _agent_event(marker=False, body="Review this PR.")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        assert _read_events(db_env) == []
+
+    def test_outcome_event_appended_on_finalize(self, db_env, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:evt-fin")
+        ros.append_pending_outcome("evt-fin", key, errors=False)
+
+        f = _load(F_PATH, "fin_evt1")
+        ev = _prompt_event("looks good, merge it", session="evt-fin")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        outcomes = [e for e in _read_events(db_env) if e["type"] == "outcome"]
+        assert len(outcomes) == 1
+        assert outcomes[0]["key"] == key
+        assert outcomes[0]["outcome"] in {"success", "failure", "neutral"}
+        assert outcomes[0]["session"] == "evt-fin"
+
+    def test_outcome_event_records_failure(self, db_env, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:evt-fail")
+        ros.append_pending_outcome("evt-fail", key, errors=True)
+
+        f = _load(F_PATH, "fin_evt_fail")
+        ev = _prompt_event("ok next", session="evt-fail")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        outcomes = [e for e in _read_events(db_env) if e["type"] == "outcome"]
+        assert outcomes and outcomes[0]["outcome"] == "failure"
+
+    def test_log_is_append_only_across_dispatches(self, db_env, monkeypatch):
+        # Two recorded dispatches => two decision lines, none overwritten.
+        a = _load(A_PATH, "rdr_evt_append")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        for i, skill in enumerate(("go-patterns", "test-driven-development")):
+            ev = _agent_event(skill=skill, body=f"task {i}", session=f"append-{i}")
+            with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+                a.main()
+        decisions = [e for e in _read_events(db_env) if e["type"] == "decision"]
+        assert {d["skill"] for d in decisions} == {"go-patterns", "test-driven-development"}
+        assert len(decisions) == 2
+
+    def test_decision_event_write_error_does_not_break_hook(self, db_env, monkeypatch):
+        # A failing event append must NOT prevent the aggregate row being written
+        # and must NOT raise — the hook stays non-blocking.
+        a = _load(A_PATH, "rdr_evt_safe")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        import route_events
+
+        monkeypatch.setattr(
+            route_events,
+            "_append",
+            lambda *_a, **_k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+        event = _agent_event(skill="go-patterns", session="evt-safe")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()  # must not raise
+        # Aggregate row still recorded despite the event-log failure.
+        keys = {r["key"] for r in _query_routing(db_env)}
+        assert "python-general-engineer:go-patterns" in keys
+
+    def test_malformed_events_dir_does_not_crash_recorder(self, db_env, monkeypatch):
+        # CLAUDE_LEARNING_DIR pointing at a non-creatable path => event append
+        # fails silently; the hook still exits 0 (subprocess end-to-end).
+        bad = db_env["db_dir"] / "notadir"
+        bad.write_text("i am a file, not a directory")
+        env = dict(os.environ)
+        env["CLAUDE_LEARNING_DIR"] = str(bad)  # base path is a file => mkdir fails
+        event = _agent_event(skill="go-patterns", session="evt-baddir")
+        p = subprocess.run(
+            [sys.executable, str(A_PATH)],
+            input=json.dumps(event),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert p.returncode == 0
+
+
+class TestOutcomeEventReasonAndRelevance:
+    """record_outcome_event writes reason + routing_relevant only when supplied,
+    and the finalizer always stamps both so a decay is queryable from the JSONL
+    alone (no per-key basis table needed)."""
+
+    def test_reason_written_when_given(self, db_env):
+        sys.path.insert(0, str(LIB_DIR))
+        import route_events
+
+        route_events.record_outcome_event(session="s", key="a:b", outcome="failure", reason="tool-errors")
+        ev = next(e for e in _read_events(db_env) if e["type"] == "outcome")
+        assert ev["reason"] == "tool-errors"
+
+    def test_routing_relevant_written_when_given(self, db_env):
+        sys.path.insert(0, str(LIB_DIR))
+        import route_events
+
+        route_events.record_outcome_event(session="s", key="a:b", outcome="failure", routing_relevant=True)
+        ev = next(e for e in _read_events(db_env) if e["type"] == "outcome")
+        assert ev["routing_relevant"] is True
+
+    def test_routing_relevant_absent_when_none(self, db_env):
+        sys.path.insert(0, str(LIB_DIR))
+        import route_events
+
+        # Default None => field omitted, so old callers stay byte-compatible.
+        route_events.record_outcome_event(session="s", key="a:b", outcome="neutral")
+        ev = next(e for e in _read_events(db_env) if e["type"] == "outcome")
+        assert "routing_relevant" not in ev
+        assert "reason" not in ev
+
+    def test_finalizer_writes_reason_and_routing_relevant(self, db_env, monkeypatch):
+        # End-to-end: a rejection decay must carry reason + routing_relevant in
+        # the JSONL OUTCOME event so the demotion cause is queryable.
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:evt-reason")
+        ros.append_pending_outcome("evt-reason", key, errors=False)
+
+        f = _load(F_PATH, "fin_reason")
+        ev = _prompt_event("that's wrong, redo it", session="evt-reason")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
+            f.main()
+        outcome = next(e for e in _read_events(db_env) if e["type"] == "outcome")
+        assert outcome["outcome"] == "failure"
+        assert outcome["reason"] == "rejection"
+        assert outcome["routing_relevant"] is True
+
+
+# ---------------------------------------------------------------------------
+# Step 1.5 — health gate inputs carried on the [do-route] marker
+# ---------------------------------------------------------------------------
+
+
+def _health_event(marker_body, *, session="hs1", description="do work"):
+    """PostToolUse:Agent event whose prompt is the supplied marker line verbatim."""
+    return {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Agent",
+        "session_id": session,
+        "tool_input": {
+            "subagent_type": "python-general-engineer",
+            "description": description,
+            "prompt": marker_body + "\ndo the work",
+        },
+        "tool_result": {"output": "ok", "is_error": False},
+    }
+
+
+class TestHealthMarkerParse:
+    """Step 1.5: the recorder reads {health, n, fail, action, alts} off the marker
+    and writes them to the DECISION event. `health=-` writes null health.
+
+    Three-state instrumentation contract (decommission clock validity):
+      (a) numeric  health=<float>  => health_at_decision float, gate_inputs_present True
+      (b) no-row   health=-        => health_at_decision null,  gate_inputs_present True
+      (c) legacy   no health= token => health_at_decision null,  gate_inputs_present False
+    States (a)+(b) are instrumented (marker carried the gate input); only (c)
+    counts against the 95% rate. `gate_inputs_present` is the validity signal,
+    not non-null health — most live picks are state (b) (pair has no weight row)."""
+
+    def test_health_fields_written_to_decision_event(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_health1")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        marker = (
+            "[do-route] agent=python-general-engineer skill=go-patterns "
+            "complexity=Medium health=0.20 n=6 fail=4 action=demote alts=direct:pr-workflow,explore:codebase-overview"
+        )
+        event = _health_event(marker, session="hs-demote")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] == 0.20
+        assert d["n"] == 6
+        assert d["failure"] == 4
+        assert d["action"] == "demote"
+        assert d["alternates"] == ["direct:pr-workflow", "explore:codebase-overview"]
+        # State (a): marker carried gate inputs.
+        assert d["gate_inputs_present"] is True
+
+    def test_health_dash_writes_null(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_health2")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        marker = "[do-route] agent=python-general-engineer skill=go-patterns complexity=Medium health=-"
+        event = _health_event(marker, session="hs-null")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] is None
+        assert d["n"] is None
+        assert d["failure"] is None
+        assert d["action"] is None
+        assert d["alternates"] is None
+        # State (b): marker said no-row (`-`). The pick has no weight row — valid,
+        # expected data — so it is INSTRUMENTED, not missing. This is the fix: the
+        # gate must read this as instrumented, distinguishable from state (c).
+        assert d["gate_inputs_present"] is True
+
+    def test_absent_health_field_writes_null(self, db_env, monkeypatch):
+        # State (c): a legacy marker with no health= token => null health, all
+        # fields null, gate_inputs_present False (no marker gate input at all).
+        a = _load(A_PATH, "rdr_health3")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        marker = "[do-route] agent=python-general-engineer skill=go-patterns complexity=Medium"
+        event = _health_event(marker, session="hs-legacy")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] is None
+        assert d["action"] is None
+        assert d["gate_inputs_present"] is False
+
+
+class TestHealthMarkerLineScoping:
+    """Findings 70/15/97 regression guards.
+
+    70: gate inputs are read from the marker LINE only — a task body mentioning
+        `health=`/`fail=` must NOT poison gate_inputs_present or the clock.
+    15: a malformed `health=1.2.3` reads as field-absent (state c), and the
+        decision event is STILL recorded — never silently dropped.
+    """
+
+    def test_health_in_body_is_ignored(self, db_env, monkeypatch):
+        # Marker line carries NO gate input (state c); the BODY mentions
+        # health=/fail= — those must not be read. Expect state (c): null health,
+        # gate_inputs_present False.
+        a = _load(A_PATH, "rdr_body_ignored")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        event = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Agent",
+            "session_id": "body-health",
+            "tool_input": {
+                "subagent_type": "python-general-engineer",
+                "description": "do work",
+                "prompt": (
+                    "[do-route] agent=python-general-engineer skill=go-patterns complexity=Medium\n"
+                    "Fix the gate: when health=0.9 and fail=3 the action=demote path is wrong."
+                ),
+            },
+            "tool_result": {"output": "ok", "is_error": False},
+        }
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] is None  # body health=0.9 NOT read
+        assert d["failure"] is None  # body fail=3 NOT read
+        assert d["action"] is None  # body action=demote NOT read
+        assert d["gate_inputs_present"] is False  # state (c): clean of body poison
+
+    def test_health_on_marker_line_is_parsed(self, db_env, monkeypatch):
+        # Same body health= bait, but the marker line ALSO carries health=0.20.
+        # The marker-line value must win; body values are never read.
+        a = _load(A_PATH, "rdr_line_parsed")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        event = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Agent",
+            "session_id": "line-health",
+            "tool_input": {
+                "subagent_type": "python-general-engineer",
+                "description": "do work",
+                "prompt": (
+                    "[do-route] agent=python-general-engineer skill=go-patterns "
+                    "complexity=Medium health=0.20 fail=4 action=demote\n"
+                    "Body text that says health=0.99 and fail=9 must be ignored."
+                ),
+            },
+            "tool_result": {"output": "ok", "is_error": False},
+        }
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] == 0.20  # marker line, not body 0.99
+        assert d["failure"] == 4  # marker line, not body 9
+        assert d["action"] == "demote"
+        assert d["gate_inputs_present"] is True
+
+    def test_malformed_health_is_field_absent_but_event_recorded(self, db_env, monkeypatch):
+        # health=1.2.3 is malformed: it must read as field-absent (state c) and
+        # the decision event MUST still be recorded — never dropped by a raised
+        # float(). gate_inputs_present False, decision + routing rows still land.
+        a = _load(A_PATH, "rdr_malformed_health")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        marker = "[do-route] agent=python-general-engineer skill=go-patterns complexity=Medium health=1.2.3"
+        event = _health_event(marker, session="hs-malformed")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] is None  # malformed => field absent
+        assert d["gate_inputs_present"] is False  # state (c), honest "not instrumented"
+        # The event is still recorded — the malformed value did NOT drop it.
+        keys = {r["key"] for r in _query_routing(db_env)}
+        assert "python-general-engineer:go-patterns" in keys
+
+    def test_valid_health_dash_still_state_b(self, db_env, monkeypatch):
+        # Regression: the tightened regex must still accept `health=-` => state b
+        # (null health, gate_inputs_present True).
+        a = _load(A_PATH, "rdr_dash_stateb")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        marker = "[do-route] agent=python-general-engineer skill=go-patterns complexity=Medium health=-"
+        event = _health_event(marker, session="hs-dash-b")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["health_at_decision"] is None
+        assert d["gate_inputs_present"] is True
+
+    def test_recorder_failure_writes_stderr_line(self, db_env, monkeypatch, capsys):
+        # Finding 97: an uncaught recorder error must surface ONE short stderr
+        # line (class: msg) even WITHOUT CLAUDE_HOOKS_DEBUG, and still exit 0.
+        # Force a failure inside main() (claim_dispatch raises) and assert the
+        # outer handler wrote the line and exit(0) was called.
+        monkeypatch.delenv("CLAUDE_HOOKS_DEBUG", raising=False)  # prove no-debug logging
+        a = _load(A_PATH, "rdr_stderr_fail")
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("forced failure")
+
+        monkeypatch.setattr(a, "claim_dispatch", _boom)
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        event = _agent_event(skill="go-patterns", session="stderr-fail")
+        with patch("sys.exit") as ex, patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        ex.assert_called_with(0)  # still non-blocking
+        err = capsys.readouterr().err
+        assert "routing-decision-recorder: RuntimeError: forced failure" in err
 
 
 # ---------------------------------------------------------------------------
@@ -950,8 +1413,10 @@ class TestPerAgentAttribution:
         ros.append_pending_outcome(session, good, errors=False)
         ros.append_pending_outcome(session, bad, errors=True)
 
-        # Neutral next turn (no rejection): good=success (own flag), bad=failure
-        # (own flag). The session-level reaction does NOT broadcast errors.
+        # Neutral next turn (no acceptance, no rejection) with >1 pending: the
+        # turn reaction is NOT attributable. Each entry resolves on its OWN flag —
+        # good=neutral (T4: clean, no acceptance => no-op), bad=failure (own
+        # error). The sibling's error does NOT broadcast a decay onto good.
         f = _load(HOOKS_DIR / "routing-outcome-finalizer.py", "fin_attrib")
         event = {"hook_event_name": "UserPromptSubmit", "session_id": session, "prompt": "ok, next task"}
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
@@ -959,10 +1424,10 @@ class TestPerAgentAttribution:
 
         good_after = next(r for r in _query_routing_all(db_env) if r["key"] == good)
         bad_after = next(r for r in _query_routing_all(db_env) if r["key"] == bad)
-        # Clean key boosted (success), NOT decayed by the sibling's error.
-        assert good_after["success_count"] == 1
+        # Clean key is NEUTRAL (no boost, no decay) — NOT decayed by the sibling.
+        assert good_after["success_count"] == 0
         assert good_after["failure_count"] == 0
-        assert good_after["confidence"] > good_before
+        assert good_after["confidence"] == good_before
         # Failing key decayed on its own flag.
         assert bad_after["failure_count"] == 1
 
@@ -1060,7 +1525,8 @@ STOP_PATH = HOOKS_DIR / "session-learning-recorder.py"
 class TestStopFallback:
     def test_session_end_resolves_pending_via_error_flag(self, db_env, monkeypatch):
         """No next user prompt: the Stop hook resolves still-pending dispatches
-        using each dispatch's own error flag (the deterministic floor)."""
+        from each dispatch's own error flag (T4 deterministic floor):
+        error => failure (decay); CLEAN run => NEUTRAL no-op (no boost)."""
         sys.path.insert(0, str(LIB_DIR))
         import routing_outcome_state as ros
 
@@ -1070,6 +1536,7 @@ class TestStopFallback:
         session = "autorun"
         ros.append_pending_outcome(session, ok, errors=False)
         ros.append_pending_outcome(session, bad, errors=True)
+        ok_before = next(r for r in _query_routing_all(db_env) if r["key"] == ok)
 
         s = _load(STOP_PATH, "stop1")
         event = {"hook_event_name": "Stop", "session_id": session, "session_data": {"files_modified": ["x"]}}
@@ -1078,8 +1545,11 @@ class TestStopFallback:
 
         ok_row = next(r for r in _query_routing_all(db_env) if r["key"] == ok)
         bad_row = next(r for r in _query_routing_all(db_env) if r["key"] == bad)
-        assert ok_row["success_count"] == 1  # no error => boost
-        assert bad_row["failure_count"] == 1  # error => decay
+        # T4: a clean autonomous run is NEUTRAL — no boost, no count change.
+        assert ok_row["success_count"] == ok_before["success_count"]
+        assert ok_row["failure_count"] == 0
+        assert ok_row["confidence"] == ok_before["confidence"]
+        assert bad_row["failure_count"] == 1  # error => decay (unchanged)
         # Pending cleared — nothing left to double-resolve.
         assert ros.peek_pending_outcomes(session) == []
 
@@ -1106,6 +1576,30 @@ class TestStopFallback:
             s.main()
         row = next(r for r in _query_routing_all(db_env) if r["key"] == key)
         assert row["success_count"] == 1, "Stop double-resolved a finalized dispatch"
+
+    def test_stop_clean_run_is_neutral(self, db_env, monkeypatch):
+        """T4: a clean autonomous run (no errors, no next prompt) resolves to
+        NEUTRAL at Stop — no boost, no count change. Regression guard against the
+        old 'else boost' that inflated success on every quiet session."""
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
+        key = _seed_decision("python-general-engineer:clean-neutral")
+        session = "clean-run"
+        ros.append_pending_outcome(session, key, errors=False)
+        before = next(r for r in _query_routing_all(db_env) if r["key"] == key)
+
+        s = _load(STOP_PATH, "stop_clean")
+        event = {"hook_event_name": "Stop", "session_id": session, "session_data": {"files_modified": ["x"]}}
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            s.main()
+
+        after = next(r for r in _query_routing_all(db_env) if r["key"] == key)
+        assert after["success_count"] == before["success_count"]
+        assert after["failure_count"] == before["failure_count"]
+        assert after["confidence"] == before["confidence"]
+        assert ros.peek_pending_outcomes(session) == []
 
     def test_stop_exits_zero_on_malformed(self):
         assert _run_hook(STOP_PATH, {}).returncode == 0
@@ -1209,10 +1703,12 @@ class TestSingleDispatchAttribution:
 
         a_after = next(r for r in _query_routing_all(db_env) if r["key"] == a)
         b_after = next(r for r in _query_routing_all(db_env) if r["key"] == b)
-        # Both clean siblings score SUCCESS, neither decayed by the ambiguous turn.
+        # CORE GUARD: neither sibling is DECAYED by the unattributable turn. Under
+        # T4 a clean unattributable sibling is NEUTRAL (no boost either), not the
+        # old auto-success — but the misattribution guard (no false decay) holds.
         assert a_after["failure_count"] == 0 and b_after["failure_count"] == 0
-        assert a_after["success_count"] == 1 and b_after["success_count"] == 1
-        assert a_after["confidence"] > a_before and b_after["confidence"] > b_before
+        assert a_after["success_count"] == 0 and b_after["success_count"] == 0
+        assert a_after["confidence"] == a_before and b_after["confidence"] == b_before
 
     def test_multi_dispatch_per_entry_error_still_fails(self, db_env, monkeypatch):
         # With >1 pending, the IGNORED turn-reaction does not stop a per-entry
@@ -1238,7 +1734,9 @@ class TestSingleDispatchAttribution:
             f.main()
         clean_after = next(r for r in _query_routing_all(db_env) if r["key"] == clean)
         errd_after = next(r for r in _query_routing_all(db_env) if r["key"] == errd)
-        assert clean_after["success_count"] == 1 and clean_after["failure_count"] == 0
+        # T4: clean sibling is NEUTRAL (no acceptance, unattributable turn) — no
+        # boost, no decay. The errored sibling still fails on its own flag.
+        assert clean_after["success_count"] == 0 and clean_after["failure_count"] == 0
         assert errd_after["failure_count"] == 1 and errd_after["success_count"] == 0
 
     def test_single_dispatch_rejection_decays(self, db_env, monkeypatch):
@@ -1360,13 +1858,17 @@ class TestRejectionPrecision:
         for p in self.NAMED_GENUINE:
             assert f.is_rejection(p) is True, f"review-named genuine missed: {p!r}"
 
-    def test_benign_prompt_scores_success_end_to_end(self, db_env, monkeypatch):
-        # A single dispatch + a benign "redo it in a later clause" prompt => the
-        # reaction is acceptance/neutral in the first clause => SUCCESS, no decay.
+    def test_benign_prompt_never_decays_end_to_end(self, db_env, monkeypatch):
+        # CORE GUARD: a benign prompt (rework verb only in a LATER clause, or a
+        # spec/instructional first clause) must NEVER DECAY the route. Under T4 the
+        # outcome is SUCCESS only when the first clause carries an acceptance
+        # marker; an instructional/spec first clause is NEUTRAL (no boost). Either
+        # way failure_count stays 0 — the precision guard this test exists for.
         sys.path.insert(0, str(LIB_DIR))
         import learning_db_v2 as ldb
         import routing_outcome_state as ros
 
+        f_unit = _load(F_PATH, "fin_benign_unit")
         monkeypatch.setattr(ros, "_STATE_DIR", db_env["state"])
         for i, prompt in enumerate(self.BENIGN):
             key = f"python-general-engineer:benign-{i}"
@@ -1385,11 +1887,15 @@ class TestRejectionPrecision:
                 f.main()
             after = next(r for r in _query_routing_all(db_env) if r["key"] == key)
             assert after["failure_count"] == 0, f"benign prompt decayed route: {prompt!r}"
-            assert after["success_count"] == 1
+            # acceptance first clause => success; instructional/spec => neutral.
+            expected = 1 if f_unit.is_acceptance(prompt) else 0
+            assert after["success_count"] == expected, prompt
 
-    def test_named_rollback_phrase_scores_success_end_to_end(self, db_env, monkeypatch):
-        # Spec-required E2E: a single clean dispatch + the review's roll-back spec
-        # phrase => SUCCESS (success_count=1, failure_count=0), no decay.
+    def test_named_rollback_phrase_does_not_decay_end_to_end(self, db_env, monkeypatch):
+        # Spec-required E2E false-positive guard: a single clean dispatch + the
+        # review's roll-back SPEC phrase must NOT decay the route. T4: it carries
+        # no acceptance marker (instructional/conditional clause) => NEUTRAL
+        # (failure_count=0, success_count=0). The guard is "no false decay".
         sys.path.insert(0, str(LIB_DIR))
         import learning_db_v2 as ldb
         import routing_outcome_state as ros
@@ -1403,6 +1909,7 @@ class TestRejectionPrecision:
             category="effectiveness",
             source="test",
         )
+        before = next(r for r in _query_routing_all(db_env) if r["key"] == key)["confidence"]
         session = "named-rollback-e2e"
         ros.append_pending_outcome(session, key, errors=False)
         f = _load(F_PATH, "fin_named_rollback_e2e")
@@ -1410,7 +1917,9 @@ class TestRejectionPrecision:
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(ev)):
             f.main()
         after = next(r for r in _query_routing_all(db_env) if r["key"] == key)
-        assert after["success_count"] == 1, "named roll-back spec phrase failed to score success"
+        assert after["failure_count"] == 0, "spec phrase falsely decayed the route"
+        assert after["success_count"] == 0, "spec phrase is neutral, not success (T4)"
+        assert after["confidence"] == before
         assert after["failure_count"] == 0, "named roll-back spec phrase falsely decayed route"
 
 

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -30,12 +30,15 @@ Usage:
     python3 scripts/learning-db.py telemetry-query --topic eval:evals/<dir> [--git-sha SHA] [--format json]
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --success
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --failure --reason "user re-routed"
+    python3 scripts/learning-db.py route-failure AGENT:SKILL --reason "re-route after unusable output" --routing-relevant yes [--session SID --marker MK]
     python3 scripts/learning-db.py backfill-routing-outcomes
     python3 scripts/learning-db.py route-health [--json]
+    python3 scripts/learning-db.py route-weights --json
     python3 scripts/learning-db.py skip-rate [--json] [--include-test]
 """
 
 import argparse
+import inspect
 import json
 import re
 import sqlite3
@@ -620,6 +623,43 @@ def cmd_route_stats(args: argparse.Namespace) -> None:
         print(json_mod.dumps(records, indent=2, default=str))
 
 
+def collect_route_weights() -> dict[str, dict[str, object]]:
+    """Read routing/effectiveness rows into a weight map.
+
+    Returns a dict keyed `<agent>:<skill>` with the fields confidence, n
+    (observation_count), success, failure, last_seen. Read-only; excludes
+    obvious test rows (source LIKE 'test%'); deterministic key ordering.
+    """
+    init_db()
+    # Read only the columns we emit, ordered by key, for speed and determinism.
+    # Excludes obvious test rows (source LIKE 'test%'); read-only.
+    with get_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT key, confidence, observation_count, success_count, failure_count, last_seen
+            FROM learnings
+            WHERE topic = 'routing' AND category = 'effectiveness'
+              AND source NOT LIKE 'test%'
+            ORDER BY key ASC
+            """
+        ).fetchall()
+    return {
+        row["key"]: {
+            "confidence": round(float(row["confidence"]), 4),
+            "n": int(row["observation_count"] or 0),
+            "success": int(row["success_count"] or 0),
+            "failure": int(row["failure_count"] or 0),
+            "last_seen": row["last_seen"],
+        }
+        for row in rows
+    }
+
+
+def cmd_route_weights(args: argparse.Namespace) -> None:
+    """Emit routing weights as JSON for health-aware re-ranking."""
+    print(json.dumps(collect_route_weights(), indent=2, default=str))
+
+
 # Default minimum cohort size below which route-delta prints a low-sample WARNING.
 # Report-only — it never blocks; the numbers still print (ADR: learning-telemetry-envelope).
 MIN_N = 5
@@ -984,6 +1024,114 @@ def cmd_record_routing_outcome(args: argparse.Namespace) -> None:
 
     outcome = "success" if args.success else "failure"
     print(f"Recorded {outcome} for routing/{key} — confidence: {new_conf:.4f}")
+
+
+def _ensure_route_failure_dedup_table(conn: sqlite3.Connection) -> None:
+    """Create the route_failure_dedup table if absent (idempotence ledger).
+
+    learning_db_v2.py is never edited (a pre-existing SQLi false-positive there
+    trips the commit security gate), so the table is created here, like
+    _ensure_archive_table. One row per (session, marker) dispatch key records a
+    failure already counted, so a retry loop cannot decay a pair repeatedly.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS route_failure_dedup (
+            session TEXT NOT NULL,
+            marker TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            PRIMARY KEY (session, marker)
+        )
+        """
+    )
+    conn.commit()
+
+
+def cmd_route_failure(args: argparse.Namespace) -> None:
+    """Record an orchestrator-reported routing failure (ADR: orchestrator-reported-route-failures).
+
+    Routing-relevant => decay the pair's weight row via the finalizer's decay
+    path (apply_outcome failure) AND append a reasoned failure event. Not-relevant
+    => event only, zero decay (a task failure by the right route must not poison
+    route health). Idempotent per dispatch key (session, marker): a duplicate is a
+    no-op, exit 0. Malformed pair (no ':') exits non-zero.
+    """
+    key = args.agent_skill
+    if ":" not in key:
+        print(f"Error: pair must be 'agent:skill', got {key!r}", file=sys.stderr)
+        sys.exit(2)
+
+    init_db()
+    routing_relevant = args.routing_relevant == "yes"
+    session = args.session or ""
+    marker = args.marker or ""
+
+    # Idempotence ordering — at-least-once, NOT at-most-once. The failure signal
+    # is the scarcest resource in this loop, so a dropped signal is worse than a
+    # re-applied one. Ordering:
+    #   (a) fast dup exit: if the dedup row already exists, no-op (exit 0);
+    #   (b) do the decay + outcome-event work;
+    #   (c) THEN insert + commit the dedup row.
+    # A crash between (b) and (c) leaves no dedup row, so a retry re-applies ONE
+    # decay — bounded and acceptable on a single-user toolkit. The old order
+    # (commit dedup first) silently DROPPED the signal on a crash between commit
+    # and decay: a retry hit IntegrityError and no-op'd, exit 0, no error.
+    # Two identical concurrent invocations can both pass (a) and both apply once;
+    # accepted (single-user, no concurrent route-failure calls).
+    dedup_active = bool(session and marker)
+    if dedup_active:
+        with get_connection() as conn:
+            _ensure_route_failure_dedup_table(conn)
+            row = conn.execute(
+                "SELECT 1 FROM route_failure_dedup WHERE session = ? AND marker = ?",
+                (session, marker),
+            ).fetchone()
+        if row is not None:
+            print(f"Duplicate dispatch key (session={session}, marker={marker}); no-op.")
+            return
+
+    # route_events lives in hooks/lib (already on sys.path via the header).
+    from route_events import record_outcome_event
+
+    decayed_note = "no decay (not routing-relevant)"
+    if routing_relevant:
+        # Reuse the finalizer's decay path — do NOT invent a second formula.
+        from routing_outcome_score import apply_outcome, decision_row_exists
+
+        if decision_row_exists(key):
+            new_conf = apply_outcome(key, "failure")
+            decayed_note = f"decayed routing/{key} -> confidence {new_conf:.4f}"
+        else:
+            decayed_note = f"no weight row for {key}; event logged, nothing to decay"
+
+    # Pass routing_relevant only if record_outcome_event accepts it. A sibling
+    # change adds the optional param; guard via signature so neither agent breaks
+    # the other while both land.
+    event_kwargs: dict[str, object] = {
+        "session": session,
+        "key": key,
+        "outcome": "failure",
+        "reason": args.reason,
+    }
+    if "routing_relevant" in inspect.signature(record_outcome_event).parameters:
+        event_kwargs["routing_relevant"] = routing_relevant
+    record_outcome_event(**event_kwargs)
+
+    # (c) Mark the dispatch key done only AFTER the work succeeded.
+    if dedup_active:
+        with get_connection() as conn:
+            _ensure_route_failure_dedup_table(conn)
+            try:
+                conn.execute(
+                    "INSERT INTO route_failure_dedup (session, marker, recorded_at) VALUES (?, ?, ?)",
+                    (session, marker, datetime.now().isoformat()),
+                )
+                conn.commit()
+            except sqlite3.IntegrityError:
+                # A concurrent invocation won the insert race; the work is done.
+                pass
+
+    print(f"Recorded route failure: {key} (routing-relevant={args.routing_relevant}) — {decayed_note}")
 
 
 def cmd_backfill_routing_outcomes(args: argparse.Namespace) -> None:
@@ -1488,6 +1636,13 @@ def main():
     p_route_stats.add_argument("--json", action="store_true", help="Also output raw JSON")
     p_route_stats.set_defaults(func=cmd_route_stats)
 
+    # route-weights
+    p_route_weights = subparsers.add_parser(
+        "route-weights", help="Emit routing weights as JSON (read-only) for health-aware re-rank"
+    )
+    p_route_weights.add_argument("--json", action="store_true", help="Output as JSON (only supported format)")
+    p_route_weights.set_defaults(func=cmd_route_weights)
+
     # review-roi — per-tier review cost/findings ROI (report-only).
     p_review_roi = subparsers.add_parser("review-roi", help="Per-tier review cost/findings ROI")
     p_review_roi.add_argument("--json", action="store_true", help="Output as JSON")
@@ -1521,6 +1676,21 @@ def main():
     p_rro_group.add_argument("--failure", action="store_true", help="Route failed")
     p_rro.add_argument("--reason", help="Reason for outcome (appended to value)")
     p_rro.set_defaults(func=cmd_record_routing_outcome)
+
+    # route-failure — orchestrator-reported routing failure (ADR: orchestrator-reported-route-failures)
+    p_rf = subparsers.add_parser("route-failure", help="Record an orchestrator-reported routing failure")
+    p_rf.add_argument("agent_skill", help="Routing key (e.g., golang-general-engineer:go-patterns)")
+    p_rf.add_argument("--reason", required=True, help="Why the route failed (recorded with the event)")
+    p_rf.add_argument(
+        "--routing-relevant",
+        dest="routing_relevant",
+        required=True,
+        choices=["yes", "no"],
+        help="yes => decay the pair + log event; no => log event only, no decay",
+    )
+    p_rf.add_argument("--session", help="Session ID (with --marker, the idempotence dispatch key)")
+    p_rf.add_argument("--marker", help="Dispatch marker (with --session, the idempotence dispatch key)")
+    p_rf.set_defaults(func=cmd_route_failure)
 
     # backfill-routing-outcomes
     p_backfill = subparsers.add_parser(

--- a/scripts/lib/route_policy.py
+++ b/scripts/lib/route_policy.py
@@ -1,0 +1,238 @@
+"""Pure health-aware re-rank policy for routing decisions.
+
+`health_adjust()` decides whether the semantic routing pick stands, is demoted
+to a healthier alternate, or is tie-broken toward a healthier alternate. It is
+PURE: no DB, no clock, no filesystem, no mutation of its inputs. The caller
+(skills/meta/do Step 1.5) supplies the semantic pick, the alternates, the T1
+weight map (`route-weights --json`), and the set of force-routed pairs.
+
+Design (frozen spec T2):
+  - Evidence gate: never demote a pick with n < MIN_OBSERVATIONS (5).
+  - Floor demote: demote ONLY if confidence < FLOOR_CONFIDENCE (0.30) AND
+    failure >= FLOOR_FAILURES (3) AND n >= MIN_OBSERVATIONS.
+  - Force-route / security pairs are NEVER demoted (hard exempt) — checked
+    first, before any health logic.
+  - Tie-break toward a higher-health alternate ONLY when the semantic
+    confidence is "low" (< LOW_CONFIDENCE, 0.35) AND the alternate clears the
+    evidence gate (n >= MIN_OBSERVATIONS). Under-evidenced alternates are never
+    preferred.
+  - Default: the semantic pick stands.
+
+force_route_flags form contract: the caller (SKILL.md Step 1.5, route-replay)
+passes either bare skill names (the manifest's form, e.g. ``security-review``)
+or full ``agent:skill`` pairs. Exemption is decided by SKILL name, so a security
+skill is protected regardless of which agent the semantic layer paired it with.
+
+Reachability on current real data:
+  - DEMOTE cannot fire: every live row is >= 0.5 confidence with 0 failures, so
+    the floor (conf<0.30 AND fail>=3 AND n>=5) matches no row.
+  - TIE-BREAK CAN fire: it is gated on SEMANTIC confidence, not on the floor.
+    On a live /do where the semantic layer reports low confidence (< 0.35) AND
+    supplies an evidenced healthier alternate, the route is moved. This is
+    intended behavior (spec T2), not a defect — but it means Step 1.5 is NOT a
+    pure no-op on current data; the precise claim is "demote is unreachable;
+    tie-break only fires on low-confidence picks with an evidenced alternate."
+The synthetic replay arm (T7) proves both demote (help) and the force-route
+exemption; the tie-break arm proves the low-confidence path moves toward gold.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+
+# Gate / floor thresholds (frozen spec T2).
+MIN_OBSERVATIONS = 5
+FLOOR_CONFIDENCE = 0.30
+FLOOR_FAILURES = 3
+LOW_CONFIDENCE = 0.35
+
+
+def _key_of(item: object) -> str | None:
+    """Extract the `agent:skill` key from a pick/alternate (str or mapping)."""
+    if isinstance(item, str):
+        return item
+    if isinstance(item, Mapping):
+        key = item.get("key")
+        return key if isinstance(key, str) else None
+    return None
+
+
+def _skill_of(token: str) -> str:
+    """Skill name from a flag/key that may be a bare skill or ``agent:skill``."""
+    return token.split(":", 1)[1] if ":" in token else token
+
+
+def _norm_skill(token: str) -> str:
+    """Skill name from a token, normalized for comparison: strip + casefold.
+
+    Defense-in-depth. Inputs are canonical in practice (manifest skill names and
+    route keys are lowercase, untrimmed), so this normalization should be a
+    no-op on real data — Codex rates operational reachability medium confidence.
+    It closes the bypass class where a noncanonical pick or flag (changed case
+    or surrounding whitespace) slips past the force-route exemption.
+    """
+    return _skill_of(token).strip().casefold()
+
+
+def _is_exempt(key: str, force_route_flags: Iterable[str]) -> bool:
+    """True iff `key` is force-routed. Skill-name match is authoritative.
+
+    The caller may pass force_route_flags as bare skill names (the manifest's
+    form) OR full ``agent:skill`` pairs. Force-route / security protection is
+    keyed by SKILL, not agent: a security skill must be exempt no matter which
+    agent the semantic layer paired it with. So a pick is exempt when its skill
+    name matches ANY flag's skill name (full-pair flags are reduced to their
+    skill), or when the full pick key matches a flag verbatim.
+
+    Hardened against attack C: a flag given as ``otheragent:security-review``
+    no longer fails to protect a pick ``pickagent:security-review`` — both
+    reduce to skill ``security-review`` and match.
+
+    Codex C2: the skill-name reduction is normalized (strip + casefold) on BOTH
+    sides, so a noncanonical pick/flag (case-changed or whitespace-padded)
+    cannot bypass the exemption. This is defense-in-depth; inputs are canonical
+    in practice (medium confidence on operational reachability).
+    """
+    flags = set(force_route_flags)
+    if key in flags:
+        return True
+    pick_skill = _norm_skill(key)
+    return any(_norm_skill(flag) == pick_skill for flag in flags)
+
+
+def _health_score(entry: Mapping[str, object]) -> float:
+    """Rank candidates: success rate weighted by confidence. Higher = healthier."""
+    n = int(entry.get("n", 0) or 0)
+    success = int(entry.get("success", 0) or 0)
+    confidence = float(entry.get("confidence", 0.0) or 0.0)
+    rate = (success / n) if n > 0 else 0.0
+    return rate * confidence
+
+
+def _is_floor(entry: Mapping[str, object]) -> bool:
+    """True iff the entry meets ALL floor-demote conditions."""
+    n = int(entry.get("n", 0) or 0)
+    failure = int(entry.get("failure", 0) or 0)
+    confidence = float(entry.get("confidence", 0.0) or 0.0)
+    return confidence < FLOOR_CONFIDENCE and failure >= FLOOR_FAILURES and n >= MIN_OBSERVATIONS
+
+
+def _healthiest_alternate(
+    alternates: Sequence[object],
+    weights: Mapping[str, Mapping[str, object]],
+    must_beat: float,
+    require_evidence: bool = False,
+) -> str | None:
+    """Return the alternate key with the highest health score above `must_beat`.
+
+    Skips alternates with no weight row (no evidence to prefer them). When
+    ``require_evidence`` is set, also skips alternates below MIN_OBSERVATIONS —
+    used by tie-break so a route is never moved toward an under-evidenced
+    alternate. Deterministic: ties resolve to the first alternate in input order.
+    """
+    best_key: str | None = None
+    best_score = must_beat
+    for alt in alternates:
+        alt_key = _key_of(alt)
+        if alt_key is None or alt_key not in weights:
+            continue
+        entry = weights[alt_key]
+        if require_evidence and int(entry.get("n", 0) or 0) < MIN_OBSERVATIONS:
+            continue
+        score = _health_score(entry)
+        if score > best_score:
+            best_score = score
+            best_key = alt_key
+    return best_key
+
+
+def health_adjust(
+    semantic_pick: Mapping[str, object],
+    alternates: Sequence[object],
+    weights: Mapping[str, Mapping[str, object]],
+    force_route_flags: Iterable[str],
+) -> dict[str, object]:
+    """Decide the final route given semantic pick + health weights. Pure.
+
+    Args:
+        semantic_pick: the LLM's pick. Mapping with ``key`` (``agent:skill``)
+            and ``confidence`` (the semantic confidence, 0..1).
+        alternates: candidate keys/dicts to re-rank toward (each a str or a
+            mapping with ``key``).
+        weights: the T1 weight map keyed ``agent:skill`` ->
+            {confidence, n, success, failure, last_seen}.
+        force_route_flags: pairs or skill names that are force-routed and must
+            never be demoted.
+
+    Returns:
+        ``{final_pick, action, reason}`` where action is one of
+        ``keep`` | ``demote`` | ``tiebreak``.
+    """
+    pick_key = _key_of(semantic_pick)
+    if pick_key is None:
+        return {
+            "final_pick": None,
+            "action": "keep",
+            "reason": "no pick key supplied; nothing to adjust",
+        }
+
+    # 1) Force-route / security exemption — checked FIRST, before any health.
+    if _is_exempt(pick_key, force_route_flags):
+        return {
+            "final_pick": pick_key,
+            "action": "keep",
+            "reason": f"force-route exempt: {pick_key} is never demoted",
+        }
+
+    entry = weights.get(pick_key)
+
+    # 2) Evidence gate: no row, or n < MIN_OBSERVATIONS => never demote.
+    if entry is None:
+        return {
+            "final_pick": pick_key,
+            "action": "keep",
+            "reason": "fresh pick: no health evidence; semantic pick stands",
+        }
+    n = int(entry.get("n", 0) or 0)
+    if n < MIN_OBSERVATIONS:
+        return {
+            "final_pick": pick_key,
+            "action": "keep",
+            "reason": f"evidence gate: n={n} < {MIN_OBSERVATIONS}; semantic pick stands",
+        }
+
+    # 3) Floor demote: confidence < 0.30 AND failure >= 3 AND n >= 5.
+    if _is_floor(entry):
+        target = _healthiest_alternate(alternates, weights, must_beat=_health_score(entry))
+        if target is not None:
+            conf = float(entry.get("confidence", 0.0) or 0.0)
+            fail = int(entry.get("failure", 0) or 0)
+            return {
+                "final_pick": target,
+                "action": "demote",
+                "reason": (f"floor demote: {pick_key} (conf={conf:.2f}, fail/n={fail}/{n}) -> {target}"),
+            }
+        # No healthier alternate to move to — pick stands.
+        return {
+            "final_pick": pick_key,
+            "action": "keep",
+            "reason": "floor met but no healthier alternate; semantic pick stands",
+        }
+
+    # 4) Low-confidence tie-break: only when the SEMANTIC confidence is low.
+    sem_conf = float(semantic_pick.get("confidence", 1.0) or 0.0)
+    if sem_conf < LOW_CONFIDENCE:
+        target = _healthiest_alternate(alternates, weights, must_beat=_health_score(entry), require_evidence=True)
+        if target is not None:
+            return {
+                "final_pick": target,
+                "action": "tiebreak",
+                "reason": (f"low semantic confidence ({sem_conf:.2f}); tie-break toward healthier {target}"),
+            }
+
+    # 5) Default: the semantic pick stands.
+    return {
+        "final_pick": pick_key,
+        "action": "keep",
+        "reason": "semantic pick stands (healthy / above floor / confident)",
+    }

--- a/scripts/route-signal-check.py
+++ b/scripts/route-signal-check.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Route-loop signal check: the cheap successor to the dropped eval harness.
+
+Reads `<CLAUDE_LEARNING_DIR or ~/.claude/learning>/route-events.jsonl`
+(same path convention as hooks/lib/route_events.py) and counts:
+
+  - routing-relevant failure outcome events,
+  - decisions with non-null health_at_decision,
+  - decisions whose recorded would-action is demote or tiebreak.
+
+Exit 0 = NO-SIGNAL (informational). Exit 3 = SIGNAL: at least one
+routing-relevant failure OR one would-demote/would-tiebreak — re-propose the
+actuator (see docs/route-loop-validation.md). Read-only: never writes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+EXIT_NO_SIGNAL = 0
+EXIT_SIGNAL = 3
+
+
+def events_path() -> Path:
+    """Resolve route-events.jsonl honoring CLAUDE_LEARNING_DIR."""
+    env_dir = os.environ.get("CLAUDE_LEARNING_DIR")
+    base = Path(env_dir) if env_dir else Path.home() / ".claude" / "learning"
+    return base / "route-events.jsonl"
+
+
+def main() -> int:
+    """Count signal events and report NO-SIGNAL (0) or SIGNAL (3)."""
+    failures = scored = would_act = 0
+    path = events_path()
+    if path.is_file():
+        for line in path.read_text(encoding="utf-8").splitlines():
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # tolerate interleaved/partial lines in the append-only log
+            if not isinstance(event, dict):
+                continue
+            if event.get("type") == "outcome":
+                if event.get("outcome") == "failure" and event.get("routing_relevant") is True:
+                    failures += 1
+            elif event.get("type") == "decision":
+                if event.get("health_at_decision") is not None:
+                    scored += 1
+                if event.get("action") in ("demote", "tiebreak"):
+                    would_act += 1
+    print(f"routing-relevant failures: {failures}")
+    print(f"decisions with health_at_decision: {scored}")
+    print(f"would-demote/would-tiebreak decisions: {would_act}")
+    if failures or would_act:
+        print("SIGNAL: re-propose the actuator (docs/route-loop-validation.md)")
+        return EXIT_SIGNAL
+    print("NO-SIGNAL")
+    return EXIT_NO_SIGNAL
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_route_failure.py
+++ b/scripts/tests/test_route_failure.py
@@ -1,0 +1,179 @@
+"""Tests for the route-failure subcommand (orchestrator-reported route failures).
+
+ADR orchestrator-reported-route-failures: the /do router reports routing
+failures it observes. Routing-relevant failures decay the pair's weight row
+(the finalizer's decay path) and append a reasoned failure event. Not-relevant
+failures log an event only, never decay. One failure per dispatch key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parent.parent.parent
+_repo_hooks_lib = str(_repo_root / "hooks" / "lib")
+
+sys_path_entry = str(Path(__file__).resolve().parent.parent)
+sys.path.insert(0, sys_path_entry)
+learning_db = importlib.import_module("learning-db")
+sys.path.pop(0)
+
+sys.path.insert(0, _repo_hooks_lib)
+if "learning_db_v2" in sys.modules:
+    del sys.modules["learning_db_v2"]
+import learning_db_v2 as _ld2_repo
+
+for attr_name in dir(_ld2_repo):
+    if hasattr(learning_db, attr_name) and not attr_name.startswith("__"):
+        try:
+            setattr(learning_db, attr_name, getattr(_ld2_repo, attr_name))
+        except (AttributeError, TypeError):
+            pass
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the learning DB and route-events log at a temp dir."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+
+    import learning_db_v2
+
+    monkeypatch.setattr(learning_db_v2, "_initialized", False)
+    return db_dir
+
+
+def _ns(**kwargs: object) -> argparse.Namespace:
+    base = {
+        "agent_skill": "agent-x:skill-x",
+        "reason": "re-route after unusable output",
+        "routing_relevant": "yes",
+        "session": None,
+        "marker": None,
+    }
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+def _seed(key: str) -> None:
+    from learning_db_v2 import record_learning
+
+    record_learning(
+        topic="routing",
+        key=key,
+        value="agent: x | skill: x",
+        category="effectiveness",
+        source="test:routing",
+    )
+
+
+def _confidence(key: str) -> float | None:
+    from learning_db_v2 import get_connection, init_db
+
+    init_db()
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT confidence FROM learnings WHERE topic = 'routing' AND key = ?",
+            (key,),
+        ).fetchone()
+    return None if row is None else float(row["confidence"])
+
+
+def _events(db_dir: Path) -> list[dict]:
+    path = db_dir / "route-events.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+class TestRoutingRelevant:
+    def test_decays_weight_row(self, isolated_db: Path) -> None:
+        _seed("agent-x:skill-x")
+        learning_db.cmd_route_failure(_ns(routing_relevant="yes"))
+        # finalizer decay path: 0.50 - 0.08
+        assert _confidence("agent-x:skill-x") == pytest.approx(0.42, abs=0.001)
+
+    def test_appends_failure_event_with_reason(self, isolated_db: Path) -> None:
+        _seed("agent-x:skill-x")
+        learning_db.cmd_route_failure(_ns(reason="lazy-completion re-dispatch", routing_relevant="yes"))
+        events = _events(isolated_db)
+        outcome = [e for e in events if e.get("type") == "outcome"]
+        assert len(outcome) == 1
+        assert outcome[0]["outcome"] == "failure"
+        assert outcome[0]["key"] == "agent-x:skill-x"
+        assert outcome[0]["reason"] == "lazy-completion re-dispatch"
+
+    def test_no_weight_row_logs_event_and_skips_decay(
+        self, isolated_db: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # routing_relevant=yes for a pair never routed (no weight row). The event
+        # must still be logged, nothing decays, exit 0, and the message says so.
+        key = "fresh-agent:fresh-skill"
+        learning_db.cmd_route_failure(_ns(agent_skill=key, routing_relevant="yes"))
+        out = capsys.readouterr().out
+
+        assert _confidence(key) is None  # no row created, nothing decayed
+        outcome = [e for e in _events(isolated_db) if e.get("type") == "outcome"]
+        assert len(outcome) == 1
+        assert outcome[0]["key"] == key
+        assert outcome[0]["outcome"] == "failure"
+        assert "nothing to decay" in out
+
+
+class TestNotRelevant:
+    def test_no_decay(self, isolated_db: Path) -> None:
+        _seed("agent-x:skill-x")
+        learning_db.cmd_route_failure(_ns(routing_relevant="no"))
+        # weight row unchanged
+        assert _confidence("agent-x:skill-x") == pytest.approx(0.50, abs=0.001)
+
+    def test_event_still_written(self, isolated_db: Path) -> None:
+        _seed("agent-x:skill-x")
+        learning_db.cmd_route_failure(_ns(routing_relevant="no", reason="bad output, right route"))
+        outcome = [e for e in _events(isolated_db) if e.get("type") == "outcome"]
+        assert len(outcome) == 1
+        assert outcome[0]["reason"] == "bad output, right route"
+
+
+class TestIdempotence:
+    def test_duplicate_key_is_noop(self, isolated_db: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _seed("agent-x:skill-x")
+        args1 = _ns(session="s1", marker="m1", routing_relevant="yes")
+        learning_db.cmd_route_failure(args1)
+        after_first = _confidence("agent-x:skill-x")
+
+        args2 = _ns(session="s1", marker="m1", routing_relevant="yes")
+        learning_db.cmd_route_failure(args2)
+        out = capsys.readouterr().out
+
+        # second run decays nothing and writes no second event
+        assert _confidence("agent-x:skill-x") == pytest.approx(after_first, abs=0.001)
+        assert "duplicate" in out.lower()
+        assert len([e for e in _events(isolated_db) if e.get("type") == "outcome"]) == 1
+
+    def test_different_marker_not_deduped(self, isolated_db: Path) -> None:
+        _seed("agent-x:skill-x")
+        learning_db.cmd_route_failure(_ns(session="s1", marker="m1", routing_relevant="yes"))
+        learning_db.cmd_route_failure(_ns(session="s1", marker="m2", routing_relevant="yes"))
+        # two distinct dispatches => two decays: 0.50 - 0.08 - 0.08
+        assert _confidence("agent-x:skill-x") == pytest.approx(0.34, abs=0.001)
+
+
+class TestExitCodes:
+    def test_duplicate_exits_zero(self, isolated_db: Path) -> None:
+        _seed("agent-x:skill-x")
+        learning_db.cmd_route_failure(_ns(session="s1", marker="m1"))
+        # duplicate run must not raise SystemExit (exit 0)
+        learning_db.cmd_route_failure(_ns(session="s1", marker="m1"))
+
+    def test_malformed_pair_exits_nonzero(self, isolated_db: Path) -> None:
+        with pytest.raises(SystemExit) as exc:
+            learning_db.cmd_route_failure(_ns(agent_skill="no-colon-here"))
+        assert exc.value.code != 0

--- a/scripts/tests/test_route_policy.py
+++ b/scripts/tests/test_route_policy.py
@@ -1,0 +1,367 @@
+"""Tests for the pure `health_adjust()` routing policy (scripts/lib/route_policy.py).
+
+health_adjust is a PURE function: no I/O, no DB, no clock. Given the semantic
+pick, its alternates, the T1 weight map, and the set of force-routed pairs, it
+returns {final_pick, action, reason}. The policy:
+
+  - Evidence gate: with fewer than MIN_OBSERVATIONS (5) observations on the
+    pick, never demote (insufficient evidence). Default = semantic pick stands.
+  - Floor demote: demote ONLY if confidence < 0.30 AND failure >= 3 AND n >= 5.
+  - Force-route / security pairs are NEVER demoted (hard exempt) — the most
+    important guarantee in the build.
+  - Tie-break toward higher-health alternate ONLY when the semantic confidence
+    is "low"; otherwise the semantic pick stands.
+  - High-failure pick loses to a high-success alternate (when demotable + a
+    healthier candidate exists).
+  - A fresh pick (n < 5) is never demoted.
+
+These tests import the function directly — no subprocess, no DB.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from scripts.lib.route_policy import (
+    MIN_OBSERVATIONS,
+    health_adjust,
+)
+
+
+def _w(confidence: float, n: int, success: int, failure: int) -> dict[str, object]:
+    """Build one weight-map entry."""
+    return {
+        "confidence": confidence,
+        "n": n,
+        "success": success,
+        "failure": failure,
+        "last_seen": "2026-06-01T00:00:00",
+    }
+
+
+# --- evidence gate ---------------------------------------------------------
+
+
+def test_gate_noop_below_min_observations() -> None:
+    """A pick with n < 5 is never demoted even if confidence is in the floor."""
+    pick = {"key": "agent-a:skill-a", "confidence": 0.9}
+    weights = {"agent-a:skill-a": _w(0.10, MIN_OBSERVATIONS - 1, 0, MIN_OBSERVATIONS - 1)}
+    result = health_adjust(pick, [], weights, set())
+    assert result["final_pick"] == "agent-a:skill-a"
+    assert result["action"] == "keep"
+
+
+def test_fresh_pick_never_demoted() -> None:
+    """A pick with no weight row at all (brand new) stands unchanged."""
+    pick = {"key": "agent-new:skill-new", "confidence": 0.9}
+    result = health_adjust(pick, ["agent-b:skill-b"], {}, set())
+    assert result["final_pick"] == "agent-new:skill-new"
+    assert result["action"] == "keep"
+
+
+# --- floor demote ----------------------------------------------------------
+
+
+def test_floor_demote_fires_on_seeded_data() -> None:
+    """conf < 0.30 AND failure >= 3 AND n >= 5 demotes the pick."""
+    pick = {"key": "agent-bad:skill-bad", "confidence": 0.5}
+    weights = {
+        "agent-bad:skill-bad": _w(0.20, 8, 2, 6),
+        "agent-good:skill-good": _w(0.85, 10, 9, 1),
+    }
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, set())
+    assert result["action"] == "demote"
+    assert result["final_pick"] == "agent-good:skill-good"
+
+
+def test_floor_held_when_failure_below_three() -> None:
+    """Low confidence alone (failure < 3) does NOT demote."""
+    pick = {"key": "agent-x:skill-x", "confidence": 0.5}
+    weights = {"agent-x:skill-x": _w(0.20, 6, 4, 2)}
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, set())
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "agent-x:skill-x"
+
+
+def test_floor_held_when_confidence_at_or_above_threshold() -> None:
+    """confidence == 0.30 is not below the floor; no demote."""
+    pick = {"key": "agent-x:skill-x", "confidence": 0.5}
+    weights = {"agent-x:skill-x": _w(0.30, 9, 3, 5)}
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, set())
+    assert result["action"] == "keep"
+
+
+# --- force-route exemption (THE critical test) -----------------------------
+
+
+def test_force_route_pair_never_demoted() -> None:
+    """A force-routed pair in the floor with a healthier alternate STAYS.
+
+    This is the most important guarantee in the entire build: a force-route /
+    security pair can never be re-ranked away, regardless of its health.
+    """
+    pick = {"key": "security-reviewer:security-review", "confidence": 0.5}
+    weights = {
+        "security-reviewer:security-review": _w(0.05, 20, 1, 18),
+        "agent-good:skill-good": _w(0.99, 50, 50, 0),
+    }
+    result = health_adjust(
+        pick,
+        ["agent-good:skill-good"],
+        weights,
+        {"security-reviewer:security-review"},
+    )
+    assert result["final_pick"] == "security-reviewer:security-review"
+    assert result["action"] == "keep"
+    assert "force" in result["reason"].lower() or "exempt" in result["reason"].lower()
+
+
+def test_force_route_by_skill_name_exempt() -> None:
+    """Force-route flag given as bare skill name (not full pair) still exempts."""
+    pick = {"key": "security-reviewer:security-review", "confidence": 0.5}
+    weights = {
+        "security-reviewer:security-review": _w(0.05, 20, 1, 18),
+        "agent-good:skill-good": _w(0.99, 50, 50, 0),
+    }
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"security-review"})
+    assert result["final_pick"] == "security-reviewer:security-review"
+    assert result["action"] == "keep"
+
+
+def test_force_route_pair_flag_different_agent_still_exempt() -> None:
+    """Attack C: flag is a full pair whose AGENT differs from the pick's agent.
+
+    Force-route protection is keyed by SKILL: a security skill must be exempt no
+    matter which agent the semantic layer paired it with. A flag
+    ``other-agent:security-review`` must still protect a pick
+    ``pick-agent:security-review`` (same skill, different agent). Pre-fix this
+    returned demote (the skill-name fallback compared against a full-pair flag
+    and missed).
+    """
+    pick = {"key": "pick-agent:security-review", "confidence": 0.5}
+    weights = {
+        "pick-agent:security-review": _w(0.05, 20, 1, 18),
+        "agent-good:skill-good": _w(0.99, 50, 50, 0),
+    }
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"other-agent:security-review"})
+    assert result["final_pick"] == "pick-agent:security-review"
+    assert result["action"] == "keep"
+
+
+# --- force-route exemption: normalization (Codex C2 adversarial table) ------
+#
+# _is_exempt must normalize (strip + casefold) the skill-name reduction on both
+# sides. These cover Codex's proven bypasses: a noncanonical pick or flag must
+# still KEEP. The empty-flags control must still DEMOTE (proves the floor logic
+# is reachable and the exemption is not silently swallowing every case).
+
+
+def _floor_pick_and_weights(pick_key: str) -> tuple[dict[str, object], dict[str, object]]:
+    """A floor-demotable pick plus a healthier alternate, for exemption tests."""
+    pick = {"key": pick_key, "confidence": 0.5}
+    weights = {
+        pick_key: _w(0.05, 20, 1, 18),
+        "agent-good:skill-good": _w(0.99, 50, 50, 0),
+    }
+    return pick, weights
+
+
+def test_exempt_case_changed_pick() -> None:
+    """Case-changed pick (Security-Review) vs canonical flag still KEEPS."""
+    pick, weights = _floor_pick_and_weights("direct:Security-Review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"security-review"})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "direct:Security-Review"
+
+
+def test_exempt_case_changed_flag() -> None:
+    """Case-changed flag (Security-Review) vs canonical pick still KEEPS."""
+    pick, weights = _floor_pick_and_weights("direct:security-review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"Security-Review"})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "direct:security-review"
+
+
+def test_exempt_whitespace_pick() -> None:
+    """Trailing-whitespace pick skill still KEEPS."""
+    pick, weights = _floor_pick_and_weights("direct:security-review ")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"security-review"})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "direct:security-review "
+
+
+def test_exempt_whitespace_flag() -> None:
+    """Surrounding-whitespace flag still KEEPS."""
+    pick, weights = _floor_pick_and_weights("direct:security-review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {" security-review "})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "direct:security-review"
+
+
+def test_exempt_agent_mismatch_full_pair_flag() -> None:
+    """Full-pair flag with a different agent but same skill still KEEPS."""
+    pick, weights = _floor_pick_and_weights("pick-agent:security-review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"other-agent:security-review"})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "pick-agent:security-review"
+
+
+def test_exempt_bare_skill_flag() -> None:
+    """Bare skill-name flag (manifest form) still KEEPS."""
+    pick, weights = _floor_pick_and_weights("direct:security-review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"security-review"})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "direct:security-review"
+
+
+def test_exempt_exact_full_pair() -> None:
+    """Exact full-pair flag matching the pick verbatim still KEEPS."""
+    pick, weights = _floor_pick_and_weights("direct:security-review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, {"direct:security-review"})
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "direct:security-review"
+
+
+def test_exempt_control_empty_flags_demotes() -> None:
+    """Control: with NO flags, the same floor pick DEMOTES (exemption is real)."""
+    pick, weights = _floor_pick_and_weights("direct:security-review")
+    result = health_adjust(pick, ["agent-good:skill-good"], weights, set())
+    assert result["action"] == "demote"
+    assert result["final_pick"] == "agent-good:skill-good"
+
+
+# --- comparative health ----------------------------------------------------
+
+
+def test_high_failure_loses_to_high_success() -> None:
+    """A demotable high-failure pick yields to the healthiest alternate."""
+    pick = {"key": "agent-bad:skill-bad", "confidence": 0.5}
+    weights = {
+        "agent-bad:skill-bad": _w(0.10, 12, 2, 10),
+        "agent-mid:skill-mid": _w(0.55, 10, 6, 4),
+        "agent-best:skill-best": _w(0.95, 20, 19, 1),
+    }
+    result = health_adjust(pick, ["agent-mid:skill-mid", "agent-best:skill-best"], weights, set())
+    assert result["action"] == "demote"
+    assert result["final_pick"] == "agent-best:skill-best"
+
+
+def test_demote_keeps_pick_when_no_healthier_alternate() -> None:
+    """If every alternate is also unhealthy, the pick stands (nowhere to go)."""
+    pick = {"key": "agent-bad:skill-bad", "confidence": 0.5}
+    weights = {
+        "agent-bad:skill-bad": _w(0.10, 12, 2, 10),
+        "agent-worse:skill-worse": _w(0.05, 15, 1, 14),
+    }
+    result = health_adjust(pick, ["agent-worse:skill-worse"], weights, set())
+    assert result["final_pick"] == "agent-bad:skill-bad"
+    assert result["action"] == "keep"
+
+
+# --- low-confidence tie-break ----------------------------------------------
+
+
+def test_tiebreak_only_when_semantic_low() -> None:
+    """With LOW semantic confidence, tie-break toward the higher-health alternate."""
+    pick = {"key": "agent-a:skill-a", "confidence": 0.2}
+    weights = {
+        "agent-a:skill-a": _w(0.50, 8, 4, 4),
+        "agent-b:skill-b": _w(0.90, 12, 11, 1),
+    }
+    result = health_adjust(pick, ["agent-b:skill-b"], weights, set())
+    assert result["action"] == "tiebreak"
+    assert result["final_pick"] == "agent-b:skill-b"
+
+
+def test_tiebreak_requires_evidenced_alternate() -> None:
+    """Tie-break never moves toward an under-evidenced alternate (n < 5).
+
+    Low semantic confidence alone is not enough: the healthier alternate must
+    clear the evidence gate. A flashy but under-observed alternate is ignored,
+    and the semantic pick stands. This bounds the tie-break path so it cannot
+    reroute toward thin evidence.
+    """
+    pick = {"key": "agent-a:skill-a", "confidence": 0.2}
+    weights = {
+        "agent-a:skill-a": _w(0.50, 8, 4, 4),
+        "agent-b:skill-b": _w(0.99, MIN_OBSERVATIONS - 1, MIN_OBSERVATIONS - 1, 0),
+    }
+    result = health_adjust(pick, ["agent-b:skill-b"], weights, set())
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "agent-a:skill-a"
+
+
+def test_tiebreak_does_not_fire_with_no_alternates() -> None:
+    """Low semantic confidence + no alternates supplied => pick stands.
+
+    The real-DB replay arm offers no alternates, so tie-break cannot fire there
+    even though semantic confidence is moot. Documents why the real arm is 0.
+    """
+    pick = {"key": "agent-a:skill-a", "confidence": 0.1}
+    weights = {"agent-a:skill-a": _w(0.50, 8, 4, 4)}
+    result = health_adjust(pick, [], weights, set())
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "agent-a:skill-a"
+
+
+def test_no_tiebreak_when_semantic_high() -> None:
+    """With HIGH semantic confidence, the semantic pick stands despite health gap."""
+    pick = {"key": "agent-a:skill-a", "confidence": 0.95}
+    weights = {
+        "agent-a:skill-a": _w(0.50, 8, 4, 4),
+        "agent-b:skill-b": _w(0.90, 12, 11, 1),
+    }
+    result = health_adjust(pick, ["agent-b:skill-b"], weights, set())
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "agent-a:skill-a"
+
+
+def test_default_semantic_pick_stands() -> None:
+    """Healthy pick, healthy data, normal confidence => keep, no surprises."""
+    pick = {"key": "agent-a:skill-a", "confidence": 0.7}
+    weights = {"agent-a:skill-a": _w(0.80, 30, 28, 2)}
+    result = health_adjust(pick, ["agent-b:skill-b"], weights, set())
+    assert result["action"] == "keep"
+    assert result["final_pick"] == "agent-a:skill-a"
+
+
+# --- output contract -------------------------------------------------------
+
+
+def test_result_shape_has_required_keys() -> None:
+    """Every return carries final_pick, action, reason."""
+    pick = {"key": "agent-a:skill-a", "confidence": 0.7}
+    result = health_adjust(pick, [], {}, set())
+    assert set(result) >= {"final_pick", "action", "reason"}
+    assert isinstance(result["reason"], str) and result["reason"]
+
+
+def test_purity_inputs_not_mutated() -> None:
+    """The function mutates none of its inputs (pure)."""
+    pick = {"key": "agent-bad:skill-bad", "confidence": 0.5}
+    alternates = ["agent-good:skill-good"]
+    weights = {
+        "agent-bad:skill-bad": _w(0.10, 8, 1, 7),
+        "agent-good:skill-good": _w(0.95, 10, 10, 0),
+    }
+    forced: set[str] = set()
+    import copy
+
+    pick_c, alt_c, w_c, f_c = (
+        copy.deepcopy(pick),
+        copy.deepcopy(alternates),
+        copy.deepcopy(weights),
+        set(forced),
+    )
+    health_adjust(pick, alternates, weights, forced)
+    assert pick == pick_c
+    assert alternates == alt_c
+    assert weights == w_c
+    assert forced == f_c

--- a/scripts/tests/test_route_signal_check.py
+++ b/scripts/tests/test_route_signal_check.py
@@ -1,0 +1,117 @@
+"""Tests for scripts/route-signal-check.py (the cheap actuator re-propose gate).
+
+Exit 0 = NO-SIGNAL; exit 3 = SIGNAL (>=1 routing-relevant failure outcome OR
+>=1 would-demote/would-tiebreak decision). Read-only: the script must never
+write to the learning dir. Tests isolate via CLAUDE_LEARNING_DIR.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_repo_root = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _repo_root / "scripts" / "route-signal-check.py"
+
+
+def _run(learning_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={"CLAUDE_LEARNING_DIR": str(learning_dir), "PATH": "/usr/bin:/bin"},
+    )
+
+
+def _write_events(learning_dir: Path, events: list[dict[str, object]], *, raw_suffix: str = "") -> None:
+    learning_dir.mkdir(parents=True, exist_ok=True)
+    lines = "".join(json.dumps(e) + "\n" for e in events) + raw_suffix
+    (learning_dir / "route-events.jsonl").write_text(lines, encoding="utf-8")
+
+
+def _decision(health: float | None, action: str | None) -> dict[str, object]:
+    return {"type": "decision", "health_at_decision": health, "action": action}
+
+
+def test_missing_log_is_no_signal(tmp_path: Path) -> None:
+    """No route-events.jsonl at all: counts 0, exit 0."""
+    result = _run(tmp_path / "learning")
+    assert result.returncode == 0
+    assert "routing-relevant failures: 0" in result.stdout
+    assert "NO-SIGNAL" in result.stdout
+
+
+def test_keep_decisions_are_no_signal(tmp_path: Path) -> None:
+    """Scored keep-only decisions count as instrumented but carry no signal."""
+    learning = tmp_path / "learning"
+    _write_events(learning, [_decision(0.72, "keep"), _decision(None, None)])
+    result = _run(learning)
+    assert result.returncode == 0
+    assert "decisions with health_at_decision: 1" in result.stdout
+
+
+def test_routing_relevant_failure_signals(tmp_path: Path) -> None:
+    """One routing-relevant failure outcome => exit 3."""
+    learning = tmp_path / "learning"
+    _write_events(
+        learning,
+        [{"type": "outcome", "outcome": "failure", "routing_relevant": True}],
+    )
+    result = _run(learning)
+    assert result.returncode == 3
+    assert "routing-relevant failures: 1" in result.stdout
+    assert "SIGNAL" in result.stdout
+
+
+def test_non_relevant_failure_is_no_signal(tmp_path: Path) -> None:
+    """A failure without routing_relevant=true never signals."""
+    learning = tmp_path / "learning"
+    _write_events(
+        learning,
+        [
+            {"type": "outcome", "outcome": "failure"},
+            {"type": "outcome", "outcome": "failure", "routing_relevant": False},
+            {"type": "outcome", "outcome": "neutral", "routing_relevant": True},
+        ],
+    )
+    result = _run(learning)
+    assert result.returncode == 0
+
+
+def test_would_demote_signals(tmp_path: Path) -> None:
+    """One would-demote decision => exit 3."""
+    learning = tmp_path / "learning"
+    _write_events(learning, [_decision(0.2, "demote")])
+    result = _run(learning)
+    assert result.returncode == 3
+    assert "would-demote/would-tiebreak decisions: 1" in result.stdout
+
+
+def test_would_tiebreak_signals(tmp_path: Path) -> None:
+    """One would-tiebreak decision => exit 3."""
+    learning = tmp_path / "learning"
+    _write_events(learning, [_decision(0.9, "tiebreak")])
+    result = _run(learning)
+    assert result.returncode == 3
+
+
+def test_malformed_lines_tolerated(tmp_path: Path) -> None:
+    """Partial/garbage lines in the append-only log are skipped, not fatal."""
+    learning = tmp_path / "learning"
+    _write_events(learning, [_decision(0.5, "keep")], raw_suffix='{"type": "deci\nnot json\n')
+    result = _run(learning)
+    assert result.returncode == 0
+    assert "decisions with health_at_decision: 1" in result.stdout
+
+
+def test_read_only(tmp_path: Path) -> None:
+    """The script never writes to the learning dir."""
+    learning = tmp_path / "learning"
+    _write_events(learning, [_decision(0.5, "keep")])
+    before = sorted(p.name for p in learning.iterdir())
+    mtime = (learning / "route-events.jsonl").stat().st_mtime_ns
+    _run(learning)
+    assert sorted(p.name for p in learning.iterdir()) == before
+    assert (learning / "route-events.jsonl").stat().st_mtime_ns == mtime

--- a/scripts/tests/test_route_weights.py
+++ b/scripts/tests/test_route_weights.py
@@ -1,0 +1,175 @@
+"""Tests for the `route-weights --json` subcommand of learning-db.py.
+
+route-weights is a thin read-only reader over routing/effectiveness rows.
+It emits JSON keyed `<agent>:<skill>` with {confidence, n, success, failure,
+last_seen}, where n = observation_count. It must:
+  - be deterministic in ordering,
+  - exclude obvious test rows (source LIKE 'test%'),
+  - never write to the DB,
+  - run fast (<100ms at 10k rows).
+
+Rows are seeded into a temp DB via record_learning / boost_confidence /
+decay_confidence; the command runs as a subprocess so we exercise the real
+CLI entry point against CLAUDE_LEARNING_DIR.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parent.parent.parent
+_repo_hooks_lib = str(_repo_root / "hooks" / "lib")
+_cli_path = str(_repo_root / "scripts" / "learning-db.py")
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the learning DB at a temp dir so tests never touch real data."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+
+    # Make the repo hooks/lib importable and reset the init flag for this proc.
+    if _repo_hooks_lib not in sys.path:
+        sys.path.insert(0, _repo_hooks_lib)
+    import learning_db_v2
+
+    monkeypatch.setattr(learning_db_v2, "_initialized", False)
+    return db_dir
+
+
+def _seed_route(key: str, *, source: str = "routing:decision") -> None:
+    """Seed one routing/effectiveness row."""
+    from learning_db_v2 import record_learning
+
+    record_learning(
+        topic="routing",
+        key=key,
+        value=f"agent: {key.split(':')[0]} | skill: {key.split(':')[-1]}",
+        category="effectiveness",
+        source=source,
+    )
+
+
+def _run_cli(db_dir: Path) -> subprocess.CompletedProcess[str]:
+    """Run `learning-db.py route-weights --json` as a subprocess."""
+    env = dict(os.environ)
+    env["CLAUDE_LEARNING_DIR"] = str(db_dir)
+    return subprocess.run(
+        [sys.executable, _cli_path, "route-weights", "--json"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_shape_and_math(isolated_db: Path) -> None:
+    """Output is keyed agent:skill with the documented fields and correct math."""
+    from learning_db_v2 import boost_confidence, decay_confidence
+
+    _seed_route("golang-general-engineer:go-patterns")
+    boost_confidence("routing", "golang-general-engineer:go-patterns")
+    boost_confidence("routing", "golang-general-engineer:go-patterns")
+
+    _seed_route("python-general-engineer:test-driven-development")
+    decay_confidence("routing", "python-general-engineer:test-driven-development")
+
+    result = _run_cli(isolated_db)
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+
+    go = data["golang-general-engineer:go-patterns"]
+    assert set(go) == {"confidence", "n", "success", "failure", "last_seen"}
+    assert go["success"] == 2
+    assert go["failure"] == 0
+    assert go["n"] >= 1
+    assert isinstance(go["confidence"], float)
+    assert go["last_seen"]
+
+    py = data["python-general-engineer:test-driven-development"]
+    assert py["success"] == 0
+    assert py["failure"] == 1
+
+
+def test_excludes_test_rows(isolated_db: Path) -> None:
+    """Rows from a test source are omitted."""
+    _seed_route("real-agent:real-skill", source="routing:decision")
+    _seed_route("fake-agent:fake-skill", source="test:fixture")
+
+    result = _run_cli(isolated_db)
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+
+    assert "real-agent:real-skill" in data
+    assert "fake-agent:fake-skill" not in data
+
+
+def test_deterministic_ordering(isolated_db: Path) -> None:
+    """Two runs over the same data yield byte-identical key ordering."""
+    for key in ("b-agent:b-skill", "a-agent:a-skill", "c-agent:c-skill"):
+        _seed_route(key)
+
+    first = _run_cli(isolated_db)
+    second = _run_cli(isolated_db)
+    assert first.returncode == 0 and second.returncode == 0
+    assert first.stdout == second.stdout
+    keys = list(json.loads(first.stdout).keys())
+    assert keys == sorted(keys)
+
+
+def test_empty_db_emits_object(isolated_db: Path) -> None:
+    """No routing rows -> empty JSON object, exit 0."""
+    result = _run_cli(isolated_db)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {}
+
+
+def test_no_writes(isolated_db: Path) -> None:
+    """The command does not mutate the DB file."""
+    _seed_route("x-agent:x-skill")
+    db_file = isolated_db / "learning.db"
+    before = db_file.stat().st_mtime_ns
+    time.sleep(0.01)
+    result = _run_cli(isolated_db)
+    assert result.returncode == 0, result.stderr
+    after = db_file.stat().st_mtime_ns
+    assert before == after, "route-weights must not write to the DB"
+
+
+@pytest.mark.slow
+def test_performance_10k_rows(isolated_db: Path) -> None:
+    """Reads 10k rows in under 100ms (query time, excluding interpreter start)."""
+    from learning_db_v2 import record_learning
+
+    for i in range(10000):
+        record_learning(
+            topic="routing",
+            key=f"agent{i}:skill{i}",
+            value="agent: a | skill: s",
+            category="effectiveness",
+            source="routing:decision",
+        )
+
+    # Time only the query path, in-process, not subprocess startup.
+    sys.path.insert(0, str(_repo_root / "scripts"))
+    import importlib
+
+    learning_db = importlib.import_module("learning-db")
+    sys.path.pop(0)
+
+    start = time.perf_counter()
+    rows = learning_db.collect_route_weights()
+    elapsed = time.perf_counter() - start
+    assert len(rows) == 10000
+    # Guard against accidental O(n^2)/full-table-scan regressions, not runner jitter.
+    # At 10k rows a real regression lands in seconds; 0.5s keeps the guard while
+    # absorbing shared-runner variance (a clean run is ~0.01s; shared CI runners
+    # have measured ~0.114s for this same correct query).
+    assert elapsed < 0.5, f"route-weights query took {elapsed * 1000:.1f}ms (>500ms)"

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -205,6 +205,32 @@ If the Haiku JSON is malformed, fall back to `general-purpose` + verification-be
 
 Route to the simplest agent+skill that satisfies the request. On `[cross-repo]` output, route to `.claude/agents/` local agents. Route all code changes to domain agents.
 
+**Step 1.5: Health evaluation (shadow-only instrumentation)**
+
+Runs AFTER the semantic pick (Step 0/0b), BEFORE the Step 1 safety-net.
+
+Once per /do, read the routing weights and score the semantic pick:
+
+```bash
+SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
+python3 "$SDIR/learning-db.py" route-weights --json
+```
+
+Call `health_adjust(semantic_pick, alternates, weights, force_route_flags)` (`scripts/lib/route_policy.py`). It returns `{final_pick, action, reason}` with `action` in `keep | demote | tiebreak`. The `action` is the policy's WOULD-action only.
+
+**Shadow-only: the policy's would-action is recorded for the signal check (scripts/route-signal-check.py); the route is never altered.** The semantic pick always dispatches. Activation is gated on the first recorded negative signal — see docs/route-loop-validation.md.
+
+Policy thresholds (for reading the recorded would-action, not for changing the route):
+
+- Would-demote floor: `confidence < 0.30 AND failure >= 3 AND n >= 5`, toward a healthier alternate.
+- Would-tiebreak: semantic confidence `< 0.35` AND an evidenced (`n >= 5`) healthier alternate supplied.
+- Force-route/security pairs are hard-exempt — always `keep`. Exemption is by SKILL name and accepts force_route_flags as bare skill names or full `agent:skill` pairs.
+- Evidence gate: `n < 5` or no row => `keep`.
+
+**Always log the evaluation** to the T3 event stream: set `health_at_decision` to the picked pair's `confidence` scalar (a float, or `null` when the pair has no weight row); `n` and `failure` are separate fields. The recorder writes all three from the marker onto the per-dispatch DECISION event in `<CLAUDE_LEARNING_DIR>/route-events.jsonl`. Every route is scored even though nothing changes.
+
+Carry the gate inputs on the routing marker (Phase 4 Step 2) so the recorder snapshots them at decision time. Confidence alone cannot reconstruct the demote floor — it needs `n` and `failure` too. Append to the marker: ` health={confidence} n={n} fail={failure} action={keep|demote|tiebreak}` (the would-action), and ` alts={k1,k2}` when you passed alternates. When the picked pair has no weight row, append ` health=-` (the recorder writes null health and drops the n/fail/action fields).
+
 **Step 1: Deterministic safety-net** (`pre-route.py` — runs AFTER the semantic decision, never short-circuits it)
 
 Use its result ONLY as a guardrail:
@@ -408,6 +434,8 @@ Four injections (verbatim): completeness and density standards on Simple+; refer
 
 **MANDATORY: Stamp the routing marker on every routed agent prompt.** Prepend verbatim: `[do-route] agent={agent} skill={skill} complexity={complexity}` (use `skill=-` when routing agent-only). It is the SOLE signal `routing-decision-recorder` uses to record a `routing` row, reading `agent`/`skill` straight from it. Dispatches without it (pr-review sub-agents, nested fan-out) are correctly excluded from route-health. Stamp each agent in a roster.
 
+Append the Step 1.5 gate inputs to the same marker line so the recorder snapshots the route's decision-time health: ` health={confidence} n={n} fail={failure} action={keep|demote|tiebreak}`, plus ` alts={k1,k2}` when alternates were passed. When the picked pair has no weight row, append ` health=-` only (the recorder writes null). Example: `[do-route] agent=python-general-engineer skill=test-driven-development complexity=Medium health=0.72 n=6 fail=0 action=keep`.
+
 **Token budget signal (optional, documented).** Read `orchestration.token_budget` from `.claude/settings.json` (default 500000 when absent). Subtract a rough estimate of tokens spent; prepend to each agent prompt: "~{remaining} tokens available for this task; prioritize accordingly." Advisory, not a hard cap. Read the key once per session.
 
 ```bash
@@ -446,7 +474,7 @@ Detect: "first...then", "and also", numbered lists, semicolons. Sequential depen
 
 Invoke `auto-pipeline` for unmatched requests. If none matches — or when uncertain — **ROUTE ANYWAY** to the closest agent + verification-before-completion as safety net.
 
-**Lazy-completion check (before declaring done).** When an agent returns a "done" claim on an enumerable objective ("all N", a file list, a count), compare claimed scope vs objective scope; if claimed < objective, reject the early "done" and re-dispatch the remainder. See `skills/meta/do/references/lazy-completion-detector.md`.
+**Lazy-completion check (before declaring done).** When an agent returns a "done" claim on an enumerable objective ("all N", a file list, a count), compare claimed scope vs objective scope; if claimed < objective, reject the early "done" and re-dispatch the remainder. See `skills/meta/do/references/lazy-completion-detector.md`. On a re-dispatch from this check, report the route failure (see Learning Capture, "Report routing failures").
 
 **Gate**: Agent invoked, results delivered. Learning capture runs automatically (see note below).
 
@@ -454,7 +482,7 @@ Invoke `auto-pipeline` for unmatched requests. If none matches — or when uncer
 
 ### Learning Capture (automatic — no router step)
 
-Hooks capture everything; the router records nothing by hand:
+Hooks capture everything automatically. The router records by hand exactly one case: orchestrator-reported route failures it observes directly (see "Report routing failures" below) — the single deliberate manual capture step, by ADR design. Everything else is hook-driven:
 
 | Capture | Hook | Event |
 |---------|------|-------|
@@ -468,7 +496,15 @@ Hooks capture everything; the router records nothing by hand:
 
 These feed the routing loop: `learning-db.py route-health` reads the decision rows (denominator) and boost/decay outcomes (numerator). See ADR `learn-step-to-hook`.
 
-**Outcome fidelity (note).** An outcome resolves deterministically on the user's NEXT turn at zero LLM cost: the pending outcome stays *provisional* (no eager boost/decay) and finalizes once — **failure** on tool errors OR a clear rejection/rework/re-route, **success** otherwise (no complaint = accepted). The Stop fallback resolves autonomous runs from the error flag alone. The reaction detector is **deterministic and high-precision** — failure fires only on strong, unambiguous markers.
+**Outcome fidelity (note).** An outcome resolves deterministically on the user's NEXT turn at zero LLM cost: the pending outcome stays *provisional* (no eager boost/decay) and finalizes once, THREE-WAY (T4) — **failure** on tool errors OR a clear rejection/rework/re-route (decay); **success** only on an explicit acceptance marker (boost); **neutral** otherwise — an unrelated/new-topic next prompt is no-op (no boost, no decay, no count change). No complaint is NOT acceptance. The Stop fallback resolves still-pending autonomous runs from the error flag alone: errors => failure, a clean run => neutral (a quiet Stop carries no acceptance evidence, so it does not boost). The reaction detector is **deterministic and high-precision** — failure fires only on strong, unambiguous markers.
+
+**Report routing failures (router-reported channel).** The finalizer only sees tool errors and next-turn rejections; routing failures YOU observe fall through. On a HIGH-CONFIDENCE routing failure only, run:
+
+```bash
+python3 ~/.claude/scripts/learning-db.py route-failure AGENT:SKILL --reason "<cause>" --routing-relevant yes --session $SESSION --marker $DISPATCH_ID
+```
+
+Run it for: re-route after unusable output; lazy-completion re-dispatch; section-validator misroute that reached dispatch; harness-rejected agent type. Bad execution by the RIGHT route -> `--routing-relevant no` (event only, no decay). Ambiguous -> record nothing (precision over recall). `--routing-relevant yes` decays the pair via the finalizer's decay path; one failure per dispatch key (re-runs are no-ops). Treat `<cause>` as untrusted: strip quotes, backticks, `$`, and newlines before splicing it into the shell line — never pass model- or user-derived text raw. See ADR `orchestrator-reported-route-failures`.
 
 **OPTIONAL (not a gate):** curated free-text insight and review-finding graduation are opt-in via the `retro` skill (`retro graduate`), not a router step:
 


### PR DESCRIPTION
## Summary
Sensor subset of #755 (~600 LOC). Keeps the route event log, three-way outcome finalization, the orchestrator-reported failure channel, the pure policy lib, and shadow instrumentation. The actuator and its measurement harness were dropped and close with #755.

## Changes
- `hooks/lib/route_events.py` — append-only per-dispatch decision/outcome event log (`route-events.jsonl`)
- `hooks/routing-outcome-finalizer.py`, `hooks/lib/routing_outcome_score.py`, `hooks/confidence-decay.py` — three-way outcomes: failure decays, explicit acceptance boosts, neutral is a no-op
- `scripts/learning-db.py` — `route-failure` subcommand: orchestrator-reported routing failures, idempotent per (session, marker)
- `scripts/lib/route_policy.py` — pure `health_adjust()` policy with force-route/security hard exemption
- `skills/meta/do/SKILL.md` — Step 1.5 is shadow-only: the would-action is logged on the marker and event stream; the route is never altered
- `scripts/route-signal-check.py` — re-propose gate: exit 0 = no signal, exit 3 = signal (≥1 routing-relevant failure or would-demote/would-tiebreak)
- `docs/route-loop-validation.md` — sensor-kept / actuator-dropped verdict and evidence

## Notes
- Actuator dropped with #755: the demote floor is unreachable on current data (133 routes, min confidence 0.5, zero recorded failures), unknown_rate 0.98 invalidated the decommission clock (2/101 decisions ever joined an outcome), and the live A/B got k=0 structurally (all 39 floor hits force-route-exempt).
- Re-propose the actuator when `scripts/route-signal-check.py` exits 3.
- Three kept files carry comment references to the dropped harness, preserved verbatim from the source branch.