### PR TITLE
fix: normalize diffs before dedup fingerprinting to ignore rebuild-only churn

### DIFF
--- a/hooks/lib/hook_utils.py
+++ b/hooks/lib/hook_utils.py
@@ -719,14 +719,61 @@ def has_reviewable_content(diff: str, scannable_exts: frozenset[str]) -> bool:
     return False
 
 
-class DiffDedup:
-    """Byte-identical working-tree-diff dedup with atomic state + opt-in TTL.
+def normalize_diff_for_fingerprint(diff: str) -> str:
+    """Strip volatile-only noise from a unified diff before fingerprinting.
 
-    Hashes ``sha256(cwd, diff)`` so different repos with identical diffs do not
-    collide. State persists to a JSON file via atomic write (tempfile in the
-    same dir + ``os.replace``). By default dedup is permanent — the same
-    ``(cwd, diff)`` hash means the same review until the diff actually changes;
-    a non-matching hash overwrites the old record (self-healing).
+    The dedup fingerprint must be stable across re-fires that carry the SAME
+    semantic change. Raw ``git diff`` output embeds a few volatile fields that
+    churn even when the file paths and hunks are unchanged — most importantly
+    the ``index <oldsha>..<newsha> <mode>`` line, whose blob SHAs change whenever
+    a build artifact is regenerated (e.g. ``static/game/*`` rebuilds produce the
+    same hunks but fresh blob SHAs). Hashing the raw bytes therefore misses the
+    duplicate and re-reviews the identical change over and over.
+
+    This normalizer removes ONLY those volatile lines, preserving everything
+    that defines WHAT changed:
+
+    Dropped (volatile, carry no review signal):
+      - ``index <sha>..<sha>[ mode]`` — blob SHAs / churn on rebuild
+      - ``old mode`` / ``new mode``   — bare permission churn
+      - ``deleted file mode`` / ``new file mode`` — mode digits only
+      - ``similarity index NN%`` / ``dissimilarity index NN%`` — rename heuristic noise
+
+    Kept (load-bearing — ANY change here yields a new fingerprint → full review):
+      - ``diff --git a/... b/...`` headers (file paths)
+      - ``--- `` / ``+++ `` headers (file paths)
+      - ``rename from`` / ``rename to`` (path moves are real changes)
+      - every ``@@`` hunk header and every ``+``/``-``/context line
+
+    Hardening-preserving: this only collapses byte-noise to a stable form; it
+    never widens what counts as "the same diff" beyond identical paths + hunks.
+    A new file, a changed hunk, or a renamed path all still differ here.
+    """
+    out = []
+    for line in diff.split("\n"):
+        if line.startswith("index "):
+            continue
+        if line.startswith("old mode ") or line.startswith("new mode "):
+            continue
+        if line.startswith("deleted file mode ") or line.startswith("new file mode "):
+            continue
+        if line.startswith("similarity index ") or line.startswith("dissimilarity index "):
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+class DiffDedup:
+    """Working-tree-diff dedup with atomic state + opt-in TTL.
+
+    Hashes ``sha256(cwd, normalize_diff_for_fingerprint(diff))`` so different
+    repos with identical diffs do not collide, and so re-fires of the SAME
+    semantic change (same paths + same hunks) fingerprint identically even when
+    git's volatile blob-SHA / mode noise churns underneath. State persists to a
+    JSON file via atomic write (tempfile in the same dir + ``os.replace``). By
+    default dedup is permanent — the same fingerprint means the same review until
+    the diff actually changes; a non-matching hash overwrites the old record
+    (self-healing).
 
     A positive ``ttl_seconds`` re-enables a time window: a hash match older than
     the TTL is treated as a miss.
@@ -738,11 +785,22 @@ class DiffDedup:
         self.ttl_seconds = ttl_seconds if ttl_seconds and ttl_seconds > 0 else 0
 
     def signature(self, cwd: Optional[str], diff: str) -> str:
-        """Hash (cwd, diff) so different repos with identical diffs don't collide."""
+        """Hash (cwd, normalized-diff) so identical changes fingerprint stably.
+
+        The diff is first run through ``normalize_diff_for_fingerprint`` to drop
+        volatile-only noise (blob-SHA index lines, bare mode churn) while keeping
+        file paths and hunks. ``cwd`` keeps different repos with identical diffs
+        from colliding. Fails open: if normalization ever raises, fall back to
+        hashing the raw diff (the original byte-identical behavior).
+        """
+        try:
+            normalized = normalize_diff_for_fingerprint(diff)
+        except Exception:
+            normalized = diff
         h = hashlib.sha256()
         h.update((cwd or "").encode("utf-8", errors="replace"))
         h.update(b"\x00")
-        h.update(diff.encode("utf-8", errors="replace"))
+        h.update(normalized.encode("utf-8", errors="replace"))
         return h.hexdigest()
 
     def _load(self) -> dict:

--- a/hooks/tests/test_hook_utils_security.py
+++ b/hooks/tests/test_hook_utils_security.py
@@ -28,6 +28,7 @@ from hook_utils import (
     async_rewake,
     diff_post_image_ext,
     has_reviewable_content,
+    normalize_diff_for_fingerprint,
     working_tree_diff,
 )
 
@@ -216,6 +217,90 @@ class TestDiffDedup:
         d = DiffDedup(tmp_path / "nope", tmp_path / "nope" / "deep" / "s.json")
         with patch("hook_utils.os.replace", side_effect=OSError("ro")):
             d.record("/repo", "diffA")  # must not raise
+
+    # --- fingerprint normalization: blob-SHA / mode churn must NOT re-trigger ---
+
+    def test_signature_ignores_index_blob_sha_churn(self, tmp_path):
+        """Same paths + same hunks but fresh ``index`` blob SHAs → same signature."""
+        d = DiffDedup(tmp_path, tmp_path / "s.json")
+        before = (
+            "diff --git a/static/game/index.html b/static/game/index.html\n"
+            "index 71aae3b..739f207 100644\n"
+            "--- a/static/game/index.html\n"
+            "+++ b/static/game/index.html\n"
+            "@@ -1 +1,2 @@\n x\n+rebuilt\n"
+        )
+        after = before.replace("index 71aae3b..739f207", "index aaaaaaa..bbbbbbb")
+        assert d.signature("/repo", before) == d.signature("/repo", after)
+
+    def test_index_churn_dedups_end_to_end(self, tmp_path):
+        """Record a diff, then re-fire with only blob-SHA churn → duplicate."""
+        d = DiffDedup(tmp_path, tmp_path / "s.json")
+        first = (
+            "diff --git a/app.js b/app.js\nindex 1111111..2222222 100644\n"
+            "--- a/app.js\n+++ b/app.js\n@@ -1 +1,2 @@\n y\n+z\n"
+        )
+        d.record("/repo", first)
+        rebuilt = first.replace("index 1111111..2222222", "index 9999999..8888888")
+        is_dup, _ = d.is_duplicate("/repo", rebuilt)
+        assert is_dup is True
+
+    def test_real_content_change_is_not_duplicate(self, tmp_path):
+        """A changed hunk (one new added line) still produces a fresh review."""
+        d = DiffDedup(tmp_path, tmp_path / "s.json")
+        first = (
+            "diff --git a/app.js b/app.js\nindex 1111111..2222222 100644\n"
+            "--- a/app.js\n+++ b/app.js\n@@ -1 +1,2 @@\n y\n+z\n"
+        )
+        d.record("/repo", first)
+        changed = first.replace("+z\n", "+z\n+brand_new_line\n")
+        is_dup, _ = d.is_duplicate("/repo", changed)
+        assert is_dup is False
+
+    def test_new_file_path_is_not_duplicate(self, tmp_path):
+        """A new file path differs from the recorded diff → fresh review."""
+        d = DiffDedup(tmp_path, tmp_path / "s.json")
+        first = (
+            "diff --git a/app.js b/app.js\nindex 1111111..2222222 100644\n"
+            "--- a/app.js\n+++ b/app.js\n@@ -1 +1,2 @@\n y\n+z\n"
+        )
+        d.record("/repo", first)
+        with_new = first + (
+            "diff --git a/extra.js b/extra.js\nindex 0000000..3333333 100644\n"
+            "--- a/extra.js\n+++ b/extra.js\n@@ -0,0 +1 @@\n+added\n"
+        )
+        is_dup, _ = d.is_duplicate("/repo", with_new)
+        assert is_dup is False
+
+
+class TestNormalizeDiffForFingerprint:
+    def test_drops_index_line(self):
+        norm = normalize_diff_for_fingerprint("index 71aae3b..739f207 100644\n")
+        assert "index " not in norm
+
+    def test_drops_mode_lines(self):
+        diff = "old mode 100644\nnew mode 100755\n"
+        assert normalize_diff_for_fingerprint(diff).strip() == ""
+
+    def test_drops_similarity_index(self):
+        diff = "similarity index 95%\ndissimilarity index 5%\n"
+        assert normalize_diff_for_fingerprint(diff).strip() == ""
+
+    def test_keeps_file_paths_and_hunks(self):
+        diff = (
+            "diff --git a/app.py b/app.py\nindex abc..def 100644\n--- a/app.py\n+++ b/app.py\n@@ -1 +1,2 @@\n x\n+y\n"
+        )
+        norm = normalize_diff_for_fingerprint(diff)
+        for keep in ("diff --git a/app.py b/app.py", "--- a/app.py", "+++ b/app.py", "@@ -1 +1,2 @@", "+y"):
+            assert keep in norm
+
+    def test_keeps_rename_path_lines(self):
+        diff = "rename from old.py\nrename to new.py\n"
+        norm = normalize_diff_for_fingerprint(diff)
+        assert "rename from old.py" in norm and "rename to new.py" in norm
+
+    def test_empty_diff_is_empty(self):
+        assert normalize_diff_for_fingerprint("") == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Cherry-pick of @notque's own commit abe8cb0a from feat/outcome-routing-loop (#755), extracted verbatim so it survives the close of that PR. Blob-SHA and mode-bit churn in `git diff index` lines made DiffDedup treat rebuild-only changes as new reviews, re-triggering security audits on identical code.

## Changes
- `hooks/lib/hook_utils.py` — add `normalize_diff_for_fingerprint()`; `DiffDedup.signature()` hashes the normalized diff, failing open to raw bytes
- `hooks/tests/test_hook_utils_security.py` — blob-SHA churn keeps the signature stable; identical churn deduplicates end-to-end

## Notes
- Verbatim cherry-pick: patch-id matches the original commit; authorship preserved (notque).