### PR TITLE
fix(routing): not_for disambiguation on sibling skills and agents

### DIFF
--- a/agents/golang-general-engineer.md
+++ b/agents/golang-general-engineer.md
@@ -44,6 +44,7 @@ routing:
     - go-patterns
     - concurrency
     - debugging
+  not_for: "tasks using 'go' as a verb (go ahead, go fix this)"
   pairs_with:
     - go-patterns
   complexity: Medium-Complex

--- a/agents/typescript-frontend-engineer.md
+++ b/agents/typescript-frontend-engineer.md
@@ -16,6 +16,7 @@ routing:
   retro-topics:
     - typescript-patterns
     - debugging
+  not_for: "React Native mobile apps (use react-native-engineer)"
   pairs_with:
     - universal-quality-gate
     - typescript-check

--- a/skills/business/productivity/SKILL.md
+++ b/skills/business/productivity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: productivity
-description: Productivity workflows — task management, daily planning, weekly reviews, meeting optimization, focus management, goal setting, status updates. Use when planning days, managing tasks, running weekly reviews, optimizing meetings, or writing status updates.
+description: Personal productivity — sort out what to work on next, prioritize tasks, plan your day, run weekly reviews, optimize meetings, set goals, write status updates. Use when planning days, managing tasks, running weekly reviews, optimizing meetings, or writing status updates.
 routing:
   triggers:
     - "productivity"
@@ -15,6 +15,7 @@ routing:
     - "prioritize tasks"
     - "standup"
     - "retrospective"
+  not_for: "software task specs, requirements, or plan-lifecycle management — that is planning. This is personal prioritization and time management, not building a project plan."
   category: business
   force_route: false
   pairs_with: []

--- a/skills/content/professional-communication/SKILL.md
+++ b/skills/content/professional-communication/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: professional-communication
-description: "Transform technical communication into structured business formats."
+description: "Draft interpersonal and meeting messages — emails, memos, status updates, and pushing back or disagreeing in a structured business format."
 user-invocable: false
 allowed-tools:
   - Read
@@ -15,6 +15,7 @@ routing:
     - "executive summary"
     - "summarize for management"
     - "status update"
+  not_for: "critiquing or stress-testing a proposal's merits — that is multi-persona-critique. This drafts the message, it does not judge the idea."
   category: content-creation
   pairs_with:
     - voice-writer

--- a/skills/process/planning/SKILL.md
+++ b/skills/process/planning/SKILL.md
@@ -20,7 +20,7 @@ allowed-tools:
   - Skill
 routing:
   force_route: true
-  not_for: "city planning, financial planning, meeting planning, travel itineraries, casual 'planning meeting notes' — only for software task planning, specs, and plan-lifecycle management"
+  not_for: "city/financial/meeting/travel planning; and personal prioritization like 'what should I work on next' — that is productivity. Only for software task planning, specs, and plan-lifecycle management."
   triggers:
     - "write spec"
     - "user stories"

--- a/skills/research/multi-persona-critique/SKILL.md
+++ b/skills/research/multi-persona-critique/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multi-persona-critique
-description: "Parallel critique of proposals via 5 philosophical personas with consensus synthesis."
+description: "Critique a written proposal or design artifact via 5 philosophical personas in parallel, with consensus synthesis."
 user-invocable: true
 argument-hint: "<proposals to critique, or 'generate N ideas about X'>"
 allowed-tools:
@@ -20,6 +20,7 @@ routing:
     - "evaluate from multiple perspectives"
     - "get different viewpoints"
     - "critique proposals"
+  not_for: "speaking to a person, a meeting, or pushing back in a conversation — that is professional-communication. This critiques an artifact, not interpersonal messaging."
   pairs_with:
     - roast
     - decision-helper

--- a/skills/research/research-pipeline/SKILL.md
+++ b/skills/research/research-pipeline/SKILL.md
@@ -25,6 +25,7 @@ routing:
     - "systematic investigation"
     - "research report"
     - "gather evidence"
+  not_for: "a quick one-off web search or chat-style lookup — that is deep-research. Pick this when the user wants a sourced report saved as an artifact (SCOPE-to-DELIVER), even when phrased as 'dig into X and give me a sourced report'."
   category: research
   pairs_with:
     - kb

--- a/skills/review/systematic-code-review/SKILL.md
+++ b/skills/review/systematic-code-review/SKILL.md
@@ -15,6 +15,7 @@ routing:
     - "code audit"
     - "review methodology"
     - "comprehensive review"
+  not_for: "vague no-target requests like 'make this better' — those are interview-mode, where the agent asks what to improve. Only for reviewing a named file, diff, or PR."
   category: code-review
   pairs_with:
     - forensics


### PR DESCRIPTION
## Summary
Frontmatter-only extraction from #755 (commits 97feda42 + fba833b5): sharpen `description`/`not_for` so the Haiku router tells sibling skills apart, per the blind routing dogfood.

## Changes
- `skills/research/multi-persona-critique`, `skills/content/professional-communication` — artifact critique vs interpersonal/meeting messaging (both directions)
- `skills/research/research-pipeline` — formal SCOPE-to-DELIVER artifact flow vs ad-hoc deep-research lookup
- `skills/process/planning`, `skills/business/productivity` — sibling boundary sharpened
- `skills/review/systematic-code-review` — scope clause added
- `agents/golang-general-engineer.md` — 'go' as a verb does not route here
- `agents/typescript-frontend-engineer.md` — React Native routes to react-native-engineer

## Notes
- INDEX.json is generated in CI (untracked); `check-routing-drift.py --verbose` passes with these changes.