### PR TITLE
feat(do): per-dispatch router cost diet (four reductions)

### DIFF
--- a/scripts/routing-manifest.py
+++ b/scripts/routing-manifest.py
@@ -7,6 +7,7 @@ then outputs a compact text manifest that an LLM can parse efficiently.
 Usage:
     python3 scripts/routing-manifest.py
     python3 scripts/routing-manifest.py --json
+    python3 scripts/routing-manifest.py --tiered
 
 Exit codes:
     0 — Always (advisory)
@@ -16,10 +17,18 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import sqlite3
 import sys
+import time
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Tiered mode: how far back a route-events DECISION keeps a name in the
+# working set, and how many description words a stub line keeps.
+WORKING_SET_WINDOW_SECONDS = 30 * 86400
+STUB_DESC_WORDS = 6
 
 
 def _resolve_index(tracked: Path, local_name: str) -> Path:
@@ -74,6 +83,125 @@ def load_entries() -> list[dict]:
             entries.append(entry)
 
     return entries
+
+
+def _learning_dir() -> Path:
+    """Resolve the learning dir from CLAUDE_LEARNING_DIR (tests redirect it)."""
+    env_dir = os.environ.get("CLAUDE_LEARNING_DIR")
+    return Path(env_dir) if env_dir else Path.home() / ".claude" / "learning"
+
+
+def _names_from_key(key: str, names: set[str]) -> None:
+    """Add the agent and skill names from an `agent:skill` route key."""
+    for part in key.split(":", 1):
+        part = part.strip()
+        if part and part != "-":
+            names.add(part)
+
+
+def load_working_set(now: float | None = None) -> set[str]:
+    """Names (agents and skills) with recorded routes.
+
+    Union of: route-weight rows (n >= 1, test rows excluded) from learning.db,
+    and DECISION events from route-events.jsonl in the last 30 days.
+    Read-only. Any read failure yields a smaller set, never an error —
+    a smaller working set only means more stub lines.
+    """
+    names: set[str] = set()
+    base = _learning_dir()
+
+    db_path = base / "learning.db"
+    if db_path.exists():
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+            try:
+                rows = conn.execute(
+                    "SELECT key FROM learnings"
+                    " WHERE topic = 'routing' AND category = 'effectiveness'"
+                    " AND observation_count >= 1 AND source NOT LIKE 'test%'"
+                ).fetchall()
+            finally:
+                conn.close()
+            for (key,) in rows:
+                _names_from_key(str(key), names)
+        except sqlite3.Error:
+            pass
+
+    events_path = base / "route-events.jsonl"
+    cutoff = (now if now is not None else time.time()) - WORKING_SET_WINDOW_SECONDS
+    try:
+        with open(events_path, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict) or event.get("type") != "decision":
+                    continue
+                ts = event.get("ts")
+                if not isinstance(ts, (int, float)) or ts < cutoff:
+                    continue
+                for field in ("agent", "skill"):
+                    value = event.get(field)
+                    if isinstance(value, str) and value and value != "-":
+                        names.add(value)
+    except OSError:
+        pass
+
+    return names
+
+
+def _stub_line(entry: dict) -> str:
+    """One-line stub: name + first STUB_DESC_WORDS words of the description."""
+    desc = " ".join(str(entry["description"]).split()[:STUB_DESC_WORDS])
+    return f"  {entry['name']} — {desc}"
+
+
+def format_tiered(entries: list[dict], working_set: set[str]) -> str:
+    """Format entries with FULL lines for the working set, stubs for the rest.
+
+    FULL: working-set names (recorded routes) and every force-route entry —
+    force-route entries are never stubbed. Stub: name + 6-word description.
+    Pipelines are few; they always render FULL.
+    """
+    agents = []
+    skills = []
+    pipelines = []
+
+    for e in entries:
+        name = e["name"]
+        full = name in working_set or e.get("force_route", False)
+
+        if e["type"] == "pipeline":
+            pipelines.append(f"  {name} — {e['description']}")
+            continue
+        if not full:
+            (agents if e["type"] == "agent" else skills).append(_stub_line(e))
+            continue
+
+        desc = e["description"]
+        pairs = ", ".join(e["pairs_with"][:3]) if e["pairs_with"] else ""
+        not_for = e.get("not_for", "")
+        not_for_str = f" NOT: {not_for}" if not_for else ""
+
+        if e["type"] == "agent":
+            pairs_str = f" [{pairs}]" if pairs else ""
+            agents.append(f"  {name}{pairs_str} — {desc}{not_for_str}")
+        else:
+            force_str = " FORCE" if e.get("force_route") else ""
+            agent_str = f" agent={e['agent']}" if e.get("agent") else ""
+            cat_str = f" ({e['category']})" if e.get("category") else ""
+            skills.append(f"  {name}{force_str}{agent_str}{cat_str} — {desc}{not_for_str}")
+
+    sections = []
+    if agents:
+        sections.append("AGENTS:\n" + "\n".join(sorted(agents)))
+    if skills:
+        sections.append("SKILLS:\n" + "\n".join(sorted(skills)))
+    if pipelines:
+        sections.append("PIPELINES:\n" + "\n".join(sorted(pipelines)))
+
+    return "\n\n".join(sections)
 
 
 def format_compact(entries: list[dict]) -> str:
@@ -179,6 +307,11 @@ def main() -> int:
         default="",
         help="Request text (used with --compact to decide whether to include PIPELINES)",
     )
+    parser.add_argument(
+        "--tiered",
+        action="store_true",
+        help="Tiered mode: FULL lines for the live working set and force-route entries, one-line stubs otherwise",
+    )
     args = parser.parse_args()
 
     entries = load_entries()
@@ -187,6 +320,8 @@ def main() -> int:
         print(json.dumps(entries, indent=2))
     elif args.compact:
         print(format_compact_mode(entries, request_text=args.request))
+    elif args.tiered:
+        print(format_tiered(entries, load_working_set()))
     else:
         print(format_compact(entries))
 

--- a/scripts/routing-manifest.py
+++ b/scripts/routing-manifest.py
@@ -152,9 +152,19 @@ def load_working_set(now: float | None = None) -> set[str]:
 
 
 def _stub_line(entry: dict) -> str:
-    """One-line stub: name + first STUB_DESC_WORDS words of the description."""
+    """One-line stub: name + router-critical metadata + first STUB_DESC_WORDS description words.
+
+    Skill stubs keep the agent= pairing and not_for — dropping them made the
+    router return the right skill with agent: null (tiered-v1 REJECT).
+    Agent stubs stay name + truncated description.
+    """
     desc = " ".join(str(entry["description"]).split()[:STUB_DESC_WORDS])
-    return f"  {entry['name']} — {desc}"
+    if entry["type"] != "skill":
+        return f"  {entry['name']} — {desc}"
+    agent_str = f" agent={entry['agent']}" if entry.get("agent") else ""
+    not_for = entry.get("not_for", "")
+    not_for_str = f" NOT: {not_for}" if not_for else ""
+    return f"  {entry['name']}{agent_str} — {desc}{not_for_str}"
 
 
 def format_tiered(entries: list[dict], working_set: set[str]) -> str:

--- a/scripts/routing-manifest.py
+++ b/scripts/routing-manifest.py
@@ -9,6 +9,12 @@ Usage:
     python3 scripts/routing-manifest.py --json
     python3 scripts/routing-manifest.py --tiered
 
+--tiered is REJECTED for production routing: two blind A/B runs failed
+gates (c) safety misses and (d) stub-tier (verdicts in
+scripts/routing-ab-results/tiered-v1|v2/VERDICT.md on PR #771's branch).
+The flag stays for experimentation only; the /do router uses the full
+manifest (no flag).
+
 Exit codes:
     0 — Always (advisory)
 """
@@ -320,7 +326,7 @@ def main() -> int:
     parser.add_argument(
         "--tiered",
         action="store_true",
-        help="Tiered mode: FULL lines for the live working set and force-route entries, one-line stubs otherwise",
+        help="Tiered mode (EXPERIMENT ONLY — rejected for production by two A/B runs, see module docstring): FULL lines for the live working set and force-route entries, one-line stubs otherwise",
     )
     args = parser.parse_args()
 

--- a/scripts/tests/test_routing_manifest_tiered.py
+++ b/scripts/tests/test_routing_manifest_tiered.py
@@ -71,6 +71,20 @@ ENTRIES = [
         not_for="metaphorical uses",
     ),
     _entry("a-pipeline", "pipeline", "Pipeline description stays full"),
+    _entry(
+        "paired-cold-skill",
+        "skill",
+        "Cold skill that declares an agent pairing here",
+        agent="alpha-agent",
+        category="misc",
+    ),
+    _entry(
+        "guarded-cold-skill",
+        "skill",
+        "Cold skill carrying a not_for guard clause tail",
+        not_for="metaphorical uses of guard",
+        category="misc",
+    ),
 ]
 
 
@@ -188,6 +202,28 @@ def test_working_set_entries_full() -> None:
     assert "Agent for alpha domain tasks plus extra trailing words" in alpha
     cold = next(line for line in lines if line.startswith("  cold-skill"))
     assert cold.strip() == "cold-skill — Never routed skill with a very"
+
+
+def test_stub_skill_keeps_agent_pairing() -> None:
+    """Stub skill lines carry agent= — dropping it made the router return agent: null."""
+    tiered = rm.format_tiered(ENTRIES, working_set=set())
+    line = next(ln for ln in tiered.splitlines() if ln.startswith("  paired-cold-skill"))
+    assert "agent=alpha-agent" in line
+    assert "Cold skill that declares an agent" in line  # first 6 words kept
+    assert "pairing here" not in line  # description still truncated
+
+
+def test_stub_skill_keeps_not_for() -> None:
+    tiered = rm.format_tiered(ENTRIES, working_set=set())
+    line = next(ln for ln in tiered.splitlines() if ln.startswith("  guarded-cold-skill"))
+    assert "NOT: metaphorical uses of guard" in line
+    assert "clause tail" not in line  # description still truncated
+
+
+def test_agent_stub_stays_name_and_description() -> None:
+    tiered = rm.format_tiered(ENTRIES, working_set=set())
+    line = next(ln for ln in tiered.splitlines() if ln.startswith("  beta-agent"))
+    assert line.strip() == "beta-agent — Agent for beta domain tasks plus"
 
 
 def test_pipelines_always_full() -> None:

--- a/scripts/tests/test_routing_manifest_tiered.py
+++ b/scripts/tests/test_routing_manifest_tiered.py
@@ -1,0 +1,225 @@
+"""Tests for scripts/routing-manifest.py --tiered mode.
+
+Covers the tiered-manifest contract:
+- tiered output is smaller than full output
+- stub entries still parse (name + em-dash + description)
+- force-route entries always render FULL
+- working set = weight rows (n >= 1) UNION recent route-events DECISIONs
+
+All learning reads go through a temp CLAUDE_LEARNING_DIR — never the live one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "routing-manifest.py"
+
+_spec = importlib.util.spec_from_file_location("routing_manifest", SCRIPT)
+assert _spec and _spec.loader
+rm = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rm)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _entry(
+    name: str,
+    entry_type: str = "skill",
+    description: str = "A long description with many words to exercise stub truncation behavior",
+    force_route: bool = False,
+    **extra: object,
+) -> dict:
+    return {
+        "name": name,
+        "type": entry_type,
+        "description": description,
+        "triggers": [],
+        "category": extra.get("category", ""),
+        "agent": extra.get("agent"),
+        "model": None,
+        "pairs_with": extra.get("pairs_with", []),
+        "force_route": force_route,
+        **({"not_for": extra["not_for"]} if "not_for" in extra else {}),
+    }
+
+
+ENTRIES = [
+    _entry("alpha-agent", "agent", "Agent for alpha domain tasks plus extra trailing words"),
+    _entry("beta-agent", "agent", "Agent for beta domain tasks plus extra trailing words"),
+    _entry("cold-skill", "skill", "Never routed skill with a very long description tail", category="misc"),
+    _entry("hot-skill", "skill", "Recently routed skill with a very long description tail", category="misc"),
+    _entry(
+        "force-skill",
+        "skill",
+        "Force-routed skill with a very long description tail",
+        force_route=True,
+        category="git-workflow",
+        not_for="metaphorical uses",
+    ),
+    _entry("a-pipeline", "pipeline", "Pipeline description stays full"),
+]
+
+
+@pytest.fixture
+def learning_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Temp learning dir; CLAUDE_LEARNING_DIR points at it for module reads."""
+    d = tmp_path / "learning"
+    d.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(d))
+    return d
+
+
+def _write_db(learning_dir: Path, rows: list[tuple[str, int, str]]) -> None:
+    """Write a minimal learning.db with (key, observation_count, source) rows."""
+    conn = sqlite3.connect(learning_dir / "learning.db")
+    conn.execute("CREATE TABLE learnings (key TEXT, topic TEXT, category TEXT, observation_count INTEGER, source TEXT)")
+    conn.executemany(
+        "INSERT INTO learnings VALUES (?, 'routing', 'effectiveness', ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def _write_events(learning_dir: Path, events: list[dict]) -> None:
+    lines = "".join(json.dumps(e) + "\n" for e in events)
+    (learning_dir / "route-events.jsonl").write_text(lines, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# load_working_set
+# ---------------------------------------------------------------------------
+
+
+def test_working_set_empty_when_no_data(learning_dir: Path) -> None:
+    assert rm.load_working_set() == set()
+
+
+def test_working_set_from_weight_rows(learning_dir: Path) -> None:
+    _write_db(
+        learning_dir,
+        [
+            ("alpha-agent:hot-skill", 3, "hook"),
+            ("beta-agent:other", 0, "hook"),  # n=0 excluded
+            ("x-agent:y-skill", 5, "test-fixture"),  # test source excluded
+        ],
+    )
+    assert rm.load_working_set() == {"alpha-agent", "hot-skill"}
+
+
+def test_working_set_from_recent_events_only(learning_dir: Path) -> None:
+    now = time.time()
+    _write_events(
+        learning_dir,
+        [
+            {"type": "decision", "ts": now - 86400, "agent": "beta-agent", "skill": "hot-skill"},
+            {"type": "decision", "ts": now - 40 * 86400, "agent": "stale-agent", "skill": "stale-skill"},
+            {"type": "outcome", "ts": now, "key": "o-agent:o-skill"},  # not a decision
+            {"type": "decision", "ts": now, "agent": "solo-agent", "skill": "-"},  # skill=- dropped
+        ],
+    )
+    assert rm.load_working_set(now=now) == {"beta-agent", "hot-skill", "solo-agent"}
+
+
+def test_working_set_unions_db_and_events(learning_dir: Path) -> None:
+    _write_db(learning_dir, [("alpha-agent:cold-skill", 1, "hook")])
+    _write_events(learning_dir, [{"type": "decision", "ts": time.time(), "agent": "beta-agent", "skill": "hot-skill"}])
+    assert rm.load_working_set() == {"alpha-agent", "cold-skill", "beta-agent", "hot-skill"}
+
+
+def test_working_set_survives_garbage_inputs(learning_dir: Path) -> None:
+    (learning_dir / "learning.db").write_bytes(b"not a sqlite file")
+    (learning_dir / "route-events.jsonl").write_text("not json\n{\n", encoding="utf-8")
+    assert rm.load_working_set() == set()
+
+
+# ---------------------------------------------------------------------------
+# format_tiered
+# ---------------------------------------------------------------------------
+
+
+def test_tiered_smaller_than_full() -> None:
+    tiered = rm.format_tiered(ENTRIES, working_set=set())
+    full = rm.format_compact(ENTRIES)
+    assert len(tiered) < len(full)
+
+
+def test_stub_entries_parse() -> None:
+    tiered = rm.format_tiered(ENTRIES, working_set=set())
+    stub = next(line for line in tiered.splitlines() if line.startswith("  cold-skill"))
+    name, _, desc = stub.strip().partition(" — ")
+    assert name == "cold-skill"
+    assert desc == "Never routed skill with a very"  # first 6 words
+    # Section structure intact: every entry name still present.
+    for e in ENTRIES:
+        assert e["name"] in tiered
+    assert tiered.index("AGENTS:") < tiered.index("SKILLS:") < tiered.index("PIPELINES:")
+
+
+def test_force_route_always_full() -> None:
+    tiered = rm.format_tiered(ENTRIES, working_set=set())
+    line = next(line for line in tiered.splitlines() if line.startswith("  force-skill"))
+    assert "FORCE" in line
+    assert "Force-routed skill with a very long description tail" in line
+    assert "NOT: metaphorical uses" in line
+
+
+def test_working_set_entries_full() -> None:
+    tiered = rm.format_tiered(ENTRIES, working_set={"hot-skill", "alpha-agent"})
+    lines = tiered.splitlines()
+    hot = next(line for line in lines if line.startswith("  hot-skill"))
+    assert "Recently routed skill with a very long description tail" in hot
+    assert "(misc)" in hot
+    alpha = next(line for line in lines if line.startswith("  alpha-agent"))
+    assert "Agent for alpha domain tasks plus extra trailing words" in alpha
+    cold = next(line for line in lines if line.startswith("  cold-skill"))
+    assert cold.strip() == "cold-skill — Never routed skill with a very"
+
+
+def test_pipelines_always_full() -> None:
+    tiered = rm.format_tiered(ENTRIES, working_set=set())
+    assert "  a-pipeline — Pipeline description stays full" in tiered
+
+
+# ---------------------------------------------------------------------------
+# CLI integration (real INDEX files; temp learning dir)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not (REPO_ROOT / "skills" / "INDEX.json").exists(), reason="INDEX.json not generated")
+def test_cli_tiered_smaller_than_full(learning_dir: Path) -> None:
+    env = {**os.environ, "CLAUDE_LEARNING_DIR": str(learning_dir)}
+
+    def run(*args: str) -> str:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            env=env,
+            check=True,
+        ).stdout
+
+    tiered = run("--tiered")
+    full = run()
+    assert len(tiered) < len(full)
+    # force-route entries (e.g. pr-workflow) keep their full line in both modes
+    if "pr-workflow FORCE" in full:
+        full_line = next(line for line in full.splitlines() if line.startswith("  pr-workflow"))
+        assert full_line in tiered
+    # --json and --compact behavior unchanged by the new flag
+    json.loads(run("--json"))

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -109,9 +109,21 @@ If ANY creation signal AND complexity Simple+: set `is_creation = true`; Phase 4
 
 ### Phase 2: ROUTE
 
-**Goal**: Select the correct agent + skill. Semantic intent routing (Haiku) is primary; the pre-router is a safety-net, not a short-circuit. Prefer FORCE-labeled entries when intent matches semantically.
+**Goal**: Select the correct agent + skill. Semantic intent routing (Haiku) is primary; the pre-router is a safety-net, not a short-circuit — the fast path below is the one exception, and it only commits routes the safety-net would force anyway. Prefer FORCE-labeled entries when intent matches semantically.
 
 **Contract: read for INTENT.** Read what the user MEANS; trigger keywords are hints, never gates. Plain or non-native-English phrasing routes as well as jargon ("send my commits to the server" routes like "git push"). Cost: ~+0.1 Haiku calls/request — measured, accepted (`references/semantic-first-ab-results.md`).
+
+**Fast path: high-confidence force-route (run FIRST, before Step 0)**
+
+Resolve SDIR as in Step 0, then run:
+
+```bash
+python3 "$SDIR/pre-route.py" --request "{user_request}" --json-compact
+```
+
+If the result has `"confidence": "high"` AND `"match_type": "force_route"` AND the skill is `pr-workflow` or a security skill: dispatch that pair directly. Skip Step 0 (manifest + Haiku), Step 1.5 (weights read), and Step 1 (pre-route already ran). Everything else stays mandatory: the routing banner (Step 3), Step 2 skill overrides where compatible, Phase 3 enhancements, and ALL Phase 4 injections — stamp the `[do-route]` marker with `health=-`. Agent: pre-route's `agent` when non-null, else the domain agent implied by Phase 1 classification, else `general-purpose`.
+
+**Equivalence**: Step 1(a) already overrides any semantic pick with exactly these high-confidence force-routes, so the full flow always lands on this same force-routed skill. The fast path changes cost (~18.7k tokens of manifest + Haiku round-trip skipped), not behavior. Guards already ran inside pre-route, so idiom false-positives ("push back", "fish out") never reach the fast path. Any other result — no match, medium/low confidence, non-force match, or a skill outside pr-workflow/security — falls through to Step 0 unchanged.
 
 **Step 0: Semantic intent routing (PRIMARY)**
 
@@ -119,7 +131,7 @@ Generate the manifest, then dispatch the Haiku routing agent.
 
 ```bash
 SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
-python3 "$SDIR/routing-manifest.py"
+python3 "$SDIR/routing-manifest.py" --tiered
 ```
 
 Dispatch the Agent tool with `model: "haiku"`, omitting `isolation: "worktree"` (the agent only reads a manifest and returns JSON; worktree isolation fails outside a git repo). Use this prompt structure:
@@ -174,6 +186,7 @@ Rules:
 - If the request implies a task verb (review, debug, refactor, test), prefer skills that match that verb.
 - If nothing matches well, return all nulls with reasoning.
 - Prefer entries whose description semantically matches the request, not just keyword overlap.
+- Stub entries are valid picks — if a stub matches the intent best, return it.
 - For GENUINE git / version-control operations — actually pushing code, committing files to a repository, or opening/merging a pull request — ALWAYS select pr-workflow. Do NOT route metaphorical or non-version-control uses of these words (e.g. 'commit to a decision/plan', 'merge ideas in your head', 'push back on a proposal') to pr-workflow.
 - Return a single skill name as a string, not an array. If multiple skills are needed, pick the primary one.
 ```
@@ -209,10 +222,9 @@ Route to the simplest agent+skill that satisfies the request. On `[cross-repo]` 
 
 Runs AFTER the semantic pick (Step 0/0b), BEFORE the Step 1 safety-net.
 
-Once per /do, read the routing weights and score the semantic pick:
+Once per /do, read the routing weights and score the semantic pick. Resolve SDIR as in Step 0, then run:
 
 ```bash
-SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
 python3 "$SDIR/learning-db.py" route-weights --json
 ```
 
@@ -229,14 +241,13 @@ Policy thresholds (for reading the recorded would-action, not for changing the r
 
 **Always log the evaluation** to the T3 event stream: set `health_at_decision` to the picked pair's `confidence` scalar (a float, or `null` when the pair has no weight row); `n` and `failure` are separate fields. The recorder writes all three from the marker onto the per-dispatch DECISION event in `<CLAUDE_LEARNING_DIR>/route-events.jsonl`. Every route is scored even though nothing changes.
 
-Carry the gate inputs on the routing marker (Phase 4 Step 2) so the recorder snapshots them at decision time. Confidence alone cannot reconstruct the demote floor — it needs `n` and `failure` too. Append to the marker: ` health={confidence} n={n} fail={failure} action={keep|demote|tiebreak}` (the would-action), and ` alts={k1,k2}` when you passed alternates. When the picked pair has no weight row, append ` health=-` (the recorder writes null health and drops the n/fail/action fields).
+Carry the gate inputs on the routing marker so the recorder snapshots them at decision time — confidence alone cannot reconstruct the demote floor; it needs `n` and `failure` too. Append format and example: Phase 4 Step 2.
 
 **Step 1: Deterministic safety-net** (`pre-route.py` — runs AFTER the semantic decision, never short-circuits it)
 
-Use its result ONLY as a guardrail:
+Use its result ONLY as a guardrail. Reuse the fast-path gate's pre-route output when it ran this turn; otherwise resolve SDIR as in Step 0 and run:
 
 ```bash
-SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
 python3 "$SDIR/pre-route.py" --request "{user_request}" --json-compact
 ```
 
@@ -343,66 +354,10 @@ Load `references/quality-loop.md` as the **outer orchestration wrapper**:
 
 Quality-loop absorbs Steps 0-1. The Phase 2 agent+skill is the implementation agent; force-route skills run INSIDE the loop. Skip when: Trivial/Simple (use `quick`), review-only/research/debugging/content creation, or user wants a simpler flow.
 
-**Step 1b (native Workflow dispatch): run the deterministic variant when the harness supports it, else the prose pipeline.** When the Haiku router emitted a pipeline `pick` (#686), select the executor with this ADR decision table (`harness-conditional-workflow-dispatch`):
+**Step 1b/1c (Workflow dispatch — lazy-loaded):**
 
-```
-pick = haiku_route.pipeline                         # #686, may be null
-cap  = scripts/detect-workflow-capability.py        # env proxy: {harness, workflow_capable}
-reg  = scripts/workflow-registry.py                 # auto-derived {meta.name: path}
-{scope, tier} = scripts/right-size-review.py        # #688 right-sizing (review picks)
-complex4 = (complexity == Complex) or (tier == 4)   # ADR native-fast-path Stage 2
-
-if pick is not None and reg.get(pick) and cap.workflow_capable and (Workflow tool in MY tool list):
-        # NAMED pipeline: env proxy AND LLM tool-list self-check (authoritative gate)
-                                                            -> Workflow.run(reg[pick], {scope, tier})
-elif pick is not None and reg.get(pick):                    -> run the prose pipeline markdown (unchanged)
-elif pick is None and complex4 and cap.workflow_capable and (Workflow tool in MY tool list):
-        # NO named pipeline + Complex/tier-4: generic native fan-out (Stage 2)
-                                                            -> Workflow.run("fan-out-workflow", {scope, tier, roster})
-elif pick is None and complex4:                             # Workflow tool absent -> floor
-                                                            -> dispatching-parallel-agents (prose fan-out, unchanged)
-else:                                                       -> agent + skill direct (simpler; unchanged)
-```
-
-Build `roster` from the Phase-3 enhancement signals, scaled by `tier`. **Each entry is `{agentType, skills: [...], lens}` — `skills` is a LIST carrying the FULL Phase-3 stack a direct dispatch would build.** Per agent, emit one `Skill("<name>")` per `skills` element and the four /do mandatory injections. Native forms: `comprehensive-review-workflow.js` (named pipeline), `fan-out-workflow.js` (generic Complex/tier-4). Both pseudocode gates (env proxy AND the orchestrator's own tool-list self-check) must hold; a `pick` with no registry entry is prose-only.
-
-**Banner parity (R4):** expand the pipeline name → phase list for the routing banner on BOTH paths, so it reads identically regardless of executor (e.g. complexity-trigger fan-out shows `fan-out → synthesize`).
-
-**Step 1c (inline-authored Workflow scripts): when the user explicitly asks to "run through a workflow" with no named pipeline `pick`, the orchestrator MUST dictate roster size and skill stacks — never delegate those to the Workflow tool** (whose defaults skew toward many-skeptic adversarial fan-outs and rarely emit `Skill(...)`). Before any inline `script:`, build the same `roster` Step 1b uses and pin:
-
-| Constraint | Rule |
-|------------|------|
-| **Agent count** | Dictate explicit roster length per task class (table below), not the Workflow tool's "comprehensiveness" heuristics. |
-| **Skill stacks** | EVERY `agent()` call MUST be preceded by one `Skill("<name>")` per element of its roster entry's `skills` list. Empty `skills` is a routing bug — fail closed and re-route. |
-| **Adversarial passes** | Default to **single skeptic per finding**, not 3–5. Escalate to 3 only on a request for "adversarial," "heavy refute," or "high-stakes review," and only on findings surviving the first pass. |
-| **Phase count** | Reuse a registry pipeline's phase shape (`comprehensive-review-workflow`, `fan-out-workflow`, `research-pipeline`) over inventing novel phase names. |
-
-Roster-size table (counts dictated, NOT advisory):
-
-| Request class | Roster size | Skeptic pass |
-|---------------|-------------|--------------|
-| PR review (Tier 1, ≤6 files) | 3 reviewers | none default; 1 skeptic on user request |
-| PR review (Tier 2–3) | 12 / 17 reviewers per `right-size-review.py` | 1 skeptic on "Critical" findings only |
-| PR review (Tier 4) | 27 reviewers | 1 skeptic on Critical+High findings |
-| Adversarial validation of N findings | 1 skeptic × N (not 3 × N) | escalate to 3 only on user-flagged "heavy pushback" |
-| Research fan-out | 3–5 researchers per `research-pipeline` Wave 1 | n/a |
-| Generic complexity-trigger fan-out | use `fan-out-workflow` registered roster | n/a |
-
-Inline `script:` shape (a `Skill(...)` directive in EVERY worker, count from the roster):
-
-```js
-const ROSTER = [/* dictated count, NOT model-chosen */
-  {agentType: "reviewer-system",       skills: ["systematic-code-review", "anti-rationalization-review"], lens: "security"},
-  {agentType: "reviewer-domain",       skills: ["systematic-code-review", "anti-rationalization-review"], lens: "domain"},
-  {agentType: "reviewer-perspectives", skills: ["systematic-code-review", "anti-rationalization-review"], lens: "newcomer"},
-];
-const findings = await parallel(ROSTER.map(r => async () => {
-  for (const s of r.skills) await Skill(s);   // FULL stack, one directive per skill
-  return agent(buildPrompt(r), {agentType: r.agentType, schema: FINDINGS_SCHEMA});
-}));
-```
-
-Catching a model-chosen N (`parallel(Array.from({length: N}, ...))`) or a missing `Skill(...)` directive means **stop and rebuild the script from the roster table above**.
+On a pipeline `pick`, a Complex/tier-4 task with no pick, or an explicit "run through a workflow" request, load `${CLAUDE_SKILL_DIR}/references/workflow-dispatch.md` and follow it.
+It carries the executor decision table, roster rules, and inline-script constraints verbatim.
 
 **Step 2: Invoke agent with skill**
 

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -131,7 +131,7 @@ Generate the manifest, then dispatch the Haiku routing agent.
 
 ```bash
 SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.gemini/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
-python3 "$SDIR/routing-manifest.py" --tiered
+python3 "$SDIR/routing-manifest.py"
 ```
 
 Dispatch the Agent tool with `model: "haiku"`, omitting `isolation: "worktree"` (the agent only reads a manifest and returns JSON; worktree isolation fails outside a git repo). Use this prompt structure:
@@ -186,7 +186,6 @@ Rules:
 - If the request implies a task verb (review, debug, refactor, test), prefer skills that match that verb.
 - If nothing matches well, return all nulls with reasoning.
 - Prefer entries whose description semantically matches the request, not just keyword overlap.
-- Stub entries are valid picks — if a stub matches the intent best, return it.
 - For GENUINE git / version-control operations — actually pushing code, committing files to a repository, or opening/merging a pull request — ALWAYS select pr-workflow. Do NOT route metaphorical or non-version-control uses of these words (e.g. 'commit to a decision/plan', 'merge ideas in your head', 'push back on a proposal') to pr-workflow.
 - Return a single skill name as a string, not an array. If multiple skills are needed, pick the primary one.
 ```

--- a/skills/meta/do/references/workflow-dispatch.md
+++ b/skills/meta/do/references/workflow-dispatch.md
@@ -1,0 +1,64 @@
+# Workflow Dispatch (Phase 4 Steps 1b/1c)
+
+Native-Workflow executor selection and roster rules, moved verbatim from `SKILL.md` Phase 4. Load on: a pipeline `pick`, Complex/tier-4 with no pick, or an explicit "run through a workflow" request.
+
+**Step 1b (native Workflow dispatch): run the deterministic variant when the harness supports it, else the prose pipeline.** When the Haiku router emitted a pipeline `pick` (#686), select the executor with this ADR decision table (`harness-conditional-workflow-dispatch`):
+
+```
+pick = haiku_route.pipeline                         # #686, may be null
+cap  = scripts/detect-workflow-capability.py        # env proxy: {harness, workflow_capable}
+reg  = scripts/workflow-registry.py                 # auto-derived {meta.name: path}
+{scope, tier} = scripts/right-size-review.py        # #688 right-sizing (review picks)
+complex4 = (complexity == Complex) or (tier == 4)   # ADR native-fast-path Stage 2
+
+if pick is not None and reg.get(pick) and cap.workflow_capable and (Workflow tool in MY tool list):
+        # NAMED pipeline: env proxy AND LLM tool-list self-check (authoritative gate)
+                                                            -> Workflow.run(reg[pick], {scope, tier})
+elif pick is not None and reg.get(pick):                    -> run the prose pipeline markdown (unchanged)
+elif pick is None and complex4 and cap.workflow_capable and (Workflow tool in MY tool list):
+        # NO named pipeline + Complex/tier-4: generic native fan-out (Stage 2)
+                                                            -> Workflow.run("fan-out-workflow", {scope, tier, roster})
+elif pick is None and complex4:                             # Workflow tool absent -> floor
+                                                            -> dispatching-parallel-agents (prose fan-out, unchanged)
+else:                                                       -> agent + skill direct (simpler; unchanged)
+```
+
+Build `roster` from the Phase-3 enhancement signals, scaled by `tier`. **Each entry is `{agentType, skills: [...], lens}` — `skills` is a LIST carrying the FULL Phase-3 stack a direct dispatch would build.** Per agent, emit one `Skill("<name>")` per `skills` element and the four /do mandatory injections. Native forms: `comprehensive-review-workflow.js` (named pipeline), `fan-out-workflow.js` (generic Complex/tier-4). Both pseudocode gates (env proxy AND the orchestrator's own tool-list self-check) must hold; a `pick` with no registry entry is prose-only.
+
+**Banner parity (R4):** expand the pipeline name → phase list for the routing banner on BOTH paths, so it reads identically regardless of executor (e.g. complexity-trigger fan-out shows `fan-out → synthesize`).
+
+**Step 1c (inline-authored Workflow scripts): when the user explicitly asks to "run through a workflow" with no named pipeline `pick`, the orchestrator MUST dictate roster size and skill stacks — never delegate those to the Workflow tool** (whose defaults skew toward many-skeptic adversarial fan-outs and rarely emit `Skill(...)`). Before any inline `script:`, build the same `roster` Step 1b uses and pin:
+
+| Constraint | Rule |
+|------------|------|
+| **Agent count** | Dictate explicit roster length per task class (table below), not the Workflow tool's "comprehensiveness" heuristics. |
+| **Skill stacks** | EVERY `agent()` call MUST be preceded by one `Skill("<name>")` per element of its roster entry's `skills` list. Empty `skills` is a routing bug — fail closed and re-route. |
+| **Adversarial passes** | Default to **single skeptic per finding**, not 3–5. Escalate to 3 only on a request for "adversarial," "heavy refute," or "high-stakes review," and only on findings surviving the first pass. |
+| **Phase count** | Reuse a registry pipeline's phase shape (`comprehensive-review-workflow`, `fan-out-workflow`, `research-pipeline`) over inventing novel phase names. |
+
+Roster-size table (counts dictated, NOT advisory):
+
+| Request class | Roster size | Skeptic pass |
+|---------------|-------------|--------------|
+| PR review (Tier 1, ≤6 files) | 3 reviewers | none default; 1 skeptic on user request |
+| PR review (Tier 2–3) | 12 / 17 reviewers per `right-size-review.py` | 1 skeptic on "Critical" findings only |
+| PR review (Tier 4) | 27 reviewers | 1 skeptic on Critical+High findings |
+| Adversarial validation of N findings | 1 skeptic × N (not 3 × N) | escalate to 3 only on user-flagged "heavy pushback" |
+| Research fan-out | 3–5 researchers per `research-pipeline` Wave 1 | n/a |
+| Generic complexity-trigger fan-out | use `fan-out-workflow` registered roster | n/a |
+
+Inline `script:` shape (a `Skill(...)` directive in EVERY worker, count from the roster):
+
+```js
+const ROSTER = [/* dictated count, NOT model-chosen */
+  {agentType: "reviewer-system",       skills: ["systematic-code-review", "anti-rationalization-review"], lens: "security"},
+  {agentType: "reviewer-domain",       skills: ["systematic-code-review", "anti-rationalization-review"], lens: "domain"},
+  {agentType: "reviewer-perspectives", skills: ["systematic-code-review", "anti-rationalization-review"], lens: "newcomer"},
+];
+const findings = await parallel(ROSTER.map(r => async () => {
+  for (const s of r.skills) await Skill(s);   // FULL stack, one directive per skill
+  return agent(buildPrompt(r), {agentType: r.agentType, schema: FINDINGS_SCHEMA});
+}));
+```
+
+Catching a model-chosen N (`parallel(Array.from({length: N}, ...))`) or a missing `Skill(...)` directive means **stop and rebuild the script from the roster table above**.


### PR DESCRIPTION
## Verdict rework (5b8bd1f2)
Shipped: the force-route fast path, lazy `references/workflow-dispatch.md` loading, and the ceremony cuts. Cut: the tiered manifest as the production Step 0 default — two pre-registered blind A/B runs REJECTED it on gates (c) new safety-bucket misses and (d) stub-tier regression ([tiered-v1 VERDICT.md](https://github.com/notque/vexjoy-agent/blob/feat/route-ab-tiered-v2/scripts/routing-ab-results/tiered-v1/VERDICT.md), [tiered-v2 VERDICT.md](https://github.com/notque/vexjoy-agent/blob/feat/route-ab-tiered-v2/scripts/routing-ab-results/tiered-v2/VERDICT.md), [verdict comment](https://github.com/notque/vexjoy-agent/pull/761#issuecomment-4666068349)). SKILL.md Step 0 is back on the full manifest; the `--tiered` flag, `format_tiered()`, `_stub_line()`, and their tests stay in `scripts/routing-manifest.py` for experimentation only.

## Summary
Cuts the /do router's per-dispatch context cost (measured ~19,349 tokens) without losing routing quality: a force-route fast path, a lazy workflow-dispatch reference, and ceremony dedup. Stacked on #758 (`feat/route-sensor`). ADR: `do-cost-diet` (local).

Measured (bytes; tokens ≈ bytes/4):
- `skills/meta/do/SKILL.md`: 38,194 → 34,013 bytes (−4,181 B ≈ −1,045 tok), with 5,572 B moved to a lazy-loaded reference.
- Fast-path dispatches skip the manifest read, the Haiku round-trip, and the Step 1.5 weights read entirely (~18.7k tok per fast-path dispatch).

## Changes
- `skills/meta/do/SKILL.md` — add Phase 2 fast path: pre-route `confidence=high` + `force_route` for pr-workflow/security dispatches directly; skips Step 0/1.5/1, keeps banner, `[do-route]` marker (`health=-`), and all Phase 3/4 injections.
- `skills/meta/do/SKILL.md` — SDIR resolution occurrences 2 and 3 become "Resolve SDIR as in Step 0"; Step 1.5 marker-append format now points at Phase 4 Step 2 (single statement).
- `skills/meta/do/references/workflow-dispatch.md` — Step 1b/1c native-Workflow decision table + roster tables moved verbatim; 3-line pointer remains in SKILL.md.
- `scripts/routing-manifest.py` — add `--tiered` (default OFF, experiment only; REJECTED for production per the verdicts above): FULL lines for the working set, 6-word stubs otherwise; `--json`/`--compact` unchanged.
- `scripts/tests/test_routing_manifest_tiered.py` — 14 tests covering the experimental tiered formatter.

## Notes
- Fast path is behavior-equivalent by construction: it only commits routes Step 1(a) already overrides the semantic pick with (high-confidence force-routes for pr-workflow/security); pre-route's idiom guards run before the gate. Equivalence documented in SKILL.md.
- Force-route overrides, security exemptions, the section validator, and the `[do-route]` marker contract are unchanged in effect; the four mandatory injection texts stay verbatim.
- Routing-drift check passes (124/124 skills present; default manifest mode unchanged).
