### PR TITLE
fix(sync): protect voice-shared-references from stale-cleanup

### DIFF
--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -349,8 +349,8 @@ def _sync_skills_flat_symlinks(src: Path, dst: Path) -> None:
         ~/.claude/skills/do → repo/skills/meta/do
         ~/.claude/skills/planning → repo/skills/process/planning
 
-    Root-level items (INDEX.json, shared-patterns/, workflow/, kb/) are
-    also symlinked directly.
+    Root-level items (INDEX.json, support dirs like shared-patterns/,
+    workflow/, kb/, voice-shared-references/) are symlinked directly.
 
     Index-symlink policy (prevents the private-skill leak into the *tracked*
     skills/INDEX.json): ~/.claude/skills/INDEX.json is the runtime index the
@@ -392,11 +392,32 @@ def _sync_skills_flat_symlinks(src: Path, dst: Path) -> None:
                 target.unlink()
             target.symlink_to(link_src)
 
-    # Symlink root-level utility directories (shared-patterns, workflow, kb)
-    # These contain no SKILL.md at the category level — they're utility refs.
-    root_dirs = {"shared-patterns", "workflow", "kb"}
+    # Symlink root-level support directories (shared-patterns, workflow, kb,
+    # voice-shared-references). These hold reference files, not skills.
+    root_dirs = {"shared-patterns", "workflow", "kb", "voice-shared-references"}
+
+    def _is_support_dir(item: Path) -> bool:
+        """Support dirs hold reference .md files at their root, not skills.
+
+        They must enter expected_names or the stale-cleanup loop below
+        unlinks them every SessionStart (the voice-shared-references bug).
+        A dir counts as support when allowlisted, or when it has .md files
+        directly inside and no skill subdirectory — category folders always
+        hold at least one subdirectory with a SKILL.md.
+        """
+        if item.name in root_dirs:
+            return True
+        if item.name.startswith(".") or (item / "SKILL.md").exists():
+            return False
+        children = list(item.iterdir())
+        has_md = any(c.is_file() and c.suffix == ".md" for c in children)
+        has_skill_subdir = any(c.is_dir() and (c / "SKILL.md").exists() for c in children)
+        return has_md and not has_skill_subdir
+
+    support_dirs: set[str] = set()
     for item in src.iterdir():
-        if item.is_dir() and item.name in root_dirs:
+        if item.is_dir() and _is_support_dir(item):
+            support_dirs.add(item.name)
             expected_names.add(item.name)
             _ensure_symlink(item, dst / item.name)
 
@@ -405,7 +426,7 @@ def _sync_skills_flat_symlinks(src: Path, dst: Path) -> None:
     for category_dir in sorted(src.iterdir()):
         if not category_dir.is_dir():
             continue
-        if category_dir.name in root_dirs:
+        if category_dir.name in support_dirs:
             continue  # Already handled above
         if category_dir.name.startswith("."):
             continue

--- a/hooks/tests/test_sync_to_user_claude.py
+++ b/hooks/tests/test_sync_to_user_claude.py
@@ -240,6 +240,98 @@ class TestSkillsFlatSymlinkIndexPolicy:
         assert (dst / "INDEX.json").resolve() == (src / "INDEX.json").resolve()
 
 
+class TestSupportDirSurvivesCleanup:
+    """Support dirs (reference .md files, no SKILL.md) must enter
+    expected_names, or the stale-cleanup loop unlinks them every
+    SessionStart. Regression test for the voice-shared-references bug:
+    the dir was missing from the root_dirs allowlist, so the cleanup
+    deleted its symlink 4 times in one session."""
+
+    def _make_src(self, tmp_path: Path) -> Path:
+        src = tmp_path / "skills"
+        refs = src / "voice-shared-references"
+        refs.mkdir(parents=True)
+        for name in (
+            "anti-rhetorical-pivot.md",
+            "voice-first-writing.md",
+            "wabi-sabi-authenticity.md",
+        ):
+            (refs / name).write_text("# ref\n")
+        # one real skill so the flatten loop has something to do
+        skill = src / "meta" / "do"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("---\nname: do\n---\n")
+        return src
+
+    def test_voice_shared_references_survives_sync(self, tmp_path: Path) -> None:
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "out"
+        with patch.object(sync_mod, "_is_ephemeral_path", return_value=False):
+            sync_mod._sync_skills_flat_symlinks(src, dst)
+            # Second pass exercises the stale-cleanup against existing links
+            sync_mod._sync_skills_flat_symlinks(src, dst)
+
+        link = dst / "voice-shared-references"
+        assert link.is_symlink()
+        assert link.resolve() == (src / "voice-shared-references").resolve()
+        assert (link / "voice-first-writing.md").read_text() == "# ref\n"
+
+    def test_preexisting_support_symlink_not_unlinked(self, tmp_path: Path) -> None:
+        """The original failure: a symlink already in dst was unlinked
+        because its name never entered expected_names."""
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "out"
+        dst.mkdir()
+        (dst / "voice-shared-references").symlink_to(src / "voice-shared-references")
+
+        with patch.object(sync_mod, "_is_ephemeral_path", return_value=False):
+            sync_mod._sync_skills_flat_symlinks(src, dst)
+
+        assert (dst / "voice-shared-references").is_symlink()
+
+    def test_future_support_dir_protected_without_allowlist(self, tmp_path: Path) -> None:
+        """Any root dir with .md files and no skill subdir is treated as a
+        support dir, so the next shared-reference dir cannot repeat the bug."""
+        src = self._make_src(tmp_path)
+        refs = src / "new-shared-refs"
+        refs.mkdir()
+        (refs / "pattern.md").write_text("# pattern\n")
+        dst = tmp_path / "out"
+
+        with patch.object(sync_mod, "_is_ephemeral_path", return_value=False):
+            sync_mod._sync_skills_flat_symlinks(src, dst)
+            sync_mod._sync_skills_flat_symlinks(src, dst)
+
+        assert (dst / "new-shared-refs").is_symlink()
+
+    def test_stale_symlink_still_removed(self, tmp_path: Path) -> None:
+        """Cleanup still unlinks symlinks whose source left the repo."""
+        src = self._make_src(tmp_path)
+        gone = tmp_path / "gone-skill"
+        gone.mkdir()
+        dst = tmp_path / "out"
+        dst.mkdir()
+        (dst / "gone-skill").symlink_to(gone)
+
+        with patch.object(sync_mod, "_is_ephemeral_path", return_value=False):
+            sync_mod._sync_skills_flat_symlinks(src, dst)
+
+        assert not (dst / "gone-skill").exists()
+
+    def test_category_with_readme_still_flattened(self, tmp_path: Path) -> None:
+        """A category folder holding a stray README.md plus skill subdirs is
+        NOT a support dir — its skills must still be flattened per-skill."""
+        src = self._make_src(tmp_path)
+        (src / "meta" / "README.md").write_text("# meta\n")
+        dst = tmp_path / "out"
+
+        with patch.object(sync_mod, "_is_ephemeral_path", return_value=False):
+            sync_mod._sync_skills_flat_symlinks(src, dst)
+
+        assert (dst / "do").is_symlink()
+        assert not (dst / "meta").exists()
+
+
 class TestMainSymlinkMode:
     """Integration tests for main() in symlink mode."""
 


### PR DESCRIPTION
## Summary
Stops the SessionStart sync hook from deleting `skills/voice-shared-references/`. Forensic finding: the `root_dirs` allowlist in `_sync_skills_flat_symlinks()` listed only shared-patterns, workflow, kb — voice-shared-references (reference .md files, no SKILL.md) never entered `expected_names`, so the stale-cleanup loop unlinked it on every SessionStart, reaching the repo working tree through the symlinked install (4 deletions in one session).

## Changes
- `hooks/sync-to-user-claude.py` — add `voice-shared-references` to the allowlist; generalize: any skills/ root dir with .md files directly inside and no skill subdirectory counts as a support dir (symlinked whole, kept in `expected_names`).
- `hooks/tests/test_sync_to_user_claude.py` — add 5 regression tests: the dir survives a sync + cleanup pass, a pre-existing symlink is not unlinked, future support dirs are protected without allowlisting, stale symlinks are still removed, category folders with a stray README still flatten per-skill.

## Notes
- The generalization cannot protect genuinely stale dirs: `expected_names` only gains names found in the repo, so links to removed dirs are still cleaned.