### PR TITLE
fix(hooks): gate error-learner on actual tool failure, not stdout keywords

### DIFF
--- a/hooks/error-learner.py
+++ b/hooks/error-learner.py
@@ -24,7 +24,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
 from feedback_tracker import check_pending_feedback, set_pending_feedback
-from hook_utils import get_tool_error, get_tool_output, get_tool_result
+from hook_utils import get_tool_error, get_tool_output, get_tool_result, is_tool_error
 from learning_db_v2 import (
     DEFAULT_FIX_ACTIONS,
     boost_confidence,
@@ -64,97 +64,34 @@ def process_automatic_feedback(current_error: str | None) -> None:
 
 
 def detect_error(event: dict) -> tuple[bool, str]:
-    """Detect if tool execution had an error.
+    """Detect if tool execution actually failed.
+
+    Gates on the payload's real failure signals via hook_utils:
+    error field, is_error flag, or non-zero exitCode — the same
+    detectors record-waste and routing-decision-recorder use.
+    A successful execution records nothing, regardless of stdout
+    content. Keyword scanning of output caused false positives
+    (a successful `git log` mentioning "timeout" became a learning
+    row). Keywords classify the error TYPE only after this gate,
+    in classify_error.
 
     Returns:
         Tuple of (has_error, error_message)
     """
     tool_result = get_tool_result(event)
 
-    # Direct error field
     err = get_tool_error(tool_result)
-    if err:
-        return True, str(err)
+    if not err and not is_tool_error(tool_result):
+        return False, ""
 
-    # Check for error in output
-    output = get_tool_output(tool_result)
-    if isinstance(output, str):
-        output_lower = output.lower()
+    # Failed: prefer explicit error text, fall back to output.
+    message = str(err).strip() if err else ""
+    if not message:
+        message = str(get_tool_output(tool_result)).strip()
+    if not message:
+        return False, ""  # failure with no text: nothing to learn
 
-        # Error indicators that match our ERROR_TYPES patterns
-        error_indicators = [
-            "error",
-            "failed",
-            "permission denied",
-            "access denied",
-            "not found",
-            "no such file",
-            "cannot find",
-            "does not exist",
-            "syntax error",
-            "unexpected token",
-            "type error",
-            "import error",
-            "module not found",
-            "no module named",
-            "timeout",
-            "timed out",
-            "connection refused",
-            "traceback",
-            "exception",
-        ]
-
-        if any(indicator in output_lower for indicator in error_indicators):
-            # Avoid false positives for success messages
-            if "0 errors" not in output_lower and "no errors" not in output_lower:
-                # Avoid false positives for benign text patterns
-                false_positive_phrases = [
-                    "error handling",
-                    "error handler",
-                    "failed over",
-                    "failover",
-                    "not found in cache",
-                    # Timeout false positives: "timeout" appears in config output,
-                    # import lines, and success messages — not as an actual error.
-                    "timeout=",  # e.g. timeout=2000 in hook config output
-                    "stdin_timeout",  # e.g. from stdin_timeout import ...
-                    "timeout caps",  # e.g. "PASS: all hooks now have timeout caps"
-                    "timeout/",  # e.g. "Graduated: timeout/abc123 → ..."
-                    "read_stdin(timeout",  # e.g. raw = read_stdin(timeout=2)
-                ]
-                if any(phrase in output_lower for phrase in false_positive_phrases):
-                    return False, ""
-                # Avoid false positives for error keywords inside code identifiers
-                # e.g., ErrorType, handle_error, on_error, etc.
-                import re as _re
-
-                if _re.search(r"[A-Z][a-z]*[Ee]rror[A-Z]|[a-z_][Ee]rror[A-Za-z_]|[Hh]andle[_]?[Ee]rror", output):
-                    # Only suppress if ALL error indicators are inside identifiers
-                    plain_indicators = [
-                        "failed",
-                        "permission denied",
-                        "access denied",
-                        "no such file",
-                        "cannot find",
-                        "does not exist",
-                        "syntax error",
-                        "unexpected token",
-                        "module not found",
-                        "no module named",
-                        "traceback",
-                        "exception",
-                    ]
-                    if not any(indicator in output_lower for indicator in plain_indicators):
-                        return False, ""
-                return True, output
-
-    # Check for non-zero exit code mention in Bash tool
-    tool_name = event.get("tool_name", "")
-    if tool_name == "Bash" and isinstance(output, str):
-        if "exit code" in output.lower() and "exit code 0" not in output.lower():
-            return True, output
-
-    return False, ""
+    return True, message
 
 
 def main():

--- a/hooks/tests/test_error_learner.py
+++ b/hooks/tests/test_error_learner.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Tests for the error-learner PostToolUse hook.
+
+The hook must gate learning capture on the payload's actual failure
+signals (is_error flag, error field, non-zero exitCode) — never on
+keyword matches against successful stdout. Audit found ~135 false
+learning rows in 24h from successful commands whose output merely
+mentioned "error", "timeout", or "not found".
+
+Run with: python3 -m pytest hooks/tests/test_error_learner.py -v
+"""
+
+import importlib.util
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+HOOK_PATH = Path(__file__).parent.parent / "error-learner.py"
+LIB_PATH = Path(__file__).parent.parent / "lib"
+
+# ---------------------------------------------------------------------------
+# Import the module under test (for unit tests of detect_error)
+# ---------------------------------------------------------------------------
+
+sys.path.insert(0, str(LIB_PATH))
+
+spec = importlib.util.spec_from_file_location("error_learner", HOOK_PATH)
+mod = importlib.util.module_from_spec(spec)
+with patch("sys.exit"):
+    spec.loader.exec_module(mod)
+
+
+# ---------------------------------------------------------------------------
+# detect_error: failure-signal gate
+# ---------------------------------------------------------------------------
+
+
+def test_success_with_error_keywords_not_detected():
+    """Successful command whose stdout mentions error keywords records nothing."""
+    event = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_result": {
+            "output": "abc123 fix: retry timeout error\ndef456 handle file not found",
+            "is_error": False,
+        },
+    }
+    has_error, message = mod.detect_error(event)
+    assert has_error is False
+    assert message == ""
+
+
+def test_success_without_flags_not_detected():
+    """No is_error / error / exitCode signal means success, whatever stdout says."""
+    event = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_result": {"output": "ls: scan-error.py test-timeout.py notfound.md"},
+    }
+    has_error, message = mod.detect_error(event)
+    assert has_error is False
+    assert message == ""
+
+
+def test_failure_error_field_detected():
+    """Explicit error field is a genuine failure."""
+    event = {
+        "tool_name": "Read",
+        "tool_result": {"is_error": True, "error": "No such file or directory: foo.txt"},
+    }
+    has_error, message = mod.detect_error(event)
+    assert has_error is True
+    assert "No such file" in message
+
+
+def test_failure_exitcode_detected_factory_schema():
+    """Factory schema: non-zero exitCode with stderr is a genuine failure."""
+    event = {
+        "tool_name": "Bash",
+        "tool_response": {"exitCode": 1, "stderr": "Permission denied", "stdout": ""},
+    }
+    has_error, message = mod.detect_error(event)
+    assert has_error is True
+    assert "Permission denied" in message
+
+
+def test_failure_is_error_flag_uses_output():
+    """is_error=True with no error field falls back to output text."""
+    event = {
+        "tool_name": "Bash",
+        "tool_result": {"is_error": True, "output": "Traceback (most recent call last): ValueError"},
+    }
+    has_error, message = mod.detect_error(event)
+    assert has_error is True
+    assert "Traceback" in message
+
+
+def test_failure_without_any_text_records_nothing():
+    """Failure with no error text gives the learner nothing to store."""
+    event = {"tool_name": "Bash", "tool_result": {"is_error": True, "output": ""}}
+    has_error, message = mod.detect_error(event)
+    assert has_error is False
+    assert message == ""
+
+
+def test_empty_event_safe():
+    has_error, message = mod.detect_error({})
+    assert has_error is False
+    assert message == ""
+
+
+# ---------------------------------------------------------------------------
+# Full hook runs (subprocess, isolated HOME + CLAUDE_LEARNING_DIR)
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(stdin_text: str, tmp_path: Path) -> subprocess.CompletedProcess:
+    """Run the hook with all on-disk state redirected into tmp_path."""
+    env = dict(os.environ)
+    env["HOME"] = str(tmp_path)  # feedback_tracker state under tmp HOME
+    env["CLAUDE_LEARNING_DIR"] = str(tmp_path / "learning")
+    env.pop("CLAUDE_HOOKS_DEBUG", None)
+    return subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+
+def _learner_rows(tmp_path: Path) -> list[tuple]:
+    """Rows the hook wrote to the isolated learning DB."""
+    db = tmp_path / "learning" / "learning.db"
+    if not db.exists():
+        return []
+    conn = sqlite3.connect(db)
+    try:
+        return conn.execute("SELECT error_type, value FROM learnings WHERE source = 'hook:error-learner'").fetchall()
+    finally:
+        conn.close()
+
+
+def _event(tool_result: dict, tool_name: str = "Bash") -> str:
+    return json.dumps({"hook_event_name": "PostToolUse", "tool_name": tool_name, "tool_result": tool_result})
+
+
+def test_hook_successful_command_records_nothing(tmp_path):
+    """The audit scenario: successful git log mentioning timeout/error/not found."""
+    stdout = "a1b2c3 fix: connection timeout error\n9f8e7d docs: file not found page"
+    result = _run_hook(_event({"output": stdout, "is_error": False}), tmp_path)
+    assert result.returncode == 0
+    assert "[new-error]" not in result.stdout
+    assert "[learned-solution]" not in result.stdout
+    assert _learner_rows(tmp_path) == []
+
+
+def test_hook_failed_command_records_with_classification(tmp_path):
+    """Genuine failure still captures, classified correctly."""
+    result = _run_hook(
+        _event({"is_error": True, "error": "No such file or directory: foo.txt"}, "Read"),
+        tmp_path,
+    )
+    assert result.returncode == 0
+    assert "[new-error]" in result.stdout
+    rows = _learner_rows(tmp_path)
+    assert len(rows) == 1
+    assert rows[0][0] == "missing_file"
+    assert "No such file" in rows[0][1]
+
+
+def test_hook_empty_stdin_safe(tmp_path):
+    result = _run_hook("", tmp_path)
+    assert result.returncode == 0
+    assert _learner_rows(tmp_path) == []
+
+
+def test_hook_malformed_json_safe(tmp_path):
+    result = _run_hook("{not valid json", tmp_path)
+    assert result.returncode == 0
+    assert _learner_rows(tmp_path) == []
+
+
+def test_hook_non_posttooluse_ignored(tmp_path):
+    payload = json.dumps({"hook_event_name": "SessionStart"})
+    result = _run_hook(payload, tmp_path)
+    assert result.returncode == 0
+    assert _learner_rows(tmp_path) == []


### PR DESCRIPTION
## Summary
error-learner.py recorded successful command output as error patterns: it keyword-matched stdout substrings ("error", "timeout", "not found"), producing ~135 false learning rows in one 24h window — including rows from read-only audit queries — all feeding [learned-context] injection. detect_error now gates on the payload's actual failure signal before recording anything.

## Changes
- `hooks/error-learner.py` — detect_error requires a real failure signal (error field, is_error flag, or non-zero exitCode via hook_utils `get_tool_error`/`is_tool_error`, the same detectors record-waste and routing-decision-recorder use); deletes the 19-keyword stdout scan, the false-positive phrase list, and the identifier regex. classify_error still keyword-refines the error TYPE, but only after the gate passes.
- `hooks/tests/test_error_learner.py` — 12 tests, fully isolated (subprocess runs get tmp HOME + CLAUDE_LEARNING_DIR): successful output with error keywords records nothing; genuine failures still capture on both Claude (is_error/error) and Factory (exitCode/stderr) schemas with correct classification (missing_file, row asserted in the isolated DB); empty/malformed payload safe; exit 0 on every path.

## Notes
- Genuine errors still capture: a failed Read with "No such file" records a missing_file row and emits [new-error] (asserted in tests); failure with no error text records nothing.
- The live-DB "Test error for lookup XXXX → Test solution" rows came from elsewhere: `hooks/tests/test_learning_system.py::test_record_and_lookup` calls `record_learning()` without setting CLAUDE_LEARNING_DIR, so pytest runs write to the live ~/.claude/learning/learning.db. Not chased here per scope; `scripts/purge-test-entries.py` already targets those rows. Follow-up: a conftest fixture setting CLAUDE_LEARNING_DIR for the learning-system tests.
- `hooks/lib/feedback_tracker.py` resolves its state file from `Path.home()` and ignores CLAUDE_LEARNING_DIR; the new tests isolate it via HOME override. Out of scope to change.