### PR TITLE
fix(hooks): graduation gate requires verified entries, not just recurrence

### DIFF
--- a/hooks/retro-graduation-gate.py
+++ b/hooks/retro-graduation-gate.py
@@ -31,6 +31,14 @@ EVENT = "PostToolUse"
 # 'voice' is corpus data; none can ever satisfy this gate.
 GRADUATABLE_CATEGORIES = ("design", "gotcha")
 
+# Verified = confirmed by an executed check at least once. success_count is
+# incremented only by boost_confidence() (learning_db_v2.py), which fires when
+# feedback tracking sees an injected solution succeed or after an explicit
+# `learning-db.py boost` following a check. Recurrence alone can entrench a
+# wrong guess (docs/PHILOSOPHY.md, "memory needs a verify step"); only
+# verified rows are graduatable. Unverified rows are listed separately.
+VERIFIED = "COALESCE(success_count, 0) >= 1"
+
 
 def main() -> None:
     try:
@@ -61,14 +69,15 @@ def main() -> None:
         empty_output(EVENT).print_and_exit(0)
         return
 
-    rows = []
+    verified = []
+    unverified = []
     try:
         with sqlite3.connect(DB_PATH, timeout=2) as conn:
             conn.row_factory = sqlite3.Row
             placeholders = ",".join("?" * len(GRADUATABLE_CATEGORIES))
             rows = conn.execute(
                 f"""
-                SELECT topic, key, value FROM learnings
+                SELECT topic, key, value, {VERIFIED} AS verified FROM learnings
                 WHERE graduated_to IS NULL
                   AND confidence >= 0.7
                   AND last_seen >= datetime('now', '-24 hours')
@@ -78,21 +87,35 @@ def main() -> None:
                 """,
                 GRADUATABLE_CATEGORIES,
             ).fetchall()
+            verified = [r for r in rows if r["verified"]]
+            unverified = [r for r in rows if not r["verified"]]
     except sqlite3.Error as e:
         print(f"[retro-gate] DB error (advisory skip): {e}", file=sys.stderr)
         empty_output(EVENT).print_and_exit(0)
         return
 
-    if not rows:
+    if not verified and not unverified:
         empty_output(EVENT).print_and_exit(0)
         return
 
     # Build advisory warning
-    lines = [f"[retro-gate] Found {len(rows)} ungraduated retro entries from this session."]
-    lines.append("Before merging, graduate findings into the responsible agents/skills:")
-    for row in rows:
-        lines.append(f"  - {row['topic']}: {row['key']}")
-    lines.append('Use: python3 ~/.claude/scripts/learning-db.py graduate TOPIC KEY "target-file.md"')
+    lines = []
+    if verified:
+        lines.append(f"[retro-gate] Found {len(verified)} ungraduated verified retro entries from this session.")
+        lines.append("Before merging, graduate findings into the responsible agents/skills:")
+        for row in verified:
+            lines.append(f"  - {row['topic']}: {row['key']}")
+        lines.append('Use: python3 ~/.claude/scripts/learning-db.py graduate TOPIC KEY "target-file.md"')
+    if unverified:
+        lines.append(
+            f"[retro-gate] Not graduatable — needs verification ({len(unverified)} entries,"
+            " no executed check has confirmed them yet):"
+        )
+        for row in unverified:
+            lines.append(f"  - {row['topic']}: {row['key']}")
+        lines.append(
+            "Confirm each with an executed check, then: python3 ~/.claude/scripts/learning-db.py boost TOPIC KEY"
+        )
 
     context_output(EVENT, "\n".join(lines)).print_and_exit(0)
 

--- a/hooks/tests/test_retro_graduation_gate.py
+++ b/hooks/tests/test_retro_graduation_gate.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
-"""Tests for hooks/retro-graduation-gate.py category filtering.
+"""Tests for hooks/retro-graduation-gate.py category and verification filtering.
 
 The gate must count only categories the retro skill can graduate
-(design, gotcha — see skills/meta/retro/SKILL.md, candidate query).
+(design, gotcha — see skills/meta/retro/SKILL.md, candidate query),
+and only rows confirmed by an executed check (success_count >= 1).
+Recurrence alone can entrench a wrong guess (docs/PHILOSOPHY.md,
+"memory needs a verify step"). Unverified design/gotcha rows are
+listed separately as "needs verification", never as graduatable.
 Injection-only rows (error, effectiveness) and voice corpus rows must
-not trip it.
+not trip either list.
 
 Run with: python3 -m pytest hooks/tests/test_retro_graduation_gate.py -v
 """
@@ -57,6 +61,7 @@ def _init_db(env: dict) -> Path:
                 category TEXT NOT NULL,
                 confidence REAL DEFAULT 0.5,
                 source TEXT NOT NULL DEFAULT 'test',
+                success_count INTEGER DEFAULT 0,
                 last_seen TEXT DEFAULT (datetime('now')),
                 graduated_to TEXT,
                 UNIQUE(topic, key)
@@ -67,16 +72,23 @@ def _init_db(env: dict) -> Path:
 
 
 def _insert(
-    env: dict, topic: str, key: str, category: str, confidence: float = 0.9, graduated_to: str | None = None
+    env: dict,
+    topic: str,
+    key: str,
+    category: str,
+    confidence: float = 0.9,
+    graduated_to: str | None = None,
+    success_count: int = 0,
 ) -> None:
     db_path = Path(env["CLAUDE_LEARNING_DIR"]) / "learning.db"
     with sqlite3.connect(db_path) as conn:
         conn.execute(
             """
-            INSERT INTO learnings (topic, key, value, category, confidence, graduated_to, last_seen)
-            VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+            INSERT INTO learnings
+                (topic, key, value, category, confidence, graduated_to, success_count, last_seen)
+            VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
             """,
-            (topic, key, f"value for {key}", category, confidence, graduated_to),
+            (topic, key, f"value for {key}", category, confidence, graduated_to, success_count),
         )
 
 
@@ -92,36 +104,39 @@ def _run_hook(env: dict, stdin: str = PR_EVENT) -> subprocess.CompletedProcess[s
 
 
 def test_error_rows_do_not_trip_gate(env):
-    """Injection-only 'error' rows are not graduation candidates."""
+    """Injection-only 'error' rows are not graduation candidates, even verified."""
     _init_db(env)
-    _insert(env, "debugging", "missing-import", "error", confidence=0.95)
+    _insert(env, "debugging", "missing-import", "error", confidence=0.95, success_count=3)
     result = _run_hook(env)
     assert result.returncode == 0
     assert "ungraduated" not in result.stdout
+    assert "needs verification" not in result.stdout
 
 
 def test_voice_rows_do_not_trip_gate(env):
     """Voice corpus rows are not graduation candidates."""
     _init_db(env)
-    _insert(env, "voice-amy", "phrase-cadence", "voice", confidence=0.9)
+    _insert(env, "voice-amy", "phrase-cadence", "voice", confidence=0.9, success_count=2)
     result = _run_hook(env)
     assert result.returncode == 0
     assert "ungraduated" not in result.stdout
+    assert "needs verification" not in result.stdout
 
 
 def test_effectiveness_rows_do_not_trip_gate(env):
     """Routing 'effectiveness' rows are not graduation candidates."""
     _init_db(env)
-    _insert(env, "routing", "agent-skill-pair", "effectiveness", confidence=0.9)
+    _insert(env, "routing", "agent-skill-pair", "effectiveness", confidence=0.9, success_count=2)
     result = _run_hook(env)
     assert result.returncode == 0
     assert "ungraduated" not in result.stdout
+    assert "needs verification" not in result.stdout
 
 
-def test_gotcha_row_trips_gate(env):
-    """An ungraduated high-confidence gotcha row triggers the advisory."""
+def test_verified_gotcha_row_trips_gate(env):
+    """A verified (success_count >= 1) ungraduated gotcha triggers the graduation advisory."""
     _init_db(env)
-    _insert(env, "go-patterns", "mutex-state-machine", "gotcha", confidence=0.8)
+    _insert(env, "go-patterns", "mutex-state-machine", "gotcha", confidence=0.8, success_count=1)
     result = _run_hook(env)
     assert result.returncode == 0
     assert "ungraduated" in result.stdout
@@ -129,31 +144,67 @@ def test_gotcha_row_trips_gate(env):
     assert "mutex-state-machine" in result.stdout
 
 
-def test_design_row_trips_gate(env):
-    """An ungraduated high-confidence design row triggers the advisory."""
+def test_verified_design_row_trips_gate(env):
+    """A verified ungraduated design row triggers the graduation advisory."""
     _init_db(env)
-    _insert(env, "hooks", "atomic-write-pattern", "design", confidence=0.75)
+    _insert(env, "hooks", "atomic-write-pattern", "design", confidence=0.75, success_count=2)
     result = _run_hook(env)
     assert result.returncode == 0
     assert "ungraduated" in result.stdout
 
 
-def test_graduated_design_row_does_not_trip_gate(env):
-    """Already-graduated rows are excluded."""
+def test_unverified_gotcha_is_not_graduatable(env):
+    """An unverified (success_count = 0) gotcha is listed as needs-verification, not graduatable."""
     _init_db(env)
-    _insert(env, "hooks", "done-pattern", "design", confidence=0.9, graduated_to="agents/x.md")
+    _insert(env, "go-patterns", "unconfirmed-guess", "gotcha", confidence=0.9, success_count=0)
     result = _run_hook(env)
     assert result.returncode == 0
     assert "ungraduated" not in result.stdout
+    assert "needs verification" in result.stdout
+    assert "unconfirmed-guess" in result.stdout
+
+
+def test_unverified_design_is_not_graduatable(env):
+    """An unverified design row is listed as needs-verification, not graduatable."""
+    _init_db(env)
+    _insert(env, "hooks", "untested-pattern", "design", confidence=0.85, success_count=0)
+    result = _run_hook(env)
+    assert result.returncode == 0
+    assert "ungraduated" not in result.stdout
+    assert "needs verification" in result.stdout
+
+
+def test_mixed_rows_split_into_both_sections(env):
+    """Verified and unverified rows appear in their own sections of one advisory."""
+    _init_db(env)
+    _insert(env, "hooks", "proven-pattern", "design", confidence=0.8, success_count=1)
+    _insert(env, "hooks", "unproven-pattern", "gotcha", confidence=0.8, success_count=0)
+    result = _run_hook(env)
+    assert result.returncode == 0
+    assert "ungraduated" in result.stdout
+    assert "proven-pattern" in result.stdout
+    assert "needs verification" in result.stdout
+    assert "unproven-pattern" in result.stdout
+
+
+def test_graduated_design_row_does_not_trip_gate(env):
+    """Already-graduated rows are excluded from both sections."""
+    _init_db(env)
+    _insert(env, "hooks", "done-pattern", "design", confidence=0.9, graduated_to="agents/x.md", success_count=1)
+    result = _run_hook(env)
+    assert result.returncode == 0
+    assert "ungraduated" not in result.stdout
+    assert "needs verification" not in result.stdout
 
 
 def test_low_confidence_gotcha_does_not_trip_gate(env):
-    """Rows below the 0.7 confidence threshold are excluded."""
+    """Rows below the 0.7 confidence threshold are excluded from both sections."""
     _init_db(env)
-    _insert(env, "hooks", "weak-finding", "gotcha", confidence=0.5)
+    _insert(env, "hooks", "weak-finding", "gotcha", confidence=0.5, success_count=1)
     result = _run_hook(env)
     assert result.returncode == 0
     assert "ungraduated" not in result.stdout
+    assert "needs verification" not in result.stdout
 
 
 def test_empty_db_is_safe(env):
@@ -174,7 +225,17 @@ def test_missing_db_is_safe(env):
 def test_advisory_never_blocks(env):
     """Advisory contract: exit 0 even when the gate fires, output is valid JSON without a block decision."""
     _init_db(env)
-    _insert(env, "go-patterns", "mutex-state-machine", "gotcha", confidence=0.8)
+    _insert(env, "go-patterns", "mutex-state-machine", "gotcha", confidence=0.8, success_count=1)
+    result = _run_hook(env)
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload.get("decision") != "block"
+
+
+def test_needs_verification_advisory_never_blocks(env):
+    """Needs-verification advisory is also non-blocking valid JSON."""
+    _init_db(env)
+    _insert(env, "hooks", "unproven-pattern", "design", confidence=0.8, success_count=0)
     result = _run_hook(env)
     assert result.returncode == 0
     payload = json.loads(result.stdout)


### PR DESCRIPTION
## Summary

Validation path for the `docs/PHILOSOPHY.md` OPEN entry **"memory needs a verify step"** (Learning System Discipline, follow-up to PR #766): a learned pattern earns graduation only after an executed check confirms it; recurrence alone can entrench a wrong guess.

## Design

Least invasive option the existing data supports — the gate reads the existing `success_count` evidence field. No schema change, no sidecar, no edits to the protected `hooks/lib/learning_db_v2.py`.

`success_count` is incremented only by `boost_confidence()` (`learning_db_v2.py:1114`), which fires when feedback tracking sees an injected solution succeed, or after an explicit `learning-db.py boost` following a check. So `success_count >= 1` = confirmed by an executed check at least once.

New gate predicate: `category IN (design, gotcha) AND graduated_to IS NULL AND confidence >= 0.7 AND COALESCE(success_count, 0) >= 1`.

Unverified design/gotcha rows that pass every other filter are listed in a separate "needs verification" advisory section with the verification path (`learning-db.py boost TOPIC KEY` after an executed check) — never as graduatable.

## Measured before/after (safe-backup copy of live DB, original untouched)

| Predicate | Before (recurrence-only) | After (verified) | Needs verification |
|---|---|---|---|
| Graduatable pool (no time window) | 22 | 0 | 22 |
| Gate predicate (24h window) | 0 | 0 | 0 |

All 22 current candidates have `success_count = 0` — every one is recurrence-only, which is exactly the failure mode the PHILOSOPHY entry predicts.

## Tests (TDD: RED first, then implement)

- `hooks/tests/test_retro_graduation_gate.py`: 15 tests (was 11). New: unverified gotcha/design not graduatable, mixed verified/unverified split sections, needs-verification advisory non-blocking; verification added to existing category/graduated/confidence tests.
- Full suite: 4359 passed, 1 skipped, 75 xfailed.
- `ruff check` and `ruff format --check` clean.
- Hook contract: exit 0 on empty stdin and garbage stdin; wall time unchanged from main (~70ms incl. interpreter startup; this change adds ~0ms).

Do not merge without operator review — advisory-only hook, but it changes what the gate reports as graduatable.