### PR TITLE
fix(routing): merge INDEX.local.json over tracked index instead of replacing it

### DIFF
--- a/scripts/index-router.py
+++ b/scripts/index-router.py
@@ -30,16 +30,40 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-def _resolve_index(tracked: Path, local_name: str) -> Path:
-    """Return the local override path when it exists, otherwise the tracked path."""
-    local = tracked.parent / local_name
-    return local if local.exists() else tracked
+def _load_index_items(tracked: Path, local_name: str | None, key: str) -> dict:
+    """Load index items from the tracked file, overlaying the local override.
+
+    Local override files (INDEX.local.json) are gitignored supersets produced
+    by the generator with --include-private; they add entries for
+    symlinked/private directories. The local file regenerates less often than
+    the tracked one, so it can be stale. Merging (tracked first, local
+    overlays per-name) guarantees a stale local never hides a skill or agent
+    that exists in the tracked index — full replacement did exactly that.
+
+    Duplicated by hand in routing-manifest.py and pre-route.py (the routing
+    scripts share no lib module); keep the three copies in sync.
+    """
+    items: dict = {}
+    paths = [tracked]
+    if local_name:
+        local = tracked.parent / local_name
+        if local.exists():
+            paths.append(local)
+    for path in paths:
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        loaded = raw.get(key, {})
+        if isinstance(loaded, dict):
+            items.update(loaded)
+    return items
 
 
-INDEX_PATHS: dict[str, Path] = {
-    "skills": _resolve_index(REPO_ROOT / "skills" / "INDEX.json", "INDEX.local.json"),
-    "pipelines": REPO_ROOT / "skills" / "workflow" / "references" / "pipeline-index.json",
-    "agents": _resolve_index(REPO_ROOT / "agents" / "INDEX.json", "INDEX.local.json"),
+INDEX_PATHS: dict[str, tuple[Path, str | None]] = {
+    "skills": (REPO_ROOT / "skills" / "INDEX.json", "INDEX.local.json"),
+    "pipelines": (REPO_ROOT / "skills" / "workflow" / "references" / "pipeline-index.json", None),
+    "agents": (REPO_ROOT / "agents" / "INDEX.json", "INDEX.local.json"),
 }
 
 # Composition chains encode common multi-skill workflows.
@@ -138,16 +162,9 @@ def load_indexes() -> list[IndexEntry]:
     """
     entries: list[IndexEntry] = []
 
-    for index_type, path in INDEX_PATHS.items():
-        try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-        except (FileNotFoundError, json.JSONDecodeError, OSError):
-            continue
-
-        # Each INDEX file uses its type as the top-level key
-        items = raw.get(index_type, {})
-        if not isinstance(items, dict):
-            continue
+    for index_type, (tracked, local_name) in INDEX_PATHS.items():
+        # Each INDEX file uses its type as the top-level key.
+        items = _load_index_items(tracked, local_name, index_type)
 
         for name, data in items.items():
             if not isinstance(data, dict):

--- a/scripts/index-router.py
+++ b/scripts/index-router.py
@@ -36,9 +36,10 @@ def _load_index_items(tracked: Path, local_name: str | None, key: str) -> dict:
     Local override files (INDEX.local.json) are gitignored supersets produced
     by the generator with --include-private; they add entries for
     symlinked/private directories. The local file regenerates less often than
-    the tracked one, so it can be stale. Merging (tracked first, local
-    overlays per-name) guarantees a stale local never hides a skill or agent
-    that exists in the tracked index — full replacement did exactly that.
+    the tracked one, so it can be stale. The merge is add-only (tracked first,
+    local fills gaps per-name): a stale local can never hide a tracked skill
+    or agent, and never overrides tracked entry content such as triggers or
+    force_route — full replacement and per-name update both did.
 
     Duplicated by hand in routing-manifest.py and pre-route.py (the routing
     scripts share no lib module); keep the three copies in sync.
@@ -56,7 +57,8 @@ def _load_index_items(tracked: Path, local_name: str | None, key: str) -> dict:
             continue
         loaded = raw.get(key, {})
         if isinstance(loaded, dict):
-            items.update(loaded)
+            for name, data in loaded.items():
+                items.setdefault(name, data)
     return items
 
 

--- a/scripts/pre-route.py
+++ b/scripts/pre-route.py
@@ -44,10 +44,34 @@ _INDEX_GENERATORS = {
 }
 
 
-def _resolve_index(tracked: Path, local_name: str) -> Path:
-    """Return the local override path when it exists, otherwise the tracked path."""
-    local = tracked.parent / local_name
-    return local if local.exists() else tracked
+def _load_index_items(tracked: Path, local_name: str | None, key: str) -> dict:
+    """Load index items from the tracked file, overlaying the local override.
+
+    Local override files (INDEX.local.json) are gitignored supersets produced
+    by the generator with --include-private; they add entries for
+    symlinked/private directories. The local file regenerates less often than
+    the tracked one, so it can be stale. Merging (tracked first, local
+    overlays per-name) guarantees a stale local never hides a skill or agent
+    that exists in the tracked index — full replacement did exactly that.
+
+    Duplicated by hand in routing-manifest.py and index-router.py (the
+    routing scripts share no lib module); keep the three copies in sync.
+    """
+    items: dict = {}
+    paths = [tracked]
+    if local_name:
+        local = tracked.parent / local_name
+        if local.exists():
+            paths.append(local)
+    for path in paths:
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        loaded = raw.get(key, {})
+        if isinstance(loaded, dict):
+            items.update(loaded)
+    return items
 
 
 def _ensure_index(index_type: str, path: Path) -> None:
@@ -75,8 +99,8 @@ def _ensure_index(index_type: str, path: Path) -> None:
 
 
 INDEX_PATHS = {
-    "skills": _resolve_index(REPO_ROOT / "skills" / "INDEX.json", "INDEX.local.json"),
-    "agents": _resolve_index(REPO_ROOT / "agents" / "INDEX.json", "INDEX.local.json"),
+    "skills": (REPO_ROOT / "skills" / "INDEX.json", "INDEX.local.json"),
+    "agents": (REPO_ROOT / "agents" / "INDEX.json", "INDEX.local.json"),
 }
 
 # Verbs/nouns that signal working ON a site (build, edit, debug, discuss) rather
@@ -398,17 +422,11 @@ def load_entries() -> list[dict]:
     """Load all INDEX entries into a flat list."""
     entries: list[dict] = []
 
-    for index_type, path in INDEX_PATHS.items():
-        # Auto-regenerate a missing (untracked) index before reading. Fail-safe.
-        _ensure_index(index_type, path)
-        try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-        except (FileNotFoundError, json.JSONDecodeError, OSError):
-            continue
-
-        items = raw.get(index_type, {})
-        if not isinstance(items, dict):
-            continue
+    for index_type, (tracked, local_name) in INDEX_PATHS.items():
+        # Auto-regenerate a missing (untracked) tracked index before reading.
+        # Fail-safe.
+        _ensure_index(index_type, tracked)
+        items = _load_index_items(tracked, local_name, index_type)
 
         for name, data in items.items():
             if not isinstance(data, dict):

--- a/scripts/pre-route.py
+++ b/scripts/pre-route.py
@@ -50,9 +50,10 @@ def _load_index_items(tracked: Path, local_name: str | None, key: str) -> dict:
     Local override files (INDEX.local.json) are gitignored supersets produced
     by the generator with --include-private; they add entries for
     symlinked/private directories. The local file regenerates less often than
-    the tracked one, so it can be stale. Merging (tracked first, local
-    overlays per-name) guarantees a stale local never hides a skill or agent
-    that exists in the tracked index — full replacement did exactly that.
+    the tracked one, so it can be stale. The merge is add-only (tracked first,
+    local fills gaps per-name): a stale local can never hide a tracked skill
+    or agent, and never overrides tracked entry content such as triggers or
+    force_route — full replacement and per-name update both did.
 
     Duplicated by hand in routing-manifest.py and index-router.py (the
     routing scripts share no lib module); keep the three copies in sync.
@@ -70,7 +71,8 @@ def _load_index_items(tracked: Path, local_name: str | None, key: str) -> dict:
             continue
         loaded = raw.get(key, {})
         if isinstance(loaded, dict):
-            items.update(loaded)
+            for name, data in loaded.items():
+                items.setdefault(name, data)
     return items
 
 

--- a/scripts/routing-manifest.py
+++ b/scripts/routing-manifest.py
@@ -50,10 +50,13 @@ def _load_index_items(tracked: Path, local_name: str | None, key: str) -> dict:
     Local override files (INDEX.local.json) are gitignored supersets produced
     by the generator with --include-private --output <local-path>; they add
     entries for symlinked/private directories. The local file regenerates less
-    often than the tracked one, so it can be stale. Merging (tracked first,
-    local overlays per-name) guarantees a stale local never hides a skill or
-    agent that exists in the tracked index — full replacement did exactly
-    that, dropping newly added skills from the routing manifest.
+    often than the tracked one, so it can be stale. The merge is add-only
+    (tracked first, local fills gaps per-name): a stale local can never hide a
+    tracked skill or agent, and never overrides tracked entry content such as
+    triggers or force_route — full replacement and per-name update both did.
+
+    Duplicated by hand in pre-route.py and index-router.py (the routing
+    scripts share no lib module); keep the three copies in sync.
     """
     items: dict = {}
     paths = [tracked]
@@ -68,7 +71,8 @@ def _load_index_items(tracked: Path, local_name: str | None, key: str) -> dict:
             continue
         loaded = raw.get(key, {})
         if isinstance(loaded, dict):
-            items.update(loaded)
+            for name, data in loaded.items():
+                items.setdefault(name, data)
     return items
 
 

--- a/scripts/routing-manifest.py
+++ b/scripts/routing-manifest.py
@@ -37,37 +37,47 @@ WORKING_SET_WINDOW_SECONDS = 30 * 86400
 STUB_DESC_WORDS = 6
 
 
-def _resolve_index(tracked: Path, local_name: str) -> Path:
-    """Return the local override path when it exists, otherwise the tracked path.
-
-    Local override files (INDEX.local.json) are gitignored and may contain
-    entries for symlinked directories. They are produced by running the
-    generator with --include-private --output <local-path>.
-    """
-    local = tracked.parent / local_name
-    return local if local.exists() else tracked
-
-
 INDEX_PATHS = {
-    "skills": _resolve_index(REPO_ROOT / "skills" / "INDEX.json", "INDEX.local.json"),
-    "agents": _resolve_index(REPO_ROOT / "agents" / "INDEX.json", "INDEX.local.json"),
-    "pipelines": REPO_ROOT / "skills" / "workflow" / "references" / "pipeline-index.json",
+    "skills": (REPO_ROOT / "skills" / "INDEX.json", "INDEX.local.json"),
+    "agents": (REPO_ROOT / "agents" / "INDEX.json", "INDEX.local.json"),
+    "pipelines": (REPO_ROOT / "skills" / "workflow" / "references" / "pipeline-index.json", None),
 }
+
+
+def _load_index_items(tracked: Path, local_name: str | None, key: str) -> dict:
+    """Load index items from the tracked file, overlaying the local override.
+
+    Local override files (INDEX.local.json) are gitignored supersets produced
+    by the generator with --include-private --output <local-path>; they add
+    entries for symlinked/private directories. The local file regenerates less
+    often than the tracked one, so it can be stale. Merging (tracked first,
+    local overlays per-name) guarantees a stale local never hides a skill or
+    agent that exists in the tracked index — full replacement did exactly
+    that, dropping newly added skills from the routing manifest.
+    """
+    items: dict = {}
+    paths = [tracked]
+    if local_name:
+        local = tracked.parent / local_name
+        if local.exists():
+            paths.append(local)
+    for path in paths:
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        loaded = raw.get(key, {})
+        if isinstance(loaded, dict):
+            items.update(loaded)
+    return items
 
 
 def load_entries() -> list[dict]:
     """Load all INDEX entries into a flat list."""
     entries = []
 
-    for index_type, path in INDEX_PATHS.items():
-        try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-        except (FileNotFoundError, json.JSONDecodeError, OSError):
-            continue
-
-        items = raw.get(index_type, {})
-        if not isinstance(items, dict):
-            continue
+    for index_type, (tracked, local_name) in INDEX_PATHS.items():
+        items = _load_index_items(tracked, local_name, index_type)
 
         for name, data in items.items():
             if not isinstance(data, dict):

--- a/scripts/tests/test_index_router.py
+++ b/scripts/tests/test_index_router.py
@@ -139,15 +139,19 @@ def mock_indexes(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def _patched_paths(root: Path) -> dict:
+    """Build an INDEX_PATHS dict (tracked path, local override name) for tmp files."""
+    return {
+        "skills": (root / "skills" / "INDEX.json", "INDEX.local.json"),
+        "pipelines": (root / "skills" / "workflow" / "references" / "pipeline-index.json", None),
+        "agents": (root / "agents" / "INDEX.json", "INDEX.local.json"),
+    }
+
+
 @pytest.fixture(autouse=True)
 def _patch_repo_root(mock_indexes: Path) -> None:
     """Patch INDEX_PATHS to use temporary files."""
-    patched_paths = {
-        "skills": mock_indexes / "skills" / "INDEX.json",
-        "pipelines": mock_indexes / "skills" / "workflow" / "references" / "pipeline-index.json",
-        "agents": mock_indexes / "agents" / "INDEX.json",
-    }
-    with patch.object(index_router, "INDEX_PATHS", patched_paths):
+    with patch.object(index_router, "INDEX_PATHS", _patched_paths(mock_indexes)):
         yield
 
 
@@ -191,12 +195,7 @@ class TestLoadIndexes:
 
     def test_missing_index_file_graceful(self, mock_indexes: Path) -> None:
         (mock_indexes / "agents" / "INDEX.json").unlink()
-        patched_paths = {
-            "skills": mock_indexes / "skills" / "INDEX.json",
-            "pipelines": mock_indexes / "skills" / "workflow" / "references" / "pipeline-index.json",
-            "agents": mock_indexes / "agents" / "INDEX.json",
-        }
-        with patch.object(index_router, "INDEX_PATHS", patched_paths):
+        with patch.object(index_router, "INDEX_PATHS", _patched_paths(mock_indexes)):
             entries = index_router.load_indexes()
         # Should still load skills and pipelines (5 + 3 = 8 entries)
         assert len(entries) == 8
@@ -204,15 +203,33 @@ class TestLoadIndexes:
 
     def test_malformed_json_graceful(self, mock_indexes: Path) -> None:
         (mock_indexes / "skills" / "INDEX.json").write_text("not json {{{")
-        patched_paths = {
-            "skills": mock_indexes / "skills" / "INDEX.json",
-            "pipelines": mock_indexes / "skills" / "workflow" / "references" / "pipeline-index.json",
-            "agents": mock_indexes / "agents" / "INDEX.json",
-        }
-        with patch.object(index_router, "INDEX_PATHS", patched_paths):
+        with patch.object(index_router, "INDEX_PATHS", _patched_paths(mock_indexes)):
             entries = index_router.load_indexes()
         # Should still load pipelines and agents (3 + 2 = 5 entries)
         assert len(entries) == 5
+
+    def test_local_overlay_adds_entries(self, mock_indexes: Path) -> None:
+        """A local INDEX.local.json adds entries on top of the tracked index."""
+        local = {"skills": {"private-skill": {"triggers": ["private thing"]}}}
+        (mock_indexes / "skills" / "INDEX.local.json").write_text(json.dumps(local))
+        entries = index_router.load_indexes()
+        names = {e.name for e in entries}
+        assert "private-skill" in names
+
+    def test_stale_local_never_hides_tracked_entries(self, mock_indexes: Path) -> None:
+        """A stale local index (missing tracked entries) cannot drop them.
+
+        Regression for the stale-local-override bug: _resolve_index replaced
+        the tracked index wholesale with INDEX.local.json, hiding newly added
+        skills from routing.
+        """
+        stale_local = {"skills": {"private-skill": {"triggers": ["private thing"]}}}
+        (mock_indexes / "skills" / "INDEX.local.json").write_text(json.dumps(stale_local))
+        entries = index_router.load_indexes()
+        names = {e.name for e in entries}
+        # Tracked skills survive alongside the local addition.
+        assert "go-patterns" in names
+        assert "private-skill" in names
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_index_router.py
+++ b/scripts/tests/test_index_router.py
@@ -231,6 +231,15 @@ class TestLoadIndexes:
         assert "go-patterns" in names
         assert "private-skill" in names
 
+    def test_stale_local_never_overrides_tracked_content(self, mock_indexes: Path) -> None:
+        """A stale local superset cannot revert tracked entry content (add-only merge)."""
+        stale_local = {"skills": {"go-patterns": {"triggers": ["stale trigger"], "force_route": False}}}
+        (mock_indexes / "skills" / "INDEX.local.json").write_text(json.dumps(stale_local))
+        entries = index_router.load_indexes()
+        go_patterns = next(e for e in entries if e.name == "go-patterns")
+        assert go_patterns.force_route is True
+        assert "Go test" in go_patterns.triggers
+
 
 # ---------------------------------------------------------------------------
 # check_force_routes tests

--- a/scripts/tests/test_pre_route.py
+++ b/scripts/tests/test_pre_route.py
@@ -400,6 +400,14 @@ class TestLocalIndexMerge:
         items = pre_route._load_index_items(tracked, "INDEX.local.json", "skills")
         assert set(items) == {"tracked-skill", "local-skill"}
 
+    def test_stale_local_never_overrides_tracked_content(self, pre_route, tmp_path: Path) -> None:
+        """A stale local superset cannot revert tracked entry content (add-only merge)."""
+        tracked = tmp_path / "INDEX.json"
+        tracked.write_text(json.dumps({"skills": {"skill": {"triggers": ["fresh"]}}}))
+        (tmp_path / "INDEX.local.json").write_text(json.dumps({"skills": {"skill": {"triggers": ["stale"]}}}))
+        items = pre_route._load_index_items(tracked, "INDEX.local.json", "skills")
+        assert items["skill"]["triggers"] == ["fresh"]
+
     def test_no_local_file_reads_tracked_only(self, pre_route, tmp_path: Path) -> None:
         tracked = tmp_path / "INDEX.json"
         tracked.write_text(json.dumps({"skills": {"tracked-skill": {"triggers": ["t"]}}}))

--- a/scripts/tests/test_pre_route.py
+++ b/scripts/tests/test_pre_route.py
@@ -378,3 +378,30 @@ class TestCLI:
             cwd=str(REPO_ROOT),
         )
         assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# Local index merge semantics
+# ---------------------------------------------------------------------------
+
+
+class TestLocalIndexMerge:
+    """_load_index_items merges the local override instead of replacing.
+
+    Regression for the stale-local-override bug: _resolve_index replaced the
+    tracked index wholesale with INDEX.local.json, hiding newly added skills
+    from routing.
+    """
+
+    def test_local_overlay_adds_but_never_hides(self, pre_route, tmp_path: Path) -> None:
+        tracked = tmp_path / "INDEX.json"
+        tracked.write_text(json.dumps({"skills": {"tracked-skill": {"triggers": ["t"]}}}))
+        (tmp_path / "INDEX.local.json").write_text(json.dumps({"skills": {"local-skill": {"triggers": ["l"]}}}))
+        items = pre_route._load_index_items(tracked, "INDEX.local.json", "skills")
+        assert set(items) == {"tracked-skill", "local-skill"}
+
+    def test_no_local_file_reads_tracked_only(self, pre_route, tmp_path: Path) -> None:
+        tracked = tmp_path / "INDEX.json"
+        tracked.write_text(json.dumps({"skills": {"tracked-skill": {"triggers": ["t"]}}}))
+        items = pre_route._load_index_items(tracked, "INDEX.local.json", "skills")
+        assert set(items) == {"tracked-skill"}

--- a/scripts/tests/test_routing_manifest_tiered.py
+++ b/scripts/tests/test_routing_manifest_tiered.py
@@ -259,3 +259,38 @@ def test_cli_tiered_smaller_than_full(learning_dir: Path) -> None:
         assert full_line in tiered
     # --json and --compact behavior unchanged by the new flag
     json.loads(run("--json"))
+
+
+# ---------------------------------------------------------------------------
+# Local index merge semantics
+# ---------------------------------------------------------------------------
+
+
+class TestLocalIndexMerge:
+    """_load_index_items merges the local override add-only.
+
+    Regression for the stale-local-override bug: full replacement hid tracked
+    entries; per-name update let a stale local superset revert tracked entry
+    content. Mirrors the merge tests in test_pre_route.py and
+    test_index_router.py — the three scripts carry hand-duplicated copies.
+    """
+
+    def test_local_overlay_adds_but_never_hides(self, tmp_path: Path) -> None:
+        tracked = tmp_path / "INDEX.json"
+        tracked.write_text(json.dumps({"skills": {"tracked-skill": {"triggers": ["t"]}}}))
+        (tmp_path / "INDEX.local.json").write_text(json.dumps({"skills": {"local-skill": {"triggers": ["l"]}}}))
+        items = rm._load_index_items(tracked, "INDEX.local.json", "skills")
+        assert set(items) == {"tracked-skill", "local-skill"}
+
+    def test_stale_local_never_overrides_tracked_content(self, tmp_path: Path) -> None:
+        tracked = tmp_path / "INDEX.json"
+        tracked.write_text(json.dumps({"skills": {"skill": {"triggers": ["fresh"]}}}))
+        (tmp_path / "INDEX.local.json").write_text(json.dumps({"skills": {"skill": {"triggers": ["stale"]}}}))
+        items = rm._load_index_items(tracked, "INDEX.local.json", "skills")
+        assert items["skill"]["triggers"] == ["fresh"]
+
+    def test_no_local_file_reads_tracked_only(self, tmp_path: Path) -> None:
+        tracked = tmp_path / "INDEX.json"
+        tracked.write_text(json.dumps({"skills": {"tracked-skill": {"triggers": ["t"]}}}))
+        items = rm._load_index_items(tracked, "INDEX.local.json", "skills")
+        assert set(items) == {"tracked-skill"}


### PR DESCRIPTION
## Summary
A stale gitignored `skills/INDEX.local.json` fully replaced the tracked `skills/INDEX.json` in three routing scripts, silently dropping newly added tracked skills (`objective-loop`) from the routing manifest — 139/140 drift failure. Fix: merge semantics — load tracked items first, overlay local entries per-name. Local can add private entries; it can no longer hide tracked ones.

## Changes
- `scripts/routing-manifest.py` — replace wholesale local-index preference with tracked-first merge in `_load_index_items` (3d8ae022)
- `scripts/pre-route.py`, `scripts/index-router.py` — mirror the same merge in `_resolve_index`; helper duplicated by hand since the routing scripts share no lib module (2ac15294)
- `scripts/tests/test_index_router.py`, `scripts/tests/test_pre_route.py` — regression tests: overlay adds without hiding; fixtures updated to (tracked, local) form

## Notes
- Verified locally: drift check 140/140 PASS, 187 routing tests pass.
- The merge helper exists in three copies on purpose; each copy notes its siblings.