### PR TITLE
fix(references): real loading-table signals; zero orphan reference files

### DIFF
--- a/agents/base-instructions.md
+++ b/agents/base-instructions.md
@@ -47,5 +47,5 @@ Load these reference files when the task signals match. Do not load preemptively
 
 | Task signal | Reference file | What it adds |
 |------------|----------------|--------------|
-| Writing progress updates, completing tasks, summarizing work | `agents/base-instructions/references/communication-patterns.md` | Failure mode catalog for output style: self-congratulation, narration, hollow completions — with grep detection and before/after fixes |
-| Creating temp files, scaffolds, debug scripts; task cleanup phase | `agents/base-instructions/references/testing.md` | Detection patterns for test scaffolds and temporary files; keep-vs-delete decision table; cleanup grep commands |
+| Writing progress updates, completing tasks, summarizing work | [communication-patterns.md](base-instructions/references/communication-patterns.md) | Failure mode catalog for output style: self-congratulation, narration, hollow completions — with grep detection and before/after fixes |
+| Creating temp files, scaffolds, debug scripts; task cleanup phase | [testing.md](base-instructions/references/testing.md) | Detection patterns for test scaffolds and temporary files; keep-vs-delete decision table; cleanup grep commands |

--- a/agents/perses-engineer.md
+++ b/agents/perses-engineer.md
@@ -52,7 +52,6 @@ allowed-tools:
 You are a **Perses observability platform engineer** covering all Perses domains.
 
 Load the appropriate reference based on the task:
-- **Core development** (Go backend, React frontend, CUE schemas, architecture): Read `references/core.md`
 - **Dashboards** (create, manage, variables, queries, datasources, DaC): Read `references/dashboard.md`
 - **Operator** (Kubernetes CRDs, Helm charts, K8s deployment): Read `references/operator.md`
 - **Plugins** (scaffolding, CUE schema authoring, React components, testing): Read `references/plugin.md`
@@ -74,7 +73,6 @@ After making changes to CRDs, Helm values, or operator configuration, STOP and a
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| Go backend, React frontend, CUE schemas, auth, build, contribution, architecture, API handlers, storage | `references/core.md` | Core Perses development patterns |
-| dashboard, DaC, Dashboard-as-Code, percli, variable, query, datasource, PromQL, panel, timeseries, migrate Grafana | `references/dashboard.md` | Dashboard creation and DaC SDK patterns |
-| Kubernetes, CRD, operator, Helm, k8s, PersesDashboard, PersesProject, RBAC, cert-manager, manifest | `references/operator.md` | Kubernetes operator CRDs and deployment |
-| plugin, Module Federation, CUE schema, scaffold, panel plugin, datasource plugin, percli plugin, webpack | `references/plugin.md` | Plugin development, CUE schemas, and React components |
+| dashboard, DaC, Dashboard-as-Code, percli, variable, query, datasource, PromQL, panel, timeseries, migrate Grafana | [references/dashboard.md](perses-engineer/references/dashboard.md) | Dashboard creation and DaC SDK patterns |
+| Kubernetes, CRD, operator, Helm, k8s, PersesDashboard, PersesProject, RBAC, cert-manager, manifest | [references/operator.md](perses-engineer/references/operator.md) | Kubernetes operator CRDs and deployment |
+| plugin, Module Federation, CUE schema, scaffold, panel plugin, datasource plugin, percli plugin, webpack | [references/plugin.md](perses-engineer/references/plugin.md) | Plugin development, CUE schemas, and React components |

--- a/agents/prometheus-grafana-engineer.md
+++ b/agents/prometheus-grafana-engineer.md
@@ -134,9 +134,9 @@ Cardinality Check: [Label cardinality analysis]
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| Writing or debugging PromQL — `rate()`, `irate()`, `histogram_quantile()`, recording rules, subqueries | `promql-patterns.md` | Routes to the matching deep reference |
-| Designing SLO alerts, burn rate alerts, Alertmanager routing, inhibition rules, runbook annotations | `alerting-patterns.md` | Routes to the matching deep reference |
-| High cardinality, OOM, label explosion, `relabel_configs`, `metric_relabel_configs`, TSDB analysis | `cardinality-management.md` | Routes to the matching deep reference |
+| Writing or debugging PromQL — `rate()`, `irate()`, `histogram_quantile()`, recording rules, subqueries | [promql-patterns.md](prometheus-grafana-engineer/references/promql-patterns.md) | Routes to the matching deep reference |
+| Designing SLO alerts, burn rate alerts, Alertmanager routing, inhibition rules, runbook annotations | [alerting-patterns.md](prometheus-grafana-engineer/references/alerting-patterns.md) | Routes to the matching deep reference |
+| High cardinality, OOM, label explosion, `relabel_configs`, `metric_relabel_configs`, TSDB analysis | [cardinality-management.md](prometheus-grafana-engineer/references/cardinality-management.md) | Routes to the matching deep reference |
 
 ## Error Handling
 

--- a/agents/python-general-engineer.md
+++ b/agents/python-general-engineer.md
@@ -136,11 +136,17 @@ See `agents/python-general-engineer/references/capabilities.md` for full CAN/CAN
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| errors | `python-errors.md` | Loads detailed guidance from `python-errors.md`. |
-| implementation patterns | `python-preferred-patterns.md` | Loads detailed pattern guidance from `python-preferred-patterns.md`. |
-| implementation patterns | `python-patterns.md` | Loads detailed guidance from `python-patterns.md`. |
-| tasks related to this reference | `python-modern-features.md` | Loads detailed guidance from `python-modern-features.md`. |
-| security, auth, injection, XSS, CSRF, SSRF, or any vulnerability-related code | `python-security.md` | Secure implementation patterns for Python, Django, FastAPI, Flask. |
+| quick error lookup: async deadlock, mypy, mutable defaults, imports, mocks | [error-handling.md](python-general-engineer/references/error-handling.md) | Short error-to-fix list; points to the full catalog |
+| debugging a specific error or exception in depth | [python-errors.md](python-general-engineer/references/python-errors.md) | Comprehensive error catalog with causes and fixes |
+| quick pattern check before writing code | [preferred-patterns.md](python-general-engineer/references/preferred-patterns.md) | Short pattern list; points to the full catalog |
+| auditing code against the full pattern catalog with detection commands | [python-preferred-patterns.md](python-general-engineer/references/python-preferred-patterns.md) | Action-first patterns plus grep detection per violation |
+| choosing language constructs: type hints, dataclasses, protocols, context managers | [python-patterns.md](python-general-engineer/references/python-patterns.md) | Code examples for core Python idioms |
+| Python 3.11+/3.12 features, TaskGroup, Pydantic v2, uv, FastAPI | [python-modern-features.md](python-general-engineer/references/python-modern-features.md) | Modern feature and tooling reference |
+| security, auth, injection, XSS, CSRF, SSRF, or any vulnerability-related code | [python-security.md](python-general-engineer/references/python-security.md) | Secure implementation patterns for Python, Django, FastAPI, Flask. |
+| before writing any Python code (forbidden-pattern gate) | [hard-gate-patterns.md](python-general-engineer/references/hard-gate-patterns.md) | STOP/REPORT/FIX pattern table with detection commands |
+| fundamental design choices, retry limits, recovery | [blocker-criteria.md](python-general-engineer/references/blocker-criteria.md) | Blocker table, retry limits, recovery protocol |
+| before claiming Python work complete | [anti-rationalization.md](python-general-engineer/references/anti-rationalization.md) | Python-specific rationalization table |
+| scoping what this agent can do; output format | [capabilities.md](python-general-engineer/references/capabilities.md) | CAN/CANNOT lists and Implementation Schema template |
 
 ## Error Handling
 

--- a/agents/python-general-engineer/references/anti-rationalization.md
+++ b/agents/python-general-engineer/references/anti-rationalization.md
@@ -2,7 +2,7 @@
 
 See `shared-patterns/anti-rationalization-core.md` for universal patterns.
 
-### Python-Specific Rationalizations
+## Python-Specific Rationalizations
 
 | Rationalization Attempt | Why It's Wrong | Required Action |
 |------------------------|----------------|-----------------|

--- a/agents/python-general-engineer/references/error-handling.md
+++ b/agents/python-general-engineer/references/error-handling.md
@@ -2,22 +2,22 @@
 
 Common Python errors and solutions. See `python-errors.md` for comprehensive catalog.
 
-### Async Deadlock / Hanging
+## Async Deadlock / Hanging
 **Cause**: Awaiting on non-awaitable, missing await keyword, or deadlock in event loop
 **Solution**: Use `asyncio.TaskGroup` for structured concurrency, verify all async functions use `await`, check for circular dependencies in async code. Debug with `asyncio.create_task()` and task names.
 
-### Type Errors (mypy)
+## Type Errors (mypy)
 **Cause**: Incorrect type hints, missing types, or actual type bugs in logic
 **Solution**: Fix the underlying issue instead of adding `# type: ignore` - use TypedDict for dicts, proper Union types, or fix the actual bug mypy found.
 
-### Mutable Default Arguments (B006)
+## Mutable Default Arguments (B006)
 **Cause**: Using mutable defaults like `def func(items=[]):` creates shared state
 **Solution**: Use `def func(items=None):` and create instance in function body: `items = items or []` or `items = items if items is not None else []`
 
-### Import Errors
+## Import Errors
 **Cause**: Circular imports, missing dependencies, or incorrect import paths
 **Solution**: Reorganize imports, use TYPE_CHECKING for type-only imports, check virtual environment activation, verify package installation.
 
-### AttributeError in Tests
+## AttributeError in Tests
 **Cause**: Mock objects missing attributes or methods
 **Solution**: Configure mocks properly: `mock_obj.return_value`, `mock_obj.side_effect`, or use `spec=` parameter to validate attributes.

--- a/agents/python-general-engineer/references/hard-gate-patterns.md
+++ b/agents/python-general-engineer/references/hard-gate-patterns.md
@@ -21,7 +21,7 @@ See `shared-patterns/forbidden-patterns-template.md` for framework.
 | `print()` in production code | No log levels, no structured output | Use logging module |
 | `os.system()` or `shell=True` | Shell injection risk | subprocess with list args, shell=False |
 
-### Detection
+## Detection
 ```bash
 grep -rn "^except:" --include="*.py"
 grep -rn "eval(" --include="*.py" | grep -v "literal_eval"
@@ -29,7 +29,7 @@ grep -rn "# type: ignore$" --include="*.py"
 grep -rn "from .* import \*" --include="*.py"
 ```
 
-### Exceptions
+## Exceptions
 - `# type: ignore[specific-error]` with reason in comment
 - `eval()` only with validated, sandboxed input from trusted source
 - `print()` in CLI scripts and debugging (not production services)

--- a/agents/python-general-engineer/references/preferred-patterns.md
+++ b/agents/python-general-engineer/references/preferred-patterns.md
@@ -2,47 +2,47 @@
 
 Common Python patterns to follow. See `python-preferred-patterns.md` for full catalog.
 
-### Use Virtual Environments for All Installs
+## Use Virtual Environments for All Installs
 **Signal**: Running `pip3 install` without a virtual environment, hitting version mismatches between Python and pip
 **Why this matters**: System pip may resolve to a different Python version (e.g., Python 3.14 but pip from 3.9), causing install failures or packages installed to wrong site-packages
 **Preferred action**: Always use pyenv + virtual environments. Create venv first: `python -m venv .venv && source .venv/bin/activate`. Never install packages with system pip.
 
-### Start Concrete, Abstract Later
+## Start Concrete, Abstract Later
 **Signal**: Creating abstract base classes before you have multiple implementations
 **Why this matters**: Adds complexity without proven benefit, makes code harder to navigate, violates YAGNI
 **Preferred action**: Start with concrete class, add abstraction when you have 2+ implementations, use Protocols for structural typing
 
-### Use Async Only for I/O Concurrency
+## Use Async Only for I/O Concurrency
 **Signal**: Converting CPU-bound operations to async without I/O benefit
 **Why this matters**: Adds async overhead for no performance gain, async is for I/O concurrency not CPU parallelism
 **Preferred action**: Keep synchronous for CPU operations, only use async for actual I/O (network, disk, database)
 
-### Fix Types Instead of Ignoring Them
+## Fix Types Instead of Ignoring Them
 **Signal**: Silencing type checker with `# type: ignore` instead of fixing types
 **Why this matters**: Loses type safety, hides bugs, makes refactoring dangerous
 **Preferred action**: Use proper type hints (TypedDict for dicts, correct Union types), fix the root cause
 
-### Use str.join for String Assembly
+## Use str.join for String Assembly
 **Signal**: `result = ""; for item in items: result += str(item)`
 **Why this matters**: Strings are immutable, creates new string each iteration, O(n²) time complexity
 **Preferred action**: Use `"".join(str(item) for item in items)` - O(n) time
 
-### Catch Specific Exception Types
+## Catch Specific Exception Types
 **Signal**: `except:` without specifying exception type
 **Why this matters**: Catches SystemExit and KeyboardInterrupt, prevents debugging
 **Preferred action**: `except Exception:` at minimum, or specific exception types
 
-### Validate All Input on New CLI Handlers
+## Validate All Input on New CLI Handlers
 **Signal**: New subcommand handler accepts subreddit/path from stdin JSON or env var without validating format
 **Why this matters**: Every OTHER handler validates input (e.g., `_resolve_subreddit`), new handler bypasses the pattern. Creates path traversal via crafted stdin JSON.
 **Preferred action**: Use the same validation function as existing handlers. If input comes from a new source (stdin JSON), validate BEFORE any file path construction.
 
-### Surface All Computed Data in LLM Prompts
+## Surface All Computed Data in LLM Prompts
 **Signal**: Calculating `repeat_offender_count` but not including it in the prompt string
 **Why this matters**: The LLM can only use data that appears in the prompt. Computed-but-invisible data is dead computation.
 **Preferred action**: Every signal computed for classification MUST appear in the rendered prompt. Test: "is this value in the prompt string?"
 
-### Define Every New Category
+## Define Every New Category
 **Signal**: Adding `BAN_RECOMMENDED` to a classification list without explaining when to use it
 **Why this matters**: LLM has no guidance to distinguish it from existing categories, making it dead code
 **Preferred action**: Each new category needs a definition, usage criteria, and auto-mode behavior in the prompt

--- a/agents/python-openstack-engineer.md
+++ b/agents/python-openstack-engineer.md
@@ -111,10 +111,13 @@ See `python-openstack-engineer/references/openstack-patterns.md` for oslo.config
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| oslo.config option registration, oslo.log setup, oslo.messaging transport, oslo.db sessions, oslo.policy enforcement, `CONF.register_opts`, `enginefacade`, `get_rpc_transport` | `oslo-patterns.md` | Routes to the matching deep reference |
-| H201, H301, H303, H304, H501, `tox -e pep8`, import ordering, bare except, wildcard imports, i18n hacking rules, flake8 H-series | `hacking-rules.md` | Routes to the matching deep reference |
-| RPC version negotiation, rolling upgrades, `RPC_API_VERSION`, `prepare(version=X)`, `version_cap`, `RPCVersionCapError`, oslo.messaging Target | `rpc-versioning.md` | Routes to the matching deep reference |
-| Tempest service clients, scenario tests, `addCleanup`, tempest-lib, API validation, `TempestClient` | `tempest-testing.md` | Routes to the matching deep reference |
+| oslo.config option registration, oslo.log setup, oslo.messaging transport, oslo.db sessions, oslo.policy enforcement, `CONF.register_opts`, `enginefacade`, `get_rpc_transport` | [oslo-patterns.md](python-openstack-engineer/references/oslo-patterns.md) | Routes to the matching deep reference |
+| quick Oslo code examples: oslo.config integration, RPC server, Alembic migration | [openstack-patterns.md](python-openstack-engineer/references/openstack-patterns.md) | Short code-example summary; points to the full Oslo reference |
+| H201, H301, H303, H304, H501, `tox -e pep8`, import ordering, bare except, wildcard imports, i18n hacking rules, flake8 H-series | [hacking-rules.md](python-openstack-engineer/references/hacking-rules.md) | Routes to the matching deep reference |
+| RPC version negotiation, rolling upgrades, `RPC_API_VERSION`, `prepare(version=X)`, `version_cap`, `RPCVersionCapError`, oslo.messaging Target | [rpc-versioning.md](python-openstack-engineer/references/rpc-versioning.md) | Routes to the matching deep reference |
+| quick error lookup: bare except (H201), missing i18n, import order (H301-H307) | [error-handling.md](python-openstack-engineer/references/error-handling.md) | Error-to-fix examples for the three most common hacking violations |
+| failure mode list, rationalization table, blocker criteria | [preferred-patterns.md](python-openstack-engineer/references/preferred-patterns.md) | OpenStack failure modes and stop conditions |
+| scoping what this agent can do; output format | [output-format.md](python-openstack-engineer/references/output-format.md) | Implementation Schema phases and CAN/CANNOT lists |
 
 ## Error Handling
 

--- a/agents/reviewer-domain.md
+++ b/agents/reviewer-domain.md
@@ -194,3 +194,9 @@ STOP and ask the user when:
 | **Business Logic** | `business-logic.md` | Domain correctness, edge cases, state machines, data validation |
 | **SAP CC Structural** | `sapcc-structural.md` | 9 structural categories for sapcc Go repos: type exports, wrappers, Option timing, go-bits usage |
 | **Pragmatic Builder** | `pragmatic-builder.md` | Production readiness: deployment, error handling, observability, edge cases, scalability |
+| enumerating edge cases by data type during business logic review | [edge-case-tables.md](reviewer-domain/references/edge-case-tables.md) | Systematic edge cases for numeric, string, collection, date, file, state types |
+| reviewing state machines or stateful business logic | [state-machine-verification.md](reviewer-domain/references/state-machine-verification.md) | Transition tables, review checklist, state-machine review template |
+| checking calculations, off-by-one, validation, race conditions | [common-bugs.md](reviewer-domain/references/common-bugs.md) | Real-world business logic bug catalog with examples |
+| classifying a sapcc Go finding into its structural category | [structural-categories.md](reviewer-domain/references/structural-categories.md) | The 9 categories in depth: exports, wrappers, Option timing, go-bits |
+| production readiness gaps: deployment, rollback, observability, scaling | [production-gaps.md](reviewer-domain/references/production-gaps.md) | Gap catalog with solutions per area |
+| flagging operational mistakes during pragmatic builder review | [operational-preferred-patterns.md](reviewer-domain/references/operational-preferred-patterns.md) | Operational corrections: rollback plans, logging, circuit breakers, monitoring |

--- a/agents/reviewer-perspectives.md
+++ b/agents/reviewer-perspectives.md
@@ -196,3 +196,5 @@ See [shared-patterns/anti-rationalization-review.md](../skills/shared-patterns/a
 | **User Advocate** | `user-advocate.md` | User impact: complexity vs value, learning curve, workflow disruption |
 | **Meta-Process** | `meta-process.md` | System design: SPOFs, indispensability, authority concentration, reversibility |
 | **All Perspectives** | `review-detection-commands.md` | grep/rg detection commands for each perspective — load during VERIFY phase |
+| Newcomer or Contrarian review on a real codebase | [clarity-and-assumption-detection.md](reviewer-perspectives/references/clarity-and-assumption-detection.md) | Clarity (magic numbers, naming) and hidden-assumption detection with error-fix mappings |
+| Skeptical Senior or Pedant review on a real codebase | [code-review-detection.md](reviewer-perspectives/references/code-review-detection.md) | Production-readiness and spec-compliance pattern catalog with fixes |

--- a/agents/sqlite-peewee-engineer.md
+++ b/agents/sqlite-peewee-engineer.md
@@ -137,9 +137,9 @@ SQLite Constraints: [Limitations to work within]
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| N+1, prefetch, join, slow query, index, WAL, EXPLAIN | `peewee-query-patterns.md` | Query optimization, N+1 prevention, index strategy, SQLite pragmas |
-| test, pytest, fixture, in-memory, :memory:, bind_ctx, migration test | `peewee-testing.md` | Per-test isolation, factory fixtures, transaction rollback tests |
-| migration, ALTER, schema change, add column, drop column, playhouse.migrate | `peewee-migrations.md` | Playhouse migrate operations, SQLite ALTER limitations, rebuild procedure |
+| N+1, prefetch, join, slow query, index, WAL, EXPLAIN | [peewee-query-patterns.md](sqlite-peewee-engineer/references/peewee-query-patterns.md) | Query optimization, N+1 prevention, index strategy, SQLite pragmas |
+| test, pytest, fixture, in-memory, :memory:, bind_ctx, migration test | [peewee-testing.md](sqlite-peewee-engineer/references/peewee-testing.md) | Per-test isolation, factory fixtures, transaction rollback tests |
+| migration, ALTER, schema change, add column, drop column, playhouse.migrate | [peewee-migrations.md](sqlite-peewee-engineer/references/peewee-migrations.md) | Playhouse migrate operations, SQLite ALTER limitations, rebuild procedure |
 
 ## Error Handling
 

--- a/agents/swift-general-engineer.md
+++ b/agents/swift-general-engineer.md
@@ -179,6 +179,6 @@ See [references/swift-security-testing.md](swift-general-engineer/references/swi
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| implementation patterns | `swift-patterns.md` | Loads detailed guidance from `swift-patterns.md`. |
-| security-sensitive work, tests | `swift-security-testing.md` | Loads detailed guidance from `swift-security-testing.md`. |
-| security, auth, Keychain, ATS, WebView, biometrics, deep links, or any vulnerability-related code | `swift-security.md` | Secure implementation patterns for Swift iOS, macOS, and server-side. |
+| immutability, actors, Sendable, protocol-oriented design, state modeling | [swift-patterns.md](swift-general-engineer/references/swift-patterns.md) | Core Swift idiom and concurrency patterns |
+| writing or reviewing Swift tests; failure mode detection | [swift-security-testing.md](swift-general-engineer/references/swift-security-testing.md) | Testing methodology and failure mode detection table |
+| security, auth, Keychain, ATS, WebView, biometrics, deep links, or any vulnerability-related code | [swift-security.md](swift-general-engineer/references/swift-security.md) | Secure implementation patterns for Swift iOS, macOS, and server-side. |

--- a/agents/technical-documentation-engineer.md
+++ b/agents/technical-documentation-engineer.md
@@ -158,7 +158,7 @@ Load `documentation-templates.md` plus the relevant domain file when writing doc
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| Writing docs from scratch, API endpoint template, integration guide, verification workflow, adversarial self-check | `documentation-templates.md` | Templates, 4-phase workflow, preferred patterns with before/after |
-| Parameter tables, error tables, heading structure, prose style | `documentation-standards.md` | Google style guide standards, column order, 30-word endpoint descriptions |
-| Hallucinated params, type mismatches, untested examples, stale response examples | `api-doc-verification-failures.md` | Verification failures with detection commands for each |
-| Runbook, incident response, troubleshooting guide, operational doc, deploy runbook | `runbook-patterns.md` | 5-section runbook format, command-first diagnosis, rollback requirements |
+| Writing docs from scratch, API endpoint template, integration guide, verification workflow, adversarial self-check | [documentation-templates.md](technical-documentation-engineer/references/documentation-templates.md) | Templates, 4-phase workflow, preferred patterns with before/after |
+| Parameter tables, error tables, heading structure, prose style | [documentation-standards.md](technical-documentation-engineer/references/documentation-standards.md) | Google style guide standards, column order, 30-word endpoint descriptions |
+| Hallucinated params, type mismatches, untested examples, stale response examples | [api-doc-verification-failures.md](technical-documentation-engineer/references/api-doc-verification-failures.md) | Verification failures with detection commands for each |
+| Runbook, incident response, troubleshooting guide, operational doc, deploy runbook | [runbook-patterns.md](technical-documentation-engineer/references/runbook-patterns.md) | 5-section runbook format, command-first diagnosis, rollback requirements |

--- a/agents/technical-journalist-writer.md
+++ b/agents/technical-journalist-writer.md
@@ -148,6 +148,6 @@ STOP and ask the user when:
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| implementation patterns | `article-structure-patterns.md` | Loads detailed guidance from `article-structure-patterns.md`. |
-| tasks related to this reference | `sourcing-and-claims.md` | Loads detailed guidance from `sourcing-and-claims.md`. |
-| implementation patterns | `voice-patterns.md` | Loads detailed guidance from `voice-patterns.md`. |
+| structuring an explainer, opinion, or analysis article | [article-structure-patterns.md](technical-journalist-writer/references/article-structure-patterns.md) | Structure templates, header and topic-sentence patterns per article type |
+| citing sources, classifying claims, marking inference vs fact | [sourcing-and-claims.md](technical-journalist-writer/references/sourcing-and-claims.md) | Claim classification, inference marking, validation detection commands |
+| auditing draft tone; banned phrases and replacements | [voice-patterns.md](technical-journalist-writer/references/voice-patterns.md) | Banned-pattern reference, replacement map, voice detection commands |

--- a/agents/toolkit-governance-engineer.md
+++ b/agents/toolkit-governance-engineer.md
@@ -185,10 +185,10 @@ Use this format for consistency checks, audits, and multi-file operations. Singl
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `adr-lifecycle.md` | Loads detailed guidance from `adr-lifecycle.md`. |
-| tasks related to this reference | `frontmatter-compliance.md` | Loads detailed guidance from `frontmatter-compliance.md`. |
-| tasks related to this reference | `hook-standardization.md` | Loads detailed guidance from `hook-standardization.md`. |
-| implementation patterns | `routing-table-patterns.md` | Loads detailed guidance from `routing-table-patterns.md`. |
+| ADR status transitions, validation criteria, consultation records | [adr-lifecycle.md](toolkit-governance-engineer/references/adr-lifecycle.md) | Status line format, transition rules, stale ADR detection commands |
+| frontmatter audit, `allowed-tools` review, YAML parse errors | [frontmatter-compliance.md](toolkit-governance-engineer/references/frontmatter-compliance.md) | Required fields, ADR-063 tool restrictions, detection commands |
+| hook registration, event types, timeout config, exit code review | [hook-standardization.md](toolkit-governance-engineer/references/hook-standardization.md) | settings.json format, advisory vs blocking exit codes |
+| routing table edits, `pairs_with` validation, trigger conflicts, INDEX.json | [routing-table-patterns.md](toolkit-governance-engineer/references/routing-table-patterns.md) | Phantom route detection, trigger conflict checks, index validation |
 
 ## Agent Reference File Validation
 

--- a/agents/ui-design-engineer.md
+++ b/agents/ui-design-engineer.md
@@ -154,6 +154,8 @@ Uses the **Implementation Schema**: ANALYZE (surface type, narrative brief, cont
 | card, table, badge, avatar, progress, alert | `component-library-display.md` | Cards, tables, badges, avatars, progress indicators, alerts |
 | Tailwind config, @apply, responsive, purge, JIT, arbitrary | `tailwind-preferred-patterns.md` | Tailwind configuration, class composition, purge issues, `@apply`, responsive prefixes, arbitrary values |
 | animation, Framer Motion, transition, reduced motion, exit, AnimatePresence | `animation-patterns.md` | Framer Motion, CSS transitions, prefers-reduced-motion, exit animations, AnimatePresence, micro-interactions |
+| interaction states, hover, focus, disabled, loading, active, pressed | [interaction-state-coverage.md](ui-design-engineer/references/interaction-state-coverage.md) | 6-state matrix, transition timing bounds, element-by-element checklist |
+| AI slop, generic UI, AI-generated look, template look, default styling | [ai-slop-detection.md](ui-design-engineer/references/ai-slop-detection.md) | Purposeful gradients, contextual fonts and colors, spacing scale rules |
 
 ## Error Handling
 

--- a/scripts/validate-references.py
+++ b/scripts/validate-references.py
@@ -340,6 +340,33 @@ def validate_agent(agent_file: Path, check_structure: bool = True) -> AgentResul
     return result
 
 
+# Generic signals that cannot disambiguate which reference to load.
+PLACEHOLDER_SIGNALS = ("tasks related to this reference",)
+
+_PLACEHOLDER_SCAN_PATTERNS = ["agents/*.md", "skills/**/SKILL.md"]
+
+
+def find_placeholder_signals() -> list[tuple[str, int, str]]:
+    """Return (relative path, line number, signal) for loading-table rows with placeholder signals."""
+    found: list[tuple[str, int, str]] = []
+    for pattern in _PLACEHOLDER_SCAN_PATTERNS:
+        for path in sorted(REPO_ROOT.glob(pattern)):
+            if not path.is_file():
+                continue
+            try:
+                lines = path.read_text(encoding="utf-8").splitlines()
+            except (OSError, UnicodeDecodeError):
+                continue
+            for lineno, line in enumerate(lines, start=1):
+                cells = [c.strip() for c in line.split("|")]
+                if len(cells) < 3 or not line.lstrip().startswith("|"):
+                    continue
+                signal = cells[1].lower()
+                if signal in PLACEHOLDER_SIGNALS:
+                    found.append((str(path.relative_to(REPO_ROOT)), lineno, cells[1]))
+    return found
+
+
 def find_all_reference_files() -> list[Path]:
     """Find every .md file inside any references/ subdirectory under agents/."""
     return list(AGENTS_DIR.rglob("references/*.md"))
@@ -359,7 +386,11 @@ def find_orphan_references(all_results: list[AgentResult]) -> list[Path]:
     return orphans
 
 
-def print_text_results(results: list[AgentResult], orphans: list[Path]) -> None:
+def print_text_results(
+    results: list[AgentResult],
+    orphans: list[Path],
+    placeholders: list[tuple[str, int, str]] | None = None,
+) -> None:
     """Print human-readable validation output."""
     for result in results:
         total = len(result.declared)
@@ -383,6 +414,11 @@ def print_text_results(results: list[AgentResult], orphans: list[Path]) -> None:
         for orphan in orphans:
             print(f"  ORPHAN: {orphan.relative_to(AGENTS_DIR)}")
 
+    if placeholders:
+        print("\nPlaceholder loading-table signals (cannot disambiguate which reference to load):")
+        for rel, lineno, signal in placeholders:
+            print(f"  PLACEHOLDER_SIGNAL: {rel}:{lineno} — {signal!r}")
+
     ok_count = sum(1 for r in results if r.ok)
     issue_count = sum(1 for r in results if not r.ok)
     total_missing = sum(len(r.missing) for r in results)
@@ -397,11 +433,17 @@ def print_text_results(results: list[AgentResult], orphans: list[Path]) -> None:
         parts.append(f"{total_issues} structure issue(s)")
     if orphans:
         parts.append(f"{len(orphans)} orphan(s)")
+    if placeholders:
+        parts.append(f"{len(placeholders)} placeholder signal(s)")
 
     print(f"\nSummary: {', '.join(parts)}")
 
 
-def build_json_results(results: list[AgentResult], orphans: list[Path]) -> dict:
+def build_json_results(
+    results: list[AgentResult],
+    orphans: list[Path],
+    placeholders: list[tuple[str, int, str]] | None = None,
+) -> dict:
     """Build JSON-serializable results dict."""
     agents_out = []
     for result in results:
@@ -422,17 +464,22 @@ def build_json_results(results: list[AgentResult], orphans: list[Path]) -> dict:
     structure_issues = sum(len(r.issues) for r in results)
     has_failures = issue_count > 0 or missing_count > 0
 
+    placeholders = placeholders or []
     return {
         "agents": agents_out,
         "orphans": [str(o.relative_to(AGENTS_DIR)) for o in orphans],
+        "placeholder_signals": [
+            {"file": rel, "line": lineno, "signal": signal} for rel, lineno, signal in placeholders
+        ],
         "summary": {
             "ok": ok_count,
             "issues": issue_count,
             "missing_files": missing_count,
             "structure_issues": structure_issues,
             "orphans": len(orphans),
+            "placeholder_signals": len(placeholders),
         },
-        "exit_code": 1 if has_failures else 0,
+        "exit_code": 1 if has_failures or placeholders else 0,
     }
 
 
@@ -486,9 +533,11 @@ def main() -> None:
 
     all_results_for_orphans = results if args.all else []
     orphans: list[Path] = []
+    placeholders: list[tuple[str, int, str]] = []
     if args.all and check_structure:
         all_agent_results = [validate_agent(f, check_structure=False) for f in sorted(AGENTS_DIR.glob("*.md"))]
         orphans = find_orphan_references(all_agent_results)
+        placeholders = find_placeholder_signals()
 
     # Filter for --failures-only: only agents with issues
     total_agents = len(results)
@@ -497,16 +546,16 @@ def main() -> None:
     display_orphans = orphans  # always show orphans (they are issues)
 
     if args.json_output:
-        output = build_json_results(display_results, display_orphans)
+        output = build_json_results(display_results, display_orphans, placeholders)
         if args.failures_only:
             output["summary"]["message"] = f"{passing_agents} of {total_agents} agents passed validation"
         print(json.dumps(output, indent=2))
-        sys.exit(1 if any(not r.ok for r in results) or bool(orphans) else 0)
+        sys.exit(1 if any(not r.ok for r in results) or bool(orphans) or bool(placeholders) else 0)
     else:
-        print_text_results(display_results, display_orphans)
+        print_text_results(display_results, display_orphans, placeholders)
         if args.failures_only:
             print(f"\n{passing_agents} of {total_agents} agents passed validation")
-        has_failures = any(not r.ok for r in results) or bool(orphans)
+        has_failures = any(not r.ok for r in results) or bool(orphans) or bool(placeholders)
         sys.exit(1 if has_failures else 0)
 
 

--- a/skills/code-quality/code-cleanup/SKILL.md
+++ b/skills/code-quality/code-cleanup/SKILL.md
@@ -56,9 +56,9 @@ Scan repositories for 9 categories of technical debt (TODOs, unused imports, dea
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `report-template.md` | Loads detailed guidance from `report-template.md`. |
-| tasks related to this reference | `scan-commands.md` | Loads detailed guidance from `scan-commands.md`. |
-| tasks related to this reference | `tools.md` | Loads detailed guidance from `tools.md`. |
+| writing the cleanup report | `report-template.md` | Loads detailed guidance from `report-template.md`. |
+| running per-language scans: unused imports, dead code, debug statements | `scan-commands.md` | Loads detailed guidance from `scan-commands.md`. |
+| checking which cleanup tools are installed per language | `tools.md` | Loads detailed guidance from `tools.md`. |
 
 ## Instructions
 

--- a/skills/code-quality/joy-check/SKILL.md
+++ b/skills/code-quality/joy-check/SKILL.md
@@ -46,8 +46,8 @@ This skill checks *framing*, not *topic* and not *voice*. Voice fidelity belongs
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `instruction-rubric.md` | Loads detailed guidance from `instruction-rubric.md`. |
-| tasks related to this reference | `writing-rubric.md` | Loads detailed guidance from `writing-rubric.md`. |
+| scoring instruction files (agents, skills, pipelines): positive-framing rubric | `instruction-rubric.md` | Loads detailed guidance from `instruction-rubric.md`. |
+| scoring human-facing prose (blog posts, emails, docs): joy-grievance rubric | `writing-rubric.md` | Loads detailed guidance from `writing-rubric.md`. |
 
 ## Instructions
 

--- a/skills/code-quality/python-quality-gate/SKILL.md
+++ b/skills/code-quality/python-quality-gate/SKILL.md
@@ -38,8 +38,8 @@ Run four quality tools in deterministic order -- ruff, pytest, mypy, bandit -- a
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `report-template.md` | Loads detailed guidance from `report-template.md`. |
-| tasks related to this reference | `tool-commands.md` | Loads detailed guidance from `tool-commands.md`. |
+| writing the quality gate report | `report-template.md` | Loads detailed guidance from `report-template.md`. |
+| invoking ruff/mypy/pytest; severity classification and pass/fail thresholds | `tool-commands.md` | Loads detailed guidance from `tool-commands.md`. |
 
 ## Instructions
 

--- a/skills/content/content-calendar/SKILL.md
+++ b/skills/content/content-calendar/SKILL.md
@@ -31,11 +31,11 @@ Manage editorial content through 6 pipeline stages: Ideas, Outlined, Drafted, Ed
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `calendar-format.md` | Loads detailed guidance from `calendar-format.md`. |
+| calendar file location, template, section formats | `calendar-format.md` | Loads detailed guidance from `calendar-format.md`. |
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
-| tasks related to this reference | `metrics.md` | Loads detailed guidance from `metrics.md`. |
-| tasks related to this reference | `operations.md` | Loads detailed guidance from `operations.md`. |
-| tasks related to this reference | `pipeline-stages.md` | Loads detailed guidance from `pipeline-stages.md`. |
+| velocity tracking and stuck-content detection | `metrics.md` | Loads detailed guidance from `metrics.md`. |
+| executing view, add, move, schedule, archive operations | `operations.md` | Loads detailed guidance from `operations.md`. |
+| stage definitions and transition rules | `pipeline-stages.md` | Loads detailed guidance from `pipeline-stages.md`. |
 
 ## Instructions
 

--- a/skills/content/content-engine/SKILL.md
+++ b/skills/content/content-engine/SKILL.md
@@ -40,8 +40,8 @@ Platform-native means each variant is written from scratch for its target platfo
 | Signal | Load These Files | Why |
 |---|---|---|
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
-| tasks related to this reference | `phase-playbook.md` | Loads detailed guidance from `phase-playbook.md`. |
-| tasks related to this reference | `platform-specs.md` | Loads detailed guidance from `platform-specs.md`. |
+| drafting variants: platform rules, banned hype phrases, delivery handoff | `phase-playbook.md` | Loads detailed guidance from `phase-playbook.md`. |
+| character limits and format rules per platform | `platform-specs.md` | Loads detailed guidance from `platform-specs.md`. |
 
 ## Instructions
 

--- a/skills/content/create-voice/SKILL.md
+++ b/skills/content/create-voice/SKILL.md
@@ -44,13 +44,13 @@ Create a complete voice profile from writing samples through a 7-phase pipeline.
 |---|---|---|
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
 | extraction validation, pattern verdict, triple-validation | `extraction-validation.md` | Triple-validation rubric (recurrence, generative power, exclusivity) gating which patterns survive into the profile. |
-| tasks related to this reference | `iteration-guide.md` | Loads detailed guidance from `iteration-guide.md`. |
+| Steps 6-7: validation procedure and authorship matching | `iteration-guide.md` | Loads detailed guidance from `iteration-guide.md`. |
 | implementation patterns | `pattern-identification.md` | Loads detailed guidance from `pattern-identification.md`. |
-| tasks related to this reference | `phase-banners.md` | Loads detailed guidance from `phase-banners.md`. |
-| tasks related to this reference | `reference-implementations.md` | Loads detailed guidance from `reference-implementations.md`. |
-| tasks related to this reference | `sample-collection.md` | Loads detailed guidance from `sample-collection.md`. |
-| tasks related to this reference | `skill-generation.md` | Loads detailed guidance from `skill-generation.md`. |
-| tasks related to this reference | `voice-rules-template.md` | Loads detailed guidance from `voice-rules-template.md`. |
+| reporting progress at phase gates | `phase-banners.md` | Loads detailed guidance from `phase-banners.md`. |
+| locating exemplar voice skills and components | `reference-implementations.md` | Loads detailed guidance from `reference-implementations.md`. |
+| Step 1 COLLECT: finding, vetting, and formatting samples | `sample-collection.md` | Loads detailed guidance from `sample-collection.md`. |
+| Step 5 GENERATE: skill files, frontmatter, sample organization | `skill-generation.md` | Loads detailed guidance from `skill-generation.md`. |
+| Step 4 RULE: writing positive and contrastive identity rules | `voice-rules-template.md` | Loads detailed guidance from `voice-rules-template.md`. |
 
 ## Instructions
 

--- a/skills/content/image-to-video/SKILL.md
+++ b/skills/content/image-to-video/SKILL.md
@@ -36,7 +36,7 @@ Combine a static image with an audio file to produce an MP4 video using FFmpeg. 
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `ffmpeg-filters.md` | Loads detailed guidance from `ffmpeg-filters.md`. |
+| building FFmpeg filter graphs for audio visualization; encoding settings | `ffmpeg-filters.md` | Loads detailed guidance from `ffmpeg-filters.md`. |
 
 ## Instructions
 

--- a/skills/content/professional-communication/SKILL.md
+++ b/skills/content/professional-communication/SKILL.md
@@ -37,7 +37,7 @@ This skill transforms dense technical communication into clear, structured busin
 | Signal | Load These Files | Why |
 |---|---|---|
 | example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
-| tasks related to this reference | `templates.md` | Loads detailed guidance from `templates.md`. |
+| drafting from section templates; phrase transformations | `templates.md` | Loads detailed guidance from `templates.md`. |
 
 ## Instructions
 

--- a/skills/content/series-planner/SKILL.md
+++ b/skills/content/series-planner/SKILL.md
@@ -37,10 +37,10 @@ This skill plans multi-part content series with proper structure, cross-linking,
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `cadence-guidelines.md` | Loads detailed guidance from `cadence-guidelines.md`. |
-| tasks related to this reference | `cross-linking.md` | Loads detailed guidance from `cross-linking.md`. |
-| tasks related to this reference | `output-format.md` | Loads detailed guidance from `output-format.md`. |
-| tasks related to this reference | `series-types.md` | Loads detailed guidance from `series-types.md`. |
+| choosing publication frequency and managing delays | `cadence-guidelines.md` | Loads detailed guidance from `cadence-guidelines.md`. |
+| series navigation links and Hugo implementation | `cross-linking.md` | Loads detailed guidance from `cross-linking.md`. |
+| writing the series plan output | `output-format.md` | Loads detailed guidance from `output-format.md`. |
+| selecting series type, part count, word targets | `series-types.md` | Loads detailed guidance from `series-types.md`. |
 
 ## Instructions
 

--- a/skills/content/topic-brainstormer/SKILL.md
+++ b/skills/content/topic-brainstormer/SKILL.md
@@ -38,9 +38,9 @@ Core principle: **Assess-Decide-Generate with Domain Intelligence**. Gather sign
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `content-filter.md` | Loads detailed guidance from `content-filter.md`. |
-| tasks related to this reference | `priority-scoring.md` | Loads detailed guidance from `priority-scoring.md`. |
-| tasks related to this reference | `topic-sources.md` | Loads detailed guidance from `topic-sources.md`. |
+| filtering topics against blog identity: the three-question test | `content-filter.md` | Loads detailed guidance from `content-filter.md`. |
+| scoring topics on impact, vex level, resolution | `priority-scoring.md` | Loads detailed guidance from `priority-scoring.md`. |
+| mining topics: problems, gaps, technology expansion | `topic-sources.md` | Loads detailed guidance from `topic-sources.md`. |
 
 ## Instructions
 

--- a/skills/content/wordpress-live-validation/SKILL.md
+++ b/skills/content/wordpress-live-validation/SKILL.md
@@ -50,10 +50,10 @@ This skill loads a real WordPress post in a Playwright headless browser and veri
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `validation-checks.md` | Loads detailed guidance from `validation-checks.md`. |
-| tasks related to this reference | `playwright-tools.md` | Loads detailed guidance from `playwright-tools.md`. |
-| tasks related to this reference | `phase-checks.md` | Loads detailed guidance from `phase-checks.md`. |
-| tasks related to this reference | `output-format.md` | Loads detailed guidance from `output-format.md`. |
+| check specifications: severities, edge cases, JS extraction | `validation-checks.md` | Loads detailed guidance from `validation-checks.md`. |
+| Playwright MCP tool signatures, pitfalls, availability detection | `playwright-tools.md` | Loads detailed guidance from `playwright-tools.md`. |
+| step-by-step NAVIGATE, VALIDATE, RESPONSIVE procedures | `phase-checks.md` | Loads detailed guidance from `phase-checks.md`. |
+| Phase 4 REPORT output format | `output-format.md` | Loads detailed guidance from `output-format.md`. |
 | example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
 

--- a/skills/engineering/sapcc-review/SKILL.md
+++ b/skills/engineering/sapcc-review/SKILL.md
@@ -54,8 +54,8 @@ Each specialist loads only its domain-specific reference file to keep context ti
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `agent-dispatch-prompts.md` | Loads detailed guidance from `agent-dispatch-prompts.md`. |
-| tasks related to this reference | `report-template.md` | Loads detailed guidance from `report-template.md`. |
+| Phase 2 DISPATCH: the 10 domain-specialist prompts | `agent-dispatch-prompts.md` | Loads detailed guidance from `agent-dispatch-prompts.md`. |
+| Phase 3 AGGREGATE: report structure and severity boosts | `report-template.md` | Loads detailed guidance from `report-template.md`. |
 
 ## Instructions
 

--- a/skills/frontend/distinctive-frontend-design/SKILL.md
+++ b/skills/frontend/distinctive-frontend-design/SKILL.md
@@ -35,18 +35,18 @@ Optional capabilities (off unless explicitly enabled by the user): design system
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| implementation patterns | `animation-patterns.md` | Loads detailed guidance from `animation-patterns.md`. |
-| tasks related to this reference | `app-vs-landing-rules.md` | Loads detailed guidance from `app-vs-landing-rules.md`. |
-| tasks related to this reference | `background-techniques.md` | Loads detailed guidance from `background-techniques.md`. |
-| implementation patterns | `css-audit-patterns.md` | Loads detailed guidance from `css-audit-patterns.md`. |
+| adding motion: page load orchestration, state transitions, scroll reveals, easing | `animation-patterns.md` | Loads detailed guidance from `animation-patterns.md`. |
+| applying layout rules after Phase 1 surface-type classification (app vs landing) | `app-vs-landing-rules.md` | Loads detailed guidance from `app-vs-landing-rules.md`. |
+| building backgrounds: gradients, noise, geometric patterns, atmosphere | `background-techniques.md` | Loads detailed guidance from `background-techniques.md`. |
+| auditing CSS for banned fonts, hardcoded colors, over-animation | `css-audit-patterns.md` | Loads detailed guidance from `css-audit-patterns.md`. |
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
-| example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
+| brief-level walkthroughs: new landing page, app surface | `examples.md` | Loads detailed guidance from `examples.md`. |
 | game UI, AAA game, polished game, Steam game, roguelike UI, Slay the Spire | `game-ui-polish.md` | Loads game-native polish rules that prevent website-like surfaces, excessive gradients, nested boxes, and fake-premium chrome. |
-| example-driven tasks | `implementation-examples.md` | Loads detailed guidance from `implementation-examples.md`. |
+| starter code: design tokens, base styles, React/Tailwind and HTML templates | `implementation-examples.md` | Loads detailed guidance from `implementation-examples.md`. |
 | performance work | `performance-budgets.md` | Loads detailed guidance from `performance-budgets.md`. |
-| tasks related to this reference | `phase-details.md` | Loads detailed guidance from `phase-details.md`. |
+| aesthetic direction examples and expanded phase steps | `phase-details.md` | Loads detailed guidance from `phase-details.md`. |
 | picking a page structure in Phase 1 | `macrostructure-catalog.md` | Load only the single chosen `macro:*` entry by its heading anchor (e.g. `#macrostat-led`), never the whole file — one entry carries every rule the build needs. |
-| tasks related to this reference | `vocabulary.md` | Loads detailed guidance from `vocabulary.md`. |
+| before Phase 1: definitions of Hero, Full-bleed, Surface type, and other gating terms | `vocabulary.md` | Loads detailed guidance from `vocabulary.md`. |
 
 ## Instructions
 

--- a/skills/infrastructure/fish-shell-config/SKILL.md
+++ b/skills/infrastructure/fish-shell-config/SKILL.md
@@ -41,8 +41,8 @@ Fish is not POSIX. Every pattern here targets Fish 3.0+ (supports `$()`, `&&`, `
 |---|---|---|
 | migrations | `bash-migration.md` | Loads detailed guidance from `bash-migration.md`. |
 | implementation patterns | `fish-preferred-patterns.md` | Loads detailed guidance from `fish-preferred-patterns.md`. |
-| tasks related to this reference | `fish-quick-reference.md` | Loads detailed guidance from `fish-quick-reference.md`. |
-| tasks related to this reference | `tool-integrations.md` | Loads detailed guidance from `tool-integrations.md`. |
+| syntax lookup: variable scope, PATH, functions, abbreviations, conditionals, debugging | `fish-quick-reference.md` | Loads detailed guidance from `fish-quick-reference.md`. |
+| wiring dev tools into fish: Go, Rust, Node, Python, Docker, PATH and init hooks | `tool-integrations.md` | Loads detailed guidance from `tool-integrations.md`. |
 
 ## Instructions
 

--- a/skills/meta/agent-comparison/SKILL.md
+++ b/skills/meta/agent-comparison/SKILL.md
@@ -32,13 +32,13 @@ Compare agent variants through controlled A/B benchmarks. Runs identical tasks o
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `benchmark-tasks.md` | Loads detailed guidance from `benchmark-tasks.md`. |
+| selecting benchmark tasks and directory layout (Phase 1) | `benchmark-tasks.md` | Loads detailed guidance from `benchmark-tasks.md`. |
 | example-driven tasks, errors | `examples-and-errors.md` | Loads detailed guidance from `examples-and-errors.md`. |
-| tasks related to this reference | `grading-rubric.md` | Loads detailed guidance from `grading-rubric.md`. |
-| tasks related to this reference | `methodology.md` | Loads detailed guidance from `methodology.md`. |
-| tasks related to this reference | `optimization-guide.md` | Loads detailed guidance from `optimization-guide.md`. |
-| tasks related to this reference | `optimize-phase.md` | Loads detailed guidance from `optimize-phase.md`. |
-| tasks related to this reference | `report-template.md` | Loads detailed guidance from `report-template.md`. |
+| scoring solutions: 5-criteria rubric and effective cost calculation | `grading-rubric.md` | Loads detailed guidance from `grading-rubric.md`. |
+| deciding when to run comparisons; December 2024 baseline data | `methodology.md` | Loads detailed guidance from `methodology.md`. |
+| configuring autoresearch: targets, task formats, eval isolation modes | `optimization-guide.md` | Loads detailed guidance from `optimization-guide.md`. |
+| executing Phase 5 OPTIMIZE step by step | `optimize-phase.md` | Loads detailed guidance from `optimize-phase.md`. |
+| writing the Phase 4 comparison report | `report-template.md` | Loads detailed guidance from `report-template.md`. |
 
 ## Instructions
 

--- a/skills/meta/agent-evaluation/SKILL.md
+++ b/skills/meta/agent-evaluation/SKILL.md
@@ -31,10 +31,10 @@ Objective, evidence-based quality assessment for agents and skills. Implements a
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `batch-evaluation.md` | Loads detailed guidance from `batch-evaluation.md`. |
-| tasks related to this reference | `common-issues.md` | Loads detailed guidance from `common-issues.md`. |
-| tasks related to this reference | `report-templates.md` | Loads detailed guidance from `report-templates.md`. |
-| tasks related to this reference | `scoring-rubric.md` | Loads detailed guidance from `scoring-rubric.md`. |
+| evaluating an entire agent/skill collection | `batch-evaluation.md` | Loads detailed guidance from `batch-evaluation.md`. |
+| diagnosing recurring structural and content issues | `common-issues.md` | Loads detailed guidance from `common-issues.md`. |
+| writing single-item or collection evaluation reports | `report-templates.md` | Loads detailed guidance from `report-templates.md`. |
+| assigning points against v2.0 standards; grade boundaries | `scoring-rubric.md` | Loads detailed guidance from `scoring-rubric.md`. |
 
 ## Instructions
 

--- a/skills/meta/docs-sync-checker/SKILL.md
+++ b/skills/meta/docs-sync-checker/SKILL.md
@@ -39,9 +39,9 @@ Optional flags: `--auto-fix` (experimental, requires explicit opt-in), `--strict
 |---|---|---|
 | documentation work | `documentation-structure.md` | Loads detailed guidance from `documentation-structure.md`. |
 | example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
-| tasks related to this reference | `integration-guide.md` | Loads detailed guidance from `integration-guide.md`. |
-| tasks related to this reference | `markdown-formats.md` | Loads detailed guidance from `markdown-formats.md`. |
-| tasks related to this reference | `sync-rules.md` | Loads detailed guidance from `sync-rules.md`. |
+| wiring the checker into CI, pre-commit, or auto-fix mode | `integration-guide.md` | Loads detailed guidance from `integration-guide.md`. |
+| expected table and list formats per README file | `markdown-formats.md` | Loads detailed guidance from `markdown-formats.md`. |
+| which docs must list which tools; sync score and deprecation rules | `sync-rules.md` | Loads detailed guidance from `sync-rules.md`. |
 
 ## Instructions
 

--- a/skills/meta/generate-claudemd/SKILL.md
+++ b/skills/meta/generate-claudemd/SKILL.md
@@ -36,7 +36,7 @@ This skill does not use `context: fork` because it requires interactive user gat
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `CLAUDEMD_TEMPLATE.md` | Loads detailed guidance from `CLAUDEMD_TEMPLATE.md`. |
+| drafting CLAUDE.md sections in Phase 3 | `CLAUDEMD_TEMPLATE.md` | Loads detailed guidance from `CLAUDEMD_TEMPLATE.md`. |
 | example-driven tasks, errors | `examples-and-errors.md` | Loads detailed guidance from `examples-and-errors.md`. |
 
 ## Instructions

--- a/skills/meta/reference-enrichment/SKILL.md
+++ b/skills/meta/reference-enrichment/SKILL.md
@@ -234,8 +234,8 @@ Load when the task type matches:
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `quality-rubric.md` | Loads detailed guidance from `quality-rubric.md`. |
-| tasks related to this reference | `reference-file-template.md` | Loads detailed guidance from `reference-file-template.md`. |
+| classifying reference depth Level 0-3 (DISCOVER gaps, VALIDATE Tier 2) | `quality-rubric.md` | Loads detailed guidance from `quality-rubric.md`. |
+| writing new reference files (Phase 3 COMPILE) | `reference-file-template.md` | Loads detailed guidance from `reference-file-template.md`. |
 
 ## Error Handling
 

--- a/skills/meta/routing-table-updater/SKILL.md
+++ b/skills/meta/routing-table-updater/SKILL.md
@@ -38,13 +38,13 @@ The skill reads metadata from all skills and agents (never modifies them) and sa
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `batch-mode.md` | Loads detailed guidance from `batch-mode.md`. |
-| tasks related to this reference | `conflict-resolution.md` | Loads detailed guidance from `conflict-resolution.md`. |
+| batch registration of many skills (invoked by pipeline-scaffolder) | `batch-mode.md` | Loads detailed guidance from `batch-mode.md`. |
+| resolving trigger conflicts: priority rules and severity levels | `conflict-resolution.md` | Loads detailed guidance from `conflict-resolution.md`. |
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
-| example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
+| worked update scenarios: new skill, conflict, manual entry, complexity change | `examples.md` | Loads detailed guidance from `examples.md`. |
 | implementation patterns | `extraction-patterns.md` | Loads detailed guidance from `extraction-patterns.md`. |
-| tasks related to this reference | `routing-format.md` | Loads detailed guidance from `routing-format.md`. |
-| example-driven tasks | `skill-examples.md` | Loads detailed guidance from `skill-examples.md`. |
+| /do routing table structure, auto-generated markers, ordering rules | `routing-format.md` | Loads detailed guidance from `routing-format.md`. |
+| skill-entry examples for registering a newly created skill | `skill-examples.md` | Loads detailed guidance from `skill-examples.md`. |
 
 ## Instructions
 

--- a/skills/meta/skill-composer/SKILL.md
+++ b/skills/meta/skill-composer/SKILL.md
@@ -36,10 +36,10 @@ Orchestrate complex workflows by chaining multiple skills into validated executi
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `compatibility-matrix.md` | Loads detailed guidance from `compatibility-matrix.md`. |
-| implementation patterns | `composition-patterns.md` | Loads detailed guidance from `composition-patterns.md`. |
+| checking skill chain compatibility and input/output type matching | `compatibility-matrix.md` | Loads detailed guidance from `compatibility-matrix.md`. |
+| choosing sequential vs parallel composition; chain length limits | `composition-patterns.md` | Loads detailed guidance from `composition-patterns.md`. |
 | example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
-| implementation patterns | `skill-patterns.md` | Loads detailed guidance from `skill-patterns.md`. |
+| selecting a proven composition pattern; troubleshooting compositions | `skill-patterns.md` | Loads detailed guidance from `skill-patterns.md`. |
 
 ## Instructions
 

--- a/skills/meta/skill-creator/SKILL.md
+++ b/skills/meta/skill-creator/SKILL.md
@@ -644,13 +644,13 @@ but only if the queries are well-designed.
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| implementation patterns | `preferred-patterns.md` | Loads detailed guidance from `preferred-patterns.md`. |
-| tasks related to this reference | `artifact-schemas.md` | Loads detailed guidance from `artifact-schemas.md`. |
-| tasks related to this reference | `bundled-components.md` | Loads detailed guidance from `bundled-components.md`. |
-| tasks related to this reference | `complexity-tiers.md` | Loads detailed guidance from `complexity-tiers.md`. |
-| tasks related to this reference | `domain-research-targets.md` | Loads detailed guidance from `domain-research-targets.md`. |
-| workflow steps | `enrichment-workflow.md` | Loads detailed guidance from `enrichment-workflow.md`. |
+| fixing skill design issues: descriptions, gates, file size, retries | `preferred-patterns.md` | Loads detailed guidance from `preferred-patterns.md`. |
+| reading or writing eval pipeline JSON artifacts | `artifact-schemas.md` | Loads detailed guidance from `artifact-schemas.md`. |
+| bundling agents or scripts inside the skill package | `bundled-components.md` | Loads detailed guidance from `bundled-components.md`. |
+| choosing the skill's complexity tier and line budget | `complexity-tiers.md` | Loads detailed guidance from `complexity-tiers.md`. |
+| RESEARCH phase: documentation sources to mine per skill domain | `domain-research-targets.md` | Loads detailed guidance from `domain-research-targets.md`. |
+| enriching an existing skill: AUDIT through PUBLISH loop | `enrichment-workflow.md` | Loads detailed guidance from `enrichment-workflow.md`. |
 | errors | `error-catalog.md` | Loads detailed guidance from `error-catalog.md`. |
-| tasks related to this reference | `progressive-disclosure.md` | Loads detailed guidance from `progressive-disclosure.md`. |
-| tasks related to this reference | `skill-template.md` | Loads detailed guidance from `skill-template.md`. |
-| workflow steps, implementation patterns | `workflow-patterns.md` | Loads detailed guidance from `workflow-patterns.md`. |
+| splitting content between SKILL.md and references/ | `progressive-disclosure.md` | Loads detailed guidance from `progressive-disclosure.md`. |
+| drafting the SKILL.md skeleton with required sections | `skill-template.md` | Loads detailed guidance from `skill-template.md`. |
+| choosing a phase structure: sequential, multi-service, iterative, eval-driven | `workflow-patterns.md` | Loads detailed guidance from `workflow-patterns.md`. |

--- a/skills/meta/skill-eval/SKILL.md
+++ b/skills/meta/skill-eval/SKILL.md
@@ -44,8 +44,8 @@ Measure and improve skill quality through empirical testing — because structur
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `schemas.md` | Loads detailed guidance from `schemas.md`. |
-| tasks related to this reference | `self-improve-loop.md` | Loads detailed guidance from `self-improve-loop.md`. |
+| reading or writing eval artifacts: evals.json, grading.json, metrics.json, history.json | `schemas.md` | Loads detailed guidance from `schemas.md`. |
+| improving a skill via variant generation and blind A/B promotion | `self-improve-loop.md` | Loads detailed guidance from `self-improve-loop.md`. |
 | "bake-off", "head-to-head", "compare implementations", "grade two versions", "which Feynman skill is better" | `bake-off-methodology.md` | Loads the bake-off rubric, anti-rationalization gate, fold-filter, and worked Feynman example. |
 
 ## Instructions

--- a/skills/meta/toolkit-evolution/SKILL.md
+++ b/skills/meta/toolkit-evolution/SKILL.md
@@ -44,10 +44,10 @@ Invoke: `/evolve`, `/evolve routing`, `/evolve hooks`, `/evolve --discover`. Cro
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `diagnose-scripts.md` | Loads detailed guidance from `diagnose-scripts.md`. |
-| tasks related to this reference | `evolution-report-template.md` | Loads detailed guidance from `evolution-report-template.md`. |
+| running DISCOVER/DIAGNOSE commands: learning DB queries, git scan, drift checks | `diagnose-scripts.md` | Loads detailed guidance from `diagnose-scripts.md`. |
+| writing the evolution cycle report | `evolution-report-template.md` | Loads detailed guidance from `evolution-report-template.md`. |
 | implementation patterns | `evolve-preferred-patterns.md` | Loads detailed guidance from `evolve-preferred-patterns.md`. |
-| tasks related to this reference | `evolve-scripts.md` | Loads detailed guidance from `evolve-scripts.md`. |
+| Phase 6 EVOLVE: PR creation, merge, branch cleanup, learning records | `evolve-scripts.md` | Loads detailed guidance from `evolve-scripts.md`. |
 
 ## Instructions
 

--- a/skills/process/adr-consultation/SKILL.md
+++ b/skills/process/adr-consultation/SKILL.md
@@ -32,9 +32,9 @@ Multi-agent architecture consultation that dispatches 3 specialized reviewers in
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `agent-prompts.md` | Loads detailed guidance from `agent-prompts.md`. |
-| implementation patterns | `consultation-preferred-patterns.md` | Loads detailed guidance from `consultation-preferred-patterns.md`. |
-| implementation patterns | `consultation-patterns.md` | Loads detailed guidance from `consultation-patterns.md`. |
+| Phase 2 DISPATCH: consultation agent prompt templates | `agent-prompts.md` | Loads detailed guidance from `agent-prompts.md`. |
+| orchestration corrections: dispatch, artifact, and verdict aggregation fixes | `consultation-preferred-patterns.md` | Loads detailed guidance from `consultation-preferred-patterns.md`. |
+| core consultation patterns and Phase 3 artifact templates | `consultation-patterns.md` | Loads detailed guidance from `consultation-patterns.md`. |
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
 
 ## Instructions

--- a/skills/process/feature-lifecycle/SKILL.md
+++ b/skills/process/feature-lifecycle/SKILL.md
@@ -106,14 +106,14 @@ Each phase produces an artifact consumed by the next. Skipping phases is not sup
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `design.md` | Loads detailed guidance from `design.md`. |
+| Phase 1 DESIGN: idea to design document | `design.md` | Loads detailed guidance from `design.md`. |
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
-| tasks related to this reference | `implement.md` | Loads detailed guidance from `implement.md`. |
-| tasks related to this reference | `pipeline.md` | Loads detailed guidance from `pipeline.md`. |
-| tasks related to this reference | `plan.md` | Loads detailed guidance from `plan.md`. |
-| tasks related to this reference | `release.md` | Loads detailed guidance from `release.md`. |
-| tasks related to this reference | `shared.md` | Loads detailed guidance from `shared.md`. |
-| tasks related to this reference | `validate.md` | Loads detailed guidance from `validate.md`. |
+| Phase 3 IMPLEMENT: dispatching task waves to domain agents | `implement.md` | Loads detailed guidance from `implement.md`. |
+| running the full design-to-release pipeline | `pipeline.md` | Loads detailed guidance from `pipeline.md`. |
+| Phase 2 PLAN: decomposing design into wave-ordered tasks | `plan.md` | Loads detailed guidance from `plan.md`. |
+| Phase 5 RELEASE: PR merge, tagging, worktree cleanup | `release.md` | Loads detailed guidance from `release.md`. |
+| feature state directory layout, naming, write protection | `shared.md` | Loads detailed guidance from `shared.md`. |
+| Phase 4 VALIDATE: running quality gates | `validate.md` | Loads detailed guidance from `validate.md`. |
 
 ## Error Handling
 

--- a/skills/process/forensics/SKILL.md
+++ b/skills/process/forensics/SKILL.md
@@ -48,9 +48,9 @@ Investigate failed or stuck workflows through post-mortem analysis of git histor
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `detectors.md` | Loads detailed guidance from `detectors.md`. |
-| tasks related to this reference | `evidence-collection.md` | Loads detailed guidance from `evidence-collection.md`. |
-| tasks related to this reference | `failure-signatures.md` | Loads detailed guidance from `failure-signatures.md`. |
+| Phase 2 DETECT: running the 5 anomaly detectors | `detectors.md` | Loads detailed guidance from `detectors.md`. |
+| Phase 1 GATHER: git extraction, loop queries, credential scrubbing | `evidence-collection.md` | Loads detailed guidance from `evidence-collection.md`. |
+| matching observed symptoms to the 5 failure types | `failure-signatures.md` | Loads detailed guidance from `failure-signatures.md`. |
 
 ## Instructions
 

--- a/skills/process/quick/SKILL.md
+++ b/skills/process/quick/SKILL.md
@@ -67,7 +67,7 @@ Quick covers the full lightweight tier from zero-ceremony inline fixes (≤3 edi
 | Signal | Load These Files | Why |
 |---|---|---|
 | example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
-| tasks related to this reference | `templates.md` | Loads detailed guidance from `templates.md`. |
+| emitting banners, commit format, or STATE.md entries | `templates.md` | Loads detailed guidance from `templates.md`. |
 
 ## Instructions
 

--- a/skills/process/verification-before-completion/SKILL.md
+++ b/skills/process/verification-before-completion/SKILL.md
@@ -38,7 +38,7 @@ This skill prevents the most common form of premature completion: claiming succe
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `adversarial-methodology.md` | Loads detailed guidance from `adversarial-methodology.md`. |
+| verifying artifacts are real and substantive, not stubs | `adversarial-methodology.md` | Loads detailed guidance from `adversarial-methodology.md`. |
 | checklist-driven work | `checklist.md` | Loads detailed guidance from `checklist.md`. |
 | example-driven tasks | `verification-examples.md` | Loads detailed guidance from `verification-examples.md`. |
 

--- a/skills/research/codebase-analyzer/SKILL.md
+++ b/skills/research/codebase-analyzer/SKILL.md
@@ -45,9 +45,9 @@ Load these files when the corresponding signals appear:
 | Signal | Load These Files | Why |
 |---|---|---|
 | example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
-| tasks related to this reference | `metrics-catalog.md` | Loads detailed guidance from `metrics-catalog.md`. |
-| tasks related to this reference | `phase-details.md` | Loads detailed guidance from `phase-details.md`. |
-| tasks related to this reference | `three-lenses.md` | Loads detailed guidance from `three-lenses.md`. |
+| computing the 100 metrics across 25 categories | `metrics-catalog.md` | Loads detailed guidance from `metrics-catalog.md`. |
+| phase banners, reconciliation matrix, rule format | `phase-details.md` | Loads detailed guidance from `phase-details.md`. |
+| understanding the measure-don't-read statistical approach | `three-lenses.md` | Loads detailed guidance from `three-lenses.md`. |
 
 ## Instructions
 

--- a/skills/research/codebase-overview/SKILL.md
+++ b/skills/research/codebase-overview/SKILL.md
@@ -35,8 +35,8 @@ Systematic 4-phase codebase exploration that produces an evidence-backed onboard
 | Signal | Load These Files | Why |
 |---|---|---|
 | example-driven tasks, errors | `examples-and-errors.md` | Loads detailed guidance from `examples-and-errors.md`. |
-| tasks related to this reference | `exploration-strategies.md` | Loads detailed guidance from `exploration-strategies.md`. |
-| tasks related to this reference | `report-template.md` | Loads detailed guidance from `report-template.md`. |
+| language-specific discovery commands per exploration phase | `exploration-strategies.md` | Loads detailed guidance from `exploration-strategies.md`. |
+| writing the 12-section overview report | `report-template.md` | Loads detailed guidance from `report-template.md`. |
 
 ## Instructions
 

--- a/skills/research/data-analysis/SKILL.md
+++ b/skills/research/data-analysis/SKILL.md
@@ -49,11 +49,11 @@ Every analysis begins with the decision being supported, works backward to the e
 | Signal | Load These Files | Why |
 |---|---|---|
 | implementation patterns | `preferred-patterns.md` | Loads detailed guidance from `preferred-patterns.md`. |
-| example-driven tasks | `compute-examples.md` | Loads detailed guidance from `compute-examples.md`. |
+| writing analysis scripts: tool detection and metric computation code | `compute-examples.md` | Loads detailed guidance from `compute-examples.md`. |
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
-| tasks related to this reference | `output-templates.md` | Loads detailed guidance from `output-templates.md`. |
-| tasks related to this reference | `rigor-gates.md` | Loads detailed guidance from `rigor-gates.md`. |
-| example-driven tasks | `worked-examples.md` | Loads detailed guidance from `worked-examples.md`. |
+| writing analysis-report.md per analysis type (A/B, trend, distribution) | `output-templates.md` | Loads detailed guidance from `output-templates.md`. |
+| applying Phase 4 statistical gates: adequacy, fairness, correction, significance | `rigor-gates.md` | Loads detailed guidance from `rigor-gates.md`. |
+| end-to-end phase walkthroughs on realistic inputs | `worked-examples.md` | Loads detailed guidance from `worked-examples.md`. |
 
 ## Instructions
 

--- a/skills/research/full-repo-review/SKILL.md
+++ b/skills/research/full-repo-review/SKILL.md
@@ -48,7 +48,7 @@ identical.
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `report-template.md` | Loads detailed guidance from `report-template.md`. |
+| writing full-repo-review-report.md | `report-template.md` | Loads detailed guidance from `report-template.md`. |
 
 ## Instructions
 

--- a/skills/research/multi-persona-critique/SKILL.md
+++ b/skills/research/multi-persona-critique/SKILL.md
@@ -55,8 +55,8 @@ This skill takes a set of proposals — feature ideas, architectural decisions, 
 | Signal | Load These Files | Why |
 |---|---|---|
 | example-driven tasks, errors | `examples-and-errors.md` | Loads detailed guidance from `examples-and-errors.md`. |
-| tasks related to this reference | `personas.md` | Loads detailed guidance from `personas.md`. |
-| tasks related to this reference | `synthesis-template.md` | Loads detailed guidance from `synthesis-template.md`. |
+| dispatching the five critique personas (Phase 2) | `personas.md` | Loads detailed guidance from `personas.md`. |
+| writing the Phase 5 synthesis report | `synthesis-template.md` | Loads detailed guidance from `synthesis-template.md`. |
 
 ## Instructions
 

--- a/skills/research/repo-value-analysis/SKILL.md
+++ b/skills/research/repo-value-analysis/SKILL.md
@@ -40,10 +40,10 @@ The pipeline enforces **full file reading** (not sampling), **parallel execution
 | Signal | Load These Files | Why |
 |---|---|---|
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
-| tasks related to this reference | `phase2-agent-template.md` | Loads detailed guidance from `phase2-agent-template.md`. |
-| tasks related to this reference | `phase3-inventory-template.md` | Loads detailed guidance from `phase3-inventory-template.md`. |
-| tasks related to this reference | `phase5-audit-template.md` | Loads detailed guidance from `phase5-audit-template.md`. |
-| tasks related to this reference | `phase6-report-template.md` | Loads detailed guidance from `phase6-report-template.md`. |
+| Phase 2 DEEP-READ: zone agent dispatch | `phase2-agent-template.md` | Loads detailed guidance from `phase2-agent-template.md`. |
+| Phase 3 INVENTORY: cataloging our system | `phase3-inventory-template.md` | Loads detailed guidance from `phase3-inventory-template.md`. |
+| Phase 5 AUDIT: verifying HIGH/MEDIUM recommendations | `phase5-audit-template.md` | Loads detailed guidance from `phase5-audit-template.md`. |
+| Phase 6 REPORT: final report structure | `phase6-report-template.md` | Loads detailed guidance from `phase6-report-template.md`. |
 
 ## Instructions
 

--- a/skills/research/roast/SKILL.md
+++ b/skills/research/roast/SKILL.md
@@ -47,8 +47,8 @@ This skill produces evidence-based constructive critique through 5 specialized H
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `personas.md` | Loads detailed guidance from `personas.md`. |
-| tasks related to this reference | `report-template.md` | Loads detailed guidance from `report-template.md`. |
+| dispatching roast personas; claim format and validation verdicts | `personas.md` | Loads detailed guidance from `personas.md`. |
+| writing the synthesized roast report | `report-template.md` | Loads detailed guidance from `report-template.md`. |
 
 ## Instructions
 

--- a/skills/review/integration-checker/SKILL.md
+++ b/skills/review/integration-checker/SKILL.md
@@ -38,7 +38,7 @@ This is a read-only analysis skill -- it reads and reports but does not fix wiri
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| tasks related to this reference | `wiring-checks.md` | Loads detailed guidance from `wiring-checks.md`. |
+| classifying exports/imports and tracing data flow (Phases 0-2) | `wiring-checks.md` | Loads detailed guidance from `wiring-checks.md`. |
 
 ## Instructions
 

--- a/skills/review/systematic-code-review/SKILL.md
+++ b/skills/review/systematic-code-review/SKILL.md
@@ -32,8 +32,8 @@ Systematic 4-phase code review: UNDERSTAND changes, VERIFY claims against actual
 | Signal | Load These Files | Why |
 |---|---|---|
 | implementation patterns | `go-review-patterns.md` | Loads detailed guidance from `go-review-patterns.md`. |
-| tasks related to this reference | `receiving-feedback.md` | Loads detailed guidance from `receiving-feedback.md`. |
-| tasks related to this reference | `severity-classification.md` | Loads detailed guidance from `severity-classification.md`. |
+| responding to review feedback on your own code | `receiving-feedback.md` | Loads detailed guidance from `receiving-feedback.md`. |
+| labeling findings: BLOCKING vs SHOULD FIX vs SUGGESTION | `severity-classification.md` | Loads detailed guidance from `severity-classification.md`. |
 
 ## Instructions
 

--- a/skills/testing/test-driven-development/SKILL.md
+++ b/skills/testing/test-driven-development/SKILL.md
@@ -38,7 +38,7 @@ Enforce the RED-GREEN-REFACTOR cycle for all code changes. Tests are written bef
 |---|---|---|
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
 | example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
-| tasks related to this reference | `phase-guidance.md` | Loads detailed guidance from `phase-guidance.md`. |
+| detailed phase steps, rationale, or language-specific test commands | `phase-guidance.md` | Loads detailed guidance from `phase-guidance.md`. |
 
 ## Instructions
 

--- a/skills/testing/testing-preferred-patterns/SKILL.md
+++ b/skills/testing/testing-preferred-patterns/SKILL.md
@@ -47,12 +47,12 @@ This skill identifies and fixes common testing mistakes across unit, integration
 | Signal | Load These Files | Why |
 |---|---|---|
 | implementation patterns | `preferred-pattern-catalog.md` | Loads detailed guidance from `preferred-pattern-catalog.md`. |
-| tasks related to this reference | `blind-spot-taxonomy.md` | Loads detailed guidance from `blind-spot-taxonomy.md`. |
+| auditing coverage gaps: concurrency, boundaries, security, error recovery | `blind-spot-taxonomy.md` | Loads detailed guidance from `blind-spot-taxonomy.md`. |
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
 | fixing review feedback | `fix-strategies.md` | Loads detailed guidance from `fix-strategies.md`. |
 | tests | `load-test-scenarios.md` | Loads detailed guidance from `load-test-scenarios.md`. |
-| tasks related to this reference | `quality-catalog.md` | Loads detailed guidance from `quality-catalog.md`. |
-| tasks related to this reference | `quick-reference.md` | Loads detailed guidance from `quick-reference.md`. |
+| classifying test-quality failure modes found during SCAN | `quality-catalog.md` | Loads detailed guidance from `quality-catalog.md`. |
+| fast pattern-symptom-fix lookup | `quick-reference.md` | Loads detailed guidance from `quick-reference.md`. |
 
 ## Instructions
 


### PR DESCRIPTION
## Summary
Closes the toolkit's largest reference-loading quality gap: every placeholder loading-table signal is replaced with a content-derived, task-disambiguating signal, and every orphan agent reference file is wired into its owner's loading table. validate-references.py --all now reports zero placeholder signals and zero orphans, and fails on either.

## Changes
- skills/**/SKILL.md (40 files) - rewrite 109 placeholder/duplicate Signal cells with signals derived from each reference's content
- agents/*.md (13 files) - rewrite 13 placeholder/generic signals; convert loading-table cells to dir-qualified markdown links (the validator declares references only via links); add table rows for 17 previously unlisted reference files
- agents/python-openstack-engineer.md, agents/perses-engineer.md - remove 2 phantom rows pointing at files that do not exist (tempest-testing.md, core.md)
- agents/python-general-engineer/references/ (4 files) - promote H3 to H2 in heading-less references
- scripts/validate-references.py - add PLACEHOLDER_SIGNAL detection to --all (text + JSON output, summary count, nonzero exit), preventing regression

## Notes
- All 46 orphans were wired; none deleted - every file carries unique content (deletion required evidence of superseded/empty/duplicate; none qualified).
- Validator still exits 1 on pre-existing out-of-scope items: 2 phantom refs in typescript-debugging-engineer and the EMPTY_SECTION reviewer templates.