### PR TITLE
fix(validator): harden placeholder-signal gate; orphans fail JSON exit_code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
       - run: ruff check . --config pyproject.toml
       - run: ruff format --check . --config pyproject.toml
       - run: python scripts/validate-references.py --check-do-framing
+      # Scoped flag: --all carries known pre-existing failures, so it cannot gate CI.
+      - run: python scripts/validate-references.py --check-placeholders
       - run: python scripts/validate-skill-frontmatter.py
       - run: python scripts/validate-index-integrity.py
       - run: python scripts/validate-doc-links.py

--- a/agents/typescript-debugging-engineer.md
+++ b/agents/typescript-debugging-engineer.md
@@ -130,9 +130,9 @@ Test Plan: [How to reproduce]
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| workflow steps | `debugging-workflows.md` | Race conditions, type errors, production debugging, async issues, git bisect, memory leaks |
+| debugging race conditions, async/await issues, memory leaks, production errors; bisecting regressions | `debugging-workflows.md` | Race conditions, type errors, production debugging, async issues, git bisect, memory leaks |
 | errors | `typescript-errors.md` | Build errors, type system errors, React errors |
-| implementation patterns | `typescript-preferred-patterns.md` | Preferred patterns and detection |
+| writing or reviewing TypeScript for preferred-pattern violations | `typescript-preferred-patterns.md` | Preferred patterns and detection |
 
 ## Error Handling
 

--- a/scripts/tests/test_find_placeholder_signals.py
+++ b/scripts/tests/test_find_placeholder_signals.py
@@ -1,0 +1,75 @@
+"""Tests for validate-references.py find_placeholder_signals and orphan exit codes.
+
+Covers PR #779 review findings F1-F3:
+1. Every PLACEHOLDER_SIGNALS variant in a loading-table row is flagged.
+2. Content-derived signals pass.
+3. Matching is case-insensitive and exact per cell; prose lines are ignored.
+4. build_json_results exit_code counts orphans as failures.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+vr = importlib.import_module("validate-references")
+
+
+@pytest.fixture()
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the validator at a temp repo; return a factory writing agents/*.md."""
+    (tmp_path / "agents").mkdir()
+    monkeypatch.setattr(vr, "REPO_ROOT", tmp_path)
+
+    def _write(table_row: str, name: str = "test-agent.md") -> Path:
+        f = tmp_path / "agents" / name
+        f.write_text(f"# Agent\n\n| Signal | File | Why |\n|---|---|---|\n{table_row}\n", encoding="utf-8")
+        return f
+
+    return _write
+
+
+class TestFindPlaceholderSignals:
+    @pytest.mark.parametrize("signal", vr.PLACEHOLDER_SIGNALS)
+    def test_each_variant_flagged(self, repo, signal: str) -> None:
+        repo(f"| {signal} | `ref.md` | Loads guidance. |")
+        hits = vr.find_placeholder_signals()
+        assert [(h[0], h[2]) for h in hits] == [(str(Path("agents") / "test-agent.md"), signal)]
+
+    def test_match_is_case_insensitive(self, repo) -> None:
+        repo("| Implementation Patterns | `ref.md` | Loads guidance. |")
+        assert len(vr.find_placeholder_signals()) == 1
+
+    def test_content_derived_signal_passes(self, repo) -> None:
+        repo("| debugging race conditions, memory leaks | `ref.md` | Workflows. |")
+        assert vr.find_placeholder_signals() == []
+
+    def test_superset_signal_not_flagged(self, repo) -> None:
+        """Match is exact per cell — a signal containing a variant plus more passes."""
+        repo("| tests, implementation patterns | `ref.md` | Loads guidance. |")
+        assert vr.find_placeholder_signals() == []
+
+    def test_prose_line_ignored(self, repo) -> None:
+        f = repo("| real signal | `ref.md` | Why. |")
+        f.write_text(
+            f.read_text(encoding="utf-8") + "\nUse workflow steps to plan implementation patterns.\n", encoding="utf-8"
+        )
+        assert vr.find_placeholder_signals() == []
+
+
+class TestJsonExitCode:
+    def test_orphans_set_exit_code(self) -> None:
+        orphan = vr.AGENTS_DIR / "x" / "references" / "orphan.md"
+        out = vr.build_json_results([], [orphan], [])
+        assert out["exit_code"] == 1
+
+    def test_clean_run_exit_code_zero(self) -> None:
+        out = vr.build_json_results([], [], [])
+        assert out["exit_code"] == 0

--- a/scripts/tests/test_find_placeholder_signals.py
+++ b/scripts/tests/test_find_placeholder_signals.py
@@ -10,6 +10,7 @@ Covers PR #779 review findings F1-F3:
 from __future__ import annotations
 
 import importlib
+import json
 import sys
 from pathlib import Path
 
@@ -62,6 +63,28 @@ class TestFindPlaceholderSignals:
             f.read_text(encoding="utf-8") + "\nUse workflow steps to plan implementation patterns.\n", encoding="utf-8"
         )
         assert vr.find_placeholder_signals() == []
+
+
+class TestRunCheckPlaceholders:
+    def test_hit_returns_one_and_prints(self, repo, capsys: pytest.CaptureFixture) -> None:
+        repo("| workflow steps | `ref.md` | Loads guidance. |")
+        assert vr.run_check_placeholders(json_output=False) == 1
+        out = capsys.readouterr().out
+        assert "PLACEHOLDER_SIGNAL: " in out
+        assert "1 placeholder signal(s) found" in out
+
+    def test_clean_returns_zero(self, repo, capsys: pytest.CaptureFixture) -> None:
+        repo("| real signal | `ref.md` | Why. |")
+        assert vr.run_check_placeholders(json_output=False) == 0
+        assert "all loading-table signals OK" in capsys.readouterr().out
+
+    def test_json_output(self, repo, capsys: pytest.CaptureFixture) -> None:
+        repo("| example-driven tasks | `ref.md` | Loads guidance. |")
+        assert vr.run_check_placeholders(json_output=True) == 1
+        out = json.loads(capsys.readouterr().out)
+        assert out["exit_code"] == 1
+        assert out["total"] == 1
+        assert out["placeholder_signals"][0]["signal"] == "example-driven tasks"
 
 
 class TestJsonExitCode:

--- a/scripts/validate-references.py
+++ b/scripts/validate-references.py
@@ -341,7 +341,12 @@ def validate_agent(agent_file: Path, check_structure: bool = True) -> AgentResul
 
 
 # Generic signals that cannot disambiguate which reference to load.
-PLACEHOLDER_SIGNALS = ("tasks related to this reference",)
+PLACEHOLDER_SIGNALS = (
+    "tasks related to this reference",
+    "implementation patterns",
+    "workflow steps",
+    "example-driven tasks",
+)
 
 _PLACEHOLDER_SCAN_PATTERNS = ["agents/*.md", "skills/**/SKILL.md"]
 
@@ -479,7 +484,7 @@ def build_json_results(
             "orphans": len(orphans),
             "placeholder_signals": len(placeholders),
         },
-        "exit_code": 1 if has_failures or placeholders else 0,
+        "exit_code": 1 if has_failures or orphans or placeholders else 0,
     }
 
 
@@ -490,6 +495,11 @@ def main() -> None:
     parser.add_argument("--all", action="store_true", help="Validate all agents")
     parser.add_argument("--check-declared", action="store_true", help="Only check declared refs exist")
     parser.add_argument("--check-do-framing", action="store_true", help="Check all files for unpaired anti-patterns")
+    parser.add_argument(
+        "--check-placeholders",
+        action="store_true",
+        help="Check loading tables for placeholder signals only",
+    )
     parser.add_argument(
         "--allowlist",
         metavar="PATH",
@@ -507,8 +517,16 @@ def main() -> None:
         allowlist = Path(args.allowlist) if args.allowlist else None
         sys.exit(run_check_do_framing(json_output=args.json_output, allowlist_path=allowlist))
 
+    if args.check_placeholders:
+        hits = find_placeholder_signals()
+        for rel, lineno, signal in hits:
+            print(f"  PLACEHOLDER_SIGNAL: {rel}:{lineno} — {signal!r}")
+        if hits:
+            print(f"\n{len(hits)} placeholder signal(s) found")
+        sys.exit(1 if hits else 0)
+
     if not args.agent and not args.all:
-        parser.error("Specify --agent <name>, --all, or --check-do-framing")
+        parser.error("Specify --agent <name>, --all, --check-do-framing, or --check-placeholders")
 
     check_structure = not args.check_declared
 

--- a/scripts/validate-references.py
+++ b/scripts/validate-references.py
@@ -372,6 +372,23 @@ def find_placeholder_signals() -> list[tuple[str, int, str]]:
     return found
 
 
+def run_check_placeholders(json_output: bool) -> int:
+    """Scan loading tables for placeholder signals; return the exit code."""
+    hits = find_placeholder_signals()
+    if json_output:
+        out = {
+            "total": len(hits),
+            "placeholder_signals": [{"file": rel, "line": lineno, "signal": signal} for rel, lineno, signal in hits],
+            "exit_code": 1 if hits else 0,
+        }
+        print(json.dumps(out, indent=2))
+    else:
+        for rel, lineno, signal in hits:
+            print(f"  PLACEHOLDER_SIGNAL: {rel}:{lineno} — {signal!r}")
+        print(f"\n{len(hits)} placeholder signal(s) found" if hits else "PLACEHOLDERS: all loading-table signals OK")
+    return 1 if hits else 0
+
+
 def find_all_reference_files() -> list[Path]:
     """Find every .md file inside any references/ subdirectory under agents/."""
     return list(AGENTS_DIR.rglob("references/*.md"))
@@ -518,12 +535,7 @@ def main() -> None:
         sys.exit(run_check_do_framing(json_output=args.json_output, allowlist_path=allowlist))
 
     if args.check_placeholders:
-        hits = find_placeholder_signals()
-        for rel, lineno, signal in hits:
-            print(f"  PLACEHOLDER_SIGNAL: {rel}:{lineno} — {signal!r}")
-        if hits:
-            print(f"\n{len(hits)} placeholder signal(s) found")
-        sys.exit(1 if hits else 0)
+        sys.exit(run_check_placeholders(json_output=args.json_output))
 
     if not args.agent and not args.all:
         parser.error("Specify --agent <name>, --all, --check-do-framing, or --check-placeholders")

--- a/skills/content/create-voice/SKILL.md
+++ b/skills/content/create-voice/SKILL.md
@@ -45,7 +45,7 @@ Create a complete voice profile from writing samples through a 7-phase pipeline.
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
 | extraction validation, pattern verdict, triple-validation | `extraction-validation.md` | Triple-validation rubric (recurrence, generative power, exclusivity) gating which patterns survive into the profile. |
 | Steps 6-7: validation procedure and authorship matching | `iteration-guide.md` | Loads detailed guidance from `iteration-guide.md`. |
-| implementation patterns | `pattern-identification.md` | Loads detailed guidance from `pattern-identification.md`. |
+| Step 3: PATTERN — phrase fingerprints, thinking patterns, wabi-sabi markers | `pattern-identification.md` | Loads detailed guidance from `pattern-identification.md`. |
 | reporting progress at phase gates | `phase-banners.md` | Loads detailed guidance from `phase-banners.md`. |
 | locating exemplar voice skills and components | `reference-implementations.md` | Loads detailed guidance from `reference-implementations.md`. |
 | Step 1 COLLECT: finding, vetting, and formatting samples | `sample-collection.md` | Loads detailed guidance from `sample-collection.md`. |

--- a/skills/content/professional-communication/SKILL.md
+++ b/skills/content/professional-communication/SKILL.md
@@ -36,7 +36,7 @@ This skill transforms dense technical communication into clear, structured busin
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
+| transforming raw engineer notes: stream-of-consciousness debugging, blockers, crisis updates | `examples.md` | Loads detailed guidance from `examples.md`. |
 | drafting from section templates; phrase transformations | `templates.md` | Loads detailed guidance from `templates.md`. |
 
 ## Instructions

--- a/skills/content/wordpress-live-validation/SKILL.md
+++ b/skills/content/wordpress-live-validation/SKILL.md
@@ -54,7 +54,7 @@ This skill loads a real WordPress post in a Playwright headless browser and veri
 | Playwright MCP tool signatures, pitfalls, availability detection | `playwright-tools.md` | Loads detailed guidance from `playwright-tools.md`. |
 | step-by-step NAVIGATE, VALIDATE, RESPONSIVE procedures | `phase-checks.md` | Loads detailed guidance from `phase-checks.md`. |
 | Phase 4 REPORT output format | `output-format.md` | Loads detailed guidance from `output-format.md`. |
-| example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
+| post-upload validation walkthrough; wordpress-uploader integration | `examples.md` | Loads detailed guidance from `examples.md`. |
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
 
 ## Instructions

--- a/skills/engineering/php-testing/SKILL.md
+++ b/skills/engineering/php-testing/SKILL.md
@@ -28,7 +28,7 @@ Apply PHPUnit testing patterns for PHP projects: unit tests with data providers,
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| implementation patterns | `patterns.md` | Loads detailed guidance from `patterns.md`. |
+| writing PHPUnit tests: data providers, mocks/stubs, database or HTTP tests, coverage config | `patterns.md` | Loads detailed guidance from `patterns.md`. |
 
 ## Instructions
 

--- a/skills/infrastructure/fish-shell-config/SKILL.md
+++ b/skills/infrastructure/fish-shell-config/SKILL.md
@@ -40,7 +40,7 @@ Fish is not POSIX. Every pattern here targets Fish 3.0+ (supports `$()`, `&&`, `
 | Signal | Load These Files | Why |
 |---|---|---|
 | migrations | `bash-migration.md` | Loads detailed guidance from `bash-migration.md`. |
-| implementation patterns | `fish-preferred-patterns.md` | Loads detailed guidance from `fish-preferred-patterns.md`. |
+| editing fish config: variable assignment, PATH management, conditionals, tool integration | `fish-preferred-patterns.md` | Loads detailed guidance from `fish-preferred-patterns.md`. |
 | syntax lookup: variable scope, PATH, functions, abbreviations, conditionals, debugging | `fish-quick-reference.md` | Loads detailed guidance from `fish-quick-reference.md`. |
 | wiring dev tools into fish: Go, Rust, Node, Python, Docker, PATH and init hooks | `tool-integrations.md` | Loads detailed guidance from `tool-integrations.md`. |
 

--- a/skills/meta/docs-sync-checker/SKILL.md
+++ b/skills/meta/docs-sync-checker/SKILL.md
@@ -38,7 +38,7 @@ Optional flags: `--auto-fix` (experimental, requires explicit opt-in), `--strict
 | Signal | Load These Files | Why |
 |---|---|---|
 | documentation work | `documentation-structure.md` | Loads detailed guidance from `documentation-structure.md`. |
-| example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
+| before/after doc-update examples: adding skill docs, removing deprecated agent docs | `examples.md` | Loads detailed guidance from `examples.md`. |
 | wiring the checker into CI, pre-commit, or auto-fix mode | `integration-guide.md` | Loads detailed guidance from `integration-guide.md`. |
 | expected table and list formats per README file | `markdown-formats.md` | Loads detailed guidance from `markdown-formats.md`. |
 | which docs must list which tools; sync score and deprecation rules | `sync-rules.md` | Loads detailed guidance from `sync-rules.md`. |

--- a/skills/meta/routing-table-updater/SKILL.md
+++ b/skills/meta/routing-table-updater/SKILL.md
@@ -42,7 +42,7 @@ The skill reads metadata from all skills and agents (never modifies them) and sa
 | resolving trigger conflicts: priority rules and severity levels | `conflict-resolution.md` | Loads detailed guidance from `conflict-resolution.md`. |
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
 | worked update scenarios: new skill, conflict, manual entry, complexity change | `examples.md` | Loads detailed guidance from `examples.md`. |
-| implementation patterns | `extraction-patterns.md` | Loads detailed guidance from `extraction-patterns.md`. |
+| extracting trigger phrases: 'use when' clauses, action verbs, domain keywords, complexity inference | `extraction-patterns.md` | Loads detailed guidance from `extraction-patterns.md`. |
 | /do routing table structure, auto-generated markers, ordering rules | `routing-format.md` | Loads detailed guidance from `routing-format.md`. |
 | skill-entry examples for registering a newly created skill | `skill-examples.md` | Loads detailed guidance from `skill-examples.md`. |
 

--- a/skills/meta/skill-composer/SKILL.md
+++ b/skills/meta/skill-composer/SKILL.md
@@ -38,7 +38,7 @@ Orchestrate complex workflows by chaining multiple skills into validated executi
 |---|---|---|
 | checking skill chain compatibility and input/output type matching | `compatibility-matrix.md` | Loads detailed guidance from `compatibility-matrix.md`. |
 | choosing sequential vs parallel composition; chain length limits | `composition-patterns.md` | Loads detailed guidance from `composition-patterns.md`. |
-| example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
+| composition walkthroughs: feature+tests, debug+docs, parallel quality checks, research-driven builds | `examples.md` | Loads detailed guidance from `examples.md`. |
 | selecting a proven composition pattern; troubleshooting compositions | `skill-patterns.md` | Loads detailed guidance from `skill-patterns.md`. |
 
 ## Instructions

--- a/skills/meta/toolkit-evolution/SKILL.md
+++ b/skills/meta/toolkit-evolution/SKILL.md
@@ -46,7 +46,7 @@ Invoke: `/evolve`, `/evolve routing`, `/evolve hooks`, `/evolve --discover`. Cro
 |---|---|---|
 | running DISCOVER/DIAGNOSE commands: learning DB queries, git scan, drift checks | `diagnose-scripts.md` | Loads detailed guidance from `diagnose-scripts.md`. |
 | writing the evolution cycle report | `evolution-report-template.md` | Loads detailed guidance from `evolution-report-template.md`. |
-| implementation patterns | `evolve-preferred-patterns.md` | Loads detailed guidance from `evolve-preferred-patterns.md`. |
+| Phase 3 CRITIQUE fallback; failure modes, error handling, cost estimates, cron setup | `evolve-preferred-patterns.md` | Loads detailed guidance from `evolve-preferred-patterns.md`. |
 | Phase 6 EVOLVE: PR creation, merge, branch cleanup, learning records | `evolve-scripts.md` | Loads detailed guidance from `evolve-scripts.md`. |
 
 ## Instructions

--- a/skills/process/condition-based-waiting/SKILL.md
+++ b/skills/process/condition-based-waiting/SKILL.md
@@ -40,8 +40,8 @@ Implement condition-based polling and retry patterns with bounded timeouts, jitt
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| implementation patterns | `preferred-patterns.md` | Loads detailed guidance from `preferred-patterns.md`. |
-| implementation patterns | `implementation-patterns.md` | Loads detailed guidance from `implementation-patterns.md`. |
+| reviewing wait/retry code for polling, retry, and backoff mistakes | `preferred-patterns.md` | Loads detailed guidance from `preferred-patterns.md`. |
+| writing wait code: polling, exponential backoff, rate-limit recovery, health checks, circuit breaker | `implementation-patterns.md` | Loads detailed guidance from `implementation-patterns.md`. |
 | tests, implementation patterns | `testing-patterns.md` | Loads detailed guidance from `testing-patterns.md`. |
 
 ## Instructions

--- a/skills/process/quick/SKILL.md
+++ b/skills/process/quick/SKILL.md
@@ -66,7 +66,7 @@ Quick covers the full lightweight tier from zero-ceremony inline fixes (≤3 edi
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
+| usage examples, task ID format, error handling | `examples.md` | Loads detailed guidance from `examples.md`. |
 | emitting banners, commit format, or STATE.md entries | `templates.md` | Loads detailed guidance from `templates.md`. |
 
 ## Instructions

--- a/skills/process/verification-before-completion/SKILL.md
+++ b/skills/process/verification-before-completion/SKILL.md
@@ -40,7 +40,7 @@ This skill prevents the most common form of premature completion: claiming succe
 |---|---|---|
 | verifying artifacts are real and substantive, not stubs | `adversarial-methodology.md` | Loads detailed guidance from `adversarial-methodology.md`. |
 | checklist-driven work | `checklist.md` | Loads detailed guidance from `checklist.md`. |
-| example-driven tasks | `verification-examples.md` | Loads detailed guidance from `verification-examples.md`. |
+| good-vs-bad verification walkthroughs: bug fix, refactor, migration, config change | `verification-examples.md` | Loads detailed guidance from `verification-examples.md`. |
 
 ## Instructions
 

--- a/skills/research/codebase-analyzer/SKILL.md
+++ b/skills/research/codebase-analyzer/SKILL.md
@@ -44,7 +44,7 @@ Load these files when the corresponding signals appear:
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
+| worked analyses: single Go service, multi-repo comparison, pattern adoption and evolution tracking | `examples.md` | Loads detailed guidance from `examples.md`. |
 | computing the 100 metrics across 25 categories | `metrics-catalog.md` | Loads detailed guidance from `metrics-catalog.md`. |
 | phase banners, reconciliation matrix, rule format | `phase-details.md` | Loads detailed guidance from `phase-details.md`. |
 | understanding the measure-don't-read statistical approach | `three-lenses.md` | Loads detailed guidance from `three-lenses.md`. |

--- a/skills/research/data-analysis/SKILL.md
+++ b/skills/research/data-analysis/SKILL.md
@@ -48,7 +48,7 @@ Every analysis begins with the decision being supported, works backward to the e
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| implementation patterns | `preferred-patterns.md` | Loads detailed guidance from `preferred-patterns.md`. |
+| extended pattern catalog: methodology, statistical, communication, process fixes | `preferred-patterns.md` | Loads detailed guidance from `preferred-patterns.md`. |
 | writing analysis scripts: tool detection and metric computation code | `compute-examples.md` | Loads detailed guidance from `compute-examples.md`. |
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
 | writing analysis-report.md per analysis type (A/B, trend, distribution) | `output-templates.md` | Loads detailed guidance from `output-templates.md`. |

--- a/skills/review/systematic-code-review/SKILL.md
+++ b/skills/review/systematic-code-review/SKILL.md
@@ -31,7 +31,7 @@ Systematic 4-phase code review: UNDERSTAND changes, VERIFY claims against actual
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| implementation patterns | `go-review-patterns.md` | Loads detailed guidance from `go-review-patterns.md`. |
+| reviewing Go code: type exports, concurrency, resource management, observability, test patterns | `go-review-patterns.md` | Loads detailed guidance from `go-review-patterns.md`. |
 | responding to review feedback on your own code | `receiving-feedback.md` | Loads detailed guidance from `receiving-feedback.md`. |
 | labeling findings: BLOCKING vs SHOULD FIX vs SUGGESTION | `severity-classification.md` | Loads detailed guidance from `severity-classification.md`. |
 

--- a/skills/testing/test-driven-development/SKILL.md
+++ b/skills/testing/test-driven-development/SKILL.md
@@ -37,7 +37,7 @@ Enforce the RED-GREEN-REFACTOR cycle for all code changes. Tests are written bef
 | Signal | Load These Files | Why |
 |---|---|---|
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
-| example-driven tasks | `examples.md` | Loads detailed guidance from `examples.md`. |
+| full RED-GREEN-REFACTOR walkthroughs in Go, Python, JavaScript | `examples.md` | Loads detailed guidance from `examples.md`. |
 | detailed phase steps, rationale, or language-specific test commands | `phase-guidance.md` | Loads detailed guidance from `phase-guidance.md`. |
 
 ## Instructions

--- a/skills/testing/testing-agents-with-subagents/SKILL.md
+++ b/skills/testing/testing-agents-with-subagents/SKILL.md
@@ -42,7 +42,7 @@ Each test runs in a fresh subagent to avoid context pollution. After any fix, re
 | Signal | Load These Files | Why |
 |---|---|---|
 | example-driven tasks, errors | `examples-and-errors.md` | Loads detailed guidance from `examples-and-errors.md`. |
-| implementation patterns | `testing-patterns.md` | Loads detailed guidance from `testing-patterns.md`. |
+| dispatch-and-capture, negative, consistency, A/B, and routing-verification test patterns | `testing-patterns.md` | Loads detailed guidance from `testing-patterns.md`. |
 
 ## Instructions
 

--- a/skills/testing/testing-preferred-patterns/SKILL.md
+++ b/skills/testing/testing-preferred-patterns/SKILL.md
@@ -46,7 +46,7 @@ This skill identifies and fixes common testing mistakes across unit, integration
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| implementation patterns | `preferred-pattern-catalog.md` | Loads detailed guidance from `preferred-pattern-catalog.md`. |
+| BAD/GOOD code examples for all 10 testing failure modes | `preferred-pattern-catalog.md` | Loads detailed guidance from `preferred-pattern-catalog.md`. |
 | auditing coverage gaps: concurrency, boundaries, security, error recovery | `blind-spot-taxonomy.md` | Loads detailed guidance from `blind-spot-taxonomy.md`. |
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
 | fixing review feedback | `fix-strategies.md` | Loads detailed guidance from `fix-strategies.md`. |


### PR DESCRIPTION
## Summary
Applies PR #779 review findings F1-F3: the placeholder-signal check now catches the generic variants the sweep observed, runs in CI, and JSON output no longer reports exit_code 0 when orphans fail the process.

## Changes
- `scripts/validate-references.py` — F1: add 'implementation patterns', 'workflow steps', 'example-driven tasks' to `PLACEHOLDER_SIGNALS`; F3: count orphans in JSON `exit_code`; add scoped `--check-placeholders` flag
- `scripts/tests/test_find_placeholder_signals.py` — F2: unit tests for each variant, case-insensitivity, exact-cell matching, prose immunity, and orphan exit codes
- `.github/workflows/test.yml` — F2: run `--check-placeholders` in the lint job
- 19 `SKILL.md` files + `agents/typescript-debugging-engineer.md` — rewrite the 21 loading-table signals the new variants flagged with content-derived phrases

## Notes
- CI gets the scoped flag, not `--all` — `--all` carries known pre-existing failures (2 typescript MISSING + structure advisories)
- `typescript-preferred-patterns.md` row signal rewritten from its table's Why cell; the file itself is a known pre-existing MISSING, untouched here