### PR TITLE
fix(sync): materialize runtime skills index as tracked-first merge

### DIFF
--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -337,6 +337,72 @@ def _ensure_symlink(src: Path, dst: Path) -> bool:
     return True
 
 
+def _merged_runtime_index(tracked: Path, local: Path) -> dict | None:
+    """Merge the tracked skills index with the gitignored local override.
+
+    Tracked items load first; local items fill gaps per-name (setdefault,
+    add-only). A stale INDEX.local.json can never hide a tracked skill and
+    never overrides tracked entry content — the same merge semantics as
+    _load_index_items in scripts/routing-manifest.py, pre-route.py, and
+    index-router.py (PR #778). Top-level metadata comes from the tracked
+    file; local supplies it only when the tracked file is missing/invalid.
+
+    Returns None when neither file yields a JSON object.
+    """
+    docs = []
+    for path in (tracked, local):
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if isinstance(raw, dict):
+            docs.append(raw)
+    if not docs:
+        return None
+    merged = dict(docs[0])
+    skills: dict = {}
+    for doc in docs:
+        loaded = doc.get("skills", {})
+        if isinstance(loaded, dict):
+            for name, data in loaded.items():
+                skills.setdefault(name, data)
+    merged["skills"] = skills
+    return merged
+
+
+def _sync_runtime_skill_index(src: Path, dst: Path) -> bool:
+    """Write ~/.claude/skills/INDEX.json as a real merged file.
+
+    The runtime index the harness reads — and may rewrite in place — must be
+    a regular file, never a symlink into the repo:
+    - A symlink to the tracked INDEX.json leaks in-place harness writes into
+      the repo's public index (the recurring private-skill leak).
+    - A symlink to the gitignored INDEX.local.json lets a stale local file
+      hide newly added tracked skills (replace semantics, PR #778 bug class).
+    A materialized tracked-first merge gives both invariants: every tracked
+    entry is present, and writes land in ~/.claude only.
+
+    Returns True when the runtime index exists after the call.
+    """
+    merged = _merged_runtime_index(src / "INDEX.json", src / "INDEX.local.json")
+    if merged is None:
+        return False
+    runtime = dst / "INDEX.json"
+    # Skip the write when content already matches. Only compare a real file:
+    # reading through a symlink would compare repo content and leave the
+    # leaking symlink in place.
+    if runtime.is_file() and not runtime.is_symlink():
+        try:
+            if json.loads(runtime.read_text(encoding="utf-8")) == merged:
+                return True
+        except (json.JSONDecodeError, OSError):
+            pass
+    # _atomic_json_write swaps via os.replace, which replaces a pre-fix
+    # symlink's directory entry — the repo file it pointed at is untouched.
+    _atomic_json_write(runtime, merged)
+    return True
+
+
 def _sync_skills_flat_symlinks(src: Path, dst: Path) -> None:
     """Create flat per-skill symlinks from nested category structure.
 
@@ -352,13 +418,9 @@ def _sync_skills_flat_symlinks(src: Path, dst: Path) -> None:
     Root-level items (INDEX.json, support dirs like shared-patterns/,
     workflow/, kb/, voice-shared-references/) are symlinked directly.
 
-    Index-symlink policy (prevents the private-skill leak into the *tracked*
-    skills/INDEX.json): ~/.claude/skills/INDEX.json is the runtime index the
-    harness reads — and may rewrite in place. The private-inclusive view lives
-    in the gitignored skills/INDEX.local.json. So when a local index exists we
-    point ~/.claude/skills/INDEX.json at INDEX.local.json: any in-place harness
-    write then lands in the gitignored file, never the tracked public index.
-    Without a local index, INDEX.json falls back to the tracked public file.
+    Runtime-index policy: ~/.claude/skills/INDEX.json is materialized as a
+    real merged file (tracked first, local fills gaps per-name), never a
+    symlink. See _sync_runtime_skill_index for the two invariants this keeps.
     """
     # If dst is a single symlink to the repo (old-style), replace with a real dir
     if dst.is_symlink():
@@ -369,28 +431,21 @@ def _sync_skills_flat_symlinks(src: Path, dst: Path) -> None:
     # Track what we create so we can clean stale entries
     expected_names: set[str] = set()
 
-    # Resolve the index-symlink targets per the leak-prevention policy above.
-    local_index = src / "INDEX.local.json"
-    runtime_index_target = local_index if local_index.is_file() else (src / "INDEX.json")
+    # Materialize the runtime index as a real merged file (never a symlink).
+    if _sync_runtime_skill_index(src, dst):
+        expected_names.add("INDEX.json")
 
-    def _index_target(item: Path) -> Path:
-        # Redirect the runtime INDEX.json symlink to the private-inclusive
-        # local index so harness writes never reach the tracked public file.
-        if item.name == "INDEX.json":
-            return runtime_index_target
-        return item
-
-    # Symlink root-level files (INDEX.json, INDEX.local.json, README.md)
+    # Symlink root-level files (INDEX.local.json, README.md). INDEX.json is
+    # excluded: it was materialized above.
     for item in src.iterdir():
-        if item.is_file():
+        if item.is_file() and item.name != "INDEX.json":
             expected_names.add(item.name)
-            link_src = _index_target(item)
             target = dst / item.name
             if target.is_symlink() or target.exists():
-                if target.is_symlink() and target.resolve() == link_src.resolve():
+                if target.is_symlink() and target.resolve() == item.resolve():
                     continue
                 target.unlink()
-            target.symlink_to(link_src)
+            target.symlink_to(item)
 
     # Symlink root-level support directories (shared-patterns, workflow, kb,
     # voice-shared-references). These hold reference files, not skills.
@@ -634,6 +689,13 @@ def main():
                     else:
                         shutil.copy2(item, target)
                     count += 1
+
+            # Runtime skill index: overwrite the plain tracked copy with the
+            # tracked+local merge (same invariants as symlink mode). Record
+            # its path so deferred stale cleanup spares it even when the repo
+            # has only INDEX.local.json.
+            if src_name == "skills" and _sync_runtime_skill_index(src, dst):
+                src_relative_paths.add(Path("INDEX.json"))
 
             # Accumulate paths per destination for deferred stale cleanup
             if src_name not in additive_only:

--- a/hooks/tests/test_sync_to_user_claude.py
+++ b/hooks/tests/test_sync_to_user_claude.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -196,48 +197,135 @@ class TestEnsureSymlink:
         assert not dst.exists()
 
 
-class TestSkillsFlatSymlinkIndexPolicy:
-    """The runtime ~/.claude/skills/INDEX.json symlink must point at the
-    gitignored INDEX.local.json (when present) so in-place harness writes never
-    reach the tracked public INDEX.json. Root cause of the recurring private-
-    skill leak."""
+class TestRuntimeIndexMerge:
+    """The runtime ~/.claude/skills/INDEX.json must be a real file holding
+    the tracked-first merge of skills/INDEX.json and skills/INDEX.local.json.
 
-    def _make_src(self, tmp_path: Path, with_local: bool) -> Path:
+    Two invariants (PR #778 bug class plus the private-skill leak):
+    1. Every tracked entry is present; local entries add per-name. A stale
+       local can neither hide nor override tracked entries.
+    2. In-place writes to the runtime index never reach the repo files.
+    """
+
+    TRACKED: ClassVar[dict] = {
+        "version": "2.0",
+        "skills": {
+            "do": {"description": "tracked do"},
+            "new-skill": {"description": "added after local was generated"},
+        },
+    }
+    LOCAL: ClassVar[dict] = {
+        "version": "2.0",
+        "skills": {
+            "do": {"description": "STALE do"},
+            "voice-x": {"description": "private"},
+        },
+    }
+
+    def _make_src(self, tmp_path: Path, with_tracked: bool = True, with_local: bool = True) -> Path:
         src = tmp_path / "skills"
         src.mkdir()
-        (src / "INDEX.json").write_text('{"skills": {}}\n')
+        if with_tracked:
+            (src / "INDEX.json").write_text(json.dumps(self.TRACKED))
         if with_local:
-            (src / "INDEX.local.json").write_text('{"skills": {"voice-x": {}}}\n')
+            # Stale local: superset of old entries, missing "new-skill"
+            (src / "INDEX.local.json").write_text(json.dumps(self.LOCAL))
         # one real skill so the flatten loop has something to do
         skill = src / "meta" / "do"
         skill.mkdir(parents=True)
         (skill / "SKILL.md").write_text("---\nname: do\n---\n")
         return src
 
-    def test_index_redirects_to_local_when_present(self, tmp_path: Path) -> None:
-        src = self._make_src(tmp_path, with_local=True)
+    def test_stale_local_does_not_hide_tracked_entries(self, tmp_path: Path) -> None:
+        src = self._make_src(tmp_path)
         dst = tmp_path / "out"
         sync_mod._sync_skills_flat_symlinks(src, dst)
-        # INDEX.json symlink resolves to the gitignored local file
-        assert (dst / "INDEX.json").resolve() == (src / "INDEX.local.json").resolve()
-        # INDEX.local.json still maps to itself
-        assert (dst / "INDEX.local.json").resolve() == (src / "INDEX.local.json").resolve()
 
-    def test_inplace_write_through_index_spares_tracked_file(self, tmp_path: Path) -> None:
-        src = self._make_src(tmp_path, with_local=True)
+        runtime = dst / "INDEX.json"
+        assert runtime.is_file() and not runtime.is_symlink()
+        skills = json.loads(runtime.read_text())["skills"]
+        # Every tracked entry present; local adds its private entry
+        assert set(self.TRACKED["skills"]) <= set(skills)
+        assert "voice-x" in skills
+
+    def test_local_cannot_override_tracked_content(self, tmp_path: Path) -> None:
+        src = self._make_src(tmp_path)
         dst = tmp_path / "out"
         sync_mod._sync_skills_flat_symlinks(src, dst)
+
+        skills = json.loads((dst / "INDEX.json").read_text())["skills"]
+        assert skills["do"] == {"description": "tracked do"}
+
+    def test_inplace_write_never_reaches_repo_files(self, tmp_path: Path) -> None:
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "out"
+        sync_mod._sync_skills_flat_symlinks(src, dst)
+
         # Simulate a harness rewriting the runtime index in place
-        (dst / "INDEX.json").write_text('{"skills": {"voice-x": {}, "leak": {}}}\n')
-        # Tracked public index is untouched; the local (gitignored) one absorbs it
-        assert json.loads((src / "INDEX.json").read_text()) == {"skills": {}}
-        assert "leak" in json.loads((src / "INDEX.local.json").read_text())["skills"]
+        (dst / "INDEX.json").write_text('{"skills": {"leak": {}}}\n')
 
-    def test_index_falls_back_to_tracked_without_local(self, tmp_path: Path) -> None:
+        assert json.loads((src / "INDEX.json").read_text()) == self.TRACKED
+        assert json.loads((src / "INDEX.local.json").read_text()) == self.LOCAL
+
+    def test_inplace_write_spares_tracked_without_local(self, tmp_path: Path) -> None:
+        """No local index: runtime must still be a real file, not a symlink
+        to the tracked index (the old fallback leaked writes into the repo)."""
         src = self._make_src(tmp_path, with_local=False)
         dst = tmp_path / "out"
         sync_mod._sync_skills_flat_symlinks(src, dst)
-        assert (dst / "INDEX.json").resolve() == (src / "INDEX.json").resolve()
+
+        runtime = dst / "INDEX.json"
+        assert runtime.is_file() and not runtime.is_symlink()
+        assert json.loads(runtime.read_text())["skills"] == self.TRACKED["skills"]
+
+        runtime.write_text('{"skills": {"leak": {}}}\n')
+        assert json.loads((src / "INDEX.json").read_text()) == self.TRACKED
+
+    def test_local_only_still_materializes(self, tmp_path: Path) -> None:
+        src = self._make_src(tmp_path, with_tracked=False)
+        dst = tmp_path / "out"
+        sync_mod._sync_skills_flat_symlinks(src, dst)
+
+        skills = json.loads((dst / "INDEX.json").read_text())["skills"]
+        assert skills == self.LOCAL["skills"]
+
+    def test_pre_fix_symlink_replaced_by_real_file(self, tmp_path: Path) -> None:
+        """A pre-fix install left dst/INDEX.json as a symlink into the repo.
+        Sync must swap it for the real merged file without touching the repo
+        file it pointed at."""
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "out"
+        dst.mkdir()
+        (dst / "INDEX.json").symlink_to(src / "INDEX.local.json")
+
+        sync_mod._sync_skills_flat_symlinks(src, dst)
+
+        runtime = dst / "INDEX.json"
+        assert runtime.is_file() and not runtime.is_symlink()
+        assert "new-skill" in json.loads(runtime.read_text())["skills"]
+        assert json.loads((src / "INDEX.local.json").read_text()) == self.LOCAL
+
+    def test_unchanged_index_not_rewritten(self, tmp_path: Path) -> None:
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "out"
+        sync_mod._sync_skills_flat_symlinks(src, dst)
+        mtime_before = (dst / "INDEX.json").stat().st_mtime_ns
+
+        sync_mod._sync_skills_flat_symlinks(src, dst)
+        assert (dst / "INDEX.json").stat().st_mtime_ns == mtime_before
+
+    def test_no_index_files_creates_nothing(self, tmp_path: Path) -> None:
+        src = self._make_src(tmp_path, with_tracked=False, with_local=False)
+        dst = tmp_path / "out"
+        sync_mod._sync_skills_flat_symlinks(src, dst)
+        assert not (dst / "INDEX.json").exists()
+
+    def test_local_symlink_still_created(self, tmp_path: Path) -> None:
+        """INDEX.local.json keeps its plain root-file symlink."""
+        src = self._make_src(tmp_path)
+        dst = tmp_path / "out"
+        sync_mod._sync_skills_flat_symlinks(src, dst)
+        assert (dst / "INDEX.local.json").resolve() == (src / "INDEX.local.json").resolve()
 
 
 class TestSupportDirSurvivesCleanup:
@@ -497,3 +585,91 @@ class TestMainSymlinkMode:
         # Nothing should have been created
         assert not (user_claude / "agents").exists()
         assert not (user_claude / "hooks").exists()
+
+
+class TestMainRuntimeIndex:
+    """End-to-end runtime-index invariants through main(), both install modes."""
+
+    TRACKED: ClassVar[dict] = {"version": "2.0", "skills": {"sample": {"description": "tracked"}}}
+    LOCAL: ClassVar[dict] = {
+        "version": "2.0",
+        "skills": {"sample": {"description": "STALE"}, "voice-x": {"description": "private"}},
+    }
+
+    def _setup(self, tmp_path: Path, mode: str) -> tuple[Path, Path]:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        for comp in ["agents", "hooks", "commands", "scripts"]:
+            comp_dir = repo / comp
+            comp_dir.mkdir()
+            (comp_dir / "sample.md").write_text(f"# {comp} sample")
+        skills_dir = repo / "skills"
+        sample_skill = skills_dir / "meta" / "sample"
+        sample_skill.mkdir(parents=True)
+        (sample_skill / "SKILL.md").write_text("# sample skill")
+        (skills_dir / "INDEX.json").write_text(json.dumps(self.TRACKED))
+        (skills_dir / "INDEX.local.json").write_text(json.dumps(self.LOCAL))
+        repo_claude = repo / ".claude"
+        repo_claude.mkdir()
+        (repo_claude / "settings.json").write_text(json.dumps({"hooks": {"SessionStart": []}}))
+
+        user_claude = tmp_path / "home" / ".claude"
+        user_claude.mkdir(parents=True)
+        manifest = {
+            "mode": mode,
+            "toolkit_path": str(repo),
+            "components": ["agents", "skills", "hooks", "commands", "scripts"],
+        }
+        (user_claude / ".install-manifest.json").write_text(json.dumps(manifest))
+        return repo, user_claude
+
+    def _run_main(self, tmp_path: Path, repo: Path) -> None:
+        with (
+            patch.object(Path, "home", return_value=tmp_path / "home"),
+            patch.object(Path, "cwd", return_value=repo),
+            patch.object(sync_mod, "_is_git_worktree", return_value=False),
+            patch.object(sync_mod, "_is_ephemeral_path", return_value=False),
+        ):
+            sync_mod.main()
+
+    @pytest.mark.parametrize("mode", ["symlink", "copy"])
+    def test_runtime_index_merged_and_writes_stay_local(self, tmp_path: Path, mode: str) -> None:
+        repo, user_claude = self._setup(tmp_path, mode)
+        self._run_main(tmp_path, repo)
+
+        runtime = user_claude / "skills" / "INDEX.json"
+        assert runtime.is_file() and not runtime.is_symlink()
+        skills = json.loads(runtime.read_text())["skills"]
+        # Invariant 1: tracked entries win and are all present; local adds
+        assert skills["sample"] == {"description": "tracked"}
+        assert "voice-x" in skills
+
+        # Invariant 2: in-place harness write never reaches the repo
+        runtime.write_text('{"skills": {"leak": {}}}\n')
+        assert json.loads((repo / "skills" / "INDEX.json").read_text()) == self.TRACKED
+        assert json.loads((repo / "skills" / "INDEX.local.json").read_text()) == self.LOCAL
+
+    def test_copy_mode_local_only_survives_stale_cleanup(self, tmp_path: Path) -> None:
+        """Repo with only INDEX.local.json (tracked index not generated yet):
+        the materialized runtime index must survive deferred stale cleanup."""
+        repo, user_claude = self._setup(tmp_path, "copy")
+        (repo / "skills" / "INDEX.json").unlink()
+        self._run_main(tmp_path, repo)
+
+        runtime = user_claude / "skills" / "INDEX.json"
+        assert runtime.is_file()
+        assert json.loads(runtime.read_text())["skills"] == self.LOCAL["skills"]
+
+    def test_copy_mode_resync_refreshes_merge(self, tmp_path: Path) -> None:
+        """A second sync after the tracked index gains a skill must surface
+        the new entry in the runtime index (the stale-hide regression)."""
+        repo, user_claude = self._setup(tmp_path, "copy")
+        self._run_main(tmp_path, repo)
+
+        updated = {"version": "2.0", "skills": {**self.TRACKED["skills"], "brand-new": {}}}
+        (repo / "skills" / "INDEX.json").write_text(json.dumps(updated))
+        self._run_main(tmp_path, repo)
+
+        skills = json.loads((user_claude / "skills" / "INDEX.json").read_text())["skills"]
+        assert "brand-new" in skills
+        assert "voice-x" in skills


### PR DESCRIPTION
## Summary
The symlink-mode runtime-index policy pointed the runtime skills index symlink wholesale at the gitignored local index whenever that file existed — the same replace-semantics failure PR #778 fixed in the routing scripts. A stale local index hid newly added tracked skills from everything reading the runtime index. Two adjacent holes: with no local index the symlink targeted the tracked file, so in-place harness writes leaked into the repo; copy mode never overlaid local entries at all. Fix: materialize the runtime index as a real merged file in both install modes — tracked items first, local entries fill gaps per-name.

## Changes
- `hooks/sync-to-user-claude.py` — add `_merged_runtime_index` (tracked-first, add-only overlay, mirrors `_load_index_items` from d4eea119); `_sync_runtime_skill_index` writes the merge atomically, skips unchanged content, swaps a pre-fix symlink via `os.replace` without touching its repo target; copy mode records the materialized path so deferred stale cleanup spares it
- `hooks/tests/test_sync_to_user_claude.py` — 12 regression tests: stale local cannot hide tracked entries; local cannot override tracked content; in-place writes never reach repo files (with and without local); local-only still materializes; pre-fix symlink replaced; unchanged index not rewritten; no index files creates nothing; local symlink still created; copy-mode merge, local-only stale-cleanup survival, resync refresh

## Notes
- Invariants now held in both install modes: (1) runtime index contains every tracked entry, local adds per-name; (2) in-place writes to the runtime index never reach repo files.
- Sibling of #778 — same merge semantics, applied at the sync layer.