### PR TITLE
feat(install): opt-in install profile filtering (.local/profile.yaml)

### DIFF
--- a/.local.example/README.md
+++ b/.local.example/README.md
@@ -50,6 +50,7 @@ When you want **generic version** (or sharing):
 ```
 .local.example/
 ├── README.md                              # This file
+├── profile.yaml                           # Disable specific skills/agents/hooks
 ├── config.yaml                            # Environment configuration template
 ├── github-actions-check.yaml              # Repository mapping template
 ├── agents/
@@ -59,6 +60,27 @@ When you want **generic version** (or sharing):
         └── references/
             └── examples.md                # Example: your real vault paths
 ```
+
+### Profile filtering (`profile.yaml`)
+
+Pick which components `./install.sh` should skip. Run the interactive picker
+and the file is generated for you:
+
+```bash
+./install.sh --configure       # pick items, then install
+./install.sh --configure-only  # pick items, then exit
+```
+
+Or copy the template and edit by hand:
+
+```bash
+cp .local.example/profile.yaml .local/profile.yaml
+$EDITOR .local/profile.yaml
+./install.sh                   # honors the disable lists
+```
+
+When `.local/profile.yaml` is absent, `./install.sh` installs the full toolkit
+exactly as before — the feature is opt-in.
 
 ## Tips
 

--- a/.local.example/README.md
+++ b/.local.example/README.md
@@ -82,6 +82,11 @@ $EDITOR .local/profile.yaml
 When `.local/profile.yaml` is absent, `./install.sh` installs the full toolkit
 exactly as before — the feature is opt-in.
 
+The picker uses `questionary` (checkbox UI) when installed; without it, a
+plain numbered prompt runs instead. No new required dependency. The Codex
+mirror filters top-level skills, agents, and hooks; nested category skills
+are filtered in the Claude tree.
+
 ## Tips
 
 1. **Start small**: Only copy files you need to customize

--- a/.local.example/profile.yaml
+++ b/.local.example/profile.yaml
@@ -1,0 +1,21 @@
+# Toolkit profile — items listed here are excluded by ./install.sh.
+#
+# To regenerate this file interactively:
+#   ./install.sh --configure
+#
+# To install (without re-running the prompt) using the lists below:
+#   ./install.sh
+#
+# Schema:
+#   disabled:
+#     skills: ["skill-name", ...]   # directory names under skills/
+#     agents: ["agent-name", ...]   # filename stems under agents/ (no .md)
+#     hooks:  ["hook-file.py", ...] # filenames under hooks/ (with .py)
+#
+# When this file is absent, install.sh installs the full toolkit (no items
+# disabled). Copy to ../.local/profile.yaml and edit, or run --configure.
+
+disabled:
+  skills: []
+  agents: []
+  hooks: []

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AI agents skip steps.
 
 Harnesses have a second problem: given only a skill list, they do not route eagerly enough, or correctly enough. Good skills sit unused. So this toolkit connects the skills, agents, and workflows we want directly into the harness, automatically. You don't have to understand what is here. Say what you want in plain English and you get all the value we have put into it: the right specialist with the right methodology, behind gates that demand exit codes, not assertions.
 
-44 domain agents, 125 workflow skills, 83 hooks, 114 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
+44 domain agents, 125 workflow skills, 83 hooks, 118 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
 
 Works across Claude Code (`/do`), Codex (`$do`), Factory (`/do`), Reasonix (`/do`).
 
@@ -73,6 +73,8 @@ cd ~/vexjoy-agent
 ```
 
 Links into `~/.claude/` and mirrors into `~/.codex/`, `~/.factory/`, `~/.reasonix/`. The installer asks symlink (live updates via `git pull`) or copy (stable snapshot).
+
+Want only part of the toolkit? Run `./install.sh --configure` to pick which skills, agents, and hooks install, or copy `.local.example/profile.yaml` to `.local/profile.yaml` and edit. No profile file = full install, unchanged behavior. Credit: [@thomasvan](https://github.com/thomasvan). Details: [.local.example/README.md](.local.example/README.md).
 
 | CLI | Entry Point |
 |-----|-------------|
@@ -139,7 +141,7 @@ Strips built-in tool-use instructions. The toolkit's agents, skills, hooks, and 
 | Agents | 44 | Domain knowledge: idiom tables, failure mode catalogs, error-to-fix mappings |
 | Skills | 125 | Phased methodology with gates. Can't skip steps. Each phase has exit criteria requiring evidence. |
 | Hooks | 83 | Fire on lifecycle events. Block incomplete work. Zero LLM cost. |
-| Scripts | 114 | Determinism: test runners, linters, validators. No LLM judgment. |
+| Scripts | 118 | Determinism: test runners, linters, validators. No LLM judgment. |
 
 Full skill catalog: [docs/skills.md](docs/skills.md).
 

--- a/install.sh
+++ b/install.sh
@@ -62,6 +62,8 @@ MODE=""
 DRY_RUN=false
 FORCE=true  # Default to force — never prompt about existing directories
 CONFLICT_MODE=""  # per-item | replace | skip; set by --per-item/--sync or conflict prompt
+CONFIGURE=false
+CONFIGURE_ONLY=false
 while [[ $# -gt 0 ]]; do
     case $1 in
         --symlink)
@@ -102,6 +104,14 @@ while [[ $# -gt 0 ]]; do
             [ -z "$MODE" ] && MODE="symlink"
             shift
             ;;
+        --configure)
+            CONFIGURE=true
+            shift
+            ;;
+        --configure-only)
+            CONFIGURE_ONLY=true
+            shift
+            ;;
         --help|-h)
             echo "Usage: $0 [--symlink|--copy|--uninstall|--rollback|--dry-run|--force|--per-item|--sync]"
             echo ""
@@ -115,6 +125,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --no-force   Prompt before replacing existing directories"
             echo "  --per-item   Symlink each item individually; preserve external content"
             echo "  --sync       Alias for --per-item; implies --symlink mode default"
+            echo "  --configure       Run the interactive profile picker, then install"
+            echo "  --configure-only  Run the picker, write .local/profile.yaml, then exit"
             echo ""
             echo "If no option provided, will prompt interactively."
             exit 0
@@ -1037,6 +1049,13 @@ install_component() {
 
     local component_key="$base_dir/$target_name"
 
+    # Profile filtering active for this component? Whole-dir symlinks cannot
+    # exclude items, so a filtered component is always installed per-item.
+    local filtered=false
+    case $name in
+        skills|agents|hooks) _category_filtered "$name" && filtered=true ;;
+    esac
+
     # Skip mode: leave conflicting locations untouched; install conflict-free ones normally.
     if [ "$CONFLICT_MODE" = "skip" ] && [ "$MODE" = "symlink" ] && _conflict_has "$component_key"; then
         echo -e "${YELLOW}  Skipping ${target} (kept existing — skip mode)${NC}"
@@ -1044,8 +1063,9 @@ install_component() {
     fi
 
     # Per-item mode: symlink each item (file or dir) individually; preserve external content.
-    if [ "$CONFLICT_MODE" = "per-item" ] && [ "$MODE" = "symlink" ] && \
-       { _conflict_has "$component_key" || [ -d "$target" ] || [ -L "$target" ]; }; then
+    if [ "$MODE" = "symlink" ] && \
+       { [ "$filtered" = true ] || { [ "$CONFLICT_MODE" = "per-item" ] && \
+       { _conflict_has "$component_key" || [ -d "$target" ] || [ -L "$target" ]; }; }; }; then
         if [ "$DRY_RUN" = true ]; then
             if [ -L "$target" ] && _symlink_points_to "$target" "$source"; then
                 echo -e "${BLUE}  Would convert whole-dir symlink to per-item dir: ${target}${NC}"
@@ -1065,6 +1085,10 @@ install_component() {
             for item in "$source"/*; do
                 [ -e "$item" ] || [ -L "$item" ] || continue
                 item_name=$(basename "$item")
+                if [ "$filtered" = true ] && _profile_disabled "$name" "$item_name"; then
+                    echo -e "${YELLOW}  Skipping ${item_name} (disabled by profile)${NC}"
+                    continue
+                fi
                 if [ -e "$target/$item_name" ]; then
                     echo -e "${YELLOW}  WARNING: $target/$item_name already exists — skipping (kept existing)${NC}"
                     continue
@@ -1116,6 +1140,18 @@ install_component() {
         else
             cp -r "$source" "$target"
             echo -e "${GREEN}  ✓ Copied ${name}${NC}"
+            # Copy mode: prune profile-disabled items from the fresh copy.
+            if [ "$filtered" = true ]; then
+                local copied copied_name
+                for copied in "$target"/*; do
+                    [ -e "$copied" ] || continue
+                    copied_name=$(basename "$copied")
+                    if _profile_disabled "$name" "$copied_name"; then
+                        rm -rf "$copied"
+                        echo -e "${YELLOW}  Removed ${copied_name} (disabled by profile)${NC}"
+                    fi
+                done
+            fi
         fi
     fi
 }
@@ -1159,6 +1195,10 @@ link_skills_nested() {
         # Top-level file (e.g. INDEX.json) or a top-level skill dir (has SKILL.md):
         # link the whole thing at the top level.
         if [ ! -d "$entry" ] || [ -f "$entry/SKILL.md" ]; then
+            if [ -d "$entry" ] && _profile_disabled skills "$entry_name"; then
+                echo -e "${YELLOW}  Skipping ${entry_name} (disabled by profile)${NC}"
+                continue
+            fi
             if [ -e "$target/$entry_name" ] || [ -L "$target/$entry_name" ]; then
                 continue  # external/existing entry; keep it
             fi
@@ -1178,6 +1218,10 @@ link_skills_nested() {
         for child in "$entry"/*; do
             [ -e "$child" ] || [ -L "$child" ] || continue
             child_name=$(basename "$child")
+            if [ -d "$child" ] && _profile_disabled skills "$child_name"; then
+                echo -e "${YELLOW}  Skipping ${entry_name}/${child_name} (disabled by profile)${NC}"
+                continue
+            fi
             if [ -e "$target/$entry_name/$child_name" ] || [ -L "$target/$entry_name/$child_name" ]; then
                 continue  # external/existing entry; keep it
             fi
@@ -1313,6 +1357,63 @@ HOOK
     echo -e "${GREEN}  ✓ Installed post-merge hook: ${hook}${NC}"
 }
 
+# ---------------------------------------------------------------------------
+# Opt-in install profile (.local/profile.yaml) — credit: @thomasvan.
+# Absent profile = no filtering; install behaves exactly as without this block.
+# VEXJOY_INSTALL_PROFILE overrides the path (used by tests).
+# ---------------------------------------------------------------------------
+PROFILE_FILE="${VEXJOY_INSTALL_PROFILE:-${SCRIPT_DIR}/.local/profile.yaml}"
+DISABLED_SKILLS=""
+DISABLED_AGENTS=""
+DISABLED_HOOKS=""
+
+if [ "$CONFIGURE" = true ] || [ "$CONFIGURE_ONLY" = true ]; then
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${BLUE}  Would run interactive profile picker (scripts/configure-profile.py)${NC}"
+    else
+        $PYTHON_CMD "${SCRIPT_DIR}/scripts/configure-profile.py" --output "$PROFILE_FILE"
+    fi
+    if [ "$CONFIGURE_ONLY" = true ]; then
+        echo "Profile written. Run ./install.sh to apply it."
+        exit 0
+    fi
+fi
+
+if [ -f "$PROFILE_FILE" ]; then
+    DISABLED_SKILLS=$($PYTHON_CMD "${SCRIPT_DIR}/scripts/load-profile.py" --list skills --profile "$PROFILE_FILE") || DISABLED_SKILLS=""
+    DISABLED_AGENTS=$($PYTHON_CMD "${SCRIPT_DIR}/scripts/load-profile.py" --list agents --profile "$PROFILE_FILE") || DISABLED_AGENTS=""
+    DISABLED_HOOKS=$($PYTHON_CMD "${SCRIPT_DIR}/scripts/load-profile.py" --list hooks --profile "$PROFILE_FILE") || DISABLED_HOOKS=""
+    _ns=$(printf '%s' "$DISABLED_SKILLS" | grep -c . || true)
+    _na=$(printf '%s' "$DISABLED_AGENTS" | grep -c . || true)
+    _nh=$(printf '%s' "$DISABLED_HOOKS" | grep -c . || true)
+    echo -e "${YELLOW}Install profile: ${PROFILE_FILE} (disabled: ${_ns} skills, ${_na} agents, ${_nh} hooks)${NC}"
+fi
+
+# _profile_disabled CATEGORY NAME — 0 when NAME is disabled by the profile.
+# Agents match by stem (foo.md and foo/ both match "foo"); skills and hooks
+# match the basename as-is (skill dir name, hook filename like foo.py).
+_profile_disabled() {
+    local list name=$2
+    case $1 in
+        skills) list="$DISABLED_SKILLS" ;;
+        agents) list="$DISABLED_AGENTS"; name="${name%.md}" ;;
+        hooks)  list="$DISABLED_HOOKS" ;;
+        *) return 1 ;;
+    esac
+    [ -n "$list" ] || return 1
+    printf '%s\n' "$list" | grep -Fxq -- "$name"
+}
+
+# _category_filtered CATEGORY — 0 when the profile disables anything in CATEGORY.
+_category_filtered() {
+    case $1 in
+        skills) [ -n "$DISABLED_SKILLS" ] ;;
+        agents) [ -n "$DISABLED_AGENTS" ] ;;
+        hooks)  [ -n "$DISABLED_HOOKS" ] ;;
+        *) return 1 ;;
+    esac
+}
+
 # Scan for conflicts before first install_component call
 if [ "$MODE" = "symlink" ]; then
     detect_conflicts
@@ -1431,6 +1532,10 @@ echo -e "${YELLOW}Syncing Codex skills mirror...${NC}"
 CODEX_ENTRY_COUNT=0
 for item in "${SCRIPT_DIR}/skills/"*; do
     [ -e "$item" ] || continue
+    if [ -d "$item" ] && [ -f "$item/SKILL.md" ] && _profile_disabled skills "$(basename "$item")"; then
+        echo -e "${YELLOW}  Skipping $(basename "$item") (disabled by profile)${NC}"
+        continue
+    fi
     target="${CODEX_SKILLS_DIR}/$(basename "$item")"
     sync_codex_entry "$item" "$target"
     CODEX_ENTRY_COUNT=$((CODEX_ENTRY_COUNT + 1))
@@ -1462,6 +1567,10 @@ echo -e "${YELLOW}Syncing Codex agents mirror...${NC}"
 CODEX_AGENT_COUNT=0
 for item in "${SCRIPT_DIR}/agents/"*; do
     [ -e "$item" ] || continue
+    if _profile_disabled agents "$(basename "$item")"; then
+        echo -e "${YELLOW}  Skipping $(basename "$item") (disabled by profile)${NC}"
+        continue
+    fi
     target="${CODEX_AGENTS_DIR}/$(basename "$item")"
     sync_codex_entry "$item" "$target"
     CODEX_AGENT_COUNT=$((CODEX_AGENT_COUNT + 1))
@@ -1504,6 +1613,11 @@ if [ -f "$CODEX_HOOKS_ALLOWLIST" ]; then
         rest="${trimmed#*:}"
         filename="${rest%% *}"
 
+        if _profile_disabled hooks "$filename"; then
+            echo -e "${YELLOW}  Skipping ${filename} (disabled by profile)${NC}"
+            continue
+        fi
+
         source_file="${SCRIPT_DIR}/hooks/${filename}"
         if [ ! -f "$source_file" ]; then
             echo -e "${RED}  ✗ Allowlisted hook missing: ${filename}${NC}"
@@ -1527,13 +1641,24 @@ if [ -f "$CODEX_HOOKS_ALLOWLIST" ]; then
     if [ "$DRY_RUN" = true ]; then
         echo -e "${BLUE}  Would generate: ${CODEX_HOOKS_JSON}${NC}"
     else
+        # Profile filtering: generate from a filtered allowlist copy so
+        # hooks.json never references hooks we did not mirror.
+        EFFECTIVE_ALLOWLIST="$CODEX_HOOKS_ALLOWLIST"
+        if [ -n "$DISABLED_HOOKS" ]; then
+            EFFECTIVE_ALLOWLIST=$(mktemp)
+            printf '%s\n' "$DISABLED_HOOKS" | $PYTHON_CMD "${SCRIPT_DIR}/scripts/filter-codex-allowlist.py" \
+                --input "$CODEX_HOOKS_ALLOWLIST" --disabled /dev/stdin --output "$EFFECTIVE_ALLOWLIST"
+        fi
         if $PYTHON_CMD "${SCRIPT_DIR}/scripts/generate-codex-hooks-json.py" \
-            --allowlist "$CODEX_HOOKS_ALLOWLIST" \
+            --allowlist "$EFFECTIVE_ALLOWLIST" \
             --output "$CODEX_HOOKS_JSON" \
             --codex-hooks-dir "$CODEX_HOOKS_DIR" 2>&1; then
             echo -e "${GREEN}  ✓ Generated ${CODEX_HOOKS_JSON}${NC}"
         else
             echo -e "${RED}  ✗ Failed to generate hooks.json${NC}"
+        fi
+        if [ "$EFFECTIVE_ALLOWLIST" != "$CODEX_HOOKS_ALLOWLIST" ]; then
+            rm -f "$EFFECTIVE_ALLOWLIST"
         fi
     fi
 
@@ -2054,6 +2179,12 @@ with open(tmp, 'w', encoding='utf-8') as f:
 os.rename(tmp, dst)
 print('  Hooks configured from .claude/settings.json')
 "
+    # Profile filtering: drop disabled hooks from the freshly synced block.
+    if [ -n "$DISABLED_HOOKS" ]; then
+        printf '%s\n' "$DISABLED_HOOKS" | $PYTHON_CMD "${SCRIPT_DIR}/scripts/filter-settings-hooks.py" \
+            --input "$SETTINGS_FILE" --disabled /dev/stdin --output "$SETTINGS_FILE"
+        echo -e "${YELLOW}  Filtered profile-disabled hooks from settings.json${NC}"
+    fi
 else
     echo -e "${YELLOW}  Warning: ${SCRIPT_DIR}/.claude/settings.json not found, skipping hook sync${NC}"
 fi

--- a/scripts/configure-profile.py
+++ b/scripts/configure-profile.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Interactive TUI to build .local/profile.yaml.
+
+Runs three multi-select checkbox prompts (skills / agents / hooks). All items
+are pre-selected as ENABLED; the user un-checks items to disable them. On
+confirm, writes ``<repo>/.local/profile.yaml`` with the disabled lists.
+
+Sources:
+    - skills: top-level subdirectories of skills/ that contain SKILL.md
+    - agents: agents/<name>.md (excluding README*)
+    - hooks:  hooks/*.py (excluding __init__.py and the lib/ package)
+
+Requires the ``questionary`` package. If it is not installed, prints an
+install hint and exits 1.
+
+Usage:
+    python3 scripts/configure-profile.py
+    python3 scripts/configure-profile.py --output .local/profile.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = REPO_ROOT / ".local" / "profile.yaml"
+
+PROFILE_HEADER = """\
+# Toolkit profile — items listed here are excluded by ./install.sh.
+#
+# This file is regenerated each time you run:
+#   ./install.sh --configure
+#
+# To install without prompting (using the lists below as-is), pass
+# --non-interactive to install.sh, or simply run ./install.sh.
+"""
+
+
+def list_skills() -> list[str]:
+    skills_dir = REPO_ROOT / "skills"
+    if not skills_dir.is_dir():
+        return []
+    names: list[str] = []
+    for entry in sorted(skills_dir.iterdir()):
+        if entry.is_dir() and (entry / "SKILL.md").is_file():
+            names.append(entry.name)
+    return names
+
+
+def list_agents() -> list[str]:
+    agents_dir = REPO_ROOT / "agents"
+    if not agents_dir.is_dir():
+        return []
+    names: list[str] = []
+    for entry in sorted(agents_dir.glob("*.md")):
+        stem = entry.stem
+        if stem.upper().startswith("README"):
+            continue
+        names.append(stem)
+    return names
+
+
+def list_hooks() -> list[str]:
+    hooks_dir = REPO_ROOT / "hooks"
+    if not hooks_dir.is_dir():
+        return []
+    names: list[str] = []
+    for entry in sorted(hooks_dir.glob("*.py")):
+        if entry.name == "__init__.py":
+            continue
+        names.append(entry.name)
+    return names
+
+
+def run_prompts(skills: list[str], agents: list[str], hooks: list[str]) -> dict[str, list[str]]:
+    try:
+        import questionary
+    except ImportError:
+        print(
+            "error: 'questionary' is required for --configure.\n"
+            "Install with: pip install questionary  (or pip install -r requirements.txt)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not sys.stdin.isatty():
+        print(
+            "error: --configure requires an interactive terminal (TTY).\n"
+            "Edit .local/profile.yaml by hand or run from a terminal.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    def ask(label: str, items: list[str]) -> list[str]:
+        if not items:
+            return []
+        choices = [questionary.Choice(name, checked=True) for name in items]
+        result = questionary.checkbox(
+            f"{label} — uncheck items to DISABLE (space toggles, enter confirms):",
+            choices=choices,
+        ).ask()
+        if result is None:
+            # User aborted (Ctrl-C / Esc).
+            print("aborted: no changes written.", file=sys.stderr)
+            sys.exit(130)
+        enabled = set(result)
+        return [name for name in items if name not in enabled]
+
+    disabled_skills = ask("Skills", skills)
+    disabled_agents = ask("Agents", agents)
+    disabled_hooks = ask("Hooks", hooks)
+    return {
+        "skills": disabled_skills,
+        "agents": disabled_agents,
+        "hooks": disabled_hooks,
+    }
+
+
+def write_profile(path: Path, disabled: dict[str, list[str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = yaml.safe_dump({"disabled": disabled}, sort_keys=False, default_flow_style=False)
+    path.write_text(PROFILE_HEADER + "\n" + body, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    skills = list_skills()
+    agents = list_agents()
+    hooks = list_hooks()
+
+    disabled = run_prompts(skills, agents, hooks)
+    write_profile(args.output, disabled)
+
+    print(
+        f"wrote {args.output} "
+        f"(disabled: {len(disabled['skills'])} skills, "
+        f"{len(disabled['agents'])} agents, {len(disabled['hooks'])} hooks)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/configure-profile.py
+++ b/scripts/configure-profile.py
@@ -76,24 +76,41 @@ def list_hooks() -> list[str]:
     return names
 
 
-def run_prompts(skills: list[str], agents: list[str], hooks: list[str]) -> dict[str, list[str]]:
+def run_plain_prompts(skills: list[str], agents: list[str], hooks: list[str]) -> dict[str, list[str]]:
+    """Stdlib picker: list items per category, read names to disable from stdin.
+
+    One line per category, comma- or space-separated names. Empty line = keep
+    all. Unknown names are reported and ignored.
+    """
+    disabled: dict[str, list[str]] = {}
+    for label, items in (("skills", skills), ("agents", agents), ("hooks", hooks)):
+        print(f"\n{label} ({len(items)} available):")
+        for name in items:
+            print(f"  {name}")
+        try:
+            raw = input(f"Names to DISABLE in {label} (comma/space separated, empty = none): ")
+        except EOFError:
+            raw = ""
+        picked = set(token for token in raw.replace(",", " ").split() if token)
+        unknown = sorted(picked - set(items))
+        if unknown:
+            print(f"warning: ignoring unknown {label}: {', '.join(unknown)}", file=sys.stderr)
+        disabled[label] = [name for name in items if name in picked]
+    return disabled
+
+
+def run_prompts(skills: list[str], agents: list[str], hooks: list[str], plain: bool = False) -> dict[str, list[str]]:
+    """Questionary checkbox picker when available and on a TTY; plain fallback otherwise."""
+    if plain:
+        return run_plain_prompts(skills, agents, hooks)
     try:
         import questionary
     except ImportError:
-        print(
-            "error: 'questionary' is required for --configure.\n"
-            "Install with: pip install questionary  (or pip install -r requirements.txt)",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
+        print("note: 'questionary' not installed — using plain picker.", file=sys.stderr)
+        return run_plain_prompts(skills, agents, hooks)
     if not sys.stdin.isatty():
-        print(
-            "error: --configure requires an interactive terminal (TTY).\n"
-            "Edit .local/profile.yaml by hand or run from a terminal.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+        print("note: no TTY — using plain picker.", file=sys.stderr)
+        return run_plain_prompts(skills, agents, hooks)
 
     def ask(label: str, items: list[str]) -> list[str]:
         if not items:
@@ -129,13 +146,14 @@ def write_profile(path: Path, disabled: dict[str, list[str]]) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--plain", action="store_true", help="Force the stdlib picker (no questionary).")
     args = parser.parse_args()
 
     skills = list_skills()
     agents = list_agents()
     hooks = list_hooks()
 
-    disabled = run_prompts(skills, agents, hooks)
+    disabled = run_prompts(skills, agents, hooks, plain=args.plain)
     write_profile(args.output, disabled)
 
     print(

--- a/scripts/filter-codex-allowlist.py
+++ b/scripts/filter-codex-allowlist.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Filter scripts/codex-hooks-allowlist.txt by removing disabled hook filenames.
+
+Reads an allowlist file in the format used by codex-hooks-allowlist.txt:
+
+    # comment
+    EVENT:filename [matcher]
+
+and writes a copy to stdout (or --output) with any line whose filename appears
+in the disabled list removed. Comments and blank lines are preserved.
+
+Usage:
+    python3 scripts/filter-codex-allowlist.py \\
+        --input  scripts/codex-hooks-allowlist.txt \\
+        --disabled disabled-hooks.txt \\
+        --output filtered-allowlist.txt
+
+The --disabled file is one filename per line (blank lines and # comments
+ignored). May be /dev/stdin to receive the list via pipe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def read_disabled(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.add(line)
+    return out
+
+
+def filter_allowlist(text: str, disabled: set[str]) -> str:
+    kept: list[str] = []
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            kept.append(raw)
+            continue
+        # Format: EVENT:filename [matcher]
+        if ":" not in stripped:
+            kept.append(raw)
+            continue
+        rest = stripped.split(":", 1)[1].strip()
+        filename = rest.split()[0] if rest else ""
+        if filename in disabled:
+            continue
+        kept.append(raw)
+    # Preserve trailing newline if input had one.
+    suffix = "\n" if text.endswith("\n") else ""
+    return "\n".join(kept) + suffix
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--disabled", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=None, help="Default: stdout.")
+    args = parser.parse_args()
+
+    if not args.input.is_file():
+        print(f"error: input not found: {args.input}", file=sys.stderr)
+        return 2
+
+    disabled = read_disabled(args.disabled)
+    filtered = filter_allowlist(args.input.read_text(encoding="utf-8"), disabled)
+
+    if args.output is None:
+        sys.stdout.write(filtered)
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(filtered, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/filter-settings-hooks.py
+++ b/scripts/filter-settings-hooks.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Remove disabled hook entries from a Claude Code settings.json hooks block.
+
+Reads a settings.json file, prunes any hook entry whose ``command`` references
+a disabled hook filename (matched against the path component after ``/hooks/``),
+and writes the result back. Empty matcher groups are dropped; events with no
+remaining groups are removed from ``hooks``.
+
+Usage:
+    python3 scripts/filter-settings-hooks.py \\
+        --input  ~/.claude/settings.json \\
+        --disabled disabled-hooks.txt \\
+        --output ~/.claude/settings.json
+
+If --output is omitted, the filtered JSON is written to stdout. The --disabled
+file is one filename per line (blank lines and # comments ignored). Pass
+/dev/stdin to receive the list via pipe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def read_disabled(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.add(line)
+    return out
+
+
+def hook_filename_from_command(command: str) -> str | None:
+    marker = "/hooks/"
+    if marker not in command:
+        return None
+    tail = command.split(marker, 1)[1]
+    return tail.split('"', 1)[0].split("'", 1)[0].split()[0]
+
+
+def filter_hooks(settings: dict[str, Any], disabled: set[str]) -> dict[str, Any]:
+    settings = dict(settings)
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return settings
+
+    filtered_hooks: dict[str, Any] = {}
+    for event, groups in hooks.items():
+        if not isinstance(groups, list):
+            filtered_hooks[event] = groups
+            continue
+        filtered_groups: list[Any] = []
+        for group in groups:
+            if not isinstance(group, dict):
+                filtered_groups.append(group)
+                continue
+            entries = group.get("hooks")
+            if not isinstance(entries, list):
+                filtered_groups.append(group)
+                continue
+            kept = []
+            for entry in entries:
+                command = entry.get("command", "") if isinstance(entry, dict) else ""
+                filename = hook_filename_from_command(command)
+                if filename and filename in disabled:
+                    continue
+                kept.append(entry)
+            if kept:
+                next_group = dict(group)
+                next_group["hooks"] = kept
+                filtered_groups.append(next_group)
+        if filtered_groups:
+            filtered_hooks[event] = filtered_groups
+
+    settings["hooks"] = filtered_hooks
+    return settings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--disabled", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=None, help="Default: stdout.")
+    args = parser.parse_args()
+
+    try:
+        settings = json.loads(args.input.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"error: cannot read {args.input}: {exc}", file=sys.stderr)
+        return 2
+
+    disabled = read_disabled(args.disabled)
+    if not disabled:
+        # Nothing to filter — write input unchanged.
+        out = settings
+    else:
+        out = filter_hooks(settings, disabled)
+
+    rendered = json.dumps(out, indent=2) + "\n"
+    if args.output is None:
+        sys.stdout.write(rendered)
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    tmp = args.output.with_suffix(args.output.suffix + ".tmp")
+    tmp.write_text(rendered, encoding="utf-8")
+    os.replace(tmp, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/load-profile.py
+++ b/scripts/load-profile.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Read .local/profile.yaml and emit one disabled item per line.
+
+Used by install.sh to drive per-component filtering. Missing or malformed
+profile files are treated as empty (no items disabled), so the installer
+behaves identically to a fresh checkout when the profile is absent.
+
+Usage:
+    python3 scripts/load-profile.py --list skills
+    python3 scripts/load-profile.py --list agents
+    python3 scripts/load-profile.py --list hooks
+
+Exit codes:
+    0 — success (output may be empty)
+    2 — bad arguments
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PROFILE = REPO_ROOT / ".local" / "profile.yaml"
+CATEGORIES = ("skills", "agents", "hooks")
+
+
+def load(profile_path: Path) -> dict[str, list[str]]:
+    if not profile_path.is_file():
+        return {cat: [] for cat in CATEGORIES}
+    try:
+        data = yaml.safe_load(profile_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        print(f"warning: {profile_path} is not valid YAML ({exc}); treating as empty", file=sys.stderr)
+        return {cat: [] for cat in CATEGORIES}
+    disabled = data.get("disabled") if isinstance(data, dict) else None
+    if not isinstance(disabled, dict):
+        return {cat: [] for cat in CATEGORIES}
+    out: dict[str, list[str]] = {}
+    for cat in CATEGORIES:
+        items = disabled.get(cat) or []
+        if not isinstance(items, list):
+            print(f"warning: disabled.{cat} in {profile_path} is not a list; ignoring", file=sys.stderr)
+            items = []
+        out[cat] = [str(x).strip() for x in items if str(x).strip()]
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--list", choices=CATEGORIES, required=True, help="Category to print.")
+    parser.add_argument("--profile", type=Path, default=DEFAULT_PROFILE, help="Path to profile.yaml.")
+    args = parser.parse_args()
+
+    items = load(args.profile)[args.list]
+    for name in items:
+        print(name)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_install_profile_filtering.py
+++ b/scripts/tests/test_install_profile_filtering.py
@@ -1,0 +1,135 @@
+"""Integration tests for opt-in install profile filtering.
+
+Runs install.sh against a temporary HOME. VEXJOY_INSTALL_PROFILE points
+install.sh at a test profile so the repo's real .local/profile.yaml is
+never touched. No profile file = behavior identical to today (opt-in pin).
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+INSTALL_SH = REPO_ROOT / "install.sh"
+CONFIGURE = REPO_ROOT / "scripts" / "configure-profile.py"
+ALLOWLIST = REPO_ROOT / "scripts" / "codex-hooks-allowlist.txt"
+
+if shutil.which("bash") is None:
+    pytest.skip("bash not available on this platform", allow_module_level=True)
+
+
+def _run_install(fake_home: Path, args: list[str], profile: Path | None = None) -> subprocess.CompletedProcess:
+    env = {**os.environ, "HOME": str(fake_home), "TERM": "dumb"}
+    if profile is not None:
+        env["VEXJOY_INSTALL_PROFILE"] = str(profile)
+    else:
+        env["VEXJOY_INSTALL_PROFILE"] = str(fake_home / "no-such-profile.yaml")
+    return subprocess.run(
+        ["bash", str(INSTALL_SH)] + args,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+def _first_agent() -> str:
+    return sorted(p.stem for p in (REPO_ROOT / "agents").glob("*.md") if not p.stem.upper().startswith("README"))[0]
+
+
+def _first_allowlisted_hook() -> str:
+    for raw in ALLOWLIST.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        return line.split(":", 1)[1].split()[0]
+    raise AssertionError("no allowlisted hooks found")
+
+
+def _first_top_level_skill() -> str:
+    for entry in sorted((REPO_ROOT / "skills").iterdir()):
+        if entry.is_dir() and (entry / "SKILL.md").is_file():
+            return entry.name
+    raise AssertionError("no top-level skill found")
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    return home
+
+
+def _write_profile(path: Path, skills: list[str], agents: list[str], hooks: list[str]) -> None:
+    lines = ["disabled:"]
+    for cat, items in (("skills", skills), ("agents", agents), ("hooks", hooks)):
+        if items:
+            lines.append(f"  {cat}:")
+            lines.extend(f"    - {i}" for i in items)
+        else:
+            lines.append(f"  {cat}: []")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_no_profile_dry_run_mentions_no_filtering(fake_home: Path) -> None:
+    """Opt-in pin: without profile.yaml, install plans nothing profile-related."""
+    result = _run_install(fake_home, ["--dry-run", "--sync"])
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert "Install profile:" not in result.stdout
+    assert "disabled by profile" not in result.stdout.lower()
+
+
+def test_no_profile_installs_everything(fake_home: Path) -> None:
+    """Opt-in pin: without profile.yaml the candidate items all install."""
+    agent, hook, skill = _first_agent(), _first_allowlisted_hook(), _first_top_level_skill()
+    result = _run_install(fake_home, ["--sync"])
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert (fake_home / ".claude" / "agents" / f"{agent}.md").exists()
+    assert (fake_home / ".claude" / "hooks" / hook).exists()
+    assert (fake_home / ".claude" / "skills" / skill).exists()
+    assert (fake_home / ".codex" / "hooks" / hook).exists()
+
+
+def test_profile_filters_per_item_install(fake_home: Path, tmp_path: Path) -> None:
+    """--sync (per-item) skips disabled agent/hook/skill in Claude + Codex + settings.json."""
+    agent, hook, skill = _first_agent(), _first_allowlisted_hook(), _first_top_level_skill()
+    profile = tmp_path / "profile.yaml"
+    _write_profile(profile, skills=[skill], agents=[agent], hooks=[hook])
+
+    result = _run_install(fake_home, ["--sync"], profile=profile)
+    assert result.returncode == 0, result.stderr[-2000:]
+
+    assert not (fake_home / ".claude" / "agents" / f"{agent}.md").exists()
+    assert not (fake_home / ".claude" / "hooks" / hook).exists()
+    assert not (fake_home / ".claude" / "skills" / skill).exists()
+    assert not (fake_home / ".codex" / "hooks" / hook).exists()
+    assert not (fake_home / ".codex" / "skills" / skill).exists()
+
+    settings = (fake_home / ".claude" / "settings.json").read_text(encoding="utf-8")
+    assert hook not in settings
+
+    # Sibling items still install.
+    other_agents = [p.stem for p in (REPO_ROOT / "agents").glob("*.md") if p.stem != agent]
+    if other_agents:
+        assert (fake_home / ".claude" / "agents" / f"{other_agents[0]}.md").exists()
+
+
+def test_configure_plain_fallback_writes_profile(tmp_path: Path) -> None:
+    """Picker works without questionary: --plain reads names from stdin."""
+    agent = _first_agent()
+    out = tmp_path / "profile.yaml"
+    result = subprocess.run(
+        [sys.executable, str(CONFIGURE), "--plain", "--output", str(out)],
+        input=f"\n{agent}\n\n",
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    text = out.read_text(encoding="utf-8")
+    assert agent in text
+    assert "disabled:" in text

--- a/scripts/tests/test_install_profile_helpers.py
+++ b/scripts/tests/test_install_profile_helpers.py
@@ -1,0 +1,209 @@
+"""Tests for scripts/load-profile.py, filter-codex-allowlist.py, filter-settings-hooks.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load_module(name: str, filename: str):
+    path = REPO_ROOT / "scripts" / filename
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def load_profile():
+    return _load_module("load_profile", "load-profile.py")
+
+
+@pytest.fixture(scope="module")
+def filter_codex():
+    return _load_module("filter_codex_allowlist", "filter-codex-allowlist.py")
+
+
+@pytest.fixture(scope="module")
+def filter_settings():
+    return _load_module("filter_settings_hooks", "filter-settings-hooks.py")
+
+
+# ---------- load-profile.py ----------
+
+
+def test_load_profile_missing_file(tmp_path: Path, load_profile) -> None:
+    out = load_profile.load(tmp_path / "missing.yaml")
+    assert out == {"skills": [], "agents": [], "hooks": []}
+
+
+def test_load_profile_basic(tmp_path: Path, load_profile) -> None:
+    profile = tmp_path / "profile.yaml"
+    profile.write_text(
+        "disabled:\n  skills: [foo, bar]\n  agents: [baz]\n  hooks: []\n",
+        encoding="utf-8",
+    )
+    out = load_profile.load(profile)
+    assert out["skills"] == ["foo", "bar"]
+    assert out["agents"] == ["baz"]
+    assert out["hooks"] == []
+
+
+def test_load_profile_malformed_yaml(tmp_path: Path, load_profile, capsys) -> None:
+    profile = tmp_path / "bad.yaml"
+    profile.write_text("disabled: [unclosed\n", encoding="utf-8")
+    out = load_profile.load(profile)
+    assert out == {"skills": [], "agents": [], "hooks": []}
+    err = capsys.readouterr().err
+    assert "not valid YAML" in err
+
+
+def test_load_profile_missing_disabled_key(tmp_path: Path, load_profile) -> None:
+    profile = tmp_path / "profile.yaml"
+    profile.write_text("other: stuff\n", encoding="utf-8")
+    out = load_profile.load(profile)
+    assert out == {"skills": [], "agents": [], "hooks": []}
+
+
+def test_load_profile_non_list_values(tmp_path: Path, load_profile, capsys) -> None:
+    profile = tmp_path / "profile.yaml"
+    profile.write_text("disabled:\n  skills: not-a-list\n", encoding="utf-8")
+    out = load_profile.load(profile)
+    assert out["skills"] == []
+    err = capsys.readouterr().err
+    assert "not a list" in err
+
+
+def test_load_profile_strips_whitespace_and_blanks(tmp_path: Path, load_profile) -> None:
+    profile = tmp_path / "profile.yaml"
+    profile.write_text(
+        "disabled:\n  hooks:\n    - '  foo.py  '\n    - ''\n    - bar.py\n",
+        encoding="utf-8",
+    )
+    out = load_profile.load(profile)
+    assert out["hooks"] == ["foo.py", "bar.py"]
+
+
+# ---------- filter-codex-allowlist.py ----------
+
+
+def test_filter_codex_preserves_comments_and_blanks(filter_codex) -> None:
+    text = "# header comment\n\nUserPromptSubmit:foo.py\nPreToolUse:bar.py Bash\n"
+    out = filter_codex.filter_allowlist(text, {"foo.py"})
+    assert out == "# header comment\n\nPreToolUse:bar.py Bash\n"
+
+
+def test_filter_codex_no_disabled_returns_input(filter_codex) -> None:
+    text = "PreToolUse:bar.py Bash\n"
+    assert filter_codex.filter_allowlist(text, set()) == text
+
+
+def test_filter_codex_strips_only_matching_filename(filter_codex) -> None:
+    text = "Event:keep.py args\nEvent:drop.py args\n"
+    out = filter_codex.filter_allowlist(text, {"drop.py"})
+    assert out == "Event:keep.py args\n"
+
+
+def test_filter_codex_handles_no_trailing_newline(filter_codex) -> None:
+    text = "Event:drop.py"
+    assert filter_codex.filter_allowlist(text, {"drop.py"}) == ""
+
+
+def test_filter_codex_read_disabled(tmp_path: Path, filter_codex) -> None:
+    f = tmp_path / "d.txt"
+    f.write_text("# comment\nfoo.py\n\nbar.py\n", encoding="utf-8")
+    assert filter_codex.read_disabled(f) == {"foo.py", "bar.py"}
+
+
+def test_filter_codex_read_disabled_missing(tmp_path: Path, filter_codex) -> None:
+    assert filter_codex.read_disabled(tmp_path / "nope.txt") == set()
+
+
+# ---------- filter-settings-hooks.py ----------
+
+
+def _hook_entry(filename: str) -> dict:
+    return {"type": "command", "command": f'python3 "$HOME/.claude/hooks/{filename}"'}
+
+
+def test_filter_settings_drops_disabled_entries(filter_settings) -> None:
+    settings = {
+        "hooks": {
+            "PreToolUse": [
+                {"matcher": "Bash", "hooks": [_hook_entry("keep.py"), _hook_entry("drop.py")]},
+                {"matcher": "Edit", "hooks": [_hook_entry("drop.py")]},
+            ]
+        }
+    }
+    out = filter_settings.filter_hooks(settings, {"drop.py"})
+    assert out["hooks"] == {
+        "PreToolUse": [
+            {"matcher": "Bash", "hooks": [_hook_entry("keep.py")]},
+        ]
+    }
+
+
+def test_filter_settings_drops_event_when_all_groups_empty(filter_settings) -> None:
+    settings = {
+        "hooks": {
+            "PreToolUse": [{"matcher": "Bash", "hooks": [_hook_entry("drop.py")]}],
+            "PostToolUse": [{"matcher": "*", "hooks": [_hook_entry("keep.py")]}],
+        }
+    }
+    out = filter_settings.filter_hooks(settings, {"drop.py"})
+    assert "PreToolUse" not in out["hooks"]
+    assert "PostToolUse" in out["hooks"]
+
+
+def test_filter_settings_no_hooks_block(filter_settings) -> None:
+    settings = {"other": "value"}
+    assert filter_settings.filter_hooks(settings, {"drop.py"}) == settings
+
+
+def test_filter_settings_command_without_hooks_marker_is_kept(filter_settings) -> None:
+    settings = {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "echo hi"}]}]}}
+    out = filter_settings.filter_hooks(settings, {"drop.py"})
+    assert out["hooks"]["PreToolUse"][0]["hooks"] == [{"type": "command", "command": "echo hi"}]
+
+
+def test_filter_settings_hook_filename_helper(filter_settings) -> None:
+    h = filter_settings.hook_filename_from_command
+    assert h('python3 "$HOME/.claude/hooks/foo.py"') == "foo.py"
+    assert h("python3 $HOME/.claude/hooks/bar.py extra") == "bar.py"
+    assert h("echo no marker") is None
+
+
+def test_filter_settings_main_writes_output(tmp_path: Path, filter_settings, monkeypatch) -> None:
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [_hook_entry("drop.py"), _hook_entry("keep.py")]}]}}
+        ),
+        encoding="utf-8",
+    )
+    disabled_path = tmp_path / "disabled.txt"
+    disabled_path.write_text("drop.py\n", encoding="utf-8")
+    out_path = tmp_path / "out.json"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "filter-settings-hooks.py",
+            "--input",
+            str(settings_path),
+            "--disabled",
+            str(disabled_path),
+            "--output",
+            str(out_path),
+        ],
+    )
+    assert filter_settings.main() == 0
+    data = json.loads(out_path.read_text(encoding="utf-8"))
+    names = [h["command"].split("/hooks/")[-1].rstrip('"') for h in data["hooks"]["PreToolUse"][0]["hooks"]]
+    assert names == ["keep.py"]


### PR DESCRIPTION
## What it does

Users can filter which skills, agents, and hooks `./install.sh` installs via an opt-in `.local/profile.yaml` (disable lists), with an interactive picker (`--configure` / `--configure-only`).

- **Helpers** (cherry-picked, authorship preserved): `scripts/load-profile.py`, `scripts/filter-codex-allowlist.py`, `scripts/filter-settings-hooks.py`, `scripts/configure-profile.py` + 18 unit tests.
- **Wiring** (reimplemented against today's install.sh): Claude install (per-item + nested skills + copy mode), Codex mirror (top-level skills, agents, allowlisted hooks, hooks.json), settings.json hooks sync. Filtered components always install per-item — a whole-dir symlink cannot exclude items.
- **Picker dependency**: `questionary` is optional. configure-profile.py falls back to a stdlib prompt when it is missing, stdin is not a TTY, or `--plain` is passed. requirements.txt unchanged (the fork's questionary-dependency commit was dropped).
- **Docs**: `.local.example/profile.yaml` template, `.local.example/README.md` section, README install note.

## Opt-in guarantee

No `.local/profile.yaml` = behavior identical to today. Pinned by `test_no_profile_dry_run_mentions_no_filtering` and `test_no_profile_installs_everything`. `VEXJOY_INSTALL_PROFILE` env var lets tests point at a temp profile without touching the repo's `.local/`.

## Credit

Adapted from [@thomasvan](https://github.com/thomasvan)'s fork branch `feat/install-profile-filtering`. Commits `7d011989` (helpers + tests) and `95e6ed87` (docs) are cherry-picked with original authorship. The install.sh wiring is reimplemented: the fork's version predates the current `--per-item`/`--sync`/conflict-mode machinery and included Gemini mirror paths (Gemini CLI support removed in #784).

## Adaptation notes

- Gemini filter paths dropped; no ported code references `~/.gemini`.
- Codex mirror filters top-level skills; nested category skills are filtered in the Claude tree (documented in .local.example/README.md).
- Starter disabled-lists from the fork's `codex/custom-install-upstream-sync` branch were not seeded — component names drifted; template ships empty lists instead.

## Tests & gates

- `pytest scripts/tests hooks/tests`: 4387 passed, 1 skipped, 75 xfailed
- New integration tests: no-profile noop ×2, per-item filtering across Claude+Codex+settings.json, plain-picker fallback
- `ruff check` + `ruff format --check`: clean
- `bash -n install.sh`: clean
- `validate-doc-counts.py` / `validate-doc-links.py`: clean