### PR TITLE
docs(readme): cross-link vexjoy.com near the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 <img src="docs/repo-hero.png" alt="VexJoy Agent" width="100%">
 
+Essays and writing behind this toolkit live at [vexjoy.com](https://vexjoy.com).
+
 AI agents skip steps.
 
 "Looks correct" replaces running tests. "Trivial change" replaces verification. The agent confidently ships broken code because nothing structurally prevented it from skipping the work.


### PR DESCRIPTION
## Summary
Make the repo discoverable from its writing home and back: add one line after the hero image linking vexjoy.com as the essays/writing home.

## Changes
- `README.md` — add one cross-link line to https://vexjoy.com after the hero image, before the first paragraph

## Notes
- Part of a discoverability pass; repo description and topics need a token with Administration permission and are reported separately for the owner to apply.