### PR TITLE
refactor(routing): extract shared INDEX merge into routing_index_merge.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AI agents skip steps.
 
 Harnesses have a second problem: given only a skill list, they do not route eagerly enough, or correctly enough. Good skills sit unused. So this toolkit connects the skills, agents, and workflows we want directly into the harness, automatically. You don't have to understand what is here. Say what you want in plain English and you get all the value we have put into it: the right specialist with the right methodology, behind gates that demand exit codes, not assertions.
 
-44 domain agents, 125 workflow skills, 83 hooks, 118 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
+44 domain agents, 125 workflow skills, 83 hooks, 119 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
 
 Works across Claude Code (`/do`), Codex (`$do`), Factory (`/do`), Reasonix (`/do`).
 

--- a/scripts/index-router.py
+++ b/scripts/index-router.py
@@ -29,38 +29,11 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-
-def _load_index_items(tracked: Path, local_name: str | None, key: str) -> dict:
-    """Load index items from the tracked file, overlaying the local override.
-
-    Local override files (INDEX.local.json) are gitignored supersets produced
-    by the generator with --include-private; they add entries for
-    symlinked/private directories. The local file regenerates less often than
-    the tracked one, so it can be stale. The merge is add-only (tracked first,
-    local fills gaps per-name): a stale local can never hide a tracked skill
-    or agent, and never overrides tracked entry content such as triggers or
-    force_route — full replacement and per-name update both did.
-
-    Duplicated by hand in routing-manifest.py and pre-route.py (the routing
-    scripts share no lib module); keep the three copies in sync.
-    """
-    items: dict = {}
-    paths = [tracked]
-    if local_name:
-        local = tracked.parent / local_name
-        if local.exists():
-            paths.append(local)
-    for path in paths:
-        try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-        except (FileNotFoundError, json.JSONDecodeError, OSError):
-            continue
-        loaded = raw.get(key, {})
-        if isinstance(loaded, dict):
-            for name, data in loaded.items():
-                items.setdefault(name, data)
-    return items
-
+# Shared tracked+local INDEX merge — single source in routing_index_merge.py.
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+from routing_index_merge import load_index_items as _load_index_items
 
 INDEX_PATHS: dict[str, tuple[Path, str | None]] = {
     "skills": (REPO_ROOT / "skills" / "INDEX.json", "INDEX.local.json"),

--- a/scripts/pre-route.py
+++ b/scripts/pre-route.py
@@ -35,6 +35,12 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
+# Shared tracked+local INDEX merge — single source in routing_index_merge.py.
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+from routing_index_merge import load_index_items as _load_index_items
+
 # INDEX.json is a generated artifact (untracked). When the tracked path is
 # missing — fresh checkout, no install.sh run — regenerate it on the fly from
 # SKILL.md/agent frontmatter via these generators.
@@ -42,38 +48,6 @@ _INDEX_GENERATORS = {
     "skills": REPO_ROOT / "scripts" / "generate-skill-index.py",
     "agents": REPO_ROOT / "scripts" / "generate-agent-index.py",
 }
-
-
-def _load_index_items(tracked: Path, local_name: str | None, key: str) -> dict:
-    """Load index items from the tracked file, overlaying the local override.
-
-    Local override files (INDEX.local.json) are gitignored supersets produced
-    by the generator with --include-private; they add entries for
-    symlinked/private directories. The local file regenerates less often than
-    the tracked one, so it can be stale. The merge is add-only (tracked first,
-    local fills gaps per-name): a stale local can never hide a tracked skill
-    or agent, and never overrides tracked entry content such as triggers or
-    force_route — full replacement and per-name update both did.
-
-    Duplicated by hand in routing-manifest.py and index-router.py (the
-    routing scripts share no lib module); keep the three copies in sync.
-    """
-    items: dict = {}
-    paths = [tracked]
-    if local_name:
-        local = tracked.parent / local_name
-        if local.exists():
-            paths.append(local)
-    for path in paths:
-        try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-        except (FileNotFoundError, json.JSONDecodeError, OSError):
-            continue
-        loaded = raw.get(key, {})
-        if isinstance(loaded, dict):
-            for name, data in loaded.items():
-                items.setdefault(name, data)
-    return items
 
 
 def _ensure_index(index_type: str, path: Path) -> None:

--- a/scripts/routing-manifest.py
+++ b/scripts/routing-manifest.py
@@ -31,6 +31,12 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
+# Shared tracked+local INDEX merge — single source in routing_index_merge.py.
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+from routing_index_merge import load_index_items as _load_index_items
+
 # Tiered mode: how far back a route-events DECISION keeps a name in the
 # working set, and how many description words a stub line keeps.
 WORKING_SET_WINDOW_SECONDS = 30 * 86400
@@ -42,38 +48,6 @@ INDEX_PATHS = {
     "agents": (REPO_ROOT / "agents" / "INDEX.json", "INDEX.local.json"),
     "pipelines": (REPO_ROOT / "skills" / "workflow" / "references" / "pipeline-index.json", None),
 }
-
-
-def _load_index_items(tracked: Path, local_name: str | None, key: str) -> dict:
-    """Load index items from the tracked file, overlaying the local override.
-
-    Local override files (INDEX.local.json) are gitignored supersets produced
-    by the generator with --include-private --output <local-path>; they add
-    entries for symlinked/private directories. The local file regenerates less
-    often than the tracked one, so it can be stale. The merge is add-only
-    (tracked first, local fills gaps per-name): a stale local can never hide a
-    tracked skill or agent, and never overrides tracked entry content such as
-    triggers or force_route — full replacement and per-name update both did.
-
-    Duplicated by hand in pre-route.py and index-router.py (the routing
-    scripts share no lib module); keep the three copies in sync.
-    """
-    items: dict = {}
-    paths = [tracked]
-    if local_name:
-        local = tracked.parent / local_name
-        if local.exists():
-            paths.append(local)
-    for path in paths:
-        try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-        except (FileNotFoundError, json.JSONDecodeError, OSError):
-            continue
-        loaded = raw.get(key, {})
-        if isinstance(loaded, dict):
-            for name, data in loaded.items():
-                items.setdefault(name, data)
-    return items
 
 
 def load_entries() -> list[dict]:

--- a/scripts/routing_index_merge.py
+++ b/scripts/routing_index_merge.py
@@ -1,0 +1,43 @@
+"""Shared tracked + local INDEX merge for the routing scripts.
+
+Single source for the merge formerly hand-duplicated in routing-manifest.py,
+pre-route.py, and index-router.py. Those scripts import this module; the
+merge can no longer diverge between them.
+
+Importable by name (underscores). The routing scripts add their own directory
+to sys.path before importing, since they run as files, not as a package.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def load_index_items(tracked: Path, local_name: str | None, key: str) -> dict:
+    """Load index items from the tracked file, overlaying the local override.
+
+    Local override files (INDEX.local.json) are gitignored supersets produced
+    by the generator with --include-private; they add entries for
+    symlinked/private directories. The local file regenerates less often than
+    the tracked one, so it can be stale. The merge is add-only (tracked first,
+    local fills gaps per-name): a stale local can never hide a tracked skill
+    or agent, and never overrides tracked entry content such as triggers or
+    force_route — full replacement and per-name update both did.
+    """
+    items: dict = {}
+    paths = [tracked]
+    if local_name:
+        local = tracked.parent / local_name
+        if local.exists():
+            paths.append(local)
+    for path in paths:
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        loaded = raw.get(key, {})
+        if isinstance(loaded, dict):
+            for name, data in loaded.items():
+                items.setdefault(name, data)
+    return items

--- a/scripts/tests/test_routing_index_merge.py
+++ b/scripts/tests/test_routing_index_merge.py
@@ -1,0 +1,137 @@
+"""Tests for scripts/routing_index_merge.py and its three importers.
+
+Invariants:
+1. routing-manifest.py, pre-route.py, and index-router.py share one merge —
+   identical output for the same tracked + local inputs.
+2. A stale local file never hides newly added tracked entries (PR #778).
+3. A stale local never overrides tracked content (force_route, triggers);
+   local fills gaps per-name only.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+
+ROUTING_MODULES = ["routing-manifest", "pre-route", "index-router"]
+
+
+@pytest.fixture
+def merge(monkeypatch: pytest.MonkeyPatch):
+    """Import the shared merge module."""
+    monkeypatch.syspath_prepend(str(SCRIPTS_DIR))
+    return importlib.import_module("routing_index_merge")
+
+
+@pytest.fixture
+def routing_modules(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Import the three routing scripts (hyphenated names need importlib)."""
+    monkeypatch.syspath_prepend(str(SCRIPTS_DIR))
+    return [importlib.import_module(name) for name in ROUTING_MODULES]
+
+
+def _write_indexes(tmp_path: Path, tracked: dict, local: dict | None) -> Path:
+    """Write tracked INDEX.json (and optional INDEX.local.json); return tracked path."""
+    tracked_path = tmp_path / "INDEX.json"
+    tracked_path.write_text(json.dumps(tracked), encoding="utf-8")
+    if local is not None:
+        (tmp_path / "INDEX.local.json").write_text(json.dumps(local), encoding="utf-8")
+    return tracked_path
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1: one merge across all three entry points
+# ---------------------------------------------------------------------------
+
+
+def test_all_three_scripts_use_shared_merge(merge, routing_modules):
+    """Each script's _load_index_items IS the shared function — divergence impossible."""
+    for mod in routing_modules:
+        assert mod._load_index_items is merge.load_index_items, mod.__name__
+
+
+def test_identical_output_across_entry_points(tmp_path, routing_modules):
+    """Same tracked + local inputs produce identical merged output everywhere."""
+    tracked_path = _write_indexes(
+        tmp_path,
+        {"skills": {"a": {"triggers": ["t1"]}, "b": {"force_route": True}}},
+        {"skills": {"a": {"triggers": ["stale"]}, "priv": {"triggers": ["p"]}}},
+    )
+    results = [mod._load_index_items(tracked_path, "INDEX.local.json", "skills") for mod in routing_modules]
+    assert results[0] == results[1] == results[2]
+    assert set(results[0]) == {"a", "b", "priv"}
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2: stale local never hides new tracked entries (PR #778)
+# ---------------------------------------------------------------------------
+
+
+def test_stale_local_does_not_hide_new_tracked_entries(tmp_path, merge):
+    tracked_path = _write_indexes(
+        tmp_path,
+        {"skills": {"old": {"triggers": ["o"]}, "brand-new": {"triggers": ["n"]}}},
+        {"skills": {"old": {"triggers": ["o"]}}},  # stale: predates brand-new
+    )
+    items = merge.load_index_items(tracked_path, "INDEX.local.json", "skills")
+    assert "brand-new" in items
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3: local fills gaps only; tracked content wins per-name
+# ---------------------------------------------------------------------------
+
+
+def test_local_never_overrides_tracked_content(tmp_path, merge):
+    tracked_path = _write_indexes(
+        tmp_path,
+        {"skills": {"s": {"triggers": ["fresh"], "force_route": True}}},
+        {"skills": {"s": {"triggers": ["stale"], "force_route": False}}},
+    )
+    items = merge.load_index_items(tracked_path, "INDEX.local.json", "skills")
+    assert items["s"] == {"triggers": ["fresh"], "force_route": True}
+
+
+def test_local_adds_missing_names_only(tmp_path, merge):
+    tracked_path = _write_indexes(
+        tmp_path,
+        {"agents": {"tracked-only": {"triggers": ["t"]}}},
+        {"agents": {"private-only": {"triggers": ["p"]}}},
+    )
+    items = merge.load_index_items(tracked_path, "INDEX.local.json", "agents")
+    assert items == {"tracked-only": {"triggers": ["t"]}, "private-only": {"triggers": ["p"]}}
+
+
+# ---------------------------------------------------------------------------
+# Edge cases preserved from the original copies
+# ---------------------------------------------------------------------------
+
+
+def test_no_local_name_reads_tracked_only(tmp_path, merge):
+    tracked_path = _write_indexes(tmp_path, {"pipelines": {"p": {"triggers": []}}}, None)
+    items = merge.load_index_items(tracked_path, None, "pipelines")
+    assert items == {"p": {"triggers": []}}
+
+
+def test_missing_local_file_is_ignored(tmp_path, merge):
+    tracked_path = _write_indexes(tmp_path, {"skills": {"s": {}}}, None)
+    items = merge.load_index_items(tracked_path, "INDEX.local.json", "skills")
+    assert items == {"s": {}}
+
+
+def test_unreadable_or_invalid_files_are_skipped(tmp_path, merge):
+    tracked_path = tmp_path / "INDEX.json"
+    tracked_path.write_text("not json", encoding="utf-8")
+    (tmp_path / "INDEX.local.json").write_text(json.dumps({"skills": {"l": {}}}), encoding="utf-8")
+    items = merge.load_index_items(tracked_path, "INDEX.local.json", "skills")
+    assert items == {"l": {}}
+
+
+def test_non_dict_section_is_ignored(tmp_path, merge):
+    tracked_path = _write_indexes(tmp_path, {"skills": ["not", "a", "dict"]}, None)
+    assert merge.load_index_items(tracked_path, None, "skills") == {}


### PR DESCRIPTION
## Summary
- Extracts the hand-duplicated `_load_index_items()` from `routing-manifest.py`, `pre-route.py`, and `index-router.py` into a single shared module `scripts/routing_index_merge.py`; all three scripts now import the same function object, making divergence impossible rather than merely detected.
- Merge semantics unchanged: tracked-first, local fills gaps per-name (`setdefault`); stale local can never hide new tracked entries (PR #778 regression) nor override tracked content.
- New `scripts/tests/test_routing_index_merge.py`: identity test across the three entry points, identical-output test, regression coverage for stale-hide/override invariants, edge cases (missing/invalid JSON, non-dict section).

## Verification
- `pytest scripts/tests`: 2920 passed, 1 skipped, 75 xfailed
- `ruff check` clean; `ruff format --check`: 479 files already formatted
- Smoke-ran all three scripts

## Provenance
Winning arm (3–0 blind grade) of experiment model-ab-v2 — fable(low) vs opus(adaptive) on identical prompts.