### PR TITLE
feat(scripts): scoped-commit and trash git-safety helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AI agents skip steps.
 
 Harnesses have a second problem: given only a skill list, they do not route eagerly enough, or correctly enough. Good skills sit unused. So this toolkit connects the skills, agents, and workflows we want directly into the harness, automatically. You don't have to understand what is here. Say what you want in plain English and you get all the value we have put into it: the right specialist with the right methodology, behind gates that demand exit codes, not assertions.
 
-44 domain agents, 125 workflow skills, 83 hooks, 118 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
+44 domain agents, 125 workflow skills, 83 hooks, 120 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
 
 Works across Claude Code (`/do`), Codex (`$do`), Factory (`/do`), Reasonix (`/do`).
 

--- a/scripts/scoped-commit.py
+++ b/scripts/scoped-commit.py
@@ -9,7 +9,8 @@ Usage:
     python3 scripts/scoped-commit.py [--force-lock] "message" path [path ...]
 
 Guards:
-    - "." is rejected; list specific paths.
+    - Paths that resolve to the repo root or cwd (".", "./", absolute repo
+      path) and pathspec magic prefixes (":/", ":(glob)") are rejected.
     - A message that matches an existing path is rejected (argument-order slip).
     - A stale .git/index.lock is removed only with --force-lock, then one retry.
 
@@ -59,8 +60,15 @@ def main(argv: list[str] | None = None) -> int:
         return _fail("commit message must not be empty")
     if Path(args.message).exists():
         return _fail(f'first argument looks like a path ("{args.message}"); pass the commit message first')
-    if "." in args.paths:
-        return _fail('"." stages the whole repository; list specific paths instead')
+    toplevel = _git(["rev-parse", "--show-toplevel"])
+    if toplevel.returncode != 0:
+        return _fail(f"not a git repository: {toplevel.stderr.strip()}")
+    repo_root = Path(toplevel.stdout.strip()).resolve()
+    for path in args.paths:
+        if path.startswith(":"):
+            return _fail(f'pathspec magic prefixes are not allowed: "{path}"')
+        if Path(path).resolve() in (Path.cwd().resolve(), repo_root):
+            return _fail(f'"{path}" stages the whole repository; list specific paths instead')
 
     for path in args.paths:
         if not Path(path).exists() and not _path_known_to_git(path):

--- a/scripts/scoped-commit.py
+++ b/scripts/scoped-commit.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Pathspec-scoped git commit helper for multi-agent worktrees.
+
+Stages and commits only the listed paths, so one agent never commits
+another agent's changes. Rebuilt in Python from the `committer` bash
+helper in steipete/agent-scripts (evidence only, no code copied).
+
+Usage:
+    python3 scripts/scoped-commit.py [--force-lock] "message" path [path ...]
+
+Guards:
+    - "." is rejected; list specific paths.
+    - A message that matches an existing path is rejected (argument-order slip).
+    - A stale .git/index.lock is removed only with --force-lock, then one retry.
+
+Exit codes: 0 = committed, 1 = error, 2 = usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+INDEX_LOCK_RE = re.compile(r"Unable to create '([^']*index\.lock)'")
+
+
+def _git(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a git command, capturing output."""
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=False)
+
+
+def _fail(message: str) -> int:
+    print(f"Error: {message}", file=sys.stderr)
+    return 1
+
+
+def _path_known_to_git(path: str) -> bool:
+    """True if the path is in the index or in HEAD (supports staging deletions)."""
+    if _git(["ls-files", "--error-unmatch", "--", path]).returncode == 0:
+        return True
+    return _git(["cat-file", "-e", f"HEAD:{path}"]).returncode == 0
+
+
+def _commit(message: str, paths: list[str]) -> subprocess.CompletedProcess[str]:
+    return _git(["commit", "-m", message, "--", *paths])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Commit only the listed paths.")
+    parser.add_argument("--force-lock", action="store_true", help="remove a stale .git/index.lock and retry once")
+    parser.add_argument("message", help="commit message")
+    parser.add_argument("paths", nargs="+", help="specific paths to stage and commit")
+    args = parser.parse_args(argv)
+
+    if not args.message.strip():
+        return _fail("commit message must not be empty")
+    if Path(args.message).exists():
+        return _fail(f'first argument looks like a path ("{args.message}"); pass the commit message first')
+    if "." in args.paths:
+        return _fail('"." stages the whole repository; list specific paths instead')
+
+    for path in args.paths:
+        if not Path(path).exists() and not _path_known_to_git(path):
+            return _fail(f"path not found: {path}")
+
+    unstage = _git(["restore", "--staged", ":/"])
+    if unstage.returncode != 0:
+        return _fail(f"could not reset index: {unstage.stderr.strip()}")
+    add = _git(["add", "-A", "--", *args.paths])
+    if add.returncode != 0:
+        return _fail(f"git add failed: {add.stderr.strip()}")
+    if _git(["diff", "--staged", "--quiet"]).returncode == 0:
+        return _fail(f"no staged changes for: {' '.join(args.paths)}")
+
+    result = _commit(args.message, args.paths)
+    if result.returncode != 0 and args.force_lock:
+        match = INDEX_LOCK_RE.search(result.stderr)
+        if match and Path(match.group(1)).exists():
+            Path(match.group(1)).unlink()
+            print(f"Removed stale git lock: {match.group(1)}", file=sys.stderr)
+            result = _commit(args.message, args.paths)
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        return 1
+
+    print(f'Committed "{args.message}" with {len(args.paths)} path(s)')
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_scoped_commit.py
+++ b/scripts/tests/test_scoped_commit.py
@@ -1,0 +1,121 @@
+"""Tests for scoped-commit.py.
+
+Covers guards (".", message-vs-path, empty message, missing path),
+pathspec-scoped staging/commit, deletion staging, and --force-lock
+stale index.lock handling. Each test uses a throwaway git repo.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys_path_entry = str(Path(__file__).resolve().parent.parent)
+sys.path.insert(0, sys_path_entry)
+scoped_commit = importlib.import_module("scoped-commit")
+sys.path.pop(0)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, check=True)
+
+
+@pytest.fixture()
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Throwaway git repo with one initial commit; cwd set inside it."""
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test")
+    (tmp_path / "base.txt").write_text("base\n")
+    _git(tmp_path, "add", "base.txt")
+    _git(tmp_path, "commit", "-q", "-m", "init")
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _last_message(repo: Path) -> str:
+    return _git(repo, "log", "-1", "--pretty=%s").stdout.strip()
+
+
+class TestGuards:
+    def test_rejects_dot_path(self, repo: Path, capsys: pytest.CaptureFixture) -> None:
+        (repo / "a.txt").write_text("a")
+        assert scoped_commit.main(["msg", "."]) == 1
+        assert "list specific paths" in capsys.readouterr().err
+
+    def test_rejects_message_that_is_a_path(self, repo: Path, capsys: pytest.CaptureFixture) -> None:
+        (repo / "a.txt").write_text("a")
+        assert scoped_commit.main(["a.txt", "base.txt"]) == 1
+        assert "looks like a path" in capsys.readouterr().err
+
+    def test_rejects_empty_message(self, repo: Path, capsys: pytest.CaptureFixture) -> None:
+        assert scoped_commit.main(["   ", "base.txt"]) == 1
+        assert "must not be empty" in capsys.readouterr().err
+
+    def test_rejects_unknown_path(self, repo: Path, capsys: pytest.CaptureFixture) -> None:
+        assert scoped_commit.main(["msg", "nope.txt"]) == 1
+        assert "path not found" in capsys.readouterr().err
+
+    def test_no_changes_fails(self, repo: Path, capsys: pytest.CaptureFixture) -> None:
+        assert scoped_commit.main(["msg", "base.txt"]) == 1
+        assert "no staged changes" in capsys.readouterr().err
+
+
+class TestCommit:
+    def test_commits_only_listed_paths(self, repo: Path) -> None:
+        (repo / "a.txt").write_text("a")
+        (repo / "b.txt").write_text("b")
+        assert scoped_commit.main(["add a", "a.txt"]) == 0
+        assert _last_message(repo) == "add a"
+        status = _git(repo, "status", "--porcelain").stdout
+        assert "b.txt" in status  # b stays uncommitted
+        assert "a.txt" not in status
+
+    def test_unstages_prestaged_unlisted_files(self, repo: Path) -> None:
+        (repo / "a.txt").write_text("a")
+        (repo / "b.txt").write_text("b")
+        _git(repo, "add", "b.txt")
+        assert scoped_commit.main(["add a", "a.txt"]) == 0
+        show = _git(repo, "show", "--name-only", "--pretty=", "HEAD").stdout
+        assert "a.txt" in show
+        assert "b.txt" not in show
+
+    def test_commits_deletion(self, repo: Path) -> None:
+        (repo / "base.txt").unlink()
+        assert scoped_commit.main(["remove base", "base.txt"]) == 0
+        assert _last_message(repo) == "remove base"
+
+
+class TestForceLock:
+    def test_lock_blocks_without_flag(self, repo: Path) -> None:
+        (repo / "a.txt").write_text("a")
+        lock = repo / ".git" / "index.lock"
+        # git add also needs the lock; stage first, then create the lock so only commit hits it.
+        _git(repo, "add", "a.txt")
+        lock.touch()
+        try:
+            assert scoped_commit.main(["msg", "a.txt"]) == 1
+        finally:
+            lock.unlink(missing_ok=True)
+        assert _last_message(repo) == "init"
+
+    def test_force_lock_removes_stale_lock_and_commits(self, repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (repo / "a.txt").write_text("a")
+        lock = repo / ".git" / "index.lock"
+        real_git = scoped_commit._git
+
+        def git_with_lock(args: list[str]) -> subprocess.CompletedProcess[str]:
+            # Plant the lock only for the first commit attempt.
+            if args[0] == "commit" and not lock.exists() and not getattr(git_with_lock, "retried", False):
+                lock.touch()
+                git_with_lock.retried = True
+            return real_git(args)
+
+        monkeypatch.setattr(scoped_commit, "_git", git_with_lock)
+        assert scoped_commit.main(["--force-lock", "msg", "a.txt"]) == 0
+        assert not lock.exists()
+        assert _last_message(repo) == "msg"

--- a/scripts/tests/test_scoped_commit.py
+++ b/scripts/tests/test_scoped_commit.py
@@ -47,6 +47,22 @@ class TestGuards:
         assert scoped_commit.main(["msg", "."]) == 1
         assert "list specific paths" in capsys.readouterr().err
 
+    def test_rejects_dot_slash_path(self, repo: Path, capsys: pytest.CaptureFixture) -> None:
+        (repo / "a.txt").write_text("a")
+        assert scoped_commit.main(["msg", "./"]) == 1
+        assert "list specific paths" in capsys.readouterr().err
+        assert "a.txt" in _git(repo, "status", "--porcelain").stdout  # still uncommitted
+
+    def test_rejects_repo_root_absolute_path(self, repo: Path, capsys: pytest.CaptureFixture) -> None:
+        (repo / "a.txt").write_text("a")
+        assert scoped_commit.main(["msg", str(repo)]) == 1
+        assert "list specific paths" in capsys.readouterr().err
+
+    def test_rejects_pathspec_magic(self, repo: Path, capsys: pytest.CaptureFixture) -> None:
+        (repo / "a.txt").write_text("a")
+        assert scoped_commit.main(["msg", ":/"]) == 1
+        assert "pathspec magic" in capsys.readouterr().err
+
     def test_rejects_message_that_is_a_path(self, repo: Path, capsys: pytest.CaptureFixture) -> None:
         (repo / "a.txt").write_text("a")
         assert scoped_commit.main(["a.txt", "base.txt"]) == 1

--- a/scripts/tests/test_trash.py
+++ b/scripts/tests/test_trash.py
@@ -1,0 +1,101 @@
+"""Tests for trash.py.
+
+Covers XDG trash root resolution, file/dir moves with .trashinfo records,
+collision-safe naming, --allow-missing, and the copy fallback path.
+All tests redirect the trash via XDG_DATA_HOME to a temp directory.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+sys_path_entry = str(Path(__file__).resolve().parent.parent)
+sys.path.insert(0, sys_path_entry)
+trash = importlib.import_module("trash")
+sys.path.pop(0)
+
+
+@pytest.fixture()
+def trash_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point XDG_DATA_HOME at a temp dir; return the resulting Trash root."""
+    data_home = tmp_path / "data"
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
+    monkeypatch.chdir(tmp_path)
+    return data_home / "Trash"
+
+
+class TestTrashRoot:
+    def test_uses_xdg_data_home(self, trash_dir: Path) -> None:
+        assert trash.trash_root() == trash_dir
+
+    def test_defaults_to_local_share(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        assert trash.trash_root() == Path.home() / ".local" / "share" / "Trash"
+
+
+class TestMove:
+    def test_moves_file_and_writes_trashinfo(self, tmp_path: Path, trash_dir: Path) -> None:
+        target = tmp_path / "doomed.txt"
+        target.write_text("bye")
+        assert trash.main([str(target)]) == 0
+        assert not target.exists()
+        assert (trash_dir / "files" / "doomed.txt").read_text() == "bye"
+        info = (trash_dir / "info" / "doomed.txt.trashinfo").read_text()
+        assert "[Trash Info]" in info
+        assert str(target) in info
+        assert "DeletionDate=" in info
+
+    def test_moves_directory(self, tmp_path: Path, trash_dir: Path) -> None:
+        target = tmp_path / "dir"
+        target.mkdir()
+        (target / "inner.txt").write_text("x")
+        assert trash.main([str(target)]) == 0
+        assert not target.exists()
+        assert (trash_dir / "files" / "dir" / "inner.txt").read_text() == "x"
+
+    def test_collision_gets_unique_name(self, tmp_path: Path, trash_dir: Path) -> None:
+        for content in ("one", "two"):
+            target = tmp_path / "same.txt"
+            target.write_text(content)
+            assert trash.main([str(target)]) == 0
+        files = sorted(p.name for p in (trash_dir / "files").iterdir())
+        assert len(files) == 2
+        assert "same.txt" in files
+        other = next(name for name in files if name != "same.txt")
+        assert other.startswith("same-") and other.endswith(".txt")
+        assert (trash_dir / "info" / f"{other}.trashinfo").exists()
+
+    def test_relative_path(self, tmp_path: Path, trash_dir: Path) -> None:
+        (tmp_path / "rel.txt").write_text("r")
+        assert trash.main(["rel.txt"]) == 0
+        assert (trash_dir / "files" / "rel.txt").exists()
+
+    def test_copy_fallback_when_rename_fails(
+        self, tmp_path: Path, trash_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "xfs.txt"
+        target.write_text("cross")
+
+        def raise_exdev(self: Path, dest: Path) -> None:
+            raise OSError(18, "Invalid cross-device link")
+
+        monkeypatch.setattr(Path, "rename", raise_exdev)
+        assert trash.main([str(target)]) == 0
+        assert not target.exists()
+        assert (trash_dir / "files" / "xfs.txt").read_text() == "cross"
+
+
+class TestMissing:
+    def test_missing_target_fails(self, tmp_path: Path, trash_dir: Path, capsys: pytest.CaptureFixture) -> None:
+        assert trash.main([str(tmp_path / "ghost.txt")]) == 1
+        assert "not found" in capsys.readouterr().err
+
+    def test_allow_missing_skips(self, tmp_path: Path, trash_dir: Path) -> None:
+        real = tmp_path / "real.txt"
+        real.write_text("r")
+        assert trash.main(["--allow-missing", str(tmp_path / "ghost.txt"), str(real)]) == 0
+        assert (trash_dir / "files" / "real.txt").exists()

--- a/scripts/tests/test_trash.py
+++ b/scripts/tests/test_trash.py
@@ -74,6 +74,17 @@ class TestMove:
         assert trash.main(["rel.txt"]) == 0
         assert (trash_dir / "files" / "rel.txt").exists()
 
+    def test_trashes_symlink_itself_not_target(self, tmp_path: Path, trash_dir: Path) -> None:
+        real = tmp_path / "real.txt"
+        real.write_text("keep")
+        link = tmp_path / "link.txt"
+        link.symlink_to(real)
+        assert trash.main([str(link)]) == 0
+        assert real.read_text() == "keep"  # target untouched
+        assert not link.exists() and not link.is_symlink()
+        trashed = trash_dir / "files" / "link.txt"
+        assert trashed.is_symlink()
+
     def test_copy_fallback_when_rename_fails(
         self, tmp_path: Path, trash_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/scripts/trash.py
+++ b/scripts/trash.py
@@ -88,7 +88,10 @@ def main(argv: list[str] | None = None) -> int:
 
     failed = False
     for raw in args.paths:
-        target = Path(raw).expanduser().resolve(strict=False)
+        expanded = Path(raw).expanduser()
+        # Resolve only the parent so a symlink target stays a symlink:
+        # resolving the full path would trash the link's target file.
+        target = expanded.parent.resolve(strict=False) / expanded.name
         if not target.exists() and not target.is_symlink():
             if args.allow_missing:
                 continue

--- a/scripts/trash.py
+++ b/scripts/trash.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Move files to the XDG Trash instead of deleting them.
+
+Safer `rm`: targets land in $XDG_DATA_HOME/Trash (default
+~/.local/share/Trash) with a .trashinfo record, so file managers can
+restore them. Rebuilt in Python from the `trash.ts` helper in
+steipete/agent-scripts (evidence only, no code copied).
+
+Usage:
+    python3 scripts/trash.py path [path ...]
+    python3 scripts/trash.py --allow-missing path [path ...]
+
+Behavior:
+    - Name collisions in the trash get a unique "-<nonce>-<n>" suffix.
+    - Cross-filesystem moves fall back to copy + delete.
+    - Missing targets fail the run unless --allow-missing is set.
+
+Exit codes: 0 = all moved, 1 = missing target or move error, 2 = usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import time
+import urllib.parse
+from datetime import datetime
+from pathlib import Path
+
+MAX_NAME_ATTEMPTS = 10_000
+
+
+def trash_root() -> Path:
+    """Return the XDG Trash root: $XDG_DATA_HOME/Trash or ~/.local/share/Trash."""
+    data_home = os.environ.get("XDG_DATA_HOME")
+    base = Path(data_home) if data_home else Path.home() / ".local" / "share"
+    return base / "Trash"
+
+
+def unique_dest(files_dir: Path, name: str) -> Path:
+    """Return a free destination path in the trash for `name`."""
+    candidate = files_dir / name
+    if not candidate.exists() and not candidate.is_symlink():
+        return candidate
+    stem, ext = os.path.splitext(name)
+    nonce = int(time.time() * 1000)
+    for attempt in range(1, MAX_NAME_ATTEMPTS):
+        candidate = files_dir / f"{stem}-{nonce}-{attempt}{ext}"
+        if not candidate.exists() and not candidate.is_symlink():
+            return candidate
+    raise OSError(f"no free trash destination for {name}")
+
+
+def write_trashinfo(info_dir: Path, dest_name: str, original: Path) -> None:
+    """Write the XDG .trashinfo record so the file can be restored."""
+    quoted = urllib.parse.quote(str(original))
+    stamp = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    info = f"[Trash Info]\nPath={quoted}\nDeletionDate={stamp}\n"
+    (info_dir / f"{dest_name}.trashinfo").write_text(info, encoding="utf-8")
+
+
+def move(source: Path, dest: Path) -> None:
+    """Rename, with copy + delete fallback for cross-filesystem moves."""
+    try:
+        source.rename(dest)
+    except OSError:
+        if source.is_dir() and not source.is_symlink():
+            shutil.copytree(source, dest, symlinks=True)
+            shutil.rmtree(source)
+        else:
+            shutil.copy2(source, dest, follow_symlinks=False)
+            source.unlink()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Move paths to the XDG Trash.")
+    parser.add_argument("--allow-missing", action="store_true", help="skip missing targets without failing")
+    parser.add_argument("paths", nargs="+", help="files or directories to trash")
+    args = parser.parse_args(argv)
+
+    root = trash_root()
+    files_dir = root / "files"
+    info_dir = root / "info"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    info_dir.mkdir(parents=True, exist_ok=True)
+
+    failed = False
+    for raw in args.paths:
+        target = Path(raw).expanduser().resolve(strict=False)
+        if not target.exists() and not target.is_symlink():
+            if args.allow_missing:
+                continue
+            print(f"Error: not found: {raw}", file=sys.stderr)
+            failed = True
+            continue
+        try:
+            dest = unique_dest(files_dir, target.name)
+            move(target, dest)
+            write_trashinfo(info_dir, dest.name, target)
+            print(f"Trashed {raw} -> {dest}")
+        except OSError as error:
+            print(f"Error: {raw}: {error}", file=sys.stderr)
+            failed = True
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Two git-safety helper scripts plus tests (PR group: git-safety-scripts, ranks 2 and 9 of the agent-scripts port).

### scripts/scoped-commit.py (rank 2)
Pathspec-scoped commit helper for multi-agent worktrees. Stages and commits only the listed paths, so one agent never commits another agent's changes.
- Rejects "." (would stage the whole repo)
- Message-vs-path guard: errors if the message argument matches an existing path
- Resets the index, stages only listed paths, refuses empty commits
- Supports staging deletions (path in HEAD but gone from disk)
- Stale .git/index.lock removed only behind explicit --force-lock, then one retry

### scripts/trash.py (rank 9)
Safer rm: moves targets to the XDG Trash ($XDG_DATA_HOME/Trash or ~/.local/share/Trash) with .trashinfo records so file managers can restore them.
- Collision-safe destination names (stem-nonce-n suffix)
- Cross-filesystem fallback: copy + delete when rename fails
- --allow-missing flag to skip absent targets

### Tests
scripts/tests/test_scoped_commit.py and scripts/tests/test_trash.py — 19 tests, throwaway git repos and XDG_DATA_HOME redirection, following existing importlib-import conventions.

## Source attribution

Evidence: steipete/agent-scripts (scripts/committer bash helper, scripts/trash.ts). Both rebuilt in Python in our style; no files copied, no source scripts executed.

## Value

- scoped-commit: prevents agents committing other agents' worktree changes; matches our multi-agent orchestration risk and the pr-workflow "never git add ." rule.
- trash: reversible deletion for agents and users; aligns with the home-account safety policy's bias against irreversible data loss.

## Checks

- pytest scripts/tests/test_scoped_commit.py scripts/tests/test_trash.py: 19 passed
- ruff check + ruff format --check: pass on all four files
- validate_positive_instruction_docs.py: findings unchanged (all pre-existing, none in this PR's files)
