### PR TITLE
docs(learnings): graduate 4 session gotchas into skill references

### DIFF
--- a/docs/what-didnt-work.md
+++ b/docs/what-didnt-work.md
@@ -22,6 +22,8 @@ Format: one `## YYYY-MM-DD <experiment>` section with the four bold fields below
 - **Decision**: rejected | deferred | revisit-if <condition>.
 ```
 
+Add new entries under the Post-seed experiments section; a CI test pins the seed-entry count (evidence: PR #798).
+
 Query it: read this file, run `grep -c '^## 2026' docs/what-didnt-work.md`, or run `/retro what-didnt-work` (prints the file; optionally mirrors a one-line pointer into learning.db for FTS search). Check it before re-running an experiment.
 
 ---

--- a/skills/meta/do/references/workflow-dispatch.md
+++ b/skills/meta/do/references/workflow-dispatch.md
@@ -25,6 +25,8 @@ else:                                                       -> agent + skill dir
 
 Build `roster` from the Phase-3 enhancement signals, scaled by `tier`. **Each entry is `{agentType, skills: [...], lens}` — `skills` is a LIST carrying the FULL Phase-3 stack a direct dispatch would build.** Per agent, emit one `Skill("<name>")` per `skills` element and the four /do mandatory injections. Native forms: `comprehensive-review-workflow.js` (named pipeline), `fan-out-workflow.js` (generic Complex/tier-4). Both pseudocode gates (env proxy AND the orchestrator's own tool-list self-check) must hold; a `pick` with no registry entry is prose-only.
 
+**File ownership batching:** batch fan-out items by file ownership before opening PRs — branches touching the same file merge serially and each later one goes CONFLICTING (evidence: PRs #789/#791/#793 each added rows to pr-workflow SKILL.md, costing a remediation wave). Put shared-file items on one branch or declare a merge order.
+
 **Banner parity (R4):** expand the pipeline name → phase list for the routing banner on BOTH paths, so it reads identically regardless of executor (e.g. complexity-trigger fan-out shows `fan-out → synthesize`).
 
 **Step 1c (inline-authored Workflow scripts): when the user explicitly asks to "run through a workflow" with no named pipeline `pick`, the orchestrator MUST dictate roster size and skill stacks — never delegate those to the Workflow tool** (whose defaults skew toward many-skeptic adversarial fan-outs and rarely emit `Skill(...)`). Before any inline `script:`, build the same `roster` Step 1b uses and pin:

--- a/skills/process/pr-workflow/references/ci-check.md
+++ b/skills/process/pr-workflow/references/ci-check.md
@@ -120,6 +120,9 @@ This reference only checks CI status. For local debugging of test failures, hand
 2. If not authenticated, suggest `gh auth login`
 3. Check if GITHUB_TOKEN environment variable is set as alternative
 
+### Conflicting PR: "no checks reported"
+A same-repo PR in `mergeable=CONFLICTING` state fires no workflow run on push, so `gh pr checks` shows "no checks reported" — a missing run, not a failure. Merge `origin/main` into the branch first; CI triggers on that push. (Evidence: PRs #789/#791/#797, 2026-06-11.)
+
 ### Error: "No workflow runs found"
 **Cause**: Workflow not triggered, branch has no workflows, or checked too early
 **Solution**:

--- a/skills/process/worktree-agent/SKILL.md
+++ b/skills/process/worktree-agent/SKILL.md
@@ -48,6 +48,8 @@ If `git checkout -b <branch-name>` fails with "X is already used by worktree at 
 git checkout -b <branch-name>-$(date +%s)
 ```
 
+To update a branch held by another worktree (e.g. an existing PR branch): work detached from `origin/<branch>` and push with `git push origin HEAD:<branch>`. `gh pr merge`'s post-merge local-checkout errors are harmless.
+
 ## Rule 3: Use Worktree-Relative Paths
 
 Never hardcode absolute paths from the main repo. Use `$(git rev-parse --show-toplevel)/path`.


### PR DESCRIPTION
## Summary
Graduates 4 verified session gotchas into the references they govern.

| File | Note added |
|---|---|
| skills/process/pr-workflow/references/ci-check.md | CONFLICTING same-repo PR fires no workflow run; merge origin/main first (PRs #789/#791/#797) |
| skills/process/worktree-agent/SKILL.md | Update a branch held by another worktree via detached push to origin HEAD ref |
| skills/meta/do/references/workflow-dispatch.md | Batch fan-out items by file ownership before opening PRs (PRs #789/#791/#793) |
| docs/what-didnt-work.md | New entries go under Post-seed experiments; CI pins seed-entry count (PR #798) |

## Verification
- validate_positive_instruction_docs.py: no new findings in edited files
- test_negative_results_registry.py: 13 passed
- gh pr view confirmed #789/#791/#793 each touched pr-workflow SKILL.md
