### PR TITLE
chore(skills): trim 11 over-long skill descriptions to <=40 router-line tokens

### DIFF
--- a/skills/business/finance/SKILL.md
+++ b/skills/business/finance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finance
-description: Finance and accounting workflows — journal entries, reconciliation, variance analysis, financial statements, audit support, month-end close, SOX testing. Use when preparing journal entries, reconciling accounts, analyzing variances, generating statements, or supporting audits.
+description: "Finance and accounting: journal entries, reconciliation, variance analysis, financial statements, audit support, month-end close, SOX testing."
 routing:
   triggers:
     - "finance"

--- a/skills/business/marketing/SKILL.md
+++ b/skills/business/marketing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: marketing
-description: Marketing workflows — SEO audits, campaign planning, content strategy, email sequences, competitive analysis, brand review, performance reporting. Use when auditing SEO, planning campaigns, creating content strategy, building email sequences, or analyzing marketing performance.
+description: "Marketing: SEO audits, campaign planning, content strategy, email sequences, competitive analysis, brand review, performance reporting."
 routing:
   triggers:
     - "marketing"

--- a/skills/business/operations/SKILL.md
+++ b/skills/business/operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: operations
-description: "Business operations workflows — vendor management, runbooks, process documentation, risk assessment, capacity planning, change management, compliance tracking. Use when reviewing vendors, writing runbooks, documenting processes, assessing risk, planning capacity, or managing change."
+description: "Business operations: vendor management, runbooks, process docs, risk assessment, capacity planning, change management, compliance tracking."
 routing:
   triggers:
     - "operations"

--- a/skills/business/product-management/SKILL.md
+++ b/skills/business/product-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-management
-description: Product management workflows — feature specs, roadmap planning, stakeholder updates, user research synthesis, competitive analysis, metrics review, sprint planning. Use when writing specs, updating roadmaps, briefing stakeholders, synthesizing research, or reviewing product metrics.
+description: "Product management: feature specs, roadmaps, stakeholder updates, user research synthesis, competitive analysis, metrics, sprint planning."
 routing:
   triggers:
     - "product management"

--- a/skills/business/productivity/SKILL.md
+++ b/skills/business/productivity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: productivity
-description: Personal productivity — sort out what to work on next, prioritize tasks, plan your day, run weekly reviews, optimize meetings, set goals, write status updates. Use when planning days, managing tasks, running weekly reviews, optimizing meetings, or writing status updates.
+description: "Personal productivity: pick what to work on next, prioritize tasks, plan your day, weekly reviews, meeting optimization, goals, status updates."
 routing:
   triggers:
     - "productivity"

--- a/skills/content/professional-communication/SKILL.md
+++ b/skills/content/professional-communication/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: professional-communication
-description: "Draft interpersonal and meeting messages — emails, memos, status updates, and pushing back or disagreeing in a structured business format."
+description: "Draft interpersonal and meeting messages: emails, memos, status updates, structured pushback or disagreement."
 user-invocable: false
 allowed-tools:
   - Read

--- a/skills/content/publish/SKILL.md
+++ b/skills/content/publish/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: publish
-description: |
-  Content-publishing umbrella covering the blog pipeline from blueprint to
-  upload: post outlining, pre-publication validation, SEO optimization, bulk
-  find/replace and frontmatter editing, link auditing, image auditing,
-  taxonomy management, and WordPress upload. Use for "outline post",
-  "article outline", "pre-publish check", "frontmatter validation", "check
-  SEO", "keyword analysis", "meta description", "batch edit posts", "bulk
-  frontmatter update", "mass edit", "audit links", "broken links", "audit
-  images", "alt text check", "audit taxonomy", "fix tags", "merge
-  categories", "upload to wordpress", "create wordpress draft", "post to
-  wordpress", "edit wordpress post", "create wp categories", "auto-create
-  categories", "search wp media", or "find existing wordpress image".
+description: "Blog publishing, blueprint to upload: post outlines, pre-publish checks, SEO, bulk frontmatter edits, link/image/taxonomy audits, WordPress upload."
 user-invocable: false
 agent: general-purpose
 allowed-tools:

--- a/skills/engineering/enterprise-search/SKILL.md
+++ b/skills/engineering/enterprise-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: enterprise-search
-description: Enterprise search engineering — relevance tuning, query understanding, index management, search quality measurement, ranking optimization, schema design. Use when building search features, debugging relevance, tuning ranking, designing indices, or measuring search quality.
+description: "Enterprise search: relevance tuning, query understanding, index management, search quality, ranking optimization, schema design."
 agent: opensearch-elasticsearch-engineer
 routing:
   triggers:

--- a/skills/engineering/opensearch-detection-engineer/SKILL.md
+++ b/skills/engineering/opensearch-detection-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opensearch-detection-engineer
-description: "OpenSearch detection engineering: SIGMA authoring, query DSL translation, MITRE ATT&CK mapping, anomaly detection, correlation rules, SOC incident escalation. Use for SIEM detection authoring, threshold tuning, alert validation, and Tier-1/Tier-2 escalation workflows."
+description: "OpenSearch SIEM detection: SIGMA, query DSL, MITRE ATT&CK mapping, anomaly/correlation rules, alert validation, SOC escalation."
 version: 1.0.0
 user-invocable: true
 allowed-tools:

--- a/skills/process/planning/SKILL.md
+++ b/skills/process/planning/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: planning
-description: |
-  Planning lifecycle umbrella: spec, pre-plan ambiguity resolution, file-backed
-  planning, plan validation, plan-lifecycle management, and session pause/resume.
-  Use for "write spec", "define requirements", "before we plan", "discuss
-  ambiguities", "create plan", "task plan", "working memory", "check plan",
-  "validate plan", "is this plan ready", "list plans", "plan status",
-  "complete plan", "pause", "save progress", "session handoff", "resume",
-  "continue work", or "where did I leave off".
+description: "Planning lifecycle: specs, requirements, pre-plan ambiguity resolution, file-backed plans, plan validation, pause/resume, session handoff."
 user-invocable: true
 agent: general-purpose
 allowed-tools:

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow
-description: "Structured multi-phase workflows: review, debug, refactor (tidy up, clean up, untangle messy code, reorganize without changing behaviour), deploy, create, research, and more."
+description: "Structured multi-phase workflows: review, debug, refactor (tidy, clean up, untangle messy code without behaviour change), deploy, create, research."
 user-invocable: false
 context: fork
 routing:


### PR DESCRIPTION
Trim the 11 skill descriptions flagged by scripts/skill-sprawl-audit.py to <=40 router-line tokens (ceil(bytes/4) of the `- name: description` line). Descriptions keep every trigger noun; triggers arrays untouched. Quoted trigger-phrase lists in planning/publish descriptions were dropped — those phrases live in the routing.triggers arrays.

| Skill | Before | After |
|---|---|---|
| opensearch-detection-engineer | 48 | 40 |
| product-management | 47 | 40 |
| workflow | 47 | 40 |
| productivity | 45 | 40 |
| enterprise-search | 44 | 38 |
| operations | 44 | 39 |
| planning | 43 | 38 |
| professional-communication | 43 | 35 |
| finance | 42 | 39 |
| marketing | 41 | 37 |
| publish | 41 | 40 |

Validation:
- skill-sprawl-audit.py: zero over-long; router budget 3200 -> 3141 tokens
- routing-benchmark.py: 68/68 valid targets, all PASS
- audit-trigger-ambiguity.py: report-only, no new collisions
- validate_positive_instruction_docs.py: no findings in edited files
