### PR TITLE
docs(skills): graduate two learnings into routing-table-updater and retro

### DIFF
--- a/skills/meta/retro/SKILL.md
+++ b/skills/meta/retro/SKILL.md
@@ -226,6 +226,8 @@ python3 ~/.claude/scripts/learning-db.py learn --topic negative-results \
   "YYYY-MM-DD <experiment>: <decision> - see docs/what-didnt-work.md"
 ```
 
+**Batching learn calls**: run `learning-db.py learn` calls individually or chained with `&&`, then confirm via `learning-db.py search`. A single failing command in a plain multi-line Bash batch silently drops the rest (observed 2026-06-12).
+
 This reuses the existing `learn` command (no new code). Confirm with either:
 
 ```bash

--- a/skills/meta/routing-table-updater/SKILL.md
+++ b/skills/meta/routing-table-updater/SKILL.md
@@ -92,6 +92,8 @@ For each capability, confirm extracted fields: `name`, `description`, `trigger_p
 
 Review against `references/extraction-patterns.md`. Patterns must be specific enough to avoid false matches, broad enough to catch common phrasings, and free of generic terms.
 
+**Description trimming**: skill descriptions trim safely to ≤40 router-line tokens when the frontmatter `routing.triggers` array stays untouched — triggers carry routing weight independently of the description. Verify trims with `scripts/skill-sprawl-audit.py` plus the routing-benchmark and trigger-ambiguity CI jobs (evidence: PR #801, 11 trims, routing-benchmark 68/68).
+
 **Gate**: All YAML parsed successfully, required fields are present, trigger patterns are extracted for skills, and domain keywords are extracted for agents. Proceed to Phase 3 only after the gate passes. See `references/error-handling.md` for gate failure recovery.
 
 ---


### PR DESCRIPTION
## Summary

Graduate two verified learning.db entries into their target skill docs.

1. `skills/meta/routing-table-updater/SKILL.md` (Phase 2, trigger pattern quality): skill descriptions trim safely to <=40 router-line tokens when the frontmatter `routing.triggers` array stays untouched; triggers carry routing weight independently. Verify with `scripts/skill-sprawl-audit.py` plus the routing-benchmark and trigger-ambiguity CI jobs. Evidence: PR #801 (11 trims, routing-benchmark 68/68).
2. `skills/meta/retro/SKILL.md` (near learn-command examples): run `learning-db.py learn` calls individually or chained with `&&`, then confirm via `learning-db.py search`; a single failing command in a plain multi-line Bash batch silently drops the rest (observed 2026-06-12).

## Verification

- `python3 scripts/skill-sprawl-audit.py` — all router lines at or under 40 tokens.
- Executed learn-and-confirm probe against learning.db; chained `&&` pattern confirmed (probe purged).
- `python3 scripts/validate_positive_instruction_docs.py` — no new findings in edited files.
