### PR TITLE
feat(learning-db): filtered prune subcommand with dry-run default

### DIFF
--- a/hooks/tests/test_stale_pruner.py
+++ b/hooks/tests/test_stale_pruner.py
@@ -299,10 +299,11 @@ class TestStalePruneSubcommand:
 class TestExistingSubcommands:
     """Verify existing subcommands still work after changes."""
 
-    def test_legacy_prune_still_works(self) -> None:
+    def test_legacy_prune_flags_now_dry_run(self) -> None:
+        """Legacy flags still parse; prune is now dry-run by default (no delete)."""
         result = _run_cli("prune", "--below-confidence", "0.3", "--older-than", "90")
         assert result.returncode == 0
-        assert "Pruned" in result.stdout
+        assert "DRY RUN" in result.stdout
 
     def test_stats_still_works(self) -> None:
         result = _run_cli("stats")

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -15,7 +15,8 @@ Usage:
     python3 scripts/learning-db.py import --from-patterns ~/.claude/learning/patterns.db
     python3 scripts/learning-db.py graduate TOPIC KEY TARGET
     python3 scripts/learning-db.py boost TOPIC KEY [--delta 0.15]
-    python3 scripts/learning-db.py prune --below-confidence 0.3 --older-than 90
+    python3 scripts/learning-db.py prune --category error --dry-run
+    python3 scripts/learning-db.py prune --topic unknown --max-confidence 0.5 --older-than 90 --apply
     python3 scripts/learning-db.py stale [--min-age-days 30] [--json]
     python3 scripts/learning-db.py stale-prune --dry-run [--min-age-days 30]
     python3 scripts/learning-db.py stale-prune --confirm [--min-age-days 30]
@@ -66,7 +67,6 @@ from learning_db_v2 import (
     import_from_retro,
     init_db,
     mark_graduated,
-    prune,
     query_instruction_skip_rate,
     query_learnings,
     record_learning,
@@ -210,10 +210,96 @@ def cmd_decay(args):
     print(f"Decayed: {args.topic}/{args.key} → confidence {new_conf:.2f}")
 
 
+# Rows always protected from prune: graduated entries and the routing/effectiveness
+# rows that route-weights and route-health read.
+_PRUNE_PROTECT_SQL = "graduated_to IS NULL AND NOT (topic = 'routing' AND category = 'effectiveness')"
+
+
+def build_prune_filter(
+    category: str | None = None,
+    topic: str | None = None,
+    max_confidence: float | None = None,
+    older_than: int | None = None,
+) -> tuple[str, list]:
+    """Build the WHERE clause and bound params for a prune run.
+
+    Filters compose with AND. Protection clauses (graduated, routing weights)
+    are always included. Raises ValueError when no filter is given — a
+    filterless prune would match the whole table.
+    """
+    clauses = [_PRUNE_PROTECT_SQL]
+    params: list = []
+    if category is not None:
+        clauses.append("category = ?")
+        params.append(category)
+    if topic is not None:
+        clauses.append("topic = ?")
+        params.append(topic)
+    if max_confidence is not None:
+        clauses.append("confidence <= ?")
+        params.append(max_confidence)
+    if older_than is not None:
+        cutoff = (datetime.now() - timedelta(days=older_than)).isoformat()
+        clauses.append("last_seen < ?")
+        params.append(cutoff)
+    if not params:
+        raise ValueError("prune requires at least one filter (--category/--topic/--max-confidence/--older-than)")
+    return " AND ".join(clauses), params
+
+
 def cmd_prune(args):
-    """Remove low-confidence old entries (legacy destructive delete)."""
-    count = prune(args.below_confidence, args.older_than)
-    print(f"Pruned {count} entries (confidence < {args.below_confidence}, older than {args.older_than} days)")
+    """Filtered prune of learnings. Dry-run by default; --apply deletes + VACUUM.
+
+    Never touches graduated rows or routing/effectiveness rows (read by
+    route-weights and route-health). FTS stays consistent via the
+    learnings_ad delete trigger; VACUUM reclaims space after --apply.
+    """
+    max_confidence = args.max_confidence if args.max_confidence is not None else args.below_confidence
+    try:
+        where, params = build_prune_filter(
+            category=args.category,
+            topic=args.topic,
+            max_confidence=max_confidence,
+            older_than=args.older_than,
+        )
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    init_db()
+    with get_connection() as conn:
+        total_before = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()[0]
+        # `where` is built only from fixed clauses; all user values are bound as ? params.
+        matched = conn.execute(f"SELECT COUNT(*) FROM learnings WHERE {where}", params).fetchone()[
+            0
+        ]  # security-review: ignore (fixed clauses; user values bound as ?)
+        breakdown = conn.execute(
+            f"SELECT category, topic, COUNT(*) AS n FROM learnings WHERE {where} "  # security-review: ignore (fixed clauses; user values bound as ?)
+            "GROUP BY category, topic ORDER BY n DESC",
+            params,
+        ).fetchall()
+
+        print(f"Total learnings before: {total_before}")
+        print(f"Matched for prune: {matched} (graduated and routing/effectiveness rows always excluded)")
+        if breakdown:
+            print("By category/topic:")
+            for row in breakdown:
+                print(f"  [{row['category']}] {row['topic']:30s} {row['n']}")
+
+        if not args.apply:
+            print()
+            print("DRY RUN — nothing deleted. Re-run with --apply to delete.")
+            print("Back up the database first: cp <db> <db>.bak-$(date +%Y%m%d)")
+            return
+
+        cursor = conn.execute(
+            f"DELETE FROM learnings WHERE {where}", params
+        )  # security-review: ignore (fixed clauses; user values bound as ?)
+        deleted = cursor.rowcount
+        conn.commit()
+        total_after = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()[0]
+        conn.execute("VACUUM")
+    print(f"Deleted {deleted} entries. Total learnings: {total_before} -> {total_after}.")
 
 
 def _query_stale_entries(conn: sqlite3.Connection, min_age_days: int) -> list[dict]:
@@ -1560,10 +1646,16 @@ def main():
     p_decay.add_argument("--delta", type=float, default=0.10)
     p_decay.set_defaults(func=cmd_decay)
 
-    # prune (legacy destructive delete)
-    p_prune = subparsers.add_parser("prune", help="Remove low-confidence old entries (destructive delete)")
-    p_prune.add_argument("--below-confidence", type=float, default=0.3)
-    p_prune.add_argument("--older-than", type=int, default=90, help="Days")
+    # prune — filtered delete, dry-run by default
+    p_prune = subparsers.add_parser("prune", help="Filtered prune of learnings (dry-run default; --apply deletes)")
+    p_prune.add_argument("--category", help="Filter by category (e.g., error)")
+    p_prune.add_argument("--topic", help="Filter by topic (e.g., unknown)")
+    p_prune.add_argument("--max-confidence", type=float, default=None, help="Match rows with confidence <= N")
+    p_prune.add_argument("--below-confidence", type=float, default=None, help="Deprecated alias for --max-confidence")
+    p_prune.add_argument("--older-than", type=int, default=None, help="Match rows with last_seen older than N days")
+    p_prune_mode = p_prune.add_mutually_exclusive_group()
+    p_prune_mode.add_argument("--dry-run", action="store_true", help="Preview counts (default)")
+    p_prune_mode.add_argument("--apply", action="store_true", help="Delete matched rows, then VACUUM")
     p_prune.set_defaults(func=cmd_prune)
 
     # stale (show stale entries)

--- a/scripts/tests/test_learning_db_prune.py
+++ b/scripts/tests/test_learning_db_prune.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Tests for the filtered `prune` subcommand in scripts/learning-db.py.
+
+Covers: dry-run counts, --apply deletion, graduated-row protection,
+routing/effectiveness protection, filter composition, no-filter refusal,
+and FTS index consistency after delete.
+
+Run with: python3 -m pytest scripts/tests/test_learning_db_prune.py -v
+"""
+
+import os
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_repo_root / "hooks" / "lib"))
+
+SCRIPT_PATH = str(_repo_root / "scripts" / "learning-db.py")
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point learning.db at a temp directory for each test."""
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(tmp_path))
+    import importlib
+
+    import learning_db_v2
+
+    importlib.reload(learning_db_v2)
+    learning_db_v2.init_db()
+    yield tmp_path
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    return subprocess.run(
+        [sys.executable, SCRIPT_PATH, *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+
+
+def _connect(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(tmp_path / "learning.db")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _insert(
+    tmp_path: Path,
+    topic: str,
+    key: str,
+    category: str = "error",
+    confidence: float = 0.5,
+    age_days: int = 0,
+    graduated_to: str | None = None,
+) -> None:
+    """Insert a learnings row directly (FTS triggers keep the index in sync)."""
+    ts = (datetime.now() - timedelta(days=age_days)).isoformat()
+    conn = _connect(tmp_path)
+    conn.execute(
+        "INSERT INTO learnings (topic, key, value, category, confidence, source, "
+        "first_seen, last_seen, graduated_to) VALUES (?, ?, ?, ?, ?, 'test', ?, ?, ?)",
+        (topic, key, f"value for {topic}/{key}", category, confidence, ts, ts, graduated_to),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _count(tmp_path: Path) -> int:
+    conn = _connect(tmp_path)
+    n = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()[0]
+    conn.close()
+    return n
+
+
+class TestDryRun:
+    def test_dry_run_is_default_and_deletes_nothing(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "t1", "k1", category="error")
+        _insert(isolated_db, "t2", "k2", category="design")
+
+        result = _run_cli("prune", "--category", "error")
+        assert result.returncode == 0
+        assert "Matched for prune: 1" in result.stdout
+        assert "DRY RUN" in result.stdout
+        assert "Back up" in result.stdout
+        assert _count(isolated_db) == 2
+
+    def test_dry_run_counts_per_filter_combo(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "unknown", "k1", category="error", confidence=0.3)
+        _insert(isolated_db, "unknown", "k2", category="error", confidence=0.9)
+        _insert(isolated_db, "real-topic", "k3", category="error", confidence=0.3)
+
+        result = _run_cli("prune", "--category", "error", "--topic", "unknown", "--max-confidence", "0.5")
+        assert result.returncode == 0
+        assert "Matched for prune: 1" in result.stdout
+        assert "[error] unknown" in result.stdout
+
+    def test_older_than_filter(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "t", "old", category="error", age_days=100)
+        _insert(isolated_db, "t", "new", category="error", age_days=1)
+
+        result = _run_cli("prune", "--category", "error", "--older-than", "30")
+        assert result.returncode == 0
+        assert "Matched for prune: 1" in result.stdout
+
+    def test_no_filter_refused(self, isolated_db: Path) -> None:
+        result = _run_cli("prune")
+        assert result.returncode == 2
+        assert "at least one filter" in result.stderr
+
+    def test_total_before_printed(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "t", "k", category="error")
+        result = _run_cli("prune", "--category", "error", "--dry-run")
+        assert result.returncode == 0
+        assert "Total learnings before: 1" in result.stdout
+
+
+class TestApply:
+    def test_apply_deletes_matched_rows(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "unknown", "k1", category="error")
+        _insert(isolated_db, "keep", "k2", category="design")
+
+        result = _run_cli("prune", "--category", "error", "--apply")
+        assert result.returncode == 0
+        assert "Deleted 1 entries" in result.stdout
+        assert "1 -> " not in result.stdout.split("Deleted")[0]  # before/after on the delete line
+        assert "2 -> 1" in result.stdout
+        assert _count(isolated_db) == 1
+
+    def test_apply_protects_graduated_rows(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "t", "grad", category="error", graduated_to="agent:x")
+        _insert(isolated_db, "t", "plain", category="error")
+
+        result = _run_cli("prune", "--category", "error", "--apply")
+        assert result.returncode == 0
+        assert "Deleted 1 entries" in result.stdout
+
+        conn = _connect(isolated_db)
+        rows = conn.execute("SELECT key FROM learnings").fetchall()
+        conn.close()
+        assert [r["key"] for r in rows] == ["grad"]
+
+    def test_apply_protects_routing_effectiveness_rows(self, isolated_db: Path) -> None:
+        """Rows read by route-weights/route-health are never pruned."""
+        _insert(isolated_db, "routing", "agent:skill", category="effectiveness", confidence=0.1)
+        _insert(isolated_db, "t", "plain", category="effectiveness", confidence=0.1)
+
+        result = _run_cli("prune", "--category", "effectiveness", "--max-confidence", "0.5", "--apply")
+        assert result.returncode == 0
+        assert "Deleted 1 entries" in result.stdout
+
+        conn = _connect(isolated_db)
+        rows = conn.execute("SELECT topic FROM learnings").fetchall()
+        conn.close()
+        assert [r["topic"] for r in rows] == ["routing"]
+
+    def test_dry_run_and_apply_mutually_exclusive(self, isolated_db: Path) -> None:
+        result = _run_cli("prune", "--category", "error", "--dry-run", "--apply")
+        assert result.returncode != 0
+
+
+class TestFTSConsistency:
+    def test_fts_index_consistent_after_apply(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "deleteme", "k1", category="error")
+        _insert(isolated_db, "keepme", "k2", category="design")
+
+        result = _run_cli("prune", "--category", "error", "--apply")
+        assert result.returncode == 0
+
+        conn = _connect(isolated_db)
+        # FTS integrity check raises SQLITE_CORRUPT_VTAB on a desynced index.
+        conn.execute("INSERT INTO learnings_fts(learnings_fts, rank) VALUES('integrity-check', 0)")
+        gone = conn.execute("SELECT COUNT(*) FROM learnings_fts WHERE learnings_fts MATCH 'deleteme'").fetchone()[0]
+        kept = conn.execute("SELECT COUNT(*) FROM learnings_fts WHERE learnings_fts MATCH 'keepme'").fetchone()[0]
+        conn.close()
+        assert gone == 0
+        assert kept == 1


### PR DESCRIPTION
## Summary
- `prune` subcommand rewritten: composable filters `--category`, `--topic`, `--max-confidence`, `--older-than DAYS`
- Dry-run is the default; `--apply` required to delete. Apply deletes, FTS stays synced via triggers, then VACUUM
- Always excludes graduated rows (`graduated_to IS NOT NULL`) and `routing`/`effectiveness` rows read by route-weights and route-health
- Refuses a filterless prune (would match the whole table); `--below-confidence` kept as deprecated alias
- Output: before-total, matched count, category/topic breakdown, backup reminder; `--apply` prints before/after totals

## Tests
- `scripts/tests/test_learning_db_prune.py`: dry-run counts, filter composition, apply deletion, graduated-row protection, routing/effectiveness protection, mutual exclusion, FTS integrity-check after delete
- Updated `hooks/tests/test_stale_pruner.py` legacy-prune test to the new dry-run-default contract
- 30 passed (new + stale-pruner regression); ruff clean

## Purpose
Lets the live learning.db shed 5586 category=error and 4142 topic=unknown bulk rows safely (backup + dry-run first), without losing graduated knowledge or routing weights.
