### PR TITLE
feat(routing): acceptance_detected basis + concrete error topics

### DIFF
--- a/hooks/error-learner.py
+++ b/hooks/error-learner.py
@@ -23,12 +23,12 @@ from pathlib import Path
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
+from error_topics import classify_error_topic
 from feedback_tracker import check_pending_feedback, set_pending_feedback
 from hook_utils import get_tool_error, get_tool_output, get_tool_result, is_tool_error
 from learning_db_v2 import (
     DEFAULT_FIX_ACTIONS,
     boost_confidence,
-    classify_error,
     decay_confidence,
     generate_signature,
     lookup_error_solution,
@@ -135,7 +135,7 @@ def main():
         source_detail = f"{tool_name}:{agent_type}" if agent_type else tool_name
 
         # Classify and generate signature
-        error_type = classify_error(error_message)
+        error_type = classify_error_topic(error_message)
         signature = generate_signature(error_message, error_type)
 
         # Sanitize before storing or replaying in context

--- a/hooks/lib/error_topics.py
+++ b/hooks/lib/error_topics.py
@@ -1,0 +1,84 @@
+"""Extended error-topic classification for the error-learner hook.
+
+The live learning DB shows topic=unknown dominating category=error rows
+(~4100 unknown vs ~1300 classified). The dominant unknown shapes are CLI
+usage errors, test failures, lint output, command-not-found, JSON parse
+failures, git conflicts, and HTTP/network errors. This module maps those
+shapes to concrete topics so new entries stop landing on "unknown".
+
+Layering: ``classify_error`` (learning_db_v2's base taxonomy) keeps first
+claim — an already-known shape is never reclassified. Only a base
+"unknown" is retried against the extended patterns; "unknown" stays the
+fallback. learning_db_v2.py itself is not edited (a pre-existing SQLi
+false-positive there trips the commit security gate); this module only
+imports its public classifier.
+
+Patterns are conservative and word/phrase-anchored — a wrong topic is
+worse than "unknown" (it attaches the wrong default fix action).
+"""
+
+import re
+
+from learning_db_v2 import classify_error
+
+# First match wins (dict order). Lower-cased message is searched.
+EXTENDED_ERROR_TYPES = {
+    "command_not_found": [
+        r"command not found",
+        r"not recognized as an internal",
+    ],
+    "json_parse": [
+        r"jsondecodeerror",
+        r"invalid json",
+        r"failed to parse json",
+        r"unexpected end of json",
+        r"expecting value: line",
+    ],
+    "git_conflict": [
+        r"merge conflict",
+        r"conflict \(content\)",
+        r"automatic merge failed",
+        r"needs merge",
+    ],
+    "usage_error": [
+        r"\busage: ",
+        r"unrecognized arguments",
+        r"the following arguments are required",
+        r"invalid option",
+        r"unknown option",
+    ],
+    "lint_error": [
+        r"\bruff (check|format)",
+        r"would reformat",
+        r"fixable with the .--fix.",
+    ],
+    "test_failure": [
+        r"assertionerror",
+        r"=== failures ===",
+        r"\b\d+ failed\b",
+    ],
+    "network": [
+        r"http error \d{3}",
+        r"\b404 not found\b",
+        r"could not resolve host",
+        r"connection reset",
+        r"\bssl(error| certificate)",
+    ],
+}
+
+
+def classify_error_topic(message: str) -> str:
+    """Topic for an error message: base taxonomy first, then extended shapes.
+
+    Returns "unknown" only when neither taxonomy matches.
+    """
+    if not message:
+        return "unknown"
+    base = classify_error(message)
+    if base != "unknown":
+        return base
+    low = message.lower()
+    for topic, patterns in EXTENDED_ERROR_TYPES.items():
+        if any(re.search(p, low) for p in patterns):
+            return topic
+    return "unknown"

--- a/hooks/lib/routing_outcome_score.py
+++ b/hooks/lib/routing_outcome_score.py
@@ -86,25 +86,29 @@ def _current_confidence(key: str) -> float:
         return 0.0
 
 
-def outcome_basis(errors: bool, reaction_failure: bool) -> str:
-    """The evidence basis for a finalized outcome — one of three labels.
+def outcome_basis(errors: bool, reaction_failure: bool, reaction_success: bool = False) -> str:
+    """The evidence basis for a finalized outcome — one of four labels.
 
     Pure and module-level so tests import it directly. Order matters: a tool
     error is the strongest, most attributable signal, so it wins even when a
-    user reaction also fired.
+    user reaction also fired; a failure reaction outranks a success reaction.
 
       tool_errors_only     dispatch's own error flag fired (a real signal)
       rejection_detected   user complaint fired, no error (a real signal)
-      default_no_complaint success on silence — the silent-failure case
+      acceptance_detected  explicit positive marker fired (a real signal)
+      default_no_complaint neutral on silence — the silent-success case
 
-    `default_no_complaint` covers clean accepted/neutral AND the multi-dispatch
+    `default_no_complaint` covers clean neutral entries AND the multi-dispatch
     case where the turn reaction is ignored: in both, no signal scored THIS
-    entry, so its success rests on no complaint.
+    entry. `reaction_success` defaults False so every pre-existing two-arg
+    caller and test is unchanged.
     """
     if errors:
         return "tool_errors_only"
     if reaction_failure:
         return "rejection_detected"
+    if reaction_success:
+        return "acceptance_detected"
     return "default_no_complaint"
 
 

--- a/hooks/routing-outcome-finalizer.py
+++ b/hooks/routing-outcome-finalizer.py
@@ -148,6 +148,7 @@ _REJECTION_PATTERNS = [
 # anchored so a substring cannot trip them.
 _ACCEPTANCE_PATTERNS = [
     r"\b(thanks|thank you|thx|great|perfect|looks good|lgtm|nice work|well done|that worked)\b",
+    r"\b(works now|that fixed it|that did it|good job)\b",
     r"\b(merge it|ship it|ship that|approve|approved)\b",
 ]
 
@@ -159,6 +160,32 @@ _INSTRUCTIONAL_CUE_PATTERNS = [
     r"\b(should|when|whether|explain|document|how to|can you|try)\b",
     r"(?:^|\W)if\b",
 ]
+
+# ACCEPTANCE-BOOST GUARDS (precision over recall — mirror of the rejection
+# detector's asymmetric-cost rule, inverted): a MISSED acceptance stays NEUTRAL,
+# the T4 floor (no harm); a FALSE acceptance boosts a route on a NEW-task prompt,
+# inflating exactly the silent-success share acceptance detection exists to
+# shrink. So the boost path (`is_acceptance`) fires only when the acceptance
+# clause LEADS the prompt (first clause) or stands alone, AND:
+#   - no negation token in the clause ("not perfect", "doesn't work")
+#   - the clause does not open with a task verb ("make a great landing page",
+#     "write the perfect README" — markers buried in new task text)
+#   - no instructional/conditional cue ("can you make it perfect", "if it
+#     looks good then merge")
+#   - the clause is terse (<= _MAX_ACCEPTANCE_CLAUSE_WORDS words) — genuine
+#     reactions are short; long clauses are task descriptions.
+# The looser `_ACCEPTANCE_RE` alone still serves acceptance PRECEDENCE inside
+# `is_rejection` (there a loose match only prevents a decay — the safe side).
+_NEGATION_RE = re.compile(
+    r"\b(not|no|never|hardly|isn'?t|wasn'?t|aren'?t|doesn'?t|don'?t|didn'?t|can'?t|won'?t)\b",
+    re.IGNORECASE,
+)
+_TASK_VERB_LEAD_RE = re.compile(
+    r"^\s*(make|build|write|add|create|fix|update|implement|refactor|run|generate"
+    r"|design|deploy|install|set up|remove|delete|rename|move|check)\b",
+    re.IGNORECASE,
+)
+_MAX_ACCEPTANCE_CLAUSE_WORDS = 8
 
 _REJECTION_RE = re.compile("|".join(_REJECTION_PATTERNS), re.IGNORECASE)
 _ACCEPTANCE_RE = re.compile("|".join(_ACCEPTANCE_PATTERNS), re.IGNORECASE)
@@ -242,11 +269,25 @@ def is_acceptance(prompt: str) -> bool:
     success. So this detector decides boost-vs-neutral; ``is_rejection`` decides
     the failure path. Same clause-scoping and word-boundary anchoring as
     ``is_rejection`` so a substring (e.g. "great" inside "greater") never trips
-    it. Returns False on empty / non-string input.
+    it, PLUS the boost-path guards (negation, leading task verb, instructional
+    cue, clause-length cap — see the guard block above): a false boost inflates
+    the silent-success share, so when in any doubt return False (=> NEUTRAL).
+    Returns False on empty / non-string input.
     """
     if not prompt or not isinstance(prompt, str):
         return False
-    return bool(_ACCEPTANCE_RE.search(_first_clause(prompt)))
+    first = _first_clause(prompt)
+    if not _ACCEPTANCE_RE.search(first):
+        return False
+    if len(first.split()) > _MAX_ACCEPTANCE_CLAUSE_WORDS:
+        return False  # task description, not a terse reaction
+    if _NEGATION_RE.search(first):
+        return False  # "not perfect", "doesn't work", "no thanks"
+    if _TASK_VERB_LEAD_RE.match(first):
+        return False  # marker buried in new task text
+    if _INSTRUCTIONAL_CUE_RE.search(first):
+        return False  # "can you make it perfect", "if it looks good …"
+    return True
 
 
 def main() -> None:
@@ -359,11 +400,13 @@ def main() -> None:
                 outcome = "success"
             else:
                 outcome = "neutral"
-            # Basis is the failure-axis evidence label (errors > rejection >
+            # Basis is the evidence label (errors > rejection > acceptance >
             # no-complaint), recorded as a per-route counter for route-health's
-            # silent-success report. Label-only: it never changes the boost/
-            # decay/no-op the three-way outcome drives.
-            basis = outcome_basis(bool(item.get("errors")), reaction_failure)
+            # silent-success report. acceptance_detected marks a boost earned by
+            # an explicit positive marker — strong feedback, not silence.
+            # Label-only: it never changes the boost/decay/no-op the three-way
+            # outcome drives.
+            basis = outcome_basis(bool(item.get("errors")), reaction_failure, reaction_success)
             new_conf = apply_outcome(key, outcome, basis=basis)
             # Short, secret-free cause for this dispatch's outcome. Computed
             # unconditionally (not debug-only) so the JSONL OUTCOME event carries

--- a/hooks/tests/test_acceptance_detector.py
+++ b/hooks/tests/test_acceptance_detector.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Golden-fixture tests for the finalizer's acceptance detector + basis label.
+
+Mirror of the rejection detector's precision contract (asymmetric costs):
+a MISSED acceptance stays NEUTRAL (the T4 floor — no harm); a FALSE
+acceptance boosts a route on a new-task prompt, inflating exactly the
+silent-success share this detector exists to shrink. So acceptance fires
+ONLY on strong, unambiguous markers that LEAD the prompt (first clause)
+or stand alone, with negation / task-verb / instructional-cue vetoes.
+
+Covers:
+- every curated marker fires (positive goldens)
+- every negation / buried-in-task / instructional case stays neutral
+- outcome_basis grows the acceptance_detected label (errors > rejection >
+  acceptance > default ordering preserved)
+
+Run with: python3 -m pytest hooks/tests/test_acceptance_detector.py -v
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(HOOKS_DIR / "lib"))
+
+spec = importlib.util.spec_from_file_location("routing_outcome_finalizer", HOOKS_DIR / "routing-outcome-finalizer.py")
+mod = importlib.util.module_from_spec(spec)
+with patch("sys.exit"):
+    spec.loader.exec_module(mod)
+
+
+# --- positive goldens: every marker fires ------------------------------------
+
+ACCEPTS = [
+    "thanks",
+    "thank you",
+    "thx",
+    "great job",
+    "perfect",
+    "looks good",
+    "lgtm",
+    "nice work",
+    "well done",
+    "that worked",
+    "works now",
+    "that fixed it",
+    "that did it",
+    "good job",
+    "merge it",
+    "ship it",
+    "approved",
+    "thanks, works",  # acceptance clause leads; comma splits it clean
+    "perfect, now add tests to the other module",  # leading acceptance, new work later
+    "great job. one more thing: update the docs",
+    "lgtm, merge it",
+    "ok that worked",
+]
+
+
+@pytest.mark.parametrize("prompt", ACCEPTS)
+def test_acceptance_fires(prompt):
+    assert mod.is_acceptance(prompt) is True, prompt
+
+
+# --- negative goldens: negation / buried / instructional stay neutral --------
+
+NEUTRALS = [
+    # negation
+    "not perfect",
+    "that's not perfect",
+    "this doesn't work, thanks anyway",
+    "it still isn't perfect",
+    "no thanks",
+    "it didn't work",
+    # marker buried in NEW task text (first clause is a task, not a reaction)
+    "make a great landing page",
+    "write the perfect README for this repo",
+    "add a thanks page to the site",
+    "build something that works now and later",
+    "create a looks good badge for the CI",
+    # instructional / conditional cues
+    "can you make it perfect",
+    "try to get it perfect this time",
+    "explain why lgtm reviews are risky",
+    "document when ship it applies",
+    "if it looks good then merge",
+    # long task-shaped first clause (not a terse reaction)
+    "refactor the parser so the output is perfect for downstream consumers and then rerun the suite",
+    # plain new-topic prompts
+    "now refactor the auth module",
+    "what does route-health report",
+    # empty / junk
+    "",
+    None,
+    123,
+]
+
+
+@pytest.mark.parametrize("prompt", NEUTRALS)
+def test_neutral_stays_neutral(prompt):
+    assert mod.is_acceptance(prompt) is False, prompt
+
+
+# --- acceptance never flips a genuine rejection -------------------------------
+
+
+def test_rejection_still_wins_its_own_goldens():
+    assert mod.is_rejection("that's wrong, redo it") is True
+    assert mod.is_rejection("thanks, that worked") is False
+
+
+# --- outcome_basis: acceptance_detected label ---------------------------------
+
+
+def test_outcome_basis_acceptance_detected():
+    from routing_outcome_score import outcome_basis
+
+    assert outcome_basis(errors=False, reaction_failure=False, reaction_success=True) == "acceptance_detected"
+
+
+def test_outcome_basis_ordering_errors_and_rejection_beat_acceptance():
+    from routing_outcome_score import outcome_basis
+
+    assert outcome_basis(errors=True, reaction_failure=False, reaction_success=True) == "tool_errors_only"
+    assert outcome_basis(errors=False, reaction_failure=True, reaction_success=True) == "rejection_detected"
+
+
+def test_outcome_basis_default_unchanged():
+    from routing_outcome_score import outcome_basis
+
+    assert outcome_basis(errors=False, reaction_failure=False) == "default_no_complaint"
+    assert outcome_basis(errors=False, reaction_failure=False, reaction_success=False) == "default_no_complaint"

--- a/hooks/tests/test_error_topics.py
+++ b/hooks/tests/test_error_topics.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Golden-fixture tests for extended error-topic classification.
+
+The live learning DB shows topic=unknown dominating category=error rows
+(4142 unknown vs ~1300 classified). The dominant unknown shapes are CLI
+usage errors, test failures, lint output, command-not-found, JSON parse,
+git conflicts, and HTTP/network errors. ``classify_error_topic`` maps
+those to concrete topics; everything else still falls back to "unknown".
+The base ``classify_error`` taxonomy keeps first claim (no reclassification
+of already-known shapes).
+
+Run with: python3 -m pytest hooks/tests/test_error_topics.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
+
+from error_topics import classify_error_topic
+
+GOLDENS = [
+    # base taxonomy keeps first claim
+    ("Error: no such file or directory: foo.txt", "missing_file"),
+    ("bash: permission denied", "permissions"),
+    ("operation timed out after 30s", "timeout"),
+    # extended: command_not_found
+    ("bash: rgg: command not found", "command_not_found"),
+    ("zsh: command not found: pnmp", "command_not_found"),
+    # extended: json_parse
+    ("json.decoder.JSONDecodeError: Expecting value: line 1 column 1", "json_parse"),
+    ("failed to parse JSON response", "json_parse"),
+    ("Unexpected end of JSON input", "json_parse"),
+    # extended: git_conflict
+    ("CONFLICT (content): Merge conflict in app.py", "git_conflict"),
+    ("Automatic merge failed; fix conflicts and then commit", "git_conflict"),
+    ("error: you need to resolve your current index first; app.py: needs merge", "git_conflict"),
+    # extended: usage_error
+    ("usage: validate.py [-h] [--json]\nvalidate.py: error: unrecognized arguments: --all", "usage_error"),
+    ("error: unrecognized arguments: --frobnicate", "usage_error"),
+    ("error: the following arguments are required: --agent", "usage_error"),
+    # extended: lint_error
+    ("ruff check failed: 5 errors found", "lint_error"),
+    ("Would reformat: hooks/error-learner.py", "lint_error"),
+    ("4 fixable with the `--fix` option", "lint_error"),
+    # extended: test_failure
+    ("AssertionError: expected 3 got 4", "test_failure"),
+    ("=== FAILURES ===\ntest_x failed", "test_failure"),
+    ("2 failed, 130 passed in 5.21s", "test_failure"),
+    # extended: network
+    ("HTTP Error 404: Not Found", "network"),
+    ("curl: (6) Could not resolve host: example.com", "network"),
+    ("Connection reset by peer", "network"),
+    # fallback stays unknown
+    ("something inexplicable happened", "unknown"),
+    ("", "unknown"),
+]
+
+
+@pytest.mark.parametrize(("message", "topic"), GOLDENS)
+def test_classify_error_topic(message, topic):
+    assert classify_error_topic(message) == topic, message

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -1241,7 +1241,7 @@ def cmd_skip_rate(args: argparse.Namespace) -> None:
         print("No instructions flagged. Threshold: >20% skip rate over 30+ observations.")
 
 
-_BASIS_LABELS = ("rejection_detected", "tool_errors_only", "default_no_complaint")
+_BASIS_LABELS = ("rejection_detected", "tool_errors_only", "acceptance_detected", "default_no_complaint")
 
 
 def _read_basis_counts() -> dict[str, int]:
@@ -1295,7 +1295,7 @@ def cmd_route_health(args: argparse.Namespace) -> None:
     # = an observed signal scored the outcome; default-success = success on
     # silence (upper bound on silent success, NOT confirmed silent failures).
     basis = _read_basis_counts()
-    strong = basis["rejection_detected"] + basis["tool_errors_only"]
+    strong = basis["rejection_detected"] + basis["tool_errors_only"] + basis["acceptance_detected"]
     default_success = basis["default_no_complaint"]
     basis_total = strong + default_success
     silent_share = (default_success / basis_total) if basis_total else None
@@ -1353,6 +1353,7 @@ def cmd_route_health(args: argparse.Namespace) -> None:
         print(f"Outcome basis: {strong} strong-feedback vs {default_success} default-success")
         print(f"  rejection_detected   {basis['rejection_detected']}")
         print(f"  tool_errors_only     {basis['tool_errors_only']}")
+        print(f"  acceptance_detected  {basis['acceptance_detected']}")
         print(f"  default_no_complaint {basis['default_no_complaint']}")
         print(f"Silent-success share: {silent_share * 100:.0f}% of scored outcomes ({default_success}/{basis_total})")
     print(f"Governed-path coverage: {has_outcome}/{total} routing rows carry a finalized outcome ({pct:.0f}%)")

--- a/scripts/tests/test_route_health_basis.py
+++ b/scripts/tests/test_route_health_basis.py
@@ -149,6 +149,7 @@ def test_json_zero_basis_no_divide_by_zero(db_env):
     assert data["basis"] == {
         "rejection_detected": 0,
         "tool_errors_only": 0,
+        "acceptance_detected": 0,
         "default_no_complaint": 0,
     }
     assert data["silent_success_share"] is None


### PR DESCRIPTION
## Why

route-health shows 89% silent success: 365 default_no_complaint vs 44 strong-feedback, 0 rejections. Boosts rest on silence, and every new error-learner row lands topic=unknown (4142 unknown vs ~1300 classified in the live DB). This PR adds high-precision positive-acceptance detection and concrete error topics. Warn-only: no new blocking gates; the T4 three-way contract is unchanged (no-complaint stays neutral).

## Acceptance detection (finalizer)

Curated, word-boundary marker list (boost fires only on these):

- thanks / thank you / thx / great / perfect / looks good / lgtm / nice work / well done / that worked
- works now / that fixed it / that did it / good job
- merge it / ship it / ship that / approve / approved

Precision rationale — mirror of the rejection detector's asymmetric-cost rule, inverted: a missed acceptance stays NEUTRAL (the T4 floor, no harm); a false acceptance boosts a route on a new-task prompt, inflating exactly the silent-success share this detector exists to shrink. So the boost path fires only when the acceptance clause leads the prompt (first clause) or stands alone, AND passes four guards:

1. Negation veto: "not perfect", "doesn't work", "no thanks" stay neutral.
2. Leading-task-verb veto: "make a great landing page", "write the perfect README" — markers buried in new task text.
3. Instructional/conditional cue veto: "can you make it perfect", "if it looks good then merge".
4. Clause-length cap (8 words): genuine reactions are terse; long clauses are task descriptions.

The looser marker regex still serves acceptance PRECEDENCE inside `is_rejection` (a loose match there only prevents a decay — the safe side).

Boosts now record `outcome_basis=acceptance_detected` (ordering: errors > rejection > acceptance > default_no_complaint). Label-only; boost/decay/no-op unchanged.

## Error-learner topics

New `hooks/lib/error_topics.py` (learning_db_v2.py untouched — its base taxonomy keeps first claim). Extended topics from the real unknown-row distribution: `usage_error`, `test_failure`, `lint_error`, `command_not_found`, `json_parse`, `git_conflict`, `network`. `unknown` stays the fallback.

## route-health

`acceptance_detected` added to the basis labels, counted as strong feedback, printed in the basis table and JSON.

## Tests

Golden fixtures both ways: every marker fires; every negation/buried/instructional case stays neutral; topic goldens per shape. Full `hooks/tests` + `scripts/tests` pass. Hooks exit 0 on empty stdin; finalizer runs in 49ms.

## Deployment note

Merged hooks go live only after sync: `python3 hooks/sync-to-user-claude.py`. This PR runs nothing against `~/.claude`.
