### PR TITLE
Fix stale Codex hooks mirror cleanup in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -230,6 +230,26 @@ _symlink_points_to() {
     [ "$(_canonical_path "$actual")" = "$(_canonical_path "$expected")" ]
 }
 
+clean_codex_hooks_mirror_if_looped() {
+    local hook_dir=$1
+    local hook_source_dir=$2
+
+    if [ -z "$hook_dir" ] || [ -z "$hook_source_dir" ]; then
+        return
+    fi
+
+    if [ -L "$hook_dir" ] && _symlink_points_to "$hook_dir" "$hook_source_dir"; then
+        if [ "$DRY_RUN" = true ]; then
+            echo -e "${YELLOW}  Would remove stale Codex hooks mirror symlink: ${hook_dir}${NC}"
+            echo -e "${YELLOW}  (points back into source hooks: ${hook_source_dir})${NC}"
+            return
+        fi
+        echo -e "${YELLOW}  Removing stale Codex hooks mirror symlink: ${hook_dir}${NC}"
+        echo -e "${YELLOW}  (points back into source hooks: ${hook_source_dir})${NC}"
+        rm -rf "$hook_dir"
+    fi
+}
+
 # unlink_skills_nested TARGET — tear down a nested skills tree built by
 # link_skills_nested, preserving any external (non-toolkit) entries.
 # Removes only symlinks; for category dirs, removes the per-skill symlinks we
@@ -1592,6 +1612,8 @@ CODEX_HOOK_COUNT=0
 CODEX_HOOKS_ALLOWLIST="${SCRIPT_DIR}/scripts/codex-hooks-allowlist.txt"
 
 if [ -f "$CODEX_HOOKS_ALLOWLIST" ]; then
+    clean_codex_hooks_mirror_if_looped "$CODEX_HOOKS_DIR" "${SCRIPT_DIR}/hooks"
+
     # Ensure hooks directory exists
     if [ "$DRY_RUN" = true ]; then
         echo -e "${BLUE}  Would create: ${CODEX_HOOKS_DIR}${NC}"

--- a/install.sh
+++ b/install.sh
@@ -2241,17 +2241,39 @@ echo ""
 echo -e "${YELLOW}Setting permissions...${NC}"
 if [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}  Would set 644 on docs/*.md${NC}"
-    echo -e "${BLUE}  Would set 755 on hooks/*.py${NC}"
-    echo -e "${BLUE}  Would set 755 on scripts/*.py${NC}"
+    echo -e "${BLUE}  Would set 755 on mirrored hooks/scripts *.py under runtime directories${NC}"
+    echo -e "${BLUE}    - ~/.claude/hooks, ~/.claude/scripts${NC}"
+    echo -e "${BLUE}    - ~/.codex/hooks, ~/.codex/scripts${NC}"
+    echo -e "${BLUE}    - ~/.factory/hooks, ~/.factory/scripts${NC}"
+    echo -e "${BLUE}    - ~/.hermes/scripts${NC}"
+    echo -e "${BLUE}    - ~/.reasonix/hooks, ~/.reasonix/scripts${NC}"
     echo -e "${BLUE}  Would set 600 on ~/.claude/settings.json${NC}"
     echo -e "${BLUE}  Would set 700 on ~/.claude/ and ~/.claude/learning/${NC}"
     echo -e "${BLUE}  Would set 600 on ~/.claude/history.jsonl (if it exists)${NC}"
     echo -e "${BLUE}  Would set 600 on ~/.factory/settings.json${NC}"
     echo -e "${BLUE}  Would set 600 on ~/.reasonix/settings.json${NC}"
 else
+    set_mirror_python_permissions() {
+        local target_dir="$1"
+        local path
+        [ -d "$target_dir" ] || return 0
+        while IFS= read -r -d '' path; do
+            chmod 755 "$path" 2>/dev/null || true
+        done < <(find "$target_dir" -type f -name "*.py" -print0 2>/dev/null)
+    }
+
+    # NOTE: Mirror-runtime paths only to avoid mutating checked-out sources.
+    set_mirror_python_permissions "$CLAUDE_DIR/hooks"
+    set_mirror_python_permissions "$CLAUDE_DIR/scripts"
+    set_mirror_python_permissions "$CODEX_HOOKS_DIR"
+    set_mirror_python_permissions "$CODEX_SCRIPTS_DIR"
+    set_mirror_python_permissions "$FACTORY_HOOKS_DIR"
+    set_mirror_python_permissions "$FACTORY_SCRIPTS_DIR"
+    set_mirror_python_permissions "$HERMES_SCRIPTS_DIR"
+    set_mirror_python_permissions "$REASONIX_HOOKS_DIR"
+    set_mirror_python_permissions "$REASONIX_SCRIPTS_DIR"
+
     chmod 644 "${SCRIPT_DIR}/docs/"*.md 2>/dev/null || true
-    find "${SCRIPT_DIR}/hooks" -name "*.py" -exec chmod 755 {} \; 2>/dev/null || true
-    find "${SCRIPT_DIR}/scripts" -name "*.py" -exec chmod 755 {} \; 2>/dev/null || true
     # Harden ~/.claude/ sensitive files (ADR-122)
     chmod 700 "${CLAUDE_DIR}" 2>/dev/null || true
     chmod 600 "${SETTINGS_FILE}" 2>/dev/null || true

--- a/install.sh
+++ b/install.sh
@@ -231,14 +231,14 @@ _symlink_points_to() {
 }
 
 clean_codex_hooks_mirror_if_looped() {
-    local hook_dir=$1
-    local hook_source_dir=$2
+    local hook_dir="$1"
+    local hook_source_dir="$2"
 
     if [ -z "$hook_dir" ] || [ -z "$hook_source_dir" ]; then
         return
     fi
 
-    if [ -L "$hook_dir" ] && _symlink_points_to "$hook_dir" "$hook_source_dir"; then
+    if _symlink_points_to "$hook_dir" "$hook_source_dir"; then
         if [ "$DRY_RUN" = true ]; then
             echo -e "${YELLOW}  Would remove stale Codex hooks mirror symlink: ${hook_dir}${NC}"
             echo -e "${YELLOW}  (points back into source hooks: ${hook_source_dir})${NC}"
@@ -246,7 +246,7 @@ clean_codex_hooks_mirror_if_looped() {
         fi
         echo -e "${YELLOW}  Removing stale Codex hooks mirror symlink: ${hook_dir}${NC}"
         echo -e "${YELLOW}  (points back into source hooks: ${hook_source_dir})${NC}"
-        rm -rf "$hook_dir"
+        unlink "$hook_dir"
     fi
 }
 


### PR DESCRIPTION
## Summary
- Add a pre-sync guard to detect and remove a stale or reverse-loop Codex hooks mirror before mirroring hooks.
- Detects if `~/.codex/hooks` is a symlink pointing back into the repo's `hooks/` directory and removes it (dry-run aware) before recreating the mirror.
- Restrict permission hardening to installed mirror targets only:
  - `~/.claude/hooks`, `~/.codex/hooks`, `~/.factory/hooks`, `~/.reasonix/hooks`
  - `~/.claude/scripts`, `~/.codex/scripts`, `~/.factory/scripts`, `~/.reasonix/scripts`
  - `~/.hermes/scripts`

This prevents source-mode executable bit churn on tracked files such as `hooks/*.py` and avoids `M` mode-noise in the repo after installs.

## Test plan
1. `rm -rf ~/.codex/hooks`
2. `./install.sh --uninstall --per-item`
3. `./install.sh --symlink --force --per-item --dry-run`
4. `./install.sh --symlink --force --per-item`
5. `readlink ~/.codex/hooks/session-learning-recorder.py`
6. `python3 ~/.codex/hooks/session-learning-recorder.py`

## Validation results
- Pre-run `ls -la ~/.codex` showed no active hooks mirror at `~/.codex/hooks`.
- Post-install `readlink` resolved to the repo source:
  - `/Users/thongvan/Sites/AI/vexjoy-agent/hooks/session-learning-recorder.py`
- Running the hook with timeout returned success (`exit 0`, output `{}`), with no "too many levels of symbolic links" error.
- Permissions updates now apply only to mirror directories, matching installed state and keeping repo files unmodified.
