### PR TITLE
docs(graduate): embed reaction-detector pattern and high-conf inflation note

### DIFF
--- a/agents/hook-development-engineer.md
+++ b/agents/hook-development-engineer.md
@@ -175,6 +175,19 @@ See [references/code-examples.md](references/code-examples.md) for detailed spec
 ## Error Handling and Preferred Patterns
 
 See [references/preferred-patterns.md](references/preferred-patterns.md) for the full pattern catalog: blocking on errors, synchronous heavy operations, direct database writes, registering before deploying, unguarded `main()`, UserPromptSubmit agent-context injection, and the atomic write pattern with code examples.
+
+### Reaction-Detector Design Pattern
+
+When a hook classifies free text into an outcome (e.g., accept/reject), decide the asymmetric cost first: which false direction is cheap? A missed acceptance stays neutral — safe. A false acceptance corrupts telemetry. Gate the expensive direction with stacked precision guards:
+
+1. Marker leads the prompt (acceptance marker must appear at the start).
+2. Negation veto (negation near the marker stays neutral).
+3. Leading-task-verb veto (a prompt that opens with a task verb is a new instruction; stays neutral).
+4. Conditional/instructional-cue veto ("if", "when", "should" cues stay neutral).
+5. Short-clause cap (long clauses after the marker stay neutral).
+
+Require golden fixtures in both directions: every marker fires, every veto case stays neutral. Evidence: `hooks/routing-outcome-finalizer.py`, PR #804.
+
 ## Anti-Rationalization
 
 ### Domain-Specific Rationalizations

--- a/skills/meta/retro/SKILL.md
+++ b/skills/meta/retro/SKILL.md
@@ -54,7 +54,7 @@ Show learning system health summary.
 python3 ~/.claude/scripts/learning-db.py stats
 ```
 
-**Step 2**: Present status report.
+**Step 2**: Present status report. Present high-confidence counts with the category breakdown; error spam inflates per-row confidence (pruning 5119 noise rows dropped high-conf 4201→564, 2026-06-12).
 
 ```
 LEARNING SYSTEM STATUS


### PR DESCRIPTION
## Summary

Graduate two verified learning-db entries into their owning docs.

- agents/hook-development-engineer.md: add the reaction-detector design pattern — decide the asymmetric cost first (missed acceptance stays neutral and safe; false acceptance corrupts telemetry), gate the expensive direction with stacked precision guards (marker leads the prompt, negation veto, leading-task-verb veto, conditional/instructional-cue veto, short-clause cap), and require golden fixtures both ways. Evidence: hooks/routing-outcome-finalizer.py, PR #804.
- skills/meta/retro/SKILL.md: status presentation now pairs high-confidence counts with the category breakdown; error spam inflates per-row confidence (pruning 5119 noise rows dropped high-conf 4201 to 564, 2026-06-12).

## Verification

- validate_positive_instruction_docs.py: no findings in edited files
- ruff check + ruff format --check: clean
- Both learning entries verified against live code/stats and boosted to 0.80
