### PR TITLE
feat(voice): deterministic stylometry lenses + profile decay metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AI agents skip steps.
 
 Harnesses have a second problem: given only a skill list, they do not route eagerly enough, or correctly enough. Good skills sit unused. So this toolkit connects the skills, agents, and workflows we want directly into the harness, automatically. You don't have to understand what is here. Say what you want in plain English and you get all the value we have put into it: the right specialist with the right methodology, behind gates that demand exit codes, not assertions.
 
-44 domain agents, 130 workflow skills, 83 hooks, 123 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
+44 domain agents, 130 workflow skills, 83 hooks, 124 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
 
 Works across Claude Code (`/do`), Codex (`$do`), Factory (`/do`), Reasonix (`/do`).
 

--- a/scripts/tests/test_voice_stylometry.py
+++ b/scripts/tests/test_voice_stylometry.py
@@ -1,0 +1,337 @@
+"""Tests for scripts/voice-stylometry.py.
+
+ADR voice-stylometry-upgrade: three deterministic lenses (burstiness band,
+punctuation profile, inverse AI-tell detectors) plus profile decay metadata.
+Seeded fixtures; pytest green is the validation verdict.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+stylo = importlib.import_module("voice-stylometry")
+
+SCRIPT = Path(__file__).resolve().parent.parent / "voice-stylometry.py"
+
+# ---------------------------------------------------------------------------
+# Seeded fixtures
+# ---------------------------------------------------------------------------
+
+VARIED_CORPUS = """Sometimes the brightest lights shine in the darkest corners of the building.
+She inspires.
+The community came together to celebrate this moment, and what a celebration it was, filled with joy and laughter and the kind of warmth that only comes from shared experience.
+She grows.
+Whether the crowd knew it or not, the night belonged to the people who showed up early and stayed late.
+Together, we rise."""
+
+UNIFORM_DRAFT = """The match was exciting today. The crowd was very loud. The performers were all great. The finish was quite good. The show was real fun. The ending was very nice. The fans were all happy. The night was a success."""
+
+VARIED_DRAFT = """The lights dimmed and the crowd held its breath, waiting for something none of them could name.
+She walked out.
+Nobody in the building expected what came next, a sequence so fast and so clean that the replay would trend for days afterward.
+Silence.
+Then the roar came back, louder than before, carrying everyone with it."""
+
+EM_DASH_DRAFT = """The match — one of the best of the year — set a new standard for the company.
+The underdog finally won — and the crowd erupted in disbelief.
+Nobody saw it coming — least of all the champion."""
+
+ANTITHESIS_DRAFT = """The crowd stayed long after the show ended.
+It's not about the winning, it's about the story they watched unfold.
+Everyone went home tired and happy."""
+
+ANTITHESIS_SENTENCE_PAIR = """This is not a story about failure. It is a story about timing.
+The rest of the night went quietly."""
+
+TEMPORAL_OPENER_DRAFT = """In today's fast-paced world, wrestling shows compete with everything for attention.
+
+The main event delivered anyway."""
+
+UNIFORM_PARAGRAPH_DRAFT = """The opener set the tone early. The crowd responded with real energy. Both workers earned the reaction.
+
+The second match slowed things down. The pacing dragged in the middle. The finish saved the segment.
+
+The third match raised the stakes. The champion looked vulnerable throughout. The challenger gained real credibility.
+
+The main event closed the loop. The story paid off every beat. The crowd left satisfied and loud."""
+
+CLEAN_DRAFT = """The lights dimmed and the crowd held its breath, waiting for something none of them could name.
+She walked out.
+Nobody in the building expected what came next, a sequence so fast and so clean that the replay would trend for days afterward.
+
+Silence. Then the roar came back, louder than before, carrying everyone with it. The night kept building from there.
+
+By the final bell the building had nothing left to give."""
+
+NOW = datetime(2026, 6, 12, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def varied_profile() -> dict:
+    """Profile banded from the varied corpus, fresh decay metadata."""
+    profile = stylo.build_band_profile([VARIED_CORPUS], refresh_after_days=90, analyzed_at=NOW)
+    return profile
+
+
+def rule_ids(findings) -> list[str]:
+    return [f.rule_id for f in findings]
+
+
+# ---------------------------------------------------------------------------
+# Burstiness band
+# ---------------------------------------------------------------------------
+
+
+class TestBurstiness:
+    def test_band_computed_from_corpus(self):
+        band = stylo.compute_burstiness([VARIED_CORPUS])
+        assert band["stdev"] > 0
+        assert 0 <= band["band"]["min"] < band["band"]["max"]
+
+    def test_uniform_draft_flagged(self, varied_profile):
+        findings = stylo.check_burstiness(varied_profile, UNIFORM_DRAFT)
+        assert rule_ids(findings) == ["burstiness.band"]
+        f = findings[0]
+        assert f.severity == "warning"
+        assert f.span == (0, len(UNIFORM_DRAFT))
+
+    def test_varied_draft_passes(self, varied_profile):
+        assert stylo.check_burstiness(varied_profile, VARIED_DRAFT) == []
+
+    def test_short_draft_skipped(self, varied_profile):
+        assert stylo.check_burstiness(varied_profile, "One line. Two lines. Three.") == []
+
+    def test_profile_without_band_skipped(self):
+        assert stylo.check_burstiness({}, UNIFORM_DRAFT) == []
+
+
+# ---------------------------------------------------------------------------
+# Punctuation profile
+# ---------------------------------------------------------------------------
+
+
+class TestPunctuation:
+    def test_classes(self):
+        assert stylo.classify_rate(0.0) == "never"
+        assert stylo.classify_rate(0.05) == "rare"
+        assert stylo.classify_rate(0.5) == "habitual"
+
+    def test_profile_rates_and_classes(self):
+        punct = stylo.compute_punctuation([EM_DASH_DRAFT])
+        assert punct["em_dash"]["class"] == "habitual"
+        assert punct["semicolon"]["class"] == "never"
+
+    def test_never_profile_flags_em_dash_draft(self, varied_profile):
+        findings = stylo.check_punctuation(varied_profile, EM_DASH_DRAFT)
+        assert "punctuation.em_dash" in rule_ids(findings)
+        f = next(x for x in findings if x.rule_id == "punctuation.em_dash")
+        assert f.severity == "warning"
+
+    def test_matching_draft_passes(self, varied_profile):
+        assert stylo.check_punctuation(varied_profile, VARIED_DRAFT) == []
+
+    def test_profile_without_punctuation_skipped(self):
+        assert stylo.check_punctuation({}, EM_DASH_DRAFT) == []
+
+
+# ---------------------------------------------------------------------------
+# Inverse AI-tell detectors
+# ---------------------------------------------------------------------------
+
+
+class TestAiTells:
+    def test_corrective_antithesis_comma_form(self):
+        findings = stylo.check_corrective_antithesis(ANTITHESIS_DRAFT)
+        assert rule_ids(findings) == ["ai_tell.corrective_antithesis"]
+        f = findings[0]
+        assert f.severity == "error"
+        start, end = f.span
+        assert "not" in ANTITHESIS_DRAFT[start:end]
+        assert f.line == 2
+
+    def test_corrective_antithesis_sentence_pair(self):
+        findings = stylo.check_corrective_antithesis(ANTITHESIS_SENTENCE_PAIR)
+        assert rule_ids(findings) == ["ai_tell.corrective_antithesis"]
+
+    def test_corrective_antithesis_clean(self):
+        assert stylo.check_corrective_antithesis(CLEAN_DRAFT) == []
+
+    def test_temporal_opener_at_paragraph_start(self):
+        findings = stylo.check_temporal_openers(TEMPORAL_OPENER_DRAFT)
+        assert rule_ids(findings) == ["ai_tell.temporal_opener"]
+        start, end = findings[0].span
+        assert TEMPORAL_OPENER_DRAFT[start:end].lower().startswith("in today")
+
+    def test_temporal_phrase_mid_paragraph_not_flagged(self):
+        text = "The show thrives even in today's crowded market.\n\nIt earned that."
+        assert stylo.check_temporal_openers(text) == []
+
+    def test_uniform_paragraphs_flagged(self):
+        findings = stylo.check_uniform_paragraphs(UNIFORM_PARAGRAPH_DRAFT)
+        assert rule_ids(findings) == ["ai_tell.uniform_paragraphs"]
+        assert findings[0].severity == "error"
+
+    def test_varied_paragraphs_pass(self):
+        assert stylo.check_uniform_paragraphs(CLEAN_DRAFT) == []
+
+    def test_few_paragraphs_skipped(self):
+        text = "One. Two. Three.\n\nFour. Five. Six."
+        assert stylo.check_uniform_paragraphs(text) == []
+
+
+# ---------------------------------------------------------------------------
+# Profile decay
+# ---------------------------------------------------------------------------
+
+
+class TestDecay:
+    def test_stale_profile_warns_advisory(self):
+        profile = {"analyzed_at": "2025-01-01T00:00:00+00:00", "refresh_after_days": 30}
+        findings = stylo.check_decay(profile, now=NOW)
+        assert rule_ids(findings) == ["profile.stale"]
+        assert findings[0].severity == "advisory"
+
+    def test_fresh_profile_passes(self):
+        profile = {"analyzed_at": "2026-06-01T00:00:00+00:00", "refresh_after_days": 90}
+        assert stylo.check_decay(profile, now=NOW) == []
+
+    def test_profile_without_metadata_skipped(self):
+        assert stylo.check_decay({}, now=NOW) == []
+
+    def test_zulu_timestamp_accepted(self):
+        profile = {"analyzed_at": "2025-01-01T00:00:00Z", "refresh_after_days": 30}
+        assert rule_ids(stylo.check_decay(profile, now=NOW)) == ["profile.stale"]
+
+
+# ---------------------------------------------------------------------------
+# Orchestration + add-only compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDraft:
+    def test_planted_violations_all_detected(self, varied_profile):
+        planted = "\n\n".join(
+            [
+                "In today's fast-paced world, every show fights for attention.",
+                "It's not about the winning, it's about the story.",
+                UNIFORM_PARAGRAPH_DRAFT,
+            ]
+        )
+        findings = stylo.check_draft(varied_profile, planted, now=NOW)
+        ids = set(rule_ids(findings))
+        assert {"ai_tell.temporal_opener", "ai_tell.corrective_antithesis", "ai_tell.uniform_paragraphs"} <= ids
+
+    def test_clean_draft_passes(self, varied_profile):
+        findings = stylo.check_draft(varied_profile, CLEAN_DRAFT, now=NOW)
+        assert [f for f in findings if f.severity in ("error", "warning")] == []
+
+    def test_legacy_profile_without_new_fields_still_valid(self):
+        legacy = json.loads((Path(__file__).parent / "fixtures" / "expected_voice_profile.json").read_text())
+        findings = stylo.check_draft(legacy, CLEAN_DRAFT, now=NOW)
+        assert [f for f in findings if f.severity in ("error", "warning")] == []
+
+    def test_stale_profile_advisory_does_not_block(self, varied_profile):
+        varied_profile["analyzed_at"] = "2020-01-01T00:00:00+00:00"
+        findings = stylo.check_draft(varied_profile, CLEAN_DRAFT, now=NOW)
+        assert rule_ids(findings) == ["profile.stale"]
+        assert stylo.verdict(findings) == "pass"
+
+    def test_finding_dict_shape(self, varied_profile):
+        findings = stylo.check_draft(varied_profile, ANTITHESIS_DRAFT, now=NOW)
+        d = findings[0].to_dict()
+        assert set(d) == {"rule_id", "severity", "span", "line", "message"}
+        assert d["span"] == {"start": d["span"]["start"], "end": d["span"]["end"]}
+
+
+# ---------------------------------------------------------------------------
+# Profile build
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBandProfile:
+    def test_fields_present_and_add_only(self):
+        profile = stylo.build_band_profile([VARIED_CORPUS], refresh_after_days=60, analyzed_at=NOW)
+        assert profile["analyzed_at"] == "2026-06-12T00:00:00+00:00"
+        assert profile["refresh_after_days"] == 60
+        sty = profile["stylometry"]
+        assert sty["burstiness"]["band"]["min"] < sty["burstiness"]["band"]["max"]
+        assert sty["punctuation"]["em_dash"]["class"] == "never"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestCli:
+    def test_band_command(self, tmp_path):
+        sample = tmp_path / "s1.md"
+        sample.write_text(VARIED_CORPUS)
+        result = run_cli("band", "--samples", str(sample), "--analyzed-at", "2026-06-12T00:00:00+00:00")
+        assert result.returncode == 0, result.stderr
+        profile = json.loads(result.stdout)
+        assert "stylometry" in profile
+        assert profile["refresh_after_days"] == 90
+
+    def test_check_clean_exits_zero(self, tmp_path):
+        sample = tmp_path / "s1.md"
+        sample.write_text(VARIED_CORPUS)
+        band = run_cli("band", "--samples", str(sample), "--analyzed-at", "2026-06-12T00:00:00+00:00")
+        profile = tmp_path / "profile.json"
+        profile.write_text(band.stdout)
+        draft = tmp_path / "draft.md"
+        draft.write_text(CLEAN_DRAFT)
+        result = run_cli(
+            "check", "--profile", str(profile), "--draft", str(draft), "--now", "2026-06-12T00:00:00+00:00"
+        )
+        assert result.returncode == 0, result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["verdict"] == "pass"
+
+    def test_check_violations_exit_one(self, tmp_path):
+        sample = tmp_path / "s1.md"
+        sample.write_text(VARIED_CORPUS)
+        band = run_cli("band", "--samples", str(sample), "--analyzed-at", "2026-06-12T00:00:00+00:00")
+        profile = tmp_path / "profile.json"
+        profile.write_text(band.stdout)
+        draft = tmp_path / "draft.md"
+        draft.write_text(ANTITHESIS_DRAFT)
+        result = run_cli(
+            "check", "--profile", str(profile), "--draft", str(draft), "--now", "2026-06-12T00:00:00+00:00"
+        )
+        assert result.returncode == 1
+        payload = json.loads(result.stdout)
+        assert payload["verdict"] == "fail"
+        assert payload["findings"][0]["rule_id"] == "ai_tell.corrective_antithesis"
+
+    def test_check_stale_profile_exits_zero(self, tmp_path):
+        sample = tmp_path / "s1.md"
+        sample.write_text(VARIED_CORPUS)
+        band = run_cli("band", "--samples", str(sample), "--analyzed-at", "2020-01-01T00:00:00+00:00")
+        profile = tmp_path / "profile.json"
+        profile.write_text(band.stdout)
+        draft = tmp_path / "draft.md"
+        draft.write_text(CLEAN_DRAFT)
+        result = run_cli(
+            "check", "--profile", str(profile), "--draft", str(draft), "--now", "2026-06-12T00:00:00+00:00"
+        )
+        assert result.returncode == 0
+        payload = json.loads(result.stdout)
+        assert [f["rule_id"] for f in payload["findings"]] == ["profile.stale"]

--- a/scripts/voice-stylometry.py
+++ b/scripts/voice-stylometry.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Deterministic stylometry lenses for the voice system.
+
+ADR voice-stylometry-upgrade. Three lenses plus decay metadata:
+1. Burstiness band — sentence-length variance band measured from the author
+   corpus; drafts whose variance falls outside the band are flagged.
+2. Punctuation profile — em-dash/semicolon/parenthetical rates classified as
+   never/rare/habitual; drafts that deviate from the author's class are flagged.
+3. Inverse AI-tell detectors — corrective antithesis ("not X, it's Y"),
+   throat-clearing temporal openers, uniform paragraph shapes.
+
+Decay: profiles carry analyzed_at + refresh_after_days; a stale profile emits
+an advisory finding that never blocks (verdict stays "pass").
+
+Usage:
+    python3 scripts/voice-stylometry.py band --samples s1.md s2.md \
+        [--refresh-after-days 90] [--analyzed-at ISO] > stylometry.json
+    python3 scripts/voice-stylometry.py check --profile profile.json \
+        --draft draft.md [--now ISO]
+
+Exit codes (check): 0 = pass (advisory findings allowed), 1 = fail, 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Severity ladder: error/warning fail the check; advisory never blocks.
+BLOCKING_SEVERITIES = ("error", "warning")
+
+# Punctuation class thresholds (rate = marks per sentence).
+RARE_THRESHOLD = 0.15
+
+# Burstiness band: corpus stdev s -> accepted draft stdev in [0.5*s, 1.5*s].
+BAND_LOW_FACTOR = 0.5
+BAND_HIGH_FACTOR = 1.5
+MIN_SENTENCES_FOR_BURSTINESS = 4
+
+# Uniform-paragraph tell: need this many paragraphs, each with >= 2 sentences,
+# all with the same sentence count.
+MIN_PARAGRAPHS_FOR_UNIFORMITY = 4
+
+DEFAULT_REFRESH_AFTER_DAYS = 90
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+_PARAGRAPH_SPLIT = re.compile(r"\n\s*\n")
+
+# Curly apostrophe and en dash spelled as escapes so the regexes match
+# typographic drafts without tripping ambiguous-Unicode lint (RUF001).
+_APO = "'\u2019"
+# "not X, it's Y" within one sentence.
+_ANTITHESIS_INLINE = re.compile(
+    rf"\bnot\s+(?:just\s+|only\s+|merely\s+|about\s+)?[\w{_APO}-]+(?:\s+[\w{_APO}-]+){{0,6}}"
+    rf"\s*[,;—\u2013]\s*(?:it|that|this|they)(?:[{_APO}]s|[{_APO}]re|\s+is|\s+was|\s+are)\b",
+    re.IGNORECASE,
+)
+# "It is not X. It is Y." across a sentence boundary.
+_ANTITHESIS_PAIR = re.compile(
+    rf"\b(?:it|this|that)(?:[{_APO}]s|\s+is)\s+not\b[^.!?\n]{{0,80}}[.!?]\s+(?:it|this|that)(?:[{_APO}]s|\s+is)\b",
+    re.IGNORECASE,
+)
+_TEMPORAL_OPENER = re.compile(
+    r"^(?:in\s+today'?s|in\s+an\s+era|in\s+a\s+world|in\s+recent\s+(?:years|months|times)"
+    r"|in\s+the\s+(?:modern|digital|current)\s+(?:age|era|world|landscape)"
+    r"|as\s+we\s+(?:move|navigate|enter)|nowadays|now\s+more\s+than\s+ever)\b",
+    re.IGNORECASE,
+)
+_EM_DASH = re.compile(r"—|--")
+
+
+@dataclass
+class Finding:
+    """One structured violation: rule, location, severity, human message."""
+
+    rule_id: str
+    severity: str
+    span: tuple[int, int]
+    line: int
+    message: str
+
+    def to_dict(self) -> dict:
+        return {
+            "rule_id": self.rule_id,
+            "severity": self.severity,
+            "span": {"start": self.span[0], "end": self.span[1]},
+            "line": self.line,
+            "message": self.message,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Text primitives
+# ---------------------------------------------------------------------------
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split text into sentences on terminal punctuation. Deterministic, no NLP."""
+    parts = _SENTENCE_SPLIT.split(text.strip())
+    return [p.strip() for p in parts if p.strip()]
+
+
+def sentence_word_counts(text: str) -> list[int]:
+    return [len(s.split()) for s in split_sentences(text)]
+
+
+def _line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _doc_finding(rule_id: str, severity: str, text: str, message: str) -> Finding:
+    return Finding(rule_id=rule_id, severity=severity, span=(0, len(text)), line=1, message=message)
+
+
+# ---------------------------------------------------------------------------
+# Lens 1: burstiness band
+# ---------------------------------------------------------------------------
+
+
+def _stdev(values: list[int]) -> float:
+    return statistics.pstdev(values) if len(values) >= 2 else 0.0
+
+
+def compute_burstiness(sample_texts: list[str]) -> dict:
+    """Pool sentence lengths across the corpus; band = [0.5*stdev, 1.5*stdev]."""
+    lengths: list[int] = []
+    for text in sample_texts:
+        lengths.extend(sentence_word_counts(text))
+    stdev = round(_stdev(lengths), 2)
+    return {
+        "stdev": stdev,
+        "band": {
+            "min": round(BAND_LOW_FACTOR * stdev, 2),
+            "max": round(BAND_HIGH_FACTOR * stdev, 2),
+        },
+    }
+
+
+def check_burstiness(profile: dict, draft: str) -> list[Finding]:
+    """Flag drafts whose sentence-length stdev falls outside the author band."""
+    band = profile.get("stylometry", {}).get("burstiness", {}).get("band")
+    if not band:
+        return []
+    counts = sentence_word_counts(draft)
+    if len(counts) < MIN_SENTENCES_FOR_BURSTINESS:
+        return []
+    draft_stdev = round(_stdev(counts), 2)
+    if band["min"] <= draft_stdev <= band["max"]:
+        return []
+    return [
+        _doc_finding(
+            "burstiness.band",
+            "warning",
+            draft,
+            f"sentence-length stdev {draft_stdev} outside author band "
+            f"[{band['min']}, {band['max']}] (uniform length is an AI tell)",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Lens 2: punctuation profile
+# ---------------------------------------------------------------------------
+
+
+def classify_rate(rate: float) -> str:
+    if rate == 0:
+        return "never"
+    if rate <= RARE_THRESHOLD:
+        return "rare"
+    return "habitual"
+
+
+def _punctuation_rates(text: str) -> dict[str, float]:
+    sentences = max(len(split_sentences(text)), 1)
+    return {
+        "em_dash": len(_EM_DASH.findall(text)) / sentences,
+        "semicolon": text.count(";") / sentences,
+        "parenthetical": text.count("(") / sentences,
+    }
+
+
+def compute_punctuation(sample_texts: list[str]) -> dict:
+    """Per-mark rate (marks per sentence) and never/rare/habitual class."""
+    corpus = "\n".join(sample_texts)
+    rates = _punctuation_rates(corpus)
+    return {mark: {"rate": round(rate, 3), "class": classify_rate(rate)} for mark, rate in rates.items()}
+
+
+def check_punctuation(profile: dict, draft: str) -> list[Finding]:
+    """Flag marks whose draft class deviates from the author's class."""
+    punct = profile.get("stylometry", {}).get("punctuation")
+    if not punct:
+        return []
+    findings: list[Finding] = []
+    draft_rates = _punctuation_rates(draft)
+    for mark, expected in punct.items():
+        if mark not in draft_rates:
+            continue
+        draft_class = classify_rate(draft_rates[mark])
+        if draft_class != expected["class"]:
+            findings.append(
+                _doc_finding(
+                    f"punctuation.{mark}",
+                    "warning",
+                    draft,
+                    f"{mark} usage is {draft_class} in draft but {expected['class']} for this author",
+                )
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Lens 3: inverse AI-tell detectors
+# ---------------------------------------------------------------------------
+
+
+def check_corrective_antithesis(draft: str) -> list[Finding]:
+    """Detect 'not X, it's Y' inline and 'It is not X. It is Y.' pair forms."""
+    findings: list[Finding] = []
+    for pattern in (_ANTITHESIS_INLINE, _ANTITHESIS_PAIR):
+        for m in pattern.finditer(draft):
+            findings.append(
+                Finding(
+                    rule_id="ai_tell.corrective_antithesis",
+                    severity="error",
+                    span=(m.start(), m.end()),
+                    line=_line_of(draft, m.start()),
+                    message=f"corrective antithesis: {draft[m.start() : m.end()]!r}",
+                )
+            )
+    return findings
+
+
+def _paragraphs_with_offsets(text: str) -> list[tuple[int, str]]:
+    paragraphs: list[tuple[int, str]] = []
+    offset = 0
+    for chunk in _PARAGRAPH_SPLIT.split(text):
+        start = text.index(chunk, offset)
+        if chunk.strip():
+            lead = len(chunk) - len(chunk.lstrip())
+            paragraphs.append((start + lead, chunk.strip()))
+        offset = start + len(chunk)
+    return paragraphs
+
+
+def check_temporal_openers(draft: str) -> list[Finding]:
+    """Detect throat-clearing temporal openers at paragraph starts."""
+    findings: list[Finding] = []
+    for start, para in _paragraphs_with_offsets(draft):
+        m = _TEMPORAL_OPENER.match(para)
+        if m:
+            findings.append(
+                Finding(
+                    rule_id="ai_tell.temporal_opener",
+                    severity="error",
+                    span=(start, start + m.end()),
+                    line=_line_of(draft, start),
+                    message=f"throat-clearing temporal opener: {m.group(0)!r}",
+                )
+            )
+    return findings
+
+
+def check_uniform_paragraphs(draft: str) -> list[Finding]:
+    """Flag any run of >=4 consecutive paragraphs sharing one sentence count (>=2 each)."""
+    paragraphs = _paragraphs_with_offsets(draft)
+    counts = [len(split_sentences(para)) for _, para in paragraphs]
+    findings: list[Finding] = []
+    run_start = 0
+    for i in range(len(counts) + 1):
+        if i < len(counts) and counts[i] == counts[run_start]:
+            continue
+        run_len = i - run_start
+        if run_len >= MIN_PARAGRAPHS_FOR_UNIFORMITY and counts[run_start] >= 2:
+            span_start = paragraphs[run_start][0]
+            last_offset, last_para = paragraphs[i - 1]
+            findings.append(
+                Finding(
+                    rule_id="ai_tell.uniform_paragraphs",
+                    severity="error",
+                    span=(span_start, last_offset + len(last_para)),
+                    line=_line_of(draft, span_start),
+                    message=f"{run_len} consecutive paragraphs all have exactly "
+                    f"{counts[run_start]} sentences (uniform shape is an AI tell)",
+                )
+            )
+        run_start = i
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Profile decay
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def check_decay(profile: dict, now: datetime) -> list[Finding]:
+    """Advisory when profile is older than its refresh window. Never blocks."""
+    analyzed_at = profile.get("analyzed_at")
+    refresh_days = profile.get("refresh_after_days")
+    if not analyzed_at or not refresh_days:
+        return []
+    expires = _parse_iso(analyzed_at) + timedelta(days=int(refresh_days))
+    if now <= expires:
+        return []
+    age_days = (now - _parse_iso(analyzed_at)).days
+    return [
+        Finding(
+            rule_id="profile.stale",
+            severity="advisory",
+            span=(0, 0),
+            line=1,
+            message=f"profile analyzed {age_days} days ago, refresh window is "
+            f"{refresh_days} days; re-run the analyzer on fresh samples",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def build_band_profile(
+    sample_texts: list[str],
+    refresh_after_days: int = DEFAULT_REFRESH_AFTER_DAYS,
+    analyzed_at: datetime | None = None,
+) -> dict:
+    """Build the add-only profile block: stylometry bands + decay metadata."""
+    analyzed = analyzed_at or datetime.now(timezone.utc)
+    return {
+        "stylometry": {
+            "burstiness": compute_burstiness(sample_texts),
+            "punctuation": compute_punctuation(sample_texts),
+        },
+        "analyzed_at": analyzed.isoformat(),
+        "refresh_after_days": refresh_after_days,
+    }
+
+
+def check_draft(profile: dict, draft: str, now: datetime | None = None) -> list[Finding]:
+    """Run all lenses plus decay. Profiles missing new fields skip those lenses."""
+    now = now or datetime.now(timezone.utc)
+    findings: list[Finding] = []
+    findings.extend(check_burstiness(profile, draft))
+    findings.extend(check_punctuation(profile, draft))
+    findings.extend(check_corrective_antithesis(draft))
+    findings.extend(check_temporal_openers(draft))
+    findings.extend(check_uniform_paragraphs(draft))
+    findings.extend(check_decay(profile, now))
+    return findings
+
+
+def verdict(findings: list[Finding]) -> str:
+    return "fail" if any(f.severity in BLOCKING_SEVERITIES for f in findings) else "pass"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _cmd_band(args: argparse.Namespace) -> int:
+    texts = [Path(p).read_text() for p in args.samples]
+    analyzed_at = _parse_iso(args.analyzed_at) if args.analyzed_at else None
+    profile = build_band_profile(texts, refresh_after_days=args.refresh_after_days, analyzed_at=analyzed_at)
+    print(json.dumps(profile, indent=2))
+    return 0
+
+
+def _cmd_check(args: argparse.Namespace) -> int:
+    profile = json.loads(Path(args.profile).read_text())
+    draft = Path(args.draft).read_text()
+    now = _parse_iso(args.now) if args.now else None
+    findings = check_draft(profile, draft, now=now)
+    result = verdict(findings)
+    print(json.dumps({"verdict": result, "findings": [f.to_dict() for f in findings]}, indent=2))
+    return 0 if result == "pass" else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Deterministic stylometry lenses for voice profiles.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    band = sub.add_parser("band", help="Compute stylometry bands + decay metadata from author samples.")
+    band.add_argument("--samples", nargs="+", required=True, help="Author sample files.")
+    band.add_argument("--refresh-after-days", type=int, default=DEFAULT_REFRESH_AFTER_DAYS)
+    band.add_argument("--analyzed-at", help="Override analyzed_at (ISO 8601) for reproducible output.")
+    band.set_defaults(func=_cmd_band)
+
+    check = sub.add_parser("check", help="Check a draft against a profile; exit 1 on violations.")
+    check.add_argument("--profile", required=True, help="Voice profile JSON.")
+    check.add_argument("--draft", required=True, help="Draft file to check.")
+    check.add_argument("--now", help="Override current time (ISO 8601) for reproducible decay checks.")
+    check.set_defaults(func=_cmd_check)
+
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/content/create-voice/SKILL.md
+++ b/skills/content/create-voice/SKILL.md
@@ -120,6 +120,16 @@ The text report gives a human-readable summary. Save it for reference during Ste
 | Structure | Fragment rate, sentence starters by type | Structural patterns |
 | Function words | Top 20 function word frequencies | Unconscious language fingerprint |
 
+#### Add Stylometry Bands and Decay Metadata
+
+```bash
+python3 scripts/voice-stylometry.py band \
+  --samples skills/voice-{name}/references/samples/*.md \
+  > /tmp/stylometry.json
+```
+
+Merge the output's top-level keys into `profile.json`: `stylometry` (burstiness band + punctuation classes measured from the samples), `analyzed_at`, and `refresh_after_days` (default 90). These fields are add-only; profiles without them stay valid. The voice-validator uses them for deterministic draft checks and stale-profile warnings.
+
 #### Verify the Output
 
 Read `profile.json` and confirm it contains all expected sections. If the script exits non-zero, check Python 3 availability, sample file readability, and file paths (glob expansion can be tricky).

--- a/skills/content/voice-validator/SKILL.md
+++ b/skills/content/voice-validator/SKILL.md
@@ -58,6 +58,27 @@ The workflow implements the **Iterative Refinement** pattern: scan → document 
 
 **Goal**: Run full checklist against content and identify all violations with evidence.
 
+**Step 0: Run deterministic stylometry checks**
+
+When the target voice has a `profile.json`, run the stylometry script first. It emits structured findings (rule_id, span, severity) that anchor the scan in measured data:
+
+```bash
+python3 scripts/voice-stylometry.py check \
+  --profile skills/voice-{name}/profile.json \
+  --draft <content-file>
+```
+
+Deterministic checks it runs:
+
+- **Burstiness band** (`burstiness.band`, warning): draft sentence-length variance must fall inside the author's measured band; uniform sentence length is an AI tell.
+- **Punctuation profile** (`punctuation.em_dash|semicolon|parenthetical`, warning): em-dash, semicolon, and parenthetical rates classified never/rare/habitual; flags drafts whose class deviates from the author's.
+- **Corrective antithesis** (`ai_tell.corrective_antithesis`, error): "not X, it's Y" constructions, inline and across sentence pairs.
+- **Temporal openers** (`ai_tell.temporal_opener`, error): throat-clearing paragraph openers ("In today's...", "In an era...", "Now more than ever...").
+- **Uniform paragraph shapes** (`ai_tell.uniform_paragraphs`, error): four or more consecutive paragraphs with identical sentence counts.
+- **Profile decay** (`profile.stale`, advisory): profile older than its `refresh_after_days` window. Advisory only — it asks for a profile refresh and never blocks the draft. Exit code stays 0 when only advisory findings exist.
+
+Exit code 1 means error/warning findings exist; carry each finding into the violation list below. Profiles without `stylometry` or decay fields skip those checks and remain valid.
+
 **Step 1: Run negative prompt checklist**
 
 Check all categories against the target voice's checklist. Standard categories include:


### PR DESCRIPTION
## Summary
- New `scripts/voice-stylometry.py`: `band` computes per-author burstiness band + punctuation classes + `analyzed_at`/`refresh_after_days` (add-only profile block); `check` emits findings with rule_id, span, line, severity. Stale-profile warning is advisory, never blocks.
- Detectors: burstiness band, em-dash/punctuation profile (never/rare/habitual), corrective antithesis (inline + sentence-pair), throat-clearing temporal openers, uniform paragraph shapes.
- create-voice EXTRACT phase gains the band step; voice-validator SCAN Step 0 names all six deterministic checks.
- 32 deterministic tests, seeded fixtures, fixed clocks; legacy-profile compatibility test included.

## Effectiveness review (deterministic, exit-code tier — per approved process)
7/7 planted violations detected, 0 false positives on clean drafts. `pytest` 32/32 new (full suite 4998 passed) · `ruff check` + `ruff format --check` pass.

ADR: `voice-stylometry-upgrade` (local). Note: the prior voice-analyzer.py was deleted in 26e1a82d; this is a new compact script, not a restoration.

Provenance: clean-room rebuild from evaluation ADR `newsjack-skills-evaluation`.