### PR TITLE
docs: ceiling-bound-eval lesson — what-didnt-work entry + PHILOSOPHY note

### DIFF
--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -318,6 +318,8 @@ Neither tier replaces the other. Pipeline: deterministic first, fix, LLM evaluat
 
 **Test:** Did Tier 1 run and pass before Tier 2 graded? LLM scores on artifacts that fail deterministic checks are wasted tokens.
 
+**Ceiling-bound evals judge nothing.** An A/B where the baseline scores at or near ceiling returns a null verdict on the eval, not the variant. Two in-house cases: the Go token-bucket density run (every arm passed build/vet/race — no effect measurable) and the fact-check skill round 1 (dead tie 19/19 catches both arms on an easy corpus; the hardened corpus — distractor sources, unit drift, false-alarm traps — separated the arms and the skill passed its pre-registered bar; evidence: `docs/what-didnt-work.md` 2026-06-12 entry, PR #811). Before accepting a null result, check the baseline's score against ceiling; harden the corpus until the baseline drops below it.
+
 ### Anti-Rationalization as Infrastructure
 
 The biggest risk: rationalization. "Already done" (assumption). "Code looks correct" (looking, not testing). "Should work" (should, not does). Auto-injected into every code modification, review, security, and testing task. An agent can rationalize past an instruction. It cannot rationalize past an exit code.

--- a/docs/what-didnt-work.md
+++ b/docs/what-didnt-work.md
@@ -35,9 +35,9 @@ Experiments recorded after the seed set. Same four bold fields; `###` headings k
 ### 2026-06-12 fact-check skill blind A/B on the original (easy) eval corpus
 
 - **Expectation**: a skill carrying journalist-grade verification methodology beats a bare sonnet baseline on a 6-fixture closed-book claim-verification corpus.
-- **What happened**: dead tie — 19/19 catches, 0/0 false alarms, 28/28 labels both arms. The corpus was ceiling-bound: obvious seeded errors, 2 sources per fixture, every claim settled by direct lookup, so methodology had nothing to add. A hardened corpus (distractor sources, unit/timeframe drift, context-stripped quotes, genuine source conflicts, false-alarm traps; 46 claims) separated the arms: skill passed the pre-registered bar — catches 34 vs 33, FA 2–2, label-correct 38 vs 32. The skill's measured edge is adjudication-vocabulary discipline, not raw catch rate.
-- **Evidence**: workflow runs `wf_ebaac077-b9c` (round 1) and `wf_e65eb0da-6f1` (round 2); eval corpus `skills/research/fact-check/evals/` (PR #811).
-- **Decision**: rejected the easy corpus, kept the skill. Rule of thumb validated: a null A/B verdict on an easy corpus judges the eval, not the variant — harden until the baseline drops below ceiling before accepting a null.
+- **What happened**: dead tie, 19/19 catches, 0/0 false alarms, 28/28 labels both arms. The corpus was ceiling-bound: obvious seeded errors, 2 sources per fixture, every claim settled by direct lookup, so methodology had nothing to add. A hardened corpus (distractor sources, unit/timeframe drift, context-stripped quotes, genuine source conflicts, false-alarm traps; 46 claims) separated the arms: skill passed the pre-registered bar with catches 34 vs 33, FA 2-2, label-correct 38 vs 32. The skill's measured edge is adjudication-vocabulary discipline, not raw catch rate.
+- **Evidence**: workflow runs `wf_ebaac077-b9c` (round 1) and `wf_e65eb0da-6f1` (round 2); eval corpus in PR #811.
+- **Decision**: rejected the easy corpus, kept the skill. Rule of thumb validated: a null A/B verdict on an easy corpus judges the eval, not the variant. Harden until the baseline drops below ceiling before accepting a null.
 
 ### 2026-06-11 review-contract-provenance port from steipete/agent-scripts
 

--- a/docs/what-didnt-work.md
+++ b/docs/what-didnt-work.md
@@ -32,6 +32,13 @@ Query it: read this file, run `grep -c '^## 2026' docs/what-didnt-work.md`, or r
 
 Experiments recorded after the seed set. Same four bold fields; `###` headings keep the seed-count checks in `scripts/tests/test_negative_results_registry.py` stable. Newest on top.
 
+### 2026-06-12 fact-check skill blind A/B on the original (easy) eval corpus
+
+- **Expectation**: a skill carrying journalist-grade verification methodology beats a bare sonnet baseline on a 6-fixture closed-book claim-verification corpus.
+- **What happened**: dead tie — 19/19 catches, 0/0 false alarms, 28/28 labels both arms. The corpus was ceiling-bound: obvious seeded errors, 2 sources per fixture, every claim settled by direct lookup, so methodology had nothing to add. A hardened corpus (distractor sources, unit/timeframe drift, context-stripped quotes, genuine source conflicts, false-alarm traps; 46 claims) separated the arms: skill passed the pre-registered bar — catches 34 vs 33, FA 2–2, label-correct 38 vs 32. The skill's measured edge is adjudication-vocabulary discipline, not raw catch rate.
+- **Evidence**: workflow runs `wf_ebaac077-b9c` (round 1) and `wf_e65eb0da-6f1` (round 2); eval corpus `skills/research/fact-check/evals/` (PR #811).
+- **Decision**: rejected the easy corpus, kept the skill. Rule of thumb validated: a null A/B verdict on an easy corpus judges the eval, not the variant — harden until the baseline drops below ceiling before accepting a null.
+
 ### 2026-06-11 review-contract-provenance port from steipete/agent-scripts
 
 - **Expectation**: an explicit review contract plus git provenance commands (master-list rank 4+5: Review Contract + provenance method into `systematic-code-review`; contributor trust block into `parallel-code-review`) beats the baseline review skills in a blind A/B.


### PR DESCRIPTION
## Summary
- `docs/what-didnt-work.md`: new entry — fact-check skill blind A/B round 1 dead-tied on the original easy corpus (19/19 catches both arms); hardened corpus separated the arms and the skill passed its pre-registered bar (catches 34v33, FA 2–2, labels 38v32). Decision: rejected the easy corpus, kept the skill.
- `docs/PHILOSOPHY.md`: one validated rule added under *Both Deterministic AND LLM Evaluation* — **ceiling-bound evals judge nothing**; check the baseline against ceiling before accepting a null A/B, citing the registry entry and PR #811 plus the prior Go token-bucket case. This is the only PHILOSOPHY addition from the newsjack program: other candidate rules (never-drop doctrine, stamp decay, cost-tiered passes) produced no discriminating evidence in our runs (both arms scored 0 silent drops), so per the validate-before-adopt rule they stay out.
- Evidence trail: workflow runs wf_ebaac077-b9c, wf_e65eb0da-6f1; PRs #808–#811.