### PR TITLE
feat(routing): benchmark cases for fact-check/headlines/news-collection + advisory coverage report

### DIFF
--- a/scripts/routing-benchmark.json
+++ b/scripts/routing-benchmark.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2",
+  "version": "1.3",
   "description": "Canonical routing benchmark for /do router regression testing. Each test case pairs a natural-language request with its expected agent and/or skill. Used to detect silent routing regressions when models or routing tables change. routing_tier classifies how strictly the router is expected to match: force_route (script must fire correct force_route), candidate (correct answer in top-3), llm_only (no false-positive force-route expected).",
   "test_cases": [
     {
@@ -555,6 +555,102 @@
       "category": "meta-tooling",
       "routing_tier": "force_route",
       "notes": "Build-a-skill intent \u2014 force-route fires on single trigger 'build a skill' (medium confidence)"
+    },
+    {
+      "request": "fact check this article before we publish",
+      "expected_agent": null,
+      "expected_skill": "fact-check",
+      "category": "research",
+      "routing_tier": "candidate",
+      "notes": "Direct trigger 'fact check' \u2014 fact-check appears in top-3 candidates (not force-routed)"
+    },
+    {
+      "request": "verify the claims in this draft against the sources",
+      "expected_agent": null,
+      "expected_skill": "fact-check",
+      "category": "research",
+      "routing_tier": "candidate",
+      "notes": "Direct trigger overlap with 'verify claims' \u2014 fact-check is top candidate"
+    },
+    {
+      "request": "make sure nothing in this draft is wrong before I post it",
+      "expected_agent": null,
+      "expected_skill": "fact-check",
+      "category": "research",
+      "routing_tier": "llm_only",
+      "notes": "Zero trigger keywords \u2014 LLM must recognize pre-publish claim verification as fact-check. Script correctly does not force-route."
+    },
+    {
+      "request": "check if these unit tests cover the facts table",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "llm_only",
+      "notes": "'facts' is a database table, not claim verification \u2014 must NOT route to fact-check"
+    },
+    {
+      "request": "give me headline options for this post",
+      "expected_agent": null,
+      "expected_skill": "headlines",
+      "category": "content-creation",
+      "routing_tier": "candidate",
+      "notes": "Direct trigger 'headline' \u2014 headlines is top candidate (not force-routed)"
+    },
+    {
+      "request": "draft a subject line for the newsletter",
+      "expected_agent": null,
+      "expected_skill": "headlines",
+      "category": "content-creation",
+      "routing_tier": "candidate",
+      "notes": "Direct trigger 'subject line' \u2014 headlines is top candidate"
+    },
+    {
+      "request": "what should I call this piece so people actually click it",
+      "expected_agent": null,
+      "expected_skill": "headlines",
+      "category": "content-creation",
+      "routing_tier": "llm_only",
+      "notes": "Zero trigger keywords \u2014 LLM must recognize title-finding intent as headlines. Script correctly does not force-route."
+    },
+    {
+      "request": "summarize the headline figures from the quarterly report",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "llm_only",
+      "notes": "'headline figures' means top-line numbers, not titles \u2014 must NOT route to headlines"
+    },
+    {
+      "request": "collect news items for tomorrow's briefing",
+      "expected_agent": null,
+      "expected_skill": "news-collection",
+      "category": "research",
+      "routing_tier": "candidate",
+      "notes": "Direct trigger 'collect news' \u2014 news-collection is top candidate (not force-routed)"
+    },
+    {
+      "request": "run news triage on this morning's feed",
+      "expected_agent": null,
+      "expected_skill": "news-collection",
+      "category": "research",
+      "routing_tier": "candidate",
+      "notes": "Direct trigger 'news triage' \u2014 news-collection is top candidate"
+    },
+    {
+      "request": "pull together what happened this week in the industry and keep only the recent stuff",
+      "expected_agent": null,
+      "expected_skill": "news-collection",
+      "category": "research",
+      "routing_tier": "llm_only",
+      "notes": "Zero trigger keywords \u2014 LLM must recognize collect-and-freshness-filter intent as news-collection. Script correctly does not force-route."
+    },
+    {
+      "request": "collect the news about our test failures from CI logs",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "llm_only",
+      "notes": "Gathering CI failure context, not a news pipeline \u2014 must NOT route to news-collection ('the' breaks the 'collect news' trigger)"
     }
   ]
 }

--- a/scripts/routing-benchmark.py
+++ b/scripts/routing-benchmark.py
@@ -6,9 +6,14 @@ in the benchmark test fixture actually exist in the INDEX.json files. This is a
 STRUCTURAL benchmark — it checks that routing targets are valid, not that the LLM
 routes correctly.
 
+Also offers an ADVISORY coverage report (--coverage, included in --verbose):
+skills in skills/INDEX.json that no benchmark case references. Warn-Only Gates
+(docs/PHILOSOPHY.md): coverage gaps are printed but never affect the exit code.
+
 Usage:
     python3 scripts/routing-benchmark.py
     python3 scripts/routing-benchmark.py --verbose
+    python3 scripts/routing-benchmark.py --coverage
     python3 scripts/routing-benchmark.py --category go-development
     python3 scripts/routing-benchmark.py --fixture path/to/custom.json
 
@@ -110,19 +115,69 @@ def validate_test_case(
     return errors
 
 
-def run_benchmark(fixture_path: Path, *, verbose: bool = False, category_filter: str | None = None) -> bool:
+def compute_coverage(test_cases: list[dict], skills: set[str]) -> tuple[set[str], set[str]]:
+    """Split known skills into benchmark-covered and uncovered sets.
+
+    A skill counts as covered when any test case names it in expected_skill
+    or expected_stacked. References to unknown skills are ignored — validity
+    is the benchmark's job, not coverage's.
+
+    Args:
+        test_cases: Benchmark test case dicts.
+        skills: Skill names from skills/INDEX.json.
+
+    Returns:
+        Tuple of (covered, uncovered) skill name sets.
+    """
+    referenced: set[str] = set()
+    for case in test_cases:
+        skill = case.get("expected_skill")
+        if skill:
+            referenced.add(skill)
+        referenced.update(case.get("expected_stacked") or [])
+    return skills & referenced, skills - referenced
+
+
+def print_coverage_report(test_cases: list[dict], skills: set[str]) -> None:
+    """Print the advisory coverage report: skills no benchmark case references.
+
+    Warn-Only Gates (docs/PHILOSOPHY.md): advisory only — never changes the
+    exit code. Blocking on coverage would need its own ADR.
+
+    Args:
+        test_cases: Benchmark test case dicts (unfiltered).
+        skills: Skill names from skills/INDEX.json.
+    """
+    covered, uncovered = compute_coverage(test_cases, skills)
+    print()
+    print(f"Coverage (advisory): {len(covered)}/{len(skills)} skills referenced by benchmark cases")
+    if uncovered:
+        print(f"Uncovered skills ({len(uncovered)}):")
+        for name in sorted(uncovered):
+            print(f"  - {name}")
+
+
+def run_benchmark(
+    fixture_path: Path,
+    *,
+    verbose: bool = False,
+    category_filter: str | None = None,
+    show_coverage: bool = False,
+) -> bool:
     """Run the routing benchmark and report results.
 
     Args:
         fixture_path: Path to the benchmark JSON fixture.
         verbose: Show per-test-case results.
         category_filter: Only run test cases in this category.
+        show_coverage: Print the advisory coverage report after the summary.
 
     Returns:
         True if all test cases pass, False otherwise.
     """
     fixture = load_json(fixture_path)
     test_cases: list[dict] = fixture.get("test_cases", [])
+    all_cases = test_cases  # coverage is fixture-wide, immune to --category
 
     if not test_cases:
         print("ERROR: No test cases found in fixture", file=sys.stderr)
@@ -205,6 +260,10 @@ def run_benchmark(fixture_path: Path, *, verbose: bool = False, category_filter:
             for err in errors:
                 print(f"    -> {err}")
 
+    # Advisory coverage report — never affects the return value
+    if show_coverage:
+        print_coverage_report(all_cases, skills)
+
     return fail_count == 0
 
 
@@ -237,9 +296,19 @@ Examples:
         default=None,
         help="Only run test cases in this category",
     )
+    parser.add_argument(
+        "--coverage",
+        action="store_true",
+        help="Print advisory skill-coverage report (also shown with --verbose); gaps never fail the run",
+    )
 
     args = parser.parse_args()
-    success = run_benchmark(args.fixture, verbose=args.verbose, category_filter=args.category)
+    success = run_benchmark(
+        args.fixture,
+        verbose=args.verbose,
+        category_filter=args.category,
+        show_coverage=args.coverage or args.verbose,
+    )
     sys.exit(0 if success else 1)
 
 

--- a/scripts/tests/test_routing_accuracy.py
+++ b/scripts/tests/test_routing_accuracy.py
@@ -8,6 +8,7 @@ Three tiers of tests:
 
 from __future__ import annotations
 
+import importlib
 import json
 import subprocess
 import sys
@@ -18,6 +19,10 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 BENCHMARK = REPO_ROOT / "scripts" / "routing-benchmark.json"
 ROUTER = REPO_ROOT / "scripts" / "index-router.py"
+BENCHMARK_SCRIPT = REPO_ROOT / "scripts" / "routing-benchmark.py"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+routing_benchmark = importlib.import_module("routing-benchmark")
 
 
 def load_benchmark() -> list[dict]:
@@ -297,3 +302,43 @@ class TestPreRoute:
             assert result.get("agent") == expected_agent, (
                 f"Expected agent={expected_agent!r}, got {result.get('agent')!r}. Reasoning: {result.get('reasoning')}"
             )
+
+
+class TestCoverageReport:
+    """Advisory benchmark-coverage report in routing-benchmark.py.
+
+    Warn-Only Gates (docs/PHILOSOPHY.md): the report names skills with zero
+    benchmark coverage but never fails the run — coverage gaps exit 0.
+    """
+
+    def test_compute_coverage_splits_known_skills(self) -> None:
+        """Skills referenced by expected_skill are covered; the rest are not."""
+        cases = [{"expected_skill": "fact-check"}, {"expected_skill": None}]
+        covered, uncovered = routing_benchmark.compute_coverage(cases, {"fact-check", "headlines"})
+        assert covered == {"fact-check"}
+        assert uncovered == {"headlines"}
+
+    def test_compute_coverage_counts_stacked_skills(self) -> None:
+        """Skills referenced via expected_stacked count as covered."""
+        cases = [{"expected_skill": None, "expected_stacked": ["go-patterns"]}]
+        covered, uncovered = routing_benchmark.compute_coverage(cases, {"go-patterns"})
+        assert covered == {"go-patterns"}
+        assert uncovered == set()
+
+    def test_compute_coverage_ignores_unknown_references(self) -> None:
+        """A reference to a skill missing from INDEX lands in neither set."""
+        cases = [{"expected_skill": "ghost-skill"}]
+        covered, uncovered = routing_benchmark.compute_coverage(cases, {"headlines"})
+        assert covered == set()
+        assert uncovered == {"headlines"}
+
+    def test_coverage_flag_exits_zero_despite_gaps(self) -> None:
+        """--coverage prints the advisory report and never fails on gaps."""
+        result = subprocess.run(
+            [sys.executable, str(BENCHMARK_SCRIPT), "--coverage"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"--coverage must exit 0, got {result.returncode}: {result.stderr}"
+        assert "Coverage (advisory):" in result.stdout


### PR DESCRIPTION
## What

- **12 benchmark cases** (4 per new skill — fact-check, headlines, news-collection): 2 direct-trigger phrasings (`candidate` tier), 1 zero-trigger paraphrase (`llm_only`), 1 false-positive guard (`false-positive-guard`, null targets). Every phrasing verified against the live `index-router.py` before adding.
- **Advisory coverage report** in `scripts/routing-benchmark.py`: `--coverage` flag, also printed with `--verbose`. Compares skills in generated `skills/INDEX.json` against skills referenced by any benchmark case (`expected_skill` + `expected_stacked`), prints the uncovered list with count. Warn-Only Gates (docs/PHILOSOPHY.md): gaps never change the exit code; blocking would need its own ADR. Existing validity checks unchanged.
- **Tests**: `TestCoverageReport` in `scripts/tests/test_routing_accuracy.py` — 3 pure `compute_coverage` tests + a subprocess test asserting `--coverage` exits 0 despite gaps.

## Results

`python3 scripts/routing-benchmark.py --verbose`:
```
Routing Benchmark: 80/80 test cases have valid targets (26 null-target guards)
Categories: code-review(2), content-creation(5), false-positive-guard(15), feature-lifecycle(5), frontend-development(2), git-operations(5), go-development(8), infrastructure(2), meta-tooling(8), pairs-with-agent-resolution(4), parallel-execution(1), pre-route-confidence(5), python-development(3), reddit(1), research(6), trivial-operations(8)
Coverage (advisory): 17/133 skills referenced by benchmark cases
Uncovered skills (116): ...
```
Exit 0.

`python3 scripts/check-routing-drift.py --verbose`:
```
Checked 133 skills against routing manifest
  Present: 133
  Missing: 0
PASS: routing manifest is in sync with INDEX.json
```
Exit 0.

## Coverage before vs after

| | covered | uncovered |
|---|---|---|
| before | 14/133 | 119 |
| after | 17/133 | 116 |

The long uncovered tail (116) is the point of the report — it makes the gap visible without blocking.

## Tests

`pytest scripts/tests/test_routing_accuracy.py -q` — **84 passed** (all 12 new fixture cases pass against the live router; 4 new coverage tests green).
`ruff check` + `ruff format --check` with pyproject.toml — clean.