### PR TITLE
fix(hooks): remove security-review Stop asyncRewake hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -588,15 +588,6 @@
           },
           {
             "type": "command",
-            "command": "python3 \"$HOME/.claude/hooks/security-review-hook.py\"",
-            "description": "Advisory: re-wake the session to run the local security-review pipeline over the working-tree diff",
-            "timeout": 20000,
-            "asyncRewake": true,
-            "rewakeMessage": "Local security review of this session's changes \u2014 address or acknowledge the findings below, then continue with the user's original request or continue waiting for their reply. This is supplementary, not a replacement for your previous response:",
-            "rewakeSummary": "Local security review found changes to review"
-          },
-          {
-            "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/stop-drift-guard.py\"",
             "description": "Advisory: re-wake the session when this session's changes introduce toolkit drift (hook smoke-test, doc-count, or routing-manifest drift) so it can be fixed before CI",
             "timeout": 20000,


### PR DESCRIPTION
## What

Removes the `security-review-hook.py` entry from the `Stop` array in `.claude/settings.json`. The hook used `asyncRewake: true` to wake the session at end-of-session and run the full local security-review pipeline over the working-tree diff.

## Why

The Stop hook fired on every session stop with reviewable changes. Byte-identical-diff dedup meant any new line invalidated the cache, so the security review effectively ran constantly and interrupted flow.

## What stays

The other two security-review entry points remain intact:
- `PreToolUse` on `git commit` — still blocks HIGH/CRITICAL findings at commit time.
- `PostToolUse` on `Edit|Write|MultiEdit` — still emits advisory findings inline.

Together those preserve the safety value (no HIGH-severity finding can leave the machine) without the end-of-session rewake loop. `/security-review` remains available for explicit deeper sweeps.

## Verification

- `python3 -m json.tool .claude/settings.json` — valid.
- `grep -c security-review-hook .claude/settings.json` — was 3, now 2.
- `ruff check` + `ruff format --check` — pass.