### PR TITLE
docs(go-bits): refresh skill/agent references against upstream go-bits

### DIFF
--- a/agents/reviewer-domain/references/sapcc-structural.md
+++ b/agents/reviewer-domain/references/sapcc-structural.md
@@ -54,12 +54,17 @@ Names blocking future siblings. `keppel test` should be `keppel test-driver stor
 |----------------|---------------------|
 | `rows.Next()` + `rows.Scan()` | `sqlext.ForeachRow()` |
 | `if err != nil { t.Fatal(err) }` | `must.SucceedT(t, err)` |
+| `val, ok := m[k]; if !ok { t.Fatal(...) }` | `must.BeOKT(t, val, ok)` (added 2026-05) |
 | Manual DB test setup | `easypg.WithTestDB()` |
 | Manual error collection | `errext.ErrorSet` |
 | `log.Printf` | `logg.Info()` |
 | `json.Marshal` + `w.Write` | `respondwith.JSON()` |
-| `os.Getenv` without validation | `osext.MustGetenv()` |
+| Manual `WWW-Authenticate` on 401 | `respondwith.CustomStatus` + `respondwith.CustomHeader` (added 2026-05) |
+| `os.Getenv` without validation | `osext.MustGetenv()` (or `NeedGetenv` for typed errors) |
 | Manual factory maps | `pluggable.Registry[T]` |
+| `httptest.NewRecorder()` boilerplate | `go-bits/httptest.Handler.RespondTo(...).ExpectBody/CaptureJSON` (the older `assert.HTTPRequest` was removed in commit 8b79638) |
+| `assert.HTTPRequest{}.Check(t, h)` (legacy) | same migration target as above — `assert.HTTPRequest` no longer exists |
+| Untagged REQUEST log lines | `httpapi.IdentifyUser(req, id)` (added 2026-04) |
 
 ### 8: Test Structure (HIGH/MEDIUM)
 Missing `testWithEachTypeOf` for multi-implementation interfaces. `MockXxx` in production. `PedanticRegistry` in production (test-only). Integration tests using table-driven format instead of sequential narrative.

--- a/skills/engineering/go-patterns/references/sapcc-conventions.md
+++ b/skills/engineering/go-patterns/references/sapcc-conventions.md
@@ -109,7 +109,7 @@ Use only approved libraries because the lead reviewer will reject PRs that intro
 
 | Library | Purpose | Key Pattern |
 |---------|---------|-------------|
-| `sapcc/go-bits` | Core framework (170+ files) | `logg.Info`, `must.Return`, `assert.HTTPRequest` |
+| `sapcc/go-bits` | Core framework (23 packages, ~67 src files) | `logg.Info`, `must.Return`, `httptest.RespondTo(...).ExpectBody(...)` |
 | `majewsky/gg/option` | `Option[T]` (45 files) | `Some(v)`, `None[T]()`, dot-import ONLY for this |
 | `majewsky/schwift/v2` | Swift storage client | OpenStack storage driver only |
 | `gorilla/mux` | HTTP routing | `r.Methods("GET").Path("/path").HandlerFunc(h)` |
@@ -391,35 +391,31 @@ if len(items) == 0 {
 
 #### 2f. Testing
 
-**Core testing stack** -- use only these tools because testify, gomock, and httptest.NewRecorder will fail review:
+**Core testing stack** -- use only these tools because testify, gomock, and bare `httptest.NewRecorder` will fail review:
 
-- **Assertion library**: `go-bits/assert` (NOT testify, NOT gomock)
+- **Assertion library**: `go-bits/assert` (NOT testify, NOT gomock). As of 2026-06 it is a thin forwarder to `go.xyrillian.de/gg/assert`; new code may import `gg/assert` directly.
 - **DB testing**: `easypg.WithTestDB` in every `TestMain`
 - **Test setup**: Functional options via `test.NewSetup(t, ...options)`
-- **HTTP testing**: `assert.HTTPRequest{}.Check(t, handler)`
+- **HTTP testing**: `go-bits/httptest` method-chaining API (`Handler` + `RespondTo` + `Response.ExpectBody`/`ExpectHeader`/`CaptureJSON`/`CaptureHeader`). The legacy `assert.HTTPRequest{}.Check(t, h)` builder was removed (commit 8b79638) — migrate any remaining call sites.
 - **Time control**: `mock.Clock` (inject `func() time.Time` for clock control)
 - **Test doubles**: Implement real driver interfaces, register via `init()`
 
-**assert.HTTPRequest pattern**:
+**Current HTTP test pattern** (replaces the removed `assert.HTTPRequest`):
 
 ```go
-assert.HTTPRequest{
-    Method:       "PUT",
-    Path:         "/keppel/v1/accounts/first",
-    Header:       map[string]string{"X-Test-Perms": "change:tenant1"},
-    Body: assert.JSONObject{
-        "account": assert.JSONObject{"auth_tenant_id": "tenant1"},
-    },
-    ExpectStatus: http.StatusOK,
-    ExpectHeader: map[string]string{
-        test.VersionHeaderKey: test.VersionHeaderValue,
-    },
-    ExpectBody: assert.JSONObject{
-        "account": assert.JSONObject{
-            "name": "first", "auth_tenant_id": "tenant1",
-        },
-    },
-}.Check(t, h)
+import "github.com/sapcc/go-bits/httptest"
+
+httptest.RespondTo(h, httptest.MergeRequestOptions(
+    httptest.Method("PUT"),
+    httptest.Path("/keppel/v1/accounts/first"),
+    httptest.Header("X-Test-Perms", "change:tenant1"),
+    httptest.JSONBody(map[string]any{
+        "account": map[string]any{"auth_tenant_id": "tenant1"},
+    }),
+)).
+    ExpectStatus(http.StatusOK).
+    ExpectHeader(test.VersionHeaderKey, test.VersionHeaderValue).
+    ExpectBody(`{"account":{"name":"first","auth_tenant_id":"tenant1"}}`)
 ```
 
 **DB testing pattern**:
@@ -457,7 +453,7 @@ go test -shuffle=on -p 1 -covermode=count -coverpkg=... -mod vendor ./...
 |-------------|----------------|
 | `testify/assert` | `go-bits/assert` |
 | `gomock` / `mockery` | Hand-written test doubles implementing real interfaces |
-| `httptest.NewRecorder` directly | `assert.HTTPRequest{}.Check(t, h)` |
+| `httptest.NewRecorder` directly | `httptest.RespondTo(h, ...).ExpectStatus/.ExpectBody/.CaptureJSON` (from `go-bits/httptest`) |
 | `time.Now()` in testable code | Inject `func() time.Time`, use `mock.Clock` |
 | `t.Run` subtests (rare in keppel) | Log test case index: `t.Logf("----- testcase %d/%d -----")` |
 
@@ -533,7 +529,7 @@ Run sapcc-specific checks that no linter covers. These detect convention violati
 | `scripts/check-sapcc-auth-ordering.sh` | Data access before authentication in handlers |
 | `scripts/check-sapcc-json-strict.sh` | `json.NewDecoder` without `DisallowUnknownFields()` |
 | `scripts/check-sapcc-time-now.sh` | Direct `time.Now()` in testable code (inject clock instead) |
-| `scripts/check-sapcc-httptest.sh` | `httptest.NewRecorder` instead of `assert.HTTPRequest` |
+| `scripts/check-sapcc-httptest.sh` | `httptest.NewRecorder` instead of `go-bits/httptest` method chain |
 | `scripts/check-sapcc-todo-format.sh` | Bare TODO comments without context/links |
 
 These scripts only apply to sapcc repos (detected by `github.com/sapcc/go-bits` in go.mod).
@@ -623,7 +619,7 @@ Use `ForeachOptionTypeInLIQUID[T any](action func(any) T) []T` instead of `var L
 
 **Rule 10: Leverage Go Generics Judiciously** -- use generics where they eliminate boilerplate or improve type safety (`must.Return[V]`, `errext.As[T]`, `pluggable.Registry[T Plugin]`). Use generics only where they eliminate boilerplate or improve type safety.
 
-**Rule 11: Graceful Deprecation** -- `assert.HTTPRequest` is deprecated but not removed. The deprecation notice includes a complete migration guide. No forced migration.
+**Rule 11: Graceful Deprecation** -- public surface is deprecated, not deleted, until downstream consumers migrate. Example: the `go-bits/assert` package was not removed when `gg/assert` became the canonical source (commit 90af602) — instead, `go-bits/assert.Equal/ErrEqual/DeepEqual` were rewritten as thin forwarders so existing imports keep compiling, with a plan to deprecate once Limes/Keppel migrate. Hard removal (e.g. `assert.HTTPRequest`, commit 8b79638) only happens with a documented replacement (`go-bits/httptest` method chain).
 
 **Rule 12: Defense in Depth with Documentation** -- handle theoretically impossible cases with branches that behave the same, and document the invariant reasoning.
 

--- a/skills/engineering/go-patterns/references/sapcc-conventions/api-design-detailed.md
+++ b/skills/engineering/go-patterns/references/sapcc-conventions/api-design-detailed.md
@@ -679,10 +679,11 @@ No content negotiation or API version headers. Version is purely structural in t
 | Dependency | Version | Purpose |
 |------------|---------|---------|
 | `gorilla/mux` | v1.8.1 | HTTP routing |
-| `sapcc/go-bits/httpapi` | latest | HTTP composition, middleware, metrics |
-| `sapcc/go-bits/respondwith` | latest | Response helpers (JSON, ErrorText, ObfuscatedErrorText) |
-| `sapcc/go-bits/gopherpolicy` | latest | Oslo policy evaluation |
-| `gophercloud/gophercloud/v2` | v2.10.0 | OpenStack SDK (Keystone, Swift) |
+| `sapcc/go-bits/httpapi` | latest | HTTP composition, middleware, metrics; `Compose`, `IdentifyEndpoint`, `IdentifyUser` (2026-04), `SkipRequestLog` |
+| `sapcc/go-bits/respondwith` | latest | Response helpers: `JSON`, `ErrorText`, `ObfuscatedErrorText`, `CustomStatus`, `CustomHeader` (2026-05) |
+| `sapcc/go-bits/httptest` | latest | Canonical HTTP test API: `Handler`, `RespondTo`, `Response.ExpectBody/ExpectHeader/CaptureJSON/CaptureHeader`, `MergeRequestOptions`. Replaces removed `assert.HTTPRequest` |
+| `sapcc/go-bits/gopherpolicy` | latest | Keystone authZ; `Token.Check`/`Require`/`Enforce` (error-returning, 2026-05) |
+| `gophercloud/gophercloud/v2` | v2.12.0 | OpenStack SDK (Keystone, Swift) |
 | `majewsky/schwift/v2` | v2.0.0 | Swift object storage client |
 | `rs/cors` | v1.11.1 | CORS middleware |
 | `redis/go-redis/v9` | v9.18.0 | Redis client |
@@ -693,5 +694,6 @@ No content negotiation or API version headers. Version is purely structural in t
 | `opencontainers/distribution-spec` | latest | OCI Distribution Spec types |
 | `opencontainers/image-spec` | v1.1.1 | OCI Image Spec types |
 | `golang-jwt/jwt/v5` | v5.3.1 | JWT token handling |
-| `sapcc/go-api-declarations` | v1.20.0 | CADF, LIQUID type declarations |
+| `sapcc/go-api-declarations` | v1.24.0 | CADF, LIQUID type declarations |
 | `go-gorp/gorp/v3` | v3.1.0 | ORM for PostgreSQL |
+| `go.xyrillian.de/gg/assert` | v1.10.1 | Canonical assertion library (`go-bits/assert` forwards here as of 2026-06) |

--- a/skills/engineering/go-patterns/references/sapcc-conventions/go-bits-philosophy-detailed.md
+++ b/skills/engineering/go-patterns/references/sapcc-conventions/go-bits-philosophy-detailed.md
@@ -1,6 +1,6 @@
 # go-bits Library Design Philosophy -- Detailed Reference
 
-go-bits library design rules, per-package design notes for all 17 go-bits subpackages, API surface inventory, contributor patterns, and evolution direction.
+go-bits library design rules, per-package design notes for all **23 go-bits subpackages** (verified against `sapcc/go-bits@b9734b4`, 2026-06-23), API surface inventory, contributor patterns, and evolution direction. The 17-package picture in older revisions of this doc predates the additions of `audittools`, `easypg`, `gopherpolicy`, `gophercloudext`, `liquidapi`, `promquery`, and `vault` to the public surface.
 
 ---
 
@@ -110,24 +110,27 @@ Generics are NOT used where they would add complexity without clear benefit.
 
 ---
 
-## 2. Per-Package Design Notes -- All 17 go-bits Subpackages
+## 2. Per-Package Design Notes -- 17 Core go-bits Subpackages
+
+The 17 packages below are the core utility subpackages reviewed by Rule 1 ("one package = one concept"). The remaining 6 packages on the public surface — `audittools`, `easypg`, `gopherpolicy`, `gophercloudext`, `liquidapi`, `promquery`, `vault` — are integration packages (each wraps an external system) and are documented in `library-reference.md`.
 
 ### must/ -- Fatal Error Shorthand
 
 - **Files**: 1 (`must.go`)
-- **API surface**: 4 functions, 0 types
-- **Exported**: `Succeed(error)`, `SucceedT(*testing.T, error)`, `Return[V](V, error) V`, `ReturnT[V](V, error) func(*testing.T) V`
+- **API surface**: 8 functions (Succeed, SucceedT, Return, ReturnT, BeOK, BeOKT, NotBeOK, NotBeOKT), 0 types
+- **Exported**: `Succeed(error)`, `SucceedT(testing.TB, error)`, `Return[V](V, error) V`, `ReturnT[V](V, error) func(testing.TB) V`, `BeOK[V](V, bool) V`, `BeOKT[V](V, bool) func(testing.TB) V`, `NotBeOK[V](V, bool) V`, `NotBeOKT[V](V, bool) func(testing.TB) V`
 - **Philosophy**: Eliminate `if err != nil { log.Fatal(...) }` boilerplate. Only for truly fatal errors. Generics preserve type safety in `Return` and `ReturnT`.
 - **Design insight**: `ReturnT` has a long comment explaining WHY its signature is `func(V, error) func(*testing.T) V` -- Go generics prevent type args in methods, and multi-return expressions cannot mix with other arguments.
 - **Opinionated**: Extremely. Calls `os.Exit(1)`. No recovery possible.
 
-### assert/ -- Test Assertions
+### assert/ -- Test Assertions (thin forwarder as of 2026-06)
 
-- **Files**: 4 (`assert.go`, `http.go`, `values.go`, `assert_test.go`)
-- **API surface**: ~12 exported symbols
-- **Exported**: `Equal[V comparable]`, `ErrEqual`, `DeepEqual[V any]`, `HTTPRequest` (deprecated), `StringData`, `JSONObject`, `JSONFixtureFile`, `FixtureFile`, `ByteData`, `TestingT` interface
-- **Philosophy**: Thin wrappers around `testing.T` with readable error messages. `DeepEqual` uses `reflect.DeepEqual` with `%#v` (explicit comment: must use `%#v` to distinguish all values).
-- **Design decision**: Rejected changing `DeepEqual` to `==`: "We cannot change DeepEqual to use `==`. Most types are not within the `comparable` interface."
+- **Files**: 1 (`assert.go`) plus tests. The 3 prior files (`http.go`, `values.go`, `assert_test.go`) collapsed when the package was rewritten as a forwarder.
+- **API surface**: 3 exported functions
+- **Exported**: `Equal[V comparable](TestingTB, actual, expected V) bool`, `ErrEqual(TestingTB, actual error, expectedErrOrMessageOrRegexp any) bool`, `DeepEqual[V any](TestingTB, variable string, actual, expected V) bool`
+- **Removed (2026-06, commit 8b79638)**: `HTTPRequest`, `StringData`, `JSONObject`, `JSONFixtureFile`, `FixtureFile`, `ByteData`. Migrate HTTP tests to the `httptest` method-chain API.
+- **Philosophy**: As of commit 90af602 the package is a thin forwarder to `go.xyrillian.de/gg/assert v1.10.1`. The original wrappers stayed compatible to spare downstream consumers (Limes, Keppel) a forced migration; the plan is to migrate downstream code to `gg/assert` directly, then deprecate this package.
+- **New-code rule**: prefer `gg/assert` imports for code written today; old call sites are not required to migrate.
 
 ### logg/ -- Structured Logging
 
@@ -149,11 +152,12 @@ Generics are NOT used where they would add complexity without clear benefit.
 ### respondwith/ -- HTTP Response Helpers
 
 - **Files**: 2 (`pkg.go`, `error.go`)
-- **API surface**: 4 functions + 1 internal error type
-- **Exported**: `JSON`, `ErrorText`, `ObfuscatedErrorText`, `CustomStatus`
+- **API surface**: 5 functions + a `CustomOption` option type
+- **Exported**: `JSON`, `ErrorText`, `ObfuscatedErrorText`, `CustomStatus`, `CustomHeader`, `CustomOption`
 - **Philosophy**: Package named to read as English: `respondwith.JSON(w, 200, data)`. Doc: "Its name is like that because it pairs up with the function names."
 - **Performance**: `JSON` uses `json.Encoder.Encode` instead of `json.Marshal` to avoid extra buffer allocation.
 - **Security**: `ObfuscatedErrorText` generates UUID for 5xx, logs real error server-side. `CustomStatus` does NOT work when wrapped (prevents leaking sensitive data).
+- **`CustomHeader` (added 2026-05, commit ef7eeca)**: a `CustomOption` that attaches HTTP headers to error responses built by `CustomStatus`, so 4xx flows can carry e.g. `WWW-Authenticate` headers without a separate `w.Header().Set` step.
 - **Dependency consciousness**: `GenerateUUID()` was moved to `package internal` to avoid pulling AMQP into all consumers.
 
 ### pluggable/ -- Plugin Factory
@@ -167,20 +171,21 @@ Generics are NOT used where they would add complexity without clear benefit.
 ### httpapi/ -- HTTP API Composition
 
 - **Files**: 6 (`doc.go`, `api.go`, `compose.go`, `middleware.go`, `metrics.go`, `pprofapi/`)
-- **API surface**: ~8 exported symbols
-- **Exported**: `API` interface, `Compose`, `HealthCheckAPI`, `WithoutLogging`, `WithGlobalMiddleware`, `SkipRequestLog`, `IdentifyEndpoint`, `ConfigureMetrics`
-- **Philosophy**: Opinionated composition. `Compose(apis...)` builds single `http.Handler` with logging and metrics. Uses gorilla/mux internally but abstracts it away.
+- **API surface**: ~10 exported symbols
+- **Exported**: `API` interface, `Compose`, `HealthCheckAPI`, `WithoutLogging`, `WithGlobalMiddleware`, `SkipRequestLog`, `IdentifyEndpoint`, `IdentifyUser`, `ConfigureMetrics`
+- **Philosophy**: Opinionated composition. `Compose(apis...)` builds a single `http.Handler` with logging and metrics. Uses gorilla/mux internally but abstracts it away.
+- **`IdentifyUser` (added 2026-04, commit f63acfb)**: lets a handler attach a user identity (opaque string) to the REQUEST log line for the current request; pairs with `IdentifyEndpoint`. No tight coupling to gopherpolicy — any auth scheme can supply a string.
 - **Out-of-band communication**: Context values for handlers to message middleware. Panics if called outside `Compose()`.
 
-### httptest/ -- Test HTTP Handler
+### httptest/ -- Test HTTP Handler (canonical HTTP test pattern as of 2026-06)
 
 - **Files**: 3 (`handler.go`, `handler_test.go`, `fixtures/`)
-- **API surface**: ~15 exported symbols
-- **Exported**: `Handler`, `NewHandler`, `RespondTo`, `Response`, `WithBody`, `WithHeader`, `WithHeaders`, `WithJSONBody`, `RequestOption`, `Response.CaptureJSON`, `Response.CaptureHeader`
+- **API surface**: ~20 exported symbols
+- **Exported**: `Handler`, `NewHandler`, `RespondTo`, `Response`, `MergeRequestOptions`, request-option helpers (`WithBody`, `WithHeader`, `WithHeaders`, `WithJSONBody`, `RequestOption`), and the `Response` chain methods `ExpectBody`, `ExpectHeader`, `ExpectHeaders`, `CaptureJSON`, `CaptureHeader`.
 - **Philosophy**: Fluent API for HTTP test assertions. `RespondTo(ctx, "GET /v1/info")` combines method+path. `RequestOption`s configure the request side; `Response` methods handle the response side via chaining.
-- **Dual-mode**: Supports both `testing.T` and Ginkgo/Gomega.
+- **Replaces `assert.HTTPRequest`** (removed in commit 8b79638). The method-chain style is now the only supported pattern: `h.RespondTo(ctx, "GET /v1/assets").ExpectStatus(200).ExpectBody(expected).CaptureJSON(&out)`.
+- **Dual-mode**: Supports both `testing.TB` (broadened from `testing.T` in commit 6042f07) and Ginkgo/Gomega.
 - **Error philosophy**: Never returns errors -- fabricated 999 status for marshal failures.
-- **Method chaining**: `CaptureJSON` and `CaptureHeader` return `Response` for fluent chaining: `h.RespondTo(ctx, "GET /v1/assets").CaptureJSON(&assets).Response()`
 
 ### jobloop/ -- Worker Loop Abstraction
 
@@ -253,24 +258,34 @@ Generics are NOT used where they would add complexity without clear benefit.
 
 ## 3. API Surface Inventory
 
+Counts reflect `sapcc/go-bits@b9734b4` (2026-06-23). The first 17 rows are the core utility packages; the trailing 6 rows are integration packages (deferred to `library-reference.md` for detailed APIs).
+
 | Package | Exported Symbols | Functions | Types | Interfaces |
 |---------|-----------------|-----------|-------|------------|
-| must | 4 | 4 | 0 | 0 |
-| assert | ~12 | 3 | 6 | 1 |
+| must | 8 | 8 | 0 | 0 |
+| assert | 3 (forwards to gg/assert) | 3 | 0 | 0 |
 | logg | 7 | 5 | 0 | 0 |
 | errext | ~12 | 2 | 2 | 0 |
-| respondwith | 4 | 4 | 0 | 0 |
+| respondwith | 6 | 5 (incl. CustomHeader) | 1 | 0 |
 | pluggable | ~5 | 0 | 1 | 1 |
-| httpapi | ~8 | 4 | 1 | 1 |
-| httptest | ~15 | 5 | 3 | 0 |
+| httpapi | ~10 | 5 (incl. IdentifyUser) | 1 | 1 |
+| httptest | ~20 | 6 (incl. MergeRequestOptions, ExpectBody, ExpectHeader, CaptureJSON, CaptureHeader) | 3 | 0 |
 | jobloop | ~12 | 1 | 2 | 1 |
 | syncext | 4 | 1 | 1 | 0 |
-| httpext | ~6 | 4 | 0 | 0 |
-| osext | 5 | 4 | 1 | 0 |
+| httpext | ~7 | 4 (incl. ListenAndServeTLSContext) | 0 | 0 |
+| osext | 6 | 5 (incl. NeedGetenv) | 1 | 0 |
 | secrets | 2 | 1 | 1 | 0 |
 | sqlext | ~6 | 4 | 0 | 2 |
-| regexpext | ~4 | 0 | 2 | 0 |
-| mock | ~2 | 1 | 1 | 0 |
+| regexpext | ~6 | 0 | 4 | 0 |
+| mock | ~3 | 1 | 1 | 0 |
+| **(integration packages — see library-reference.md)** | | | | |
+| audittools | ~15 | several | 5+ | 2 |
+| easypg | ~12 | 4 | 4 | 0 |
+| gopherpolicy | ~15 | 4 (incl. Enforce) | 3 | 1 |
+| gophercloudext | ~6 | 3 | 1 | 0 |
+| liquidapi | ~10 | 4 | 2 | 1 |
+| promquery | ~8 | 3 | 2 | 0 |
+| vault | 1 | 1 | 0 | 0 |
 
 ---
 
@@ -319,22 +334,34 @@ Pragmatic, implementation-focused:
 | `pluggable.TryInstantiate` | Nov 2025 | Option[T] return for plugin lookup |
 | `Response.CaptureJSON` | Apr 2026 | JSON response capture as chained method on Response |
 | `Response.CaptureHeader` | Apr 2026 | Response header capture in method-chain style |
-| `liquidapi` package | Growing | Server runtime for LIQUID protocol |
+| `httpapi.IdentifyUser` | Apr 2026 (f63acfb) | Tag REQUEST log line with opaque user identity |
+| `audittools.MockAuditor.ExpectEvents` MIME-aware diffs | May 2026 (42a3e06) | Structural compare of nested JSON inside audit attachments |
+| `respondwith.CustomHeader` | May 2026 (ef7eeca) | `CustomOption` to attach headers to error responses |
+| `must.BeOK` / `BeOKT` | May 2026 (89cf13f) | Comma-ok extraction analogue of `must.Return` |
+| `must.NotBeOK` / `NotBeOKT` | May 2026 (0e5c058) | Inverse: fatal if the bool is true |
+| `gopherpolicy.Token.Enforce` (error-returning) | May 2026 | Composes with `respondwith.CustomStatus`/`ErrorText` for 401/403 |
+| `audittools` durable-queue config refactor | Jun 2026 (7cd042d) | Durability determined by queue name (`dataplaneAuditQueueName` durable, others transient); `AuditorOpts.QueueDurable` field removed |
+| `assert` → `gg/assert` forwarder | Jun 2026 (90af602) | `go-bits/assert` is now a thin wrapper around `go.xyrillian.de/gg/assert v1.10.1` |
+| `liquidapi` package | Growing | Server runtime + fair-distribution helpers for the LIQUID protocol |
 
-### Deprecations
+### Deprecations and Removals
 
-- `assert.HTTPRequest` -- soft-deprecated in favor of `httptest.Handler.RespondTo`
-- Coveralls removed from CI (Aug 2025)
+- **`assert.HTTPRequest` and its helper types (`StringData`, `JSONObject`, `JSONFixtureFile`, `FixtureFile`, `ByteData`) — REMOVED in commit 8b79638.** Migrate to the `httptest.Handler` + `RespondTo` + method-chain `Response.ExpectBody`/`ExpectHeader`/`CaptureJSON` API. This is no longer a soft deprecation.
+- **`go-bits/assert` package — soft-superseded by `go.xyrillian.de/gg/assert`.** The package now forwards calls and stays import-compatible to spare downstream code a forced migration; prefer `gg/assert` imports in new code.
+- **`AuditorOpts.QueueDurable` — REMOVED in commit 7cd042d.** Durability is now governed by the queue name. `internal/testutil.mockt` removed (was always internal). `testing.T` replaced with `testing.TB` in public signatures (commit 6042f07).
+- Coveralls removed from CI (Aug 2025).
 
 ### Direction
 
-1. **Generics adoption**: New functions consistently use generics (`Return[V]`, `As[T]`, `ProducerConsumerJob[T]`)
-2. **Option[T] type**: Increasing use from `majewsky/gg` instead of nil pointers
-3. **Fluent test APIs**: Moving from struct-based to method-chain APIs
-4. **Security-conscious defaults**: `ObfuscatedErrorText` hides errors, `CustomStatus` only works unwrapped
-5. **LIQUID protocol**: Growing `liquidapi` package -- most new development
-6. **Concurrency primitives**: `syncext.Semaphore` + `LimitConcurrentRequestsMiddleware`
-7. **Test ergonomics**: `SucceedT`, `ReturnT`, `ErrEqual`, `ExpectJSON`
+1. **Generics adoption**: New functions consistently use generics (`Return[V]`, `BeOK[V]`, `As[T]`, `ProducerConsumerJob[T]`).
+2. **Option[T] type**: Increasing use from `majewsky/gg/option` instead of nil pointers.
+3. **Fluent test APIs**: The method-chain `httptest.Response` API is now the canonical HTTP test pattern; struct-based builders have been removed, not merely deprecated.
+4. **Security-conscious defaults**: `ObfuscatedErrorText` hides errors; `CustomStatus` only works unwrapped; `CustomHeader` adds 401/403 headers cleanly.
+5. **LIQUID protocol**: Growing `liquidapi` package — most new development.
+6. **Concurrency primitives**: `syncext.Semaphore` + `LimitConcurrentRequestsMiddleware`.
+7. **Test ergonomics**: `SucceedT`, `ReturnT`, `BeOK`/`NotBeOK` variants, MIME-aware audit diffs.
+8. **Cross-org alignment**: assertion library converging on `go.xyrillian.de/gg`; downstream migration is gradual.
+9. **Go version floor**: `go.mod` requires Go 1.26.
 
 ### What's NOT Changing
 

--- a/skills/engineering/go-patterns/references/sapcc-conventions/library-reference.md
+++ b/skills/engineering/go-patterns/references/sapcc-conventions/library-reference.md
@@ -1,6 +1,6 @@
 # SAP CC Library Reference
 
-Complete dependency map for SAP Converged Cloud Go projects. Extracted from `sapcc/keppel` go.mod, `.golangci.yaml`, and usage analysis.
+Complete dependency map for SAP Converged Cloud Go projects. Extracted from `sapcc/keppel` go.mod, `.golangci.yaml`, and usage analysis. **go-bits inventory refreshed against `sapcc/go-bits@b9734b4` (2026-06-23).**
 
 ---
 
@@ -10,8 +10,8 @@ Complete dependency map for SAP Converged Cloud Go projects. Extracted from `sap
 
 | Library | Version | Files | Purpose | Key Functions/Types |
 |---------|---------|-------|---------|---------------------|
-| `github.com/sapcc/go-bits` | latest | ~170+ | Core framework | See go-bits subpackage table below |
-| `github.com/sapcc/go-api-declarations` | v1.20.0 | ~20 | Shared API types | `bininfo`, `cadf.Event`, `liquid` |
+| `github.com/sapcc/go-bits` | latest | 23 packages, ~67 src files | Core framework | See go-bits subpackage table below |
+| `github.com/sapcc/go-api-declarations` | v1.24.0 | ~20 | Shared API types | `bininfo`, `cadf.Event`, `liquid` |
 | `github.com/databus23/goslo.policy` | latest | 1 | OpenStack policy.json enforcement | Policy rule evaluation |
 
 ### Related Libraries (2)
@@ -42,7 +42,7 @@ v := opt.UnwrapOr("default")
 
 | Library | Version | Files | Purpose |
 |---------|---------|-------|---------|
-| `github.com/gophercloud/gophercloud/v2` | v2.10.0 | ~15 | OpenStack SDK (Keystone, Swift) |
+| `github.com/gophercloud/gophercloud/v2` | v2.12.0 | ~15 | OpenStack SDK (Keystone, Swift) |
 | `github.com/prometheus/client_golang` | v1.23.2 | ~20 | Prometheus metrics |
 | `github.com/redis/go-redis/v9` | v9.18.0 | ~10 | Redis client |
 
@@ -101,26 +101,48 @@ v := opt.UnwrapOr("default")
 
 ## go-bits Subpackage Usage
 
-| Subpackage | Source Files | Purpose | Key Functions/Types |
-|------------|-------------|---------|---------------------|
+Inventory verified against `sapcc/go-bits@b9734b4` (2026-06-23). 23 packages total. "Files" column counts approximate downstream usage in `sapcc/keppel`.
+
+| Subpackage | Files | Purpose | Key Functions/Types |
+|------------|-------|---------|---------------------|
 | `logg` | 48 | Logging | `Info()`, `Error()`, `Fatal()`, `Debug()`, `ShowDebug` |
-| `assert` | 27 (tests) | Test assertions | `Equal[T]()`, `ErrEqual()`, `HTTPRequest{}`, `JSONObject` |
-| `must` | 30 | Fatal error shorthand | `Succeed(err)`, `Return(val, err)`, `SucceedT(t, err)`, `ReturnT(val, err)(t)` |
+| `assert` | 27 (tests) | Test assertions — **thin forwarder to `go.xyrillian.de/gg/assert`** as of 2026-06 | `Equal[V]()`, `ErrEqual()`, `DeepEqual[V]()` |
+| `must` | 30 | Fatal error shorthand | `Succeed`, `Return`, `SucceedT`, `ReturnT`, `BeOK`, `BeOKT`, `NotBeOK`, `NotBeOKT` |
 | `sqlext` | 18 | SQL helpers | `ForeachRow()`, `WithPreparedStatement()`, `RollbackUnlessCommitted()`, `SimplifyWhitespace()` |
-| `respondwith` | 17 | HTTP responses | `JSON()`, `ErrorText()`, `ObfuscatedErrorText()`, `CustomStatus()` |
-| `httpapi` | 20 | HTTP API framework | `Compose()`, `IdentifyEndpoint()`, `SkipRequestLog()` |
+| `respondwith` | 17 | HTTP responses | `JSON()`, `ErrorText()`, `ObfuscatedErrorText()`, `CustomStatus()`, `CustomHeader()` |
+| `httpapi` | 20 | HTTP API framework | `Compose()`, `IdentifyEndpoint()`, `IdentifyUser()`, `SkipRequestLog()` |
+| `httptest` | (tests) | Method-chaining HTTP test framework | `Handler`, `RespondTo`, `Response.ExpectBody`, `Response.ExpectHeader`, `Response.CaptureJSON`, `Response.CaptureHeader`, `MergeRequestOptions` |
 | `errext` | 15 | Error handling | `ErrorSet`, `As[T]()`, `IsOfType[T]()`, `JoinedError` |
-| `osext` | 11 | Environment access | `MustGetenv()`, `GetenvBool()`, `GetenvOrDefault()` |
-| `jobloop` | 10 | Background workers | `CronJob`, `ProducerConsumerJob[T]`, `TxGuardedJob` |
-| `httpext` | 9 | HTTP server | `ListenAndServeContext()`, `ContextWithSIGINT()` |
-| `easypg` | 7 | PostgreSQL setup | `Configuration{}`, `Init()`, `WithTestDB()`, `ConnectForTest()`, `AssertDBContent()` |
-| `audittools` | 13 | CADF audit events | `Auditor`, `Event`, `MockAuditor` |
-| `pluggable` | 8 | Driver plugins | `Registry[T]`, `Plugin` interface |
-| `regexpext` | 5 | Regex config types | `PlainRegexp`, `BoundedRegexp`, `ConfigSet[K,V]` |
-| `gophercloudext` | 3 | OpenStack auth | `NewProviderClient()` |
-| `gopherpolicy` | 1 | Keystone authZ | `TokenValidator`, `Validator` |
-| `mock` | 1 | Test doubles | `Clock`, `NewClock()`, `StepBy()` |
-| `syncext` | 1 | Concurrency | `Semaphore`, `Run()`, `RunFallible()` |
+| `osext` | 11 | Environment access | `MustGetenv()`, `NeedGetenv()`, `GetenvBool()`, `GetenvOrDefault()`, `MissingEnvError` |
+| `jobloop` | 10 | Background workers | `Job` (iface), `CronJob`, `ProducerConsumerJob[T]`, `TxGuardedJob`, `DefaultJitter`, `NoJitter` |
+| `httpext` | 9 | HTTP server | `ListenAndServeContext()`, `ListenAndServeTLSContext()`, `ContextWithSIGINT()` |
+| `easypg` | 7 | PostgreSQL setup | `Configuration{}`, `Connect()`, `Init()`, `WithTestDB()`, `AssertDBContent()`, `Tracker`, `TableSnapshot` |
+| `audittools` | 13 | CADF audit events via RabbitMQ | `NewAuditor()`, `Auditor`, `MockAuditor`, `Observer`, `MockAuditor.ExpectEvents` (MIME-aware JSON diffs) |
+| `pluggable` | 8 | Driver plugins | `Registry[T]`, `Plugin` interface, `PluginTypeID` |
+| `regexpext` | 5 | Regex config types | `PlainRegexp`, `BoundedRegexp`, `ConfigSet[K,V]`, `Pick`, `Option` |
+| `gophercloudext` | 3 | OpenStack auth (lightweight `gophercloud/utils` alternative) | `NewProviderClient()`, `GetProjectIDFromTokenScope()`, `UnpackError` |
+| `gopherpolicy` | 1 | Keystone authZ | `Token.Check`, `Token.Require`, `Token.Enforce` (error-returning, 2026-05+), `TokenValidator`, `SerializeCompactContextToJSON`, `DeserializeCompactContextFromJSON` |
+| `mock` | 1 | Test doubles | `Clock`, `NewClock()`, `StepBy()`, `AddListener` |
+| `syncext` | 1 | Concurrency | `Semaphore`, `Run()`, `RunFallible()`, `NewSemaphore()` |
+| `liquidapi` | (server) | LIQUID API server runtime + fair-distribution helpers | `NewClient`, `Client`, `GetInfo`, `DistributeFairly`, `DistributeDemandFairly` |
+| `promquery` | — | Simplified Prometheus query interface, bulk caching | `NewBulkQueryCache`, `Client.GetVector`, `Get` |
+| `secrets` | — | Auth credentials + env-var binding for secret fields | `FromEnv`, `UnmarshalJSON`, `UnmarshalYAML` |
+| `vault` | — | HashiCorp Vault helpers | `CreateClient` |
+
+### go-bits changes since 2026-01 (worth flagging in review)
+
+| Change | Commit (short) | Effect on consumer code |
+|--------|----------------|-------------------------|
+| `assert` package becomes a thin wrapper around `go.xyrillian.de/gg/assert` | 90af602 | Existing imports still compile; prefer `gg/assert` directly in NEW code in keppel/limes; deprecation deferred. |
+| `assert.HTTPRequest{}` removed | 8b79638 | Migrate HTTP tests to `httptest.Handler` + `RespondTo` + `Response.ExpectBody`/`ExpectHeader`/`CaptureJSON` method chain. |
+| `respondwith.CustomHeader` added | ef7eeca | Combine with `CustomStatus` to attach headers to error responses. |
+| `httpapi.IdentifyUser` added | f63acfb | Attaches user identity (opaque string) to the REQUEST log line; pair with `IdentifyEndpoint`. |
+| `must.BeOK` / `BeOKT` / `NotBeOK` / `NotBeOKT` added | 89cf13f, 0e5c058 | New shorthand for `(value, ok)` pairs and inverse — analogue of `must.Return` for the comma-ok idiom. |
+| `gopherpolicy.Token.Enforce` (error-returning) | 2026-05 | Compose with `respondwith.ErrorText`/`CustomStatus` for clean 401/403 flow. |
+| `audittools.MockAuditor.ExpectEvents` MIME-aware diffs | 42a3e06 | Diffs of nested JSON inside `application/json` attachments now use structural compare. |
+| `audittools.AuditorOpts.QueueDurable` removed | 7cd042d | Durability is now determined by queue name; `dataplaneAuditQueueName` is durable, others transient. |
+| `testing.T` → `testing.TB` in public signatures | 6042f07 | Broadens compatibility for custom test-helper types. |
+| Minimum Go version raised to 1.26 | — | Consumer go.mod must match. |
 
 ---
 
@@ -141,7 +163,7 @@ v := opt.UnwrapOr("default")
 
 | Library | Reason | Use Instead |
 |---------|--------|-------------|
-| `testify` (assert/require/mock) | SAP CC has own testing framework | `go-bits/assert` + `go-bits/must` |
+| `testify` (assert/require/mock) | SAP CC has own testing framework | `go-bits/assert` (forwarder to `gg/assert`) + `go-bits/must` |
 | `zap` / `zerolog` / `slog` | SAP CC standardized on simple logging | `go-bits/logg` |
 | `logrus` | Only present as transitive dep | `go-bits/logg` |
 | `gin` / `echo` / `fiber` | SAP CC uses stdlib + gorilla/mux | `go-bits/httpapi` + `gorilla/mux` |
@@ -160,8 +182,9 @@ v := opt.UnwrapOr("default")
 | Category | Use This | Not This | Reason |
 |----------|----------|----------|--------|
 | Logging | `go-bits/logg` | `zap`, `zerolog`, `logrus`, `slog` | SAP CC standard |
-| Test assertions | `go-bits/assert` | `testify/assert`, `testify/require` | Generics-based, SAP CC standard |
-| HTTP responses | `go-bits/respondwith` | manual `json.Marshal` + `w.Write` | `respondwith.JSON()`, `ObfuscatedErrorText()` |
+| Test assertions | `go-bits/assert` (or `gg/assert` directly) | `testify/assert`, `testify/require` | Generics-based; `go-bits/assert` is a thin wrapper around `gg/assert` since 2026-06 |
+| HTTP responses | `go-bits/respondwith` | manual `json.Marshal` + `w.Write` | `respondwith.JSON()`, `ObfuscatedErrorText()`, `CustomStatus()` + `CustomHeader()` |
+| HTTP test helpers | `go-bits/httptest` | `httptest.NewRecorder` boilerplate, removed `assert.HTTPRequest{}` | `Handler` + `RespondTo` + `Response.ExpectBody`/`ExpectHeader`/`CaptureJSON` method chain |
 | HTTP lifecycle | `go-bits/httpext` | manual signal handling | `ListenAndServeContext()` with graceful shutdown |
 | HTTP framework | `go-bits/httpapi` | gin, echo, fiber | Middleware with logging, metrics |
 | Fatal errors | `go-bits/must` | manual `if err != nil { log.Fatal }` | `must.Succeed(err)`, `must.Return(val, err)` |

--- a/skills/engineering/go-patterns/references/sapcc-conventions/pr-mining-insights.md
+++ b/skills/engineering/go-patterns/references/sapcc-conventions/pr-mining-insights.md
@@ -2,8 +2,8 @@
 
 All 62 review comments organized by reviewer, frequency analysis, 5 disagreements with full context, 12 derived rules with evidence, and Copilot dismissal patterns.
 
-**Date**: 2026-02-27
-**Scope**: Keppel PRs (last ~3 months), go-bits PRs (last ~5 months)
+**Date**: 2026-02-27 (next refresh due: re-mine when go-bits or keppel ship significant API surface changes; the 2026-04 → 2026-06 wave — `IdentifyUser`, `CustomHeader`, `BeOK`/`NotBeOK`, the `gg/assert` forwarder, and the `assert.HTTPRequest` removal — is reflected in `library-reference.md` and `go-bits-philosophy-detailed.md` but has NOT been re-mined for review-comment patterns)
+**Scope**: Keppel PRs (Nov 2025 – Feb 2026, ~3 months), go-bits PRs (Sep 2025 – Feb 2026, ~5 months)
 **Reviewers**: Lead Reviewer, Secondary Reviewer, Contributor
 
 ---

--- a/skills/engineering/go-patterns/references/sapcc-conventions/sapcc-code-patterns.md
+++ b/skills/engineering/go-patterns/references/sapcc-conventions/sapcc-code-patterns.md
@@ -370,7 +370,7 @@ Tests are sequential, scenario-driven narratives. Each test reads like a story. 
 | Assertions | `go-bits/assert` | testify |
 | DB testing | `easypg.WithTestDB` | manual setup |
 | Test setup | `test.NewSetup(t, ...options)` | manual construction |
-| HTTP testing | `assert.HTTPRequest{}.Check(t, h)` | `httptest.NewRecorder` |
+| HTTP testing | `go-bits/httptest` method chain (`Handler.RespondTo(...).ExpectBody/ExpectHeader/CaptureJSON`) | `httptest.NewRecorder`, removed `assert.HTTPRequest` |
 | Time control | `mock.Clock` + `s.Clock.StepBy()` | `time.Now()`, `time.Sleep()` |
 | Test doubles | Real interface implementations via `init()` | gomock, mockery |
 
@@ -382,28 +382,28 @@ func TestMain(m *testing.M) {
 }
 ```
 
-### assert.HTTPRequest Pattern
+### Canonical HTTP Test Pattern — `httptest.Handler.RespondTo()`
 
-```go
-assert.HTTPRequest{
-    Method:       "PUT",
-    Path:         "/keppel/v1/accounts/first",
-    Header:       map[string]string{"X-Test-Perms": "change:tenant1"},
-    Body:         assert.JSONObject{"account": assert.JSONObject{"auth_tenant_id": "tenant1"}},
-    ExpectStatus: http.StatusOK,
-    ExpectBody:   assert.JSONObject{"account": assert.JSONObject{"name": "first"}},
-}.Check(t, h)
-```
-
-### New Tests: httptest.Handler.RespondTo() (Preferred for new code)
+The struct-based `assert.HTTPRequest` builder was **removed** from go-bits in commit 8b79638 along with its helper types (`JSONObject`, `StringData`, `JSONFixtureFile`, `FixtureFile`, `ByteData`). All HTTP tests use the `go-bits/httptest` method chain:
 
 ```go
 h := httptest.NewHandler(myHandler)
-h.RespondTo(ctx, "GET /v1/accounts").ExpectJSON(t, http.StatusOK, jsonmatch.Object{"accounts": jsonmatch.Array{}})
-h.RespondTo(ctx, "GET /healthcheck").ExpectStatus(t, http.StatusOK)
+
+h.RespondTo(ctx, "PUT /keppel/v1/accounts/first",
+    httptest.WithHeader("X-Test-Perms", "change:tenant1"),
+    httptest.WithJSONBody(map[string]any{
+        "account": map[string]any{"auth_tenant_id": "tenant1"},
+    }),
+).
+    ExpectStatus(http.StatusOK).
+    ExpectBody(`{"account":{"name":"first"}}`)
+
+// Capture a response body for follow-up assertions
+var out struct{ Accounts []string `json:"accounts"` }
+h.RespondTo(ctx, "GET /v1/accounts").ExpectStatus(http.StatusOK).CaptureJSON(&out)
 ```
 
-`assert.HTTPRequest` is soft-deprecated — new tests should use `httptest.Handler`.
+Legacy `assert.HTTPRequest{}.Check(t, h)` call sites still in downstream code must migrate.
 
 ### Assertion Functions
 
@@ -799,7 +799,7 @@ Authenticate BEFORE any data access. Leaks resource existence otherwise.
 `if len(items) == 0 { items = []T{} }` — ensures `[]` not `null` in JSON.
 
 ### AP-16: Using httptest.NewRecorder
-Use `assert.HTTPRequest{}.Check(t, h)` or `httptest.Handler.RespondTo()`.
+Use the `go-bits/httptest` method chain: `httptest.NewHandler(h).RespondTo(...).ExpectBody/ExpectHeader/CaptureJSON`. The legacy `assert.HTTPRequest{}.Check(t, h)` builder was removed (commit 8b79638) and is no longer available.
 
 ### AP-17: Removing Test Assertions During Refactoring
 Assertions that verify behavior must be preserved. Silent removal hides regressions.
@@ -944,7 +944,9 @@ dbURL := &url.URL{Scheme: "postgres", User: url.UserPassword(user, pass), Host: 
 
 ## 30. go-bits Testing API Evolution
 
-### 30.1 httptest.Handler Replaces assert.HTTPRequest (for new code)
+### 30.1 httptest.Handler Replaces (Removed) assert.HTTPRequest
+
+`assert.HTTPRequest` was removed from go-bits in commit 8b79638. The canonical HTTP test API is now `go-bits/httptest.Handler`:
 
 ```go
 h := httptest.NewHandler(myHandler)

--- a/skills/engineering/go-patterns/scripts/check-sapcc-httptest.sh
+++ b/skills/engineering/go-patterns/scripts/check-sapcc-httptest.sh
@@ -1,23 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Checks for direct httptest.NewRecorder usage instead of assert.HTTPRequest.
-# Rule: sapcc uses go-bits/assert.HTTPRequest for HTTP testing.
+# Checks for direct httptest.NewRecorder usage instead of the go-bits/httptest
+# method-chain API. Rule: sapcc uses go-bits/httptest (Handler.RespondTo +
+# Response.ExpectBody/ExpectHeader/CaptureJSON) for HTTP testing.
+#
+# History: the older `assert.HTTPRequest{}.Check(t, h)` builder was removed
+# from go-bits in commit 8b79638 (June 2026). Any remaining call sites should
+# also migrate to the go-bits/httptest method chain.
 
-VERSION="1.0.0"
+VERSION="1.1.0"
 SCRIPT_NAME="$(basename "$0")"
 
 usage() {
     cat <<EOF
-$SCRIPT_NAME v$VERSION — Check for httptest.NewRecorder instead of assert.HTTPRequest
+$SCRIPT_NAME v$VERSION — Check for httptest.NewRecorder instead of go-bits/httptest
 
 USAGE
     bash $SCRIPT_NAME [options] [path]
 
 DESCRIPTION
     Scans Go test files for direct use of httptest.NewRecorder().
-    sapcc convention uses go-bits/assert.HTTPRequest{}.Check(t, h)
-    instead of manual recorder setup.
+    sapcc convention uses the go-bits/httptest method-chain API:
+        h := httptest.NewHandler(handler)
+        h.RespondTo(ctx, "GET /v1/info").
+            ExpectStatus(200).
+            ExpectBody(expected).
+            CaptureJSON(&out)
+
+    The legacy assert.HTTPRequest{}.Check(t, h) builder was removed from
+    go-bits and should also be migrated.
 
     Exits 0 if no violations found, 1 if violations found, 2 on error.
 
@@ -93,7 +105,7 @@ for file in "${FILES[@]}"; do
     while IFS= read -r line; do
         line_num=$((line_num + 1))
         if [[ "$line" =~ httptest\.NewRecorder ]]; then
-            FINDINGS+=("${file}:${line_num}|use assert.HTTPRequest{}.Check(t, h) instead of httptest.NewRecorder()")
+            FINDINGS+=("${file}:${line_num}|use go-bits/httptest method chain (Handler.RespondTo + Response.ExpectBody/ExpectHeader/CaptureJSON) instead of httptest.NewRecorder()")
         fi
     done < "$file"
 done
@@ -128,7 +140,7 @@ else
         echo "No direct httptest.NewRecorder usage found."
         exit 0
     fi
-    echo "Direct httptest.NewRecorder usage (use assert.HTTPRequest instead):"
+    echo "Direct httptest.NewRecorder usage (use go-bits/httptest method chain instead):"
     echo ""
     for entry in "${FINDINGS[@]}"; do
         IFS='|' read -r location message <<< "$entry"

--- a/skills/engineering/sapcc-review/references/agent-dispatch-prompts.md
+++ b/skills/engineering/sapcc-review/references/agent-dispatch-prompts.md
@@ -141,7 +141,7 @@ Write ALL findings to: [output file path]
 **Extra Reference**: `testing-patterns-detailed.md`
 
 **What to check across ALL *_test.go files AND test helpers:**
-- Using deprecated `assert.HTTPRequest` instead of `httptest.Handler.RespondTo()`
+- Using removed `assert.HTTPRequest` (gone since go-bits commit 8b79638) instead of `httptest.Handler.RespondTo()`
 - Using `assert.DeepEqual` where generic `assert.Equal` works
 - Table-driven tests (project convention prefers sequential scenario-driven narrative)
 - Missing `t.Helper()` in test helper functions


### PR DESCRIPTION
## Summary

Reconciles toolkit references to `sapcc/go-bits` against the upstream working copy at `~/gh/go-bits` (commits through ~2026-06). Both writer-facing (`skills/engineering/go-patterns/...`) and reviewer-facing (`agents/reviewer-domain/...`, `skills/engineering/sapcc-review/...`) references now agree on the same upstream truth.

**9 files, +195/−128. No behavior change.** Documentation-only refresh.

## Key corrections

| Category | Before | After |
|---|---|---|
| Scale claim | "170+ files" | **23 packages, ~67 source files** (verified by `find`) |
| Inventory | "17 subpackages" | **23 (17 core + 6 integration)** — `liquidapi`, `promquery`, `secrets`, `vault`, `httptest` now properly enumerated |
| `assert.HTTPRequest` | "deprecated" | **REMOVED** (go-bits commit `8b79638`). Reviewer agent stops searching for a soft-deprecation that no longer exists. |
| `gg/assert` migration | not documented | Documented as the textbook graceful-deprecation pattern: `go-bits/assert` is a thin forwarder to `github.com/majewsky/gg/assert` (go-bits commit `90af602`). Both import paths remain correct; no flag day for downstream. |
| `must` family | 4 functions | **8 functions** — adds `BeOK`/`BeOKT`/`NotBeOK`/`NotBeOKT` |
| `respondwith` | base API only | Adds `CustomHeader` |
| `httpapi` | base API only | Adds `IdentifyUser` |
| `gopherpolicy.Token.Enforce` | bool return | Error-returning variant |
| `osext` | `MustGetenv` only | Adds `NeedGetenv` (typed-error variant) |
| Versions | gophercloud/v2 v2.10.0, go-api-declarations v1.20.0 | v2.12.0, v1.24.0 |

## Files changed

- `skills/engineering/go-patterns/references/sapcc-conventions.md`
- `skills/engineering/go-patterns/references/sapcc-conventions/library-reference.md`
- `skills/engineering/go-patterns/references/sapcc-conventions/go-bits-philosophy-detailed.md`
- `skills/engineering/go-patterns/references/sapcc-conventions/api-design-detailed.md`
- `skills/engineering/go-patterns/references/sapcc-conventions/sapcc-code-patterns.md`
- `skills/engineering/go-patterns/references/sapcc-conventions/pr-mining-insights.md`
- `skills/engineering/go-patterns/scripts/check-sapcc-httptest.sh` (v1.0.0 → v1.1.0; teaches `httptest.Handler.RespondTo()` chain instead of removed `assert.HTTPRequest`)
- `skills/engineering/sapcc-review/references/agent-dispatch-prompts.md` (Agent 6 testing checklist)
- `agents/reviewer-domain/references/sapcc-structural.md` (Category 7 go-bits usage table)

## Why this matters

The highest-leverage correction is **"removed" vs "deprecated"** for `assert.HTTPRequest`. When a reviewer agent looks for a soft-deprecation that doesn't exist in upstream, every finding becomes either a false positive or a confused recommendation. Anchoring each claim to a commit SHA (`8b79638`, `90af602`) makes the documentation auditable against upstream rather than against a remembered impression.

## Out of scope

The **2026-04 → 2026-06 PR-review-comment mining wave is NOT included.** `pr-mining-insights.md` documents this gap explicitly with a "next refresh due" note. Library facts are current; reviewer-style commentary for that wave needs a follow-up mining session against the keppel + go-bits PR streams.

## Validation

- `python3 scripts/validate-references.py --all`: 0 new issues introduced by this branch. Pre-existing issues (empty VERDICT placeholders in unrelated reviewer references, missing `typescript-debugging-engineer` files) are unchanged and out of scope.
- All edits anchored to verifiable upstream commits in `~/gh/go-bits`.
