### PR TITLE
fix: closeout 2 residual findings from PR #820 review

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -154,7 +154,6 @@ Skills are invoked via `/do [request]` (routed automatically) or directly as `/s
 | `content-calendar` | no | Manage editorial content through six pipeline stages |
 | `joy-check` | no | Validate content framing on joy-grievance spectrum |
 | `professional-communication` | no | Transform technical communication into structured business formats |
-| `gemini-image-generator` | no | Generate images from text prompts via Google Gemini |
 | `image-to-video` | no | FFmpeg-based video creation from image and audio |
 | `video-editing` | no | Video editing pipeline: cut footage, assemble clips via FFmpeg and Remotion |
 | `image-gen` | no | AI image generation: Gemini and Nano Banana backends; single/series/batch workflows with prompt-to-disk. |

--- a/skills/research/research-pipeline/SKILL.md
+++ b/skills/research/research-pipeline/SKILL.md
@@ -28,7 +28,6 @@ routing:
   not_for: "a quick one-off web search or chat-style lookup — that is deep-research. Pick this when the user wants a sourced report saved as an artifact (SCOPE-to-DELIVER), even when phrased as 'dig into X and give me a sourced report'."
   category: research
   pairs_with:
-    - kb
     - topic-brainstormer
 ---
 


### PR DESCRIPTION
Removes a dangling kb pairs_with reference (research-pipeline/SKILL.md) and a phantom gemini-image-generator catalog row (docs/skills.md) that PR #820's own fixes already confirmed don't exist. Caught by PR #820's independent review, deferred as non-blocking (medium severity), closing out now.