### PR TITLE
fix: complete deny_tool_use rollout, suppress 3 scanner false positives

### DIFF
--- a/hooks/pretool-adr-creation-gate.py
+++ b/hooks/pretool-adr-creation-gate.py
@@ -39,6 +39,7 @@ import traceback
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from hook_utils import deny_tool_use
 from stdin_timeout import read_stdin
 
 _BYPASS_ENV = "ADR_CREATION_GATE_BYPASS"
@@ -198,7 +199,10 @@ def main() -> None:
     # If the file already exists this is an update, not a creation — allow through.
     if Path(file_path).exists():
         if debug:
-            print(f"[adr-creation-gate] File already exists (update), allowing: {file_path}", file=sys.stderr)
+            print(
+                f"[adr-creation-gate] File already exists (update), allowing: {file_path}",  # nosec: plain English
+                file=sys.stderr,
+            )
         sys.exit(0)
 
     # Path-shape allowlist: skills produced by named upstream pipelines whose
@@ -231,19 +235,10 @@ def main() -> None:
         file=sys.stderr,
     )
     print("[fix-with-skill] plans", file=sys.stderr)
-    print(
-        json.dumps(
-            {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": (
-                        f"Create ADR at {centralized_hint} (or adr/{component_name}.md in project root) "
-                        "before creating this new component. Use the plans skill to draft the ADR first."
-                    ),
-                }
-            }
-        )
+    deny_tool_use(
+        "PreToolUse",
+        f"Create ADR at {centralized_hint} (or adr/{component_name}.md in project root) "
+        "before creating this new component. Use the plans skill to draft the ADR first.",
     )
     sys.exit(0)
 

--- a/hooks/security-review-hook.py
+++ b/hooks/security-review-hook.py
@@ -70,6 +70,7 @@ from hook_utils import (
     DiffDedup,
     async_rewake,
     context_output,
+    deny_tool_use,
     empty_output,
     has_reviewable_content,
     working_tree_diff,
@@ -198,18 +199,11 @@ def handle_pre_tool_use(event: dict) -> None:
         f"{summary.get('critical', 0)} critical, {summary.get('high', 0)} high finding(s) "
         f"in staged files.\n"
         f"{_format_findings(blocking)}\n"
-        f"Fix the findings, or set {_SKIP_ENV}=1 to override deliberately."
+        f"Fix the findings, or set {_SKIP_ENV}=1 to override deliberately."  # nosec: "set" = plain English, not SQL
     )
     print("[security-review] BLOCKED commit — HIGH/CRITICAL staged findings:", file=sys.stderr)
     print(_format_findings(blocking), file=sys.stderr)
-    deny_output = {
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
-            "permissionDecisionReason": reason,
-        }
-    }
-    print(json.dumps(deny_output))
+    deny_tool_use("PreToolUse", reason)
     sys.exit(0)
 
 
@@ -328,7 +322,7 @@ def _has_reviewable_content(diff: str) -> bool:
     Security-relevant means: at least one scannable source file has at least one
     ADDED line. Pure deletions, doc/config-only diffs, mode-only and pure-rename
     diffs are all non-triggering. An added line in a real source file (a new
-    `eval(...)` in a `.py`) MUST still pass — true positives are preserved.
+    `eval(...)` in a `.py`) MUST still pass — true positives are preserved. (nosec: doc example, not a real eval call)
     """
     return has_reviewable_content(diff, _scannable_extensions())
 


### PR DESCRIPTION
Suppresses 3 confirmed security-scanner false positives (plain-English update/set words and a docstring eval() example, independently re-verified against a direct scanner run) via the scanner's own per-line nosec escape hatch -- no change to scripts/security-review-scan.py's detection logic. With the pre-commit gate no longer false-blocking, finishes converting hooks/pretool-adr-creation-gate.py and hooks/security-review-hook.py to hook_utils.deny_tool_use(), completing the deny_tool_use rollout PR #820 could not finish. Output verified byte-identical on the deny path for both files.