### PR TITLE
feat(retro): graduate 4 high-confidence learnings into permanent guidance

### DIFF
--- a/agents/golang-general-engineer.md
+++ b/agents/golang-general-engineer.md
@@ -133,7 +133,11 @@ Apply minimum-viable edits because over-engineering beyond the request is the mo
 ### Phase 4: VERIFY
 Run `gofmt -w` on every edited file because unformatted Go code fails CI before any logic review runs. Run `go test ./...` and paste the actual output because summarising "tests pass" without evidence is the dominant rationalisation that ships broken code. For cleanup, review, or refactoring tasks, run `deadcode ./...` after `go vet` to find unreachable functions — see [go-dead-code-analysis.md](golang-general-engineer/references/go-dead-code-analysis.md) for usage and false-positive guidance.
 
-**Gate**: `go test ./...` output shown in full, `go vet ./...` clean.
+**Render-time fixes require render-time verification.** Bugs that manifest at output-render time (table layout, template output, log formatting) are not caught by compile + `go test`. To verify, build a small standalone reproducer under `/tmp` with realistic fake data and run it; compare before/after output byte-for-byte. Use the module cache, not vendor pollution. No backend creds needed.
+
+**Rebuilt binary check.** When testing a fix to a CLI binary, confirm the binary you're running matches the fix. Check `stat -f %m ./bin/foo` vs the fix commit time, or compare the embedded version SHA against `git rev-parse HEAD`. A stale binary silently passes tests against the old (broken) code path.
+
+**Gate**: `go test ./...` output shown in full, `go vet ./...` clean. For render-time fixes: reproducer output shown with before/after diff.
 
 ### Phase 5: REPORT
 Report exit status with real command output. No "should work" — either the gates passed or they didn't.

--- a/skills/engineering/go-patterns/references/preferred-patterns.md
+++ b/skills/engineering/go-patterns/references/preferred-patterns.md
@@ -233,6 +233,26 @@ func (opts AuditorOpts) buildConnectionURL() (string, error) {
 
 ---
 
+### AP-8: Vendored Library Contract Reversal on Major-Version Bump
+
+**Symptom**: A bug appears immediately after bumping a vendored library across a major version. Same option name, opposite behavior between versions.
+
+**Concrete case**: `tablewriter` v0 vs v1. `WithColumnMax(N)` means *per-cell content cap* in v0 but *fixed width per column* in v1. With many columns and a small `N`, the v1 normalizer compresses each column to 1-3 chars. Symptom: nearly-empty table with single characters visible. Fix requires `Config.Row.ColMaxWidths.Global` / `Config.Header.ColMaxWidths.Global` instead.
+
+**Failure mode**: Assuming the option name preserves semantics across the major-version boundary. The go doc for the new version *looks* familiar, so the fix appears one-line. It isn't.
+
+**Detection**: Any bug that appears within one commit of `go get lib@vN+1`. If the code compiled and the test suite passed but runtime output is subtly wrong (layout, formatting, ordering, unit conversions), read `$(go env GOMODCACHE)/path/to/lib@vN+1/option.go` end-to-end BEFORE patching. Do not rely on memory of the old contract; do not rely on the option name.
+
+**Remediation**:
+1. Read the option-defining file end-to-end in GOMODCACHE.
+2. Enumerate every option whose name overlaps with the old version's — the ones that stayed named but changed contract are the traps.
+3. Build a `/tmp` reproducer with a minimal call site to observe actual v1 behavior.
+4. Confirm before/after output byte-for-byte in the reproducer before touching production code.
+
+**Universal rule**: Option semantics live in source, not in memory. Cross-major-version bumps demand re-reading the option file.
+
+---
+
 ## Error Handling
 
 ### Error: "False Positive -- Pattern Is Intentional"

--- a/skills/meta/do/references/routing-guide.md
+++ b/skills/meta/do/references/routing-guide.md
@@ -18,6 +18,9 @@ The `/do` command routes requests to appropriate agents and skills.
 | python, .py, pip, pytest | `python-general-engineer` |
 | kubernetes, helm, k8s | `kubernetes-helm-engineer` |
 | react, next.js | `typescript-frontend-engineer` |
+| create skill, scaffold skill, new skill, create agent, scaffold agent | `toolkit-governance-engineer` |
+
+> **skill-creator is a skill, not an agent.** No `skill-creator` subagent_type exists. The agent that owns skill/agent scaffolding is `toolkit-governance-engineer` (owns `skills/INDEX.json`, `agents/INDEX.json`, `scripts/pre-route.py`). Route skill-creation requests as: agent `toolkit-governance-engineer` + skill `skill-creator`.
 
 ## Force-Routed Skills
 

--- a/skills/process/pr-workflow/SKILL.md
+++ b/skills/process/pr-workflow/SKILL.md
@@ -156,6 +156,7 @@ Detect the user's intent and load the appropriate reference file:
 | any `gh` call writing or reading a PR/issue body | `gh-body-safety.md` | **Body safety** |
 | "update changelog", "release notes", "curate changelog" | `changelog-curation.md` | **Changelog** |
 | "decision brief", "authorization tier", "ask the owner", "is it decision-ready" | `owner-decision-briefs.md` | **Decision brief** |
+| "INDEX.json conflict", "INDEX conflict on rebase", "two PRs regenerated INDEX", "regenerate INDEX after rebase" | `index-conflict-resolution.md` | **INDEX conflict** |
 
 ## Mandatory PR Body Structure
 

--- a/skills/process/pr-workflow/references/index-conflict-resolution.md
+++ b/skills/process/pr-workflow/references/index-conflict-resolution.md
@@ -1,0 +1,27 @@
+# INDEX.json Conflict Resolution on Sequenced PRs
+
+When two branches both regenerate `agents/INDEX.json` or `skills/INDEX.json`, the second PR to land hits a merge conflict. Naïve resolution corrupts the source-of-truth.
+
+## The wrong move
+
+Popping a stale stash on the second PR — it clobbers entries the first PR added.
+
+Accepting either side of the conflict blindly — one side is always stale relative to the current `SKILL.md` / `agents/*.md` sources.
+
+## The right sequence
+
+1. `git rebase main` — take main's `INDEX.json` as the base (has PR #1's entries).
+2. `git checkout stash@{0} -- <non-INDEX paths>` — apply your non-INDEX changes individually. Never restore the whole stash.
+3. Regenerate `INDEX.json` from source of truth on the rebased branch:
+   - Skills: `python3 scripts/generate-skill-index.py`
+   - Agents: `python3 scripts/generate-agent-index.py`
+4. Verify the regen contains BOTH PR #1's entries and your branch's entries.
+5. Force-push with `--force-with-lease` — needs a prior `git fetch` on the contributor's branch to establish the lease ref, otherwise the lease check fails with an opaque error.
+
+## Why this shape
+
+`INDEX.json` is a generated artifact, not source. Merging it as text produces plausible-looking output that diverges from source. Regenerating after rebase is the only way to guarantee consistency with the actual `SKILL.md` / `*.md` files on the branch.
+
+## Provenance
+
+Pattern confirmed working on PRs #670 + #671 (2026-05-26). Rediscovered in gotcha `skill:pr-workflow/7fad9101` and `skill:do/f0f387436dc9`.


### PR DESCRIPTION
## Summary

Fold 8 retro learnings (7 gotcha, 1 already-covered design) into their target skills and agents so the patterns become durable guidance instead of injection-only hints. Each graduation was validated against the target file for zero pre-existing coverage before being applied.

## Changes

- `skills/meta/do/references/routing-guide.md` — add `toolkit-governance-engineer` row for skill/agent scaffolding triggers + note that `skill-creator` is a skill not an agent. Graduates `skill:do/2e968c5d`.
- `skills/process/pr-workflow/references/index-conflict-resolution.md` — new reference covering the correct sequence when two PRs both regenerate INDEX.json (rebase → apply non-INDEX from stash → regen from source → force-push with lease). Graduates `skill:pr-workflow/7fad9101` + `skill:do/f0f38743`.
- `skills/process/pr-workflow/SKILL.md` — wire the new reference into the Reference Loading Table.
- `agents/golang-general-engineer.md` — extend Phase 4: VERIFY with render-time reproducer requirement and stale-binary check. Graduates `agent:golang-general-engineer/4f72e3ac` + `aa886c43`.
- `skills/engineering/go-patterns/references/preferred-patterns.md` — add AP-8: Vendored Library Contract Reversal on Major-Version Bump, with the tablewriter v0→v1 `WithColumnMax` concrete case. Graduates `skill:go-patterns/f6e7236e` + `skill:systematic-debugging/c1257329`.

All 8 learning.db entries marked graduated via `scripts/learning-db.py graduate`.

## Notes

Each candidate was hard-validated against its target file for zero pre-existing coverage before graduation; the retro entry for `skill:skill-creator/5540a278` was marked graduated without a file edit because `skill-creator/SKILL.md` already carries the same force_route guidance.
