### PR TITLE
fix(do): correct two unbacked figures and the duplicate Step 1b label in SKILL.md

### DIFF
--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -201,7 +201,7 @@ Use `agent` and `skill` fields directly; if `confidence` is "low", verify agains
 - (a) Pick a skill from the manifest that covers the task verb (review→systematic-code-review, debug→systematic-debugging, refactor→systematic-refactoring, audit→audit-report, explain→codebase-overview, compare→comparative-analysis, plan→planning, loop/objective→objective-loop), OR
 - (b) Fall back to `objective-loop` as the default methodology wrapper (never leave `skill` empty on Simple+).
 
-An agent without a skill is a specialist without methodology — the router MUST NOT dispatch that combination for Simple+ work. This gate closes the observed 24% empty-skill leak (see `route-events.jsonl`).
+An agent without a skill is a specialist without methodology — the router MUST NOT dispatch that combination for Simple+ work. This gate closes the observed empty-skill leak (12.6% of 517 decision events, `route-events.jsonl`, June 2026).
 
 **Dispatch-time section validator (MANDATORY before every `Agent(subagent_type=...)` call).** A skill name in the `agent` field makes the harness reject the dispatch (`Agent type 'X' not found`). Assert the `agent` field maps to a name in the manifest's `AGENTS:` section. Pseudocode:
 
@@ -359,10 +359,11 @@ Load `references/quality-loop.md` as the **outer orchestration wrapper**:
 
 Quality-loop absorbs Steps 0-1. The Phase 2 agent+skill is the implementation agent; force-route skills run INSIDE the loop. Skip when: Trivial/Simple (use `quick`), review-only/research/debugging/content creation, or user wants a simpler flow.
 
-**Step 1b/1c (Workflow dispatch — lazy-loaded):**
+**Step 1c: Workflow dispatch (lazy-loaded)**
 
 On a pipeline `pick`, a Complex/tier-4 task with no pick, or an explicit "run through a workflow" request, load `${CLAUDE_SKILL_DIR}/references/workflow-dispatch.md` and follow it.
 It carries the executor decision table, roster rules, and inline-script constraints verbatim.
+When Step 1b and Step 1c both apply (a Medium+ code modification that also has a pipeline pick or is Complex/tier-4), quality-loop is the OUTER wrapper; Step 1c workflow dispatch runs INSIDE its IMPLEMENT phase (`references/quality-loop.md`, "outer orchestration").
 
 **Step 2: Invoke agent with skill**
 
@@ -413,7 +414,7 @@ TOKEN_BUDGET=$(python3 -c "import json,sys; print(json.load(open('.claude/settin
 
 **Category overrides** (regardless of complexity): `thinking:slow` for security work, API/schema design, migrations, 5+ file reviews, architectural decisions; `thinking:fast` for lookups, status checks, single-function renames/refactors. Hooks capture the thinking class from dispatch metadata; the router sets the directive but records nothing.
 
-**Verb-based model dispatch for Complex tasks (3+ data sources).** Extraction verbs use parallel Haiku readers; analysis verbs a single Opus agent (extraction 38% cheaper, 23% faster — A/B tested).
+**Verb-based model dispatch for Complex tasks (3+ data sources).** Extraction verbs use parallel Haiku readers; analysis verbs a single Opus agent.
 
 | Task verb class | Dispatch mode |
 |---|---|


### PR DESCRIPTION
## What changed

Three verified defects in `skills/meta/do/SKILL.md` (only file touched):

1. **Line 204 — unbacked figure.** "24% empty-skill leak" replaced with the measured figure: **12.6% (65/517 decision events, route-events.jsonl, June 2026)**. Re-measured for this PR: 517 decision events, 65 with empty/null skill = 12.6%; event timestamps span 2026-06-04 to 2026-06-26. No bucket in the log reaches 24%.
2. **Line 416 — unverified claim.** Deleted "(extraction 38% cheaper, 23% faster — A/B tested)". `grep -rn '38% cheaper|23% faster'` over the repo hits only this SKILL.md line — no artifact backs it. Dispatch table and rule kept intact.
3. **Lines 353/362 — duplicate label.** Two procedures both carried "Step 1b" (quality-loop wrapper vs Workflow dispatch) with no precedence rule. Relabeled line 362 to **Step 1c** and added one precedence sentence: when both apply (Medium+ code modification that also has a pipeline pick or is Complex/tier-4), quality-loop is the OUTER wrapper and Step 1c workflow dispatch runs INSIDE its IMPLEMENT phase — consistent with `references/quality-loop.md` ("outer orchestration"). No other in-file "Step 1b/1c" references exist (verified by grep; "Steps 0-1" at line 360 is unrelated).

## Verification

| Check | Result |
|---|---|
| YAML frontmatter parses (`yaml.safe_load`) | PASS |
| Line count 510 → 511 (+0.2%, one added sentence) | PASS |
| All referenced files exist (quality-loop.md, workflow-dispatch.md, progressive-depth.md, lazy-completion-detector.md) | PASS |
| `python3 scripts/audit-skill-content.py --root skills/meta --severity high` | exit 0, 0 violations |
| `python3 scripts/validate-skill-frontmatter.py` | 133 files OK |
| `python3 scripts/validate_positive_instruction_docs.py` | exit 0 |
| `ruff check . --config pyproject.toml` | All checks passed |
| `ruff format --check . --config pyproject.toml` | 502 files already formatted |

Pre-existing, unrelated: ruff warns about a malformed `# noqa` at `scripts/tests/test_governance_report.py:159` (ruff still exits 0); not touched — out of scope.