### PR TITLE
fix(agents): repair both TypeError snippets in routing-table-patterns.md

### DIFF
--- a/agents/toolkit-governance-engineer/references/routing-table-patterns.md
+++ b/agents/toolkit-governance-engineer/references/routing-table-patterns.md
@@ -205,7 +205,7 @@ Run the duplicate trigger detection script before adding any new trigger phrase.
 **Detection**:
 ```bash
 # Count registered agents vs filesystem agents
-registered=$(python3 -c "import json; d=json.load(open('agents/INDEX.json')); print(len(d.get('agents', [])))" 2>/dev/null)
+registered=$(python3 -c "import json; d=json.load(open('agents/INDEX.json')); print(len(d.get('agents', {})))" 2>/dev/null)
 on_disk=$(ls agents/*.md | grep -v README | wc -l)
 echo "Registered: $registered, On disk: $on_disk"
 
@@ -213,7 +213,7 @@ echo "Registered: $registered, On disk: $on_disk"
 python3 -c "
 import json, glob, os
 idx = json.load(open('agents/INDEX.json'))
-registered = {a['name'] for a in idx.get('agents', [])}
+registered = set(idx.get('agents', {}))  # 'agents' is a dict keyed by agent name
 for f in glob.glob('agents/*.md'):
     name = os.path.basename(f).replace('.md','')
     if name not in registered and name != 'README':
@@ -311,7 +311,7 @@ for t, files in triggers.items():
 python3 -c "
 import json, glob, os
 idx = json.load(open('agents/INDEX.json'))
-registered = {a['name'] for a in idx.get('agents', [])}
+registered = set(idx.get('agents', {}))  # 'agents' is a dict keyed by agent name
 for f in glob.glob('agents/*.md'):
     name = os.path.basename(f).replace('.md','')
     if name not in registered and name != 'README': print(f'UNREGISTERED: {name}')


### PR DESCRIPTION
## What changed

`agents/toolkit-governance-engineer/references/routing-table-patterns.md` — 3 lines:

- **Lines 216 and 314** (was 215-216 / 313-314): `registered = {a['name'] for a in idx.get('agents', [])}` → `registered = set(idx.get('agents', {}))`. `agents/INDEX.json` stores `agents` as a **dict keyed by agent name** (values: `file`, `short_description`, `triggers`, ... — no `name` field), so iterating yields key strings and `a['name']` raises the TypeError verbatim.
- **Line 208**: count snippet's empty default `[]` → `{}` to match the real shape. `len()` was already correct on the dict; only the default misrepresented the shape.

## Evidence (audit citations, CONFIRMED)

Reproduced against the repo `agents/INDEX.json` before the fix:

```
$ python3 -c "import json; idx = json.load(open('agents/INDEX.json')); registered = {a['name'] for a in idx.get('agents', [])}"
TypeError: string indices must be integers, not 'str'
```

Real shape: `{'version': str, 'generated_by': str, 'agents': dict}`, sample keys `ansible-automation-engineer`, `combat-effects-upgrade`, ...

## Verification (fixed snippets run read-only against repo INDEX.json)

```
--- snippet 1 (line 208 count check) ---
Registered: 43, On disk: 44
--- snippet 2/3 (fixed UNREGISTERED detection, lines 216/314) ---
UNREGISTERED: base-instructions
exit: 0
```

(`base-instructions` is a true positive: an injection doc, not a routable agent — the detector now works as documented.)

## Other snippets audited

- Phantom `pairs_with` and duplicate-trigger snippets read agent frontmatter, not INDEX.json — no shape dependency; both run clean (410 triggers parsed).
- **Follow-up, out of scope**: the phantom snippet checks `skills/{p}/SKILL.md` but skills live at `skills/{category}/{name}/SKILL.md`, producing false PHANTOMs (e.g. `go-patterns` exists at `skills/engineering/go-patterns`). Same file, separate defect against the skills layout — left for its own PR.

## Checks run

- `ruff check . --config pyproject.toml` — All checks passed (one pre-existing unrelated `# noqa` warning in `scripts/tests/test_governance_report.py:159`)
- `ruff format --check . --config pyproject.toml` — 502 files already formatted
- `python3 scripts/validate-references.py --agent toolkit-governance-engineer` — 4/4 references present, 0 issues
- `python3 -m pytest scripts/tests/test_reference_loading.py -k toolkit-governance-engineer` — 7 passed, 5 xfailed
- File integrity: 327 lines before and after; no markdown links in file; no frontmatter to break