### PR TITLE
fix(harness): back-port the genuine-git-only rule into routing-ab-test.py PROMPT_TEMPLATE

### DIFF
--- a/scripts/routing-ab-test.py
+++ b/scripts/routing-ab-test.py
@@ -139,13 +139,17 @@ VERDICT: PROMOTE (exit 0) = all gates pass AND discordant pairs >= 6.
          UNDERPOWERED (exit 2) = all gates pass but discordant pairs < 6.
          REJECT (exit 1) = any gate fails."""
 
-# Verbatim Haiku routing prompt template (REQUEST + MANIFEST filled in).
+# Haiku routing prompt template (REQUEST + MANIFEST filled in).
+# Git rule back-ported 2026-07-01 from production skills/meta/do/SKILL.md
+# (genuine-git-only). Runs before this date used the blunt "For git operations
+# (push, commit, PR, merge), ALWAYS select pr-workflow." rule and are NOT
+# template-comparable with later runs.
 PROMPT_TEMPLATE = """You are a routing agent. Given a user request and a manifest of available agents, skills, and pipelines, select the BEST agent+skill combination.
 USER REQUEST: {request}
 ROUTING MANIFEST:
 {manifest}
 Return your answer as JSON: {{"agent": "...|null","skill":"...|null","pipeline":"...|null","reasoning":"one sentence","confidence":"high/medium/low"}}
-FORCE-ROUTE RULE: Entries marked "FORCE" MUST be selected when their domain clearly matches the user's intent. FORCE matching is SEMANTIC, not keyword-based — match what the user MEANS. For git operations (push, commit, PR, merge), ALWAYS select pr-workflow. Pick the most specific match. Return a single skill name as a string."""
+FORCE-ROUTE RULE: Entries marked "FORCE" MUST be selected when their domain clearly matches the user's intent. FORCE matching is SEMANTIC, not keyword-based — match what the user MEANS. For GENUINE git / version-control operations — actually pushing code, committing files to a repository, or opening/merging a pull request — ALWAYS select pr-workflow. Do NOT route metaphorical or non-version-control uses of these words (e.g. 'commit to a decision/plan', 'merge ideas in your head', 'push back on a proposal') to pr-workflow. Pick the most specific match. Return a single skill name as a string."""
 
 # Optional corpus fields carried into queries.json/raw.json ONLY when present,
 # so legacy artifacts stay byte-identical.

--- a/scripts/tests/fixtures/routing_ab/golden/README.md
+++ b/scripts/tests/fixtures/routing_ab/golden/README.md
@@ -13,3 +13,7 @@ Regenerate ONLY from a commit whose legacy behavior is known-good, with the same
 stubbing the test applies (see `load_harness` + `run_legacy_pipeline`), then copy
 queries.json, manifest-used.txt, raw.json, judge-input.json, uid-map.json,
 scoreboard.json, pre-route-map.json, and prompts/ here.
+
+2026-07-01: prompts/ regenerated after the PROMPT_TEMPLATE git rule was
+back-ported from production skills/meta/do/SKILL.md (genuine-git-only).
+All other artifacts are unchanged pre-extension snapshots.

--- a/scripts/tests/fixtures/routing_ab/golden/prompts/q00.txt
+++ b/scripts/tests/fixtures/routing_ab/golden/prompts/q00.txt
@@ -3,4 +3,4 @@ USER REQUEST: push my changes to GitHub
 ROUTING MANIFEST:
 STUB MANIFEST v1
 Return your answer as JSON: {"agent": "...|null","skill":"...|null","pipeline":"...|null","reasoning":"one sentence","confidence":"high/medium/low"}
-FORCE-ROUTE RULE: Entries marked "FORCE" MUST be selected when their domain clearly matches the user's intent. FORCE matching is SEMANTIC, not keyword-based — match what the user MEANS. For git operations (push, commit, PR, merge), ALWAYS select pr-workflow. Pick the most specific match. Return a single skill name as a string.
+FORCE-ROUTE RULE: Entries marked "FORCE" MUST be selected when their domain clearly matches the user's intent. FORCE matching is SEMANTIC, not keyword-based — match what the user MEANS. For GENUINE git / version-control operations — actually pushing code, committing files to a repository, or opening/merging a pull request — ALWAYS select pr-workflow. Do NOT route metaphorical or non-version-control uses of these words (e.g. 'commit to a decision/plan', 'merge ideas in your head', 'push back on a proposal') to pr-workflow. Pick the most specific match. Return a single skill name as a string.

--- a/scripts/tests/fixtures/routing_ab/golden/prompts/q01.txt
+++ b/scripts/tests/fixtures/routing_ab/golden/prompts/q01.txt
@@ -3,4 +3,4 @@ USER REQUEST: push back on this approach
 ROUTING MANIFEST:
 STUB MANIFEST v1
 Return your answer as JSON: {"agent": "...|null","skill":"...|null","pipeline":"...|null","reasoning":"one sentence","confidence":"high/medium/low"}
-FORCE-ROUTE RULE: Entries marked "FORCE" MUST be selected when their domain clearly matches the user's intent. FORCE matching is SEMANTIC, not keyword-based — match what the user MEANS. For git operations (push, commit, PR, merge), ALWAYS select pr-workflow. Pick the most specific match. Return a single skill name as a string.
+FORCE-ROUTE RULE: Entries marked "FORCE" MUST be selected when their domain clearly matches the user's intent. FORCE matching is SEMANTIC, not keyword-based — match what the user MEANS. For GENUINE git / version-control operations — actually pushing code, committing files to a repository, or opening/merging a pull request — ALWAYS select pr-workflow. Do NOT route metaphorical or non-version-control uses of these words (e.g. 'commit to a decision/plan', 'merge ideas in your head', 'push back on a proposal') to pr-workflow. Pick the most specific match. Return a single skill name as a string.

--- a/scripts/tests/fixtures/routing_ab/golden/prompts/q02.txt
+++ b/scripts/tests/fixtures/routing_ab/golden/prompts/q02.txt
@@ -3,4 +3,4 @@ USER REQUEST: send my commits to the server
 ROUTING MANIFEST:
 STUB MANIFEST v1
 Return your answer as JSON: {"agent": "...|null","skill":"...|null","pipeline":"...|null","reasoning":"one sentence","confidence":"high/medium/low"}
-FORCE-ROUTE RULE: Entries marked "FORCE" MUST be selected when their domain clearly matches the user's intent. FORCE matching is SEMANTIC, not keyword-based — match what the user MEANS. For git operations (push, commit, PR, merge), ALWAYS select pr-workflow. Pick the most specific match. Return a single skill name as a string.
+FORCE-ROUTE RULE: Entries marked "FORCE" MUST be selected when their domain clearly matches the user's intent. FORCE matching is SEMANTIC, not keyword-based — match what the user MEANS. For GENUINE git / version-control operations — actually pushing code, committing files to a repository, or opening/merging a pull request — ALWAYS select pr-workflow. Do NOT route metaphorical or non-version-control uses of these words (e.g. 'commit to a decision/plan', 'merge ideas in your head', 'push back on a proposal') to pr-workflow. Pick the most specific match. Return a single skill name as a string.

--- a/scripts/tests/fixtures/routing_ab/golden/prompts/q03.txt
+++ b/scripts/tests/fixtures/routing_ab/golden/prompts/q03.txt
@@ -3,4 +3,4 @@ USER REQUEST: run ruff and mypy on this Python project
 ROUTING MANIFEST:
 STUB MANIFEST v1
 Return your answer as JSON: {"agent": "...|null","skill":"...|null","pipeline":"...|null","reasoning":"one sentence","confidence":"high/medium/low"}
-FORCE-ROUTE RULE: Entries marked "FORCE" MUST be selected when their domain clearly matches the user's intent. FORCE matching is SEMANTIC, not keyword-based — match what the user MEANS. For git operations (push, commit, PR, merge), ALWAYS select pr-workflow. Pick the most specific match. Return a single skill name as a string.
+FORCE-ROUTE RULE: Entries marked "FORCE" MUST be selected when their domain clearly matches the user's intent. FORCE matching is SEMANTIC, not keyword-based — match what the user MEANS. For GENUINE git / version-control operations — actually pushing code, committing files to a repository, or opening/merging a pull request — ALWAYS select pr-workflow. Do NOT route metaphorical or non-version-control uses of these words (e.g. 'commit to a decision/plan', 'merge ideas in your head', 'push back on a proposal') to pr-workflow. Pick the most specific match. Return a single skill name as a string.


### PR DESCRIPTION
## Summary
Back-ports the genuine-git-only routing rule into the A/B harness PROMPT_TEMPLATE. The template still carried the blunt rule "For git operations (push, commit, PR, merge), ALWAYS select pr-workflow." — the exact rule `semantic-first-ab-results.md:55` diagnosed as the root cause of false-positive-guard failures and that production `skills/meta/do/SKILL.md:192` replaced. Unchanged since b216f826 (deliberate comparability freeze, `self-route-v1/VERDICT.md:14-18`).

## Changes
- `scripts/routing-ab-test.py` — replace the blunt git rule in PROMPT_TEMPLATE with the production genuine-git-only rule, verbatim from `SKILL.md:192`; add a dated comment marking pre-2026-07-01 runs as not template-comparable.
- `scripts/tests/fixtures/routing_ab/golden/prompts/q00-q03.txt` — regenerate the 4 golden prompts that byte-pin the rendered template (`TestLegacyByteIdentical::test_prompt_bytes`); only the rule sentence differs.
- `scripts/tests/fixtures/routing_ab/golden/README.md` — record the 2026-07-01 prompt regen; all other golden artifacts stay pre-extension snapshots.

## Notes
- Golden fixtures were regenerated with the exact stubbing the test applies (`load_harness` + `emit_prompts`); the corpus SHA-256 pin (`LEGACY_CASES_SHA`) is untouched and passes — the corpus did not change, only the template.
- Verified: `pytest scripts/tests/test_routing_ab_harness.py -x -q` (38 passed) and the five other routing suites (169 passed combined); `ruff check` + `ruff format --check` clean.
- Runs stored before 2026-07-01 used the blunt rule; do not compare them template-to-template with later runs.
