### PR TITLE
fix(skills): routing-table-updater — unrunnable paths and dead target format

### DIFF
--- a/skills/meta/routing-table-updater/SKILL.md
+++ b/skills/meta/routing-table-updater/SKILL.md
@@ -57,7 +57,7 @@ The skill reads metadata from all skills and agents (never modifies them) and va
 **Step 1: Run scan script**
 
 ```bash
-python3 ~/.claude/skills/routing-table-updater/scripts/scan.py --repo $HOME/vexjoy-agent
+python3 ~/.claude/skills/meta/routing-table-updater/scripts/scan.py --repo $HOME/vexjoy-agent
 ```
 
 **Step 2: Validate scan output**
@@ -81,7 +81,7 @@ Compare discovered count against expected. If missing, check directory naming, a
 **Step 1: Run extraction script**
 
 ```bash
-python3 ~/.claude/skills/routing-table-updater/scripts/extract_metadata.py --input scan_results.json --output metadata.json
+python3 ~/.claude/skills/meta/routing-table-updater/scripts/extract_metadata.py --input scan_results.json --output metadata.json
 ```
 
 **Step 2: Verify extraction completeness**
@@ -107,7 +107,7 @@ Review against `references/extraction-patterns.md`. Patterns must be specific en
 **Step 1: Run generation script**
 
 ```bash
-python3 ~/.claude/skills/routing-table-updater/scripts/generate_routes.py --input metadata.json --output routing_entries.json
+python3 ~/.claude/skills/meta/routing-table-updater/scripts/generate_routes.py --input metadata.json --output routing_entries.json
 ```
 
 **Step 2: Understand the generation process**
@@ -165,7 +165,7 @@ EOF
 **Step 1: Run validation script**
 
 ```bash
-python3 ~/.claude/skills/routing-table-updater/scripts/validate.py
+python3 ~/.claude/skills/meta/routing-table-updater/scripts/validate.py
 ```
 
 Validates skill package structure, SKILL.md frontmatter, and script executability. Exit 0 = pass.

--- a/skills/meta/routing-table-updater/SKILL.md
+++ b/skills/meta/routing-table-updater/SKILL.md
@@ -28,9 +28,9 @@ routing:
 
 ## Overview
 
-This skill maintains /do routing tables and command references when skills or agents are added, modified, or removed. It implements a **Phase-Gated Pipeline** -- scan, extract, generate, update, verify -- with deterministic script execution at each phase.
+This skill maintains the /do routing indices when skills or agents are added, modified, or removed. It implements a **Phase-Gated Pipeline** -- scan, extract, generate, update, verify -- with deterministic script execution at each phase.
 
-The skill reads metadata from all skills and agents (never modifies them) and safely updates `skills/meta/do/SKILL.md`, `skills/meta/do/references/routing-tables.md`, `agents/INDEX.json`, and `commands/*.md` files. All changes are backed up before modification, and markdown syntax is validated before commit.
+The skill reads metadata from all skills and agents (never modifies them) and validates and repairs the generated routing indices `skills/INDEX.json` and `agents/INDEX.json`. PostToolUse hooks (`hooks/posttooluse-sync-skill-index.py`, `hooks/posttooluse-sync-agent-index.py`) regenerate the indices automatically on every SKILL.md or agent-file edit; this skill covers drift those hooks miss (bulk changes, deletes outside the harness, corrupted index files).
 
 ---
 
@@ -43,7 +43,7 @@ The skill reads metadata from all skills and agents (never modifies them) and sa
 | errors, error handling | `error-handling.md` | Loads detailed guidance from `error-handling.md`. |
 | worked update scenarios: new skill, conflict, manual entry, complexity change | `examples.md` | Loads detailed guidance from `examples.md`. |
 | extracting trigger phrases: 'use when' clauses, action verbs, domain keywords, complexity inference | `extraction-patterns.md` | Loads detailed guidance from `extraction-patterns.md`. |
-| /do routing table structure, auto-generated markers, ordering rules | `routing-format.md` | Loads detailed guidance from `routing-format.md`. |
+| routing entry format: frontmatter routing block fields, INDEX.json entry shape, regeneration | `routing-format.md` | Loads detailed guidance from `routing-format.md`. |
 | skill-entry examples for registering a newly created skill | `skill-examples.md` | Loads detailed guidance from `skill-examples.md`. |
 
 ## Instructions
@@ -57,7 +57,7 @@ The skill reads metadata from all skills and agents (never modifies them) and sa
 **Step 1: Run scan script**
 
 ```bash
-python3 ~/.claude/skills/meta/routing-table-updater/scripts/scan.py --repo $HOME/vexjoy-agent
+python3 ~/.claude/skills/routing-table-updater/scripts/scan.py --repo $HOME/vexjoy-agent
 ```
 
 **Step 2: Validate scan output**
@@ -81,7 +81,7 @@ Compare discovered count against expected. If missing, check directory naming, a
 **Step 1: Run extraction script**
 
 ```bash
-python3 ~/.claude/skills/meta/routing-table-updater/scripts/extract_metadata.py --input scan_results.json --output metadata.json
+python3 ~/.claude/skills/routing-table-updater/scripts/extract_metadata.py --input scan_results.json --output metadata.json
 ```
 
 **Step 2: Verify extraction completeness**
@@ -100,106 +100,81 @@ Review against `references/extraction-patterns.md`. Patterns must be specific en
 
 ### Phase 3: GENERATE -- Create Routing Table Entries
 
-**Goal**: Map extracted metadata to routing entries and detect conflicts.
+**Goal**: Map extracted metadata to routing entries and detect trigger conflicts before the indices are rebuilt.
 
-**Constraints**: Deterministic generation (no randomness); entries follow exact /do format spec (`references/routing-format.md`); pattern conflicts detected immediately; entries sorted alphabetically; duplicates within same table block gate passage.
+**Constraints**: Deterministic generation (no randomness); pattern conflicts detected immediately; entries sorted alphabetically; duplicates within the same group block gate passage.
 
 **Step 1: Run generation script**
 
 ```bash
-python3 ~/.claude/skills/meta/routing-table-updater/scripts/generate_routes.py --input metadata.json --output routing_entries.json
+python3 ~/.claude/skills/routing-table-updater/scripts/generate_routes.py --input metadata.json --output routing_entries.json
 ```
 
 **Step 2: Understand the generation process**
 
-1. Load routing format spec from `references/routing-format.md`
-2. Map each capability to appropriate routing table
-3. Format entries according to /do table structure
-4. Detect pattern conflicts (see `references/conflict-resolution.md`)
-5. Sort entries alphabetically within tables
+1. Group each capability by the routing classification extracted in Phase 2
+2. Detect pattern conflicts (see `references/conflict-resolution.md`)
+3. Sort entries alphabetically within groups
 
 **Step 3: Review conflict detection output**
 
 Low-severity conflicts: script applies specificity rules automatically. High-severity conflicts: script blocks gate passage and requires manual resolution.
 
-**Gate**: All capabilities are mapped, entries follow /do format, conflicts are documented, and no duplicates remain within the same table. Proceed to Phase 4 only after the gate passes. See `references/error-handling.md` for gate failure recovery.
+**Gate**: All capabilities are mapped, conflicts are documented, and no duplicates remain within the same group. Proceed to Phase 4 only after the gate passes. See `references/error-handling.md` for gate failure recovery.
 
 ---
 
-### Phase 4A: UPDATE -- Safely Modify commands/do.md
+### Phase 4: UPDATE -- Repair INDEX.json
 
-**Goal**: Apply generated routing entries to do.md with backup and validation.
+**Goal**: Bring `skills/INDEX.json` and `agents/INDEX.json` in line with filesystem state.
 
-**Constraints**: Always create timestamped backup before modification; preserve all hand-written entries (entries without `[AUTO-GENERATED]` marker are never overwritten); markdown table syntax validates after updates; atomic backup/restore on validation failure.
+**Constraints**: Both indices are generated, gitignored artifacts — repair means regenerating from frontmatter via the repo scripts; hand-edits to index files are lost on the next regeneration; source SKILL.md and agent files stay untouched; run from the repo root.
 
-**Step 1: Run update script with backup**
-
-```bash
-python3 ~/.claude/skills/meta/routing-table-updater/scripts/update_routing.py --input routing_entries.json --target $HOME/vexjoy-agent/commands/do.md --backup
-```
-
-**Step 2: Verify backup exists**
-
-Confirm backup file at `commands/.do.md.backup.{timestamp}` before any modifications proceed.
-
-**Step 3: Review the diff**
-
-The script outputs a diff showing new entries (+), modified entries (- old / + new), and preserved manual entries (unchanged). Review for correctness.
-
-**Step 4: Confirm or abort**
-
-If diff looks correct: confirm to apply. If unexpected: abort and investigate. With --auto-commit: confirmation skipped.
-
-**Step 5: Post-update validation**
-
-The script validates pipe alignment, header separator rows, consistent column counts, and no orphaned rows. On validation failure: automatic restore from backup. Report error details.
-
-**Gate**: Backup created, all manual entries preserved, markdown validated, diff confirmed. If gate fails, RESTORE from backup.
-
----
-
-### Phase 4B: UPDATE -- Update Command Files
-
-**Goal**: Update command files with current skill/agent references.
-
-**Constraints**: Command files updated only if they reference outdated/invalid skills; backups created for all modified files; all referenced skills must exist; markdown syntax validated after updates.
-
-**Step 1: Run update script with backup**
+**Step 1: Regenerate both indices**
 
 ```bash
-python3 ~/.claude/skills/meta/routing-table-updater/scripts/update_commands.py --commands-dir $HOME/vexjoy-agent/commands --metadata metadata.json --backup
+cd $HOME/vexjoy-agent
+python3 scripts/generate-skill-index.py
+python3 scripts/generate-agent-index.py
 ```
 
-**Step 2: Understand the update process**
+**Step 2: Check for phantom entries**
 
-1. Scan command files for skill invocations and references
-2. Identify outdated or invalid references (renamed/removed skills)
-3. Update references to match current metadata
-4. Create backups for all modified command files
-5. Validate updated markdown syntax
+Every entry's `file` path must exist on disk:
 
-**Gate**: Backups created for all modified files, all referenced skills exist, markdown validated.
+```bash
+python3 - <<'EOF'
+import json, os
+for idx, key in (("skills/INDEX.json", "skills"), ("agents/INDEX.json", "agents")):
+    entries = json.load(open(idx))[key]
+    phantom = [n for n, e in entries.items() if not os.path.exists(e["file"])]
+    print(idx, len(entries), "entries,", len(phantom), "phantom", phantom or "")
+EOF
+```
+
+**Gate**: Both generators exit 0 and both indices contain zero phantom `file` paths. On generator failure, fix the offending frontmatter (the error names the file) and rerun. Proceed to Phase 5 only after the gate passes.
 
 ---
 
 ### Phase 5: VERIFY -- Validate Routing Correctness
 
-**Goal**: Final validation of all routing tables.
+**Goal**: Final validation of the skill package and the rebuilt indices.
 
-**Constraints**: All auto-generated entries must have `[AUTO-GENERATED]` markers; no duplicate patterns within same routing table; all referenced skills/agents must exist; complexity values must match Simple/Medium/Complex; overlapping patterns documented with priority rules.
+**Constraints**: No duplicate trigger phrases within an index; every index entry's `file` path exists; complexity values must match Simple/Medium/Complex; overlapping patterns documented with priority rules.
 
 **Step 1: Run validation script**
 
 ```bash
-python3 ~/.claude/skills/meta/routing-table-updater/scripts/validate.py --target $HOME/vexjoy-agent/commands/do.md
+python3 ~/.claude/skills/routing-table-updater/scripts/validate.py
 ```
+
+Validates skill package structure, SKILL.md frontmatter, and script executability. Exit 0 = pass.
 
 **Step 2: Understand verification checks**
 
-1. **Structural**: All routing tables present, headers formatted, pipes aligned
-2. **Content**: All auto-generated entries marked, no duplicates, all referenced skills/agents exist
+1. **Structural**: Skill package complete (SKILL.md, scripts, references), frontmatter parses
+2. **Content**: No duplicate triggers, every index entry's `file` path exists (Phase 4 Step 2 check)
 3. **Conflicts**: Overlapping patterns documented, priority rules applied
-4. **Integration**: Sample pattern matching tests pass
 
 **Gate**: All checks pass. Task complete ONLY if final gate passes. See `references/error-handling.md` for gate failure recovery.
 
@@ -233,7 +208,7 @@ Invocation by other skills:
 skill: routing-table-updater
 ```
 
-The skill reads metadata from all skills and agents but never modifies them. It only writes to `skills/meta/do/SKILL.md`, `skills/meta/do/references/routing-tables.md`, `agents/INDEX.json`, and `commands/*.md` files.
+The skill reads metadata from all skills and agents but never modifies them. Its only write targets are the generated indices `skills/INDEX.json` and `agents/INDEX.json`, always via the repo generator scripts.
 
 ---
 
@@ -247,7 +222,7 @@ See `references/error-handling.md` for the full error matrix (YAML parse errors,
 
 ### Reference Files
 
-- `${CLAUDE_SKILL_DIR}/references/routing-format.md`: /do routing table format specification (table structure, entry formats, ordering rules)
+- `${CLAUDE_SKILL_DIR}/references/routing-format.md`: routing entry format specification (frontmatter routing block fields, INDEX.json entry shape, regeneration commands)
 - `${CLAUDE_SKILL_DIR}/references/extraction-patterns.md`: Trigger phrase extraction patterns (regex, keyword maps, complexity inference)
 - `${CLAUDE_SKILL_DIR}/references/conflict-resolution.md`: Conflict types, priority rules, severity levels, resolution process
 - `${CLAUDE_SKILL_DIR}/references/examples.md`: Real-world examples of routing table updates (new skill, updated agent, conflict detection, manual preservation)

--- a/skills/meta/routing-table-updater/references/routing-format.md
+++ b/skills/meta/routing-table-updater/references/routing-format.md
@@ -1,119 +1,94 @@
-# /do Routing Table Format Specification
+# Routing Entry Format Specification
 
-## Table Structure
+Routing metadata lives in two layers:
 
-All routing tables in commands/do.md follow markdown pipe table format:
+1. **Source of truth**: the YAML frontmatter `routing:` block in each `skills/*/SKILL.md` and `agents/*.md` file. Hand-authored, tracked in git.
+2. **Generated artifact**: `skills/INDEX.json` and `agents/INDEX.json` (schema v2.0). Built from frontmatter by the repo generator scripts. Gitignored — regenerate to repair; the generators own ordering and formatting.
 
-```
-| Column 1 Header | Column 2 Header | Column 3 Header | Column 4 (Optional) |
-|-----------------|-----------------|-----------------|---------------------|
-| Entry 1         | Entry 2         | Entry 3         | Entry 4             |
-```
+## Skill Frontmatter Routing Block
 
-## Intent Detection Patterns Table
-
-**Header:**
-```
-| User Says | Route To | Complexity |
-|-----------|----------|------------|
-```
-
-**Entry Format:**
-```
-| "trigger phrase", "alternate phrase" | tool-name type | Level | [AUTO-GENERATED] |
-```
-
-**Example:**
-```
-| "lint", "format", "style check" | code-linting skill via /lint | Simple | [AUTO-GENERATED]
+```yaml
+---
+name: routing-table-updater
+description: "Maintain /do routing tables when skills or agents change."
+user-invocable: false
+routing:
+  triggers:
+    - "update routing"
+    - "routing drift"
+  category: meta-tooling
+  pairs_with:
+    - toolkit-evolution
+---
 ```
 
-**Rules:**
-- Multiple trigger phrases separated by commas in quotes
-- Route target includes type (skill/agent/command)
-- Complexity: Trivial, Simple, Medium, Complex
-- AUTO-GENERATED marker in 4th column for automated entries
-- Alphabetical order by first trigger phrase
+| Field | Required | Purpose |
+|-------|----------|---------|
+| `name` | yes | Skill identifier; index key |
+| `description` | yes | Intent text the router reads |
+| `routing.triggers` | yes | Phrases that route to this skill |
+| `routing.category` | yes | Coverage grouping |
+| `routing.pairs_with` | no | Components commonly co-dispatched |
+| `routing.not_for` | no | Negative routing examples |
+| `routing.force_route` | no | High-confidence route on a single trigger match |
+| `user-invocable` | no | `false` hides the skill from direct user invocation |
 
-## Domain-Specific Routing Table
+## Agent Frontmatter Routing Block
 
-**Header:**
-```
-| Domain Mentioned | Agent | Typical Complexity |
-|-----------------|-------|-------------------|
-```
+Same shape; agents add `complexity` (e.g., `Medium`, `Complex`, `Medium-Complex`) and use `description` as the router's short description.
 
-**Entry Format:**
-```
-| Keyword1, Keyword2 | agent-name | Level | [AUTO-GENERATED] |
-```
+## skills/INDEX.json Entry Shape
 
-**Example:**
-```
-| Go, Golang, gofmt | golang-general-engineer | Medium-Complex | [AUTO-GENERATED]
-```
-
-**Rules:**
-- Domain keywords comma-separated
-- Agent name only (no "agent" suffix in cell)
-- Complexity can be ranges: Medium-Complex
-- AUTO-GENERATED marker in 4th column
-- Alphabetical order by primary domain keyword
-
-## Task Type Routing Table
-
-**Header:**
-```
-| Task Type | Route To Agent | Complexity |
-|-----------|----------------|------------|
+```json
+{
+  "version": "2.0",
+  "generated": "2026-07-01T23:44:02Z",
+  "generated_by": "scripts/generate-skill-index.py",
+  "skills": {
+    "routing-table-updater": {
+      "file": "skills/meta/routing-table-updater/SKILL.md",
+      "description": "Maintain /do routing tables when skills or agents change.",
+      "triggers": ["update routing", "routing drift"],
+      "category": "meta-tooling",
+      "user_invocable": false,
+      "pairs_with": ["toolkit-evolution", "generate-claudemd"]
+    }
+  }
+}
 ```
 
-**Entry Format:**
-```
-| "action phrase", "alternate phrase" | agent-name agent | Level | [AUTO-GENERATED] |
-```
+Optional per-entry fields when present in frontmatter: `not_for`, `force_route`, `agent`, `version`.
 
-**Example:**
-```
-| "create agent", "new agent", "design agent" | skill-creator | Complex | [AUTO-GENERATED]
-```
+## agents/INDEX.json Entry Shape
 
-## Combination Routing Table
-
-**Header:**
-```
-| Task Type | Combination | Complexity |
-|-----------|-------------|------------|
-```
-
-**Entry Format:**
-```
-| "task description" | primary-tool + secondary-tool | Level | [AUTO-GENERATED] |
+```json
+{
+  "agents": {
+    "ansible-automation-engineer": {
+      "file": "agents/ansible-automation-engineer.md",
+      "short_description": "Ansible automation: playbooks, roles, collections, Molecule testing, Vault security",
+      "triggers": ["ansible", "playbook"],
+      "pairs_with": ["verification-before-completion"],
+      "complexity": "Medium-Complex",
+      "category": "infrastructure"
+    }
+  }
+}
 ```
 
-**Example:**
-```
-| "Add feature with tests" | workflow-orchestrator + test-driven-development | Complex | [AUTO-GENERATED]
-```
+## Regeneration
 
-## Auto-Generated Marker
-
-**Purpose:** Distinguish automated entries from manual entries
-
-**Format:** `[AUTO-GENERATED]` in 4th column (or 3rd if table has 3 columns)
-
-**Detection Rule:**
-```python
-is_auto_generated = "[AUTO-GENERATED]" in row
+```bash
+cd $HOME/vexjoy-agent
+python3 scripts/generate-skill-index.py    # rebuilds skills/INDEX.json
+python3 scripts/generate-agent-index.py    # rebuilds agents/INDEX.json
 ```
 
-**Preservation Rule:** Only update rows with AUTO-GENERATED marker, preserve all others
+PostToolUse hooks (`hooks/posttooluse-sync-skill-index.py`, `hooks/posttooluse-sync-agent-index.py`) run these automatically when a SKILL.md or agent file is written or edited. Manual regeneration covers bulk changes, deletes outside the harness, and corrupted index files.
 
-## Ordering Rules
+## Validity Rules
 
-**Within Tables:**
-- Alphabetical by primary pattern/keyword
-- Case-insensitive sorting
-- Special characters after alphanumeric
-
-**Exception:** Manual entries maintain their original position if not auto-generated
+- Every entry's `file` path exists on disk (zero phantom entries).
+- Every on-disk skill/agent with valid frontmatter appears in its index.
+- Triggers are specific phrases, unique across components where practical; resolve overlaps per `conflict-resolution.md`.
+- Edit routing metadata in the source frontmatter, then regenerate — the index rebuild discards direct index edits.


### PR DESCRIPTION
## What changed

`skills/meta/routing-table-updater/SKILL.md` and `references/routing-format.md`. Two verified defect classes fixed:

### 1. Unrunnable script paths (SKILL.md old lines 60, 84, 110, 138, 170, 194)
All six invocations used `~/.claude/skills/meta/routing-table-updater/scripts/*.py`. The install is a flat symlink farm — verified: `~/.claude/skills/routing-table-updater -> /home/feedgen/vexjoy-agent/skills/meta/routing-table-updater`, and `~/.claude/skills/meta/` does not exist. Four paths corrected (scan.py, extract_metadata.py, generate_routes.py, validate.py); the other two (update_routing.py, update_commands.py) were removed together with the stale phases that invoked them. Note: `scripts/update_commands.py` never existed on disk — Phase 4B was doubly dead.

### 2. Stale phases targeting a dead format
Phases 4A/4B wrote `[AUTO-GENERATED]` pipe tables into `commands/do.md`. Verified: do.md is a 42-line stub, `grep -c '|' commands/do.md` = 0. Reality: `skills/INDEX.json` / `agents/INDEX.json` are the routing artifacts, auto-synced by `hooks/posttooluse-sync-skill-index.py` / `posttooluse-sync-agent-index.py` calling `scripts/generate-skill-index.py` / `generate-agent-index.py`.

Rewritten to match reality, no invented functionality:
- Phases 4A+4B collapsed into one **Phase 4: UPDATE — Repair INDEX.json** (regenerate via repo scripts, phantom-entry check).
- Phase 5 drops `--target do.md`; `validate.py` runs bare (its bare mode validates skill structure, frontmatter, script executability).
- Phase 3 keeps `generate_routes.py` (conflict detection is its live value) and drops do.md-table formatting claims.
- Overview/Integration write-target claims fixed: `skills/meta/do/references/routing-tables.md` does not exist (verified against `skills/meta/do/references/` listing); `commands/*.md` is no longer a write target.
- `references/routing-format.md` rewritten from the dead pipe-table spec to the live format: frontmatter routing block fields + INDEX.json v2.0 entry shapes (field sets verified against the generated indices) + regeneration commands.

## Verification (all run in worktree, this branch)

| Check | Result |
|---|---|
| `python3 skills/meta/routing-table-updater/scripts/validate.py` (read-only, task-required) | 17/17 checks pass, exit 0 — before and after edits |
| YAML frontmatter parse (`yaml.safe_load`) | OK, 5 triggers intact |
| `python3 scripts/validate_positive_instruction_docs.py` (joy-check) | 0 hits in edited files (17 pre-existing elsewhere, untouched) |
| `python3 scripts/audit-skill-content.py --root skills/meta --severity high` | 0 violations, 20 skills scanned |
| `python3 scripts/validate-skill-frontmatter.py` | 133 files OK |
| `ruff check . --config pyproject.toml` | exit 0 |
| `ruff format --check . --config pyproject.toml` | 502 files already formatted, exit 0 |

## Out of scope (pre-existing, noted for follow-up)
`references/examples.md`, `skill-examples.md`, `error-handling.md`, `batch-mode.md` still show do.md pipe-table worked examples; task scoped SKILL.md + routing-format.md only. The task spec named "Phases 4A/4C" — the file's phases were 4A/4B; both were the stale ones and both are rewritten.