### PR TITLE
fix(skills): point explanation-traces at route-events.jsonl (the log that exists)

### DIFF
--- a/skills/meta/explanation-traces/SKILL.md
+++ b/skills/meta/explanation-traces/SKILL.md
@@ -29,14 +29,24 @@ routing:
 
 ## Overview
 
-This skill reads the current session's `session-trace.json` and presents routing decisions, agent selections, skill phase transitions, and gate verdicts as a human-readable timeline. Every answer comes from what the trace actually recorded at decision time -- never from post-hoc reconstruction or rationalization.
+This skill reads the per-dispatch route event log and presents routing decisions and their outcomes as a human-readable timeline. It answers "why did I get routed here?" from what was recorded at decision time — never from post-hoc reconstruction or rationalization.
+
+**The log**: `<CLAUDE_LEARNING_DIR>/route-events.jsonl`, default `~/.claude/learning/route-events.jsonl`. Append-only JSONL — one JSON object per line. Written via `hooks/lib/route_events.py` by two producers:
+
+| Producer | Fires on | Appends |
+|---|---|---|
+| `hooks/routing-decision-recorder.py` | PostToolUse (Agent dispatch) | One DECISION event per /do-routed dispatch |
+| `hooks/routing-outcome-finalizer.py` | UserPromptSubmit | One OUTCOME event when it finalizes a pending dispatch |
+
+The log is auxiliary instrumentation: writes are failure-safe (worst case one lost line), and the aggregate routing rows in learning.db stay authoritative for the confidence loop.
 
 **Key constraints baked into the workflow:**
-- Read-only: this skill never modifies trace files or any other file
-- Answers must come from recorded trace data, not from memory or inference about what "probably happened"
-- If no trace file exists, explain how to enable tracing rather than guessing at decisions
-- When the user asks about a specific decision, filter to that decision -- do not dump the full log
-- Timestamps and evidence fields are authoritative; do not paraphrase away precision
+- Read-only: this skill never modifies the log or any other file
+- Answers must come from recorded events, not from memory or inference about what "probably happened"
+- If no log exists, name the real path and the real producing hook rather than guessing at decisions
+- When the user asks about a specific decision, filter to that decision — skip the full dump
+- `ts` (epoch seconds) and recorded fields are authoritative; keep their precision
+- `request_snippet` is private session data: show it to this session's own user, and keep it out of anything that leaves the session (PR bodies, issues, exports) — report counts there instead
 
 ---
 
@@ -44,119 +54,144 @@ This skill reads the current session's `session-trace.json` and presents routing
 
 ### Phase 1: LOCATE
 
-**Goal**: Find the session trace file.
+**Goal**: Find the route event log.
 
-**Step 1: Search for trace data**
+**Step 1: Resolve the path and check it**
 
-Check for `session-trace.json` in these locations, in order:
-
-1. Current working directory: `./session-trace.json`
-2. `.claude/` directory: `.claude/session-trace.json`
-3. Glob fallback: `**/session-trace.json` (in case a custom path was used)
-
-Use the Read tool on the first match found.
-
-**Step 2: Handle missing trace**
-
-If no `session-trace.json` exists anywhere, stop and inform the user:
-
-```
-No session-trace.json found.
-
-To enable decision tracing, add a hook that writes routing decisions,
-agent selections, skill phase transitions, and gate verdicts to
-session-trace.json. See: skills/meta/explanation-traces/references/trace-schema.md
-for the expected JSON format.
+```bash
+LOG="${CLAUDE_LEARNING_DIR:-$HOME/.claude/learning}/route-events.jsonl"
+wc -l "$LOG"
 ```
 
-Do not fabricate trace data. Do not attempt to reconstruct decisions from memory or conversation history. The entire value of this skill is that it reads what was actually recorded -- without a trace file, there is nothing to read.
+`CLAUDE_LEARNING_DIR` redirects the log (tests and redirected DBs use it); unset means the default `~/.claude/learning/`.
 
-**GATE**: Trace file found and readable. Proceed only when gate passes.
+**Step 2: Handle missing log**
+
+If the file is absent or empty, stop and inform the user:
+
+```
+No route event log found at ~/.claude/learning/route-events.jsonl
+(or $CLAUDE_LEARNING_DIR/route-events.jsonl when that variable is set).
+
+The log is created on the first /do-routed dispatch by the
+routing-decision-recorder hook (hooks/routing-decision-recorder.py).
+An empty or missing log means no /do-routed dispatch has been recorded
+yet — or merged hook changes were never synced to ~/.claude; run
+hooks/sync-to-user-claude.py or restart the session.
+```
+
+Recorded events are the only source this skill reads. Reconstructing decisions from memory or conversation history defeats its purpose — with no log, there is nothing to read, and the honest answer is exactly that.
+
+**GATE**: Log found and non-empty. Proceed only when gate passes.
 
 ### Phase 2: PARSE
 
-**Goal**: Extract decision points from the trace and filter to the user's query.
+**Goal**: Extract events and filter to the user's query.
 
-**Step 1: Read the trace file**
+**Step 1: Read the events**
 
-Parse the JSON from `session-trace.json`. Extract the `decisions` array. Each entry contains:
+Parse each line as one JSON object. Two event types (full semantics: `references/trace-schema.md`; source of truth: `hooks/lib/route_events.py`).
 
-| Field | Purpose |
-|-------|---------|
-| `timestamp` | When the decision was made (ISO-8601) |
-| `type` | Category: `routing`, `agent-selection`, `skill-phase`, `gate-verdict` |
-| `chosen` | What was selected |
-| `alternatives` | What else was considered |
-| `evidence` | Triggers matched, scores, signals that drove the choice |
-| `context` | The user request or phase that prompted the decision |
+DECISION — one per /do-routed dispatch:
 
-**Step 2: Filter if user asked about a specific decision**
+| Field | Meaning |
+|---|---|
+| `ts` | Epoch seconds (float) when the dispatch was recorded |
+| `session` | Session id (`""` when unknown) |
+| `request_snippet` | First 200 chars of the routed request |
+| `agent`, `skill`, `complexity` | The chosen route |
+| `health_at_decision` | Picked pair's confidence at decision time; `null` = no weight row or never evaluated (disambiguate with `gate_inputs_present`) |
+| `n`, `failure` | The other demote-floor inputs, snapshotted with health |
+| `action` | Step-1.5 health-gate outcome: `keep`, `demote`, or `tiebreak` |
+| `alternates` | Keys offered as alternatives; `null` when none recorded |
+| `gate_inputs_present` | `true` = the marker carried a `health=` token; `false`/absent = legacy marker, health never read |
 
-If the user's query targets a specific decision (e.g., "why did you pick the code reviewer?", "why that agent?"), filter the decisions array:
+OUTCOME — one per finalized dispatch:
+
+| Field | Meaning |
+|---|---|
+| `ts` | Epoch seconds when the outcome was finalized |
+| `session` | Session id |
+| `key` | Routing key `{agent}:{skill}` (agent-only `{agent}:` when skill unknown) |
+| `outcome` | `success`, `failure`, or `neutral` |
+| `reason` | Short cause (e.g. `tool-errors`, `rejection`, `acceptance`, `neutral-new-topic`); absent in older events |
+| `routing_relevant` | `true` = a signal the confidence loop acts on; absent = relevance not asserted |
+
+Additive-field history: older lines may lack `n`, `failure`, `action`, `alternates`, `gate_inputs_present`, `reason`, `routing_relevant`. An absent field means "not recorded then", never corruption.
+
+**Step 2: Filter to the user's query**
 
 | User signal | Filter strategy |
 |-------------|-----------------|
-| Names an agent | Filter to `type: agent-selection` entries mentioning that agent in `chosen` or `alternatives` |
-| Names a skill | Filter to `type: skill-phase` or `type: routing` entries involving that skill |
-| Says "routing" | Filter to `type: routing` entries |
-| Says "gate" or "failed" | Filter to `type: gate-verdict` entries |
-| No specific target | Return all decisions in chronological order |
+| Names an agent or skill | DECISION events where `agent` or `skill` matches, or the name appears in `alternates`; OUTCOME events whose `key` contains it |
+| "Why did I get routed here" / latest dispatch | Most recent DECISION events (tail of the log), current session first |
+| Asks about outcome ("did it work", "why failure") | OUTCOME events, joined back to their decisions |
+| Names a session | Filter both types on `session` |
+| No specific target | Chronological timeline of the most recent session |
 
-**Step 3: Validate data integrity**
+**Step 3: Join outcomes to decisions**
 
-Check that each decision entry has all required fields. Flag any entries missing `evidence` or `alternatives` -- these are lower-confidence records where the trace was incomplete.
+Match an OUTCOME to its DECISION on the same `session` AND `key == "{agent}:{skill}"`. A decision with no matched outcome is pending (the finalizer runs on a later user prompt) or was never finalized — report that state as-is.
 
-**GATE**: Decisions parsed and filtered. At least one decision entry available. Proceed only when gate passes.
+**GATE**: At least one decision event parsed and filtered. Proceed only when gate passes.
 
 ### Phase 3: PRESENT
 
-**Goal**: Format trace data as a human-readable decision timeline.
+**Goal**: Format events as a human-readable decision timeline.
 
 **Step 1: Build the timeline**
 
-For each decision entry, format as:
+Sort by `ts` (numeric — concurrent appends can interleave lines out of order). Convert `ts` to local ISO time for display; show raw `ts` on request. For each decision:
 
 ```
-[TIMESTAMP] TYPE
-  Decision: CHOSEN
-  Alternatives: ALTERNATIVES (or "none recorded")
-  Evidence: EVIDENCE
-  Context: CONTEXT
+[TIME] {agent} + {skill} ({complexity})
+  Request: "{request_snippet}"
+  Health at decision: {health line — see below}
+  Alternates: {alternates, or "none recorded"}
+  Outcome: {outcome} ({reason})   — or "pending: not yet finalized"
 ```
 
-Order chronologically. Group consecutive entries of the same type under a shared heading if there are more than 5 entries total, to prevent wall-of-text for long sessions.
+Health line — three recorded states, rendered distinctly:
 
-**Step 2: Highlight the answer to the user's question**
+| Recorded | Render as |
+|---|---|
+| Numeric `health_at_decision` | `0.62 (n=7, failure=1) → action=keep` |
+| `null` + `gate_inputs_present: true` | `no weight row at decision time (new pair)` |
+| `null` + `gate_inputs_present` false/absent | `health gate not instrumented for this dispatch (legacy marker)` |
 
-If the user asked "why did you choose X?", lead with the specific decision entry that answers their question, then show surrounding context:
+Group entries by session when the timeline spans more than one, to prevent wall-of-text.
+
+**Step 2: Lead with the answer to the user's question**
+
+If the user asked "why did I get routed here?", lead with the matching decision, then offer surrounding context:
 
 ```
-You asked: "Why did you choose the code reviewer?"
+You asked: "Why did I get the governance agent?"
 
-Decision found at [TIMESTAMP]:
-  Chosen: reviewer-code agent
-  Alternatives: reviewer-domain, reviewer-perspectives
-  Evidence: Request matched "review this function" trigger; code-specific
-            keywords ("function", "bug") scored highest for reviewer-code
-  Context: User said "review this function for bugs"
+Decision at [TIME]:
+  Route: toolkit-governance-engineer + pr-workflow (Complex)
+  Request: "ship the explanation-traces repoint as a green-CI PR..."
+  Health at decision: no weight row at decision time (new pair)
+  Alternates: none recorded
+  Outcome: pending — not yet finalized
 
---- Full session timeline (3 decisions) ---
+--- Session timeline (3 dispatches) ---
 [... remaining entries ...]
 ```
 
 **Step 3: Flag gaps honestly**
 
-If the trace has gaps (missing timestamps, empty evidence fields, decisions without alternatives), say so explicitly:
+When entries lack additive fields or matched outcomes, say so explicitly:
 
 ```
-Note: [N] decision(s) have incomplete evidence fields. These entries
-show WHAT was decided but not WHY -- the recording hook may not have
-captured full context for these decisions.
+Note: [N] decision(s) predate the health-gate instrumentation — they show
+WHAT was routed but carry no health data. [M] decision(s) have no matched
+outcome: pending or never finalized.
 ```
 
-Do not fill gaps with speculation. Incomplete data presented honestly is more useful than complete-looking data that includes fabrication.
+Incomplete data presented honestly beats complete-looking data that includes fabrication. Leave gaps as gaps.
 
-**GATE**: Timeline presented. User's question answered from trace data. Done.
+**GATE**: Timeline presented. User's question answered from recorded events. Done.
 
 ---
 
@@ -168,76 +203,76 @@ User says: "Show me the decision log"
 skill: explanation-traces
 ```
 Actions:
-1. Locate session-trace.json (Phase 1)
-2. Parse all decision entries (Phase 2)
-3. Present full chronological timeline (Phase 3)
-Result: Complete session decision history with evidence for each choice
+1. Locate route-events.jsonl (Phase 1)
+2. Parse decisions and outcomes for the most recent session (Phase 2)
+3. Present chronological timeline with joined outcomes (Phase 3)
+Result: Session dispatch history — route, health at decision, outcome — per entry
 
-### Example 2: Specific agent question
-User says: "Why did you pick that agent?"
+### Example 2: Specific routing question
+User says: "Why did I get routed to that agent?"
 ```
 skill: explanation-traces "why that agent?"
 ```
 Actions:
-1. Locate session-trace.json (Phase 1)
-2. Filter to agent-selection entries (Phase 2)
-3. Present the most recent agent selection with evidence, then full timeline for context (Phase 3)
-Result: Evidence-backed explanation of agent choice, not a post-hoc rationalization
+1. Locate route-events.jsonl (Phase 1)
+2. Tail the decision events; filter to the latest dispatch in this session (Phase 2)
+3. Lead with that decision — route, request snippet, health gate inputs, alternates — then the session timeline (Phase 3)
+Result: Evidence-backed routing explanation from the recorded event, never post-hoc rationalization
 
-### Example 3: Gate failure investigation
-User says: "Why did the gate fail?"
+### Example 3: Outcome investigation
+User says: "Why was that dispatch marked a failure?"
 ```
-skill: explanation-traces "gate failure"
+skill: explanation-traces "failure outcome"
 ```
 Actions:
-1. Locate session-trace.json (Phase 1)
-2. Filter to gate-verdict entries, especially failures (Phase 2)
-3. Present gate verdicts with the evidence that caused pass/fail (Phase 3)
-Result: Specific gate failure reason from the trace, with what was expected vs. what was found
+1. Locate route-events.jsonl (Phase 1)
+2. Filter to `outcome: failure` events; join each to its decision by session + key (Phase 2)
+3. Present the outcome's `reason` (e.g. `tool-errors`, `rejection`) with the originating decision (Phase 3)
+Result: The recorded failure cause, with the route and request that produced it
 
 ---
 
 ## Patterns to Detect and Fix
 
 ### Pattern 1: Evidence-Backed Trace Reading
-**Wrong**: Reconstructing "why" from memory when the trace file is missing.
-**Right**: If no trace file exists, say so and explain how to enable tracing. Never fabricate an explanation.
+**Wrong**: Reconstructing "why" from memory when the log is missing.
+**Right**: If no log exists, say so, name the real path and producing hook, and stop. Never fabricate an explanation.
 
-### Pattern 2: Preserve the Evidence Field
-**Wrong**: "The router probably picked that agent because it seemed relevant."
-**Right**: Quote the exact `evidence` field: "Trigger 'review this function' matched reviewer-code with score 0.92."
+### Pattern 2: Distinguish the Three Health States
+**Wrong**: Rendering every `null` health as "no data".
+**Right**: `null` + `gate_inputs_present: true` = pick had no weight row (new pair). `null` + false/absent = legacy marker, health never read. Different facts; render them differently.
 
-### Pattern 3: Format, Don't Dump
-**Wrong**: Printing the entire session-trace.json as-is.
-**Right**: Parse, filter to the user's question, and format as a readable timeline with clear labels.
+### Pattern 3: Join by Session and Key
+**Wrong**: Pairing an outcome with "the decision right above it" in the file.
+**Right**: Match on `session` + `key == "{agent}:{skill}"`. Interleaved sessions make file adjacency meaningless.
 
-### Pattern 4: Report Missing Trace Data
-**Wrong**: "The alternatives field is empty, but it likely considered agents X and Y."
-**Right**: "No alternatives were recorded for this decision -- the trace is incomplete at this point."
+### Pattern 4: Absent Field Is Not Corruption
+**Wrong**: Flagging pre-instrumentation lines as malformed because `gate_inputs_present` is missing.
+**Right**: Fields were added over time; treat absence as "not recorded then" and say so.
 
 ### Pattern 5: Answer the Specific Question First
-**Wrong**: Always showing the full timeline regardless of what the user asked.
+**Wrong**: Always dumping the full timeline regardless of what the user asked.
 **Right**: Lead with the specific answer, then offer full context as supplementary detail.
 
 ---
 
 ## Error Handling
 
-### Error: No Trace File Found
-**Cause**: Tracing hook not enabled or session-trace.json was cleaned up.
-**Solution**: Inform user that no trace exists. Point to `skills/meta/explanation-traces/references/trace-schema.md` for the schema a tracing hook should produce. Do not reconstruct decisions from conversation history.
+### Error: No Log File Found
+**Cause**: No /do-routed dispatch recorded yet, hooks never synced to `~/.claude`, or `CLAUDE_LEARNING_DIR` points elsewhere.
+**Solution**: Report the resolved path and the producing hook (`hooks/routing-decision-recorder.py`). Suggest `hooks/sync-to-user-claude.py` when hook changes were merged mid-session. Skip any reconstruction from conversation history.
 
-### Error: Trace File Is Malformed JSON
-**Cause**: Partial write, race condition, or manual corruption.
-**Solution**: Report the parse error with the specific line/character offset. Attempt to extract any valid decision entries before the corruption point. Flag that the trace is incomplete.
+### Error: Malformed JSONL Line
+**Cause**: Truncated append (rare — per-line appends are atomic) or manual edit.
+**Solution**: Skip the bad line, keep parsing the rest, and report the count and line numbers of skipped lines. JSONL fails per line, never whole-file.
 
-### Error: Trace File Has No Decision Entries
-**Cause**: Hook is writing the file but not recording decisions (e.g., only session metadata).
-**Solution**: Report that the trace exists but contains zero decision entries. Check whether the `decisions` array is present but empty vs. missing entirely, and report which case applies.
+### Error: Log Has No Decision Events
+**Cause**: File exists but every line is an OUTCOME, or the recorder's marker parsing is failing.
+**Solution**: Report counts by `type`. Point to `references/error-handling.md` for the recorder diagnosis steps.
 
-### Error: User Asks About a Decision Not in the Trace
-**Cause**: The specific decision the user is asking about was not recorded.
-**Solution**: Show what IS in the trace and explain that the requested decision type was not captured. Suggest which hook event type would need to emit that decision.
+### Error: User Asks About a Dispatch Not in the Log
+**Cause**: The recorder only records /do-routed top-level dispatches — nested fan-out and manual Agent calls are deliberately excluded.
+**Solution**: Show what IS recorded and explain the exclusion. Full mapping: `references/error-handling.md`.
 
 ---
 
@@ -247,12 +282,12 @@ Result: Specific gate failure reason from the trace, with what was expected vs. 
 
 | Task type | Signals | Reference file |
 |---|---|---|
-| Hook authoring / writing traces | "write hook", "add tracing", "record decisions", "emit trace" | `references/trace-schema.md` |
-| Diagnosing why trace is wrong | "alternatives null", "evidence empty", "overwrite", "post-hoc", "vague" | `references/preferred-patterns.md` |
-| Handling parse or read errors | "malformed", "missing field", "no decisions", "invalid type", "not found" | `references/error-handling.md` |
+| Reading or explaining event fields | "health_at_decision", "gate_inputs_present", "alternates", "key", "schema" | `references/trace-schema.md` |
+| Diagnosing wrong or thin trace data | "health null", "no alternates", "legacy marker", "not instrumented" | `references/preferred-patterns.md` |
+| Handling parse or read errors | "malformed", "missing field", "no decisions", "not found", "pending" | `references/error-handling.md` |
 | Presenting filtered timeline | "why did you", "show trace", "decision log", "explain routing" | `references/trace-schema.md` |
 
 ### Reference Files
-- `references/trace-schema.md`: JSON schema for session-trace.json with field descriptions and example entries
-- `references/preferred-patterns.md`: Failure mode catalog for trace producers (hooks) and consumers (skill behavior) with detection commands
-- `references/error-handling.md`: Error-fix mappings for all error states — missing file, malformed JSON, empty decisions, invalid fields
+- `references/trace-schema.md`: Real event schema for route-events.jsonl — DECISION and OUTCOME fields, health states, join rules, examples
+- `references/preferred-patterns.md`: Failure mode catalog for reading the log — join mistakes, health-state conflation, privacy — with detection commands
+- `references/error-handling.md`: Error-fix mappings — missing log, malformed lines, no decisions, unmatched outcomes, unrecorded dispatches

--- a/skills/meta/explanation-traces/references/error-handling.md
+++ b/skills/meta/explanation-traces/references/error-handling.md
@@ -1,236 +1,193 @@
 # Explanation Traces — Error Handling
 
-Error-fix mappings for every error state the skill encounters when reading and parsing
-`session-trace.json`. Each entry includes: what the error looks like, root cause, and
-exact response to give the user.
+Error-fix mappings for every error state the skill encounters when reading
+`route-events.jsonl`. Each entry includes: what the error looks like, root cause, and
+the exact response to give the user. All commands are read-only.
+
+Path used throughout:
+
+```bash
+LOG="${CLAUDE_LEARNING_DIR:-$HOME/.claude/learning}/route-events.jsonl"
+```
 
 ---
 
-## Error: No Trace File Found
+## Error: No Log File Found
 
-**Trigger**: None of the search paths (`./session-trace.json`, `.claude/session-trace.json`,
-`**/session-trace.json`) return a readable file.
+**Trigger**: `$LOG` is absent or zero lines.
 
 **Root causes**:
 | Cause | How to identify |
 |---|---|
-| Tracing hook never installed | `ls hooks/ | grep trace` returns nothing |
-| Hook installed but never fired | Hook file exists, but session-trace.json absent |
-| File written to wrong path | `find . -name "session-trace*" 2>/dev/null` finds it elsewhere |
-| File cleaned up between sessions | `git status` shows it was deleted or .gitignored |
+| No /do-routed dispatch recorded yet | `~/.claude/learning/` exists but has no `route-events.jsonl` |
+| Hooks merged but never synced to `~/.claude` | `ls ~/.claude/hooks/ \| grep routing-decision-recorder` returns nothing |
+| `CLAUDE_LEARNING_DIR` points elsewhere | `echo "$CLAUDE_LEARNING_DIR"` is set; check that directory instead |
 
 **Detection** (run to diagnose which cause applies):
 ```bash
-# Check if any hook references session-trace:
-grep -rn "session-trace" hooks/ --include="*.py"
-# Find any trace file anywhere in the project:
-find . -name "session-trace*" 2>/dev/null
-# Check gitignore:
-grep "session-trace" .gitignore
+echo "resolved: $LOG"; ls -la "$LOG" 2>/dev/null
+echo "env: CLAUDE_LEARNING_DIR=${CLAUDE_LEARNING_DIR:-<unset>}"
+ls ~/.claude/hooks/ 2>/dev/null | grep -E "routing-(decision-recorder|outcome-finalizer)"
 ```
 
 **Response to user**:
 ```
-No session-trace.json found.
+No route event log found at ~/.claude/learning/route-events.jsonl
+(or $CLAUDE_LEARNING_DIR/route-events.jsonl when that variable is set).
 
-To enable decision tracing, add a hook that writes routing decisions,
-agent selections, skill phase transitions, and gate verdicts to
-session-trace.json. See: skills/meta/explanation-traces/references/trace-schema.md
-for the expected JSON format.
+The log is created on the first /do-routed dispatch by the
+routing-decision-recorder hook (hooks/routing-decision-recorder.py).
+An empty or missing log means no /do-routed dispatch has been recorded
+yet — or merged hook changes were never synced to ~/.claude; run
+hooks/sync-to-user-claude.py or restart the session.
 ```
 
-Read decisions from the trace file only. If no file exists, report that there is nothing
+Read decisions from the log only. If no file exists, report that there is nothing
 to read.
 
 ---
 
-## Error: Trace File Is Malformed JSON
+## Error: Malformed JSONL Line
 
-**Trigger**: `json.JSONDecodeError` (Python) or `SyntaxError` when parsing.
-
-**Common error messages**:
-```
-json.JSONDecodeError: Expecting ',' delimiter: line 47 column 3 (char 1203)
-json.JSONDecodeError: Unterminated string starting at: line 23 (char 890)
-json.JSONDecodeError: Extra data: line 2 column 1 (char 247)
-```
+**Trigger**: `json.JSONDecodeError` on an individual line.
 
 **Root causes**:
 | Cause | Symptom |
 |---|---|
-| Partial write (process killed mid-write) | File truncated; last `}` or `]` missing |
-| Race condition (two hooks writing simultaneously) | Duplicate or interleaved JSON objects |
-| Manual edit error | Trailing comma, unquoted key, etc. |
+| Truncated append (process killed mid-write; rare — per-line appends are atomic) | Last line of the file is a JSON prefix |
+| Manual edit | Bad line anywhere in the file |
 
 **Detection**:
 ```bash
-# Validate JSON syntax:
-python3 -m json.tool session-trace.json > /dev/null
-# Or:
-python3 -c "import json; json.load(open('session-trace.json'))"
-# Find the exact byte offset of the error:
-python3 -c "
-import json
-try:
-    json.load(open('session-trace.json'))
-except json.JSONDecodeError as e:
-    print(f'Error at line {e.lineno}, col {e.colno}, char {e.pos}: {e.msg}')
-"
+python3 - "$LOG" <<'EOF'
+import json, sys
+bad = []
+for i, line in enumerate(open(sys.argv[1]), 1):
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        json.loads(line)
+    except json.JSONDecodeError as e:
+        bad.append((i, e.msg))
+print("malformed lines:", bad or "none")
+EOF
 ```
 
 **Response to user**:
 ```
-session-trace.json exists but cannot be parsed.
-
-Parse error: [include exact error message and line/char offset]
-
-Attempting to recover entries before the corruption point...
-[show any valid decisions found before the error position]
-
-The trace is incomplete. Decisions after char [N] are unavailable.
+route-events.jsonl has [N] unparseable line(s): [line numbers].
+Skipping them; [M] valid events remain and are shown below.
 ```
 
-**Recovery attempt**: Try to extract the valid prefix by parsing the file byte-by-byte
-up to the error position. Report what was recovered vs. what was lost.
+JSONL fails per line, never whole-file: skip each bad line, keep every parseable
+event, and report the skip count. Recovery of a truncated final line is
+unnecessary — the contract loses at most that one event.
 
 ---
 
-## Error: Trace File Has No Decision Entries
+## Error: Log Has No Decision Events
 
-**Trigger**: File parses successfully, but `data["decisions"]` is empty (`[]`) or the
-`decisions` key is absent entirely.
-
-**Distinguish the two cases**:
-```python
-data = json.load(open("session-trace.json"))
-if "decisions" not in data:
-    # Key absent — hook is writing wrong schema
-    print("decisions key missing from trace file")
-elif len(data["decisions"]) == 0:
-    # Key present but empty — hook fired but recorded nothing
-    print("decisions array is present but empty")
-```
+**Trigger**: File parses, but zero lines have `"type": "decision"`.
 
 **Detection**:
 ```bash
-python3 -c "
-import json
-data = json.load(open('session-trace.json'))
-print('decisions key present:', 'decisions' in data)
-print('decision count:', len(data.get('decisions', [])))
-print('top-level keys:', list(data.keys()))
-"
+python3 - "$LOG" <<'EOF'
+import json, sys, collections
+c = collections.Counter(json.loads(l)["type"] for l in open(sys.argv[1]) if l.strip())
+print("counts by type:", dict(c))
+EOF
 ```
 
 **Root causes**:
 | Symptom | Likely cause |
 |---|---|
-| `decisions` key missing | Hook writes different schema (e.g., only metadata) |
-| `decisions` is `[]` | Hook fires but the decision-recording code path never runs |
-| File is `{}` | Hook creates the file but never populates it |
+| Only `outcome` events | Recorder hook missing from `~/.claude/hooks/` while the finalizer is present |
+| File empty | No /do-routed dispatch since the log was created |
+| Dispatches happened but nothing recorded | Recorder skips dispatches without a `[do-route]` marker (deliberate: keeps route-health's denominator honest) — the dispatches were not /do-routed, or the marker is malformed |
 
 **Response to user**:
 ```
-session-trace.json exists [and the decisions array is present] but contains zero
-decision entries.
+route-events.jsonl exists with [N] outcome event(s) and zero decision events.
 
-This means the hook is running but no decisions were recorded. Check:
-1. Does the hook emit entries on PreToolUse (agent dispatch) or only on PostToolUse?
-2. Is the decision-writing code path gated behind a condition that never fires?
-
-See: skills/meta/explanation-traces/references/trace-schema.md for the expected
-schema and hook writing rules.
+Decisions are appended by hooks/routing-decision-recorder.py (PostToolUse on
+Agent dispatch) and only for /do-routed dispatches carrying a [do-route]
+marker. Check that the recorder is synced to ~/.claude/hooks/ and that the
+dispatches you expect were /do-routed.
 ```
 
 ---
 
-## Error: Decision Entry Missing Required Fields
+## Error: Decision Has No Matched Outcome
 
-**Trigger**: An entry in `decisions` is missing one or more of the six required fields:
-`timestamp`, `type`, `chosen`, `alternatives`, `evidence`, `context`.
+**Trigger**: A DECISION event has no OUTCOME with the same `session` and
+`key == "{agent}:{skill}"`.
 
-**Detection**:
-```bash
-python3 -c "
-import json
-REQUIRED = {'timestamp', 'type', 'chosen', 'alternatives', 'evidence', 'context'}
-data = json.load(open('session-trace.json'))
-for i, d in enumerate(data['decisions']):
-    missing = REQUIRED - set(d.keys())
-    if missing:
-        print(f'Entry [{i}]: missing fields: {missing}')
-"
-```
+**Root causes**:
+| Cause | How to identify |
+|---|---|
+| Pending — finalizer has not run yet | Decision is recent; the finalizer fires on the next user prompt |
+| Session ended before finalization | Decision `ts` is old and its session has no later events |
+| Finalizer dropped it (stale, past max pending age) | Old decision, no outcome ever appears |
 
-**Response to user**:
-```
-[N] decision entries have incomplete records:
-
-Entry [2]: missing fields: evidence, alternatives
-Entry [7]: missing fields: context
-
-These entries show WHAT was decided but not WHY. The recording hook did not
-capture full context at decision time. Presenting available fields only.
-```
-
-Flag each incomplete entry in the timeline output. Do not invent values for missing fields.
+**Response to user**: Label the entry `pending — not yet finalized` (recent) or
+`never finalized` (old). Outcomes arrive on a later user prompt, so a missing
+outcome right after a dispatch is normal, never an error. Report the recorded
+state; leave the outcome unset rather than inferring one.
 
 ---
 
-## Error: Invalid `type` Field Value
+## Error: Absent Additive Fields
 
-**Trigger**: An entry's `type` field contains a value other than `routing`, `agent-selection`,
-`skill-phase`, or `gate-verdict`.
+**Trigger**: A decision lacks `n`/`failure`/`action`/`alternates` or
+`gate_inputs_present`; an outcome lacks `reason` or `routing_relevant`.
 
-**Detection**:
-```bash
-python3 -c "
-import json
-VALID = {'routing', 'agent-selection', 'skill-phase', 'gate-verdict'}
-data = json.load(open('session-trace.json'))
-for i, d in enumerate(data['decisions']):
-    t = d.get('type', '')
-    if t not in VALID:
-        print(f'Entry [{i}]: invalid type {repr(t)} (valid: {VALID})')
-"
+**Cause**: The schema grew append-compatibly — lines written before a field
+shipped simply lack it. Also, `n`/`failure`/`action`/`alternates` stay `null`
+unless a real numeric `health=` was read (see trace-schema.md, health states).
+
+**Response to user**: Treat absence as "not recorded then". Flag counts:
 ```
-
-**Common invalid values**: `"agent_selection"` (underscore instead of hyphen),
-`"Agent"` (capitalized), `"decision"` (wrong category name).
-
-**Response to user**: Include the entry in the timeline but label it `[UNKNOWN TYPE]`.
-Do not silently drop entries with invalid types.
+Note: [N] decision(s) predate the health-gate instrumentation — they show
+WHAT was routed but carry no health data.
+```
+Present the fields that exist; leave the rest as unknown rather than inventing
+values.
 
 ---
 
-## Error: User Asks About a Decision Not in the Trace
+## Error: User Asks About a Dispatch Not in the Log
 
-**Trigger**: User asks "why did you choose X?" but no entry in `decisions` matches X
-in the `chosen` or `alternatives` fields.
+**Trigger**: User asks "why did I get routed to X?" but no DECISION matches X in
+`agent`, `skill`, or `alternates`.
 
 **Detection logic**:
 ```python
 query = "golang-general-engineer"
 matches = [d for d in decisions
-           if query in d.get("chosen", "") or query in d.get("alternatives", [])]
-if not matches:
-    # Decision was not recorded
+           if query in d.get("agent", "") or query in d.get("skill", "")
+           or query in (d.get("alternates") or [])]
 ```
+
+**Root causes**:
+| Cause | Explanation |
+|---|---|
+| Dispatch was not /do-routed | Manual Agent calls carry no `[do-route]` marker; the recorder skips them |
+| Nested fan-out | The recorder records top-level /do-routed dispatches only — recording nested sub-dispatches would inflate route-health's denominator |
+| Different session or older than the log | Filter widened to all sessions still finds nothing |
 
 **Response to user**:
 ```
-No trace entry found for [X].
+No decision event found for [X].
 
-The session trace has [N] decisions recorded:
-  - [list types and chosen values from the trace]
-
-The decision you're asking about was not captured. To record [X] decisions,
-the hook needs to emit a [routing|agent-selection|skill-phase|gate-verdict]
-entry when [X] is selected.
+The log records /do-routed top-level dispatches only. This session has [N]
+recorded decision(s): [list agent+skill pairs]. The dispatch you asked about
+was either not /do-routed or was a nested sub-dispatch, which the recorder
+deliberately excludes.
 ```
 
-Show what IS in the trace. Do not speculate about why X was chosen when it has no
-trace entry.
+Show what IS in the log. Leave unrecorded dispatches unexplained rather than
+speculating.
 
 ---
 
@@ -238,10 +195,9 @@ trace entry.
 
 | Error | Root cause | User message keyword | Fix |
 |---|---|---|---|
-| No file found | Hook not installed or wrong path | "No session-trace.json found" | Install tracing hook; see trace-schema.md |
-| Malformed JSON | Partial write or race condition | "cannot be parsed" | Show error offset; attempt recovery of pre-error entries |
-| `decisions` key missing | Wrong schema from hook | "decisions key missing" | Fix hook to use correct top-level structure |
-| `decisions` is empty | Hook fires but records nothing | "zero decision entries" | Check hook's decision-recording code path |
-| Missing required fields | Incomplete hook implementation | "incomplete records" | Flag affected entries; never invent missing values |
-| Invalid `type` value | Typo or schema drift in hook | `[UNKNOWN TYPE]` label | Label in output; do not drop |
-| Decision not in trace | Hook doesn't record that decision type | "not captured" | Show what is in trace; explain what hook change would fix it |
+| No log file | No dispatch yet, hooks unsynced, or env redirect | "No route event log found" | Name real path + producing hook; suggest sync-to-user-claude.py |
+| Malformed line | Truncated append or manual edit | "unparseable line(s)" | Skip per line; report count; keep valid events |
+| No decision events | Recorder unsynced or dispatches not /do-routed | "zero decision events" | Check recorder in ~/.claude/hooks/; confirm [do-route] marker |
+| Unmatched outcome | Pending or never finalized | "pending — not yet finalized" | Label the state; outcomes arrive on a later prompt |
+| Absent additive fields | Pre-instrumentation lines | "predate the health-gate instrumentation" | Treat as unknown; flag counts; keep values as recorded |
+| Dispatch not in log | Not /do-routed or nested fan-out | "not /do-routed" | Show recorded decisions; explain the exclusion |

--- a/skills/meta/explanation-traces/references/preferred-patterns.md
+++ b/skills/meta/explanation-traces/references/preferred-patterns.md
@@ -1,240 +1,194 @@
 # Explanation Traces — Patterns to Fix
 
-Failure modes for both trace producers (hooks that write session-trace.json) and trace
-consumers (this skill reading it). Organized by who makes the mistake.
+Failure modes when reading `route-events.jsonl`, organized by kind: consumer
+mistakes (this skill's behavior) and producer-side diagnostics (recognizing why
+the recorded data is thin). The producers are fixed toolkit code
+(`hooks/routing-decision-recorder.py`, `hooks/routing-outcome-finalizer.py`,
+both writing through `hooks/lib/route_events.py`) — thin data usually means an
+older log line or an uninstrumented marker, and the fix is correct
+interpretation, never editing the log.
 
----
+Path used throughout:
 
-## Producer Patterns to Fix (Hook Writers)
-
-### AP-1: Post-Hoc Trace Writing
-
-**Detection** (find hooks that append after execution rather than at decision time):
 ```bash
-grep -rn "session-trace" hooks/ --include="*.py" | grep -v "import\|def "
-rg 'session.trace' hooks/ -l
+LOG="${CLAUDE_LEARNING_DIR:-$HOME/.claude/learning}/route-events.jsonl"
 ```
-
-**What it looks like**:
-```python
-# Hook writes after the full agent run completes
-def on_agent_stop(event):
-    # WRONG: Writing what happened, not what was decided
-    append_trace({
-        "timestamp": datetime.utcnow().isoformat(),
-        "type": "agent-selection",
-        "chosen": event["agent"],
-        "evidence": "agent completed successfully",  # outcome, not decision signal
-        "alternatives": [],
-    })
-```
-
-**Why wrong**: Post-hoc traces record outcomes, not decisions. The `evidence` becomes
-"it worked" rather than the actual scoring signals. Callers using `explanation-traces`
-get confident-sounding but meaningless answers.
-
-**Fix**:
-```python
-# Write at classification time, before dispatch
-def on_pre_tool_use(event):
-    if event["tool"] == "Agent":
-        chosen = event["input"]["subagent_type"]
-        # Capture scoring from the router, not the outcome
-        append_trace({
-            "timestamp": datetime.utcnow().isoformat(),
-            "type": "agent-selection",
-            "chosen": chosen,
-            "evidence": router_scores.get(chosen, "no score recorded"),
-            "alternatives": list(router_scores.keys()),
-        })
-```
-
----
-
-### AP-2: Null Alternatives
-
-**Detection**:
-```bash
-grep -n '"alternatives": null' session-trace.json
-rg '"alternatives":\s*null' session-trace.json
-# Also catch missing alternatives field entirely:
-python3 -c "
-import json, sys
-data = json.load(open('session-trace.json'))
-bad = [i for i, d in enumerate(data['decisions']) if 'alternatives' not in d]
-print(f'Missing alternatives field at indices: {bad}')
-"
-```
-
-**What it looks like**:
-```json
-{
-  "timestamp": "2026-04-01T10:00:00Z",
-  "type": "routing",
-  "chosen": "skill:roast",
-  "alternatives": null,
-  "evidence": "force_route triggered"
-}
-```
-
-**Why wrong**: `null` is not the same as `[]`. The schema requires an array. When the
-skill parses this, `alternatives` fails the `isinstance(v, list)` check. Consumers
-cannot distinguish "no alternatives considered" from "alternatives field missing".
-
-**Fix**: Use `[]` (empty array) when force_route was used and no alternatives were scored:
-```json
-{ "alternatives": [] }
-```
-
----
-
-### AP-3: Vague Evidence Strings
-
-**Detection**:
-```bash
-grep -n '"evidence": ""' session-trace.json
-rg '"evidence":\s*"(seemed right|best option|obvious choice|default)"' session-trace.json
-# Check evidence length — short evidence is usually vague:
-python3 -c "
-import json
-data = json.load(open('session-trace.json'))
-short = [(i, d['evidence']) for i, d in enumerate(data['decisions'])
-         if len(d.get('evidence', '')) < 20]
-for i, ev in short: print(f'[{i}] Short evidence: {repr(ev)}')
-"
-```
-
-**What it looks like**:
-```json
-{ "evidence": "seemed like the right choice" }
-{ "evidence": "best match" }
-{ "evidence": "" }
-```
-
-**Why wrong**: These evidence strings tell the user nothing. When they ask "why did you
-pick that agent?", the skill must quote the evidence field verbatim. Vague evidence
-produces vague explanations — the opposite of what the skill exists to provide.
-
-**Fix**: Evidence must include at least one of: trigger string, score value, or matched signal:
-```json
-{ "evidence": "Trigger 'roast this' matched skill:roast force_route=true; no scoring run" }
-{ "evidence": "reviewer-code scored 0.92 vs reviewer-domain 0.41; keywords: 'function', 'bug'" }
-```
-
----
-
-### AP-4: Overwriting Instead of Appending
-
-**Detection**:
-```bash
-# Find hooks that open with 'w' mode (overwrite) instead of read-then-write:
-grep -rn "open.*session-trace.*['\"]w['\"]" hooks/
-rg 'open\([^)]*session.trace[^)]*["\']w["\']' hooks/ --type py
-```
-
-**What it looks like**:
-```python
-# WRONG: Overwrites entire file each time
-with open("session-trace.json", "w") as f:
-    json.dump({"decisions": [new_entry]}, f)
-```
-
-**Why wrong**: Every hook invocation destroys all prior decisions. A session that makes
-10 routing decisions ends up with only the last one in the trace. The timeline is
-unrecoverable.
-
-**Fix**:
-```python
-import json, os
-
-def append_trace(entry):
-    path = "session-trace.json"
-    if os.path.exists(path):
-        with open(path) as f:
-            data = json.load(f)
-    else:
-        data = {"session_id": generate_id(), "started_at": now_iso(), "decisions": []}
-    data["decisions"].append(entry)
-    with open(path, "w") as f:
-        json.dump(data, f, indent=2)
-```
-
----
-
-### AP-5: Non-Monotonic Timestamps
-
-**Detection**:
-```bash
-python3 -c "
-import json
-data = json.load(open('session-trace.json'))
-ts = [d['timestamp'] for d in data['decisions']]
-for i in range(1, len(ts)):
-    if ts[i] < ts[i-1]:
-        print(f'Non-monotonic: [{i-1}] {ts[i-1]} > [{i}] {ts[i]}')
-"
-```
-
-**Why wrong**: If timestamps go backwards, the skill cannot sort decisions reliably.
-Chronological presentation breaks. This often happens when a hook generates timestamps
-at initialization rather than at emission time.
-
-**Fix**: Always call `datetime.utcnow().isoformat() + "Z"` at the moment the entry is
-created, not at hook startup.
 
 ---
 
 ## Consumer Patterns to Fix (Skill Behavior)
 
-### AP-6: Reconstructing Decisions from Conversation History
+### AP-1: Reconstructing Decisions from Conversation History
 
 **What it looks like** (incorrect skill behavior):
-> "The trace file doesn't exist, but based on the conversation I can tell the router
+> "The log doesn't exist, but based on the conversation I can tell the router
 > probably chose the golang agent because the user mentioned Go..."
 
-**Why wrong**: This is exactly the rationalization the skill exists to prevent. If no
-trace file exists, the correct answer is "no trace file found" — not an inference from
-memory or conversation history.
+**Why wrong**: This is exactly the rationalization the skill exists to prevent.
+The recorded event is the only evidence of what the router saw at decision time.
 
-**Correct behavior**: Report the missing file. Explain how to enable tracing. Do not fill
-the gap with inference. See SKILL.md Phase 1 Step 2 for the exact message to produce.
-
----
-
-### AP-7: Dumping Raw JSON Without Filtering
-
-**What it looks like**: Printing the entire `session-trace.json` content when the user
-asks a specific question like "why did you pick the code reviewer?".
-
-**Why wrong**: Unfiltered JSON forces the user to manually scan for the relevant entry.
-A 20-decision trace printed as raw JSON is noise, not an explanation.
-
-**Correct behavior**: Filter to the specific decision type, lead with the answer to the
-user's question, then offer the full timeline as supplementary context. See SKILL.md
-Phase 2 Step 2 for the filter strategy table.
+**Correct behavior**: Report the missing log, name the real path and producing
+hook, and stop. See SKILL.md Phase 1 Step 2 for the exact message.
 
 ---
 
-### AP-8: Treating Incomplete Traces as Complete
+### AP-2: Joining Outcomes by File Adjacency
 
-**What it looks like**: Presenting a timeline without flagging that several decisions have
-empty `evidence` fields.
+**What it looks like**: Pairing an OUTCOME event with the DECISION on the line
+above it.
 
-**Why wrong**: The user assumes the explanation is authoritative. Missing evidence means
-the "why" for those decisions is unknown — presenting them without a caveat creates false
-confidence in the explanation.
+**Why wrong**: Appends from parallel sessions interleave at line granularity.
+The outcome above may belong to a different session's dispatch. An outcome also
+lands minutes-to-hours after its decision — anything can sit between them.
 
-**Correct behavior**: Flag incomplete entries explicitly (SKILL.md Phase 3 Step 3).
-Report count of entries with missing/empty evidence. Never fill gaps silently.
+**Correct behavior**: Match on same `session` AND
+`key == f"{agent}:{skill}"`. Verify join quality:
+
+```bash
+python3 - "$LOG" <<'EOF'
+import json, sys
+dec, out = {}, set()
+for line in open(sys.argv[1]):
+    if not line.strip():
+        continue
+    e = json.loads(line)
+    if e["type"] == "decision":
+        dec[(e["session"], f"{e['agent']}:{e['skill']}")] = dec.get((e["session"], f"{e['agent']}:{e['skill']}"), 0) + 1
+    else:
+        out.add((e["session"], e["key"]))
+matched = sum(1 for k in dec if k in out)
+print(f"decision keys: {len(dec)}, with matched outcome: {matched}")
+EOF
+```
+
+---
+
+### AP-3: Conflating the Three Health States
+
+**What it looks like**: Rendering every `null` `health_at_decision` as
+"no health data".
+
+**Why wrong**: `null` carries two different facts, split by
+`gate_inputs_present`:
+- `true` → instrumented, but the pick had no weight row (a new pair — valid, expected)
+- `false`/absent → legacy marker, health never read
+
+Collapsing them hides whether the health gate ran.
+
+**Correct behavior**: Render the three states distinctly (SKILL.md Phase 3
+Step 1 table). Count each state:
+
+```bash
+python3 - "$LOG" <<'EOF'
+import json, sys, collections
+c = collections.Counter()
+for line in open(sys.argv[1]):
+    if not line.strip():
+        continue
+    e = json.loads(line)
+    if e["type"] != "decision":
+        continue
+    if e.get("health_at_decision") is not None:
+        c["(a) numeric"] += 1
+    elif e.get("gate_inputs_present"):
+        c["(b) no weight row"] += 1
+    else:
+        c["(c) legacy/uninstrumented"] += 1
+print(dict(c))
+EOF
+```
+
+---
+
+### AP-4: Treating Absent Additive Fields as Corruption
+
+**What it looks like**: Flagging lines without `gate_inputs_present` or
+`reason` as malformed.
+
+**Why wrong**: The schema grew append-compatibly; old lines lack new fields by
+design. `n`/`failure`/`action`/`alternates` are also `null` on any dispatch
+where no numeric `health=` was read.
+
+**Correct behavior**: Absent = "not recorded then". Flag the count in the
+timeline note; keep the entries.
+
+---
+
+### AP-5: Sorting by File Order Instead of `ts`
+
+**What it looks like**: Presenting events in the order they appear in the file.
+
+**Why wrong**: Concurrent appends interleave; a slow hook can land its line
+after a faster one with an earlier `ts`. File order approximates time but does
+not guarantee it.
+
+**Correct behavior**: Sort numerically on `ts` (a float, epoch seconds), then
+group by session for display.
+
+---
+
+### AP-6: Dumping Raw JSONL Without Filtering
+
+**What it looks like**: Printing raw log lines when the user asks a specific
+question like "why did I get the governance agent?".
+
+**Why wrong**: A 500-event log printed raw is noise, not an explanation.
+
+**Correct behavior**: Filter to the matching decision, lead with the answer,
+offer the session timeline as supplementary context. See SKILL.md Phase 2
+Step 2 for the filter table.
+
+---
+
+### AP-7: Leaking `request_snippet` Outside the Session
+
+**What it looks like**: Pasting `request_snippet` values into a PR body, issue,
+or exported report while demonstrating the skill.
+
+**Why wrong**: The snippet is the first 200 chars of a real user request —
+private session data. Showing it to the session's own user is the skill's job;
+sending it elsewhere is a leak.
+
+**Correct behavior**: Inside the session, quote snippets freely. In anything
+that leaves the session, report counts and field-presence statistics only.
+
+---
+
+## Producer-Side Diagnostics (Why the Data Is Thin)
+
+### AP-8: Missing Decisions — the Dispatch Was Never Recorded
+
+**Detection**:
+```bash
+ls ~/.claude/hooks/ | grep -E "routing-(decision-recorder|outcome-finalizer)"
+```
+
+**Interpretation**: The recorder appends a DECISION only for /do-routed
+dispatches carrying a `[do-route]` marker; manual Agent calls and nested
+fan-out are deliberately excluded (they would inflate route-health's
+denominator). Recorder absent from `~/.claude/hooks/` means merged hook changes
+were never synced — run `hooks/sync-to-user-claude.py`.
+
+---
+
+### AP-9: High Legacy Rate — Markers Without `health=`
+
+**Detection**: Run the AP-3 state counter. A large "(c) legacy/uninstrumented"
+share among *recent* decisions means current markers lack the `health=` token.
+
+**Interpretation**: `gate_inputs_present` is the signal the decommission clock
+reads. State (c) on old lines is history; state (c) on new lines means the
+router's Step-1.5 wiring regressed — worth a report against
+`skills/meta/do/SKILL.md` Phase 4, never a log edit.
 
 ---
 
 ## Quick Detection Cheatsheet
 
-| Pattern | Detection command |
+| Question | Command |
 |---|---|
-| Empty evidence | `rg '"evidence":\s*""' session-trace.json` |
-| Null alternatives | `rg '"alternatives":\s*null' session-trace.json` |
-| Overwrite hooks | `grep -rn 'open.*session-trace.*"w"' hooks/` |
-| Non-monotonic timestamps | see AP-5 detection block |
-| Missing required fields | `python3 -c "import json; fields={'timestamp','type','chosen','alternatives','evidence','context'}; [print(i, fields-set(d)) for i,d in enumerate(json.load(open('session-trace.json'))['decisions']) if fields-set(d)]"` |
+| Event counts by type | `python3 -c "import json,collections,os;p=os.path.expandvars('$LOG');print(collections.Counter(json.loads(l)['type'] for l in open(p) if l.strip()))"` |
+| Malformed lines | see error-handling.md, "Malformed JSONL Line" |
+| Health-state split | AP-3 counter above |
+| Decisions with matched outcomes | AP-2 join checker above |
+| Recorder synced | `ls ~/.claude/hooks/ \| grep routing-decision-recorder` |

--- a/skills/meta/explanation-traces/references/trace-schema.md
+++ b/skills/meta/explanation-traces/references/trace-schema.md
@@ -1,141 +1,143 @@
-# session-trace.json Schema
+# route-events.jsonl Schema
 
-This document defines the JSON schema for `session-trace.json`, the structured decision log consumed by the `explanation-traces` skill. Hooks that record decisions must produce output conforming to this schema.
-
----
-
-## Top-Level Structure
-
-```json
-{
-  "session_id": "string",
-  "started_at": "ISO-8601",
-  "decisions": []
-}
-```
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `session_id` | string | yes | Unique identifier for the session. Use UUID or timestamp-based ID. |
-| `started_at` | string | yes | ISO-8601 timestamp of session start. |
-| `decisions` | array | yes | Ordered list of decision entries, chronological. |
+Event schema for `<CLAUDE_LEARNING_DIR>/route-events.jsonl` (default `~/.claude/learning/route-events.jsonl`), the per-dispatch decision log consumed by the `explanation-traces` skill. Source of truth: `hooks/lib/route_events.py` — when this document and that module disagree, the module wins.
 
 ---
 
-## Decision Entry Schema
+## File Contract
 
-Each entry in the `decisions` array represents a single decision point captured at the moment it was made.
+| Property | Value |
+|---|---|
+| Format | JSONL — one JSON object per line, compact separators, UTF-8 |
+| Write mode | Append-only; POSIX per-line appends are atomic, so concurrent dispatches interleave at line granularity without a lock |
+| Path | `<CLAUDE_LEARNING_DIR>/route-events.jsonl`; env var unset means `~/.claude/learning/` |
+| Failure mode | Failure-safe by contract: a write error is swallowed — worst case one lost event line, never a broken hook |
+| Authority | Auxiliary instrumentation; the aggregate routing rows in learning.db remain authoritative |
 
-```json
-{
-  "timestamp": "ISO-8601",
-  "type": "routing|agent-selection|skill-phase|gate-verdict",
-  "chosen": "string",
-  "alternatives": ["string"],
-  "evidence": "string",
-  "context": "string"
-}
-```
+Why the log exists: the aggregate rows are keyed `(topic, key)` and carry no per-dispatch history, so faithful offline replay of "request → route → outcome" is impossible from them alone. This log adds that history.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `timestamp` | string | yes | ISO-8601 timestamp of when the decision was made. Must be captured AT decision time, not reconstructed. |
-| `type` | string | yes | One of four decision categories (see below). |
-| `chosen` | string | yes | What was selected -- the agent name, skill name, phase, or verdict. |
-| `alternatives` | array of strings | yes | What else was considered. Empty array `[]` if no alternatives existed (e.g., forced route). |
-| `evidence` | string | yes | The triggers matched, scores computed, or signals observed that drove this choice. This is the most important field -- it answers "why". |
-| `context` | string | yes | The user request, phase name, or condition that prompted this decision point. |
+Two producers:
+
+| Producer | Hook event | Writes |
+|---|---|---|
+| `hooks/routing-decision-recorder.py` | PostToolUse (Agent) | DECISION event when it records a /do-routed dispatch |
+| `hooks/routing-outcome-finalizer.py` | UserPromptSubmit | OUTCOME event when it finalizes a pending dispatch |
 
 ---
 
-## Decision Types
+## DECISION Event
 
-### `routing`
-A request was classified and routed to a skill or execution tier.
+One per /do-routed dispatch, captured from the `[do-route]` marker at record time — never back-filled from later weights.
 
-**Example:**
+**Example** (illustrative values):
 ```json
-{
-  "timestamp": "2026-04-01T14:23:01Z",
-  "type": "routing",
-  "chosen": "skill:roast",
-  "alternatives": ["skill:parallel-code-review", "skill:systematic-code-review"],
-  "evidence": "Trigger 'roast this' matched with force_route=true; no scoring needed",
-  "context": "User said: 'Roast this repo'"
-}
+{"type":"decision","ts":1751400000.123,"session":"abc123","request_snippet":"fix the failing router test","agent":"python-general-engineer","skill":"pr-workflow","complexity":"Medium","health_at_decision":0.62,"n":7,"failure":1,"action":"keep","alternates":["python-general-engineer:python-quality-gate"],"gate_inputs_present":true}
 ```
 
-### `agent-selection`
-A specific agent was selected to execute part of a task.
+| Field | Type | Semantics |
+|-------|------|-----------|
+| `type` | string | Always `"decision"`. |
+| `ts` | float | Epoch seconds (`time.time()`) when the event was appended. |
+| `session` | string | Session id; `""` when unknown. |
+| `request_snippet` | string | First 200 chars of the routed request. Private session data — keep out of PR bodies, issues, exports. |
+| `agent` | string | Dispatched agent; `""` when unknown. |
+| `skill` | string | Paired skill; `""` when unknown. |
+| `complexity` | string | Complexity class from the marker; `""` when absent. |
+| `health_at_decision` | float or null | The picked pair's confidence at decision time; `null` when the pair had no weight row or health was never evaluated — `gate_inputs_present` disambiguates (see states below). |
+| `n` | int or null | Dispatch count for the pair's weight row — a demote-floor input. `null` unless a real numeric `health=` was read. |
+| `failure` | int or null | Failure count for the pair's weight row — a demote-floor input. Same null rule as `n`. |
+| `action` | string or null | The Step-1.5 health-gate outcome: `keep`, `demote`, or `tiebreak`. |
+| `alternates` | list of strings or null | The keys offered as alternatives; `null` when none recorded. |
+| `gate_inputs_present` | bool | Instrumentation signal the decommission clock reads (see states below). Additive; old readers ignore it, old lines lack it. |
 
-**Example:**
-```json
-{
-  "timestamp": "2026-04-01T14:23:02Z",
-  "type": "agent-selection",
-  "chosen": "reviewer-code",
-  "alternatives": ["reviewer-domain", "reviewer-perspectives"],
-  "evidence": "Request contains code-specific keywords ('function', 'bug'); reviewer-code agent scores 0.92 vs domain 0.41 vs perspectives 0.38",
-  "context": "Dispatching review agent for: 'review this function for bugs'"
-}
-```
+The demote floor needs all three gate inputs — `confidence < 0.30 AND failure >= 3 AND n >= 5` — which is why `n` and `failure` are snapshotted alongside health: confidence alone cannot reconstruct the floor.
 
-### `skill-phase`
-A skill transitioned from one phase to the next.
+### The Three Health States
 
-**Example:**
-```json
-{
-  "timestamp": "2026-04-01T14:23:15Z",
-  "type": "skill-phase",
-  "chosen": "Phase 3: SPAWN ROASTER AGENTS",
-  "alternatives": [],
-  "evidence": "Phase 2 GATE passed: target identified (README.md), 12 context files gathered",
-  "context": "roast skill advancing from GATHER CONTEXT to SPAWN ROASTER AGENTS"
-}
-```
+The `[do-route]` marker may carry a `health=` token. Its shape at record time yields three states the event must distinguish:
 
-### `gate-verdict`
-A quality gate was evaluated and produced a pass or fail.
+| State | Marker | `health_at_decision` | `gate_inputs_present` | Meaning |
+|---|---|---|---|---|
+| (a) numeric | `health=<float>` | the float | `true` | Health evaluated from a weight row |
+| (b) no-row | `health=-` | `null` | `true` | Instrumented, but the pick had no weight row (valid expected data — e.g. a new pair) |
+| (c) legacy | no `health=` token | `null` | `false` (or field absent on old lines) | Never instrumented — legacy or missing wiring. A malformed `health=` value also lands here |
 
-**Example:**
-```json
-{
-  "timestamp": "2026-04-01T14:24:30Z",
-  "type": "gate-verdict",
-  "chosen": "PASS",
-  "alternatives": ["FAIL"],
-  "evidence": "All 5 agents returned tagged claims; claim count: Senior=7, Pedant=4, Newcomer=5, Contrarian=3, Builder=6",
-  "context": "Phase 3 GATE: All 5 agents complete with tagged claims"
-}
-```
+`gate_inputs_present` exists because `null` health alone cannot distinguish (b) from (c). `n`, `failure`, `action`, and `alternates` stay `null` unless a real numeric `health=` was read (state a).
 
 ---
 
-## Writing Traces from Hooks
+## OUTCOME Event
 
-Hooks that emit trace data should follow these rules:
+One per finalized dispatch. Outcome resolution happens on a later user prompt, so an outcome's `ts` is minutes-to-hours after its decision's.
 
-1. **Capture at decision time.** Write the decision entry at the moment the decision is made, not after execution completes. Post-hoc entries are less trustworthy because they can be influenced by outcome knowledge.
+**Example** (illustrative values):
+```json
+{"type":"outcome","ts":1751400900.456,"session":"abc123","key":"python-general-engineer:pr-workflow","outcome":"success","reason":"acceptance","routing_relevant":true}
+```
 
-2. **Append, do not overwrite.** Read the existing `session-trace.json`, append to the `decisions` array, and write back. If the file does not exist, create it with the top-level structure and the first entry.
+| Field | Type | Semantics |
+|-------|------|-----------|
+| `type` | string | Always `"outcome"`. |
+| `ts` | float | Epoch seconds when the outcome was finalized. |
+| `session` | string | Session id; `""` when unknown. |
+| `key` | string | Routing key `{agent}:{skill}`; agent-only `{agent}:` when the skill is unknown. |
+| `outcome` | string | One of `success`, `failure`, `neutral`. |
+| `reason` | string, optional | Short cause for the outcome, free of prompt text and secrets. Written only when given — absent in older events. Finalizer values: `tool-errors`, `rejection`, `acceptance`, `reaction-ignored-multi-dispatch`, `neutral-new-topic`; other producers may write other short strings. |
+| `routing_relevant` | bool, optional | Marks whether the outcome is a routing signal the confidence loop acts on; route-value-eval counts only routing-relevant failures. Written only when asserted — absent means relevance was not asserted. |
 
-3. **Evidence must be specific.** "Seemed like the right choice" is not evidence. Record the actual triggers, scores, or conditions: "Trigger 'review this function' matched reviewer-code; keyword score 0.92."
+---
 
-4. **Alternatives must be honest.** If a force_route was used and no alternatives were considered, set `alternatives` to `[]`. Do not fabricate alternatives that were never evaluated.
+## Joining Outcomes to Decisions
 
-5. **File location.** Write to `session-trace.json` in the project root (same directory as `task_plan.md` and `STATE.md`). Hooks can also write to `.claude/session-trace.json` if project root is not writable.
+Match on **both** conditions:
+
+1. Same `session`
+2. Outcome `key` equals the decision's `f"{agent}:{skill}"`
+
+File adjacency is unreliable: parallel sessions interleave lines. A decision with no matching outcome is pending (finalizer runs on the next user prompt) or was never finalized.
+
+---
+
+## Additive-Field History
+
+The schema grew append-compatibly. Older lines lack newer fields:
+
+| Fields | Absent on |
+|---|---|
+| `n`, `failure`, `action`, `alternates` | Decisions recorded before the health-gate inputs shipped |
+| `gate_inputs_present` | Decisions recorded before the decommission-clock signal shipped |
+| `reason`, `routing_relevant` | Outcomes from older or relevance-neutral callers |
+
+Consumers treat an absent field as "not recorded then" — identical handling to `null` for health, and never a validity error.
 
 ---
 
 ## Validation Checklist
 
-A well-formed trace file satisfies all of these:
+A healthy log satisfies all of these:
 
-- [ ] `session_id` is unique per session
-- [ ] `started_at` is valid ISO-8601
-- [ ] Every decision has all 6 required fields
-- [ ] `type` is one of the 4 allowed values
-- [ ] `timestamp` values are monotonically increasing
-- [ ] `evidence` fields contain specific signals, not vague descriptions
-- [ ] `alternatives` is `[]` when no alternatives existed, not omitted
+- [ ] Every line parses as a standalone JSON object
+- [ ] Every event has `type` in `{decision, outcome}` and a float `ts`
+- [ ] Every decision has `agent`, `skill`, `request_snippet` keys
+- [ ] Every outcome has `key` and `outcome` in `{success, failure, neutral}`
+- [ ] `health_at_decision` is numeric or `null` — a `null` with `gate_inputs_present: true` is valid data, not a defect
+
+Detection (read-only, counts only):
+
+```bash
+LOG="${CLAUDE_LEARNING_DIR:-$HOME/.claude/learning}/route-events.jsonl"
+python3 - "$LOG" <<'EOF'
+import json, sys, collections
+c = collections.Counter(); bad = []
+for i, line in enumerate(open(sys.argv[1]), 1):
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        e = json.loads(line)
+        c[e.get("type", "?")] += 1
+    except json.JSONDecodeError:
+        bad.append(i)
+print("by type:", dict(c), "malformed lines:", bad or "none")
+EOF
+```


### PR DESCRIPTION
## What changed

`skills/meta/explanation-traces/` documented and searched for `session-trace.json` — a file with **zero producers repo-wide**. The real per-dispatch decision log is `<CLAUDE_LEARNING_DIR>/route-events.jsonl` (default `~/.claude/learning/route-events.jsonl`), append-only JSONL written by `hooks/lib/route_events.py` with two producers: `routing-decision-recorder.py` (DECISION, PostToolUse:Agent) and `routing-outcome-finalizer.py` (OUTCOME, UserPromptSubmit). The skill now reads that log. Scope: only `skills/meta/explanation-traces/`.

| File | Change |
|---|---|
| `SKILL.md` | Phase 1 LOCATE resolves `${CLAUDE_LEARNING_DIR:-$HOME/.claude/learning}/route-events.jsonl`; Phases 2-3, examples, patterns, error handling rewritten to the real schema. Frontmatter unchanged. The no-log branch names the real path and the real producing hook (routing-decision-recorder) and suggests `hooks/sync-to-user-claude.py` — the hook already exists. |
| `references/trace-schema.md` | Real DECISION/OUTCOME field semantics taken from `route_events.py` docstrings, no invention: three health states — (a) numeric, (b) `health=-` no weight row, (c) legacy — disambiguated by `gate_inputs_present`; demote-floor inputs `n`/`failure` snapshotted with health; `action` = keep/demote/tiebreak; outcome `key` = `{agent}:{skill}` (agent-only `{agent}:` when skill unknown); `reason`/`routing_relevant` optional; additive-field history. |
| `references/error-handling.md` | Real error states: missing log (with env-redirect and hook-sync causes), malformed JSONL line (per-line skip), no decision events, decision without matched outcome (pending vs never finalized), absent additive fields, dispatch not in log (recorder deliberately skips non-/do and nested fan-out). |
| `references/preferred-patterns.md` | Consumer patterns: join outcomes by session+key (not file adjacency), sort by `ts`, render the three health states distinctly, absent field is not corruption, `request_snippet` stays inside the session. Producer-side diagnostics: recorder sync check, legacy-marker rate. |

Skill purpose preserved — answering "why did I get routed here": chosen route from `agent`/`skill`/`complexity`, decision-time health from `health_at_decision`/`n`/`failure`/`action`, alternates when present, outcomes matched by key.

## Evidence

- `grep -rn "session-trace" hooks/ scripts/` on main: no producer writes it; `hooks/lib/route_events.py` module docstring names the real log and both producers.
- Live log verified read-only (counts only): **560 events — 521 decision / 39 outcome / 0 malformed**.
- Additive-field history confirmed against live data: 438/521 decisions carry gate inputs (`n`/`failure`/`action`/`alternates`), 410/521 carry `gate_inputs_present`; older lines lack them — documented as "not recorded then", never corruption.
- Key format confirmed in `hooks/routing-decision-recorder.py` `build_routing_key()`; finalizer `reason` values confirmed at its `record_outcome_event` call site.

## Verification

| Check | Result |
|---|---|
| `ruff check . --config pyproject.toml` | All checks passed |
| `ruff format --check . --config pyproject.toml` | 503 files already formatted |
| `pytest scripts/tests/test_joy_check_instruction_mode.py` | 196 passed |
| `scripts/validate_positive_instruction_docs.py` | 0 hits in edited files |
| `scripts/validate-skill-frontmatter.py` | 133/133 OK |
| `scripts/audit-skill-content.py --root skills/meta --severity high` | 0 violations (20 skills scanned) |
| Frontmatter YAML parse + cross-reference existence (all referenced hooks/skills on disk) | PASS |
| Stale `session-trace` strings in skill dir | 0 |