### PR TITLE
fix(hooks): teach routing-decision-recorder to see Workflow-dispatched routes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -444,11 +444,16 @@
             "command": "python3 \"$HOME/.claude/hooks/instruction-compliance.py\"",
             "description": "Instruction compliance measurement after agent dispatch",
             "timeout": 5000
-          },
+          }
+        ]
+      },
+      {
+        "matcher": "Agent|Workflow",
+        "hooks": [
           {
             "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/routing-decision-recorder.py\"",
-            "description": "Record routing-decision row per Agent dispatch (replaces /do Phase 5 action A)",
+            "description": "Record routing-decision rows per Agent dispatch and per [do-route] marker in a Workflow script (replaces /do Phase 5 action A)",
             "timeout": 3000
           }
         ]

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.0.0
+# hook-version: 1.1.0
 """
 PostToolUse Hook: Routing Decision Recorder (action A, formerly /do Phase 5)
 
@@ -7,6 +7,19 @@ Records the routing-decision row for every Agent dispatch so the routing
 feedback loop (`learning-db.py route-health`) keeps receiving the rows it
 needs. Replaces the hand-run `learning-db.py record routing ...` step that
 lived in /do Phase 2 Step 4 + Phase 5 action A.
+
+WORKFLOW DISPATCHES (v1.1.0): /do Complex dispatches run through the Workflow
+tool. Its inner agent() calls fire NO PostToolUse:Agent event — the harness
+emits ONE PostToolUse with tool_name "Workflow", carrying every worker prompt
+(marker included) inside tool_input.script. So this hook also matches
+"Workflow": it reads tool_input.script, finds ALL line-start [do-route]
+markers (same anchored regex as the Agent path), and records one decision per
+marker. Idempotency is keyed per marker LINE so a resubmitted script (workflow
+resume) is a no-op. Pending outcomes are still appended per marker: Workflow
+inner agents fire no SubagentStop, but resolution never needed one — the
+UserPromptSubmit finalizer / Stop fallback resolve pendings on their normal
+paths, and a SubagentStop from any other dispatch merely revalidates them
+(their decision rows exist, written here first).
 
 SCOPING — record ONLY /do-routed dispatches.
 Every Agent dispatch fires PostToolUse:Agent, including pr-review's reviewer
@@ -95,6 +108,13 @@ _ACTION_RE = re.compile(r"\baction=(keep|demote|tiebreak)", re.IGNORECASE)
 _ALTS_RE = re.compile(r"\balts=([a-z0-9:_,-]+)", re.IGNORECASE)
 
 
+def _line_containing(text: str, pos: int) -> str:
+    """Return the full line of ``text`` that contains char offset ``pos``."""
+    start = text.rfind("\n", 0, pos) + 1  # -1 -> 0 for the first line
+    end = text.find("\n", pos)
+    return text[start:] if end == -1 else text[start:end]
+
+
 def _marker_line(prompt: str) -> str:
     """Return the single line that carries the [do-route] marker, or "".
 
@@ -110,9 +130,7 @@ def _marker_line(prompt: str) -> str:
     m = _DO_ROUTE_RE.search(prompt)
     if not m:
         return ""
-    start = prompt.rfind("\n", 0, m.start()) + 1  # -1 -> 0 for the first line
-    end = prompt.find("\n", m.start())
-    return prompt[start:] if end == -1 else prompt[start:end]
+    return _line_containing(prompt, m.start())
 
 
 def parse_health_inputs(prompt: str) -> HealthGateInputs:
@@ -203,6 +221,29 @@ def parse_do_route_marker(prompt: str) -> tuple[str, str] | None:
     return agent, skill
 
 
+def parse_workflow_markers(script: str) -> list[tuple[str, str, str]]:
+    """All line-start [do-route] markers in a Workflow script: [(agent, skill, marker line)].
+
+    A Workflow tool_input.script carries every worker prompt of a /do Complex
+    dispatch, so ONE script holds N markers — one routing decision each.
+    finditer with the SAME line-start-anchored regex as the Agent path keeps
+    the anchor semantics: a marker quoted mid-line never counts. skill is ""
+    when the marker carries no skill or "-".
+    """
+    if not script or "[do-route]" not in script.lower():
+        return []
+    markers: list[tuple[str, str, str]] = []
+    for m in _DO_ROUTE_RE.finditer(script):
+        agent = m.group(1).strip().lower()
+        if not agent:
+            continue  # malformed marker => nothing to key on
+        skill = (m.group(2) or "").strip().lower()
+        if skill == "-":
+            skill = ""
+        markers.append((agent, skill, _line_containing(script, m.start())))
+    return markers
+
+
 def build_routing_key(agent: str, skill: str) -> str:
     """Build the {agent}:{skill} key; agent-only "{agent}:" when skill unknown."""
     return f"{agent}:{skill}" if skill else f"{agent}:"
@@ -211,6 +252,20 @@ def build_routing_key(agent: str, skill: str) -> str:
 def dispatch_signature(agent: str, skill: str, description: str, prompt: str) -> str:
     """Stable signature for one dispatch, used for idempotency."""
     raw = f"{agent}|{skill}|{description}|{prompt[:200]}"
+    return hashlib.md5(raw.encode("utf-8", errors="replace")).hexdigest()[:16]
+
+
+def workflow_dispatch_signature(occurrence: int, marker_line: str) -> str:
+    """Idempotency signature for ONE marker in a Workflow script.
+
+    Keyed on the marker LINE, not the script: a workflow resume resubmits the
+    same script (possibly with step state changed AROUND the markers), and
+    every marker must re-derive the SAME signature so the re-run claims
+    nothing and records nothing. ``occurrence`` is this line's index among
+    IDENTICAL marker lines in the script, so two duplicate worker lines stay
+    two distinct dispatches while unrelated script edits shift no signature.
+    """
+    raw = f"workflow|{occurrence}|{marker_line.strip()}"
     return hashlib.md5(raw.encode("utf-8", errors="replace")).hexdigest()[:16]
 
 
@@ -313,114 +368,150 @@ def main() -> None:
             return
         event = json.loads(raw)
 
-        # matcher "Agent" in settings.json scopes this hook; guard defensively.
+        # matcher "Agent|Workflow" in settings.json scopes this hook; guard
+        # defensively.
         tool_name = event.get("tool_name") or event.get("tool", "")
-        if tool_name != "Agent":
+        if tool_name not in ("Agent", "Workflow"):
             return
 
         tool_input = event.get("tool_input") or event.get("input") or {}
-        prompt = tool_input.get("prompt") or ""
         description = tool_input.get("description") or ""
+        session_id = event.get("session_id") or ""
 
         # SCOPING: record ONLY /do-routed dispatches. No [do-route] marker =>
         # this is a sub-agent fan-out (pr-review reviewers, nested dispatch),
         # not a /do routing decision — skip so route-health's denominator stays
         # clean. agent + skill are read straight from the marker.
-        routed = parse_do_route_marker(prompt)
-        if routed is None:
+        #
+        # Build one decision per marker: (agent, skill, signature, marker_text).
+        # Agent carries ONE marker in tool_input.prompt (marker_text = whole
+        # prompt, unchanged semantics). Workflow carries N worker prompts in
+        # tool_input.script — one decision per line-start marker, marker_text =
+        # that marker's line so complexity/health parse per marker.
+        if tool_name == "Agent":
+            prompt = tool_input.get("prompt") or ""
+            routed = parse_do_route_marker(prompt)
+            if routed is None:
+                return
+            agent, skill = routed
+            if not agent:
+                return  # malformed marker => nothing to key on
+            decisions = [(agent, skill, dispatch_signature(agent, skill, description, prompt), prompt)]
+        else:
+            script = tool_input.get("script") or ""
+            occurrence: dict[str, int] = {}  # nth sighting of each identical marker line
+            decisions = []
+            for agent, skill, line in parse_workflow_markers(script):
+                nth = occurrence.get(line.strip(), 0)
+                occurrence[line.strip()] = nth + 1
+                decisions.append((agent, skill, workflow_dispatch_signature(nth, line), line))
+        if not decisions:
             return
-        agent, skill = routed
-        if not agent:
-            return  # malformed marker => nothing to key on
-        key = build_routing_key(agent, skill)
 
-        # Idempotency (atomic, MEDIUM/TOCTOU): claim this dispatch signature.
-        # claim_dispatch performs check-and-set under one flock, so N concurrent
-        # duplicate deliveries record exactly once. False => already claimed.
-        sig = dispatch_signature(agent, skill, description, prompt)
-        session_id = event.get("session_id") or ""
-        if not claim_dispatch(session_id, sig):
-            return
+        has_errors = None  # computed once, on the first claimed marker
+        recorded = False
+        for agent, skill, sig, marker_text in decisions:
+            # Idempotency (atomic, MEDIUM/TOCTOU): claim this dispatch signature.
+            # claim_dispatch performs check-and-set under one flock, so N concurrent
+            # duplicate deliveries record exactly once. False => already claimed.
+            # For Workflow, the signature is keyed per marker line, so a resumed
+            # workflow resubmitting the same script re-claims nothing (no-op).
+            if not claim_dispatch(session_id, sig):
+                continue
+            recorded = True
+            if has_errors is None:
+                # One Workflow event carries one tool result for ALL inner
+                # agents — per-marker error attribution is not observable here,
+                # so every marker shares the event-level flag (best available).
+                has_errors = detect_errors(event)
+            key = build_routing_key(agent, skill)
+            request_snippet = (description or marker_text)[:200].replace("\n", " ").strip()
 
-        has_errors = detect_errors(event)
-        request_snippet = (description or prompt)[:200].replace("\n", " ").strip()
+            from learning_db_v2 import record_learning
 
-        from learning_db_v2 import record_learning
+            record_learning(
+                topic="routing",
+                key=key,
+                value=(
+                    f"routing-decision: agent={agent} skill={skill or '-'} "
+                    f"tool_errors={1 if has_errors else 0} user_rerouted=0 "
+                    f"request: {request_snippet}"
+                ),
+                category="effectiveness",
+                tags=["routing", agent] + ([skill] if skill else []),
+                source="hook:routing-decision-recorder",
+                session_id=session_id or None,
+            )
 
-        record_learning(
-            topic="routing",
-            key=key,
-            value=(
-                f"routing-decision: agent={agent} skill={skill or '-'} "
-                f"tool_errors={1 if has_errors else 0} user_rerouted=0 "
-                f"request: {request_snippet}"
-            ),
-            category="effectiveness",
-            tags=["routing", agent] + ([skill] if skill else []),
-            source="hook:routing-decision-recorder",
-            session_id=session_id or None,
-        )
+            # T3: per-dispatch DECISION event (JSONL), append-only + failure-safe.
+            # Auxiliary to the aggregate row above — never blocks; route_events
+            # swallows write errors so the hook stays non-blocking.
+            cm = _COMPLEXITY_RE.search(marker_text)
+            complexity = cm.group(1) if cm else ""
+            health = parse_health_inputs(marker_text)
+            from route_events import record_decision_event
 
-        # T3: per-dispatch DECISION event (JSONL), append-only + failure-safe.
-        # Auxiliary to the aggregate row above — never blocks; route_events
-        # swallows write errors so the hook stays non-blocking.
-        cm = _COMPLEXITY_RE.search(prompt)
-        complexity = cm.group(1) if cm else ""
-        health = parse_health_inputs(prompt)
-        from route_events import record_decision_event
+            record_decision_event(
+                session=session_id,
+                request_snippet=request_snippet,
+                agent=agent,
+                skill=skill,
+                complexity=complexity,
+                health_at_decision=health["health"],  # real gate inputs from the marker (Step 1.5)
+                n=health["n"],
+                failure=health["failure"],
+                action=health["action"],
+                alternates=health["alternates"],
+                gate_inputs_present=health["gate_inputs_present"],
+            )
 
-        record_decision_event(
-            session=session_id,
-            request_snippet=request_snippet,
-            agent=agent,
-            skill=skill,
-            complexity=complexity,
-            health_at_decision=health["health"],  # real gate inputs from the marker (Step 1.5)
-            n=health["n"],
-            failure=health["failure"],
-            action=health["action"],
-            alternates=health["alternates"],
-            gate_inputs_present=health["gate_inputs_present"],
-        )
+            # Per-run telemetry envelope (ADR: learning-telemetry-envelope). Append-only,
+            # one row per dispatch, AFTER the decision row so both share (topic, key).
+            # git_sha + session_id + run_id are always derivable, so this row is non-empty
+            # even when the best-effort fields (token_count, wall_clock_ms, model_id) are NULL.
+            import uuid
 
-        # Per-run telemetry envelope (ADR: learning-telemetry-envelope). Append-only,
-        # one row per dispatch, AFTER the decision row so both share (topic, key).
-        # git_sha + session_id + run_id are always derivable, so this row is non-empty
-        # even when the best-effort fields (token_count, wall_clock_ms, model_id) are NULL.
-        import uuid
+            from learning_db_v2 import record_telemetry_run
+            from telemetry_capture import git_sha_cached, model_id_from, token_count_from, wall_clock_ms_from
 
-        from learning_db_v2 import record_telemetry_run
-        from telemetry_capture import git_sha_cached, model_id_from, token_count_from, wall_clock_ms_from
+            record_telemetry_run(
+                topic="routing",
+                key=key,
+                run_id=str(uuid.uuid4()),
+                source="hook:routing-decision-recorder",
+                batch_id=os.environ.get("CLAUDE_TELEMETRY_BATCH") or session_id or None,
+                session_id=session_id or None,
+                git_sha=git_sha_cached(session_id),
+                model_id=model_id_from(event),
+                skill_version=None,  # PR-A: None (ADR Alternative D — populate when cheap)
+                token_count=token_count_from(event),
+                wall_clock_ms=wall_clock_ms_from(event),
+                tool_errors=has_errors,
+            )
 
-        record_telemetry_run(
-            topic="routing",
-            key=key,
-            run_id=str(uuid.uuid4()),
-            source="hook:routing-decision-recorder",
-            batch_id=os.environ.get("CLAUDE_TELEMETRY_BATCH") or session_id or None,
-            session_id=session_id or None,
-            git_sha=git_sha_cached(session_id),
-            model_id=model_id_from(event),
-            skill_version=None,  # PR-A: None (ADR Alternative D — populate when cheap)
-            token_count=token_count_from(event),
-            wall_clock_ms=wall_clock_ms_from(event),
-            tool_errors=has_errors,
-        )
+            # Bridge to the outcome resolvers. The dispatch was already claimed
+            # (marked seen) atomically above, so no separate mark. Decision row
+            # is written BEFORE this append (ordering: A-before-B). Workflow
+            # inner agents fire no SubagentStop — that's fine: resolution lives
+            # in the UserPromptSubmit finalizer / Stop fallback, and any other
+            # dispatch's SubagentStop merely revalidates these entries (their
+            # decision rows exist, written above).
+            append_pending_outcome(session_id, key, has_errors)
+
+        if not recorded:
+            return  # every marker already claimed (duplicate delivery / resume)
 
         # (C) right-sizing feedback, parse-only. extract_output_text flattens
         # the LIVE Agent content-block shape (list of {"type","text"} blocks)
         # as well as the Bash-style {"output": "..."} the tests simulate, so the
-        # banner is found regardless of payload shape.
+        # banner is found regardless of payload shape. Runs once per EVENT (not
+        # per marker) and only when a decision was claimed, so a duplicate
+        # delivery / resubmitted script never double-accumulates the tier sums.
         from hook_utils import get_tool_result
 
         output = extract_output_text(get_tool_result(event))
         if output:
             record_rightsizing(output, session_id)
-
-        # Bridge to the SubagentStop outcome hook (action B). The dispatch was
-        # already claimed (marked seen) atomically above, so no separate mark.
-        # Decision row is written BEFORE this append (ordering: A-before-B).
-        append_pending_outcome(session_id, key, has_errors)
 
     except Exception as e:
         # Always surface ONE short line so a recorder failure is visible, not

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -6,6 +6,9 @@ Covers:
 - A reads agent + skill from the [do-route] marker; agent-only when skill=-.
 - A records ONLY /do-routed dispatches: marker present => recorded; marker
   absent (reviewer sub-agent / nested fan-out) => skipped.
+- A records Workflow dispatches (/do Complex): one decision per line-start
+  [do-route] marker in tool_input.script; a resubmitted script (workflow
+  resume) is a no-op; the Agent path is unchanged.
 - A records a rightsizing row when the banner is present (C), silent otherwise.
 - A is idempotent: the same dispatch is recorded once.
 - B records success (boost) / failure (decay) from drained pending outcomes.
@@ -105,6 +108,38 @@ def _agent_event(
         },
         "tool_result": {"output": output, "is_error": is_error},
     }
+
+
+def _workflow_event(script, *, session="wf-s1", output="ok", is_error=False, description=""):
+    """Build a synthetic PostToolUse:Workflow event (/do Complex dispatch).
+
+    The Workflow tool's inner agent() calls fire NO PostToolUse:Agent event —
+    the harness emits ONE PostToolUse with tool_name "Workflow" whose
+    tool_input.script carries every worker prompt, [do-route] markers included.
+    """
+    return {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Workflow",
+        "session_id": session,
+        "tool_input": {"description": description, "script": script},
+        "tool_result": {"output": output, "is_error": is_error},
+    }
+
+
+# Two workers, two line-start markers, distinct gate inputs per marker line.
+_TWO_MARKER_SCRIPT = (
+    "results = []\n"
+    'prompt_a = """\n'
+    "[do-route] agent=python-general-engineer skill=go-patterns complexity=Complex health=-\n"
+    "Fix the bug.\n"
+    '"""\n'
+    'prompt_b = """\n'
+    "[do-route] agent=hook-development-engineer skill=pr-workflow complexity=Complex health=0.8 n=6 fail=1 action=keep\n"
+    "Open the PR.\n"
+    '"""\n'
+    'results.append(agent("python-general-engineer", prompt=prompt_a))\n'
+    'results.append(agent("hook-development-engineer", prompt=prompt_b))\n'
+)
 
 
 def _query_routing(db_env):
@@ -400,6 +435,130 @@ class TestDecisionRecorder:
         with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
             a.main()
         assert _query_telemetry(db_env) == []
+
+
+class TestWorkflowDecisionRecorder:
+    """A also sees Workflow dispatches (/do Complex): one decision per
+    line-start [do-route] marker in tool_input.script, idempotent per marker
+    line so a workflow resume that resubmits the script records nothing new.
+    The Agent path stays byte-identical (regression test at the end)."""
+
+    def test_two_markers_record_two_decisions(self, db_env, tmp_path, monkeypatch):
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+        import telemetry_capture as tc
+
+        monkeypatch.setattr(tc, "_STATE_DIR", tmp_path / "telstate")
+        a = _load(A_PATH, "rdr_wf_two")
+        event = _workflow_event(_TWO_MARKER_SCRIPT, session="wf-two")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+
+        # Two decision rows, one per marker.
+        keys = {r["key"] for r in _query_routing(db_env)}
+        assert "python-general-engineer:go-patterns" in keys
+        assert "hook-development-engineer:pr-workflow" in keys
+
+        # Two DECISION events with per-marker complexity + gate inputs.
+        decisions = [e for e in _read_events(db_env) if e["type"] == "decision"]
+        assert len(decisions) == 2
+        by_agent = {d["agent"]: d for d in decisions}
+        assert by_agent["python-general-engineer"]["skill"] == "go-patterns"
+        assert by_agent["hook-development-engineer"]["skill"] == "pr-workflow"
+        assert all(d["complexity"] == "Complex" for d in decisions)
+        # marker A: health=- => no weight row but instrumented.
+        da = by_agent["python-general-engineer"]
+        assert da["health_at_decision"] is None and da["gate_inputs_present"] is True
+        # marker B: full numeric gate inputs, read from ITS line only.
+        db = by_agent["hook-development-engineer"]
+        assert db["health_at_decision"] == 0.8
+        assert db["n"] == 6 and db["failure"] == 1 and db["action"] == "keep"
+
+        # One telemetry envelope row per marker.
+        tel_keys = {r["key"] for r in _query_telemetry(db_env)}
+        assert tel_keys == {"python-general-engineer:go-patterns", "hook-development-engineer:pr-workflow"}
+
+        # One pending outcome per marker for the finalizer / Stop fallback
+        # (Workflow inner agents fire no SubagentStop; none is needed).
+        pending_keys = {p["key"] for p in ros.peek_pending_outcomes("wf-two")}
+        assert pending_keys == {"python-general-engineer:go-patterns", "hook-development-engineer:pr-workflow"}
+
+    def test_resubmitted_script_is_noop(self, db_env, monkeypatch):
+        # Workflow resume resubmits the SAME script: the per-marker-line
+        # signatures re-claim nothing => zero new rows/events/pendings.
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        a = _load(A_PATH, "rdr_wf_resume")
+        event = _workflow_event(_TWO_MARKER_SCRIPT, session="wf-resume")
+        for _ in range(3):
+            with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+                a.main()
+        decisions = [e for e in _read_events(db_env) if e["type"] == "decision"]
+        assert len(decisions) == 2
+        assert all(r["observation_count"] == 1 for r in _query_routing(db_env))
+        assert len(ros.peek_pending_outcomes("wf-resume")) == 2
+
+    def test_identical_duplicate_marker_lines_are_two_decisions(self, db_env):
+        # Two workers with byte-identical marker lines = two real dispatches:
+        # the occurrence index keeps their signatures distinct — while a
+        # resubmit of the same script still re-claims both (no-op).
+        line = "[do-route] agent=python-general-engineer skill=go-patterns complexity=Medium\n"
+        script = f'a = """\n{line}task one\n"""\nb = """\n{line}task two\n"""\n'
+        a = _load(A_PATH, "rdr_wf_dup")
+        event = _workflow_event(script, session="wf-dup")
+        for _ in range(2):  # second run = resume no-op
+            with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+                a.main()
+        decisions = [e for e in _read_events(db_env) if e["type"] == "decision"]
+        assert len(decisions) == 2
+
+    def test_mid_line_marker_not_recorded(self, db_env):
+        # Line-start anchor semantics carry over to the script path: a marker
+        # quoted mid-line is prose, not a routing decision.
+        script = 'x = "see the [do-route] agent=python-general-engineer skill=go-patterns line"\n'
+        a = _load(A_PATH, "rdr_wf_midline")
+        event = _workflow_event(script, session="wf-mid")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        assert _query_routing(db_env) == []
+        assert _read_events(db_env) == []
+
+    def test_workflow_rightsizing_accumulates_once_per_event(self, db_env):
+        # The banner lives in the ONE Workflow tool result: accumulate it once
+        # per event (not per marker), and never again on a resubmit.
+        a = _load(A_PATH, "rdr_wf_rs")
+        event = _workflow_event(
+            _TWO_MARKER_SCRIPT,
+            session="wf-rs",
+            output="done. rightsizing: tier=3 files=15 packages=4 agents_dispatched=17",
+        )
+        for _ in range(2):  # second run = resume no-op
+            with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+                a.main()
+        row = next(r for r in _query_routing(db_env) if r["key"] == "rightsizing:tier3")
+        assert "reviews: 1" in row["value"]
+
+    def test_agent_payload_regression(self, db_env):
+        # The Agent path must behave exactly as before the Workflow change:
+        # one row, one decision event, snippet from description, prompt-scoped
+        # complexity, one pending outcome.
+        sys.path.insert(0, str(LIB_DIR))
+        import routing_outcome_state as ros
+
+        a = _load(A_PATH, "rdr_wf_agent_reg")
+        event = _agent_event(skill="go-patterns", description="do work", session="wf-agent-reg")
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        rows = _query_routing(db_env)
+        assert len(rows) == 1
+        assert rows[0]["key"] == "python-general-engineer:go-patterns"
+        assert "tool_errors=0" in rows[0]["value"]
+        decisions = [e for e in _read_events(db_env) if e["type"] == "decision"]
+        assert len(decisions) == 1
+        assert decisions[0]["request_snippet"] == "do work"
+        assert decisions[0]["complexity"] == "Medium"
+        assert [p["key"] for p in ros.peek_pending_outcomes("wf-agent-reg")] == ["python-general-engineer:go-patterns"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Routing telemetry has been blind to /do Complex dispatches since 2026-06-26: they run through the Workflow tool, whose inner `agent()` calls fire no PostToolUse:Agent event. The recorder was matcher-scoped to `Agent`, guarded on `tool_name != "Agent"`, and read only `tool_input.prompt` — while Workflow carries the worker prompts (markers included) in `tool_input.script`. This teaches the recorder to see Workflow dispatches, restoring learning.db recorder rows and route-events.jsonl decision events.

## Changes
- `.claude/settings.json` — move routing-decision-recorder to its own matcher block `Agent|Workflow`; review-capture and instruction-compliance stay Agent-only, untouched.
- `hooks/routing-decision-recorder.py` — accept tool_name `Workflow`; find ALL line-start `[do-route]` markers in `tool_input.script` (same anchored regex as the Agent path); emit one decision row + JSONL event + telemetry row + pending outcome per marker; Agent path unchanged.
- `hooks/routing-decision-recorder.py` — idempotency signature keyed per marker line (plus occurrence index for byte-identical duplicate lines), so a resumed workflow resubmitting the same script records nothing.
- `hooks/tests/test_routing_decision_recorder.py` — 6 tests: two markers → two decision events with per-marker gate inputs; resubmitted script → no-op; identical duplicate marker lines → two decisions; mid-line marker skipped; rightsizing accumulates once per event; Agent-payload regression.

## Notes
- Pending outcomes are kept for Workflow decisions even though inner agents fire no SubagentStop: resolution lives in the UserPromptSubmit finalizer and Stop fallback, neither of which needs SubagentStop; a SubagentStop from any other dispatch only revalidates entries whose decision row exists (written first by this hook). Verified against routing-outcome-recorder/finalizer code before keeping the bridge.
- The recorder shared its old matcher block with review-capture and instruction-compliance; widening that block would have fired both on Workflow events, so the recorder was split into its own block instead.
- One Workflow event carries one tool result for all inner agents, so every marker shares the event-level `tool_errors` flag (per-marker attribution is not observable at this event).
- Manual verification beyond CI: simulated Workflow payload with two line-start markers produced two decision events end-to-end (subprocess, throwaway DB); resubmit produced zero new events; `validate-hook-health.py` ALL CHECKS PASS.
