### PR TITLE
fix(docs,routing): close verified drift — runbook claims, dead example ref, 'update routing' trigger overlap

### DIFF
--- a/agents/toolkit-governance-engineer.md
+++ b/agents/toolkit-governance-engineer.md
@@ -5,10 +5,9 @@ color: blue
 routing:
   triggers:
     - edit skill
-    - update routing
+    - routing table governance
     - ADR management
     - toolkit maintenance
-    - update routing tables
     - check coverage
     - skill compliance
     - hook standardization
@@ -18,7 +17,7 @@ routing:
     - scaffold skill
     - build a skill
     - create a skill
-  not_for: "authoring one new skill end-to-end (use skill-creator). This agent governs fleet-wide policy, routing consistency, and ADR conformance, not single-skill scaffolding."
+  not_for: "authoring one new skill end-to-end (use skill-creator), or mechanically regenerating routing INDEX files (use the routing-table-updater skill). This agent governs fleet-wide policy, routing consistency, and ADR conformance, not single-skill scaffolding or index sync."
   pairs_with:
     - adr-consultation
     - routing-table-updater

--- a/docs/router-ab-runbook.md
+++ b/docs/router-ab-runbook.md
@@ -60,12 +60,10 @@ python3 scripts/routing-ab-test.py --pre-route-map --assert-buckets --out-dir "$
 
 It asserts every benchmark-force_route, paraphrase-git, and paraphrase-security
 case is fast-path eligible (pre-route confidence `high` + `force_route`) and no
-false-positive-guard case is. Exit 0/1. As of corpus v1.1 this FAILS (13
-violations): all 10 paraphrase-git/security cases fall through the keyword
-pre-router by design, and 3 keyword force-route cases sit at `medium`
-confidence. Meaning: a fast path keyed on high-confidence force_route fires on
-only 8/99 corpus cases and never on paraphrased safety intents — those still
-need the semantic router. The guard direction holds (0/7 guards eligible).
+false-positive-guard case is. Exit 0/1. PR #833 closed the coverage hole this
+check originally exposed (13 violations under corpus v1.1); the check now
+PASSES (exit 0): all asserted buckets are fast-path eligible and no guard case
+is (0/7).
 
 ## The answer-collection bridge
 
@@ -189,12 +187,11 @@ the Opus orchestrator session driving it.
 2. **Force-route fast path**: SHIPPED in `skills/meta/do/SKILL.md` Phase 2,
    keyed on pre-route `confidence: high` + `force_route` for pr-workflow and
    security skills. The zero-model check (`--pre-route-map --assert-buckets`,
-   baseline above) still FAILS with 13 assert-bucket violations — 10
-   paraphrase-git/security cases fall through the keyword pre-router and 3
-   force-route cases sit at medium confidence — so the shipped fast path fires
-   on only 8/99 corpus cases; the guard direction holds (0/7 guards eligible).
-   A coverage fix for the 13 violations is in flight on
-   `fix/preroute-fastpath-coverage`.
+   above) initially FAILED with 13 assert-bucket violations — 10
+   paraphrase-git/security cases fell through the keyword pre-router and 3
+   force-route cases sat at medium confidence. PR #833 merged the coverage fix;
+   the check now PASSES (exit 0) and the guard direction holds (0/7 guards
+   eligible).
 
 ## Known limits
 

--- a/skills/meta/do/references/progressive-depth.md
+++ b/skills/meta/do/references/progressive-depth.md
@@ -22,7 +22,7 @@ Use `quick --trivial` for tasks that appear to be 1-3 file edits.
 
 **When**: The change looks self-contained — a bug fix, a config tweak, adding a small block of code. The agent attempts the fix and watches for escalation signals.
 
-**Examples**: "Fix the typo in routing-guide.md", "Add a --verbose flag to index-router.py", "Update the version number in SKILL.md."
+**Examples**: "Fix the typo in docs/router-ab-runbook.md", "Add a --verbose flag to index-router.py", "Update the version number in SKILL.md."
 
 **Escalation signals** (any one triggers escalation):
 - More than 3 files need changes
@@ -58,7 +58,7 @@ When an agent at any level determines it needs escalation, it must emit a struct
 Current level: 1 (Fast)
 Reason: Found 7 files need changes, original estimate was 2
 Recommended level: 2 (Methodical)
-Work completed so far: Fixed the primary file (routing-guide.md), discovered 6 other references that need matching updates
+Work completed so far: Fixed the primary file (docs/router-ab-runbook.md), discovered 6 other references that need matching updates
 ```
 
 The router receives this signal, preserves the work completed so far, and re-dispatches at the recommended level with context about what was already done.

--- a/skills/meta/routing-table-updater/SKILL.md
+++ b/skills/meta/routing-table-updater/SKILL.md
@@ -13,11 +13,12 @@ allowed-tools:
   - Skill
 routing:
   triggers:
-    - "update routing"
+    - "update routing tables"
     - "sync routing tables"
     - "routing maintenance"
     - "rebuild routing index"
     - "routing drift"
+  not_for: "fleet-wide routing policy, trigger governance, or standards enforcement (use the toolkit-governance-engineer agent). This skill mechanically regenerates and repairs the INDEX files."
   category: meta-tooling
   pairs_with:
     - toolkit-evolution

--- a/skills/meta/routing-table-updater/references/routing-format.md
+++ b/skills/meta/routing-table-updater/references/routing-format.md
@@ -14,7 +14,7 @@ description: "Maintain /do routing tables when skills or agents change."
 user-invocable: false
 routing:
   triggers:
-    - "update routing"
+    - "update routing tables"
     - "routing drift"
   category: meta-tooling
   pairs_with:
@@ -48,7 +48,7 @@ Same shape; agents add `complexity` (e.g., `Medium`, `Complex`, `Medium-Complex`
     "routing-table-updater": {
       "file": "skills/meta/routing-table-updater/SKILL.md",
       "description": "Maintain /do routing tables when skills or agents change.",
-      "triggers": ["update routing", "routing drift"],
+      "triggers": ["update routing tables", "routing drift"],
       "category": "meta-tooling",
       "user_invocable": false,
       "pairs_with": ["toolkit-evolution", "generate-claudemd"]


### PR DESCRIPTION
Closes three findings from the toolkit audit, each re-verified against current main (48f185ce) before fixing. All three were still live.

## 1. Runbook claimed a check fails that now passes

`docs/router-ab-runbook.md` said the router fast-path safety check "FAILS (13 violations)" and that a fix was still in flight on a side branch. That was true when written, but PR #833 merged the fix: running `python3 scripts/routing-ab-test.py --pre-route-map --assert-buckets` today passes (exit 0, "PASS: all asserted buckets conform"). Both stale passages now state that — anyone following the runbook no longer chases a solved problem.

## 2. Example pointed at a deleted file

`skills/meta/do/references/progressive-depth.md` used `routing-guide.md` in two examples, but that file no longer exists anywhere in the repo. The examples now use `docs/router-ab-runbook.md`, a real file, so they stay copy-paste honest.

## 3. Two components claimed the same routing phrase

The phrase "update routing" was a trigger on both the `routing-table-updater` skill and the `toolkit-governance-engineer` agent, so the router could not tell them apart. Fixed at the source (each component's own frontmatter, which the routing index is generated from):

- The **skill** — the tool that mechanically rebuilds the routing index files — keeps the table work: its trigger is now the more specific "update routing tables".
- The **agent** — which sets fleet-wide routing policy — drops "update routing" and "update routing tables" and gains "routing table governance".
- Each side's `not_for` note now points at the other, so a misrouted request self-corrects.

`python3 scripts/validate-index-integrity.py` no longer emits the "update routing" overlap warning and reports 0 errors.

## Verification

| Check | Result |
|---|---|
| `routing-ab-test.py --pre-route-map --assert-buckets` | PASS, exit 0 |
| `validate-index-integrity.py` (after index regen) | 0 errors, overlap warning gone |
| `validate-references.py --agent toolkit-governance-engineer` | 0 issues |
| `validate-skill-frontmatter.py` | 133 files OK |
| `routing-benchmark.py` | 80/80 valid targets |
| `check-routing-drift.py` | clean |
| pytest: reference-loading, trigger-ambiguity, AB harness | 62 passed |
| `ruff check` + `ruff format --check` | clean |

Not touched: `skills/meta/do/SKILL.md` (owned by a later PR).