### PR TITLE
feat(hooks): complexity enum + stack telemetry, creation gate covers hooks, deploy-parity warning

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -96,6 +96,13 @@
             "description": "Inject pending rules-distillation candidates at session start (ADR-114); silent when none pending",
             "timeout": 2000,
             "once": true
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/hook-version-parity-check.py\"",
+            "description": "Warn-only: compare deployed ~/.claude/hooks hook-version headers against the repo checkout; silent on parity",
+            "timeout": 3000,
+            "once": true
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AI agents skip steps.
 Harnesses have a second problem: given only a skill list, they do not route eagerly enough, or correctly enough. Good skills sit unused. So this toolkit connects the skills, agents, and workflows we want directly into the harness, automatically. You don't have to understand what is here. Say what you want in plain English and you get all the value we have put into it: the right specialist with the right methodology, behind gates that demand exit codes, not assertions.
 
 <!-- Counts here must match the Four Layers table (~line 143). Verify both: python3 scripts/validate-doc-counts.py -->
-44 domain agents, 133 workflow skills, 83 hooks, 124 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
+44 domain agents, 133 workflow skills, 84 hooks, 124 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
 
 Works across Claude Code (`/do`), Codex (`$do`), Factory (`/do`), Reasonix (`/do`).
 

--- a/docs/for-ai-wizards.md
+++ b/docs/for-ai-wizards.md
@@ -151,7 +151,7 @@ Ten event types, registered in settings.json:
 
 | Event | When | Hooks Registered |
 |-------|------|-----------------|
-| `SessionStart` | Session begins | sync-to-user-claude, afk-mode, session-context, cross-repo-agents, fish-shell-detector, sapcc-go-detector, operator-context-detector, session-github-briefing, session-adr-health-check |
+| `SessionStart` | Session begins | sync-to-user-claude, afk-mode, session-context, cross-repo-agents, fish-shell-detector, sapcc-go-detector, operator-context-detector, session-github-briefing, session-adr-health-check, hook-version-parity-check |
 | `UserPromptSubmit` | Before processing each prompt | pipeline-context-detector, user-correction-capture, codex-auto-review, prompt-capture |
 | `PreToolUse` | Before tool execution | suggest-compact, pretool-unified-gate, pretool-branch-safety, ci-merge-gate, pretool-ruff-format-gate, pretool-index-sync-check, pretool-learning-injector, pretool-synthesis-gate, pretool-plan-gate, pretool-prompt-injection-scanner, pipeline-phase-gate, reference-loading-gate, pretool-adr-creation-gate, pretool-file-backup, reference-loading-enforcer, pretool-subagent-warmstart, creation-protocol-enforcer |
 | `PostToolUse` | After tool execution | posttool-lint-hint, agent-grade-on-change, adr-enforcement, posttool-security-scan, posttool-skill-frontmatter-check, posttooluse-joy-check-warn, posttooluse-sync-skill-index, posttool-docs-drift-alert, retro-graduation-gate, adr-lifecycle-on-merge, posttool-rename-sweep, record-activation, posttool-session-reads, usage-tracker, review-capture, instruction-compliance, error-learner, record-waste, completion-evidence-check, posttool-auto-test |

--- a/docs/injected-context-contracts.md
+++ b/docs/injected-context-contracts.md
@@ -116,6 +116,12 @@ Source: `hooks/session-adr-health-check.py`.
 Meaning: An `.adr-session.json` was detected; the listed ADR governs creation work this session.
 Action: Treat the named ADR as binding for any creation request. Read it via `adr-query.py context` before writing new agents, skills, pipelines, or hooks. The `adr-enforcement` PostToolUse hook will flag drift.
 
+### `[hook-parity] WARNING: N deployed hook(s) differ from this checkout`
+
+Source: `hooks/hook-version-parity-check.py`.
+Meaning: The `# hook-version:` headers of the named deployed hooks in `~/.claude/hooks/` do not match this checkout — merged code is not deployed, so hook telemetry may be running stale logic.
+Action: Warn-only; nothing is blocked. Surface the drift to the user and suggest the included fix command (`python3 ~/.claude/hooks/sync-to-user-claude.py`). Expected in worktree sessions on hook-touching branches. Do not treat hook telemetry gaps as code bugs while this warning is active.
+
 ## Prompt-Signal Tags (emitted mid-conversation, require routing action)
 
 ### `[pipeline-creator]` plus `[auto-skill] pipeline-scaffolder` (plus JSON snapshot)

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -33,6 +33,7 @@ Task completes: TaskCompleted
 | `afk-mode` | Injects autonomous behavioral posture for unattended sessions (SSH, tmux, or `CLAUDE_AFK_MODE=always`). See [AFK Mode docs](afk-mode/README.md) |
 | `cross-repo-agents` | Discovers local `.claude/agents/` in the working directory and injects them for `/do` routing |
 | `fish-shell-detector` | Detects Fish shell users and injects the `fish-shell-config` skill |
+| `hook-version-parity-check` | Warn-only: compares deployed `~/.claude/hooks/*.py` hook-version headers against the repo checkout; on drift names the hooks and the sync command |
 | `session-github-briefing` | Injects GitHub monitoring briefing into session context (opt-in: `CLAUDE_KAIROS_ENABLED=true`) |
 | `operator-context-detector` | Detects operator context (personal/work/ci/production) and injects behavioral profile |
 | `retro-knowledge-injector` | Stub — previously injected retro knowledge; replaced by auto-dream via `session-context.py` |
@@ -68,7 +69,7 @@ Task completes: TaskCompleted
 | `pretool-unified-gate` | Bash, Write, Edit | Consolidated gate (ADR-068): gitignore bypass, git submission, dangerous commands, creation gate, sensitive file guard |
 | `ci-merge-gate` | Bash | Blocks `gh pr merge` when CI checks have not passed |
 | `mcp-health-check` | MCP tools | Probes MCP servers before tool calls; blocks (exit 2) if unhealthy and within backoff window. Also records failures in PostToolUse |
-| `pretool-adr-creation-gate` | Write | Blocks new agent/skill/pipeline creation when no corresponding ADR exists |
+| `pretool-adr-creation-gate` | Write | Blocks new agent/skill/pipeline/hook creation when no corresponding ADR exists |
 | `pretool-branch-safety` | Bash | Blocks `git commit` when on `main` or `master` branch |
 | `pretool-config-protection` | Write, Edit, MultiEdit | Blocks modifications to linter/formatter config files (ESLint, Prettier, Biome, Ruff, golangci-lint, etc.) |
 | `pretool-plan-gate` | Write, Edit | Blocks implementation in `agents/`, `skills/` when `task_plan.md` does not exist |

--- a/hooks/hook-version-parity-check.py
+++ b/hooks/hook-version-parity-check.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+SessionStart Hook: Hook-Version Parity Check
+
+Warn-only guard for the "merged is not deployed" gotcha: a hook change lands
+on main but ~/.claude/hooks/ still runs the old copy (worktree sessions skip
+sync-to-user-claude; copy-mode installs drift until the next main-repo sync),
+so telemetry hooks silently starve the feedback loop.
+
+Compares the `# hook-version: X.Y.Z` header of every repo hook .py against
+the deployed copy in ~/.claude/hooks/. On any mismatch (or a deployed file
+missing entirely) it emits ONE warning line naming the drifted hooks and the
+sync command. On full parity it stays silent.
+
+Skip conditions (silent):
+- Not the toolkit repo (no hooks/sync-to-user-claude.py in the checkout)
+- ~/.claude/hooks resolves to this checkout's hooks/ dir (symlink install —
+  drift is impossible)
+- ~/.claude/hooks does not exist (nothing deployed to compare)
+
+Design (Warn-Only Gates doctrine):
+- Never denies, never blocks — always exits 0
+- Fast (<50ms): reads only the first bytes of each file, no subprocess
+- ADR: adr/hook-version-parity-check.md
+"""
+
+import os
+import re
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from hook_utils import context_output, empty_output
+
+EVENT_NAME = "SessionStart"
+
+# Deployed hooks location. Module-level so tests can point it at a tmp dir.
+DEPLOYED_HOOKS_DIR = Path.home() / ".claude" / "hooks"
+
+# `# hook-version: X.Y.Z` header, expected within the first few lines.
+_VERSION_RE = re.compile(r"^#\s*hook-version:\s*(\S+)", re.MULTILINE)
+
+# How many drifted hook names the one-line warning spells out.
+_MAX_NAMED = 10
+
+SYNC_CMD = "python3 ~/.claude/hooks/sync-to-user-claude.py"
+
+
+def read_hook_version(path: Path) -> str | None:
+    """Return the hook-version header value, or None (missing file/header)."""
+    try:
+        head = path.open("r", encoding="utf-8", errors="replace").read(512)
+    except OSError:
+        return None
+    m = _VERSION_RE.search(head)
+    return m.group(1) if m else None
+
+
+def find_drifted_hooks(repo_hooks: Path, deployed_hooks: Path) -> list[str]:
+    """Names of repo hooks whose deployed copy is missing or version-differs.
+
+    Only files carrying a version header participate: a header-less repo file
+    has nothing to compare, so it is skipped (bumping headers on change is the
+    convention that feeds this check). A deployed copy that is missing or
+    lacks the repo's header counts as drift — it is running older code.
+    """
+    drifted: list[str] = []
+    for repo_file in sorted(repo_hooks.rglob("*.py")):
+        rel = repo_file.relative_to(repo_hooks)
+        if "tests" in rel.parts or "__pycache__" in rel.parts:
+            continue
+        repo_version = read_hook_version(repo_file)
+        if repo_version is None:
+            continue
+        deployed_version = read_hook_version(deployed_hooks / rel)
+        if deployed_version != repo_version:
+            drifted.append(str(rel))
+    return drifted
+
+
+def build_warning(drifted: list[str]) -> str:
+    """One line: count, names (capped), and the fix command."""
+    named = ", ".join(drifted[:_MAX_NAMED])
+    more = f" (+{len(drifted) - _MAX_NAMED} more)" if len(drifted) > _MAX_NAMED else ""
+    return (
+        f"[hook-parity] WARNING: {len(drifted)} deployed hook(s) differ from this checkout: "
+        f"{named}{more} — merged is not deployed; run: {SYNC_CMD}"
+    )
+
+
+def main() -> None:
+    debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
+
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())).resolve()
+    repo_hooks = project_dir / "hooks"
+    if not (repo_hooks / "sync-to-user-claude.py").is_file():
+        # Not the toolkit repo — nothing to compare.
+        empty_output(EVENT_NAME).print_and_exit()
+        return
+
+    deployed = DEPLOYED_HOOKS_DIR
+    if not deployed.is_dir():
+        if debug:
+            print(f"[hook-parity] no deployed hooks dir at {deployed}", file=sys.stderr)
+        empty_output(EVENT_NAME).print_and_exit()
+        return
+    try:
+        if deployed.resolve() == repo_hooks.resolve():
+            # Symlink install pointing at this checkout — drift impossible.
+            empty_output(EVENT_NAME).print_and_exit()
+            return
+    except OSError:
+        pass
+
+    drifted = find_drifted_hooks(repo_hooks, deployed)
+    if not drifted:
+        if debug:
+            print("[hook-parity] all deployed hook versions match", file=sys.stderr)
+        empty_output(EVENT_NAME).print_and_exit()
+        return
+
+    msg = build_warning(drifted)
+    print(msg, file=sys.stderr)
+    context_output(EVENT_NAME, msg).print_and_exit()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise  # Let sys.exit(0) propagate normally
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            traceback.print_exc(file=sys.stderr)
+        else:
+            print(f"[hook-parity] Error: {type(e).__name__}: {e}", file=sys.stderr)
+        # Crashed hook must fail open — never block session start.
+    finally:
+        sys.exit(0)

--- a/hooks/lib/route_events.py
+++ b/hooks/lib/route_events.py
@@ -64,6 +64,8 @@ def record_decision_event(
     agent: str,
     skill: str,
     complexity: str = "",
+    complexity_invalid: str = "",
+    stack: list[str] | None = None,
     health_at_decision: float | None = None,
     n: int | None = None,
     failure: int | None = None,
@@ -87,24 +89,33 @@ def record_decision_event(
     marker carried no `health=` token (state c, legacy/missing wiring). This
     distinguishes "no-row, but instrumented" from "never instrumented" — null
     health_at_decision alone cannot. Additive field; old readers ignore it.
+
+    complexity is the NORMALIZED enum value (trivial/simple/medium/complex) or
+    "". complexity_invalid carries a raw marker value that failed validation
+    (e.g. "Low") — written only when non-empty, so the bad value is kept for
+    audit instead of dropped. stack is the parsed ` stack={s1,s2}` marker token;
+    written only when present, so stack-free markers write unchanged events.
     """
-    _append(
-        {
-            "type": "decision",
-            "ts": time.time(),
-            "session": session or "",
-            "request_snippet": (request_snippet or "")[:200],
-            "agent": agent or "",
-            "skill": skill or "",
-            "complexity": complexity or "",
-            "health_at_decision": health_at_decision,
-            "n": n,
-            "failure": failure,
-            "action": action,
-            "alternates": alternates,
-            "gate_inputs_present": gate_inputs_present,
-        }
-    )
+    event: dict[str, Any] = {
+        "type": "decision",
+        "ts": time.time(),
+        "session": session or "",
+        "request_snippet": (request_snippet or "")[:200],
+        "agent": agent or "",
+        "skill": skill or "",
+        "complexity": complexity or "",
+        "health_at_decision": health_at_decision,
+        "n": n,
+        "failure": failure,
+        "action": action,
+        "alternates": alternates,
+        "gate_inputs_present": gate_inputs_present,
+    }
+    if complexity_invalid:
+        event["complexity_invalid"] = complexity_invalid
+    if stack is not None:
+        event["stack"] = stack
+    _append(event)
 
 
 def record_outcome_event(

--- a/hooks/pretool-adr-creation-gate.py
+++ b/hooks/pretool-adr-creation-gate.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-# hook-version: 1.1.0
+# hook-version: 1.2.0
 """
 PreToolUse:Write Hook: ADR Creation Gate
 
-Blocks creation of new agent/skill/pipeline component files when no ADR
+Blocks creation of new agent/skill/pipeline/hook component files when no ADR
 exists for that component.
 
 This is a HARD GATE — exits 0 with JSON permissionDecision:deny to block the Write tool.
@@ -18,6 +18,8 @@ that, the directory basename of the project root.
 Detection logic:
 - Tool is Write (edits to existing files pass through)
 - Target path matches /agents/<name>.md, /skills/<name>/SKILL.md,
+  /pipelines/<name>/SKILL.md, or /hooks/<name>.py (top level; lib/ and
+  tests/ never match)
 - The target file does not already exist on disk (new creation only)
 - ADR not found in either lookup path
 
@@ -50,6 +52,11 @@ _AGENT_RE = re.compile(r"/agents/([^/]+)\.md$")
 _SKILL_RE = re.compile(r"/skills/(?:[^/]+/)?([^/]+)/SKILL\.md$")
 # Match pipelines/foo-bar/SKILL.md → "foo-bar"
 _PIPELINE_RE = re.compile(r"/pipelines/([^/]+)/SKILL\.md$")
+# Match hooks/foo-bar.py → "foo-bar". Top-level hook files only: lib/ and
+# tests/ paths carry an extra segment so [^/]+ never matches them. Hooks are
+# the component class PHILOSOPHY.md calls hardest to govern — same
+# ADR-before-creation rule as agents/skills/pipelines.
+_HOOK_RE = re.compile(r"/hooks/([^/]+)\.py$")
 
 # Path-shape allowlist for components whose creation is governed by an upstream
 # skill's own methodology, not by a per-component ADR. Mirrors the allowlist in
@@ -158,9 +165,10 @@ def _extract_component_name(file_path: str) -> str | None:
         Component name string, or None if the path is not a component file.
     """
     normalised = file_path.replace("\\", "/")
-    for pattern in (_AGENT_RE, _SKILL_RE, _PIPELINE_RE):
+    for pattern in (_AGENT_RE, _SKILL_RE, _PIPELINE_RE, _HOOK_RE):
         match = pattern.search(normalised)
-        if match:
+        if match and match.group(1) != "__init__":
+            # __init__.py is packaging, not a hook component.
             return match.group(1)
     return None
 

--- a/hooks/pretool-adr-creation-gate.py
+++ b/hooks/pretool-adr-creation-gate.py
@@ -19,7 +19,8 @@ Detection logic:
 - Tool is Write (edits to existing files pass through)
 - Target path matches /agents/<name>.md, /skills/<name>/SKILL.md,
   /pipelines/<name>/SKILL.md, or /hooks/<name>.py (top level; lib/ and
-  tests/ never match)
+  tests/ never match; hook gating applies only in toolkit-shaped repos —
+  agents/ and skills/ dirs beside the hooks/ dir)
 - The target file does not already exist on disk (new creation only)
 - ADR not found in either lookup path
 
@@ -55,8 +56,27 @@ _PIPELINE_RE = re.compile(r"/pipelines/([^/]+)/SKILL\.md$")
 # Match hooks/foo-bar.py → "foo-bar". Top-level hook files only: lib/ and
 # tests/ paths carry an extra segment so [^/]+ never matches them. Hooks are
 # the component class PHILOSOPHY.md calls hardest to govern — same
-# ADR-before-creation rule as agents/skills/pipelines.
+# ADR-before-creation rule as agents/skills/pipelines. UNLIKE the sibling
+# patterns, this rule is scoped to toolkit-shaped repos (_is_toolkit_repo):
+# the gate runs user-level in every repo, and a random project's hooks/ dir
+# (git hooks, cookiecutter layouts) must not be denied with toolkit-specific
+# ADR guidance.
 _HOOK_RE = re.compile(r"/hooks/([^/]+)\.py$")
+
+
+def _is_toolkit_repo(root: Path) -> bool:
+    """Toolkit marker: agents/ AND skills/ dirs at the repo root.
+
+    Same detection convention as sync-to-user-claude.py and the PR pipeline's
+    toolkit-only phases. ``root`` is the directory CONTAINING the matched
+    hooks/ dir, derived from the target path itself (not cwd), so a Write
+    into another repo is judged by that repo's own shape.
+    """
+    try:
+        return (root / "agents").is_dir() and (root / "skills").is_dir()
+    except OSError:
+        return False
+
 
 # Path-shape allowlist for components whose creation is governed by an upstream
 # skill's own methodology, not by a per-component ADR. Mirrors the allowlist in
@@ -165,12 +185,23 @@ def _extract_component_name(file_path: str) -> str | None:
         Component name string, or None if the path is not a component file.
     """
     normalised = file_path.replace("\\", "/")
-    for pattern in (_AGENT_RE, _SKILL_RE, _PIPELINE_RE, _HOOK_RE):
+    for pattern in (_AGENT_RE, _SKILL_RE, _PIPELINE_RE):
         match = pattern.search(normalised)
-        if match and match.group(1) != "__init__":
-            # __init__.py is packaging, not a hook component.
+        if match:
             return match.group(1)
-    return None
+    # Hooks: match the lexically resolved path so hooks/sub/../new.py cannot
+    # skip the pattern. Normalization is scoped to the hook rule so sibling
+    # pattern behavior is unchanged.
+    resolved = os.path.normpath(normalised).replace("\\", "/")
+    match = _HOOK_RE.search(resolved)
+    if match is None or match.group(1) == "__init__":
+        # __init__.py is packaging, not a hook component.
+        return None
+    # Opt-in scoping: gate hooks only in toolkit-shaped repos (see _HOOK_RE).
+    repo_root = Path(resolved[: match.start()] or "/")
+    if not _is_toolkit_repo(repo_root):
+        return None
+    return match.group(1)
 
 
 def main() -> None:

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.1.0
+# hook-version: 1.2.0
 """
 PostToolUse Hook: Routing Decision Recorder (action A, formerly /do Phase 5)
 
@@ -80,7 +80,9 @@ EVENT_NAME = "PostToolUse"
 # /do routing decision; agent + skill are read straight from it. Sub-agent
 # fan-out (pr-review reviewers, nested dispatches) carries no marker → skipped.
 #   [do-route] agent=python-general-engineer skill=test-driven-development complexity=Medium
-# skill may be empty/"-"/absent (agent-only routing).
+# skill may be empty/"-"/absent (agent-only routing). The same line may carry
+# optional tokens: health=/n=/fail=/action=/alts= (Step 1.5 gate inputs) and
+# stack={s1,s2} (the composed skill stack, instrumentation only).
 # Anchored to line start (^\s*, MULTILINE) so a quoted/forwarded marker
 # mid-prose (e.g. a user pasting "...the [do-route] line...") doesn't get
 # recorded — only a marker /do itself emitted at the head of a line counts.
@@ -92,6 +94,18 @@ _DO_ROUTE_RE = re.compile(
 # Optional complexity field on the same marker line, recorded into the T3 event
 # log for replay. Absent => "".
 _COMPLEXITY_RE = re.compile(r"\bcomplexity=([a-z0-9-]+)", re.IGNORECASE)
+
+# The router's complexity enum (do/SKILL.md Phase 1). Marker values are
+# lowercased and validated against it: production events carried both case
+# splits ("medium" vs "Medium") and invalid values ("Low"), which fragmented
+# per-complexity aggregation. Valid => store normalized; invalid => store ""
+# and keep the raw value in the event's complexity_invalid field for audit.
+_VALID_COMPLEXITY = frozenset({"trivial", "simple", "medium", "complex"})
+
+# Optional stack token on the marker line: ` stack={s1,s2}` — the skill stack
+# the router composed for this dispatch. Instrumentation only: parsed onto the
+# decision event as a list; absent token => no field. Same charset as alts=.
+_STACK_RE = re.compile(r"\bstack=\{([a-z0-9:_,-]*)\}", re.IGNORECASE)
 
 # Step 1.5 health gate inputs on the same marker line (do/SKILL.md Phase 4 Step 2).
 # Each is an independent \b token. `health=-` => null (no weight row); else float.
@@ -188,6 +202,43 @@ def parse_health_inputs(prompt: str) -> HealthGateInputs:
         "alternates": [k for k in altm.group(1).split(",") if k] if altm else None,
         "gate_inputs_present": True,
     }
+
+
+def parse_marker_complexity(marker_text: str) -> tuple[str, str]:
+    """Read complexity off the marker LINE: (normalized, invalid_raw).
+
+    Scoped to the marker line (same rationale as parse_health_inputs, Finding
+    70): a task body mentioning `complexity=...` must not be read as the
+    router's value. Returns:
+      valid value   => ("medium", "")   — lowercased, in _VALID_COMPLEXITY
+      invalid value => ("", "Low")      — raw kept for the complexity_invalid
+                                          event field, never silently dropped
+      absent        => ("", "")
+    """
+    line = _marker_line(marker_text)
+    m = _COMPLEXITY_RE.search(line)
+    if not m:
+        return "", ""
+    raw = m.group(1)
+    normalized = raw.lower()
+    if normalized in _VALID_COMPLEXITY:
+        return normalized, ""
+    return "", raw
+
+
+def parse_stack(marker_text: str) -> list[str] | None:
+    """Read the optional ` stack={s1,s2}` token off the marker LINE, or None.
+
+    None when the token is absent (or empty) => the decision event carries no
+    stack field. Instrumentation only — the router spec change that EMITS the
+    token lands separately; this parser is forward-tolerant of it.
+    """
+    line = _marker_line(marker_text)
+    m = _STACK_RE.search(line)
+    if not m:
+        return None
+    items = [s for s in m.group(1).split(",") if s]
+    return items or None
 
 
 # Right-sizing banner. The first four fields are required; findings= and the
@@ -446,8 +497,8 @@ def main() -> None:
             # T3: per-dispatch DECISION event (JSONL), append-only + failure-safe.
             # Auxiliary to the aggregate row above — never blocks; route_events
             # swallows write errors so the hook stays non-blocking.
-            cm = _COMPLEXITY_RE.search(marker_text)
-            complexity = cm.group(1) if cm else ""
+            complexity, complexity_invalid = parse_marker_complexity(marker_text)
+            stack = parse_stack(marker_text)
             health = parse_health_inputs(marker_text)
             from route_events import record_decision_event
 
@@ -457,6 +508,8 @@ def main() -> None:
                 agent=agent,
                 skill=skill,
                 complexity=complexity,
+                complexity_invalid=complexity_invalid,
+                stack=stack,
                 health_at_decision=health["health"],  # real gate inputs from the marker (Step 1.5)
                 n=health["n"],
                 failure=health["failure"],

--- a/hooks/tests/test_hook_version_parity.py
+++ b/hooks/tests/test_hook_version_parity.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tests for the hook-version-parity-check SessionStart hook.
+
+Covers:
+- Warns (context injection) when a deployed hook's version header differs.
+- Missing deployed file counts as drift.
+- Silent on full parity, outside the toolkit repo, and when the deployed dir
+  resolves to the checkout's hooks/ dir (symlink install).
+- Header-less repo files are skipped (nothing to compare).
+- Always exits 0 (subprocess, empty stdin).
+
+Run with: python3 -m pytest hooks/tests/test_hook_version_parity.py -v
+"""
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+HOOK_PATH = Path(__file__).parent.parent / "hook-version-parity-check.py"
+
+spec = importlib.util.spec_from_file_location("hook_version_parity_check", HOOK_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+def _hook_file(path: Path, version: str | None) -> None:
+    """Write a minimal hook file, optionally carrying a version header."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = f"# hook-version: {version}\n" if version else ""
+    path.write_text(f"#!/usr/bin/env python3\n{header}pass\n")
+
+
+def _toolkit_repo(root: Path) -> Path:
+    """Make root look like the toolkit repo; return its hooks dir."""
+    repo_hooks = root / "hooks"
+    _hook_file(repo_hooks / "sync-to-user-claude.py", "1.0.0")
+    return repo_hooks
+
+
+def _run_main(project_dir: Path, deployed_dir: Path) -> str:
+    """Run mod.main() with dirs pointed at tmp; return captured stdout."""
+    stdout = io.StringIO()
+    with (
+        patch.dict("os.environ", {"CLAUDE_PROJECT_DIR": str(project_dir)}),
+        patch.object(mod, "DEPLOYED_HOOKS_DIR", deployed_dir),
+        patch("sys.stdout", stdout),
+    ):
+        try:
+            mod.main()
+        except SystemExit:
+            pass
+    return stdout.getvalue()
+
+
+def _context(output: str) -> str:
+    """Extract additionalContext from the hook's JSON stdout, or ""."""
+    if not output.strip():
+        return ""
+    parsed = json.loads(output.strip())
+    return parsed.get("hookSpecificOutput", {}).get("additionalContext", "") or ""
+
+
+class TestFindDriftedHooks:
+    def test_version_mismatch_is_drift(self, tmp_path):
+        repo = tmp_path / "repo-hooks"
+        deployed = tmp_path / "deployed"
+        _hook_file(repo / "recorder.py", "1.2.0")
+        _hook_file(deployed / "recorder.py", "1.1.0")
+        assert mod.find_drifted_hooks(repo, deployed) == ["recorder.py"]
+
+    def test_missing_deployed_file_is_drift(self, tmp_path):
+        repo = tmp_path / "repo-hooks"
+        deployed = tmp_path / "deployed"
+        deployed.mkdir()
+        _hook_file(repo / "brand-new.py", "1.0.0")
+        assert mod.find_drifted_hooks(repo, deployed) == ["brand-new.py"]
+
+    def test_matching_versions_no_drift(self, tmp_path):
+        repo = tmp_path / "repo-hooks"
+        deployed = tmp_path / "deployed"
+        _hook_file(repo / "recorder.py", "1.2.0")
+        _hook_file(deployed / "recorder.py", "1.2.0")
+        assert mod.find_drifted_hooks(repo, deployed) == []
+
+    def test_headerless_repo_file_skipped(self, tmp_path):
+        # No version header => nothing to compare => never reported.
+        repo = tmp_path / "repo-hooks"
+        deployed = tmp_path / "deployed"
+        deployed.mkdir()
+        _hook_file(repo / "legacy.py", None)
+        assert mod.find_drifted_hooks(repo, deployed) == []
+
+    def test_tests_and_pycache_excluded(self, tmp_path):
+        repo = tmp_path / "repo-hooks"
+        deployed = tmp_path / "deployed"
+        deployed.mkdir()
+        _hook_file(repo / "tests" / "test_x.py", "9.9.9")
+        _hook_file(repo / "__pycache__" / "junk.py", "9.9.9")
+        _hook_file(repo / "lib" / "helper.py", "1.0.0")  # lib IS compared
+        assert mod.find_drifted_hooks(repo, deployed) == ["lib/helper.py"]
+
+
+class TestMainBehavior:
+    def test_warns_on_mismatch(self, tmp_path):
+        repo_hooks = _toolkit_repo(tmp_path / "repo")
+        deployed = tmp_path / "deployed"
+        _hook_file(repo_hooks / "drifty.py", "2.0.0")
+        _hook_file(deployed / "drifty.py", "1.0.0")
+        _hook_file(deployed / "sync-to-user-claude.py", "1.0.0")
+        ctx = _context(_run_main(tmp_path / "repo", deployed))
+        assert "[hook-parity] WARNING" in ctx
+        assert "drifty.py" in ctx
+        assert "sync-to-user-claude.py" in ctx  # the fix command names the sync script
+        assert "python3 ~/.claude/hooks/sync-to-user-claude.py" in ctx
+
+    def test_silent_on_parity(self, tmp_path):
+        repo_hooks = _toolkit_repo(tmp_path / "repo")
+        deployed = tmp_path / "deployed"
+        _hook_file(repo_hooks / "steady.py", "1.0.0")
+        _hook_file(deployed / "steady.py", "1.0.0")
+        _hook_file(deployed / "sync-to-user-claude.py", "1.0.0")
+        assert _context(_run_main(tmp_path / "repo", deployed)) == ""
+
+    def test_silent_outside_toolkit_repo(self, tmp_path):
+        # No hooks/sync-to-user-claude.py in the checkout => not the toolkit.
+        (tmp_path / "repo" / "hooks").mkdir(parents=True)
+        deployed = tmp_path / "deployed"
+        _hook_file(deployed / "anything.py", "1.0.0")
+        assert _context(_run_main(tmp_path / "repo", deployed)) == ""
+
+    def test_silent_when_deployed_is_symlink_to_checkout(self, tmp_path):
+        # Symlink install: ~/.claude/hooks -> <repo>/hooks. Drift impossible.
+        repo_hooks = _toolkit_repo(tmp_path / "repo")
+        _hook_file(repo_hooks / "any.py", "1.0.0")
+        deployed = tmp_path / "deployed-link"
+        deployed.symlink_to(repo_hooks)
+        assert _context(_run_main(tmp_path / "repo", deployed)) == ""
+
+    def test_silent_when_no_deployed_dir(self, tmp_path):
+        _toolkit_repo(tmp_path / "repo")
+        assert _context(_run_main(tmp_path / "repo", tmp_path / "missing")) == ""
+
+
+class TestNonBlocking:
+    def test_exit_zero_on_empty_stdin(self):
+        p = subprocess.run([sys.executable, str(HOOK_PATH)], input="", capture_output=True, text=True)
+        assert p.returncode == 0
+
+    def test_exit_zero_with_unreadable_project_dir(self, tmp_path):
+        p = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input="",
+            capture_output=True,
+            text=True,
+            env={"CLAUDE_PROJECT_DIR": str(tmp_path / "nope"), "PATH": "/usr/bin:/bin", "HOME": str(tmp_path)},
+        )
+        assert p.returncode == 0

--- a/hooks/tests/test_pretool_adr_creation_gate.py
+++ b/hooks/tests/test_pretool_adr_creation_gate.py
@@ -153,17 +153,28 @@ class TestADRCreationGate:
 
 class TestHookCreationGate:
     """New hooks/*.py files are components too: ADR-before-Write, same hard
-    gate as agents/skills/pipelines. Edits to existing hooks stay allowed;
-    hooks/lib/ and hooks/tests/ files are infrastructure, not components."""
+    gate as agents/skills/pipelines — but ONLY in toolkit-shaped repos
+    (agents/ + skills/ dirs beside hooks/). The gate runs user-level in every
+    repo, so a random project's hooks/ dir must pass through. Edits to
+    existing hooks stay allowed; hooks/lib/ and hooks/tests/ files are
+    infrastructure, not components."""
+
+    @staticmethod
+    def _mark_toolkit(tmp: str) -> None:
+        """Give tmp the toolkit shape: agents/ and skills/ at the root."""
+        (Path(tmp) / "agents").mkdir()
+        (Path(tmp) / "skills").mkdir()
 
     def test_new_hook_without_adr_blocked(self):
         with tempfile.TemporaryDirectory() as tmp:
+            self._mark_toolkit(tmp)
             target = Path(tmp) / "hooks" / "shiny-new-hook.py"
             payload = _make_write_event(str(target), cwd=tmp)
             assert _run_main(payload) == 2
 
     def test_new_hook_with_adr_allowed(self):
         with tempfile.TemporaryDirectory() as tmp:
+            self._mark_toolkit(tmp)
             adr_dir = Path(tmp) / "adr"
             adr_dir.mkdir()
             (adr_dir / "shiny-new-hook.md").write_text("# ADR\n")
@@ -171,9 +182,18 @@ class TestHookCreationGate:
             payload = _make_write_event(str(target), cwd=tmp)
             assert _run_main(payload) == 0
 
+    def test_new_hook_in_non_toolkit_repo_passes(self):
+        """No agents/+skills/ beside hooks/ => not the toolkit => never denied
+        (git hooks dirs, cookiecutter layouts, other projects)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "hooks" / "post-receive.py"
+            payload = _make_write_event(str(target), cwd=tmp)
+            assert _run_main(payload) == 0
+
     def test_existing_hook_edit_allowed(self):
         """Overwriting an existing hook file is an update, not a creation."""
         with tempfile.TemporaryDirectory() as tmp:
+            self._mark_toolkit(tmp)
             hooks_dir = Path(tmp) / "hooks"
             hooks_dir.mkdir()
             target = hooks_dir / "existing-hook.py"
@@ -184,6 +204,7 @@ class TestHookCreationGate:
     def test_hook_lib_and_tests_files_not_gated(self):
         """Nested hooks/lib/ and hooks/tests/ paths are not hook components."""
         with tempfile.TemporaryDirectory() as tmp:
+            self._mark_toolkit(tmp)
             for rel in ("hooks/lib/new_helper.py", "hooks/tests/test_new_hook.py"):
                 target = Path(tmp) / rel
                 payload = _make_write_event(str(target), cwd=tmp)
@@ -192,12 +213,27 @@ class TestHookCreationGate:
     def test_hook_init_py_not_gated(self):
         """hooks/__init__.py is packaging, not a component."""
         with tempfile.TemporaryDirectory() as tmp:
+            self._mark_toolkit(tmp)
             target = Path(tmp) / "hooks" / "__init__.py"
             payload = _make_write_event(str(target), cwd=tmp)
             assert _run_main(payload) == 0
 
+    def test_traversal_path_still_gated(self):
+        """hooks/sub/../new.py resolves to hooks/new.py — the gate matches the
+        normalized path, so traversal cannot skip the pattern."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._mark_toolkit(tmp)
+            target = f"{tmp}/hooks/sub/../sneaky-hook.py"
+            payload = _make_write_event(target, cwd=tmp)
+            assert _run_main(payload) == 2
+
     def test_extract_component_name_for_hook(self):
-        assert mod._extract_component_name("/repo/hooks/my-hook.py") == "my-hook"
-        assert mod._extract_component_name("/repo/hooks/lib/util.py") is None
-        assert mod._extract_component_name("/repo/hooks/tests/test_x.py") is None
-        assert mod._extract_component_name("/repo/hooks/__init__.py") is None
+        with tempfile.TemporaryDirectory() as tmp:
+            self._mark_toolkit(tmp)
+            assert mod._extract_component_name(f"{tmp}/hooks/my-hook.py") == "my-hook"
+            assert mod._extract_component_name(f"{tmp}/hooks/sub/../my-hook.py") == "my-hook"
+            assert mod._extract_component_name(f"{tmp}/hooks/lib/util.py") is None
+            assert mod._extract_component_name(f"{tmp}/hooks/tests/test_x.py") is None
+            assert mod._extract_component_name(f"{tmp}/hooks/__init__.py") is None
+        # Non-toolkit root: hook paths are not components at all.
+        assert mod._extract_component_name("/no-such-toolkit/hooks/my-hook.py") is None

--- a/hooks/tests/test_pretool_adr_creation_gate.py
+++ b/hooks/tests/test_pretool_adr_creation_gate.py
@@ -149,3 +149,55 @@ class TestADRCreationGate:
     def test_malformed_json_fails_open(self):
         """Invalid JSON must exit cleanly without blocking."""
         assert _run_main("not valid json {{{") == 0
+
+
+class TestHookCreationGate:
+    """New hooks/*.py files are components too: ADR-before-Write, same hard
+    gate as agents/skills/pipelines. Edits to existing hooks stay allowed;
+    hooks/lib/ and hooks/tests/ files are infrastructure, not components."""
+
+    def test_new_hook_without_adr_blocked(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "hooks" / "shiny-new-hook.py"
+            payload = _make_write_event(str(target), cwd=tmp)
+            assert _run_main(payload) == 2
+
+    def test_new_hook_with_adr_allowed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adr_dir = Path(tmp) / "adr"
+            adr_dir.mkdir()
+            (adr_dir / "shiny-new-hook.md").write_text("# ADR\n")
+            target = Path(tmp) / "hooks" / "shiny-new-hook.py"
+            payload = _make_write_event(str(target), cwd=tmp)
+            assert _run_main(payload) == 0
+
+    def test_existing_hook_edit_allowed(self):
+        """Overwriting an existing hook file is an update, not a creation."""
+        with tempfile.TemporaryDirectory() as tmp:
+            hooks_dir = Path(tmp) / "hooks"
+            hooks_dir.mkdir()
+            target = hooks_dir / "existing-hook.py"
+            target.write_text("# hook\n")
+            payload = _make_write_event(str(target), cwd=tmp)
+            assert _run_main(payload) == 0
+
+    def test_hook_lib_and_tests_files_not_gated(self):
+        """Nested hooks/lib/ and hooks/tests/ paths are not hook components."""
+        with tempfile.TemporaryDirectory() as tmp:
+            for rel in ("hooks/lib/new_helper.py", "hooks/tests/test_new_hook.py"):
+                target = Path(tmp) / rel
+                payload = _make_write_event(str(target), cwd=tmp)
+                assert _run_main(payload) == 0, rel
+
+    def test_hook_init_py_not_gated(self):
+        """hooks/__init__.py is packaging, not a component."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "hooks" / "__init__.py"
+            payload = _make_write_event(str(target), cwd=tmp)
+            assert _run_main(payload) == 0
+
+    def test_extract_component_name_for_hook(self):
+        assert mod._extract_component_name("/repo/hooks/my-hook.py") == "my-hook"
+        assert mod._extract_component_name("/repo/hooks/lib/util.py") is None
+        assert mod._extract_component_name("/repo/hooks/tests/test_x.py") is None
+        assert mod._extract_component_name("/repo/hooks/__init__.py") is None

--- a/hooks/tests/test_routing_decision_recorder.py
+++ b/hooks/tests/test_routing_decision_recorder.py
@@ -465,7 +465,8 @@ class TestWorkflowDecisionRecorder:
         by_agent = {d["agent"]: d for d in decisions}
         assert by_agent["python-general-engineer"]["skill"] == "go-patterns"
         assert by_agent["hook-development-engineer"]["skill"] == "pr-workflow"
-        assert all(d["complexity"] == "Complex" for d in decisions)
+        # complexity is normalized to the lowercase enum at record time.
+        assert all(d["complexity"] == "complex" for d in decisions)
         # marker A: health=- => no weight row but instrumented.
         da = by_agent["python-general-engineer"]
         assert da["health_at_decision"] is None and da["gate_inputs_present"] is True
@@ -557,7 +558,7 @@ class TestWorkflowDecisionRecorder:
         decisions = [e for e in _read_events(db_env) if e["type"] == "decision"]
         assert len(decisions) == 1
         assert decisions[0]["request_snippet"] == "do work"
-        assert decisions[0]["complexity"] == "Medium"
+        assert decisions[0]["complexity"] == "medium"  # normalized enum value
         assert [p["key"] for p in ros.peek_pending_outcomes("wf-agent-reg")] == ["python-general-engineer:go-patterns"]
 
 
@@ -1325,6 +1326,129 @@ class TestHealthMarkerLineScoping:
         ex.assert_called_with(0)  # still non-blocking
         err = capsys.readouterr().err
         assert "routing-decision-recorder: RuntimeError: forced failure" in err
+
+
+# ---------------------------------------------------------------------------
+# Complexity enum normalization + optional stack= token on the marker
+# ---------------------------------------------------------------------------
+
+
+class TestComplexityNormalization:
+    """The recorder lowercases the marker's complexity and validates it against
+    the router enum {trivial, simple, medium, complex}. Valid => normalized
+    value stored. Invalid (production carried `Low`) => complexity "" and the
+    raw value kept in complexity_invalid — recorded, never dropped. Read from
+    the marker LINE only (same scoping as the health gate inputs)."""
+
+    def _record(self, a, marker, session):
+        event = _health_event(marker, session=session)
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+
+    def test_valid_complexity_case_normalized(self, db_env, monkeypatch):
+        # Production case-split: `Medium` and `medium` must land as ONE value.
+        a = _load(A_PATH, "rdr_cx_case")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        self._record(a, "[do-route] agent=python-general-engineer skill=go-patterns complexity=Medium", "cx-case")
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["complexity"] == "medium"
+        assert "complexity_invalid" not in d
+
+    def test_invalid_complexity_recorded_not_dropped(self, db_env, monkeypatch):
+        # Production invalid value `Low`: normalized field stays "", the raw
+        # value lands in complexity_invalid, and the decision event + routing
+        # row are STILL recorded.
+        a = _load(A_PATH, "rdr_cx_invalid")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        self._record(a, "[do-route] agent=python-general-engineer skill=go-patterns complexity=Low", "cx-invalid")
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["complexity"] == ""
+        assert d["complexity_invalid"] == "Low"
+        keys = {r["key"] for r in _query_routing(db_env)}
+        assert "python-general-engineer:go-patterns" in keys  # event not dropped
+
+    def test_absent_complexity_is_empty_without_invalid_field(self, db_env, monkeypatch):
+        a = _load(A_PATH, "rdr_cx_absent")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        self._record(a, "[do-route] agent=python-general-engineer skill=go-patterns", "cx-absent")
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["complexity"] == ""
+        assert "complexity_invalid" not in d
+
+    def test_body_complexity_not_read(self, db_env, monkeypatch):
+        # Marker-line scoping: a body mentioning complexity= must not be read
+        # (same rationale as the health gate inputs, Finding 70).
+        a = _load(A_PATH, "rdr_cx_body")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        event = _health_event("[do-route] agent=python-general-engineer skill=go-patterns", session="cx-body")
+        event["tool_input"]["prompt"] += "\nThe old complexity=Weird value must be ignored."
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        d = next(e for e in _read_events(db_env) if e["type"] == "decision")
+        assert d["complexity"] == ""
+        assert "complexity_invalid" not in d
+
+
+class TestStackTokenParse:
+    """Optional ` stack={s1,s2}` marker token => decision event `stack` list.
+    Absent (or empty) token => NO field, so stack-free markers write unchanged
+    events. Instrumentation only — the router emits the token in a later PR."""
+
+    def _decision(self, db_env, monkeypatch, marker, session, body_suffix=""):
+        a = _load(A_PATH, f"rdr_stack_{session}")
+        monkeypatch.setattr(a, "append_pending_outcome", lambda *_a, **_k: None)
+        monkeypatch.setattr(a, "claim_dispatch", lambda *_a, **_k: True)
+        event = _health_event(marker, session=session)
+        if body_suffix:
+            event["tool_input"]["prompt"] += body_suffix
+        with patch("sys.exit"), patch("sys.stdin.read", return_value=json.dumps(event)):
+            a.main()
+        return next(e for e in _read_events(db_env) if e["type"] == "decision")
+
+    def test_stack_token_parsed_to_list(self, db_env, monkeypatch):
+        d = self._decision(
+            db_env,
+            monkeypatch,
+            "[do-route] agent=python-general-engineer skill=go-patterns "
+            "complexity=Medium stack={test-driven-development,pr-workflow}",
+            "yes",
+        )
+        assert d["stack"] == ["test-driven-development", "pr-workflow"]
+        assert d["complexity"] == "medium"  # sibling tokens still parse
+
+    def test_absent_stack_token_writes_no_field(self, db_env, monkeypatch):
+        d = self._decision(
+            db_env,
+            monkeypatch,
+            "[do-route] agent=python-general-engineer skill=go-patterns complexity=Medium",
+            "no",
+        )
+        assert "stack" not in d
+
+    def test_empty_stack_braces_write_no_field(self, db_env, monkeypatch):
+        d = self._decision(
+            db_env,
+            monkeypatch,
+            "[do-route] agent=python-general-engineer skill=go-patterns stack={}",
+            "empty",
+        )
+        assert "stack" not in d
+
+    def test_stack_in_body_ignored(self, db_env, monkeypatch):
+        # Marker-line scoping: a body mentioning stack={...} is prose, not a
+        # router token.
+        d = self._decision(
+            db_env,
+            monkeypatch,
+            "[do-route] agent=python-general-engineer skill=go-patterns",
+            "body",
+            body_suffix="\nDiscuss the stack={a,b} syntax in the docs.",
+        )
+        assert "stack" not in d
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Four fixes to the hook layer — the small Python programs that record how `/do` routes work and that guard component creation. Together they make routing telemetry cleaner, add a new telemetry field, extend governance to hooks themselves, and warn when deployed hooks fall behind the repo.

## Changes
- `hooks/routing-decision-recorder.py` — routing events used to store complexity exactly as typed, so the log held both `medium` and `Medium` (76 vs 181 events) plus invalid values like `Low`. The recorder now lowercases the value and checks it against the real set (trivial/simple/medium/complex); anything invalid is kept for audit in a new `complexity_invalid` field instead of polluting the main field or vanishing. Complexity is also read only from the routing marker line, so prose in a task body can no longer be mistaken for the router's value.
- `hooks/routing-decision-recorder.py` — the recorder now understands an optional ` stack={s1,s2}` token on the routing marker and records it as a `stack` list on the decision event; markers without the token write exactly the same events as before. Recording side only: the router change that emits the token ships in a separate PR.
- `hooks/pretool-adr-creation-gate.py` — the "write a design note (ADR) before creating a new component" gate covered agents, skills, and pipelines but not hooks — the component class PHILOSOPHY.md calls hardest to govern. New top-level `hooks/*.py` files now need an ADR first; editing existing hooks, and files under `hooks/lib/` or `hooks/tests/`, stay ungated.
- `hooks/hook-version-parity-check.py` (new) — merging a hook change does not deploy it, so `~/.claude/hooks/` can silently run stale code and starve telemetry. This SessionStart check compares version headers between the repo checkout and the deployed copies; on any difference it prints one warning naming the drifted hooks and the exact sync command. Warn-only: it never blocks anything, and it stays silent on symlink installs where drift is impossible.
- `.claude/settings.json` — register the new SessionStart check (after sync, so it only reports residual drift).
- `hooks/tests/` — 20 new tests across the three areas: invalid complexity is recorded not dropped, case is normalized, stack parses and absent-token is a no-op, the gate fires on new hook files but not on edits/lib/tests, and the parity check warns on mismatch and stays silent on match.
- `hooks/README.md`, `docs/for-ai-wizards.md`, `docs/injected-context-contracts.md` — document the new hook, its `[hook-parity]` warning tag, and the widened gate.

## Notes
- ADR for the new hook is at `adr/hook-version-parity-check.md` (the `adr/` directory is gitignored by design, so it is local-only and not in this diff).
- Created from a worktree agent; the caller should remove the worktree (`git worktree remove`) before deleting the branch.
