### PR TITLE
feat(routing): replay regression corpus expansion + router-self-audit script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AI agents skip steps.
 Harnesses have a second problem: given only a skill list, they do not route eagerly enough, or correctly enough. Good skills sit unused. So this toolkit connects the skills, agents, and workflows we want directly into the harness, automatically. You don't have to understand what is here. Say what you want in plain English and you get all the value we have put into it: the right specialist with the right methodology, behind gates that demand exit codes, not assertions.
 
 <!-- Counts here must match the Four Layers table (~line 143). Verify both: python3 scripts/validate-doc-counts.py -->
-44 domain agents, 133 workflow skills, 84 hooks, 126 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
+44 domain agents, 133 workflow skills, 84 hooks, 127 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
 
 Works across Claude Code (`/do`), Codex (`$do`), Factory (`/do`), Reasonix (`/do`).
 
@@ -148,7 +148,7 @@ Strips built-in tool-use instructions. The toolkit's agents, skills, hooks, and 
 | Agents | 44 | Domain knowledge: idiom tables, failure mode catalogs, error-to-fix mappings |
 | Skills | 133 | Phased methodology with gates. Can't skip steps. Each phase has exit criteria requiring evidence. |
 | Hooks | 83 | Fire on lifecycle events. Block incomplete work. Zero LLM cost. |
-| Scripts | 126 | Determinism: test runners, linters, validators. No LLM judgment. |
+| Scripts | 127 | Determinism: test runners, linters, validators. No LLM judgment. |
 
 Full skill catalog: [docs/skills.md](docs/skills.md).
 

--- a/scripts/router-self-audit.py
+++ b/scripts/router-self-audit.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Composite /do router health check — manual-run only.
+
+MANUAL-RUN ONLY: do not install this script as a cron job, systemd unit or
+timer, shell startup entry, or any other scheduled/background job. Persistence
+requires explicit owner approval (OWNER-APPROVED-PERSISTENCE); ADR
+router-improvement-program ships C3 manual-run only.
+
+One composite report over four checks, exit 0/1:
+  1. manifest     — routing-manifest.py output byte size + merged skill/agent
+                    entry counts (via the live pre-route.py loader).
+  2. merged-index — validate-merged-index.py --strict findings: phantom files,
+                    dead agent refs, missing fields, "NOT: " doubling.
+  3. replay-suite — pass rate of the route-replay regression corpus
+                    (routing-benchmark.json tiers + pre-route corpus pins),
+                    run through pytest.
+  4. drift        — check-routing-drift.py: every INDEX skill appears in the
+                    routing manifest.
+
+Usage:
+    python3 scripts/router-self-audit.py
+
+Exit codes:
+    0 — all checks passed
+    1 — one or more checks failed
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "scripts"
+
+# Replay regression corpus runners: the benchmark-fixture replay
+# (test_routing_accuracy.py) plus the pre-route corpus pins.
+REPLAY_TEST_FILES = (
+    "scripts/tests/test_routing_accuracy.py",
+    "scripts/tests/test_pre_route_planning.py",
+    "scripts/tests/test_pre_route_pr_workflow.py",
+    "scripts/tests/test_pre_route_public_web_deploy.py",
+)
+
+_SUBPROCESS_TIMEOUT = 300  # seconds; replay suite shells pytest over ~180 cases
+
+
+@dataclass
+class CheckResult:
+    """Outcome of one audit check."""
+
+    name: str
+    ok: bool
+    summary: str
+    detail: str = ""
+
+
+def _run(cmd: list[str], timeout: int = _SUBPROCESS_TIMEOUT) -> subprocess.CompletedProcess[str]:
+    """Run a command, capturing text output. Raises on timeout/missing binary."""
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        timeout=timeout,
+        check=False,
+    )
+
+
+def parse_pytest_counts(output: str) -> tuple[int, int]:
+    """Parse (passed, failed) from pytest terminal output.
+
+    Reads the summary tokens ("2 failed, 146 passed in 12.3s"). Errors count
+    as failures. Returns (0, 0) when no summary is found.
+
+    Args:
+        output: Full pytest stdout.
+
+    Returns:
+        Tuple of (passed count, failed+error count).
+    """
+    passed = failed = 0
+    for count, kind in re.findall(r"(\d+) (passed|failed|error)", output):
+        if kind == "passed":
+            passed = int(count)
+        else:
+            failed += int(count)
+    return passed, failed
+
+
+def check_manifest() -> CheckResult:
+    """Report routing-manifest byte size and merged index entry counts."""
+    proc = _run([sys.executable, str(SCRIPTS / "routing-manifest.py")])
+    if proc.returncode != 0:
+        return CheckResult("manifest", False, f"routing-manifest.py exited {proc.returncode}", proc.stderr.strip())
+    size = len(proc.stdout.encode("utf-8"))
+
+    # Count entries through the live pre-route loader (merged tracked+local,
+    # regenerates a missing INDEX) so the audit sees what the router sees.
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    pre_route = importlib.import_module("pre-route")
+    entries = pre_route.load_entries()
+    skills = sum(1 for e in entries if e["type"] == "skill")
+    agents = sum(1 for e in entries if e["type"] == "agent")
+    return CheckResult(
+        "manifest",
+        True,
+        f"{size} bytes; merged entries: {skills} skills, {agents} agents",
+    )
+
+
+def check_merged_index() -> CheckResult:
+    """Run validate-merged-index.py --strict; fail on critical/error findings."""
+    proc = _run([sys.executable, str(SCRIPTS / "validate-merged-index.py"), "--strict"])
+    tail = proc.stdout.strip().splitlines()
+    summary = tail[-1] if tail else "no output"
+    ok = proc.returncode == 0
+    detail = "" if ok else proc.stdout.strip()
+    return CheckResult("merged-index", ok, summary, detail)
+
+
+def check_replay_suite() -> CheckResult:
+    """Run the replay regression corpus through pytest; fail on any failure."""
+    cmd = [sys.executable, "-m", "pytest", "-q", "--tb=line", "-p", "no:cacheprovider", *REPLAY_TEST_FILES]
+    try:
+        proc = _run(cmd)
+    except FileNotFoundError:
+        return CheckResult("replay-suite", False, "pytest not available")
+    passed, failed = parse_pytest_counts(proc.stdout)
+    total = passed + failed
+    if total == 0:
+        return CheckResult("replay-suite", False, "no replay cases collected", proc.stdout.strip()[-2000:])
+    rate = 100.0 * passed / total
+    ok = failed == 0 and proc.returncode == 0
+    detail = "" if ok else proc.stdout.strip()[-2000:]
+    return CheckResult("replay-suite", ok, f"{passed}/{total} passed ({rate:.1f}%)", detail)
+
+
+def check_drift() -> CheckResult:
+    """Run check-routing-drift.py; fail when a skill is missing from the manifest."""
+    proc = _run([sys.executable, str(SCRIPTS / "check-routing-drift.py")])
+    lines = proc.stdout.strip().splitlines()
+    ok = proc.returncode == 0
+    default = "OK (all INDEX skills present in manifest)" if ok else f"exit {proc.returncode}"
+    summary = lines[-1] if lines else default
+    detail = "" if ok else (proc.stdout + proc.stderr).strip()
+    return CheckResult("drift", ok, summary, detail)
+
+
+def main() -> int:
+    """Run all checks and print the composite report."""
+    checks = (check_manifest, check_merged_index, check_replay_suite, check_drift)
+    results: list[CheckResult] = []
+    for check in checks:
+        try:
+            results.append(check())
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            results.append(CheckResult(check.__name__.removeprefix("check_"), False, f"{type(exc).__name__}: {exc}"))
+
+    print("Router Self-Audit")
+    print("=================")
+    for r in results:
+        status = "PASS" if r.ok else "FAIL"
+        print(f"[{status}] {r.name:13} {r.summary}")
+        if r.detail:
+            for line in r.detail.splitlines():
+                print(f"       {line}")
+    all_ok = all(r.ok for r in results)
+    print()
+    print(f"RESULT: {'PASS' if all_ok else 'FAIL'}")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/routing-benchmark.json
+++ b/scripts/routing-benchmark.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.3",
-  "description": "Canonical routing benchmark for /do router regression testing. Each test case pairs a natural-language request with its expected agent and/or skill. Used to detect silent routing regressions when models or routing tables change. routing_tier classifies how strictly the router is expected to match: force_route (script must fire correct force_route), candidate (correct answer in top-3), llm_only (no false-positive force-route expected).",
+  "version": "1.4",
+  "description": "Canonical routing benchmark for /do router regression testing. Each test case pairs a natural-language request with its expected agent and/or skill. Used to detect silent routing regressions when models or routing tables change. routing_tier classifies how strictly the router is expected to match: force_route (script must fire correct force_route), candidate (correct answer in top-3), llm_only (no false-positive force-route expected). Two pre-route tiers exercise pre-route.py (the /do deterministic safety net): pre_route_only (must match the expected route), pre_route_negative (must not force-route; idiom guards, D7 planning classes, fallthroughs, and sanitized route-events history patterns).",
   "test_cases": [
     {
       "request": "push my changes to GitHub",
@@ -651,6 +651,318 @@
       "category": "false-positive-guard",
       "routing_tier": "llm_only",
       "notes": "Gathering CI failure context, not a news pipeline \u2014 must NOT route to news-collection ('the' breaks the 'collect news' trigger)"
+    },
+    {
+      "request": "push back on this design",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "Disagreement idiom, not git push - pre-route must not force-route (guard word 'back')"
+    },
+    {
+      "request": "fish out the bug",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "Search idiom, not the Fish shell - phrase guard 'fish out' must suppress"
+    },
+    {
+      "request": "commit to a decision",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "Resolve idiom, not git commit - pre-route must not force-route"
+    },
+    {
+      "request": "merge ideas in your head",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "Thinking idiom, not git merge - phrase guard 'merge ideas' must suppress"
+    },
+    {
+      "request": "commit to a decision by friday",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "Deadline idiom, not git commit - pre-route must not force-route"
+    },
+    {
+      "request": "push back on the proposed architecture",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "Disagreement idiom, not git push - guard word 'back' must suppress"
+    },
+    {
+      "request": "merge these ideas into one proposal",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "Synthesis idiom, not git merge - phrase guard 'merge ideas' must suppress"
+    },
+    {
+      "request": "ship of theseus argument about identity",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "Philosophy idiom, not shipping code - phrase guard 'ship of theseus' must suppress"
+    },
+    {
+      "request": "review my essay draft",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "Prose review, not a code/PR review - guard word 'essay' must suppress"
+    },
+    {
+      "request": "publish a paper on distributed consensus",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "Academic publishing, not publishing code - phrase guard 'publish a paper' must suppress"
+    },
+    {
+      "request": "make the parser thread safe",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "Concurrency mechanics, not a security review - 'code safe' guard word 'thread' must suppress"
+    },
+    {
+      "request": "break this function into smaller pieces",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "Refactor phrasing - 'break into' routes to security-review only with an intrusion companion"
+    },
+    {
+      "request": "upload my work to google drive",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "File sync, not version control - phrase guard 'google drive' must suppress"
+    },
+    {
+      "request": "continue debugging the flaky integration test",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "planning-d7-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "D7 class 'continue': ordinary work continuation, not a plan-lifecycle request"
+    },
+    {
+      "request": "resume playback where the video stopped",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "planning-d7-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "D7 class 'resume': media control, not a plan-lifecycle request"
+    },
+    {
+      "request": "pause the batch job while we investigate",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "planning-d7-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "D7 class 'pause': process control, not a plan-lifecycle request"
+    },
+    {
+      "request": "unsure whether this cache is stale",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "planning-d7-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "D7 class 'unsure': uncertainty about a fact, not a plan-lifecycle request"
+    },
+    {
+      "request": "hand off the request to the load balancer",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "planning-d7-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "D7 class 'handoff': traffic routing, not a session handoff"
+    },
+    {
+      "request": "explain how the scheduler picks the next job",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "fallthrough",
+      "routing_tier": "pre_route_negative",
+      "notes": "Explanation request with no trigger keywords - must fall through to semantic routing"
+    },
+    {
+      "request": "what does this regex match",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "fallthrough",
+      "routing_tier": "pre_route_negative",
+      "notes": "Quick question with no trigger keywords - must fall through"
+    },
+    {
+      "request": "rename the helper for clarity",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "fallthrough",
+      "routing_tier": "pre_route_negative",
+      "notes": "Small edit with no trigger keywords - must fall through"
+    },
+    {
+      "request": "summarize the differences between these two configs",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "fallthrough",
+      "routing_tier": "pre_route_negative",
+      "notes": "Comparison request with no trigger keywords - must fall through"
+    },
+    {
+      "request": "root-cause the ranking bug in the report",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "History pattern: debugging requests route semantically (systematic-debugging); pre-route must not force-route"
+    },
+    {
+      "request": "go live with the feature flag rollout",
+      "expected_agent": null,
+      "expected_skill": null,
+      "category": "false-positive-guard",
+      "routing_tier": "pre_route_negative",
+      "notes": "Feature launch idiom, not a web deploy - 'go live' needs a deploy companion word"
+    },
+    {
+      "request": "commit these changes and push to origin",
+      "expected_agent": null,
+      "expected_skill": "pr-workflow",
+      "category": "git-operations",
+      "routing_tier": "pre_route_only",
+      "notes": "Commit+push intent must force-route to pr-workflow so git quality gates always run"
+    },
+    {
+      "request": "git push my branch and open a pull request",
+      "expected_agent": null,
+      "expected_skill": "pr-workflow",
+      "category": "git-operations",
+      "routing_tier": "pre_route_only",
+      "notes": "Push+PR intent must force-route to pr-workflow"
+    },
+    {
+      "request": "check whether CI went green on my pull request",
+      "expected_agent": null,
+      "expected_skill": "pr-workflow",
+      "category": "git-operations",
+      "routing_tier": "pre_route_only",
+      "notes": "CI status on a submitted change - supplemental trigger 'went green' must fire"
+    },
+    {
+      "request": "push my work, open a PR, and watch the checks",
+      "expected_agent": null,
+      "expected_skill": "pr-workflow",
+      "category": "git-operations",
+      "routing_tier": "pre_route_only",
+      "notes": "History pattern (push, PR, CI, merge requests): must force-route to pr-workflow"
+    },
+    {
+      "request": "stage and commit my changes",
+      "expected_agent": null,
+      "expected_skill": "pr-workflow",
+      "category": "git-operations",
+      "routing_tier": "pre_route_only",
+      "notes": "Stage+commit intent must force-route to pr-workflow"
+    },
+    {
+      "request": "submit my changes for review",
+      "expected_agent": null,
+      "expected_skill": "pr-workflow",
+      "category": "git-operations",
+      "routing_tier": "pre_route_only",
+      "notes": "Paraphrased git intent - supplemental trigger 'submit changes' must fire"
+    },
+    {
+      "request": "run a security review on the upload handler",
+      "expected_agent": null,
+      "expected_skill": "security-review",
+      "category": "security",
+      "routing_tier": "pre_route_only",
+      "notes": "Explicit security review must force-route to security-review"
+    },
+    {
+      "request": "check whether anyone could break into this server",
+      "expected_agent": null,
+      "expected_skill": "security-review",
+      "category": "security",
+      "routing_tier": "pre_route_only",
+      "notes": "Intrusion phrasing - 'break into' with companion 'anyone' must force-route"
+    },
+    {
+      "request": "did I leave any passwords or keys in the code",
+      "expected_agent": null,
+      "expected_skill": "security-review",
+      "category": "security",
+      "routing_tier": "pre_route_only",
+      "notes": "Secret-leak check - supplemental trigger 'passwords keys' must fire"
+    },
+    {
+      "request": "scan this diff for security vulnerabilities",
+      "expected_agent": null,
+      "expected_skill": "security-review",
+      "category": "security",
+      "routing_tier": "pre_route_only",
+      "notes": "Vulnerability scan must force-route to security-review"
+    },
+    {
+      "request": "is this endpoint code safe to expose",
+      "expected_agent": null,
+      "expected_skill": "security-review",
+      "category": "security",
+      "routing_tier": "pre_route_only",
+      "notes": "Safety question about code - 'code safe' trigger with no mechanics guard word must fire"
+    },
+    {
+      "request": "resume the plan for the schema migration",
+      "expected_agent": null,
+      "expected_skill": "planning",
+      "category": "planning-d7-guard",
+      "routing_tier": "pre_route_only",
+      "notes": "D7 positive class: plan resume must keep force-route (new phrasing; originals in test_pre_route_planning.py)"
+    },
+    {
+      "request": "pause the plan until the review lands",
+      "expected_agent": null,
+      "expected_skill": "planning",
+      "category": "planning-d7-guard",
+      "routing_tier": "pre_route_only",
+      "notes": "D7 positive class: plan pause must keep force-route"
+    },
+    {
+      "request": "create a plan for splitting the monolith",
+      "expected_agent": null,
+      "expected_skill": "planning",
+      "category": "planning-d7-guard",
+      "routing_tier": "pre_route_only",
+      "notes": "D7 positive class: plan creation must keep force-route"
+    },
+    {
+      "request": "run the go tests for the parser package",
+      "expected_agent": null,
+      "expected_skill": "go-patterns",
+      "category": "go-development",
+      "routing_tier": "pre_route_only",
+      "notes": "History pattern (Go test/fix traffic): go test intent must force-route to go-patterns"
     }
   ]
 }

--- a/scripts/tests/test_router_self_audit.py
+++ b/scripts/tests/test_router_self_audit.py
@@ -1,0 +1,40 @@
+"""Unit tests for scripts/router-self-audit.py helpers.
+
+The audit script shells to four other scripts; those have their own tests.
+Here we pin the pure pieces: the pytest-summary parser and the replay
+test-file list (a renamed file would silently shrink the audited suite).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+audit = importlib.import_module("router-self-audit")
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("148 passed in 12.30s", (148, 0)),
+        ("2 failed, 146 passed in 11.02s", (146, 2)),
+        ("1 error in 0.10s", (0, 1)),
+        ("1 failed, 1 error, 10 passed in 2.00s", (10, 2)),
+        ("no tests ran in 0.01s", (0, 0)),
+        ("", (0, 0)),
+    ],
+)
+def test_parse_pytest_counts(output: str, expected: tuple[int, int]) -> None:
+    """Summary tokens parse into (passed, failed+errors)."""
+    assert audit.parse_pytest_counts(output) == expected
+
+
+def test_replay_test_files_exist() -> None:
+    """Every audited replay test file exists — a rename must update the audit."""
+    for rel in audit.REPLAY_TEST_FILES:
+        assert (REPO_ROOT / rel).is_file(), f"replay test file missing: {rel}"

--- a/scripts/tests/test_routing_accuracy.py
+++ b/scripts/tests/test_routing_accuracy.py
@@ -304,6 +304,37 @@ class TestPreRoute:
             )
 
 
+class TestPreRouteNegative:
+    """pre-route.py must NOT force-route these requests (tier: pre_route_negative).
+
+    The corpus pins idiom guards ("push back on this design"), the D7 planning
+    unigram classes (continue/resume/pause/unsure/handoff — originals in
+    test_pre_route_planning.py), pure fallthroughs, and sanitized patterns from
+    route-events history. A force-route here would override the semantic route
+    in /do Phase 2, so any force_route match at any confidence is a failure.
+    The corpus is the contract: if a phrase fails, fix the trigger or guard,
+    do not drop the case. See adr/router-improvement-program.md (C3).
+    """
+
+    @pytest.mark.parametrize(
+        "case",
+        _tier_cases("pre_route_negative"),
+        ids=_case_id,
+    )
+    def test_no_force_route(self, case: dict) -> None:
+        """Assert pre-route.py fires no force_route for the request.
+
+        Args:
+            case: Test case dict from routing-benchmark.json.
+        """
+        result = run_pre_route(case["request"])
+        assert result.get("match_type") != "force_route", (
+            f"{case['request']!r} must not force-route but got "
+            f"skill={result.get('skill')!r} agent={result.get('agent')!r} "
+            f"confidence={result.get('confidence')!r}. Reasoning: {result.get('reasoning')}"
+        )
+
+
 class TestCoverageReport:
     """Advisory benchmark-coverage report in routing-benchmark.py.
 


### PR DESCRIPTION
Implements ADR `router-improvement-program` component C3: turn routing history into a regression suite and ship a manual-run router health check.

## What changed

**Replay corpus: +39 cases (80 → 119) in `scripts/routing-benchmark.json` (v1.4)**

No new harness. The existing replay stack is extended: `scripts/routing-benchmark.py` (structural CI check) validates the new cases' targets, and `scripts/tests/test_routing_accuracy.py` (CI pytest job) replays them as pre-route.py decisions.

New tier `pre_route_negative` (24 cases — pre-route.py must not force-route at any confidence):
- Idiom guards: "push back on this design", "fish out the bug", "commit to a decision", "merge ideas in your head", + 9 more
- D7 planning classes (continue/resume/pause/unsure/handoff) in new phrasings — originals stay pinned in `scripts/tests/test_pre_route_planning.py`
- Pure fallthroughs (4)
- Sanitized route-events history patterns (debugging, feature-launch idiom)

Existing tier `pre_route_only` (+15 cases — pre-route.py must match the expected route):
- Git force-routes → pr-workflow (6, incl. history pattern "push my work, open a PR, and watch the checks")
- Security force-routes → security-review (5)
- D7 planning positives → planning (3)
- History-derived go test intent → go-patterns (1)

History-derived cases are task-shaped patterns generalized from route-events.jsonl; no raw user text was copied.

**Runner: `TestPreRouteNegative` added to `scripts/tests/test_routing_accuracy.py`** — replays the new tier through pre-route.py and fails on any force_route match.

**`scripts/router-self-audit.py` (new, manual-run only)** — composite router health report, exit 0/1:
- manifest byte size + merged skill/agent entry counts (via the live pre-route loader)
- `validate-merged-index.py --strict` findings
- replay-suite pass rate (benchmark tiers + pre-route corpus pins)
- `check-routing-drift.py` result

Docstring forbids cron/systemd/background installation: persistence requires `OWNER-APPROVED-PERSISTENCE` (ADR out-of-scope). Unit tests pin the pytest-summary parser and the audited file list.

## Mutation proof (corpus flips fail the run)

Flipped `"run the go tests for the parser package"` expected_skill go-patterns → pr-workflow:

```
FAILED scripts/tests/test_routing_accuracy.py::TestPreRoute::test_pre_route_matches[run the go tests for the parser package]
AssertionError: Expected skill='pr-workflow', got 'go-patterns'. Reasoning: matched triggers ['go test'] for go-patterns
1 failed, 122 passed — exit 1
```

Reverted; suite green (123 passed).

## Self-audit output

```
Router Self-Audit
=================
[PASS] manifest      36817 bytes; merged entries: 133 skills, 43 agents
[PASS] merged-index  VERDICT: PASS (--strict)
[PASS] replay-suite  255/255 passed (100.0%)
[PASS] drift         OK (all INDEX skills present in manifest)

RESULT: PASS
exit: 0
```

## Verification

- `python3 scripts/routing-benchmark.py` → 119/119 valid targets
- Replay + corpus pin tests → 262 passed
- Full pytest suite green (3.12 local; CI covers 3.10)
- `ruff check` + `ruff format --check` clean; mypy and bandit clean on the new script

ADR: `adr/router-improvement-program.md` C3 (local-only file).
