### PR TITLE
feat(do): deterministic dispatch builder — build-dispatch.py + Phase 4 rewire

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AI agents skip steps.
 Harnesses have a second problem: given only a skill list, they do not route eagerly enough, or correctly enough. Good skills sit unused. So this toolkit connects the skills, agents, and workflows we want directly into the harness, automatically. You don't have to understand what is here. Say what you want in plain English and you get all the value we have put into it: the right specialist with the right methodology, behind gates that demand exit codes, not assertions.
 
 <!-- Counts here must match the Four Layers table (~line 143). Verify both: python3 scripts/validate-doc-counts.py -->
-44 domain agents, 133 workflow skills, 84 hooks, 126 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
+44 domain agents, 133 workflow skills, 84 hooks, 127 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
 
 Works across Claude Code (`/do`), Codex (`$do`), Factory (`/do`), Reasonix (`/do`).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AI agents skip steps.
 Harnesses have a second problem: given only a skill list, they do not route eagerly enough, or correctly enough. Good skills sit unused. So this toolkit connects the skills, agents, and workflows we want directly into the harness, automatically. You don't have to understand what is here. Say what you want in plain English and you get all the value we have put into it: the right specialist with the right methodology, behind gates that demand exit codes, not assertions.
 
 <!-- Counts here must match the Four Layers table (~line 143). Verify both: python3 scripts/validate-doc-counts.py -->
-44 domain agents, 133 workflow skills, 84 hooks, 127 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
+44 domain agents, 133 workflow skills, 84 hooks, 128 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
 
 Works across Claude Code (`/do`), Codex (`$do`), Factory (`/do`), Reasonix (`/do`).
 

--- a/scripts/build-dispatch.py
+++ b/scripts/build-dispatch.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Deterministic /do Phase 4 dispatch-preamble builder (ADR: router-improvement-program, C4).
+
+Takes one routing decision as JSON and prints the complete dispatch-prompt
+preamble the router prepends to the agent prompt. Hand-assembly of these
+blocks dropped mandatory injections; this script is the single source of
+truth for every one of them ("LLMs orchestrate, programs execute"):
+
+  1. `[do-route]` marker line — full grammar: agent/skill/complexity,
+     health gate inputs (`health= n= fail= action=` or `health=-`),
+     optional `alts={...}`, optional `stack={...}`. Emitted in the exact
+     shape hooks/routing-decision-recorder.py parses.
+  2. Thinking directive by complexity, with slow/fast category overrides.
+  3. Token-budget line (input value, else `orchestration.token_budget`
+     from .claude/settings.json, default 500000).
+  4. Task Specification block from the provided fields.
+  5. The four MANDATORY verbatim injections: reference loading,
+     completeness, Dense-Complete Writing, base instructions.
+  6. Optional worktree rules and LOCAL-ONLY block, on flags.
+
+Input schema (missing optional fields degrade gracefully — block omitted):
+
+    {
+      "agent": "python-general-engineer",          // required
+      "skill": "test-driven-development",          // optional; empty => skill=-
+      "complexity": "medium",                      // required enum, case-insensitive:
+                                                   // trivial|simple|medium|complex
+      "health": {"confidence": 0.72, "n": 6,       // optional; absent/blank
+                 "failure": 0, "action": "keep",   // confidence => health=-
+                 "alts": ["a:b", "c:d"]},
+      "stack": ["s1", "s2"],                       // optional
+      "task_spec": {"intent": "...", "constraints": "...", "acceptance": "...",
+                    "files": "...", "operator_context": "..."},
+      "flags": {"worktree": false, "local_only": false,
+                "thinking_override": "slow"|"fast"|null},
+      "token_remaining": 480000                    // optional
+    }
+
+Usage:
+    python3 scripts/build-dispatch.py --json '<routing decision JSON>'
+    python3 scripts/build-dispatch.py --json-file /tmp/route.json   # "-" = stdin
+
+Exit codes:
+    0 — preamble printed to stdout
+    2 — invalid input (message on stderr, nothing on stdout)
+
+Stdlib only. Deterministic: same input, same output, byte for byte.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SETTINGS_PATH = REPO_ROOT / ".claude" / "settings.json"
+DEFAULT_TOKEN_BUDGET = 500000
+
+# ---------------------------------------------------------------------------
+# Verbatim injection texts — the ONE place they live. skills/meta/do/SKILL.md
+# Phase 4 Step 2 points here instead of quoting them. Changing a word here
+# changes every dispatched prompt; keep in lockstep with the files each cites.
+# ---------------------------------------------------------------------------
+
+INJ_REFERENCE_LOADING = (
+    "Before starting work, read your agent .md file to find the Reference Loading Table. "
+    "Load EVERY reference file whose signal matches this task. "
+    "Load greedily — if multiple signals match, load all matching references."
+)
+
+INJ_COMPLETENESS = "Deliver the finished product. Ship the complete thing."
+
+INJ_DENSE_COMPLETE = (
+    "Write to the Dense-Complete Writing standard — your structural guide for everything you do. "
+    "It governs your output, code comments, any skill or reference files you write, "
+    "AND every one of your thinking turns: "
+    "(1) shortest accurate word; "
+    "(2) cut every word that carries no instruction, rule, or decision; "
+    "(3) plain English, not jargon; "
+    "(4) concrete over abstract; "
+    "(5) heavy qualifications in separate short sentences; "
+    "(6) Completeness: treat content as fixed and wording as negotiable: "
+    "carry every required point through the draft, then choose the shortest plain words "
+    "that say those points exactly. "
+    "Say everything the task needs and not one word more. Report what changed, not how. "
+    "Full rules: `skills/shared-patterns/dense-complete-writing.md`."
+)
+
+INJ_BASE_INSTRUCTIONS = "Before starting work, also load `agents/base-instructions.md` for universal operational rules."
+
+THINKING_FAST = "Prioritize responding quickly rather than thinking deeply. When in doubt, respond directly."
+
+THINKING_SLOW = "Think carefully and step-by-step before responding; this problem is harder than it looks."
+
+WORKTREE_RULES = (
+    "Worktree rules: Verify CWD contains .claude/worktrees/. Create feature branch before edits. "
+    "Skip task_plan.md. Stage specific files only."
+)
+
+# Injection template from skills/shared-patterns/local-only.md.
+LOCAL_ONLY_BLOCK = (
+    "**LOCAL-ONLY MODE.** Do not push, commit, create PRs, or deploy. "
+    "All work stays on disk. Read-only git is fine. The user will decide when to commit."
+)
+
+# ---------------------------------------------------------------------------
+# Marker grammar. Charsets mirror hooks/routing-decision-recorder.py exactly,
+# so every emitted marker is parseable by the real recorder — the round-trip
+# tests (scripts/tests/test_build_dispatch.py) assert it against that parser.
+# ---------------------------------------------------------------------------
+
+VALID_COMPLEXITY = ("trivial", "simple", "medium", "complex")
+VALID_ACTIONS = ("keep", "demote", "tiebreak")
+
+_AGENT_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_SKILL_RE = re.compile(r"^[a-z0-9-]+$")
+_KEY_RE = re.compile(r"^[a-z0-9:_-]+$")  # alts= / stack= items (comma is the separator)
+
+# Complexity -> thinking directive. Trivial never dispatches; medium is
+# adaptive (no directive). Overrides: "slow" => THINKING_SLOW, "fast" =>
+# THINKING_FAST, regardless of complexity.
+_THINKING_BY_COMPLEXITY = {"simple": THINKING_FAST, "complex": THINKING_SLOW}
+
+# task_spec input key -> Task Specification block label, in emit order.
+_TASK_SPEC_FIELDS = (
+    ("intent", "Intent"),
+    ("constraints", "Constraints"),
+    ("acceptance", "Acceptance criteria"),
+    ("files", "Relevant file locations"),
+    ("operator_context", "Operator context"),
+)
+
+
+class InputError(ValueError):
+    """Invalid routing decision — message tells the caller what to fix."""
+
+
+def _fmt_confidence(value: float) -> str:
+    """Canonical health= float: 0.72 -> '0.72', 0.5 -> '0.5', 1.0 -> '1'.
+
+    Must match the recorder's `\\d+(\\.\\d+)?` — never scientific notation,
+    never a sign, never a trailing dot.
+    """
+    if not 0 <= value <= 1:
+        raise InputError(f"health.confidence must be within [0, 1], got {value}")
+    text = f"{value:.4f}".rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def _require_str(decision: dict, key: str) -> str:
+    value = decision.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise InputError(f"'{key}' is required and must be a non-empty string")
+    return value.strip()
+
+
+def _key_list(raw: object, field: str) -> list[str]:
+    """Validate an alts=/stack= item list; items carry no commas or spaces."""
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise InputError(f"'{field}' must be a list of strings")
+    items = [item.strip().lower() for item in raw if item.strip()]
+    for item in items:
+        if not _KEY_RE.match(item):
+            raise InputError(f"'{field}' item {item!r} — allowed chars: a-z 0-9 : _ -")
+    return items
+
+
+def build_marker(decision: dict) -> str:
+    """Build the `[do-route]` marker line from one routing decision."""
+    agent = _require_str(decision, "agent").lower()
+    if not _AGENT_RE.match(agent):
+        raise InputError(f"'agent' {agent!r} — must match [a-z0-9][a-z0-9-]*")
+
+    skill = str(decision.get("skill") or "").strip().lower()
+    if skill and skill != "-" and not _SKILL_RE.match(skill):
+        raise InputError(f"'skill' {skill!r} — must match [a-z0-9-]+")
+    skill = skill or "-"
+
+    complexity = _require_str(decision, "complexity").lower()
+    if complexity not in VALID_COMPLEXITY:
+        raise InputError(f"'complexity' {complexity!r} — must be one of {'/'.join(VALID_COMPLEXITY)}")
+
+    parts = [f"[do-route] agent={agent}", f"skill={skill}", f"complexity={complexity}"]
+
+    health = decision.get("health") or {}
+    if not isinstance(health, dict):
+        raise InputError("'health' must be an object")
+    confidence = health.get("confidence")
+    if confidence is None:
+        # No weight row for the pick — the recorder writes null but marks the
+        # gate inputs present (instrumented, state b).
+        parts.append("health=-")
+    else:
+        if not isinstance(confidence, (int, float)) or isinstance(confidence, bool):
+            raise InputError("'health.confidence' must be a number or null")
+        parts.append(f"health={_fmt_confidence(float(confidence))}")
+        for key, token in (("n", "n"), ("failure", "fail")):
+            value = health.get(key)
+            if value is None:
+                continue
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise InputError(f"'health.{key}' must be a non-negative integer")
+            parts.append(f"{token}={value}")
+        action = health.get("action")
+        if action is not None:
+            if str(action).lower() not in VALID_ACTIONS:
+                raise InputError(f"'health.action' {action!r} — must be one of {'/'.join(VALID_ACTIONS)}")
+            parts.append(f"action={str(action).lower()}")
+        alts = _key_list(health.get("alts") or [], "health.alts")
+        if alts:
+            parts.append(f"alts={','.join(alts)}")
+
+    stack = _key_list(decision.get("stack") or [], "stack")
+    if stack:
+        parts.append(f"stack={{{','.join(stack)}}}")
+
+    return " ".join(parts)
+
+
+def build_thinking(decision: dict) -> str:
+    """Thinking directive for the dispatch, or "" when adaptive/none."""
+    override = (decision.get("flags") or {}).get("thinking_override")
+    if override is not None:
+        directive = {"slow": THINKING_SLOW, "fast": THINKING_FAST}.get(str(override).lower())
+        if directive is None:
+            raise InputError(f"'flags.thinking_override' {override!r} — must be 'slow', 'fast', or null")
+        return directive
+    complexity = str(decision.get("complexity") or "").lower()
+    return _THINKING_BY_COMPLEXITY.get(complexity, "")
+
+
+def read_token_budget(settings_path: Path = SETTINGS_PATH) -> int:
+    """`orchestration.token_budget` from settings.json; 500000 on any miss."""
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        budget = settings.get("orchestration", {}).get("token_budget", DEFAULT_TOKEN_BUDGET)
+        return int(budget)
+    except Exception:
+        return DEFAULT_TOKEN_BUDGET
+
+
+def build_token_line(decision: dict, settings_path: Path = SETTINGS_PATH) -> str:
+    remaining = decision.get("token_remaining")
+    if remaining is None:
+        remaining = read_token_budget(settings_path)
+    if not isinstance(remaining, int) or isinstance(remaining, bool) or remaining < 0:
+        raise InputError("'token_remaining' must be a non-negative integer")
+    return f"~{remaining} tokens available for this task; prioritize accordingly."
+
+
+def build_task_spec(decision: dict) -> str:
+    """Task Specification block from provided fields, or "" when none given."""
+    spec = decision.get("task_spec") or {}
+    if not isinstance(spec, dict):
+        raise InputError("'task_spec' must be an object")
+    lines = []
+    for key, label in _TASK_SPEC_FIELDS:
+        value = spec.get(key)
+        if value is None or not str(value).strip():
+            continue
+        lines.append(f"**{label}:** {str(value).strip()}")
+    if not lines:
+        return ""
+    return "## Task Specification (auto-extracted)\n\n" + "\n".join(lines)
+
+
+def build_preamble(decision: dict, settings_path: Path = SETTINGS_PATH) -> str:
+    """Complete dispatch preamble, blocks in dispatch order, blank-line separated."""
+    if not isinstance(decision, dict):
+        raise InputError("routing decision must be a JSON object")
+    flags = decision.get("flags") or {}
+    if not isinstance(flags, dict):
+        raise InputError("'flags' must be an object")
+
+    blocks = [
+        build_marker(decision),
+        build_thinking(decision),
+        build_token_line(decision, settings_path),
+        build_task_spec(decision),
+        INJ_REFERENCE_LOADING,
+        INJ_COMPLETENESS,
+        INJ_DENSE_COMPLETE,
+        INJ_BASE_INSTRUCTIONS,
+        WORKTREE_RULES if flags.get("worktree") else "",
+        LOCAL_ONLY_BLOCK if flags.get("local_only") else "",
+    ]
+    return "\n\n".join(block for block in blocks if block) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build the /do Phase 4 dispatch preamble from a routing decision.")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--json", help="Routing decision as a JSON string")
+    source.add_argument("--json-file", help="Path to a routing-decision JSON file ('-' = stdin)")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.json is not None:
+            raw = args.json
+        elif args.json_file == "-":
+            raw = sys.stdin.read()
+        else:
+            raw = Path(args.json_file).read_text(encoding="utf-8")
+        decision = json.loads(raw)
+    except OSError as exc:
+        print(f"build-dispatch: cannot read input: {exc}", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as exc:
+        print(f"build-dispatch: invalid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        sys.stdout.write(build_preamble(decision))
+    except InputError as exc:
+        print(f"build-dispatch: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_build_dispatch.py
+++ b/scripts/tests/test_build_dispatch.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Tests for scripts/build-dispatch.py (ADR: router-improvement-program, C4).
+
+Covers:
+- Marker round-trip against the REAL recorder parser
+  (hooks/routing-decision-recorder.py) on 7 marker variants: agent/skill,
+  complexity, health gate inputs (numeric and `health=-`), alts, stack.
+- Preamble completeness and block order: marker first, then thinking
+  directive, token line, Task Specification, the 4 mandatory injections,
+  optional worktree/local-only blocks.
+- Thinking directive by complexity + slow/fast overrides.
+- Graceful degradation: missing optional fields omit their block only.
+- Token budget: explicit value, settings.json read, 500000 default.
+- CLI: --json / --json-file / stdin; exit 2 + empty stdout on bad input.
+
+Run with: python3 -m pytest scripts/tests/test_build_dispatch.py -v
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "build-dispatch.py"
+RECORDER_PATH = REPO_ROOT / "hooks" / "routing-decision-recorder.py"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    with patch("sys.exit"):
+        spec.loader.exec_module(mod)
+    return mod
+
+
+bd = _load(SCRIPT_PATH, "build_dispatch")
+recorder = _load(RECORDER_PATH, "routing_decision_recorder")
+
+
+def _decision(**overrides):
+    """A complete, valid routing decision; overrides replace top-level keys."""
+    base = {
+        "agent": "python-general-engineer",
+        "skill": "test-driven-development",
+        "complexity": "medium",
+        "health": {"confidence": 0.72, "n": 6, "failure": 0, "action": "keep"},
+        "stack": ["verification-before-completion"],
+        "task_spec": {
+            "intent": "Fix the flaky retry test.",
+            "constraints": "Branch from main; no force-push.",
+            "acceptance": "pytest green; CI green.",
+            "files": "scripts/retry.py, scripts/tests/test_retry.py",
+            "operator_context": "personal profile, full autonomy",
+        },
+        "flags": {"worktree": False, "local_only": False, "thinking_override": None},
+        "token_remaining": 480000,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Marker round-trip: build with the script, parse with the REAL recorder.
+# Each case: (decision overrides, expected recorder reads).
+# ---------------------------------------------------------------------------
+
+ROUND_TRIP_CASES = [
+    pytest.param(  # V1: everything — numeric health, all gate inputs, alts, stack
+        {
+            "agent": "golang-general-engineer",
+            "skill": "go-patterns",
+            "complexity": "complex",
+            "health": {
+                "confidence": 0.72,
+                "n": 6,
+                "failure": 1,
+                "action": "keep",
+                "alts": ["claude:quick", "python-general-engineer:tdd"],
+            },
+            "stack": ["test-driven-development", "verification-before-completion"],
+        },
+        {
+            "agent": "golang-general-engineer",
+            "skill": "go-patterns",
+            "complexity": "complex",
+            "health": 0.72,
+            "n": 6,
+            "failure": 1,
+            "action": "keep",
+            "alternates": ["claude:quick", "python-general-engineer:tdd"],
+            "gate_inputs_present": True,
+            "stack": ["test-driven-development", "verification-before-completion"],
+        },
+        id="full-gate-inputs-alts-stack",
+    ),
+    pytest.param(  # V2: no weight row (health=-) with a stack
+        {"health": {}, "stack": ["worktree-agent"]},
+        {
+            "agent": "python-general-engineer",
+            "skill": "test-driven-development",
+            "complexity": "medium",
+            "health": None,
+            "n": None,
+            "failure": None,
+            "action": None,
+            "alternates": None,
+            "gate_inputs_present": True,
+            "stack": ["worktree-agent"],
+        },
+        id="health-dash-with-stack",
+    ),
+    pytest.param(  # V3: agent-only routing => skill=-, recorder reads ""
+        {"skill": "", "health": None, "stack": []},
+        {
+            "agent": "python-general-engineer",
+            "skill": "",
+            "complexity": "medium",
+            "health": None,
+            "gate_inputs_present": True,
+            "stack": None,
+        },
+        id="agent-only-skill-dash",
+    ),
+    pytest.param(  # V4: numeric health alone — no n/fail/action/alts tokens
+        {"health": {"confidence": 0.5}, "stack": []},
+        {
+            "agent": "python-general-engineer",
+            "skill": "test-driven-development",
+            "complexity": "medium",
+            "health": 0.5,
+            "n": None,
+            "failure": None,
+            "action": None,
+            "alternates": None,
+            "gate_inputs_present": True,
+            "stack": None,
+        },
+        id="numeric-health-alone",
+    ),
+    pytest.param(  # V5: simple complexity, health key absent entirely
+        {"complexity": "simple", "health": None, "stack": []},
+        {
+            "agent": "python-general-engineer",
+            "skill": "test-driven-development",
+            "complexity": "simple",
+            "health": None,
+            "gate_inputs_present": True,
+            "stack": None,
+        },
+        id="simple-no-health-key",
+    ),
+    pytest.param(  # V6: confidence 1.0 formats as integer '1'; tiebreak action
+        {"health": {"confidence": 1.0, "n": 12, "failure": 0, "action": "tiebreak"}, "stack": []},
+        {
+            "agent": "python-general-engineer",
+            "skill": "test-driven-development",
+            "complexity": "medium",
+            "health": 1.0,
+            "n": 12,
+            "failure": 0,
+            "action": "tiebreak",
+            "gate_inputs_present": True,
+            "stack": None,
+        },
+        id="confidence-one-tiebreak",
+    ),
+    pytest.param(  # V7: trivial complexity, uppercase input normalized
+        {"complexity": "Trivial", "agent": "CLAUDE", "skill": "quick", "health": None, "stack": []},
+        {
+            "agent": "claude",
+            "skill": "quick",
+            "complexity": "trivial",
+            "health": None,
+            "gate_inputs_present": True,
+            "stack": None,
+        },
+        id="case-normalized-trivial",
+    ),
+]
+
+
+@pytest.mark.parametrize(("overrides", "expected"), ROUND_TRIP_CASES)
+def test_marker_round_trip_with_real_recorder(overrides, expected):
+    """Every emitted marker parses with the shipped recorder, field for field."""
+    preamble = bd.build_preamble(_decision(**overrides))
+
+    routed = recorder.parse_do_route_marker(preamble)
+    assert routed == (expected["agent"], expected["skill"])
+
+    complexity, invalid = recorder.parse_marker_complexity(preamble)
+    assert (complexity, invalid) == (expected["complexity"], "")
+
+    assert recorder.parse_stack(preamble) == expected["stack"]
+
+    health = recorder.parse_health_inputs(preamble)
+    assert health["health"] == expected["health"]
+    assert health["gate_inputs_present"] == expected["gate_inputs_present"]
+    for key in ("n", "failure", "action", "alternates"):
+        assert health[key] == expected.get(key), key
+
+
+def test_marker_is_first_line_at_line_start():
+    """The recorder anchors ^\\s*\\[do-route\\]; the marker must open line 1."""
+    preamble = bd.build_preamble(_decision())
+    assert preamble.splitlines()[0].startswith("[do-route] agent=")
+
+
+# ---------------------------------------------------------------------------
+# Preamble completeness and order.
+# ---------------------------------------------------------------------------
+
+
+def test_preamble_contains_every_mandatory_block_in_order():
+    preamble = bd.build_preamble(_decision(complexity="complex"))
+    ordered = [
+        "[do-route] agent=python-general-engineer skill=test-driven-development complexity=complex",
+        bd.THINKING_SLOW,
+        "~480000 tokens available for this task; prioritize accordingly.",
+        "## Task Specification (auto-extracted)",
+        "**Intent:** Fix the flaky retry test.",
+        "**Constraints:** Branch from main; no force-push.",
+        "**Acceptance criteria:** pytest green; CI green.",
+        "**Relevant file locations:** scripts/retry.py, scripts/tests/test_retry.py",
+        "**Operator context:** personal profile, full autonomy",
+        bd.INJ_REFERENCE_LOADING,
+        bd.INJ_COMPLETENESS,
+        bd.INJ_DENSE_COMPLETE,
+        bd.INJ_BASE_INSTRUCTIONS,
+    ]
+    pos = -1
+    for piece in ordered:
+        found = preamble.find(piece)
+        assert found > pos, f"missing or out of order: {piece[:60]!r}"
+        pos = found
+
+
+def test_worktree_and_local_only_blocks_follow_flags():
+    both = bd.build_preamble(_decision(flags={"worktree": True, "local_only": True}))
+    assert bd.WORKTREE_RULES in both
+    assert bd.LOCAL_ONLY_BLOCK in both
+    neither = bd.build_preamble(_decision())
+    assert bd.WORKTREE_RULES not in neither
+    assert bd.LOCAL_ONLY_BLOCK not in neither
+
+
+@pytest.mark.parametrize(
+    ("complexity", "override", "expected"),
+    [
+        ("simple", None, "THINKING_FAST"),
+        ("medium", None, ""),
+        ("trivial", None, ""),
+        ("complex", None, "THINKING_SLOW"),
+        ("simple", "slow", "THINKING_SLOW"),  # category override beats complexity
+        ("complex", "fast", "THINKING_FAST"),
+    ],
+)
+def test_thinking_directive_by_complexity_and_override(complexity, override, expected):
+    decision = _decision(complexity=complexity, flags={"thinking_override": override})
+    directive = bd.build_thinking(decision)
+    assert directive == (getattr(bd, expected) if expected else "")
+    if expected:
+        assert getattr(bd, expected) in bd.build_preamble(decision)
+    else:
+        assert bd.THINKING_FAST not in bd.build_preamble(decision)
+        assert bd.THINKING_SLOW not in bd.build_preamble(decision)
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation and token budget.
+# ---------------------------------------------------------------------------
+
+
+def test_missing_optional_fields_omit_their_blocks_only():
+    minimal = {"agent": "claude", "complexity": "medium"}
+    preamble = bd.build_preamble(minimal)
+    assert preamble.startswith("[do-route] agent=claude skill=- complexity=medium health=-\n")
+    assert "## Task Specification" not in preamble
+    assert "stack={" not in preamble
+    # Mandatory blocks survive the minimal input.
+    for injection in (bd.INJ_REFERENCE_LOADING, bd.INJ_COMPLETENESS, bd.INJ_DENSE_COMPLETE, bd.INJ_BASE_INSTRUCTIONS):
+        assert injection in preamble
+    assert "tokens available for this task" in preamble
+
+
+def test_partial_task_spec_emits_only_given_fields():
+    preamble = bd.build_preamble(_decision(task_spec={"intent": "Do the thing."}))
+    assert "**Intent:** Do the thing." in preamble
+    assert "**Constraints:**" not in preamble
+    assert "**Acceptance criteria:**" not in preamble
+
+
+def test_token_budget_reads_settings_and_defaults(tmp_path):
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({"orchestration": {"token_budget": 250000}}))
+    decision = _decision(token_remaining=None)
+    line = bd.build_token_line(decision, settings_path=settings)
+    assert line == "~250000 tokens available for this task; prioritize accordingly."
+    # Missing file => documented default 500000.
+    line = bd.build_token_line(decision, settings_path=tmp_path / "absent.json")
+    assert line == "~500000 tokens available for this task; prioritize accordingly."
+
+
+def test_determinism_same_input_same_bytes():
+    decision = _decision()
+    assert bd.build_preamble(decision) == bd.build_preamble(decision)
+
+
+# ---------------------------------------------------------------------------
+# Validation errors.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"agent": ""},
+        {"agent": "Bad Agent!"},
+        {"complexity": "low"},  # the audit's real-world invalid value
+        {"complexity": ""},
+        {"health": {"confidence": 1.5}},
+        {"health": {"confidence": -0.1}},
+        {"health": {"confidence": 0.5, "action": "boost"}},
+        {"health": {"confidence": 0.5, "n": -1}},
+        {"stack": ["has space"]},
+        {"flags": {"thinking_override": "deep"}},
+        {"token_remaining": -5},
+    ],
+)
+def test_invalid_input_raises(overrides):
+    with pytest.raises(bd.InputError):
+        bd.build_preamble(_decision(**overrides))
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(*args, stdin_text=None):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_json_flag_emits_preamble():
+    result = _run_cli("--json", json.dumps(_decision()))
+    assert result.returncode == 0
+    assert result.stdout == bd.build_preamble(_decision())
+
+
+def test_cli_json_file_and_stdin(tmp_path):
+    decision = _decision()
+    path = tmp_path / "route.json"
+    path.write_text(json.dumps(decision))
+    from_file = _run_cli("--json-file", str(path))
+    from_stdin = _run_cli("--json-file", "-", stdin_text=json.dumps(decision))
+    assert from_file.returncode == from_stdin.returncode == 0
+    assert from_file.stdout == from_stdin.stdout == bd.build_preamble(decision)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not json",
+        json.dumps({"complexity": "medium"}),  # agent missing
+        json.dumps({"agent": "claude", "complexity": "Low"}),  # invalid enum
+    ],
+)
+def test_cli_bad_input_exits_2_with_empty_stdout(payload):
+    result = _run_cli("--json", payload)
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "build-dispatch:" in result.stderr

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -48,7 +48,7 @@ Confidence in handling a task directly is a signal to route: direct handling ski
 
 ## Output Discipline
 
-Every word the router prints and every dispatched agent prompt follows the **Dense-Complete Writing standard** (quoted verbatim in the Phase 4 injection). Full rules: `skills/shared-patterns/dense-complete-writing.md`.
+Every word the router prints and every dispatched agent prompt follows the **Dense-Complete Writing standard** (injected verbatim by `scripts/build-dispatch.py` at Phase 4 dispatch). Full rules: `skills/shared-patterns/dense-complete-writing.md`.
 
 **User sees:** phase banners, routing decision banner, brief post-agent summary (what changed, not how).
 **Internal only:** routing JSON, classification reasoning, enhancement stacking (unless Verbose Routing ON).
@@ -249,7 +249,7 @@ Policy thresholds (for reading the recorded would-action, not for changing the r
 
 **Always log the evaluation** to the T3 event stream: set `health_at_decision` to the picked pair's `confidence` scalar (a float, or `null` when the pair has no weight row); `n` and `failure` are separate fields. The recorder writes all three from the marker onto the per-dispatch DECISION event in `<CLAUDE_LEARNING_DIR>/route-events.jsonl`. Every route is scored even though nothing changes.
 
-Carry the gate inputs on the routing marker so the recorder snapshots them at decision time — confidence alone cannot reconstruct the demote floor; it needs `n` and `failure` too. Append format and example: Phase 4 Step 2.
+Carry the gate inputs on the routing marker so the recorder snapshots them at decision time — confidence alone cannot reconstruct the demote floor; it needs `n` and `failure` too. Pass them as the `health` field of the routing JSON; `scripts/build-dispatch.py` emits the marker (Phase 4 Step 2).
 
 **Step 1: Deterministic safety-net** (reads `PRE_ROUTE_RESULT` — runs AFTER the semantic decision, never short-circuits it)
 
@@ -370,52 +370,37 @@ When Step 1b and Step 1c both apply (a Medium+ code modification that also has a
 
 Dispatch the agent. Inject no MCP instructions; tool discovery is the agent's job.
 
-**Prepend Task Specification for Medium+ tasks.** For Simple tasks, include Intent and Acceptance when extractable. Invent no criteria; expand no scope.
-
-```
-## Task Specification (auto-extracted)
-
-**Intent:** <one sentence: what does success look like?>
-**Constraints:** <branch rules, operator-context, file paths, memory feedback>
-**Acceptance criteria:** <observable: tests pass, file exists, PR merges, specific output>
-**Relevant file locations:** <paths from request + expected paths>
-**Operator context:** <from [operator-context] tag>
-```
-
-Extraction: Intent from verb+object; Constraints include branch safety (keep main protected); Acceptance = observable outcomes. For creation, add "Implementation must match ADR `<kebab-case-name>`."
-
-Four injections (verbatim): completeness and density standards on Simple+; reference-loading and base instructions on all dispatches.
-
-**MANDATORY: Reference loading.** MUST include: "Before starting work, read your agent .md file to find the Reference Loading Table. Load EVERY reference file whose signal matches this task. Load greedily — if multiple signals match, load all matching references."
-
-**MANDATORY: Completeness standard.** MUST include: "Deliver the finished product. Ship the complete thing."
-
-**MANDATORY: Dense-Complete Writing standard.** MUST include: "Write to the Dense-Complete Writing standard — your structural guide for everything you do. It governs your output, code comments, any skill or reference files you write, AND every one of your thinking turns: (1) shortest accurate word; (2) cut every word that carries no instruction, rule, or decision; (3) plain English, not jargon; (4) concrete over abstract; (5) heavy qualifications in separate short sentences; (6) Completeness: treat content as fixed and wording as negotiable: carry every required point through the draft, then choose the shortest plain words that say those points exactly. Say everything the task needs and not one word more. Report what changed, not how. Full rules: `skills/shared-patterns/dense-complete-writing.md`."
-
-**MANDATORY: Base instructions.** MUST include: "Before starting work, also load `agents/base-instructions.md` for universal operational rules."
-
-**MANDATORY: Stamp the routing marker on every routed agent prompt.** Prepend verbatim: `[do-route] agent={agent} skill={skill} complexity={complexity}` (use `skill=-` when routing agent-only). It is the SOLE signal `routing-decision-recorder` uses to record a `routing` row, reading `agent`/`skill` straight from it. Dispatches without it (pr-review sub-agents, nested fan-out) are correctly excluded from route-health. Stamp each agent in a roster.
-
-Append the Step 1.5 gate inputs to the same marker line so the recorder snapshots the route's decision-time health: ` health={confidence} n={n} fail={failure} action={keep|demote|tiebreak}`, plus ` alts={k1,k2}` when alternates were passed. When the picked pair has no weight row, append ` health=-` only (the recorder writes null). Example: `[do-route] agent=python-general-engineer skill=test-driven-development complexity=Medium health=0.72 n=6 fail=0 action=keep`.
-
-When Phase 3 stacked enhancement skills on this dispatch, append the optional ` stack={s1,s2}` token (comma-separated skill names, no spaces) to the same marker line; omit it when nothing was stacked. The recorder parses it onto the decision event — instrumentation only. Example: `[do-route] agent=golang-general-engineer skill=go-patterns complexity=Complex health=- stack={test-driven-development,verification-before-completion}`.
-
-**Token budget signal (optional, documented).** Read `orchestration.token_budget` from `.claude/settings.json` (default 500000 when absent). Subtract a rough estimate of tokens spent; prepend to each agent prompt: "~{remaining} tokens available for this task; prioritize accordingly." Advisory, not a hard cap. Read the key once per session.
+**Build the dispatch preamble with `scripts/build-dispatch.py` (MANDATORY).** The script is the single source of truth for the `[do-route]` marker grammar, the thinking directives, the token-budget line, the Task Specification skeleton, the four mandatory verbatim injections (reference loading, completeness, Dense-Complete Writing, base instructions), and the optional worktree/local-only blocks. Never hand-assemble them. Assemble one routing-decision JSON per dispatch, run the script, prepend its stdout verbatim to the agent prompt. Roster: one run per worker prompt.
 
 ```bash
-TOKEN_BUDGET=$(python3 -c "import json,sys; print(json.load(open('.claude/settings.json')).get('orchestration',{}).get('token_budget',500000))" 2>/dev/null || echo 500000)
+python3 scripts/build-dispatch.py --json '{
+  "agent": "<agent>", "skill": "<skill; omit when agent-only>",
+  "complexity": "<trivial|simple|medium|complex>",
+  "health": {"confidence": 0.72, "n": 6, "failure": 0, "action": "keep", "alts": ["k1","k2"]},
+  "stack": ["s1","s2"],
+  "task_spec": {"intent": "...", "constraints": "...", "acceptance": "...",
+                "files": "...", "operator_context": "..."},
+  "flags": {"worktree": false, "local_only": false, "thinking_override": null},
+  "token_remaining": 480000
+}'
 ```
 
-**Inject thinking directive.** Prepend verbatim, no framing:
+Field sourcing (omit any optional field; the script degrades gracefully):
 
-| Complexity | Thinking Directive |
-|---|---|
-| Trivial | None (no agent) |
-| Simple | "Prioritize responding quickly rather than thinking deeply. When in doubt, respond directly." |
-| Medium | None (adaptive) |
-| Complex | "Think carefully and step-by-step before responding; this problem is harder than it looks." |
+- `agent`/`skill`/`complexity`: the Phase 2 decision. Omitted skill => marker gets `skill=-`.
+- `health`: the Step 1.5 gate inputs (`confidence`/`n`/`failure`/`action`, `alts` when alternates were offered). Omit when the picked pair has no weight row => marker gets `health=-`. The recorder snapshots these at decision time.
+- `stack`: the Phase 3 enhancement skills stacked on this dispatch; omit when none. Instrumentation only.
+- `task_spec`: extract per the rules below. Mandatory for Medium+; for Simple include intent and acceptance when extractable. Invent no criteria; expand no scope.
+- `flags.worktree`: true for `isolation: "worktree"` agents — the script injects the worktree rules.
+- `flags.local_only`: true when Phase 3 detected local-only signals — the script injects the LOCAL-ONLY block.
+- `flags.thinking_override`: "slow" for security work, API/schema design, migrations, 5+ file reviews, architectural decisions; "fast" for lookups, status checks, single-function renames/refactors; else omit (the script picks the directive by complexity). Hooks capture the thinking class from dispatch metadata; the router records nothing.
+- `token_remaining`: `orchestration.token_budget` (`.claude/settings.json`, default 500000) minus a rough spend estimate; omit to emit the full budget. Advisory, not a hard cap.
 
-**Category overrides** (regardless of complexity): `thinking:slow` for security work, API/schema design, migrations, 5+ file reviews, architectural decisions; `thinking:fast` for lookups, status checks, single-function renames/refactors. Hooks capture the thinking class from dispatch metadata; the router sets the directive but records nothing.
+Task Specification extraction: Intent from verb+object; Constraints include branch safety (keep main protected), operator-context, memory feedback; Acceptance = observable outcomes. For creation, add "Implementation must match ADR `<kebab-case-name>`."
+
+The emitted `[do-route]` marker is the SOLE signal `routing-decision-recorder` uses to record a `routing` row, reading `agent`/`skill` straight from it. Dispatches without it (pr-review sub-agents, nested fan-out) are correctly excluded from route-health.
+
+**Fallback (script failed: non-zero exit or empty output).** Treat as "Router Script Failed" for the preamble only: hand-stamp the single line `[do-route] agent={agent} skill={skill|-} complexity={complexity} health=-` at the head of the prompt (the recorder depends on it), add the Task Specification inline, dispatch, and report the script failure.
 
 **Verb-based model dispatch for Complex tasks (3+ data sources).** Extraction verbs use parallel Haiku readers; analysis verbs a single Opus agent.
 
@@ -426,7 +411,7 @@ TOKEN_BUDGET=$(python3 -c "import json,sys; print(json.load(open('.claude/settin
 
 Simple/Medium: dispatch directly.
 
-Route to agents that create feature branches; for file modifications, include "commit your changes on the branch". For `isolation: "worktree"` agents, inject `worktree-agent` rules: "Verify CWD contains .claude/worktrees/. Create feature branch before edits. Skip task_plan.md. Stage specific files only."
+Route to agents that create feature branches; for file modifications, include "commit your changes on the branch". For `isolation: "worktree"` agents set `flags.worktree` in the routing JSON — the script injects the `worktree-agent` rules.
 
 Non-org repos: up to 3 `/pr-review` → fix iterations before PR creation. Org-gated repos (via `scripts/classify-repo.py`): require user confirmation before EACH git action.
 


### PR DESCRIPTION
ADR `router-improvement-program` component C4: /do Phase 4 dispatch assembly was hand-done per dispatch (drop risk); this makes it a program.

## What changed

- **`scripts/build-dispatch.py`** (new): takes one routing decision as JSON (`--json` / `--json-file`, `-` = stdin) and emits the complete dispatch preamble, in order: `[do-route]` marker (full grammar: agent/skill/complexity, `health= n= fail= action=` or `health=-`, optional `alts=`, optional `stack={}`), thinking directive by complexity with slow/fast overrides, token-budget line (input value, else `orchestration.token_budget`, default 500000), Task Specification block, the 4 mandatory verbatim injections (reference loading, completeness, Dense-Complete Writing, base instructions), optional worktree rules and LOCAL-ONLY block on flags. Stdlib only; exit 2 + empty stdout on invalid input; missing optional fields omit their block only.
- **`skills/meta/do/SKILL.md`** Phase 4 Step 2 rewired: build routing JSON → run the script → prepend stdout verbatim. The verbatim injection texts now live ONLY in the script (SKILL.md keeps field-sourcing rules + a hand-stamp marker fallback for script failure). 37,769 → 36,351 bytes (−1,418, −3.8%).
- **`scripts/tests/test_build_dispatch.py`** (new, 36 tests): 7-variant marker round-trip against the REAL recorder parser (`hooks/routing-decision-recorder.py`), block order/completeness, flag blocks, graceful degradation, token default, CLI error paths.
- **README.md**: script count 126 → 127.

## Validation evidence (C4 gate)

**Blind A/B — 10 routing decisions × (script + 3 hand-assembled baselines) = 40 blinded outputs**, baselines assembled by subagents following the pre-rewrite SKILL.md Phase 4 text, scored by a deterministic checker (element presence + marker parseability via the real recorder parser):

| Arm | Elements present | Missing |
|---|---|---|
| script | 162/162 | **0** |
| baseline1 | 159/162 | 3 |
| baseline2 | 159/162 | 3 |
| baseline3 | 159/162 | 3 |

Every baseline miss is the same defect: on all 3 alts-bearing samples, all 3 baselines wrote `alts={k1,k2}` (braces, as the old SKILL.md placeholder suggested) — the recorder's `alts=` regex rejects braces, silently dropping the alternates gate input (9/9 drops on that element; 0 drops elsewhere). Exactly the drop class C4 exists to close.

Blinded judge (tie-quality): script mean 9.1 vs 8.7/8.3/8.7, best-pick 7/10; the judge's 3 anti-script picks preferred braced `alts={...}` on style — the unparseable form.

**End-to-end recorder proof**: dispatched a live agent with the script's preamble; `route-events.jsonl` gained the decision row (`agent=claude skill=quick complexity=simple`, `health_at_decision: null`, `gate_inputs_present: true`).

**Quality gate**: ruff check + format clean (whole repo), mypy clean, bandit clean, pytest 5281 passed / 5 skipped / 75 xfailed.