### PR TITLE
feat(do): hash-gated manifest cache — Phase 2 reads disk, regenerates only on INDEX change

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -103,6 +103,13 @@
             "description": "Warn-only: compare deployed ~/.claude/hooks hook-version headers against the repo checkout; silent on parity",
             "timeout": 3000,
             "once": true
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/session-manifest-cache.py\"",
+            "description": "Hash-gated /do routing-manifest cache: verify ~/.claude/cache/routing-manifest.txt, regenerate only when INDEX inputs changed (ADR router-improvement-program C5)",
+            "timeout": 20000,
+            "once": true
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AI agents skip steps.
 Harnesses have a second problem: given only a skill list, they do not route eagerly enough, or correctly enough. Good skills sit unused. So this toolkit connects the skills, agents, and workflows we want directly into the harness, automatically. You don't have to understand what is here. Say what you want in plain English and you get all the value we have put into it: the right specialist with the right methodology, behind gates that demand exit codes, not assertions.
 
 <!-- Counts here must match the Four Layers table (~line 143). Verify both: python3 scripts/validate-doc-counts.py -->
-44 domain agents, 133 workflow skills, 84 hooks, 128 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
+44 domain agents, 133 workflow skills, 85 hooks, 128 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
 
 Works across Claude Code (`/do`), Codex (`$do`), Factory (`/do`), Reasonix (`/do`).
 

--- a/docs/injected-context-contracts.md
+++ b/docs/injected-context-contracts.md
@@ -122,6 +122,12 @@ Source: `hooks/hook-version-parity-check.py`.
 Meaning: The `# hook-version:` headers of the named deployed hooks in `~/.claude/hooks/` do not match this checkout — merged code is not deployed, so hook telemetry may be running stale logic.
 Action: Warn-only; nothing is blocked. Surface the drift to the user and suggest the included fix command (`python3 ~/.claude/hooks/sync-to-user-claude.py`). Expected in worktree sessions on hook-touching branches. Do not treat hook telemetry gaps as code bugs while this warning is active.
 
+### `[manifest-cache] fresh|refreshed: <path>`
+
+Source: `hooks/session-manifest-cache.py`.
+Meaning: The /do routing-manifest cache at the given path is verified against current INDEX inputs (`fresh`) or was just rebuilt (`refreshed`).
+Action: None required now. When /do Phase 2 Step 0 runs, its cache-first block reads this file instead of running `routing-manifest.py`; the bash sha256 check re-proves freshness at read time.
+
 ## Prompt-Signal Tags (emitted mid-conversation, require routing action)
 
 ### `[pipeline-creator]` plus `[auto-skill] pipeline-scaffolder` (plus JSON snapshot)

--- a/hooks/lib/manifest_cache.py
+++ b/hooks/lib/manifest_cache.py
@@ -1,0 +1,124 @@
+"""Hash-gated routing-manifest cache (ADR router-improvement-program C5).
+
+Keeps a disk copy of `routing-manifest.py` output so /do Phase 2 reads a
+file instead of starting Python. Staleness = sha256 over the generator's
+inputs: routing-manifest.py, routing_index_merge.py, skills/INDEX.json,
+skills/INDEX.local.json, agents/INDEX.json, agents/INDEX.local.json, and
+pipeline-index.json — missing files are skipped, so the digest is
+byte-identical to the bash check in skills/meta/do/SKILL.md Phase 2:
+`cat <inputs> 2>/dev/null | sha256sum`. Keep both sides in step.
+
+Writers: hooks/session-manifest-cache.py (SessionStart) and the two
+posttooluse-sync-*-index.py hooks (after INDEX regeneration).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+CACHE_DIR = Path.home() / ".claude" / "cache"
+CACHE_FILE = CACHE_DIR / "routing-manifest.txt"
+HASH_FILE = CACHE_DIR / "routing-manifest.hash"
+
+# Same search order as the SDIR resolution in skills/meta/do/SKILL.md Phase 2.
+_SCRIPT_DIR_CANDIDATES = (".claude", ".hermes", ".factory", ".codex", ".reasonix")
+
+GENERATOR_TIMEOUT = 20  # seconds; full manifest generation completes in ~1s
+
+
+def resolve_scripts_dir(home: Path | None = None) -> Path | None:
+    """First deployed scripts dir containing routing-manifest.py, or None."""
+    home = home or Path.home()
+    for name in _SCRIPT_DIR_CANDIDATES:
+        scripts = home / name / "scripts"
+        if (scripts / "routing-manifest.py").is_file():
+            return scripts
+    return None
+
+
+def input_paths(scripts_dir: Path) -> list[Path]:
+    """Generator inputs in the fixed order the digest concatenates them."""
+    base = scripts_dir.parent
+    return [
+        scripts_dir / "routing-manifest.py",
+        scripts_dir / "routing_index_merge.py",
+        base / "skills" / "INDEX.json",
+        base / "skills" / "INDEX.local.json",
+        base / "agents" / "INDEX.json",
+        base / "agents" / "INDEX.local.json",
+        base / "skills" / "workflow" / "references" / "pipeline-index.json",
+    ]
+
+
+def compute_input_hash(scripts_dir: Path) -> str:
+    """sha256 hex over the concatenated input files; missing files skipped."""
+    digest = hashlib.sha256()
+    for path in input_paths(scripts_dir):
+        try:
+            digest.update(path.read_bytes())
+        except OSError:
+            continue
+    return digest.hexdigest()
+
+
+def _stored_hash() -> str:
+    try:
+        return HASH_FILE.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def is_fresh(scripts_dir: Path) -> bool:
+    """True when the cache exists and the sidecar matches current inputs."""
+    stored = _stored_hash()
+    if not stored or not CACHE_FILE.is_file():
+        return False
+    return stored == compute_input_hash(scripts_dir)
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)
+
+
+def refresh(scripts_dir: Path, force: bool = False) -> str:
+    """Verify the cache; regenerate only when stale, absent, or forced.
+
+    Returns "fresh" (hash matched, no generator run), "refreshed"
+    (generator ran, cache + sidecar rewritten), or "failed: <why>"
+    (generator failed; any existing cache is left untouched).
+
+    The input hash is computed BEFORE the generator runs: if an input
+    changes mid-generation, the stored sidecar no longer matches and the
+    next check regenerates — the race resolves toward regeneration.
+    """
+    current = compute_input_hash(scripts_dir)
+    if not force and CACHE_FILE.is_file() and _stored_hash() == current:
+        return "fresh"
+
+    import subprocess  # lazy: the fresh path (every session) never pays for it
+
+    try:
+        result = subprocess.run(
+            [sys.executable, str(scripts_dir / "routing-manifest.py")],
+            capture_output=True,
+            text=True,
+            timeout=GENERATOR_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return f"failed: generator did not run ({type(e).__name__})"
+
+    if result.returncode != 0:
+        return f"failed: generator exit {result.returncode}"
+    if not result.stdout.strip():
+        return "failed: generator produced empty output"
+
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    # Cache first, sidecar second: a crash between the writes leaves a
+    # mismatched sidecar, which reads as stale — never as falsely fresh.
+    _atomic_write(CACHE_FILE, result.stdout)
+    _atomic_write(HASH_FILE, current + "\n")
+    return "refreshed"

--- a/hooks/posttooluse-sync-agent-index.py
+++ b/hooks/posttooluse-sync-agent-index.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.0.0
+# hook-version: 1.1.0
 """
 PostToolUse Hook: Auto-sync agents/INDEX.json on agent-file changes.
 
@@ -32,6 +32,22 @@ from stdin_timeout import read_stdin
 # agents/<name>.md, flat layout (exactly one segment after agents/).
 AGENT_FILE_RE = re.compile(r"(?:^|/)agents/[^/]+\.md$")
 _EXCLUDE = {"INDEX.md", "README.md"}
+
+
+def _refresh_manifest_cache() -> None:
+    """Refresh the /do routing-manifest cache after an INDEX regen (C5).
+
+    Best-effort: the SessionStart hook re-checks next session, and /do
+    Phase 2's hash check falls back to the generator on any mismatch.
+    """
+    try:
+        from manifest_cache import refresh, resolve_scripts_dir
+
+        sdir = resolve_scripts_dir()
+        if sdir is not None:
+            refresh(sdir)
+    except Exception:
+        pass
 
 
 def is_agent_file(file_path: str) -> bool:
@@ -69,6 +85,7 @@ def main() -> None:
 
         if result.returncode == 0:
             print(f"[sync-agent-index] INDEX.json regenerated after {Path(file_path).name} edit")
+            _refresh_manifest_cache()
         else:
             print(f"[sync-agent-index] generator failed (exit {result.returncode})", file=sys.stderr)
             for line in result.stderr.strip().splitlines()[:10]:

--- a/hooks/posttooluse-sync-skill-index.py
+++ b/hooks/posttooluse-sync-skill-index.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.0.0
+# hook-version: 1.1.0
 """
 PostToolUse Hook: Auto-sync INDEX.json on SKILL.md frontmatter changes
 
@@ -40,6 +40,22 @@ from stdin_timeout import read_stdin
 
 # Matches skills/**/SKILL.md (flat and nested category layouts)
 SKILL_FILE_RE = re.compile(r"skills/(?:[^/]+/)+SKILL\.md$")
+
+
+def _refresh_manifest_cache() -> None:
+    """Refresh the /do routing-manifest cache after an INDEX regen (C5).
+
+    Best-effort: the SessionStart hook re-checks next session, and /do
+    Phase 2's hash check falls back to the generator on any mismatch.
+    """
+    try:
+        from manifest_cache import refresh, resolve_scripts_dir
+
+        sdir = resolve_scripts_dir()
+        if sdir is not None:
+            refresh(sdir)
+    except Exception:
+        pass
 
 
 def main() -> None:
@@ -84,6 +100,7 @@ def main() -> None:
             # Emit a brief confirmation — model sees this as context
             skill_name = Path(file_path).parent.name
             print(f"[sync-skill-index] INDEX.json regenerated after {skill_name}/SKILL.md edit")
+            _refresh_manifest_cache()
         else:
             print(
                 f"[sync-skill-index] generator failed (exit {result.returncode})",

--- a/hooks/session-manifest-cache.py
+++ b/hooks/session-manifest-cache.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""SessionStart Hook: hash-gated /do routing-manifest cache.
+
+ADR router-improvement-program C5. Verifies (or rebuilds) the disk cache of
+`routing-manifest.py` output so /do Phase 2 reads a file instead of starting
+Python. Freshness = sha256 sidecar over the generator's inputs — see
+hooks/lib/manifest_cache.py for the input list and digest contract.
+
+Paths:
+- Cache:   ~/.claude/cache/routing-manifest.txt
+- Sidecar: ~/.claude/cache/routing-manifest.hash
+
+Behavior:
+- Inputs unchanged: no generator run, injects the cache path (fresh path
+  measured <50ms).
+- Inputs changed or cache absent: runs the generator once, rewrites cache +
+  sidecar atomically (bounded by the 20s settings timeout, like the INDEX
+  sync hooks).
+- Generator failure or no deployed scripts dir: silent, /do Phase 2 falls
+  back to running routing-manifest.py itself.
+- Advisory: always exits 0.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from hook_utils import context_output, empty_output
+from manifest_cache import CACHE_FILE, refresh, resolve_scripts_dir
+
+EVENT_NAME = "SessionStart"
+
+
+def main() -> None:
+    scripts_dir = resolve_scripts_dir()
+    if scripts_dir is None:
+        # No deployed toolkit — nothing to cache.
+        empty_output(EVENT_NAME).print_and_exit()
+        return
+
+    status = refresh(scripts_dir)
+    if status.startswith("failed"):
+        print(f"[manifest-cache] {status}; /do falls back to routing-manifest.py", file=sys.stderr)
+        empty_output(EVENT_NAME).print_and_exit()
+        return
+
+    context_output(EVENT_NAME, f"[manifest-cache] {status}: {CACHE_FILE}").print_and_exit()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise  # Let print_and_exit's sys.exit(0) propagate normally
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            import traceback
+
+            traceback.print_exc(file=sys.stderr)
+        else:
+            print(f"[manifest-cache] Error: {type(e).__name__}: {e}", file=sys.stderr)
+        # Crashed hook must fail open — never block session start.
+    finally:
+        sys.exit(0)

--- a/hooks/tests/test_manifest_cache.py
+++ b/hooks/tests/test_manifest_cache.py
@@ -1,0 +1,220 @@
+"""Tests for the hash-gated routing-manifest cache (ADR router-improvement-program C5).
+
+Covers hooks/lib/manifest_cache.py and hooks/session-manifest-cache.py:
+- cache hit: no generator run when inputs are unchanged
+- cache miss: changed input hash triggers regeneration
+- corrupted sidecar triggers regeneration (never falsely fresh)
+- absent cache triggers regeneration
+- generator failure keeps the old cache
+- python digest == bash `cat <inputs> | sha256sum` (guards the SKILL.md
+  Phase 2 freshness check)
+- SessionStart hook exits 0 and emits valid JSON on all paths
+
+Run with: python3 -m pytest hooks/tests/test_manifest_cache.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HOOKS_DIR / "lib"))
+
+import manifest_cache as mc
+
+HOOK_PATH = HOOKS_DIR / "session-manifest-cache.py"
+
+# Stub generator: bumps a run counter, prints a manifest derived from
+# skills/INDEX.json so regeneration is observable in the cache content.
+STUB_GENERATOR = textwrap.dedent(
+    """\
+    #!/usr/bin/env python3
+    import sys
+    from pathlib import Path
+
+    base = Path(__file__).resolve().parent.parent
+    counter = base / "gen-count.txt"
+    n = int(counter.read_text()) if counter.exists() else 0
+    counter.write_text(str(n + 1))
+    print("AGENTS:\\n  demo\\n\\nSKILLS:")
+    print("marker: " + (base / "skills" / "INDEX.json").read_text().strip())
+    sys.exit(0)
+    """
+)
+
+FAILING_GENERATOR = "#!/usr/bin/env python3\nimport sys\nsys.exit(1)\n"
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """A fake $HOME with a deployed ~/.claude tree and isolated cache paths."""
+    home = tmp_path / "home"
+    scripts = home / ".claude" / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "routing-manifest.py").write_text(STUB_GENERATOR, encoding="utf-8")
+    (scripts / "routing_index_merge.py").write_text("# merge lib v1\n", encoding="utf-8")
+
+    base = home / ".claude"
+    (base / "skills").mkdir()
+    (base / "skills" / "INDEX.json").write_text('{"skills": {"a": {}}}', encoding="utf-8")
+    (base / "agents").mkdir()
+    (base / "agents" / "INDEX.json").write_text('{"agents": {"x": {}}}', encoding="utf-8")
+    pipeline_dir = base / "skills" / "workflow" / "references"
+    pipeline_dir.mkdir(parents=True)
+    (pipeline_dir / "pipeline-index.json").write_text('{"pipelines": {}}', encoding="utf-8")
+
+    cache_dir = base / "cache"
+    monkeypatch.setattr(mc, "CACHE_DIR", cache_dir)
+    monkeypatch.setattr(mc, "CACHE_FILE", cache_dir / "routing-manifest.txt")
+    monkeypatch.setattr(mc, "HASH_FILE", cache_dir / "routing-manifest.hash")
+    return home
+
+
+def gen_count(home: Path) -> int:
+    counter = home / ".claude" / "gen-count.txt"
+    return int(counter.read_text()) if counter.exists() else 0
+
+
+def scripts_dir(home: Path) -> Path:
+    return home / ".claude" / "scripts"
+
+
+def test_absent_cache_regenerates(fake_home):
+    sdir = scripts_dir(fake_home)
+    assert not mc.is_fresh(sdir)
+    assert mc.refresh(sdir) == "refreshed"
+    assert gen_count(fake_home) == 1
+    assert "AGENTS:" in mc.CACHE_FILE.read_text(encoding="utf-8")
+    assert mc.HASH_FILE.read_text(encoding="utf-8").strip() == mc.compute_input_hash(sdir)
+    assert mc.is_fresh(sdir)
+
+
+def test_cache_hit_runs_no_generator(fake_home):
+    sdir = scripts_dir(fake_home)
+    assert mc.refresh(sdir) == "refreshed"
+    before = mc.CACHE_FILE.read_text(encoding="utf-8")
+
+    assert mc.refresh(sdir) == "fresh"
+    assert gen_count(fake_home) == 1  # generator ran exactly once
+    assert mc.CACHE_FILE.read_text(encoding="utf-8") == before
+
+
+def test_changed_input_hash_regenerates(fake_home):
+    sdir = scripts_dir(fake_home)
+    mc.refresh(sdir)
+
+    index = fake_home / ".claude" / "skills" / "INDEX.json"
+    index.write_text('{"skills": {"a": {}, "brand-new": {}}}', encoding="utf-8")
+
+    assert not mc.is_fresh(sdir)
+    assert mc.refresh(sdir) == "refreshed"
+    assert gen_count(fake_home) == 2
+    assert "brand-new" in mc.CACHE_FILE.read_text(encoding="utf-8")
+
+
+def test_corrupted_hash_sidecar_regenerates(fake_home):
+    sdir = scripts_dir(fake_home)
+    mc.refresh(sdir)
+
+    mc.HASH_FILE.write_text("deadbeef-corrupted\n", encoding="utf-8")
+
+    assert not mc.is_fresh(sdir)
+    assert mc.refresh(sdir) == "refreshed"
+    assert gen_count(fake_home) == 2
+    assert mc.is_fresh(sdir)
+
+
+def test_input_presence_changes_hash(fake_home):
+    sdir = scripts_dir(fake_home)
+    without_local = mc.compute_input_hash(sdir)
+
+    local = fake_home / ".claude" / "skills" / "INDEX.local.json"
+    local.write_text('{"skills": {"local-only": {}}}', encoding="utf-8")
+    assert mc.compute_input_hash(sdir) != without_local
+
+    local.unlink()
+    assert mc.compute_input_hash(sdir) == without_local
+
+
+def test_generator_failure_keeps_old_cache(fake_home):
+    sdir = scripts_dir(fake_home)
+    mc.refresh(sdir)
+    old_cache = mc.CACHE_FILE.read_text(encoding="utf-8")
+
+    (sdir / "routing-manifest.py").write_text(FAILING_GENERATOR, encoding="utf-8")
+
+    status = mc.refresh(sdir)
+    assert status.startswith("failed")
+    assert mc.CACHE_FILE.read_text(encoding="utf-8") == old_cache
+    assert not mc.is_fresh(sdir)  # stale sidecar: next check retries
+
+
+@pytest.mark.skipif(shutil.which("sha256sum") is None, reason="sha256sum not available")
+def test_python_digest_matches_bash_check(fake_home):
+    """The SKILL.md Phase 2 bash freshness check must equal the python digest."""
+    sdir = scripts_dir(fake_home)
+    # Include one missing input (INDEX.local.json) to prove skip parity.
+    quoted = " ".join(f'"{p}"' for p in mc.input_paths(sdir))
+    bash_digest = subprocess.run(
+        ["bash", "-c", f"cat {quoted} 2>/dev/null | sha256sum | cut -d' ' -f1"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert bash_digest == mc.compute_input_hash(sdir)
+
+
+def run_hook(home: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ, HOME=str(home))
+    return subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input="",
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+def test_hook_cold_then_fresh(fake_home):
+    """Hook exits 0, populates the cache, then reports fresh on rerun."""
+    result = run_hook(fake_home)
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    context = payload["hookSpecificOutput"]["additionalContext"]
+    assert "[manifest-cache] refreshed:" in context
+    assert (fake_home / ".claude" / "cache" / "routing-manifest.txt").is_file()
+    assert (fake_home / ".claude" / "cache" / "routing-manifest.hash").is_file()
+
+    result = run_hook(fake_home)
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert "[manifest-cache] fresh:" in payload["hookSpecificOutput"]["additionalContext"]
+    assert gen_count(fake_home) == 1  # second run hit the cache
+
+
+def test_hook_without_deployed_scripts_is_silent_exit_0(tmp_path):
+    """No ~/.claude/scripts: hook must emit empty JSON and exit 0."""
+    home = tmp_path / "empty-home"
+    home.mkdir()
+    result = run_hook(home)
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload.get("hookSpecificOutput", {}).get("additionalContext") is None
+
+
+def test_hook_generator_failure_is_silent_exit_0(fake_home):
+    (scripts_dir(fake_home) / "routing-manifest.py").write_text(FAILING_GENERATOR, encoding="utf-8")
+    result = run_hook(fake_home)
+    assert result.returncode == 0
+    assert "falls back" in result.stderr
+    payload = json.loads(result.stdout)
+    assert payload.get("hookSpecificOutput", {}).get("additionalContext") is None

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -134,12 +134,21 @@ Read `PRE_ROUTE_RESULT`. If it has `"confidence": "high"` AND `"match_type": "fo
 
 **Step 0: Semantic intent routing (PRIMARY — orchestrator self-route)**
 
-Generate the manifest, then route directly off it in-session. No routing sub-dispatch: the orchestrator reads the manifest and applies the rules below itself. (Self-route-v1 blind A/B, n=99: PROMOTE — +8.1 accuracy points over the Haiku hop, zero new safety-bucket misses, stub-tier 9→12; it fixes the agent-attribution failure and deletes a dispatch round trip. `scripts/routing-ab-results/self-route-v1/VERDICT.md`.)
+Acquire the manifest (cache-first, below), then route directly off it in-session. No routing sub-dispatch: the orchestrator reads the manifest and applies the rules below itself. (Self-route-v1 blind A/B, n=99: PROMOTE — +8.1 accuracy points over the Haiku hop, zero new safety-bucket misses, stub-tier 9→12; it fixes the agent-attribution failure and deletes a dispatch round trip. `scripts/routing-ab-results/self-route-v1/VERDICT.md`.)
+
+Acquire the manifest cache-first. A hash-gated disk cache (`~/.claude/cache/routing-manifest.txt` + `.hash` sidecar, ADR router-improvement-program C5) is kept fresh by the `session-manifest-cache` SessionStart hook and by the INDEX sync hooks after regeneration. Read the cache when the sidecar digest matches the generator's inputs; on absent/stale cache, fall back to running the generator (verbatim command, unchanged behavior):
 
 ```bash
 SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
-python3 "$SDIR/routing-manifest.py"
+BASE="$(dirname "$SDIR")"; CACHE="${HOME}/.claude/cache/routing-manifest.txt"; CHASH="${HOME}/.claude/cache/routing-manifest.hash"
+if [ -s "$CACHE" ] && [ -s "$CHASH" ] && [ "$(cat "$SDIR/routing-manifest.py" "$SDIR/routing_index_merge.py" "$BASE/skills/INDEX.json" "$BASE/skills/INDEX.local.json" "$BASE/agents/INDEX.json" "$BASE/agents/INDEX.local.json" "$BASE/skills/workflow/references/pipeline-index.json" 2>/dev/null | sha256sum | cut -d' ' -f1)" = "$(cat "$CHASH")" ]; then
+  cat "$CACHE"    # cache hit: manifest read from disk, no Python start
+else
+  python3 "$SDIR/routing-manifest.py"
+fi
 ```
+
+The digest recompute is the freshness proof: it hashes the exact files the generator reads (missing files skipped — `hooks/lib/manifest_cache.py` computes the identical digest), so a stale sidecar can never serve an outdated manifest. Any mismatch, missing file, or empty cache runs the generator exactly as before.
 
 Given the user request and the manifest of available agents, skills, and pipelines, select the BEST agent+skill combination, and optionally a pipeline. Hold the decision internally as JSON (never printed; the `[do-route]` marker in Phase 4 is its only external trace):
 


### PR DESCRIPTION
ADR `router-improvement-program` component C5: eliminate the per-/do manifest regeneration cost. A hash-gated cache keeps `routing-manifest.py` output fresh on disk; /do Phase 2 reads the cache instead of starting Python.

## Design

- **Cache**: `~/.claude/cache/routing-manifest.txt` + sha256 sidecar `~/.claude/cache/routing-manifest.hash` (no prior hook cache convention in `~/.claude/cache/`; spec location used).
- **Staleness**: sha256 over the generator's inputs — `routing-manifest.py`, `routing_index_merge.py`, `skills/INDEX.json`, `skills/INDEX.local.json`, `agents/INDEX.json`, `agents/INDEX.local.json`, `pipeline-index.json` — missing files skipped, so the digest is byte-identical to bash `cat <inputs> 2>/dev/null | sha256sum`. A unit test locks the bash/python parity.
- **Refresh triggers**: new `session-manifest-cache.py` SessionStart hook, plus best-effort refresh in the two existing PostToolUse INDEX sync hooks (`posttooluse-sync-{skill,agent}-index.py`, bumped to 1.1.0) — they already fire on INDEX regeneration, so no new event was added.
- **Phase 2 Step 0** (`skills/meta/do/SKILL.md`): reads the cache when the sidecar digest matches (recomputed in bash — a stale sidecar can never serve an outdated manifest); falls back to the verbatim `python3 "$SDIR/routing-manifest.py"` when absent/stale.
- **Safety**: atomic writes (cache first, sidecar second — a crash reads as stale, never falsely fresh); generator failure keeps the old cache; hook always exits 0; input hash computed before generation so a mid-generation input change resolves toward regeneration.

## Measured (median of 10-15 runs, this host)

| Path | Time | Python subprocesses |
|------|------|--------------------|
| Phase 2 cold: `python3 routing-manifest.py` | 45.9 ms | 1 |
| Phase 2 cache-hit: sha256 check + `cat` cache | **7.5 ms** | **0** |
| SessionStart hook, fresh path | 68.6 ms | 0 |
| SessionStart hook, regen path | ~1 run of the generator, inside its 20 s timeout | 1 |

Cache-hit output verified byte-identical to generator output (`diff` clean). Reference points: bare `python3 -c ''` is 23.2 ms here and `hook_utils` import is 32 ms, so the hook's fresh-path logic adds ~14 ms; the existing `hook-version-parity-check.py` SessionStart hook measures 89.9 ms on the same host. SessionStart fires once per session.

## Tests

`hooks/tests/test_manifest_cache.py` (10 tests): cache hit runs no generator (run-counter proof), changed-input hash regenerates, **corrupted sidecar regenerates**, absent cache regenerates, input presence flips the hash, generator failure keeps the old cache, bash/python digest parity, hook cold→fresh / no-scripts / generator-failure paths all exit 0 with valid JSON. Full hooks suite: 1714 passed. ruff check + format, mypy (new modules), bandit, hook-health `--ci`, and all doc validators green locally.

## Activation

**Session restart required**: the SessionStart registration in `.claude/settings.json` takes effect on the next session (after merge + `sync-to-user-claude`). The hook and lib are already deployed to `~/.claude/hooks/` (deploy-before-register), and Phase 2's fallback keeps /do fully functional either way.

## Rollback

Remove the SessionStart registration; Phase 2's verbatim fallback needs no code rollback (ADR C5).