### PR TITLE
feat(learning): weak-positive routing signal — repeat dispatch without failure accrues bounded evidence

### DIFF
--- a/docs/route-loop-validation.md
+++ b/docs/route-loop-validation.md
@@ -72,7 +72,24 @@ Every `/do` dispatch is scored, never altered:
    rejection/rework/re-route (decay); **success** only on an explicit
    acceptance marker (boost); **neutral** otherwise (no-op). No complaint is
    NOT acceptance.
-5. The orchestrator reports routing failures it observes directly via
+5. **Weak-positive** (C6, ADR router-improvement-program): a would-be-neutral
+   entry upgrades to **weak_success** when the same `agent:skill` pair was
+   finalized non-failure earlier in the same session — a repeat dispatch with
+   no intervening failure means the user kept re-using the route. Bounded:
+   +0.02 per event, clamped so weak boosts never lift confidence past 0.65
+   (strictly below the 0.70 high-confidence/injection threshold — crossing it
+   requires explicit acceptance); `success_count`/n still accrue at the cap,
+   so the n>=5 evidence gate becomes reachable. Guards: the entry must be
+   clean (tool errors still decay, unchanged), and any rejection on the turn
+   — even an unattributable multi-dispatch one — suppresses the upgrade. The
+   upgrade reads dispatch history (per-key, per-session, in the bridge state
+   file), never prompt text: the reaction detector is unchanged, and a first
+   dispatch followed by an unrelated prompt stays a neutral no-op. Basis label
+   `repeat_dispatch_weak`; event outcome `weak_success`, reason
+   `repeat-dispatch-no-failure`. This closes the signal starvation that held
+   every weight at 0.5/n<5 (success previously required an explicit acceptance
+   marker that almost never appears).
+6. The orchestrator reports routing failures it observes directly via
    `learning-db.py route-failure` (ADR orchestrator-reported-route-failures,
    local working document). `--routing-relevant yes` decays the pair;
    idempotent per (session, marker).

--- a/hooks/lib/route_events.py
+++ b/hooks/lib/route_events.py
@@ -126,7 +126,8 @@ def record_outcome_event(
     reason: str | None = None,
     routing_relevant: bool | None = None,
 ) -> None:
-    """Append a per-dispatch OUTCOME event (outcome in {success, failure, neutral}).
+    """Append a per-dispatch OUTCOME event (outcome in {success, failure,
+    neutral, weak_success}).
 
     ``reason`` is the short cause for the outcome (e.g. tool-errors, rejection,
     acceptance, neutral-new-topic). Free of prompt text/secrets. Included only

--- a/hooks/lib/routing_outcome_score.py
+++ b/hooks/lib/routing_outcome_score.py
@@ -15,6 +15,24 @@ import sqlite3
 BOOST_DELTA = 0.05
 DECAY_DELTA = 0.08
 
+# WEAK-POSITIVE signal (ADR router-improvement-program C6): a repeat dispatch
+# of the same agent:skill pair with no intervening failure is weak evidence the
+# route works — the user kept re-using it. Bounded so repetition alone can
+# never make a pair high-confidence:
+#   - WEAK_BOOST_DELTA (0.02) < acceptance boost (0.05) < failure decay (0.08):
+#     one failure erases four weak boosts; explicit signals always dominate.
+#   - WEAK_CONFIDENCE_CAP (0.65) sits strictly below the 0.70 high-confidence /
+#     injection threshold: crossing 0.70 requires explicit acceptance. The cap
+#     clamps the DELTA (never lowers a row already above it from explicit
+#     boosts); success_count still increments at the cap, so n keeps accruing
+#     toward the evidence gate (n >= 5) while confidence stays bounded.
+WEAK_BOOST_DELTA = 0.02
+WEAK_CONFIDENCE_CAP = 0.65
+
+# Basis label for a weak-positive outcome (route-health reports it as its own
+# line — neither strong feedback nor silent default-success).
+BASIS_REPEAT_WEAK = "repeat_dispatch_weak"
+
 
 def decision_row_exists(key: str) -> bool:
     """True iff a routing decision row was already written for ``key``.
@@ -60,6 +78,7 @@ def decision_row_exists(key: str) -> bool:
 SUCCESS = "success"
 FAILURE = "failure"
 NEUTRAL = "neutral"
+WEAK_SUCCESS = "weak_success"
 
 # Sentinel for "no positional outcome supplied" — distinct from any valid
 # outcome and from None, so the public `outcome` type is `str | bool` (None is
@@ -151,6 +170,12 @@ def apply_outcome(
     ``outcome`` is one of:
       - ``"failure"`` — decay the row (errors or attributable rejection).
       - ``"success"`` — boost the row (acceptance / continuation).
+      - ``"weak_success"`` — bounded small boost (C6 weak-positive: repeat
+        dispatch of the same pair with no intervening failure). Delta is
+        ``WEAK_BOOST_DELTA`` clamped so confidence never exceeds
+        ``WEAK_CONFIDENCE_CAP`` via weak boosts (delta 0 at/above the cap — the
+        row is never lowered). success_count still increments at the cap, so n
+        keeps accruing while confidence stays bounded.
       - ``"neutral"`` — NO-OP: no boost, no decay, no count change, no schema
         migration. Returns the row's current confidence unchanged. Neutral is the
         new default for unrelated/new-topic next prompts and clean autonomous Stop
@@ -203,7 +228,16 @@ def apply_outcome(
         return decay_confidence("routing", key, delta=DECAY_DELTA)
     if outcome == SUCCESS:
         return boost_confidence("routing", key, delta=BOOST_DELTA)
+    if outcome == WEAK_SUCCESS:
+        # Bounded: the delta shrinks to fit under the cap and clamps at 0 once
+        # confidence reaches it, so repetition alone can never lift a pair past
+        # WEAK_CONFIDENCE_CAP. delta=0 still increments success_count (n accrues).
+        current = _current_confidence(key)
+        delta = max(0.0, min(WEAK_BOOST_DELTA, WEAK_CONFIDENCE_CAP - current))
+        return boost_confidence("routing", key, delta=delta)
     # Unknown/typo outcome must NOT silently boost. Callers pass the literal
-    # SUCCESS/FAILURE/NEUTRAL constants; an unrecognized string is a bug to
-    # surface, not a default boost that inflates confidence.
-    raise ValueError(f"unknown routing outcome {outcome!r}; expected one of {SUCCESS!r}, {FAILURE!r}, {NEUTRAL!r}")
+    # SUCCESS/FAILURE/NEUTRAL/WEAK_SUCCESS constants; an unrecognized string is
+    # a bug to surface, not a default boost that inflates confidence.
+    raise ValueError(
+        f"unknown routing outcome {outcome!r}; expected one of {SUCCESS!r}, {FAILURE!r}, {NEUTRAL!r}, {WEAK_SUCCESS!r}"
+    )

--- a/hooks/lib/routing_outcome_state.py
+++ b/hooks/lib/routing_outcome_state.py
@@ -35,7 +35,10 @@ File shape:
     {
       "seen": ["<dispatch-sig>", ...],     # idempotency for the decision hook
       "pending": [{"key": "agent:skill", "errors": false,
-                   "attempts": 0, "created": 1735000000.0}, ...]
+                   "attempts": 0, "created": 1735000000.0}, ...],
+      "history": {"agent:skill": "neutral", ...}  # last finalized outcome per
+                   key this session — the weak-positive signal (C6) reads it to
+                   tell a repeat dispatch with no intervening failure
     }
 
 Idempotency (MEDIUM, TOCTOU): the decision hook claims a dispatch signature via
@@ -109,6 +112,12 @@ _STATE_DIR = Path("/tmp")
 # pending key (decision row never written) cannot grow the file unbounded.
 MAX_REQUEUE_ATTEMPTS = 5
 
+# Bounded outcome history: last finalized outcome per route key this session
+# (the C6 weak-positive signal's memory). A session rarely touches more than a
+# few dozen distinct pairs; 200 keys bounds the file while never evicting in
+# practice. Eviction drops the OLDEST insertion (dict order round-trips JSON).
+MAX_HISTORY_KEYS = 200
+
 # Bounded pending age: a provisional pending entry that is never finalized by
 # UserPromptSubmit or Stop (e.g. a crashed session that emits neither a next
 # user prompt nor a clean Stop) must not live forever. ``finalize_pending_outcomes``
@@ -180,11 +189,12 @@ def _load(path: Path) -> dict[str, Any]:
             if isinstance(data, dict):
                 data.setdefault("seen", [])
                 data.setdefault("pending", [])
+                data.setdefault("history", {})
                 return data
     except (json.JSONDecodeError, OSError, ValueError) as e:
         if os.environ.get("CLAUDE_HOOKS_DEBUG"):
             print(f"[routing-outcome-state] _load: {type(e).__name__}: {e}", file=sys.stderr)
-    return {"seen": [], "pending": []}
+    return {"seen": [], "pending": [], "history": {}}
 
 
 def _atomic_write(path: Path, data: dict[str, Any]) -> None:
@@ -364,6 +374,52 @@ def drain_pending_outcomes(session_id: str) -> list[dict[str, Any]]:
         if os.environ.get("CLAUDE_HOOKS_DEBUG"):
             print(f"[routing-outcome-state] drain_pending_outcomes: {type(e).__name__}: {e}", file=sys.stderr)
         return []
+
+
+def get_outcome_history(session_id: str) -> dict[str, str]:
+    """Last finalized outcome per route key this session. {} on any error.
+
+    Read-only. The weak-positive signal (C6) reads it in the UserPromptSubmit
+    finalizer: a pending key whose PREVIOUS finalization this session was not a
+    failure is a repeat dispatch with no intervening failure.
+    """
+    try:
+        history = _load(_state_file(session_id)).get("history", {})
+        return dict(history) if isinstance(history, dict) else {}
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            print(f"[routing-outcome-state] get_outcome_history: {type(e).__name__}: {e}", file=sys.stderr)
+        return {}
+
+
+def record_outcome_history(session_id: str, updates: dict[str, str]) -> None:
+    """Merge finalized outcomes into the per-key session history. Best-effort.
+
+    Latest write wins per key (the finalizer applies failure precedence within
+    one turn BEFORE calling). Bounded to ``MAX_HISTORY_KEYS`` — oldest insertion
+    evicted first — so a long session cannot grow the file unbounded.
+    """
+    if not updates:
+        return
+    try:
+        path = _state_file(session_id)
+        with _state_lock(path):
+            data = _load(path)
+            history = data.get("history", {})
+            if not isinstance(history, dict):
+                history = {}
+            for key, outcome in updates.items():
+                if not key or not isinstance(outcome, str):
+                    continue
+                history.pop(key, None)  # re-insert => freshest position
+                history[key] = outcome
+            while len(history) > MAX_HISTORY_KEYS:
+                history.pop(next(iter(history)))
+            data["history"] = history
+            _atomic_write(path, data)
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            print(f"[routing-outcome-state] record_outcome_history: {type(e).__name__}: {e}", file=sys.stderr)
 
 
 def requeue_pending_outcomes(session_id: str, items: list[dict[str, Any]]) -> None:

--- a/hooks/routing-outcome-finalizer.py
+++ b/hooks/routing-outcome-finalizer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.0.0
+# hook-version: 1.1.0
 """
 UserPromptSubmit Hook: Routing Outcome Finalizer (next-turn resolution)
 
@@ -20,6 +20,22 @@ THREE-WAY (T4):
 then boost (success) / decay (failure) / no-op (neutral) the routing/{key} row,
 ONCE, and clear the pending list so a re-delivered prompt resolves nothing
 further (idempotent).
+
+WEAK-POSITIVE UPGRADE (C6, ADR router-improvement-program): explicit acceptance
+almost never appears, so healthy routes sat at confidence 0.5 forever (signal
+starvation). A REPEAT dispatch of the same agent:skill pair with no intervening
+failure is weak evidence the route works — the user kept re-using it. So a
+would-be-NEUTRAL entry upgrades to weak_success (small bounded boost, see
+routing_outcome_score.WEAK_BOOST_DELTA / WEAK_CONFIDENCE_CAP) when ALL hold:
+  - the entry itself is clean (no tool errors — the failure path is untouched),
+  - the same key was finalized NON-FAILURE earlier THIS session (per-key
+    history in the bridge state file; sessions start fresh),
+  - the turn carries NO rejection signal, even an unattributable one (a
+    multi-dispatch turn with a complaint upgrades nothing — conservative).
+The upgrade reads dispatch HISTORY, not prompt text: the reaction detector and
+its neutral classification are byte-identical. First dispatch of a pair plus an
+unrelated next prompt stays a neutral no-op exactly as before. Failure, decay,
+and explicit-acceptance paths are unchanged.
 
 SIGNAL FIDELITY (T4): the prior detector boosted EVERYTHING that was not an
 unambiguous failure — including neutral new-topic prompts — inflating success
@@ -215,6 +231,11 @@ _THATS_COMPLAINT_RE = re.compile(
 # first clause and lets "revert that, you broke the build" test "revert that".
 _CLAUSE_SPLIT_RE = re.compile(r"[.,;\n]")
 
+# Prior same-session outcomes that qualify a repeat dispatch for the C6
+# weak-positive upgrade: anything but a failure. A key whose LAST finalization
+# was a failure gets no weak boost — that repeat has an intervening failure.
+_NON_FAILURE_OUTCOMES = frozenset({"neutral", "success", "weak_success"})
+
 
 def _first_clause(prompt: str) -> str:
     """The user's immediate reaction: text up to the first `. ; \\n` terminator.
@@ -317,9 +338,17 @@ def main() -> None:
         import time
 
         from learning_db_v2 import init_db
-        from routing_outcome_score import apply_outcome, decision_row_exists, outcome_basis
+        from routing_outcome_score import (
+            BASIS_REPEAT_WEAK,
+            WEAK_SUCCESS,
+            apply_outcome,
+            decision_row_exists,
+            outcome_basis,
+        )
         from routing_outcome_state import (
             MAX_PENDING_AGE_SEC,
+            get_outcome_history,
+            record_outcome_history,
             requeue_pending_outcomes,
             revalidate_pending_outcomes,
         )
@@ -328,6 +357,11 @@ def main() -> None:
         # (decision_row_exists no longer calls init_db itself).
         init_db()
         now = time.time()
+
+        # C6 weak-positive: snapshot the per-key outcome history BEFORE scoring.
+        # Entries resolve against the PRE-turn snapshot only, so two same-pair
+        # siblings drained in one turn cannot weak-boost each other.
+        history = get_outcome_history(session_id)
 
         # HIGH-1: a turn-level rejection can only be ATTRIBUTED to a route when
         # exactly ONE dispatch is pending resolution this turn. /do Phase 4 fans
@@ -360,6 +394,7 @@ def main() -> None:
         debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
         to_revalidate: list[dict] = []
         to_requeue: list[dict] = []
+        history_updates: dict[str, str] = {}
         for item in pending:
             key = item.get("key")
             if not key:
@@ -400,14 +435,31 @@ def main() -> None:
                 outcome = "success"
             else:
                 outcome = "neutral"
+            # C6 WEAK-POSITIVE UPGRADE: a would-be-neutral CLEAN entry whose key
+            # was finalized non-failure earlier this session is a repeat
+            # dispatch with no intervening failure => small bounded boost.
+            # Suppressed for the whole turn when ANY rejection fired (even an
+            # unattributable multi-dispatch one): never boost on a complaint
+            # turn. Failure / explicit-acceptance branches above are untouched.
+            if outcome == "neutral" and not rejected and history.get(key) in _NON_FAILURE_OUTCOMES:
+                outcome = WEAK_SUCCESS
             # Basis is the evidence label (errors > rejection > acceptance >
             # no-complaint), recorded as a per-route counter for route-health's
             # silent-success report. acceptance_detected marks a boost earned by
             # an explicit positive marker — strong feedback, not silence.
-            # Label-only: it never changes the boost/decay/no-op the three-way
-            # outcome drives.
-            basis = outcome_basis(bool(item.get("errors")), reaction_failure, reaction_success)
+            # repeat_dispatch_weak marks the C6 inferred signal — neither strong
+            # feedback nor silence. Label-only: it never changes the
+            # boost/decay/no-op the outcome drives.
+            if outcome == WEAK_SUCCESS:
+                basis = BASIS_REPEAT_WEAK
+            else:
+                basis = outcome_basis(bool(item.get("errors")), reaction_failure, reaction_success)
             new_conf = apply_outcome(key, outcome, basis=basis)
+            # Session history feeds the NEXT repeat's weak-positive check.
+            # Failure precedence within the turn: one failed sibling marks the
+            # key failed even if another same-key entry scored clean.
+            if history_updates.get(key) != "failure":
+                history_updates[key] = outcome
             # Short, secret-free cause for this dispatch's outcome. Computed
             # unconditionally (not debug-only) so the JSONL OUTCOME event carries
             # the demotion cause — an operator reading route-events.jsonl after a
@@ -418,6 +470,8 @@ def main() -> None:
                 reason = "rejection"
             elif reaction_success:
                 reason = "acceptance"
+            elif outcome == WEAK_SUCCESS:
+                reason = "repeat-dispatch-no-failure"
             elif (rejected or accepted) and not attributable:
                 reason = "reaction-ignored-multi-dispatch"
             else:
@@ -441,6 +495,11 @@ def main() -> None:
                     f"[routing-outcome-finalizer] {outcome} routing/{key} ({reason}) conf={new_conf:.4f}",
                     file=sys.stderr,
                 )
+
+        # Persist this turn's finalized outcomes so the NEXT dispatch of each
+        # key can read them (the weak-positive signal's memory). Only actually
+        # scored entries land here — requeued/stale/malformed ones never do.
+        record_outcome_history(session_id, history_updates)
 
         if to_requeue:
             requeue_pending_outcomes(session_id, to_requeue)

--- a/hooks/tests/fixtures/weak_positive_replay.jsonl
+++ b/hooks/tests/fixtures/weak_positive_replay.jsonl
@@ -1,0 +1,30 @@
+{"type": "dispatch", "key": "python-general-engineer:test-driven-development", "errors": false}
+{"type": "prompt", "text": "now update the docs for the parser"}
+{"type": "dispatch", "key": "python-general-engineer:test-driven-development", "errors": false}
+{"type": "prompt", "text": "add a retry to the fetch helper"}
+{"type": "dispatch", "key": "python-general-engineer:test-driven-development", "errors": false}
+{"type": "prompt", "text": "rename the config module"}
+{"type": "dispatch", "key": "python-general-engineer:test-driven-development", "errors": false}
+{"type": "prompt", "text": "wire the new endpoint into the router"}
+{"type": "dispatch", "key": "python-general-engineer:test-driven-development", "errors": false}
+{"type": "prompt", "text": "bump the timeout on the slow test"}
+{"type": "dispatch", "key": "python-general-engineer:test-driven-development", "errors": false}
+{"type": "prompt", "text": "split the utils file into two modules"}
+{"type": "dispatch", "key": "python-general-engineer:test-driven-development", "errors": false}
+{"type": "prompt", "text": "add pagination to the list command"}
+{"type": "dispatch", "key": "python-general-engineer:test-driven-development", "errors": false}
+{"type": "prompt", "text": "handle the empty-input case in the CLI"}
+{"type": "dispatch", "key": "python-general-engineer:test-driven-development", "errors": false}
+{"type": "prompt", "text": "port the date parsing to the shared helper"}
+{"type": "dispatch", "key": "python-general-engineer:test-driven-development", "errors": false}
+{"type": "prompt", "text": "log the cache misses at debug level"}
+{"type": "dispatch", "key": "python-general-engineer:test-driven-development", "errors": false}
+{"type": "prompt", "text": "extract the validation into its own function"}
+{"type": "dispatch", "key": "python-general-engineer:test-driven-development", "errors": false}
+{"type": "prompt", "text": "sort the report output by date"}
+{"type": "dispatch", "key": "golang-general-engineer:go-patterns", "errors": false}
+{"type": "prompt", "text": "tighten the channel buffer sizes"}
+{"type": "dispatch", "key": "golang-general-engineer:go-patterns", "errors": true}
+{"type": "prompt", "text": "swap the mutex for a rwlock"}
+{"type": "dispatch", "key": "golang-general-engineer:go-patterns", "errors": false}
+{"type": "prompt", "text": "add the context deadline to the client"}

--- a/hooks/tests/test_weak_positive.py
+++ b/hooks/tests/test_weak_positive.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Weak-positive routing signal (ADR router-improvement-program C6).
+
+A repeat dispatch of the same agent:skill pair with no intervening failure
+counts as WEAK success in the UserPromptSubmit finalizer: a small boost,
+bounded so repetition alone can never make a pair high-confidence.
+
+Covers, in order:
+  1. apply_outcome weak semantics: smaller-than-acceptance delta; cap
+     enforced; counts still accrue at the cap; failure/decay and explicit
+     acceptance byte-identical to pre-C6 (the regression direction matters as
+     much as the new signal — a loop that gets optimistic by accident is
+     worse than one that learns nothing).
+  2. Session outcome history in the bridge state file: round-trip, bound.
+  3. Finalizer end-to-end (subprocess): first dispatch stays neutral; repeat
+     gets the weak boost; intervening tool error blocks it; explicit
+     acceptance and attributable rejection unchanged; a rejection turn (even
+     unattributable) suppresses the upgrade.
+  4. Fixture replay (hooks/tests/fixtures/weak_positive_replay.jsonl): a
+     0.5/n=1 weight moves upward, the cap holds after many repeats, and the
+     row crosses the n>=5 evidence gate — while shadow-policy thresholds
+     (demote floor, tiebreak, evidence gate) still read correctly.
+
+All tests isolate via CLAUDE_LEARNING_DIR + CLAUDE_ROUTING_STATE_DIR; the
+live learning DB and /tmp state are never touched.
+
+Run: python3 -m pytest hooks/tests/test_weak_positive.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parent.parent
+LIB_DIR = HOOKS_DIR / "lib"
+FINALIZER = HOOKS_DIR / "routing-outcome-finalizer.py"
+FIXTURE = Path(__file__).parent / "fixtures" / "weak_positive_replay.jsonl"
+SCRIPTS_LIB = HOOKS_DIR.parent / "scripts" / "lib"
+
+sys.path.insert(0, str(LIB_DIR))
+
+
+@pytest.fixture()
+def env(tmp_path, monkeypatch):
+    """Throwaway learning DB + routing state dir; both env vars set so the
+    in-process seeding and the finalizer subprocess agree on locations."""
+    db_dir = tmp_path / "learning"
+    db_dir.mkdir()
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(db_dir))
+    monkeypatch.setenv("CLAUDE_ROUTING_STATE_DIR", str(state_dir))
+    import learning_db_v2 as ldb
+
+    monkeypatch.setattr(ldb, "_initialized", False, raising=False)
+    ldb.init_db()
+    return {"db_dir": db_dir, "state_dir": state_dir, "ldb": ldb}
+
+
+def _row(key: str) -> dict:
+    """Read the routing weight row straight from the throwaway DB."""
+    from learning_db_v2 import get_db_path
+
+    conn = sqlite3.connect(get_db_path())
+    try:
+        r = conn.execute(
+            "SELECT confidence, observation_count, success_count, failure_count "
+            "FROM learnings WHERE topic = 'routing' AND key = ?",
+            (key,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert r is not None, f"no routing row for {key}"
+    return {"confidence": r[0], "n": r[1], "success": r[2], "failure": r[3]}
+
+
+def _seed(ldb, key: str) -> None:
+    ldb.record_learning(
+        topic="routing",
+        key=key,
+        value=f"routing-decision: {key}",
+        category="effectiveness",
+        source="replay-fixture",
+    )
+
+
+# --- 1. apply_outcome weak semantics -----------------------------------------
+
+
+class TestApplyOutcomeWeak:
+    KEY = "agent-x:skill-x"
+
+    @pytest.fixture(autouse=True)
+    def _seeded(self, env):
+        _seed(env["ldb"], self.KEY)
+        self.ldb = env["ldb"]
+
+    def test_weak_boosts_by_weak_delta(self):
+        import routing_outcome_score as ros
+
+        before = _row(self.KEY)
+        ros.apply_outcome(self.KEY, ros.WEAK_SUCCESS)
+        after = _row(self.KEY)
+        assert after["confidence"] == pytest.approx(before["confidence"] + ros.WEAK_BOOST_DELTA)
+        assert after["success"] == before["success"] + 1
+
+    def test_weak_delta_smaller_than_acceptance_boost(self):
+        import routing_outcome_score as ros
+
+        assert ros.WEAK_BOOST_DELTA < ros.BOOST_DELTA < ros.DECAY_DELTA
+
+    def test_cap_enforced_counts_still_accrue(self):
+        """Many weak boosts stop at the cap; success_count keeps counting."""
+        import routing_outcome_score as ros
+
+        for _ in range(20):
+            ros.apply_outcome(self.KEY, ros.WEAK_SUCCESS)
+        after = _row(self.KEY)
+        assert after["confidence"] == pytest.approx(ros.WEAK_CONFIDENCE_CAP)
+        assert after["confidence"] <= ros.WEAK_CONFIDENCE_CAP + 1e-9
+        assert after["success"] == 20  # evidence accrues past the cap
+
+    def test_weak_only_row_stays_below_high_confidence(self):
+        """Repetition alone can never make a pair high-confidence (>= 0.70)."""
+        import routing_outcome_score as ros
+
+        for _ in range(50):
+            ros.apply_outcome(self.KEY, ros.WEAK_SUCCESS)
+        assert _row(self.KEY)["confidence"] < 0.70
+
+    def test_weak_never_lowers_a_row_above_the_cap(self):
+        """Explicit acceptances may push past the cap; weak leaves it there."""
+        import routing_outcome_score as ros
+
+        for _ in range(5):  # 0.50 + 5*0.05 = 0.75 > cap
+            ros.apply_outcome(self.KEY, ros.SUCCESS)
+        high = _row(self.KEY)["confidence"]
+        assert high > ros.WEAK_CONFIDENCE_CAP
+        ros.apply_outcome(self.KEY, ros.WEAK_SUCCESS)
+        after = _row(self.KEY)
+        assert after["confidence"] == pytest.approx(high)  # unchanged, not lowered
+        assert after["success"] == 6
+
+    # -- regression direction: failure/decay and explicit paths unchanged --
+
+    def test_failure_decay_unchanged_after_weak_boosts(self):
+        import routing_outcome_score as ros
+
+        for _ in range(3):
+            ros.apply_outcome(self.KEY, ros.WEAK_SUCCESS)
+        before = _row(self.KEY)
+        ros.apply_outcome(self.KEY, ros.FAILURE)
+        after = _row(self.KEY)
+        assert after["confidence"] == pytest.approx(before["confidence"] - ros.DECAY_DELTA)
+        assert after["failure"] == before["failure"] + 1
+
+    def test_explicit_success_delta_unchanged(self):
+        import routing_outcome_score as ros
+
+        before = _row(self.KEY)["confidence"]
+        ros.apply_outcome(self.KEY, ros.SUCCESS)
+        assert _row(self.KEY)["confidence"] == pytest.approx(before + ros.BOOST_DELTA)
+
+    def test_neutral_still_noop(self):
+        import routing_outcome_score as ros
+
+        before = _row(self.KEY)
+        ros.apply_outcome(self.KEY, ros.NEUTRAL)
+        assert _row(self.KEY) == before
+
+
+# --- 2. session outcome history -----------------------------------------------
+
+
+class TestOutcomeHistory:
+    def test_roundtrip(self, env):
+        from routing_outcome_state import get_outcome_history, record_outcome_history
+
+        assert get_outcome_history("s1") == {}
+        record_outcome_history("s1", {"a:b": "neutral", "c:d": "failure"})
+        assert get_outcome_history("s1") == {"a:b": "neutral", "c:d": "failure"}
+        record_outcome_history("s1", {"a:b": "weak_success"})  # latest wins
+        assert get_outcome_history("s1")["a:b"] == "weak_success"
+
+    def test_bounded_evicts_oldest(self, env):
+        from routing_outcome_state import MAX_HISTORY_KEYS, get_outcome_history, record_outcome_history
+
+        record_outcome_history("s1", {f"k{i}:s": "neutral" for i in range(MAX_HISTORY_KEYS + 5)})
+        history = get_outcome_history("s1")
+        assert len(history) == MAX_HISTORY_KEYS
+        assert "k0:s" not in history  # oldest insertion evicted
+        assert f"k{MAX_HISTORY_KEYS + 4}:s" in history
+
+    def test_sessions_are_isolated(self, env):
+        from routing_outcome_state import get_outcome_history, record_outcome_history
+
+        record_outcome_history("s1", {"a:b": "neutral"})
+        assert get_outcome_history("s2") == {}
+
+
+# --- 3. finalizer end-to-end ---------------------------------------------------
+
+
+def _finalize(prompt: str, session: str = "sess-1") -> subprocess.CompletedProcess:
+    """Run the real finalizer hook against the throwaway env."""
+    event = {"hook_event_name": "UserPromptSubmit", "session_id": session, "prompt": prompt}
+    res = subprocess.run(
+        [sys.executable, str(FINALIZER)],
+        input=json.dumps(event),
+        capture_output=True,
+        text=True,
+        env=dict(os.environ),
+    )
+    assert res.returncode == 0, res.stderr  # non-blocking contract
+    return res
+
+
+def _pend(key: str, errors: bool = False, session: str = "sess-1") -> None:
+    from routing_outcome_state import append_pending_outcome
+
+    append_pending_outcome(session, key, errors)
+
+
+class TestFinalizerWeakPositive:
+    KEY = "agent-x:skill-x"
+
+    @pytest.fixture(autouse=True)
+    def _seeded(self, env):
+        _seed(env["ldb"], self.KEY)
+        self.env = env
+
+    def test_first_dispatch_neutral_prompt_stays_noop(self):
+        """Regression: neutral stays neutral for an unrelated next prompt."""
+        before = _row(self.KEY)
+        _pend(self.KEY)
+        _finalize("now refactor the parser module")
+        after = _row(self.KEY)
+        assert after["confidence"] == pytest.approx(before["confidence"])
+        assert after["success"] == 0 and after["failure"] == 0
+
+    def test_repeat_dispatch_gets_weak_boost(self):
+        import routing_outcome_score as ros
+
+        _pend(self.KEY)
+        _finalize("now refactor the parser module")  # 1st: neutral, history recorded
+        before = _row(self.KEY)
+        _pend(self.KEY)
+        _finalize("add a retry to the fetch helper")  # repeat: weak boost
+        after = _row(self.KEY)
+        assert after["confidence"] == pytest.approx(before["confidence"] + ros.WEAK_BOOST_DELTA)
+        assert after["success"] == 1 and after["failure"] == 0
+
+    def test_weak_outcome_event_logged(self):
+        _pend(self.KEY)
+        _finalize("now refactor the parser module")
+        _pend(self.KEY)
+        _finalize("add a retry to the fetch helper")
+        lines = (self.env["db_dir"] / "route-events.jsonl").read_text().splitlines()
+        events = [json.loads(ln) for ln in lines]
+        weak = [e for e in events if e.get("outcome") == "weak_success"]
+        assert len(weak) == 1
+        assert weak[0]["key"] == self.KEY
+        assert weak[0]["reason"] == "repeat-dispatch-no-failure"
+        assert weak[0]["routing_relevant"] is True
+
+    def test_intervening_tool_error_blocks_weak_boost(self):
+        import routing_outcome_score as ros
+
+        _pend(self.KEY)
+        _finalize("now refactor the parser module")  # neutral, history=neutral
+        _pend(self.KEY, errors=True)
+        _finalize("add a retry to the fetch helper")  # failure: decay, history=failure
+        decayed = _row(self.KEY)
+        assert decayed["confidence"] == pytest.approx(0.50 - ros.DECAY_DELTA)
+        assert decayed["failure"] == 1
+        _pend(self.KEY)
+        _finalize("sort the report output by date")  # repeat AFTER failure: no boost
+        after = _row(self.KEY)
+        assert after["confidence"] == pytest.approx(decayed["confidence"])
+        assert after["success"] == 0
+
+    def test_explicit_acceptance_path_unchanged_on_repeat(self):
+        """An acceptance turn still earns the FULL boost, never the weak one."""
+        import routing_outcome_score as ros
+
+        _pend(self.KEY)
+        _finalize("now refactor the parser module")  # history=neutral
+        before = _row(self.KEY)
+        _pend(self.KEY)
+        _finalize("thanks, that worked")
+        after = _row(self.KEY)
+        assert after["confidence"] == pytest.approx(before["confidence"] + ros.BOOST_DELTA)
+
+    def test_attributable_rejection_still_decays_on_repeat(self):
+        """Regression: the failure path outranks the weak signal."""
+        import routing_outcome_score as ros
+
+        _pend(self.KEY)
+        _finalize("now refactor the parser module")  # history=neutral
+        before = _row(self.KEY)
+        _pend(self.KEY)
+        _finalize("that's wrong, the tests fail")
+        after = _row(self.KEY)
+        assert after["confidence"] == pytest.approx(before["confidence"] - ros.DECAY_DELTA)
+        assert after["failure"] == 1
+
+    def test_rejection_turn_suppresses_weak_even_unattributable(self, env):
+        """Multi-dispatch turn + a complaint: nothing gets the weak upgrade."""
+        other = "agent-y:skill-y"
+        _seed(env["ldb"], other)
+        _pend(self.KEY)
+        _finalize("now refactor the parser module")  # history[KEY]=neutral
+        before = _row(self.KEY)
+        _pend(self.KEY)
+        _pend(other)  # 2 live pendings => reaction unattributable
+        _finalize("that's wrong, the tests fail")
+        after = _row(self.KEY)
+        assert after["confidence"] == pytest.approx(before["confidence"])  # no boost, no decay
+        assert after["success"] == 0 and after["failure"] == 0
+
+    def test_weak_basis_counter_recorded(self):
+        _pend(self.KEY)
+        _finalize("now refactor the parser module")
+        _pend(self.KEY)
+        _finalize("add a retry to the fetch helper")
+        from learning_db_v2 import get_db_path
+
+        conn = sqlite3.connect(get_db_path())
+        try:
+            r = conn.execute(
+                "SELECT count FROM routing_outcome_basis WHERE key = ? AND basis = 'repeat_dispatch_weak'",
+                (self.KEY,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert r is not None and r[0] == 1
+
+
+# --- 4. fixture replay ----------------------------------------------------------
+
+
+def _replay_fixture(env) -> None:
+    """Drive the pipeline exactly as the hooks do: a dispatch event records the
+    decision row + pending entry (action A); a prompt event runs the REAL
+    finalizer hook as a subprocess."""
+    session = "replay-1"
+    for line in FIXTURE.read_text().splitlines():
+        event = json.loads(line)
+        if event["type"] == "dispatch":
+            _seed(env["ldb"], event["key"])
+            _pend(event["key"], errors=event["errors"], session=session)
+        else:
+            _finalize(event["text"], session=session)
+
+
+class TestFixtureReplay:
+    KEY_A = "python-general-engineer:test-driven-development"  # 12 clean repeats
+    KEY_B = "golang-general-engineer:go-patterns"  # clean, FAILURE, clean
+
+    def test_replay_moves_weight_up_and_cap_holds(self, env):
+        import routing_outcome_score as ros
+
+        _replay_fixture(env)
+        a = _row(self.KEY_A)
+        # Before: 0.5 / n=1 (the starved baseline). After 12 dispatches / 11
+        # repeats: capped confidence, full evidence trail.
+        assert a["n"] == 12
+        assert a["success"] == 11
+        assert a["failure"] == 0
+        assert a["confidence"] == pytest.approx(ros.WEAK_CONFIDENCE_CAP)
+        assert a["confidence"] <= ros.WEAK_CONFIDENCE_CAP + 1e-9  # cap holds
+        assert a["confidence"] < 0.70  # never high-confidence on repetition alone
+
+    def test_replay_intervening_failure_blocks_weak(self, env):
+        _replay_fixture(env)
+        b = _row(self.KEY_B)
+        # neutral, then tool-error decay, then a repeat that must NOT boost.
+        # NOTE: confidence reads 0.50, not 0.42 — the recorder's upsert
+        # (record_learning: confidence = max(confidence, excluded.confidence))
+        # re-floors a decayed row to the 0.5 default on the NEXT dispatch.
+        # Pre-existing action-A behavior, untouched here. What C6 must prove:
+        # the repeat after a failure earns NO weak boost — success stays 0 and
+        # confidence never rises above the recorder's floor.
+        assert b["n"] == 3
+        assert b["failure"] == 1
+        assert b["success"] == 0
+        assert b["confidence"] <= 0.50 + 1e-9
+
+    def test_replayed_row_crosses_evidence_gate(self, env):
+        """A weak-signal row with n>=5 is evidence-eligible; the shadow-policy
+        thresholds (evidence gate, demote floor, tiebreak) read it correctly."""
+        _replay_fixture(env)
+        sys.path.insert(0, str(SCRIPTS_LIB))
+        import route_policy
+
+        a = _row(self.KEY_A)
+        assert a["n"] >= route_policy.MIN_OBSERVATIONS
+        weights = {self.KEY_A: a}
+        # Evidence-eligible + healthy: the pick stands on merit, not on the gate.
+        result = route_policy.health_adjust({"key": self.KEY_A, "confidence": 0.9}, [], weights, [])
+        assert result["action"] == "keep"
+        assert "semantic pick stands" in result["reason"]
+        # A capped weak-only row can never sit on the demote floor.
+        assert not route_policy._is_floor(a)
+        # Threshold regression: a genuine floor row still demotes ...
+        floor = {"confidence": 0.20, "n": 6, "success": 1, "failure": 4}
+        healthy = {"confidence": 0.65, "n": 12, "success": 11, "failure": 0}
+        moved = route_policy.health_adjust(
+            {"key": "bad:route", "confidence": 0.9},
+            [self.KEY_A],
+            {"bad:route": floor, self.KEY_A: healthy},
+            [],
+        )
+        assert moved["action"] == "demote"
+        # ... and the evidence gate still protects an n<5 pick from demotion.
+        fresh = {"confidence": 0.10, "n": 2, "success": 0, "failure": 2}
+        kept = route_policy.health_adjust(
+            {"key": "new:route", "confidence": 0.9},
+            [self.KEY_A],
+            {"new:route": fresh, self.KEY_A: healthy},
+            [],
+        )
+        assert kept["action"] == "keep"

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -270,9 +270,10 @@ def cmd_prune(args):
     with get_connection() as conn:
         total_before = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()[0]
         # `where` is built only from fixed clauses; all user values are bound as ? params.
-        matched = conn.execute(f"SELECT COUNT(*) FROM learnings WHERE {where}", params).fetchone()[
-            0
-        ]  # security-review: ignore (fixed clauses; user values bound as ?)
+        matched_sql = (
+            f"SELECT COUNT(*) FROM learnings WHERE {where}"  # security-review: ignore (fixed clauses; bound ?)
+        )
+        matched = conn.execute(matched_sql, params).fetchone()[0]
         breakdown = conn.execute(
             f"SELECT category, topic, COUNT(*) AS n FROM learnings WHERE {where} "  # security-review: ignore (fixed clauses; user values bound as ?)
             "GROUP BY category, topic ORDER BY n DESC",
@@ -292,9 +293,8 @@ def cmd_prune(args):
             print("Back up the database first: cp <db> <db>.bak-$(date +%Y%m%d)")
             return
 
-        cursor = conn.execute(
-            f"DELETE FROM learnings WHERE {where}", params
-        )  # security-review: ignore (fixed clauses; user values bound as ?)
+        delete_sql = f"DELETE FROM learnings WHERE {where}"  # security-review: ignore (fixed clauses; bound ? params)
+        cursor = conn.execute(delete_sql, params)
         deleted = cursor.rowcount
         conn.commit()
         total_after = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()[0]
@@ -1338,7 +1338,16 @@ def cmd_skip_rate(args: argparse.Namespace) -> None:
         print("No instructions flagged. Threshold: >20% skip rate over 30+ observations.")
 
 
-_BASIS_LABELS = ("rejection_detected", "tool_errors_only", "acceptance_detected", "default_no_complaint")
+_BASIS_LABELS = (
+    "rejection_detected",
+    "tool_errors_only",
+    "acceptance_detected",
+    "default_no_complaint",
+    # C6 weak-positive: repeat dispatch, no intervening failure. Neither strong
+    # feedback nor silent default-success — reported on its own line and kept
+    # OUT of the silent-success share (strong + default formula unchanged).
+    "repeat_dispatch_weak",
+)
 
 
 def _read_basis_counts() -> dict[str, int]:
@@ -1394,6 +1403,9 @@ def cmd_route_health(args: argparse.Namespace) -> None:
     basis = _read_basis_counts()
     strong = basis["rejection_detected"] + basis["tool_errors_only"] + basis["acceptance_detected"]
     default_success = basis["default_no_complaint"]
+    # repeat_dispatch_weak (C6) is reported but stays OUT of strong/default and
+    # the silent-success share: it is an inferred signal, not user feedback and
+    # not silence-scored success. Formula unchanged from pre-C6.
     basis_total = strong + default_success
     silent_share = (default_success / basis_total) if basis_total else None
 
@@ -1452,6 +1464,7 @@ def cmd_route_health(args: argparse.Namespace) -> None:
         print(f"  tool_errors_only     {basis['tool_errors_only']}")
         print(f"  acceptance_detected  {basis['acceptance_detected']}")
         print(f"  default_no_complaint {basis['default_no_complaint']}")
+        print(f"  repeat_dispatch_weak {basis['repeat_dispatch_weak']} (weak-positive; outside the share below)")
         print(f"Silent-success share: {silent_share * 100:.0f}% of scored outcomes ({default_success}/{basis_total})")
     print(f"Governed-path coverage: {has_outcome}/{total} routing rows carry a finalized outcome ({pct:.0f}%)")
     print(

--- a/scripts/tests/test_route_health_basis.py
+++ b/scripts/tests/test_route_health_basis.py
@@ -151,5 +151,6 @@ def test_json_zero_basis_no_divide_by_zero(db_env):
         "tool_errors_only": 0,
         "acceptance_detected": 0,
         "default_no_complaint": 0,
+        "repeat_dispatch_weak": 0,
     }
     assert data["silent_success_share"] is None


### PR DESCRIPTION
## Problem

Route weights sat starved at confidence 0.5 with n<5: success required an explicit acceptance marker ("thanks", "lgtm") that almost never appears in real next prompts, so healthy routes accumulated no evidence and the shadow policy (demote floor, tiebreak, n>=5 evidence gate) could never fire on real data.

## Change (ADR router-improvement-program, component C6)

New WEAK-POSITIVE signal in the UserPromptSubmit finalizer (`hooks/routing-outcome-finalizer.py`): a would-be-neutral clean entry whose `agent:skill` pair was finalized non-failure earlier in the same session is a repeat dispatch with no intervening failure — the user kept re-using the route — and scores `weak_success`, a small bounded boost.

**Preserved semantics (by construction + regression tests):**
- Failure/decay paths byte-identical (tool errors and attributable rejections still decay −0.08).
- Explicit-acceptance boost unchanged (+0.05, may exceed the weak cap).
- Neutral stays neutral for a first dispatch + unrelated next prompt.
- The reaction detector is untouched — the upgrade reads dispatch HISTORY, never prompt text.
- Any rejection on the turn, even an unattributable multi-dispatch one, suppresses the upgrade (never boost on a complaint turn).

## Chosen bound and rationale (ADR update)

`WEAK_BOOST_DELTA = 0.02`, `WEAK_CONFIDENCE_CAP = 0.65` (`hooks/lib/routing_outcome_score.py`):

- **Delta ordering** 0.02 < 0.05 (acceptance) < 0.08 (decay): one failure erases four weak boosts; explicit signals always dominate inferred ones.
- **Cap 0.65 sits strictly below the 0.70 high-confidence/injection threshold**: repetition alone can NEVER make a pair high-confidence — crossing 0.70 requires explicit acceptance. The delta clamps to fit under the cap (0 at the cap) and never lowers a row that explicit boosts pushed above it.
- **Evidence still accrues at the cap**: `success_count`/n increment even when the delta is 0, so a weak-only pair becomes evidence-eligible (n>=5) while its confidence stays bounded. Cap 0.65 also stays far above the 0.30 demote floor and the 0.35 tiebreak band, so weak evidence keeps healthy routes clear of both.

## Evidence

Fixture replay (`hooks/tests/fixtures/weak_positive_replay.jsonl`, replayed through the real finalizer subprocess in `hooks/tests/test_weak_positive.py`):

```
--- BEFORE (after first dispatch — the starved baseline) ---
python-general-engineer:test-driven-development   conf=0.5000 n=1  success=0  failure=0
--- AFTER replay (12 clean repeats key A; clean/FAILURE/clean key B) ---
golang-general-engineer:go-patterns               conf=0.5000 n=3  success=0  failure=1
python-general-engineer:test-driven-development   conf=0.6500 n=12 success=11 failure=0
```

- Key A: 0.5/n=1 moves upward and the **cap holds** after many repeats (0.65 exactly; 8 boosts land, then delta 0 while success keeps counting).
- Key B: intervening tool-error → decay recorded, and the repeat after it earns **no** weak boost (success stays 0). (Confidence reads 0.50, not 0.42: the recorder's pre-existing `record_learning` upsert `max(confidence, 0.5)` re-floors on the next dispatch — untouched action-A behavior, documented in the test.)
- Evidence gate: the replayed row crosses n>=5 and `route_policy.health_adjust` treats it as evidence-eligible (keeps on merit, not on the gate); threshold regressions prove a genuine floor row still demotes and an n<5 pick is still gate-protected.

## Tests

- `hooks/tests/test_weak_positive.py` (22 tests): weak delta + cap + accrual-at-cap; weak-only row never reaches 0.70; weak never lowers an above-cap row; **failure-decay and explicit-success deltas unchanged after weak boosts**; session history round-trip/bound/isolation; finalizer end-to-end (first dispatch neutral, repeat boosts, intervening error blocks, acceptance and attributable rejection unchanged, complaint turn suppresses, event + basis recorded); fixture replay + policy thresholds.
- `scripts/tests/test_route_health_basis.py`: extended exact-label assertion for the new `repeat_dispatch_weak` basis (reported on its own route-health line, kept OUT of the silent-success share — formula unchanged).
- Full suites green locally: 1726 hook tests, 3177 script tests. `ruff check` + `ruff format --check` clean.

## Also in this diff

Relocated two pre-existing `# security-review: ignore` markers in `scripts/learning-db.py` `cmd_prune` onto the exact f-string lines the scanner reads (a format reflow had split them off, so the commit gate re-flagged already-reviewed false positives — fixed clauses, bound `?` params). No behavior change.

docs/route-loop-validation.md documents the new signal's semantics (sensor mechanism, new step 5).