### PR TITLE
feat(hooks): local private-name leak gate — blocks commits/PR text naming private components

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -206,6 +206,12 @@
           },
           {
             "type": "command",
+            "command": "python3 \"$HOME/.claude/hooks/pretool-private-name-leak-gate.py\"",
+            "description": "Private-name leak gate: blocks git commit/push and gh pr text naming a private component from ~/private-skills (local-only by design; block messages redact the name)",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/security-review-hook.py\"",
             "description": "Security review gate: blocks git commit when staged files have HIGH/CRITICAL findings (VEXJOY_SECURITY_REVIEW_SKIP=1 to override)",
             "timeout": 30000

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AI agents skip steps.
 Harnesses have a second problem: given only a skill list, they do not route eagerly enough, or correctly enough. Good skills sit unused. So this toolkit connects the skills, agents, and workflows we want directly into the harness, automatically. You don't have to understand what is here. Say what you want in plain English and you get all the value we have put into it: the right specialist with the right methodology, behind gates that demand exit codes, not assertions.
 
 <!-- Counts here must match the Four Layers table (~line 143). Verify both: python3 scripts/validate-doc-counts.py -->
-44 domain agents, 133 workflow skills, 85 hooks, 128 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
+44 domain agents, 133 workflow skills, 86 hooks, 128 scripts. Agents carry knowledge, skills enforce methodology, hooks block incomplete work, scripts handle determinism.
 
 Works across Claude Code (`/do`), Codex (`$do`), Factory (`/do`), Reasonix (`/do`).
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -73,6 +73,7 @@ Task completes: TaskCompleted
 | `pretool-branch-safety` | Bash | Blocks `git commit` when on `main` or `master` branch |
 | `pretool-config-protection` | Write, Edit, MultiEdit | Blocks modifications to linter/formatter config files (ESLint, Prettier, Biome, Ruff, golangci-lint, etc.) |
 | `pretool-plan-gate` | Write, Edit | Blocks implementation in `agents/`, `skills/` when `task_plan.md` does not exist |
+| `pretool-private-name-leak-gate` | Bash | Blocks `git commit`/`git push` and `gh pr` text that names a private component from `~/private-skills`. Name set derived at runtime, minus public homonyms — local-only by design (no private tree = graceful no-op, so CI cannot host it). Block messages redact the matched name |
 | `pretool-synthesis-gate` | Write, Edit | Blocks feature implementation when ADR consultation synthesis is missing or blocked |
 
 ### Advisory Hooks (exit 0 = warn)

--- a/hooks/pretool-private-name-leak-gate.py
+++ b/hooks/pretool-private-name-leak-gate.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+# hook-version: 1.0.0
+"""
+PreToolUse:Bash Hook: Private Name Leak Gate
+
+Blocks git commit, git push, and gh pr create/edit/comment/merge when the
+text they would publish contains the name of a private component installed
+from ~/private-skills. Private component names must never reach this repo,
+its commits, or its PR text.
+
+This is a HARD GATE — exits 0 with JSON permissionDecision:deny to block the
+Bash tool.
+
+LOCAL-ONLY BY DESIGN: the private-name set is derived at runtime from the
+local ~/private-skills tree. Shipping the set with the repo would itself be
+the leak, so CI and public installs (no ~/private-skills) get a graceful
+no-op. This gate cannot and should not run in CI.
+
+Name set:
+- Directory basenames and .md stems under ~/private-skills (recursive)
+- MINUS structural basenames (SKILL, README, references, ...)
+- MINUS names shorter than 4 chars
+- MINUS tracked public skill names from skills/INDEX.json (project copy
+  first, then ~/.claude/skills/INDEX.json) — public homonyms never block
+
+Scanned text per command:
+- always: the command text itself (covers -m/--title/--body args)
+- git commit: staged diff (git diff --cached), -F/--file message files
+- git push: outgoing commit messages (@{upstream}..HEAD, else last 20)
+- gh pr create/edit/comment/merge: --body-file/-F file contents
+
+Block messages REDACT the matched name (first char + … + last char) so the
+gate never echoes a private name into transcripts.
+
+Allow-through conditions:
+- Command matches none of the gated shapes
+- ~/private-skills is absent (public install, CI)
+- Effective cwd is not inside a toolkit-shaped repo (agents/ + skills/)
+- Effective cwd is inside ~/private-skills itself (self-scan would
+  always block that repo's own commits)
+- No private name found in any scanned text
+- PRIVATE_NAME_GATE_BYPASS=1 env var
+"""
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from hook_utils import deny_tool_use
+from learning_db_v2 import record_governance_event
+from stdin_timeout import read_stdin
+
+_BYPASS_ENV = "PRIVATE_NAME_GATE_BYPASS"
+
+# Patched by tests. Runtime source of the private-name set.
+_PRIVATE_DIR = Path.home() / "private-skills"
+# Fallback public-skill index when the project has no skills/INDEX.json.
+_USER_INDEX = Path.home() / ".claude" / "skills" / "INDEX.json"
+
+# Gated command shapes. `gh pr merge` is matched broadly; a merge without
+# --body carries no new text and passes the scan anyway.
+_CMD_RE = re.compile(r"\bgit\s+commit\b|\bgit\s+push\b|\bgh\s+pr\s+(?:create|edit|comment|merge)\b")
+_GIT_COMMIT_RE = re.compile(r"\bgit\s+commit\b")
+_GIT_PUSH_RE = re.compile(r"\bgit\s+push\b")
+_GH_PR_RE = re.compile(r"\bgh\s+pr\s+(?:create|edit|comment|merge)\b")
+
+# Structural basenames that name file roles, not private components.
+_STOPLIST = frozenset(
+    {
+        "skill",
+        "skills",
+        "agent",
+        "agents",
+        "readme",
+        "index",
+        "license",
+        "changelog",
+        "contributing",
+        "claude",
+        "references",
+        "reference",
+        "assets",
+        "scripts",
+        "docs",
+        "templates",
+        "template",
+        "examples",
+        "example",
+        "hooks",
+        "lib",
+        "tests",
+        "test",
+        "notes",
+        "archive",
+        "private-skills",
+    }
+)
+_MIN_NAME_LEN = 4
+
+# File-content arguments: commit message files and PR body files.
+_COMMIT_FILE_FLAGS = {"-F", "--file"}
+_PR_BODY_FILE_FLAGS = {"-F", "--body-file"}
+
+
+def _extract_effective_cwd(command: str, default_cwd: str | None) -> str | None:
+    """Extract the effective working directory from a command string.
+
+    Detects `cd <path> && ...` / `cd <path> ; ...` and `git -C <path>`.
+    Same convention as pretool-branch-safety.
+    """
+    m = re.match(r'cd\s+(?:"([^"]+)"|(\S+))\s*(?:&&|;)', command.lstrip())
+    if m:
+        p = (m.group(1) or m.group(2) or "").strip()
+        if p:
+            return p
+    m = re.search(r'\bgit\s+-C\s+(?:"([^"]+)"|(\S+))', command)
+    if m:
+        return m.group(1) or m.group(2)
+    return default_cwd
+
+
+def _find_toolkit_root(cwd: str | None) -> Path | None:
+    """Walk up from cwd to the nearest dir with agents/ AND skills/.
+
+    Same toolkit-shape convention as pretool-adr-creation-gate. Returns None
+    when cwd is not inside a toolkit repo — the gate stays dormant there.
+    """
+    if not cwd:
+        return None
+    try:
+        candidate = Path(cwd).resolve()
+    except OSError:
+        return None
+    for _ in range(8):
+        try:
+            if (candidate / "agents").is_dir() and (candidate / "skills").is_dir():
+                return candidate
+        except OSError:
+            return None
+        parent = candidate.parent
+        if parent == candidate:
+            break
+        candidate = parent
+    return None
+
+
+def _public_skill_names(toolkit_root: Path) -> set[str]:
+    """Public skill names from skills/INDEX.json (project first, then user).
+
+    Tolerates the v2 dict format ({"skills": {name: ...}}) and a list of
+    {"name": ...} entries. Missing or malformed index yields an empty set —
+    the gate then errs toward blocking, never toward leaking.
+    """
+    names: set[str] = set()
+    for index_path in (toolkit_root / "skills" / "INDEX.json", _USER_INDEX):
+        try:
+            data = json.loads(index_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        skills = data.get("skills", data) if isinstance(data, dict) else data
+        if isinstance(skills, dict):
+            names.update(k.lower() for k in skills)
+        elif isinstance(skills, list):
+            for entry in skills:
+                if isinstance(entry, dict) and entry.get("name"):
+                    names.add(str(entry["name"]).lower())
+        if names:
+            break
+    return names
+
+
+def _private_names(toolkit_root: Path) -> set[str]:
+    """Runtime private-name set: dir basenames and .md stems, filtered."""
+    raw: set[str] = set()
+    try:
+        for _dirpath, dirnames, filenames in os.walk(_PRIVATE_DIR):
+            # Skip VCS internals.
+            dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+            raw.update(dirnames)
+            raw.update(Path(f).stem for f in filenames if f.endswith(".md"))
+    except OSError:
+        return set()
+    names = {n.lower() for n in raw}
+    names -= _STOPLIST
+    names = {n for n in names if len(n) >= _MIN_NAME_LEN and not n.startswith(".")}
+    names -= _public_skill_names(toolkit_root)
+    return names
+
+
+def _name_pattern(names: set[str]) -> re.Pattern[str]:
+    """One alternation, longest-first, kebab-aware boundaries.
+
+    `(?<![A-Za-z0-9_-])` / `(?![A-Za-z0-9_-])` keep a name from matching
+    inside a longer kebab-case identifier.
+    """
+    alternation = "|".join(re.escape(n) for n in sorted(names, key=len, reverse=True))
+    return re.compile(rf"(?<![A-Za-z0-9_-])(?:{alternation})(?![A-Za-z0-9_-])", re.IGNORECASE)
+
+
+def _redact(name: str) -> str:
+    """First char + ellipsis + last char, e.g. `v…z`. Never the full name."""
+    if len(name) <= 1:
+        return "…"
+    return f"{name[0]}…{name[-1]}"
+
+
+def _file_args(command: str, flags: set[str]) -> list[str]:
+    """Paths passed via file flags, handling both `-F p` and `--flag=p`."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    paths: list[str] = []
+    for i, token in enumerate(tokens):
+        if token in flags and i + 1 < len(tokens):
+            paths.append(tokens[i + 1])
+            continue
+        for flag in flags:
+            if flag.startswith("--") and token.startswith(flag + "="):
+                paths.append(token[len(flag) + 1 :])
+    return paths
+
+
+def _run_git(args: list[str], cwd: str | None) -> str:
+    """Run a git command; empty string on any failure (fail open)."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=cwd or None,
+        )
+        if result.returncode == 0:
+            return result.stdout
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return ""
+
+
+def _collect_scan_targets(command: str, cwd: str | None) -> list[tuple[str, str]]:
+    """(location, text) pairs to scan for the matched command."""
+    targets: list[tuple[str, str]] = [("command text", command)]
+
+    file_paths: list[tuple[str, str]] = []
+    if _GIT_COMMIT_RE.search(command):
+        targets.append(("staged diff", _run_git(["diff", "--cached"], cwd)))
+        file_paths += [("commit message file", p) for p in _file_args(command, _COMMIT_FILE_FLAGS)]
+    if _GIT_PUSH_RE.search(command):
+        messages = _run_git(["log", "@{upstream}..HEAD", "--format=%B"], cwd)
+        if not messages:
+            # No upstream yet (first push of a branch): scan recent messages.
+            messages = _run_git(["log", "-20", "--format=%B"], cwd)
+        targets.append(("outgoing commit messages", messages))
+    if _GH_PR_RE.search(command):
+        file_paths += [("PR body file", p) for p in _file_args(command, _PR_BODY_FILE_FLAGS)]
+
+    for label, path_str in file_paths:
+        path = Path(path_str)
+        if not path.is_absolute() and cwd:
+            path = Path(cwd) / path
+        try:
+            targets.append((f"{label} {path_str}", path.read_text(encoding="utf-8", errors="replace")))
+        except OSError:
+            continue
+    return targets
+
+
+def main() -> None:
+    debug = os.environ.get("CLAUDE_HOOKS_DEBUG")
+
+    raw = read_stdin(timeout=2)
+    try:
+        event = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+    if not isinstance(event, dict):
+        sys.exit(0)
+
+    command = event.get("tool_input", {}).get("command", "")
+    if not command or not _CMD_RE.search(command):
+        sys.exit(0)
+
+    if os.environ.get(_BYPASS_ENV) == "1":
+        if debug:
+            print(f"[private-name-leak-gate] Bypassed via {_BYPASS_ENV}=1", file=sys.stderr)
+        sys.exit(0)
+
+    # Graceful no-op: no private tree on this machine (public install, CI).
+    if not _PRIVATE_DIR.is_dir():
+        if debug:
+            print("[private-name-leak-gate] No private tree — dormant", file=sys.stderr)
+        sys.exit(0)
+
+    default_cwd = event.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR")
+    cwd = _extract_effective_cwd(command, default_cwd)
+
+    # Never scan the private repo's own commits — every one names itself.
+    if cwd:
+        try:
+            if Path(cwd).resolve().is_relative_to(_PRIVATE_DIR.resolve()):
+                sys.exit(0)
+        except OSError:
+            pass
+
+    toolkit_root = _find_toolkit_root(cwd)
+    if toolkit_root is None:
+        if debug:
+            print("[private-name-leak-gate] Not a toolkit repo — allowing", file=sys.stderr)
+        sys.exit(0)
+
+    names = _private_names(toolkit_root)
+    if not names:
+        sys.exit(0)
+    pattern = _name_pattern(names)
+
+    for location, text in _collect_scan_targets(command, cwd):
+        if not text:
+            continue
+        match = pattern.search(text)
+        if match:
+            redacted = _redact(match.group(0))
+            print(
+                f"[private-name-leak-gate] BLOCKED: private component name ({redacted}) found in {location}.",
+                file=sys.stderr,
+            )
+            try:
+                record_governance_event(
+                    "policy_violation", tool_name="Bash", hook_phase="pre", severity="high", blocked=True
+                )
+            except Exception:
+                pass  # Never let recording prevent a block
+            deny_tool_use(
+                "PreToolUse",
+                f"Private component name ({redacted}) found in {location}. "
+                "Private skill names must not reach commits, pushes, or PR text. "
+                "Remove the reference and retry. "
+                f"Bypass with {_BYPASS_ENV}=1 only with explicit owner approval.",
+            )
+            sys.exit(0)
+
+    if debug:
+        print("[private-name-leak-gate] Clean — allowing", file=sys.stderr)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise  # Let sys.exit(0) propagate normally
+    except Exception as e:
+        if os.environ.get("CLAUDE_HOOKS_DEBUG"):
+            traceback.print_exc(file=sys.stderr)
+        else:
+            print(f"[private-name-leak-gate] Error: {type(e).__name__}: {e}", file=sys.stderr)
+        # A crashed hook must fail OPEN — never block tools.
+    finally:
+        sys.exit(0)

--- a/hooks/tests/test_pretool_private_name_leak_gate.py
+++ b/hooks/tests/test_pretool_private_name_leak_gate.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""
+Tests for the pretool-private-name-leak-gate hook.
+
+All fixtures use SYNTHETIC names (secret-example-skill, hidden-fixture-notes,
+translate). The real ~/private-skills tree is never read: every test patches
+mod._PRIVATE_DIR to a tmp dir, so no real private name can reach test output.
+
+Run with: python3 -m pytest hooks/tests/test_pretool_private_name_leak_gate.py -v
+"""
+
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+HOOK_PATH = Path(__file__).parent.parent / "pretool-private-name-leak-gate.py"
+
+spec = importlib.util.spec_from_file_location("pretool_private_name_leak_gate", HOOK_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+SYNTH = "secret-example-skill"  # synthetic private component name
+SYNTH_REDACTED = "s…l"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def private_dir(tmp_path, monkeypatch):
+    """Synthetic ~/private-skills tree; patched into the module."""
+    root = tmp_path / "private-tree"
+    (root / SYNTH).mkdir(parents=True)
+    (root / SYNTH / "SKILL.md").write_text("---\nname: x\n---\n")
+    (root / "hidden-fixture-notes.md").write_text("notes\n")
+    monkeypatch.setattr(mod, "_PRIVATE_DIR", root)
+    # Point the user-index fallback at nothing so only the project INDEX counts.
+    monkeypatch.setattr(mod, "_USER_INDEX", tmp_path / "no-user-index.json")
+    return root
+
+
+@pytest.fixture()
+def toolkit_repo(tmp_path):
+    """Toolkit-shaped git repo (agents/ + skills/) with a public INDEX.json."""
+    repo = tmp_path / "toolkit"
+    (repo / "agents").mkdir(parents=True)
+    (repo / "skills").mkdir()
+    (repo / "skills" / "INDEX.json").write_text(json.dumps({"version": "2.0", "skills": {"translate": {}}}))
+    _git(repo, "init", "-q")
+    return repo
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@example.com", "-c", "user.name=t", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _event(command: str, cwd: Path | None = None) -> str:
+    event: dict = {"tool_input": {"command": command}}
+    if cwd:
+        event["cwd"] = str(cwd)
+    return json.dumps(event)
+
+
+def _run_main(stdin_payload: str, env: dict | None = None) -> tuple[int, dict | None, str, str]:
+    """Invoke mod.main() in-process.
+
+    Returns (logical_exit_code, parsed_stdout_json, raw_stdout, raw_stderr).
+    logical_exit_code is 2 if permissionDecision:deny was emitted, 0 otherwise.
+    """
+    base_env = dict(os.environ)
+    for var in ("PRIVATE_NAME_GATE_BYPASS", "CLAUDE_PROJECT_DIR", "CLAUDE_HOOKS_DEBUG"):
+        base_env.pop(var, None)
+    if env:
+        base_env.update(env)
+
+    stdout_capture = io.StringIO()
+    stderr_capture = io.StringIO()
+    with (
+        patch.dict(os.environ, base_env, clear=True),
+        patch.object(mod, "read_stdin", return_value=stdin_payload),
+        patch.object(mod, "record_governance_event", lambda *_args, **_kwargs: None),
+        patch("sys.stdout", stdout_capture),
+        patch("sys.stderr", stderr_capture),
+    ):
+        try:
+            mod.main()
+        except SystemExit:
+            pass
+
+    out = stdout_capture.getvalue()
+    parsed = None
+    if out.strip():
+        try:
+            parsed = json.loads(out.strip())
+        except json.JSONDecodeError:
+            pass
+
+    code = 0
+    if parsed and parsed.get("hookSpecificOutput", {}).get("permissionDecision") == "deny":
+        code = 2
+    return code, parsed, out, stderr_capture.getvalue()
+
+
+def _reason(parsed: dict) -> str:
+    return parsed["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+# ---------------------------------------------------------------------------
+# Blocks — each covered command shape fires on a synthetic name
+# ---------------------------------------------------------------------------
+
+
+class TestBlocks:
+    def test_block_on_staged_diff(self, private_dir, toolkit_repo):
+        (toolkit_repo / "f.txt").write_text(f"wires {SYNTH} into the router\n")
+        _git(toolkit_repo, "add", "f.txt")
+        code, parsed, _, _ = _run_main(_event("git commit -m 'clean message'", toolkit_repo))
+        assert code == 2
+        assert "staged diff" in _reason(parsed)
+
+    def test_block_on_commit_message_arg(self, private_dir, toolkit_repo):
+        code, parsed, _, _ = _run_main(_event(f'git commit -m "wire {SYNTH} in"', toolkit_repo))
+        assert code == 2
+        assert "command text" in _reason(parsed)
+
+    def test_block_on_commit_message_file(self, private_dir, toolkit_repo, tmp_path):
+        msg = tmp_path / "msg.txt"
+        msg.write_text(f"feat: enable {SYNTH}\n")
+        code, parsed, _, _ = _run_main(_event(f"git commit -F {msg}", toolkit_repo))
+        assert code == 2
+        assert "commit message file" in _reason(parsed)
+
+    def test_block_on_push_with_leaking_commit_message(self, private_dir, toolkit_repo):
+        (toolkit_repo / "f.txt").write_text("clean content\n")
+        _git(toolkit_repo, "add", "f.txt")
+        _git(toolkit_repo, "commit", "-q", "-m", f"add {SYNTH} support")
+        code, parsed, _, _ = _run_main(_event("git push origin feat-x", toolkit_repo))
+        assert code == 2
+        assert "outgoing commit messages" in _reason(parsed)
+
+    def test_block_on_pr_create_body_arg(self, private_dir, toolkit_repo):
+        code, parsed, _, _ = _run_main(_event(f'gh pr create --title t --body "uses {SYNTH}"', toolkit_repo))
+        assert code == 2
+
+    def test_block_on_pr_create_body_file(self, private_dir, toolkit_repo, tmp_path):
+        body = tmp_path / "body.md"
+        body.write_text(f"## Summary\nintegrates {SYNTH}\n")
+        code, parsed, _, _ = _run_main(_event(f"gh pr create --title t --body-file {body}", toolkit_repo))
+        assert code == 2
+        assert "PR body file" in _reason(parsed)
+        assert str(body) in _reason(parsed)
+
+    def test_block_on_pr_edit(self, private_dir, toolkit_repo):
+        code, _, _, _ = _run_main(_event(f'gh pr edit 5 --body "now with {SYNTH}"', toolkit_repo))
+        assert code == 2
+
+    def test_block_on_pr_comment(self, private_dir, toolkit_repo):
+        code, _, _, _ = _run_main(_event(f'gh pr comment 5 --body "see {SYNTH}"', toolkit_repo))
+        assert code == 2
+
+    def test_block_on_pr_merge_body(self, private_dir, toolkit_repo):
+        code, _, _, _ = _run_main(_event(f'gh pr merge 5 --squash --body "folds in {SYNTH}"', toolkit_repo))
+        assert code == 2
+
+    def test_block_on_md_stem_name(self, private_dir, toolkit_repo):
+        """.md basenames (recursive) are part of the name set, not just dirs."""
+        code, _, _, _ = _run_main(_event('git commit -m "port hidden-fixture-notes"', toolkit_repo))
+        assert code == 2
+
+
+# ---------------------------------------------------------------------------
+# Redaction — the gate never echoes the matched name
+# ---------------------------------------------------------------------------
+
+
+class TestRedaction:
+    def test_block_output_never_contains_raw_name(self, private_dir, toolkit_repo):
+        (toolkit_repo / "f.txt").write_text(f"{SYNTH}\n")
+        _git(toolkit_repo, "add", "f.txt")
+        code, parsed, out, err = _run_main(_event("git commit -m 'clean'", toolkit_repo))
+        assert code == 2
+        assert SYNTH not in out
+        assert SYNTH not in err
+        assert SYNTH_REDACTED in _reason(parsed)
+        assert SYNTH_REDACTED in err
+
+    def test_redact_shape(self):
+        assert mod._redact("secret-example-skill") == "s…l"
+        assert mod._redact("ab") == "a…b"
+        assert mod._redact("x") == "…"
+
+
+# ---------------------------------------------------------------------------
+# Pass-throughs
+# ---------------------------------------------------------------------------
+
+
+class TestPassThrough:
+    def test_public_homonym_never_blocks(self, private_dir, toolkit_repo):
+        """A private dir name that is also a tracked public skill passes."""
+        (private_dir / "translate").mkdir()
+        code, _, _, _ = _run_main(_event('git commit -m "improve translate flow"', toolkit_repo))
+        assert code == 0
+
+    def test_absent_private_dir_is_noop(self, toolkit_repo, tmp_path, monkeypatch):
+        """Public installs and CI have no ~/private-skills: graceful no-op."""
+        monkeypatch.setattr(mod, "_PRIVATE_DIR", tmp_path / "does-not-exist")
+        code, _, _, _ = _run_main(_event(f'git commit -m "wire {SYNTH} in"', toolkit_repo))
+        assert code == 0
+
+    def test_non_toolkit_repo_not_gated(self, private_dir, tmp_path):
+        plain = tmp_path / "plain-repo"
+        plain.mkdir()
+        _git(plain, "init", "-q")
+        code, _, _, _ = _run_main(_event(f'git commit -m "wire {SYNTH} in"', plain))
+        assert code == 0
+
+    def test_private_repo_itself_not_gated(self, private_dir):
+        """Commits inside ~/private-skills always name private components."""
+        code, _, _, _ = _run_main(_event(f'git commit -m "update {SYNTH}"', private_dir))  # nosec: fixture string, not SQL
+        assert code == 0
+
+    def test_non_matching_command_ignored(self, private_dir, toolkit_repo):
+        code, _, _, _ = _run_main(_event(f"grep -rn {SYNTH} .", toolkit_repo))
+        assert code == 0
+
+    def test_clean_commit_allowed(self, private_dir, toolkit_repo):
+        (toolkit_repo / "f.txt").write_text("clean content\n")
+        _git(toolkit_repo, "add", "f.txt")
+        code, _, _, _ = _run_main(_event("git commit -m 'feat: clean change'", toolkit_repo))
+        assert code == 0
+
+    def test_substring_of_longer_kebab_name_not_matched(self, private_dir, toolkit_repo):
+        """Kebab-aware boundaries: name inside a longer identifier passes."""
+        code, _, _, _ = _run_main(_event(f'git commit -m "use my-{SYNTH}-fork instead"', toolkit_repo))
+        assert code == 0
+
+    def test_bypass_env(self, private_dir, toolkit_repo):
+        code, _, _, _ = _run_main(
+            _event(f'git commit -m "wire {SYNTH} in"', toolkit_repo),
+            env={"PRIVATE_NAME_GATE_BYPASS": "1"},
+        )
+        assert code == 0
+
+    def test_malformed_stdin_allowed(self, private_dir):
+        code, _, _, _ = _run_main("not json{")
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Performance — repo benchmark budget (scripts/benchmark-hooks.py: 200ms)
+# ---------------------------------------------------------------------------
+
+
+class TestPerformance:
+    def test_full_scan_under_budget(self, private_dir, toolkit_repo):
+        (toolkit_repo / "f.txt").write_text("clean content\n" * 200)
+        _git(toolkit_repo, "add", "f.txt")
+        payload = _event("git commit -m 'feat: clean change'", toolkit_repo)
+        _run_main(payload)  # warm caches
+        start = time.perf_counter()
+        code, _, _, _ = _run_main(payload)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        assert code == 0
+        assert elapsed_ms < 200, f"scan took {elapsed_ms:.1f}ms (budget 200ms)"


### PR DESCRIPTION
## Summary

New PreToolUse:Bash gate `pretool-private-name-leak-gate.py`: private component names installed from `~/private-skills` can never again reach commits, pushes, or PR text.

**Covered commands:** `git commit`, `git push`, and the `gh` PR subcommands create, edit, comment, and merge (incl. `--body`).

**Scanned text per command:**
- always: the command text itself (`-m`, `--title`, `--body` args)
- commit: staged diff (`git diff --cached`) + `-F/--file` message files
- push: outgoing commit messages (`@{upstream}..HEAD`, else last 20)
- PR subcommands: `--body-file/-F` contents

**Name set (runtime-derived):** directory basenames and `.md` stems under `~/private-skills` (recursive), minus structural basenames (SKILL, README, references, ...), minus short names, minus tracked public skill names from `skills/INDEX.json` — public homonyms never block.

**LOCAL-ONLY BY DESIGN:** the name set cannot ship with the repo or CI — shipping it would itself be the leak. No `~/private-skills` (public installs, CI) = graceful no-op.

**Block behavior:** family convention (`deny_tool_use`, exit 0 + `permissionDecision:deny`). The block message names the matched location (staged diff / command text / PR body file path) but **redacts** the name to first char + `…` + last char (e.g. `s…l`), so the gate never echoes a private name into transcripts.

**Scope guards:** fires only in toolkit-shaped repos (`agents/` + `skills/` at root, same convention as pretool-adr-creation-gate); dormant inside `~/private-skills` itself; standalone hook rather than a unified-gate section because the unified gate's git-submission check returns early on the personal operator profile and this gate must fire regardless. Bypass: `PRIVATE_NAME_GATE_BYPASS=1` (owner approval only).

## Tests

22 tests, all with synthetic tmp-dir fixtures (`secret-example-skill`) — the real private tree is never read:
- block firing on every covered command shape: staged diff, commit message arg, commit `-F` file, push with leaking outgoing message, PR create/edit/comment/merge `--body`, PR `--body-file`
- redaction test asserts the raw synthetic name is ABSENT from stdout and stderr and the redacted form present
- pass-throughs: public homonym, absent private dir (CI no-op), non-toolkit repo, private repo itself, kebab-boundary substring, bypass env, malformed stdin
- performance: full scan path under the repo 200ms benchmark budget (measured ~90-100ms end-to-end on a matched event)

## Registration

`.claude/settings.json` PreToolUse, matcher `Bash`, timeout 5000ms, alongside pretool-branch-safety / ci-merge-gate / pretool-ruff-format-gate. Hook deployed to `~/.claude/hooks/` before registration and verified exit 0. Session restart required for the gate to fire in live sessions.

Local ADR written to gitignored `adr/` per creation-gate convention.
