### PR TITLE
chore: drop three project-specific ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,15 +104,12 @@ private-voices/
 skills/shared-patterns/anti-rhetorical-pivot.md
 skills/shared-patterns/wabi-sabi-authenticity.md
 skills/shared-patterns/voice-first-writing.md
-agents/wrestlejoy-*
-skills/wrestlejoy-*
 skills/voice-*
 !skills/voice-writer/
 !skills/voice-validator/
 !skills/voice-shared/
 !skills/voice-shared-references/
 skills/voice
-skills/gemini-wrestlejoy-*
 
 # Generated index artifacts — derived from SKILL.md/agent frontmatter.
 # Regenerated at install/CI/runtime (ADR untrack-generated-indexes). Never tracked.


### PR DESCRIPTION
Moves three project-specific ignore patterns out of the tracked ignore file; equivalent protection lives in the local exclude file plus the incoming leak-gate hook. Owner-requested.