### PR TITLE
fix(hooks): leak gate — leaf-only name set, public-tree homonyms, inline bypass

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -73,7 +73,7 @@ Task completes: TaskCompleted
 | `pretool-branch-safety` | Bash | Blocks `git commit` when on `main` or `master` branch |
 | `pretool-config-protection` | Write, Edit, MultiEdit | Blocks modifications to linter/formatter config files (ESLint, Prettier, Biome, Ruff, golangci-lint, etc.) |
 | `pretool-plan-gate` | Write, Edit | Blocks implementation in `agents/`, `skills/` when `task_plan.md` does not exist |
-| `pretool-private-name-leak-gate` | Bash | Blocks `git commit`/`git push` and `gh pr` text that names a private component from `~/private-skills`. Name set derived at runtime, minus public homonyms — local-only by design (no private tree = graceful no-op, so CI cannot host it). Block messages redact the matched name |
+| `pretool-private-name-leak-gate` | Bash | Blocks `git commit`/`git push` and `gh pr` text that names a private component from `~/private-skills`. Name set derived at runtime from LEAF components only (dirs with SKILL.md, agents/*.md stems), minus public-skill and public-tracked-tree homonyms — local-only by design (no private tree = graceful no-op, so CI cannot host it). Block messages redact the matched name. Bypass `PRIVATE_NAME_GATE_BYPASS=1` works as env var or inline command prefix (logged) |
 | `pretool-synthesis-gate` | Write, Edit | Blocks feature implementation when ADR consultation synthesis is missing or blocked |
 
 ### Advisory Hooks (exit 0 = warn)

--- a/hooks/pretool-private-name-leak-gate.py
+++ b/hooks/pretool-private-name-leak-gate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.0.0
+# hook-version: 1.1.0
 """
 PreToolUse:Bash Hook: Private Name Leak Gate
 
@@ -16,12 +16,18 @@ local ~/private-skills tree. Shipping the set with the repo would itself be
 the leak, so CI and public installs (no ~/private-skills) get a graceful
 no-op. This gate cannot and should not run in CI.
 
-Name set:
-- Directory basenames and .md stems under ~/private-skills (recursive)
+Name set (LEAF components only — interior reference/asset dir names and
+bare file stems inside packages are noise, not component names):
+- Directories directly containing SKILL.md; for nested
+  <name>/skill/SKILL.md packages, the package dir <name>
+- Stems of *.md files directly inside an agents/ dir
 - MINUS structural basenames (SKILL, README, references, ...)
 - MINUS names shorter than 4 chars
 - MINUS tracked public skill names from skills/INDEX.json (project copy
   first, then ~/.claude/skills/INDEX.json) — public homonyms never block
+- MINUS names already present in the public tracked tree (one git grep
+  per invocation, cached for the run) — a name that is already public on
+  main (e.g. the toolkit's own name) cannot leak by appearing again
 
 Scanned text per command:
 - always: the command text itself (covers -m/--title/--body args)
@@ -39,7 +45,11 @@ Allow-through conditions:
 - Effective cwd is inside ~/private-skills itself (self-scan would
   always block that repo's own commits)
 - No private name found in any scanned text
-- PRIVATE_NAME_GATE_BYPASS=1 env var
+- PRIVATE_NAME_GATE_BYPASS=1 as an env var OR as an inline command prefix
+  (`PRIVATE_NAME_GATE_BYPASS=1 git push ...`). The hook runs in the
+  harness process, so an inline prefix never reaches os.environ — it is
+  detected in the command string itself. Owner approval only; every
+  bypass is logged to stderr.
 """
 
 import json
@@ -106,6 +116,41 @@ _MIN_NAME_LEN = 4
 # File-content arguments: commit message files and PR body files.
 _COMMIT_FILE_FLAGS = {"-F", "--file"}
 _PR_BODY_FILE_FLAGS = {"-F", "--body-file"}
+
+
+_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def _bypass_requested(command: str) -> str | None:
+    """Return "env" or "inline" when the bypass is requested, else None.
+
+    The hook runs in the harness process: an inline `PRIVATE_NAME_GATE_BYPASS=1
+    git push ...` prefix never reaches os.environ, so the documented inline
+    form must be detected in the command string. Only leading env-assignment
+    tokens of a command segment count — the string inside a commit message
+    does not bypass.
+    """
+    if os.environ.get(_BYPASS_ENV) == "1":
+        return "env"
+    for segment in re.split(r"&&|\|\||;", command):
+        try:
+            tokens = shlex.split(segment)
+        except ValueError:
+            tokens = segment.split()
+        seen_bypass = False
+        rest = tokens
+        for i, token in enumerate(tokens):
+            if not _ENV_ASSIGN_RE.match(token):
+                rest = tokens[i:]
+                break
+            if token == f"{_BYPASS_ENV}=1":
+                seen_bypass = True
+        # The assignment must actually prefix a gated command — a stray
+        # `; {_BYPASS_ENV}=1 ...` fragment inside message text does not
+        # disarm the gate.
+        if seen_bypass and _CMD_RE.search(" ".join(rest)):
+            return "inline"
+    return None
 
 
 def _extract_effective_cwd(command: str, default_cwd: str | None) -> str | None:
@@ -175,21 +220,60 @@ def _public_skill_names(toolkit_root: Path) -> set[str]:
     return names
 
 
+def _tracked_tree_names(toolkit_root: Path, names: set[str]) -> set[str]:
+    """Names already present in the PUBLIC tracked tree (case-insensitive).
+
+    One `git grep` per invocation, against the committed public ref
+    (origin/main, else main, else HEAD) — NOT the working tree, which would
+    see a just-staged leak and defeat the gate. A name the public tree
+    already contains (the toolkit's own name, common tool words) cannot leak
+    by appearing again — blocking it only produces false positives.
+    """
+    if not names:
+        return set()
+    ref = None
+    for candidate in ("origin/main", "main", "HEAD"):
+        if _run_git(["rev-parse", "--verify", "-q", candidate], str(toolkit_root)):
+            ref = candidate
+            break
+    if ref is None:
+        return set()
+    args = ["grep", "-I", "-i", "-o", "-h", "--fixed-strings"]
+    for name in sorted(names):
+        args += ["-e", name]
+    out = _run_git([*args, ref], str(toolkit_root))
+    return {line.strip().lower() for line in out.splitlines()} & names
+
+
 def _private_names(toolkit_root: Path) -> set[str]:
-    """Runtime private-name set: dir basenames and .md stems, filtered."""
+    """Runtime private-name set: LEAF component names only, filtered.
+
+    Leaf components: dirs directly containing SKILL.md (a dir literally named
+    `skill` is the nested <name>/skill/SKILL.md package layout — use <name>),
+    plus stems of *.md files directly inside an agents/ dir. Interior
+    reference/asset dir names and bare file stems inside packages are noise,
+    not component names, and only produce false blocks.
+    """
     raw: set[str] = set()
     try:
-        for _dirpath, dirnames, filenames in os.walk(_PRIVATE_DIR):
+        for dirpath, dirnames, filenames in os.walk(_PRIVATE_DIR):
             # Skip VCS internals.
             dirnames[:] = [d for d in dirnames if not d.startswith(".")]
-            raw.update(dirnames)
-            raw.update(Path(f).stem for f in filenames if f.endswith(".md"))
+            base = Path(dirpath)
+            if "SKILL.md" in filenames:
+                name = base.name
+                if name.lower() == "skill" and base != _PRIVATE_DIR:
+                    name = base.parent.name
+                raw.add(name)
+            if base.name == "agents":
+                raw.update(Path(f).stem for f in filenames if f.endswith(".md"))
     except OSError:
         return set()
     names = {n.lower() for n in raw}
     names -= _STOPLIST
     names = {n for n in names if len(n) >= _MIN_NAME_LEN and not n.startswith(".")}
     names -= _public_skill_names(toolkit_root)
+    names -= _tracked_tree_names(toolkit_root, names)
     return names
 
 
@@ -287,9 +371,10 @@ def main() -> None:
     if not command or not _CMD_RE.search(command):
         sys.exit(0)
 
-    if os.environ.get(_BYPASS_ENV) == "1":
-        if debug:
-            print(f"[private-name-leak-gate] Bypassed via {_BYPASS_ENV}=1", file=sys.stderr)
+    bypass = _bypass_requested(command)
+    if bypass:
+        # Always logged — a bypass is an audit event, not a debug detail.
+        print(f"[private-name-leak-gate] BYPASSED ({bypass}) via {_BYPASS_ENV}=1", file=sys.stderr)
         sys.exit(0)
 
     # Graceful no-op: no private tree on this machine (public install, CI).
@@ -341,7 +426,8 @@ def main() -> None:
                 f"Private component name ({redacted}) found in {location}. "
                 "Private skill names must not reach commits, pushes, or PR text. "
                 "Remove the reference and retry. "
-                f"Bypass with {_BYPASS_ENV}=1 only with explicit owner approval.",
+                f"Bypass with {_BYPASS_ENV}=1 (env var or inline command prefix) "
+                "only with explicit owner approval.",
             )
             sys.exit(0)
 

--- a/hooks/tests/test_pretool_private_name_leak_gate.py
+++ b/hooks/tests/test_pretool_private_name_leak_gate.py
@@ -2,9 +2,10 @@
 """
 Tests for the pretool-private-name-leak-gate hook.
 
-All fixtures use SYNTHETIC names (secret-example-skill, hidden-fixture-notes,
-translate). The real ~/private-skills tree is never read: every test patches
-mod._PRIVATE_DIR to a tmp dir, so no real private name can reach test output.
+All fixtures use SYNTHETIC names (secret-example-skill, nested-package-skill,
+hidden-fixture-agent, shared-fixture-name, translate). The real
+~/private-skills tree is never read: every test patches mod._PRIVATE_DIR to a
+tmp dir, so no real private name can reach test output.
 
 Run with: python3 -m pytest hooks/tests/test_pretool_private_name_leak_gate.py -v
 """
@@ -40,11 +41,25 @@ SYNTH_REDACTED = "s…l"
 
 @pytest.fixture()
 def private_dir(tmp_path, monkeypatch):
-    """Synthetic ~/private-skills tree; patched into the module."""
+    """Synthetic ~/private-skills tree; patched into the module.
+
+    Shape exercises every collection rule: a leaf skill dir, a nested
+    <name>/skill/SKILL.md package, an agents/*.md stem, plus interior noise
+    (reference stems, asset dirs) that must NOT enter the name set.
+    """
     root = tmp_path / "private-tree"
     (root / SYNTH).mkdir(parents=True)
     (root / SYNTH / "SKILL.md").write_text("---\nname: x\n---\n")
-    (root / "hidden-fixture-notes.md").write_text("notes\n")
+    # Interior noise inside the package: excluded from the name set.
+    (root / SYNTH / "references").mkdir()
+    (root / SYNTH / "references" / "interior-topic-map.md").write_text("ref\n")
+    (root / SYNTH / "asset-bundle-dir").mkdir()
+    # Nested package layout: <name>/skill/SKILL.md -> <name>.
+    (root / "nested-package-skill" / "skill").mkdir(parents=True)
+    (root / "nested-package-skill" / "skill" / "SKILL.md").write_text("---\nname: n\n---\n")
+    # Agent component: agents/*.md stem.
+    (root / "agents").mkdir()
+    (root / "agents" / "hidden-fixture-agent.md").write_text("agent\n")
     monkeypatch.setattr(mod, "_PRIVATE_DIR", root)
     # Point the user-index fallback at nothing so only the project INDEX counts.
     monkeypatch.setattr(mod, "_USER_INDEX", tmp_path / "no-user-index.json")
@@ -179,9 +194,14 @@ class TestBlocks:
         code, _, _, _ = _run_main(_event(f'gh pr merge 5 --squash --body "folds in {SYNTH}"', toolkit_repo))
         assert code == 2
 
-    def test_block_on_md_stem_name(self, private_dir, toolkit_repo):
-        """.md basenames (recursive) are part of the name set, not just dirs."""
-        code, _, _, _ = _run_main(_event('git commit -m "port hidden-fixture-notes"', toolkit_repo))
+    def test_block_on_agent_md_stem(self, private_dir, toolkit_repo):
+        """agents/*.md stems are leaf components and part of the name set."""
+        code, _, _, _ = _run_main(_event('git commit -m "port hidden-fixture-agent"', toolkit_repo))
+        assert code == 2
+
+    def test_block_on_nested_package_name(self, private_dir, toolkit_repo):
+        """<name>/skill/SKILL.md packages contribute <name>, not `skill`."""
+        code, _, _, _ = _run_main(_event('git commit -m "port nested-package-skill"', toolkit_repo))
         assert code == 2
 
 
@@ -214,10 +234,44 @@ class TestRedaction:
 
 class TestPassThrough:
     def test_public_homonym_never_blocks(self, private_dir, toolkit_repo):
-        """A private dir name that is also a tracked public skill passes."""
+        """A private leaf name that is also a tracked public skill passes."""
         (private_dir / "translate").mkdir()
+        (private_dir / "translate" / "SKILL.md").write_text("---\nname: t\n---\n")
         code, _, _, _ = _run_main(_event('git commit -m "improve translate flow"', toolkit_repo))
         assert code == 0
+
+    def test_interior_stems_and_dirs_excluded(self, private_dir, toolkit_repo):
+        """Reference stems and asset dir names inside packages never block."""
+        for word in ("interior-topic-map", "asset-bundle-dir", "references"):
+            code, _, _, _ = _run_main(_event(f'git commit -m "touch {word} docs"', toolkit_repo))
+            assert code == 0, f"interior name {word!r} must not block"
+
+    def test_public_tracked_tree_homonym_never_blocks(self, private_dir, toolkit_repo):
+        """A private leaf name already in the committed public tree passes.
+
+        Blocking a name the public repo already contains (the toolkit's own
+        name, common words) is pointless and only produces false positives.
+        """
+        (private_dir / "shared-fixture-name").mkdir()
+        (private_dir / "shared-fixture-name" / "SKILL.md").write_text("---\nname: s\n---\n")
+        (toolkit_repo / "docs.md").write_text("mentions shared-fixture-name already\n")
+        _git(toolkit_repo, "add", "docs.md")
+        _git(toolkit_repo, "commit", "-q", "-m", "public docs")
+        code, _, _, _ = _run_main(_event('git commit -m "improve shared-fixture-name flow"', toolkit_repo))
+        assert code == 0
+
+    def test_staged_leak_does_not_launder_name(self, private_dir, toolkit_repo):
+        """The public-tree grep reads the committed ref, not the working tree.
+
+        A just-staged leak must not make its own name look 'already public'.
+        """
+        (toolkit_repo / "clean.md").write_text("clean tracked file\n")
+        _git(toolkit_repo, "add", "clean.md")
+        _git(toolkit_repo, "commit", "-q", "-m", "public docs")
+        (toolkit_repo / "leak.md").write_text(f"wires {SYNTH} in\n")
+        _git(toolkit_repo, "add", "leak.md")
+        code, _, _, _ = _run_main(_event("git commit -m 'clean message'", toolkit_repo))
+        assert code == 2
 
     def test_absent_private_dir_is_noop(self, toolkit_repo, tmp_path, monkeypatch):
         """Public installs and CI have no ~/private-skills: graceful no-op."""
@@ -253,11 +307,40 @@ class TestPassThrough:
         assert code == 0
 
     def test_bypass_env(self, private_dir, toolkit_repo):
-        code, _, _, _ = _run_main(
+        code, _, _, err = _run_main(
             _event(f'git commit -m "wire {SYNTH} in"', toolkit_repo),
             env={"PRIVATE_NAME_GATE_BYPASS": "1"},
         )
         assert code == 0
+        assert "BYPASSED (env)" in err
+
+    def test_bypass_inline_prefix(self, private_dir, toolkit_repo):
+        """Inline prefix never reaches the hook's os.environ; the command
+        string form must work as documented."""
+        code, _, _, err = _run_main(_event(f'PRIVATE_NAME_GATE_BYPASS=1 git commit -m "wire {SYNTH} in"', toolkit_repo))
+        assert code == 0
+        assert "BYPASSED (inline)" in err
+
+    def test_bypass_inline_after_cd_segment(self, private_dir, toolkit_repo):
+        code, _, _, err = _run_main(
+            _event(f"cd {toolkit_repo} && PRIVATE_NAME_GATE_BYPASS=1 git push origin x", toolkit_repo)
+        )
+        assert code == 0
+        assert "BYPASSED (inline)" in err
+
+    def test_bypass_token_inside_message_does_not_bypass(self, private_dir, toolkit_repo):
+        """Only a leading env-assignment counts — the string inside a commit
+        message must not disarm the gate."""
+        code, _, _, _ = _run_main(_event(f'git commit -m "docs: PRIVATE_NAME_GATE_BYPASS=1 and {SYNTH}"', toolkit_repo))
+        assert code == 2
+
+    def test_bypass_fragment_after_semicolon_in_message_does_not_bypass(self, private_dir, toolkit_repo):
+        """A `; TOKEN=1 ...` fragment inside message text is not a prefix of a
+        gated command and must not disarm the gate."""
+        code, _, _, _ = _run_main(
+            _event(f'git commit -m "a; PRIVATE_NAME_GATE_BYPASS=1 enables {SYNTH}"', toolkit_repo)
+        )
+        assert code == 2
 
     def test_malformed_stdin_allowed(self, private_dir):
         code, _, _, _ = _run_main("not json{")


### PR DESCRIPTION
## Summary

Fixes the three live false-positive defects in `pretool-private-name-leak-gate.py` (v1.0.0 → v1.1.0). Confirmed live: the v1.0.0 set held 239 names including generic interior stems and the toolkit's own public name; the fixed set on the same machine holds 8 leaf component names.

**1. Leaf-only name set.** v1.0.0 swept every directory basename and `.md` stem under the private tree — interior reference/asset names (generic dictionary-word stems) blocked ordinary commits. v1.1.0 collects only components: directories directly containing SKILL.md (nested `<name>/skill/SKILL.md` packages contribute `<name>`) plus `agents/*.md` stems.

**2. Public-tree homonym subtraction.** A name the committed public tree already contains (the toolkit's own name, README strings) cannot leak by appearing again. One `git grep` per invocation against the committed public ref (origin/main, else main, else HEAD) — deliberately NOT the working tree, so a just-staged leak cannot launder its own name (regression-tested). This landed self-demonstrating: committing this PR's own README row tripped v1.0.0 on a public string from the neighboring table row that entered the staged diff as context.

**3. Usable bypass.** The hook runs in the harness process, so an inline `PRIVATE_NAME_GATE_BYPASS=1` prefix never reached `os.environ` — the documented bypass was unusable. v1.1.0 detects the inline prefix in the command string (shlex-safe, per segment); only a leading env-assignment that prefixes a gated command counts — the token inside commit-message text does not disarm the gate. Every bypass (env or inline) logs to stderr as an audit event. Owner-approval wording kept.

## Tests

30 tests (was 22), synthetic fixtures only; all green:
- regression: interior stems and asset dir names excluded; nested-package naming; agent-stem naming
- regression: public-tracked-tree homonym pass-through (synthetic name committed in a tracked fixture)
- regression: staged leak does not launder its own name (grep reads the committed ref)
- regression: inline-prefix bypass allows + logs; env bypass logs; bypass token inside message text still blocks; fragment after a semicolon in message text still blocks
- all v1.0.0 block/redaction/pass-through/performance tests kept green

## Docs

Hook docstring and hooks/README row updated. No registration change (same entry, same timeout). `~/.claude/hooks` symlinks to the main checkout, so the fix goes live on the next hook invocation after merge + pull — no session restart needed.
