### PR TITLE
fix(routing): model-selection policy — reserve top-tier model for escalation only

### DIFF
--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -334,7 +334,7 @@ Owner model-selection policy (ADR `model-selection-policy`; operational table in
 |---|---|
 | `gpt-5.5` (Codex CLI, `codex` skill) | Bulk/mechanical: clear-spec implementation, data analysis, migrations, extraction/inventory sweeps |
 | `sonnet` | Substantive execution: implementation, review, synthesis, semantic rewriting |
-| `opus` / `fable` | Deep analysis and reviews of plans/implementations; user-facing work needing taste |
+| `opus` | Reviews, audits, analysis, deep work; user-facing work needing taste (consult canonical table in `/do` SKILL.md Model Selection) |
 
 Haiku is retired (routing was Haiku pre-#777; self-route since — `scripts/routing-ab-results/self-route-v1/VERDICT.md`). Defaults, not limits: escalate to a smarter model whenever cheaper output misses the bar; for anything that ships, intelligence > taste > cost, with cost a tie-breaker only.
 

--- a/docs/for-claude-code.md
+++ b/docs/for-claude-code.md
@@ -181,7 +181,7 @@ version: 1.0.0
 user-invocable: true | false
 context: fork                    # optional: run in isolated sub-agent
 agent: golang-general-engineer   # optional: declare executor agent
-model: sonnet | opus | fable     # optional: model preference (Haiku retired)
+model: sonnet | opus             # optional: model preference (consult `/do` SKILL.md Model Selection; Haiku retired)
 allowed-tools: [Read, Write, Bash, Grep, Glob, Edit, Skill, Task, Agent]
 routing:
   triggers: [keyword1]

--- a/skills/meta/agent-creator/references/agent-frontmatter-template.md
+++ b/skills/meta/agent-creator/references/agent-frontmatter-template.md
@@ -23,7 +23,7 @@ description: "Domain-specific work: concrete capability A, capability B. Not for
 color: blue
 
 # Optional: model override. Omit to use the session default.
-# Values: sonnet (implementation/review), opus or fable (deep analysis/review).
+# Values: sonnet (implementation/lighter work), opus (reviews/analysis/deep work).
 # Model-selection policy: /do SKILL.md, Model Selection. Haiku is retired.
 model: sonnet
 

--- a/skills/meta/codex/SKILL.md
+++ b/skills/meta/codex/SKILL.md
@@ -34,14 +34,14 @@ Two flows keep their own specialized codex integration — route to them instead
 
 Policy mirror — canonical copy: `/do` SKILL.md, Model Selection (edit there first, then here). Rankings, higher = better; cost = what the owner actually pays.
 
-| model | cost | intelligence | taste |
-|---|---|---|---|
-| gpt-5.5 | 9 | 8 | 5 |
-| sonnet-5 | 5 | 5 | 7 |
-| opus-4.8 | 4 | 7 | 8 |
-| fable-5 | 2 | 9 | 9 |
+| model | cost | intelligence | taste | role |
+|---|---|---|---|---|
+| gpt-5.5 | 9 | 8 | 5 | Bulk/mechanical via codex. Dispatch target. |
+| sonnet-5 | 5 | 5 | 7 | Mechanical/reader fan-out, lighter work. Dispatch target. |
+| opus-4.8 | 4 | 7 | 8 | Reviews, audits, analysis, deep work. Dispatch target. |
+| fable-5 | 2 | 9 | 9 | Highest technical requirements only — never routine dispatch. |
 
-Route here when the task is **bulk/mechanical**: clear-spec implementation, data analysis, migrations, extraction/inventory sweeps — gpt-5.5 is effectively free. Route elsewhere when the task is user-facing (UI, copy, API design — needs taste ≥ 7: sonnet/opus/fable) or is a plan/implementation review (fable-5 or opus-4.8 lead; gpt-5.5 optionally adds an extra independent perspective via pr-workflow's codex-review).
+Route here when the task is **bulk/mechanical**: clear-spec implementation, data analysis, migrations, extraction/inventory sweeps — gpt-5.5 is effectively free. Route elsewhere when the task is user-facing (UI, copy, API design — needs taste ≥ 7: sonnet/opus) or is a plan/implementation review (opus-4.8 lead; gpt-5.5 optionally adds an extra independent perspective via pr-workflow's codex-review). Consult the canonical model-selection table in `/do` SKILL.md.
 
 These are defaults, not limits. Standing permission to escalate: when gpt-5.5's output misses the bar, rerun on a smarter model without asking — judge the output, not the price tag; escalating costs less than shipping mediocre work. For anything that ships, intelligence > taste > cost; cost is a tie-breaker only.
 

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -411,22 +411,24 @@ The emitted `[do-route]` marker is the SOLE signal `routing-decision-recorder` u
 
 **Fallback (script failed: non-zero exit or empty output).** Treat as "Router Script Failed" for the preamble only: hand-stamp the single line `[do-route] agent={agent} skill={skill|-} complexity={complexity} health=-` at the head of the prompt (the recorder depends on it), add the Task Specification inline, dispatch, and report the script failure.
 
-**Model Selection (owner policy — ADR `model-selection-policy`; canonical copy of the table).** Pick the model per dispatch from this table. Rankings, higher = better; cost = what the owner actually pays.
+**Model Selection (owner policy — ADR `model-selection-policy`; this is the canonical table — all other copies cite it).** Consult the table per dispatch. Rankings, higher = better; cost = what the owner actually pays.
 
-| model | cost | intelligence | taste | reach |
+| model | cost | intelligence | taste | role |
 |---|---|---|---|---|
-| gpt-5.5 | 9 | 8 | 5 | Codex CLI only — dispatch via the `codex` skill (wrapper mechanics live there) |
-| sonnet-5 | 5 | 5 | 7 | Agent/Workflow `model: "sonnet"` |
-| opus-4.8 | 4 | 7 | 8 | Agent/Workflow `model: "opus"` |
-| fable-5 | 2 | 9 | 9 | Agent/Workflow `model: "fable"` |
+| gpt-5.5 | 9 | 8 | 5 | Bulk/mechanical via codex wrapper (`codex` skill). Dispatch target. |
+| sonnet-5 | 5 | 5 | 7 | Mechanical/reader fan-out, lighter routed work. `model: "sonnet"`. Dispatch target. |
+| opus-4.8 | 4 | 7 | 8 | Reviews, audits, analysis, deep work. `model: "opus"`. Dispatch target. |
+| fable-5 | 2 | 9 | 9 | Highest technical requirements only — deliberate escalation, never routine dispatch. |
 
 Rules:
 
-- **Defaults, not limits.** Standing permission to override: if a cheaper model's output misses the bar, rerun with a smarter model without asking. Judge the output, not the price tag. Escalating costs less than shipping mediocre work.
+- **The orchestrator is whatever model runs the main thread** — fable/opus/sonnet under Claude Code, gpt-5.5 under Codex. It classifies, routes, evaluates results, synthesizes.
+- **Explicit model required for Medium+ dispatches.** Omitting `model` inherits the session main-loop model. When an expensive model orchestrates, omission silently propagates it to every worker. Every Medium/Complex/Critical dispatch MUST set `model` explicitly. Omission is allowed only for Trivial/Simple lookups where sonnet-tier inheritance risk is acceptable.
+- **Defaults, not limits.** Standing permission to override: if a cheaper model's output misses the bar, rerun with a smarter model without asking. Judge the output, not the price tag. Escalating costs less than shipping mediocre work. Escalation path: sonnet → opus → gpt-5.5 cross-check → rerun with tighter spec.
 - For anything that ships: intelligence > taste > cost. Cost is a tie-breaker only.
 - Bulk/mechanical work (clear-spec implementation, data analysis, migrations) → gpt-5.5 — effectively free.
 - Anything user-facing (UI, copy, API design) needs taste ≥ 7.
-- Reviews of plans/implementations → fable-5 or opus-4.8; optionally gpt-5.5 as an extra independent perspective.
+- Reviews of plans/implementations → opus-4.8; optionally gpt-5.5 via codex as an extra independent perspective.
 - Haiku is retired — select only from the table above.
 - **Wrapper symmetry:** the wrapper serves whichever model family is NOT the current harness. Under Claude Code (current default), gpt-5.5 runs through a wrapper — the dispatched agent runs `codex exec` via Bash with a self-contained prompt, or a thin Claude wrapper agent (`model: "sonnet"`, low effort) writes the self-contained codex prompt, runs it, returns the result. Under the Codex harness, Claude models take the wrapper instead. Claude models under Claude Code need only the `model` parameter.
 - `codex exec -s read-only` for investigation/data-analysis prompts not covered by existing codex flows.
@@ -438,8 +440,8 @@ Decision rules live here; execution mechanics live in the `codex` skill (`skills
 
 | Task verb class | Dispatch mode |
 |---|---|
-| list, count, extract, inventory, search, check, find, grep | Mechanical extraction fan-out: gpt-5.5 via the codex wrapper (`codex` skill) or `model: "sonnet"` readers (one per data source) → `fable`/`opus` synthesizer per the table |
-| review, audit, assess, analyze, debug, investigate, evaluate | Single `fable` or `opus` agent (direct), per the table |
+| list, count, extract, inventory, search, check, find, grep | Mechanical extraction fan-out: gpt-5.5 via the codex wrapper (`codex` skill) or `model: "sonnet"` readers (one per data source) → orchestrator synthesizes in-session or `model: "opus"` synthesizer agent |
+| review, audit, assess, analyze, debug, investigate, evaluate | Single `model: "opus"` agent (direct), per the table |
 
 Simple/Medium: dispatch directly.
 

--- a/skills/meta/do/references/repo-architecture.md
+++ b/skills/meta/do/references/repo-architecture.md
@@ -23,7 +23,7 @@ description: Brief purpose description
 user-invocable: false    # Hide from slash menu (internal skills)
 context: fork            # Run in isolated sub-agent context
 agent: golang-general-engineer  # Declare executor agent
-model: sonnet            # Model preference: sonnet | opus | fable (`/do` is the router exception; Haiku retired)
+model: sonnet            # Model preference: sonnet | opus (consult `/do` SKILL.md Model Selection table; Haiku retired)
 allowed-tools:           # YAML list format
   - Read
   - Write

--- a/skills/meta/skill-creator/references/agent-template.md
+++ b/skills/meta/skill-creator/references/agent-template.md
@@ -459,7 +459,7 @@ When upgrading an agent to v2.0:
 - [ ] Moved verbose content to references/
 
 ### YAML Frontmatter
-- [ ] Model specified (`model: sonnet` for most executors; `opus`/`fable` per the model-selection policy in `/do` SKILL.md — Haiku is retired)
+- [ ] Model specified (`model: sonnet` for most executors; `opus` for reviews/analysis/deep work — consult the canonical model-selection table in `/do` SKILL.md; Haiku retired)
 - [ ] All routing metadata preserved (triggers, retro-topics, pairs_with, complexity, category)
 - [ ] Hooks preserved
 - [ ] Color preserved

--- a/skills/workflow/references/workflow-patterns.md
+++ b/skills/workflow/references/workflow-patterns.md
@@ -57,4 +57,4 @@ When a workflow reads untrusted/public content, isolate the reader from privileg
 
 ## Model-Routing Classifier
 
-For mixed-difficulty batches, dispatch a classifier agent that researches each task, then routes it: Sonnet for routine, Opus for hard. Maps to `/do` Phase 4 verb-based model dispatch (gpt-5.5/sonnet extraction readers → fable/opus synthesizer, per the Model Selection table) — the same route-by-cost idea at task granularity.
+For mixed-difficulty batches, dispatch a classifier agent that researches each task, then routes it: Sonnet for routine, Opus for hard. Maps to `/do` Phase 4 verb-based model dispatch (gpt-5.5/sonnet extraction readers → opus synthesizer, per the canonical Model Selection table in `/do` SKILL.md) — the same route-by-cost idea at task granularity.


### PR DESCRIPTION
## Summary
Amends the model-selection policy per owner directive after an incident: 5 Complex-tier review agents inherited the main-loop model via an omitted `model` param instead of using an explicit one. Reserves the highest-capability model for deliberate escalation only, never routine dispatch.

## Changes
- `docs/PHILOSOPHY.md`, `docs/for-claude-code.md` — update policy references
- `agents/*/references/agent-frontmatter-template.md` — align frontmatter template
- `skills/meta/codex/SKILL.md` — define orchestrator as harness-agnostic (whatever model runs the main thread), require explicit model on Medium+ dispatches
- `skills/meta/do/SKILL.md`, `skills/meta/do/references/repo-architecture.md` — align dispatch guidance
- `skills/meta/skill-creator/references/agent-template.md` — align template
- `skills/workflow/references/workflow-patterns.md` — align patterns
- Canonical routing table gains a role column; verb table updates reviews and synthesizer targets
- Approved dispatch targets: opus-4.8, sonnet-5, gpt-5.5 (via codex); escalation path sonnet → opus → gpt-5.5 cross-check → tighter spec

## Notes
Omitting `model` on a Medium+ dispatch now silently inherits the session model — the exact gap this PR closes; all 8 files referencing the old policy were updated to conform.
