### PR TITLE
feat(routing): halve /do skill size — blind A/B PROMOTE (do-skill-reduction-v1)

### DIFF
--- a/scripts/routing-ab-results/do-skill-reduction-v1/VERDICT.md
+++ b/scripts/routing-ab-results/do-skill-reduction-v1/VERDICT.md
@@ -1,0 +1,60 @@
+# /do Skill Reduction A/B — VERDICT (run: do-skill-reduction-v1)
+
+Date: 2026-07-03. Question: can the /do router skill shrink to ~half its size
+with no behavior loss? Arms differ ONLY by the skill text prepended to an
+identical compact manifest; same model (sonnet) both arms.
+
+## Variant construction
+
+- Baseline `full`: production `skills/meta/do/SKILL.md`, 40,924 B.
+- Challenger `reduced`: 23,738 B (58.0% of full; −42.0%). Built by
+  toolkit-governance-engineer (opus) with a 99-item behavior inventory, then
+  hardened by an independent adversarial behavior-diff review (opus) that found
+  4 BLOCKER + 8 MAJOR losses (dropped signal phrases, normative examples,
+  tiebreaker rules) — all restored before the run. All executed bash blocks
+  byte-identical to full. Dropped content: rationale, A/B provenance citations,
+  duplicated rule statements, redundant examples.
+
+## Run mechanics
+
+- Harness: `scripts/routing-ab-test.py` manifest-arm mode (one harness for any
+  router change). Corpus v3, 178 cases, one sample per (arm, query).
+- Arm files: `<skill variant>\n\n<manifest>` filled into `PROMPT_TEMPLATE`'s
+  manifest slot; manifest byte-identical across arms
+  (`manifest.txt`, 24,254 B). `arms.json` records `--model-arm` sonnet/sonnet.
+- Bridge: `collect-answers.py` (this dir) — idempotent, 6-way parallel,
+  `env -u CLAUDECODE claude -p --model sonnet`. 356 answers; 7 first-pass
+  failures (2.0% < 5% tolerance), re-collected. Total 366 calls, $87.03
+  (`call-log.jsonl`).
+- Blind judge: one opus agent over arm-stripped shuffled `judge-input.json`
+  (356 rows), uid map withheld. Verdicts: 230 correct / 113 partial / 13
+  incorrect. Rejoined: full 110/178 (61.8%) vs reduced 120/178 (67.4%) correct.
+
+## Pre-registered gates (verbatim, unchanged from prior runs)
+
+Gates (a) accuracy ±3.0, (b) McNemar harm, (c) zero new safety-bucket misses,
+(d) stub-tier ±1 — as printed by `--gate`; see `docs/router-ab-runbook.md`.
+
+## Results (deterministic gate scoring, raw.json)
+
+| Metric | full (baseline) | reduced (challenger) |
+|---|---|---|
+| Overall accuracy | 93/178 (52.2%) | 106/178 (59.6%) |
+
+Paired: D=0.073, 95% CI [0.011, 0.140], help=24, harm=11, discordant=35,
+McNemar p=0.041 (in the challenger-favoring direction — gate (b) fails only on
+harm>help). Safety buckets: zero new misses; paraphrase-git 6/6 and
+paraphrase-security 4/4 in both arms. Stub-tier 10 → 10.
+
+Gate outcomes: a PASS (+7.4), b PASS, c PASS, d PASS. Discordant 35 ≥ 6.
+
+## VERDICT: PROMOTE (exit 0)
+
+The reduced skill routes no worse — measurably better — at 58% of the size.
+Promoted: reduced variant replaced `skills/meta/do/SKILL.md` (old version in
+git history). Limitations: the harness exercises routing decisions (Step 0
+semantics, force-routes, pipeline picks, interview/vague buckets) — not
+Phase 3/4 execution behavior (enhancement stacking, dispatch building). Those
+were guarded by the behavior-inventory + adversarial diff review instead, and
+all executed bash blocks are byte-identical. Watch `route-events.jsonl`
+outcomes post-promotion; rollback = `git checkout` of the prior SKILL.md.

--- a/scripts/routing-ab-results/do-skill-reduction-v1/collect-answers.py
+++ b/scripts/routing-ab-results/do-skill-reduction-v1/collect-answers.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Idempotent answer bridge for do-skill-reduction-v1.
+
+For each prompts/<arm>/<id>.txt, calls `claude -p --model sonnet` with the
+prompt verbatim, extracts the model's JSON route object, writes
+answers/<arm>/<id>.json. Skips existing answers. Appends call-log.jsonl.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Lock
+
+RUN = Path(__file__).resolve().parent
+MODEL = "sonnet"
+WORKERS = 6
+LOG_LOCK = Lock()
+LOG = RUN / "call-log.jsonl"
+
+ENV = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+
+def extract_json(text: str) -> dict | None:
+    """First balanced {...} block that parses and has agent+skill keys."""
+    for m in re.finditer(r"\{", text):
+        depth = 0
+        for i in range(m.start(), len(text)):
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        obj = json.loads(text[m.start() : i + 1])
+                    except json.JSONDecodeError:
+                        break
+                    if isinstance(obj, dict) and "agent" in obj and "skill" in obj:
+                        return obj
+                    break
+    return None
+
+
+def one(task):
+    arm, pid, prompt_path = task
+    out_path = RUN / "answers" / arm / f"{pid}.json"
+    if out_path.exists():
+        return "skip"
+    prompt = prompt_path.read_text(encoding="utf-8")
+    try:
+        proc = subprocess.run(
+            ["claude", "-p", "--model", MODEL, "--output-format", "json"],
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env=ENV,
+        )
+        wrapper = json.loads(proc.stdout)
+        result_text = wrapper.get("result", "")
+        obj = extract_json(result_text)
+        entry = {
+            "arm": arm,
+            "id": pid,
+            "cost_usd": wrapper.get("total_cost_usd"),
+            "usage": {
+                k: wrapper.get("usage", {}).get(k)
+                for k in ("input_tokens", "output_tokens", "cache_read_input_tokens", "cache_creation_input_tokens")
+            },
+            "ok": obj is not None,
+        }
+    except Exception as exc:  # timeout, non-JSON stdout, etc.
+        obj, entry = None, {"arm": arm, "id": pid, "ok": False, "error": str(exc)[:200]}
+    with LOG_LOCK, LOG.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+    if obj is None:
+        return "fail"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(obj, indent=2, ensure_ascii=False), encoding="utf-8")
+    return "done"
+
+
+def main():
+    tasks = []
+    for arm_dir in sorted((RUN / "prompts").iterdir()):
+        for p in sorted(arm_dir.glob("*.txt")):
+            tasks.append((arm_dir.name, p.stem, p))
+    with ThreadPoolExecutor(max_workers=WORKERS) as ex:
+        results = list(ex.map(one, tasks))
+    counts = {s: results.count(s) for s in ("done", "skip", "fail")}
+    print(json.dumps(counts))
+    return 1 if counts["fail"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate-do-references.py
+++ b/scripts/validate-do-references.py
@@ -77,17 +77,12 @@ VOICE_PROFILE_RE = re.compile(r"^voice-[a-z0-9]+(?:-[a-z0-9]+)*$")
 # component name; a new entry needs the same justification.
 PROSE_TERMS = frozenset(
     {
-        "anti-rationalization",  # "anti-rationalization patterns" (the -core/-review files resolve)
         "built-in",  # "built-in verification gates"
         "cross-repo",  # the [cross-repo] output tag
         "done-criteria",  # "Objective with done-criteria"
-        "empty-skill",  # "empty-skill leak"
         "force-route",  # "force-route triggers"
-        "multi-file",  # "multi-file or comprehensive review"
         "near-matches",  # "check INDEX files for near-matches"
-        "no-match",  # "Treat as no-match"
         "non-negotiable",  # "HARD — non-negotiable"
-        "non-zero",  # "exited non-zero"
         "real-diff",  # "the real-diff row wins"
         "whole-repo",  # "whole-repo audits"
     }

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -155,11 +155,11 @@ GENERAL:
 - Single skill string, not array.
 ```
 
-**Step 0b: Apply routing decision**
+**Step 0b: Apply the routing decision**
 
 Use `agent`/`skill` directly; low confidence → verify against INDEX files. Routing JSON is internal.
 
-**Skill-greediness gate (HARD for Simple+).** Null/empty skill → pick one: review→systematic-code-review, debug→workflow (systematic-debugging), refactor→workflow (systematic-refactoring), audit→systematic-code-review (whole-repo→full-repo-review), explain→codebase-overview, compare→decision-helper (agent A/Bs→agent-comparison), plan→planning, loop→objective-loop. Fallback: `objective-loop`. Never leave skill empty on Simple+.
+**Skill-greediness gate (HARD — non-negotiable for Simple+).** Null/empty skill → pick one: review→systematic-code-review, debug→workflow (systematic-debugging), refactor→workflow (systematic-refactoring), audit→systematic-code-review (whole-repo→full-repo-review), explain→codebase-overview, compare→decision-helper (agent A/Bs→agent-comparison), plan→planning, loop→objective-loop. Fallback: `objective-loop`. Never leave skill empty on Simple+.
 
 **Section validator (MANDATORY before `Agent(subagent_type=...)`):**
 
@@ -202,7 +202,7 @@ Guardrail only. No second pre-route invocation.
 - **(a)** If pre-route has high-confidence force_route for pr-workflow/security and semantic pick disagrees → override. Git/security work MUST hit quality gates. Record `match_type`.
 - **(b)** Phrase/unigram guards suppress false matches ("fish out", metaphorical commit). Guarded requests stay with Step 0.
 
-**Step 2: Skill override** — "review"→systematic-code-review, "debug"→workflow, "refactor"→workflow, "TDD"→test-driven-development. Full table in INDEX files.
+**Step 2: Apply skill override** — "review"→systematic-code-review, "debug"→workflow (systematic-debugging pipeline), "refactor"→workflow (systematic-refactoring pipeline), "TDD"→test-driven-development. Full table in INDEX files.
 
 **Step 3: Display routing decision** (MANDATORY — FIRST visible output)
 
@@ -242,7 +242,7 @@ Stack skills based on request signals.
 | Multi-file/comprehensive review, real diff | `python3 "$SDIR/right-size-review.py" --base {base} --head {head}` (or `--files N --packages M`); Tier 1→3, 2→12, 3→17, 4→27 reviewers. Escalate one tier on CRITICAL; no tier signal → full behavior. Outranks Phase 2 `comprehensive-review` pipeline pick. |
 | Complex implementation | Offer subagent-driven-development |
 | "local only" / "no push" / "keep it local" / "don't commit" / "stay local" | Inject local-only (`shared-patterns/local-only.md`): "**LOCAL-ONLY MODE.** Do not push, commit, create PRs, or deploy. All work stays on disk. Read-only git is fine." |
-| Voice profile skill selected | Stack `voice-writer` (13-phase pipeline); voice-* loads as profile in Phase 1. |
+| Voice profile skill selected (any voice-* profile, e.g. voice-example-profile) | Stack `voice-writer` (13-phase pipeline); voice-* loads as profile in Phase 1. |
 | Interview-mode heuristic fires | `planning` (interview mode) — load `depth-first-interview.md` |
 | Objective with done-criteria / "keep going until X" / "loop until done" | Stack `objective-loop` |
 
@@ -387,7 +387,7 @@ Run for: re-route, lazy-completion re-dispatch, section-validator misroute, harn
 | Error | Cause | Solution |
 |-------|-------|----------|
 | No Agent Matches | No agent covers domain | INDEX near-matches → closest agent + verification-before-completion. Report gap. |
-| Force-Route Conflict | Multiple force-routes match | Most specific first; stack compatible secondaries. |
+| Force-Route Conflict | Multiple force-route triggers match | Most specific first; stack compatible secondaries. |
 | Plan Required | Simple+ without task_plan.md | Create plan, resume. |
 | Router Script Failed | Non-zero exit or non-JSON | No-match fallback: `general-purpose` + `verification-before-completion`. |
 

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -22,54 +22,35 @@ routing:
 
 # /do - Smart Router
 
-/do is a **ROUTER**, not a worker. Classify requests, select the right agent + skill, dispatch. All execution goes to agents.
+/do is a **ROUTER**, not a worker. Classify, select agent+skill, dispatch. All execution goes to agents.
 
-**Main thread:** (1) Classify, (2) Select agent+skill, (3) Dispatch, (4) Evaluate, (5) Re-route if needed, (6) Report.
+**Main thread:** (1) Classify, (2) Select, (3) Dispatch, (4) Evaluate, (5) Re-route if needed, (6) Report.
 
-Catching yourself reading source code, writing code, or analyzing — pause and route to an agent.
-
----
+Catching yourself reading/writing code or analyzing — pause and route to an agent.
 
 ## The Completeness Standard
 
-Do the whole thing — with tests and documentation.
-
-- The answer is the finished product, not a plan. Plans organize execution; they don't replace it.
-- Prefer the permanent solve and real fix over a workaround.
-- If an agent returns partial work, route a follow-up to finish it.
-- Search before building. Test before shipping.
-- Decompose complexity into agent-sized tasks.
-
-**The standard:** the result reads as "that's done," not "that's a start." Inject into agent prompts for Simple+ work.
-
-Confidence in handling a task directly is a signal to route: direct handling skips domain knowledge, methodology, and references.
-
----
+Do the whole thing — with tests and documentation. The answer is the finished product, not a plan. Prefer the permanent solve over a workaround. If an agent returns partial work, route a follow-up. Search before building. Test before shipping. Decompose into agent-sized tasks. The standard: the result reads as "that's done," not "that's a start." Inject for Simple+ work. Confidence in handling directly is a signal to route: direct handling skips domain knowledge, methodology, and references.
 
 ## Output Discipline
 
-Every word the router prints and every dispatched agent prompt follows the **Dense-Complete Writing standard** (injected verbatim by `scripts/build-dispatch.py` at Phase 4 dispatch). Full rules: `skills/shared-patterns/dense-complete-writing.md`.
+Every word follows **Dense-Complete Writing** (injected by `scripts/build-dispatch.py`). Full rules: `skills/shared-patterns/dense-complete-writing.md`.
 
-**User sees:** phase banners, routing decision banner, brief post-agent summary (what changed, not how).
+**User sees:** phase banners, routing banner, brief post-agent summary (what changed, not how).
 **Internal only:** routing JSON, classification reasoning, enhancement stacking (unless Verbose Routing ON).
-
----
 
 ## Instructions
 
 ### Phase Banners (MANDATORY)
 
-Every phase MUST display a banner BEFORE executing: `/do > Phase N: PHASE_NAME — description...`
-
-After Phase 2, display the full routing decision banner (`===` block). Both required: phase banners show *where*, the routing banner *what was decided*.
+Every phase displays: `/do > Phase N: PHASE_NAME — description...`
+After Phase 2, display the `===` routing decision banner. Both required.
 
 ---
 
 ### Phase 1: CLASSIFY
 
-**Goal**: Determine request complexity and whether routing is needed.
-
-Read and follow the repository CLAUDE.md first — its conventions affect agent and skill selection.
+Read and follow repository CLAUDE.md first.
 
 | Complexity | Agent | Skill | Direct Action |
 |------------|-------|-------|---------------|
@@ -78,44 +59,33 @@ Read and follow the repository CLAUDE.md first — its conventions affect agent 
 | Medium | **Required** | **Required** | Route to agent |
 | Complex | Required (2+) | Required (2+) | Route to agent |
 
-**Delegation is mandatory.** Everything beyond reading a user-named file is Simple+ and MUST route — without reasoning about whether you could handle it directly. When uncertain, classify UP.
+Everything beyond reading a user-named file is Simple+ and MUST route — without reasoning about whether you could handle it directly. When uncertain, classify UP.
 
-**Progressive Depth**: For ambiguous complexity, start shallow; let the agent escalate. See `references/progressive-depth.md`.
+**Progressive Depth**: Start shallow; let the agent escalate. See `references/progressive-depth.md`.
 
-**Common misclassifications** (NOT Trivial — route them): evaluating repos/URLs, opinions/recommendations, git operations, codebase questions (`explore-pipeline`), retro lookups (`retro`), comparisons.
+**NOT Trivial** (route them): evaluating repos/URLs, opinions, git operations, codebase questions (`explore-pipeline`), retro lookups (`retro`), comparisons.
 
-**Maximize skill/agent/pipeline usage.** If one exists, USE IT.
+Maximize skill/agent/pipeline usage. Named-pattern guide: `skills/workflow/references/workflow-patterns.md`.
 
-**Named-pattern + escalation guide:** for which workflow pattern fits, the failure modes a workflow fights, and the "does this really need more compute?" cost gate, load `skills/workflow/references/workflow-patterns.md`.
+**Parallel FIRST**: 2+ independent failures or 3+ subtasks → multiple Agent tools in one message. `fan-out-workflow.js` for Workflow. Research → `research-coordinator-engineer`; coordination → `project-coordinator-engineer`; plan+"execute" → `subagent-driven-development`; new feature → `feature-lifecycle` (`.feature/` present → `feature-state.py status`).
 
-**Check for parallel patterns FIRST**: 2+ independent failures or 3+ subtasks → dispatch multiple Agent tools in a single message (the harness runs them concurrently); `fan-out-workflow.js` provides native Workflow dispatch when available. Broad research → `research-coordinator-engineer`; multi-agent coordination → `project-coordinator-engineer`; plan + "execute" → `subagent-driven-development`; new feature → `feature-lifecycle` (check `.feature/`; if present, run `feature-state.py status`). On 2+ independent items, dispatch all in parallel in one message.
+**Force Direct** — OFF by default; explicit request only.
 
-**Optional: Force Direct** — OFF by default; applies only on explicit request.
+**Creation Request Detection** (MANDATORY before Gate):
 
-**Creation Request Detection** (MANDATORY scan before Gate):
+Creation signals: verbs ("create", "scaffold", "build", "add new", "new [component]", "implement new"), targets (agent, skill, pipeline, hook, feature, plugin, workflow, voice profile), implicit ("I need/build me a [component]"). If ANY signal AND Simple+: `is_creation = true`; Phase 4 Step 0 mandatory. Not creation: debugging, reviewing, fixing, refactoring, explaining, auditing existing. When ambiguous, check whether output is a NEW file.
 
-Creation signals:
-- Verbs: "create", "scaffold", "build", "add new", "new [component]", "implement new"
-- Targets: agent, skill, pipeline, hook, feature, plugin, workflow, voice profile
-- Implicit: "I need a [component]", "build me a [component]"
-
-If ANY creation signal AND complexity Simple+: set `is_creation = true`; Phase 4 Step 0 is MANDATORY (write ADR before dispatching).
-
-**Not creation**: debugging, reviewing, fixing, refactoring, explaining, auditing existing components. When ambiguous, check whether output is a NEW file.
-
-**Gate**: Complexity classified. If creation detected, output `[CREATION REQUEST DETECTED]` before routing banner. Display banner (ALL classifications). Trivial: handle directly. Simple+: proceed to Phase 2.
+**Gate**: Complexity classified. Creation → output `[CREATION REQUEST DETECTED]`. Display banner. Trivial: handle directly. Simple+: Phase 2.
 
 ---
 
 ### Phase 2: ROUTE
 
-**Goal**: Select the correct agent + skill. Semantic intent routing is primary, and the orchestrator does it itself — read the manifest in-session, no routing sub-dispatch (self-route beat the Haiku hop +8.1 accuracy points, zero new safety misses; `scripts/routing-ab-results/self-route-v1/VERDICT.md`, PR #776). The pre-router is a safety-net, not a short-circuit — the fast path below is the one exception, and it only commits routes the safety-net would force anyway. Prefer FORCE-labeled entries when intent matches semantically.
+Select the correct agent+skill. Semantic intent routing is primary; the orchestrator does it itself. Prefer FORCE-labeled entries when intent matches.
 
-**Contract: read for INTENT.** Read what the user MEANS; trigger keywords are hints, never gates. Plain or non-native-English phrasing routes as well as jargon ("send my commits to the server" routes like "git push"). Cost: one in-session manifest read (~38 KB, measured 2026-07-02) on requests that miss the fast path — measured, accepted (`scripts/routing-ab-results/self-route-v1/VERDICT.md`, Cost section).
+**Read for INTENT.** Keywords are hints, never gates. Plain/non-native-English routes as well as jargon ("send my commits to the server" = "git push").
 
-**Pre-route (run ONCE at Phase 2 start, before the fast-path check)**
-
-Resolve SDIR, write the request to a temp file to avoid shell-splicing, then run pre-route.py once and store the result:
+**Pre-route (run ONCE, before fast-path)**
 
 ```bash
 SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
@@ -124,19 +94,13 @@ python3 "$SDIR/pre-route.py" --request-file "$REQUEST_FILE" --json-compact
 rm -f "$REQUEST_FILE"
 ```
 
-Store this JSON as `PRE_ROUTE_RESULT`. Both the fast path and Step 1 read from it — pre-route.py is never called a second time.
+Store as `PRE_ROUTE_RESULT`. Never call pre-route.py again.
 
-**Fast path: high-confidence force-route**
+**Fast path:** If `PRE_ROUTE_RESULT` has `"confidence": "high"` AND `"match_type": "force_route"` AND skill is `pr-workflow` or a security skill: dispatch directly. Skip Steps 0/1.5/1. Keep mandatory: routing banner (Step 3), Step 2 overrides, Phase 3, ALL Phase 4 injections — stamp `[do-route]` marker with `health=-`. Agent: pre-route's `agent` when non-null, else domain agent, else `general-purpose`. The full flow lands on the same route (Step 1a would force-override to it anyway); fast path changes cost, not behavior.
 
-Read `PRE_ROUTE_RESULT`. If it has `"confidence": "high"` AND `"match_type": "force_route"` AND the skill is `pr-workflow` or a security skill: dispatch that pair directly. Skip Step 0 (manifest read + self-route), Step 1.5 (weights read), and Step 1 (stored result already covers it). Everything else stays mandatory: the routing banner (Step 3), Step 2 skill overrides where compatible, Phase 3 enhancements, and ALL Phase 4 injections — stamp the `[do-route]` marker with `health=-`. Agent: pre-route's `agent` when non-null, else the domain agent implied by Phase 1 classification, else `general-purpose`.
+**Step 0: Semantic intent routing (self-route)**
 
-**Equivalence**: Step 1(a) already overrides any semantic pick with exactly these high-confidence force-routes, so the full flow always lands on this same force-routed skill. The fast path changes cost (the ~38 KB manifest read skipped), not behavior. Guards already ran inside pre-route, so idiom false-positives ("push back", "fish out") never reach the fast path. Any other result — no match, medium/low confidence, non-force match, or a skill outside pr-workflow/security — falls through to Step 0 unchanged.
-
-**Step 0: Semantic intent routing (PRIMARY — orchestrator self-route)**
-
-Acquire the manifest (cache-first, below), then route directly off it in-session. No routing sub-dispatch: the orchestrator reads the manifest and applies the rules below itself. (Self-route-v1 blind A/B, n=99: PROMOTE — +8.1 accuracy points over the Haiku hop, zero new safety-bucket misses, stub-tier 9→12; it fixes the agent-attribution failure and deletes a dispatch round trip. `scripts/routing-ab-results/self-route-v1/VERDICT.md`.)
-
-Acquire the manifest cache-first. A hash-gated disk cache (`~/.claude/cache/routing-manifest.txt` + `.hash` sidecar, ADR router-improvement-program C5) is kept fresh by the `session-manifest-cache` SessionStart hook and by the INDEX sync hooks after regeneration. Read the cache when the sidecar digest matches the generator's inputs; on absent/stale cache, fall back to running the generator (verbatim command, unchanged behavior):
+Acquire manifest cache-first. Hash-gated disk cache (`~/.claude/cache/routing-manifest.txt` + `.hash` sidecar), kept fresh by SessionStart hook and INDEX sync hooks. On cache miss/stale:
 
 ```bash
 SDIR="${HOME}/.claude/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.hermes/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.factory/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.codex/scripts"; [ -d "$SDIR" ] || SDIR="${HOME}/.reasonix/scripts"
@@ -148,9 +112,7 @@ else
 fi
 ```
 
-The digest recompute is the freshness proof: it hashes the exact files the generator reads (missing files skipped — `hooks/lib/manifest_cache.py` computes the identical digest), so a stale sidecar can never serve an outdated manifest. Any mismatch, missing file, or empty cache runs the generator exactly as before.
-
-Given the user request and the manifest of available agents, skills, and pipelines, select the BEST agent+skill combination, and optionally a pipeline. Hold the decision internally as JSON (never printed; the `[do-route]` marker in Phase 4 is its only external trace):
+Select BEST agent+skill+pipeline. Hold internally as JSON (never printed; `[do-route]` marker is its only external trace):
 
 ```
 {
@@ -162,57 +124,44 @@ Given the user request and the manifest of available agents, skills, and pipelin
 }
 ```
 
-Apply ALL of the following rules when deciding:
+**Routing rules (ALL apply):**
 
 ```
-SECTION-INTEGRITY RULE (HARD CONSTRAINT — never violate):
-- The `agent` field MUST be a name listed in the `AGENTS:` section of the manifest, or null. Never put a skill name in `agent`.
-- The `skill` field MUST be a name listed in the `SKILLS:` section of the manifest, or null. Never put an agent name in `skill`.
-- The `pipeline` field MUST be a name listed in the `PIPELINES:` section of the manifest, or null.
-- If no agent fits the request, return `"agent": null` — DO NOT promote a skill into the `agent` slot. The router will fall back to a default agent (e.g. `general-purpose`) and pair it with your chosen skill.
-- Skills marked `FORCE (process)` are still skills, not agents. They go in the `skill` field only. Example: `zsh-shell-config` is a SKILL — if it matches, set `"skill": "zsh-shell-config"` and pick a separate agent (or null) for `agent`.
+SECTION-INTEGRITY (HARD — never violate):
+- `agent` MUST be from the manifest's AGENTS section, or null. Never put a skill name in `agent`.
+- `skill` MUST be from SKILLS section, or null. Never put an agent name in `skill`.
+- `pipeline` MUST be from PIPELINES section, or null.
+- No agent fit → `"agent": null` (router falls back to `general-purpose`). Never promote a skill into `agent`.
+- FORCE (process) skills go in `skill` only. Example: `zsh-shell-config` → `"skill": "zsh-shell-config"`, separate agent.
 
-FORCE-ROUTE RULE: Entries marked "FORCE" in the manifest MUST be selected when their domain clearly matches the user's intent. However, FORCE matching is SEMANTIC, not keyword-based. Match on what the user MEANS, not individual words. Examples:
-- "push my changes" → pr-workflow (FORCE) ✓ (user means git push)
-- "push back on this design" → NOT pr-workflow (user means resist/argue)
-- "configure my fish shell" → fish-shell-config (FORCE) ✓ (user means Fish shell)
-- "fish for bugs" → NOT fish-shell-config (user means search for bugs)
-- "quick fix to the login page" → quick (FORCE) ✓ (user wants a small edit)
-- "quick overview of the architecture" → NOT quick (user wants exploration)
+FORCE-ROUTE: FORCE entries MUST be selected when domain matches SEMANTICALLY. Match MEANING, not words:
+- "push my changes" → pr-workflow (FORCE) ✓ (git push)
+- "push back on this design" → NOT pr-workflow (resist/argue)
+- "configure my fish shell" → fish-shell-config (FORCE) ✓
+- "fish for bugs" → NOT fish-shell-config (search for bugs)
+- "quick fix to the login page" → quick (FORCE) ✓
+- "quick overview of the architecture" → NOT quick (exploration)
 
-PIPELINE-SELECTION RULE: The `pipeline` field is OPTIONAL and most requests should return `null`. Return a pipeline name ONLY when BOTH conditions hold:
-(1) the user's intent SEMANTICALLY matches a pipeline's `triggers` or `description` in the PIPELINES section of the manifest, AND
-(2) the request genuinely benefits from a multi-phase flow (research + write, scope + gather + synthesize, multi-wave review) — not just a single skill task.
-Match on MEANING, not keyword overlap. If a single agent+skill satisfies the request, return `null` for pipeline. Examples:
-- "write an article in vexjoy voice about X" → pipeline: "voice-writer" ✓ (multi-phase voice content generation matches the voice-writer pipeline)
-- "research X with artifacts and sources" → pipeline: "research-pipeline" ✓ (formal SCOPE → GATHER → SYNTHESIZE → VALIDATE → DELIVER flow)
-- "comprehensive review of these 8 files, no diff available" → pipeline: "comprehensive-review" ✓ (multi-wave per-package review across many files; with a real diff, Phase 3 right-size-review tiering outranks this pick)
-- "fix the typo on line 42 of foo.py" → pipeline: null (single trivial edit, no pipeline needed)
-- "debug this failing test" → pipeline: null (one agent+skill handles it; pipeline only if user asks for systematic debugging artifacts)
-- "review this 10-line function" → pipeline: null (single skill, no multi-wave review warranted)
-When in doubt, return null. A pipeline pick must be defensible against the manifest's PIPELINES section.
+PIPELINE: Optional, most null. Select ONLY when BOTH hold: (1) intent SEMANTICALLY matches a pipeline's triggers/description, AND (2) the request genuinely benefits from a multi-phase flow — not just a single skill task. Examples:
+- "write an article in vexjoy voice about X" → pipeline: "voice-writer" ✓
+- "research X with artifacts and sources" → pipeline: "research-pipeline" ✓
+- "fix the typo on line 42 of foo.py" → pipeline: null
+When in doubt, null. (A comprehensive-review pick is outranked by Phase 3 right-size-review tiering when a real diff exists.)
 
-Rules:
-- Pick the most specific match. "Go tests" → golang-general-engineer + go-patterns, not general-purpose.
-- Agent handles the domain. Skill handles the methodology. Pick both when possible.
-- If the request implies a task verb (review, debug, refactor, test), prefer skills that match that verb.
-- If nothing matches well, return all nulls with reasoning.
-- Prefer entries whose description semantically matches the request, not just keyword overlap.
-- For GENUINE git / version-control operations — actually pushing code, committing files to a repository, or opening/merging a pull request — ALWAYS select pr-workflow. Do NOT route metaphorical or non-version-control uses of these words (e.g. 'commit to a decision/plan', 'merge ideas in your head', 'push back on a proposal') to pr-workflow.
-- Return a single skill name as a string, not an array. If multiple skills are needed, pick the primary one.
+GENERAL:
+- Most specific match. Agent = domain, skill = methodology; pick both.
+- Task verbs → prefer matching skills. No match → all nulls with reasoning.
+- GENUINE git ops (push, commit, PR, merge) → ALWAYS pr-workflow. Metaphorical ("commit to a decision") → never.
+- Single skill string, not array.
 ```
 
-**Step 0b: Apply the routing decision**
+**Step 0b: Apply routing decision**
 
-Use `agent` and `skill` fields directly; if `confidence` is "low", verify against INDEX files. The routing JSON is internal — never printed.
+Use `agent`/`skill` directly; low confidence → verify against INDEX files. Routing JSON is internal.
 
-**Skill-greediness gate (HARD — non-negotiable for Simple+).** If complexity is Simple, Medium, or Complex AND `skill` is null or empty, you MUST either:
-- (a) Pick a skill from the manifest that covers the task verb (review→systematic-code-review, debug→workflow (systematic-debugging pipeline), refactor→workflow (systematic-refactoring pipeline), audit→systematic-code-review (whole-repo audits→full-repo-review), explain→codebase-overview, compare→decision-helper (agent A/Bs→agent-comparison), plan→planning, loop/objective→objective-loop), OR
-- (b) Fall back to `objective-loop` as the default methodology wrapper (never leave `skill` empty on Simple+).
+**Skill-greediness gate (HARD for Simple+).** Null/empty skill → pick one: review→systematic-code-review, debug→workflow (systematic-debugging), refactor→workflow (systematic-refactoring), audit→systematic-code-review (whole-repo→full-repo-review), explain→codebase-overview, compare→decision-helper (agent A/Bs→agent-comparison), plan→planning, loop→objective-loop. Fallback: `objective-loop`. Never leave skill empty on Simple+.
 
-An agent without a skill is a specialist without methodology — the router MUST NOT dispatch that combination for Simple+ work. This gate closes the observed empty-skill leak (12.6% of 517 decision events, `route-events.jsonl`, June 2026).
-
-**Dispatch-time section validator (MANDATORY before every `Agent(subagent_type=...)` call).** A skill name in the `agent` field makes the harness reject the dispatch (`Agent type 'X' not found`). Assert the `agent` field maps to a name in the manifest's `AGENTS:` section. Pseudocode:
+**Section validator (MANDATORY before `Agent(subagent_type=...)`):**
 
 ```
 agents_section = grep_section(manifest, "AGENTS:", "SKILLS:")
@@ -222,56 +171,40 @@ skill_names = [first_token(line) for line in skills_section]
 
 if route.agent and route.agent not in agent_names:
     if route.agent in skill_names:
-        # Cross-section slip: a skill landed in the agent slot.
-        route.skill = route.skill or route.agent  # promote to skill if empty
-        route.agent = None                         # clear bad agent pick
+        route.skill = route.skill or route.agent
+        route.agent = None
     record_misroute(reason="agent-slot held skill name", value=route.agent)
 
 if route.agent is None:
-    route.agent = "general-purpose"  # safe fallback; pair with chosen skill
+    route.agent = "general-purpose"
 ```
 
-If Step 0 cannot produce a defensible agent+skill pair, fall back to `general-purpose` + `objective-loop` (never leave the skill slot empty on Simple+).
+No defensible pair → `general-purpose` + `objective-loop`. Route simplest satisfying pair. `[cross-repo]` → `.claude/agents/` local agents. Code changes → domain agents.
 
-Route to the simplest agent+skill that satisfies the request. On `[cross-repo]` output, route to `.claude/agents/` local agents. Route all code changes to domain agents.
+**Step 1.5: Health evaluation (shadow-only)**
 
-**Step 1.5: Health evaluation (shadow-only instrumentation)**
-
-Runs AFTER the semantic pick (Step 0/0b), BEFORE the Step 1 safety-net.
-
-Once per /do, read the routing weights and score the semantic pick. Resolve SDIR as in Step 0, then run:
+After Step 0/0b, before Step 1. Read weights, score the pick:
 
 ```bash
 python3 "$SDIR/learning-db.py" route-weights --json
 ```
 
-Call `health_adjust(semantic_pick, alternates, weights, force_route_flags)` (`scripts/lib/route_policy.py`). It returns `{final_pick, action, reason}` with `action` in `keep | demote | tiebreak`. The `action` is the policy's WOULD-action only.
+Call `health_adjust()` (`scripts/lib/route_policy.py`). Returns `{final_pick, action, reason}`, action in `keep|demote|tiebreak`. **Shadow-only: recorded, never alters route.** Activation gated on first negative signal (`docs/route-loop-validation.md`).
 
-**Shadow-only: the policy's would-action is recorded for the signal check (scripts/route-signal-check.py); the route is never altered.** The semantic pick always dispatches. Activation is gated on the first recorded negative signal — see docs/route-loop-validation.md.
+Thresholds: demote floor `confidence<0.30 AND failure>=3 AND n>=5`; tiebreak `confidence<0.35` with healthier alternate `n>=5`; force-route/security always `keep`; `n<5` or no row → `keep`.
 
-Policy thresholds (for reading the recorded would-action, not for changing the route):
+Log to T3: `health_at_decision` (float/null), `n`, `failure` as separate fields on the DECISION event in `route-events.jsonl`. Pass as `health` field in routing JSON; `build-dispatch.py` emits the marker.
 
-- Would-demote floor: `confidence < 0.30 AND failure >= 3 AND n >= 5`, toward a healthier alternate.
-- Would-tiebreak: semantic confidence `< 0.35` AND an evidenced (`n >= 5`) healthier alternate supplied.
-- Force-route/security pairs are hard-exempt — always `keep`. Exemption is by SKILL name and accepts force_route_flags as bare skill names or full `agent:skill` pairs.
-- Evidence gate: `n < 5` or no row => `keep`.
+**Step 1: Deterministic safety-net** (reads `PRE_ROUTE_RESULT`, after semantic decision)
 
-**Always log the evaluation** to the T3 event stream: set `health_at_decision` to the picked pair's `confidence` scalar (a float, or `null` when the pair has no weight row); `n` and `failure` are separate fields. The recorder writes all three from the marker onto the per-dispatch DECISION event in `<CLAUDE_LEARNING_DIR>/route-events.jsonl`. Every route is scored even though nothing changes.
+Guardrail only. No second pre-route invocation.
 
-Carry the gate inputs on the routing marker so the recorder snapshots them at decision time — confidence alone cannot reconstruct the demote floor; it needs `n` and `failure` too. Pass them as the `health` field of the routing JSON; `scripts/build-dispatch.py` emits the marker (Phase 4 Step 2).
+- **(a)** If pre-route has high-confidence force_route for pr-workflow/security and semantic pick disagrees → override. Git/security work MUST hit quality gates. Record `match_type`.
+- **(b)** Phrase/unigram guards suppress false matches ("fish out", metaphorical commit). Guarded requests stay with Step 0.
 
-**Step 1: Deterministic safety-net** (reads `PRE_ROUTE_RESULT` — runs AFTER the semantic decision, never short-circuits it)
+**Step 2: Skill override** — "review"→systematic-code-review, "debug"→workflow, "refactor"→workflow, "TDD"→test-driven-development. Full table in INDEX files.
 
-Use `PRE_ROUTE_RESULT` (the single pre-route call at Phase 2 start) ONLY as a guardrail. No second invocation — the stored result is structurally guaranteed.
-
-- **(a) Safety-critical force-route override.** If `PRE_ROUTE_RESULT` has `"confidence": "high"` with a `force_route` match for `pr-workflow` or a security skill and the semantic pick disagrees, override to the force-route: genuine "push", "commit", "create PR", "merge" and security work MUST hit quality gates (lint, tests, CI). Record `match_type`.
-- **(b) Guards stay active.** Its phrase/unigram guards suppress false matches (e.g. "fish out", metaphorical commit/merge). A guarded request — and otherwise — stays with the Step 0 semantic decision.
-
-**Step 2: Apply skill override** (task verb overrides default skill)
-
-Common overrides: "review" → systematic-code-review, "debug" → workflow (systematic-debugging pipeline), "refactor" → workflow (systematic-refactoring pipeline), "TDD" → test-driven-development. Full override table in `INDEX files`.
-
-**Step 3: Display routing decision** (MANDATORY — FIRST visible output, before any work)
+**Step 3: Display routing decision** (MANDATORY — FIRST visible output)
 
 ```
 ===================================================================
@@ -286,100 +219,84 @@ Common overrides: "review" → systematic-code-review, "debug" → workflow (sys
 ===================================================================
 ```
 
-For Trivial: show `Classification: Trivial - [reason]` and `Handling directly (no agent/skill)`.
+Trivial: `Classification: Trivial - [reason]` and `Handling directly (no agent/skill)`.
 
-**Optional: Dry Run Mode** — OFF by default; when enabled, show the routing decision without executing.
-**Optional: Verbose Routing** — OFF by default; when enabled, explain why each alternative was rejected.
+**Dry Run Mode** / **Verbose Routing** — both OFF by default.
 
-**Learning capture is automatic** via hooks (full table in the Learning Capture section after Phase 4; ADR `learn-step-to-hook`).
+Learning capture is automatic via hooks (table in Learning Capture section).
 
-**Gate**: Agent+skill selected. Banner displayed. Proceed to Phase 3.
+**Gate**: Agent+skill selected. Banner displayed. Phase 3.
 
 ---
 
 ### Phase 3: ENHANCE
 
-**Goal**: Stack skills based on request signals. Use retro knowledge if present.
+Stack skills based on request signals.
 
-| Signal in Request | Enhancement to Add |
-|-------------------|-------------------|
-| Any substantive work (code, design, plan) | Add retro knowledge only when it materially helps the task |
-| "with tests" / "production ready" | Append test-driven-development + verification-before-completion |
+| Signal | Enhancement |
+|--------|-------------|
+| Substantive work | Retro knowledge when it materially helps |
+| "with tests" / "production ready" | test-driven-development + verification-before-completion |
 | "research needed" / "investigate first" | Prepend research-coordinator-engineer |
-| "comprehensive" / "thorough" / "full" review, or "review" with 5+ files — no diff available | Fallback: use parallel-code-review (3 reviewers: Security, Business Logic, Architecture) |
-| Multi-file or comprehensive review on a real diff | Run `python3 "$SDIR/right-size-review.py" --base {base} --head {head}` (or `--files N --packages M`); dispatch the matching tier — Tier 1→parallel-code-review (3), Tier 2→12, Tier 3→17, Tier 4→full (27). Escalate one tier on any CRITICAL finding; no tier signal → full behavior. |
+| "comprehensive"/"thorough"/"full" review, or "review" with 5+ files — no diff | Fallback: parallel-code-review (3: Security, BizLogic, Architecture) |
+| Multi-file/comprehensive review, real diff | `python3 "$SDIR/right-size-review.py" --base {base} --head {head}` (or `--files N --packages M`); Tier 1→3, 2→12, 3→17, 4→27 reviewers. Escalate one tier on CRITICAL; no tier signal → full behavior. Outranks Phase 2 `comprehensive-review` pipeline pick. |
 | Complex implementation | Offer subagent-driven-development |
-| "local only" / "no push" / "keep it local" / "don't commit" / "stay local" | Inject `local-only` constraint (see `shared-patterns/local-only.md`). Prepend: "**LOCAL-ONLY MODE.** Do not push, commit, create PRs, or deploy. All work stays on disk. Read-only git is fine." |
-| Voice profile skill selected (any voice-* profile skill, e.g. voice-example-profile) | Stack `voice-writer` (its 13-phase pipeline is required for all voice content); the voice-* skill loads as the profile in Phase 1 (LOAD). |
-| Interview-mode heuristic fires (rule below) | `planning` (interview mode) — load `depth-first-interview.md` |
-| Objective with done-criteria / "keep going until X" / "loop until done" | Stack `objective-loop` (skills/meta/objective-loop) |
+| "local only" / "no push" / "keep it local" / "don't commit" / "stay local" | Inject local-only (`shared-patterns/local-only.md`): "**LOCAL-ONLY MODE.** Do not push, commit, create PRs, or deploy. All work stays on disk. Read-only git is fine." |
+| Voice profile skill selected | Stack `voice-writer` (13-phase pipeline); voice-* loads as profile in Phase 1. |
+| Interview-mode heuristic fires | `planning` (interview mode) — load `depth-first-interview.md` |
+| Objective with done-criteria / "keep going until X" / "loop until done" | Stack `objective-loop` |
 
-**Review-row precedence.** When review signals overlap, the real-diff row wins: any multi-file or comprehensive/thorough/full review with a diff routes through `right-size-review.py` — it also outranks a Phase 2 `comprehensive-review` pipeline pick; the fallback row applies only when no diff exists.
+**Review-row precedence.** When review signals overlap, the real-diff row wins; the fallback row applies only when no diff exists.
 
-**Interview-mode heuristic.** Fires when the request is short, names no concrete file/symbol/path, states no acceptance criteria, and admits multiple plausible interpretations; the 6 examples below are the spec.
+**Interview-mode heuristic.** Fires when request is short, names no file/symbol/path, no acceptance criteria, multiple interpretations. The 6 examples below are the spec.
 
 | Example | Match? | Why |
 |---|---|---|
-| "i'm not sure how to approach this complex build" | MATCH | Uncertainty + vague verb + no target |
-| "fix the typo on line 42 of foo.py" | NO | Concrete file, location, verb |
-| "build a thing that does X" | MATCH | Vague verb + ambiguous object + no file |
-| "add a test for `parseConfig` in src/config.go" | NO | Concrete symbol + file + verb |
-| "where do i even start with this rewrite" | MATCH | Explicit uncertainty, no subject |
+| "i'm not sure how to approach this complex build" | YES | Uncertainty + vague + no target |
+| "fix the typo on line 42 of foo.py" | NO | Concrete file + location |
+| "build a thing that does X" | YES | Vague verb + no file |
+| "add a test for `parseConfig` in src/config.go" | NO | Concrete symbol + file |
+| "where do i even start with this rewrite" | YES | Explicit uncertainty, no subject |
 | "rename `cfg` to `config` in `internal/`" | NO | Concrete symbol + directory + mechanical op |
 
-When in doubt, defer injection: false positives cost one round of friction; false negatives recover via `/quick --interview`.
+When in doubt, defer injection. Check `pairs_with` in `skills/INDEX.json` before stacking; empty `pairs_with: []` means undeclared, not prohibited. Skills with built-in verification gates may not need stacking.
 
-Before stacking, check `pairs_with` in `skills/INDEX.json`; prefer listed pairs. Empty `pairs_with: []` means undeclared, not prohibited. Skills with built-in verification gates may not need stacking.
+Anti-rationalization per task type:
 
-Add anti-rationalization patterns per task type when the task benefits from explicit rigor:
-
-| Task Type | Patterns Injected |
-|-----------|-------------------|
+| Task Type | Patterns |
+|-----------|----------|
 | Code modification | anti-rationalization-core, verification-checklist |
 | Code review | anti-rationalization-core, anti-rationalization-review |
-| Security work | anti-rationalization-core, anti-rationalization-security |
+| Security | anti-rationalization-core, anti-rationalization-security |
 | Testing | anti-rationalization-core, anti-rationalization-testing |
 | Debugging | anti-rationalization-core, verification-checklist |
-| External content evaluation | **untrusted-content-handling** |
+| External content | **untrusted-content-handling** |
 
 Maximum rigor: `/with-anti-rationalization [task]`.
 
-**Gate**: Enhancements applied. Proceed to Phase 4.
+**Gate**: Enhancements applied. Phase 4.
 
 ---
 
 ### Phase 4: EXECUTE
 
-**Goal**: Invoke the selected agent + skill; deliver results.
+**Step 0: Creation Protocol** (creation only) — Write ADR at `adr/{kebab-case-name}.md`, register via `python3 "$SDIR/adr-query.py" register`, proceed to plan.
 
-**Step 0: Execute Creation Protocol** (creation requests ONLY)
+**Step 1: Create plan** (Simple+) — `task_plan.md` before execution; skip Trivial.
 
-If creation signal + Simple+: (1) Write ADR at `adr/{kebab-case-name}.md`, (2) Register via `python3 "$SDIR/adr-query.py" register`, (3) Proceed to plan. ADR hooks (`adr-context-injector`, `adr-enforcement`) handle compliance.
+**Step 1b: Quality-loop** (Medium+ code modifications)
 
-**Step 1: Create plan** (Simple+)
+Load `references/quality-loop.md` as outer wrapper: 14-phase lifecycle (ADR→PLAN→IMPLEMENT→TEST→REVIEW→INTENT VERIFY→LIVE VALIDATE→FIX→RETEST→PR→CODEX REVIEW→ADR RECONCILE→RECORD→CLEANUP). Phase 2 agent+skill is the implementation agent inside IMPLEMENT. Force-route skills run inside the loop. Skip for: Trivial/Simple, review-only/research/debugging/content, or simpler-flow request.
 
-Create `task_plan.md` before execution; skip for Trivial.
+**Step 1c: Workflow dispatch** (lazy-loaded)
 
-**Step 1b: Apply quality-loop pipeline** (Medium+ code modifications)
+On pipeline pick, Complex/tier-4 with no pick, or explicit workflow request → load `${CLAUDE_SKILL_DIR}/references/workflow-dispatch.md`. When both 1b+1c apply, quality-loop is OUTER; workflow runs inside IMPLEMENT.
 
-Load `references/quality-loop.md` as the **outer orchestration wrapper**:
-
-- **Quality-loop** (outer): 14-phase lifecycle — ADR → PLAN → IMPLEMENT → TEST → REVIEW → INTENT VERIFY → LIVE VALIDATE → FIX → RETEST → PR → CODEX REVIEW → ADR RECONCILE → RECORD → CLEANUP
-- **Agent + skill** (inner): domain expertise inside IMPLEMENT
-
-Quality-loop absorbs Steps 0-1. The Phase 2 agent+skill is the implementation agent; force-route skills run INSIDE the loop. Skip when: Trivial/Simple (use `quick`), review-only/research/debugging/content creation, or user wants a simpler flow.
-
-**Step 1c: Workflow dispatch (lazy-loaded)**
-
-On a pipeline `pick`, a Complex/tier-4 task with no pick, or an explicit "run through a workflow" request, load `${CLAUDE_SKILL_DIR}/references/workflow-dispatch.md` and follow it.
-It carries the executor decision table, roster rules, and inline-script constraints verbatim.
-When Step 1b and Step 1c both apply (a Medium+ code modification that also has a pipeline pick or is Complex/tier-4), quality-loop is the OUTER wrapper; Step 1c workflow dispatch runs INSIDE its IMPLEMENT phase (`references/quality-loop.md`, "outer orchestration").
-
-**Step 2: Invoke agent with skill**
+**Step 2: Invoke agent**
 
 Dispatch the agent. Inject no MCP instructions; tool discovery is the agent's job.
 
-**Build the dispatch preamble with `scripts/build-dispatch.py` (MANDATORY).** The script is the single source of truth for the `[do-route]` marker grammar, the thinking directives, the token-budget line, the Task Specification skeleton, the four mandatory verbatim injections (reference loading, completeness, Dense-Complete Writing, base instructions), and the optional worktree/local-only blocks. Never hand-assemble them. Assemble one routing-decision JSON per dispatch, run the script, prepend its stdout verbatim to the agent prompt. Roster: one run per worker prompt.
+**Build dispatch with `scripts/build-dispatch.py` (MANDATORY).** Single source of truth for `[do-route]` marker, thinking directives, token budget, Task Spec, four verbatim injections (reference loading, completeness, Dense-Complete Writing, base instructions), worktree/local-only blocks. Never hand-assemble. One JSON per dispatch, prepend stdout. Roster: one per worker.
 
 ```bash
 python3 "$SDIR/build-dispatch.py" --json '{
@@ -395,95 +312,63 @@ python3 "$SDIR/build-dispatch.py" --json '{
 }'
 ```
 
-Field sourcing (omit any optional field; the script degrades gracefully):
+Fields (omit optional; script degrades): `agent`/`skill`/`complexity` from Phase 2 (no skill→`skill=-`). `model` from Model Selection (**required Medium+**, script errors; values: sonnet/opus/fable/gpt-5.5/codex; trivial/simple→`model=-`). `health` from Step 1.5 (no row→omit→`health=-`). `stack` from Phase 3 (instrumentation). `task_spec` mandatory Medium+, Simple include intent+acceptance when extractable; intent=verb+object, constraints=branch safety+operator-context+memory, acceptance=observable outcomes; creation adds "must match ADR"; invent nothing. `flags.worktree` for worktree agents. `flags.local_only` on local-only signals. `flags.thinking_override`: "slow" for security/API design/migrations/5+ files/arch; "fast" for lookups/renames; else omit. `token_remaining` advisory budget minus spend.
 
-- `agent`/`skill`/`complexity`: the Phase 2 decision. Omitted skill => marker gets `skill=-`.
-- `model`: the Model Selection table pick for this dispatch. REQUIRED for medium/complex/critical — the script errors on omission. Allowed values: `sonnet`, `opus`, `fable`, `gpt-5.5`, `codex`. Omitted for trivial/simple => marker gets `model=-`.
-- `health`: the Step 1.5 gate inputs (`confidence`/`n`/`failure`/`action`, `alts` when alternates were offered). Omit when the picked pair has no weight row => marker gets `health=-`. The recorder snapshots these at decision time.
-- `stack`: the Phase 3 enhancement skills stacked on this dispatch; omit when none. Instrumentation only.
-- `task_spec`: extract per the rules below. Mandatory for Medium+; for Simple include intent and acceptance when extractable. Invent no criteria; expand no scope.
-- `flags.worktree`: true for `isolation: "worktree"` agents — the script injects the worktree rules.
-- `flags.local_only`: true when Phase 3 detected local-only signals — the script injects the LOCAL-ONLY block.
-- `flags.thinking_override`: "slow" for security work, API/schema design, migrations, 5+ file reviews, architectural decisions; "fast" for lookups, status checks, single-function renames/refactors; else omit (the script picks the directive by complexity). Hooks capture the thinking class from dispatch metadata; the router records nothing.
-- `token_remaining`: `orchestration.token_budget` (`.claude/settings.json`, default 500000) minus a rough spend estimate; omit to emit the full budget. Advisory, not a hard cap.
+The `[do-route]` marker is the SOLE signal `routing-decision-recorder` reads. Dispatches without it (sub-agents, nested fan-out) are excluded from route-health.
 
-Task Specification extraction: Intent from verb+object; Constraints include branch safety (keep main protected), operator-context, memory feedback; Acceptance = observable outcomes. For creation, add "Implementation must match ADR `<kebab-case-name>`."
+**Fallback (script failed).** Hand-stamp: `[do-route] agent={agent} skill={skill|-} complexity={complexity} health=- model={model|-}` at prompt head, add Task Specification inline, dispatch, report failure.
 
-The emitted `[do-route]` marker is the SOLE signal `routing-decision-recorder` uses to record a `routing` row, reading `agent`/`skill` straight from it. Dispatches without it (pr-review sub-agents, nested fan-out) are correctly excluded from route-health.
-
-**Fallback (script failed: non-zero exit or empty output).** Treat as "Router Script Failed" for the preamble only: hand-stamp the single line `[do-route] agent={agent} skill={skill|-} complexity={complexity} health=- model={model|-}` at the head of the prompt (the recorder depends on it), add the Task Specification inline, dispatch, and report the script failure.
-
-**Model Selection (owner policy — ADR `model-selection-policy`; this is the canonical table — all other copies cite it).** Consult the table per dispatch. Rankings, higher = better; cost = what the owner actually pays.
+**Model Selection (canonical table — ADR `model-selection-policy`).**
 
 | model | cost | intelligence | taste | role |
 |---|---|---|---|---|
-| gpt-5.5 | 9 | 8 | 5 | Bulk/mechanical via codex wrapper (`codex` skill). Dispatch target. |
-| sonnet-5 | 5 | 5 | 7 | Mechanical/reader fan-out, lighter routed work. `model: "sonnet"`. Dispatch target. |
+| gpt-5.5 | 9 | 8 | 5 | Bulk/mechanical via codex wrapper. Dispatch target. |
+| sonnet-5 | 5 | 5 | 7 | Mechanical fan-out, lighter work. `model: "sonnet"`. Dispatch target. |
 | opus-4.8 | 4 | 7 | 8 | Reviews, audits, analysis, deep work. `model: "opus"`. Dispatch target. |
-| fable-5 | 2 | 9 | 9 | Highest technical requirements only — deliberate escalation, never routine dispatch. |
+| fable-5 | 2 | 9 | 9 | Highest requirements only — deliberate escalation, never routine dispatch. |
 
-Rules:
+Rules: Orchestrator = main thread model. **Medium+ MUST set model explicitly** (omission inherits — expensive propagation). Trivial/Simple: omission OK. Defaults, not limits — cheaper output misses bar → rerun smarter. Path: sonnet→opus→gpt-5.5→tighter spec. Ships: intelligence > taste > cost. Bulk→gpt-5.5. User-facing needs taste≥7. Reviews→opus. Haiku retired. Wrapper symmetry: wrapper serves model family NOT current harness. `codex exec -s read-only` for investigation. Codex prompts leave machine — public content only. Mechanics: `codex` skill.
 
-- **The orchestrator is whatever model runs the main thread** — fable/opus/sonnet under Claude Code, gpt-5.5 under Codex. It classifies, routes, evaluates results, synthesizes.
-- **Explicit model required for Medium+ dispatches.** Omitting `model` inherits the session main-loop model. When an expensive model orchestrates, omission silently propagates it to every worker. Every Medium/Complex/Critical dispatch MUST set `model` explicitly. Omission is allowed only for Trivial/Simple lookups where sonnet-tier inheritance risk is acceptable.
-- **Defaults, not limits.** Standing permission to override: if a cheaper model's output misses the bar, rerun with a smarter model without asking. Judge the output, not the price tag. Escalating costs less than shipping mediocre work. Escalation path: sonnet → opus → gpt-5.5 cross-check → rerun with tighter spec.
-- For anything that ships: intelligence > taste > cost. Cost is a tie-breaker only.
-- Bulk/mechanical work (clear-spec implementation, data analysis, migrations) → gpt-5.5 — effectively free.
-- Anything user-facing (UI, copy, API design) needs taste ≥ 7.
-- Reviews of plans/implementations → opus-4.8; optionally gpt-5.5 via codex as an extra independent perspective.
-- Haiku is retired — select only from the table above.
-- **Wrapper symmetry:** the wrapper serves whichever model family is NOT the current harness. Under Claude Code (current default), gpt-5.5 runs through a wrapper — the dispatched agent runs `codex exec` via Bash with a self-contained prompt, or a thin Claude wrapper agent (`model: "sonnet"`, low effort) writes the self-contained codex prompt, runs it, returns the result. Under the Codex harness, Claude models take the wrapper instead. Claude models under Claude Code need only the `model` parameter.
-- `codex exec -s read-only` for investigation/data-analysis prompts not covered by existing codex flows.
-- Prompt hygiene: codex prompts leave the machine — send only public content; secrets and private component names stay local.
+**Complex tasks (3+ sources) verb dispatch:**
 
-Decision rules live here; execution mechanics live in the `codex` skill (`skills/meta/codex`).
-
-**Verb-based model dispatch for Complex tasks (3+ data sources).**
-
-| Task verb class | Dispatch mode |
+| Verb class | Mode |
 |---|---|
-| list, count, extract, inventory, search, check, find, grep | Mechanical extraction fan-out: gpt-5.5 via the codex wrapper (`codex` skill) or `model: "sonnet"` readers (one per data source) → orchestrator synthesizes in-session or `model: "opus"` synthesizer agent |
-| review, audit, assess, analyze, debug, investigate, evaluate | Single `model: "opus"` agent (direct), per the table |
+| list, count, extract, inventory, search, check, find, grep | Fan-out: gpt-5.5/sonnet readers → opus synthesizer |
+| review, audit, assess, analyze, debug, investigate, evaluate | Single opus agent |
 
-Simple/Medium: dispatch directly.
+Simple/Medium: dispatch directly. Route to feature-branch agents; for modifications, include "commit on the branch". `isolation: "worktree"` → set `flags.worktree`.
 
-Route to agents that create feature branches; for file modifications, include "commit your changes on the branch". For `isolation: "worktree"` agents set `flags.worktree` in the routing JSON — the script injects the `worktree-agent` rules.
+Non-org repos: up to 3 `/pr-review` → fix iterations before PR. Org-gated (`classify-repo.py`): confirm before each git action.
 
-Non-org repos: up to 3 `/pr-review` → fix iterations before PR creation. Org-gated repos (via `python3 "$SDIR/classify-repo.py"`): require user confirmation before EACH git action.
+**Step 3: Multi-part requests** — "first...then", "and also", numbered lists, semicolons. Sequential dependencies in order; independent items in parallel (max 10).
 
-**Step 3: Handle multi-part requests**
+**Step 4: Auto-Pipeline Fallback** (no match, Simple+) — `auto-pipeline`. Still no match → route closest agent + `objective-loop`. Never dispatch Simple+ with empty skill.
 
-Detect: "first...then", "and also", numbered lists, semicolons. Sequential dependencies run in order; independent items launch multiple Task tools in one message. Max parallelism: 10.
+**Lazy-completion check.** Agent claims "done" on enumerable objective → compare claimed vs actual scope; if short, reject and re-dispatch remainder. See `references/lazy-completion-detector.md`. Re-dispatch → report route failure.
 
-**Step 4: Auto-Pipeline Fallback** (no match AND complexity >= Simple)
-
-Invoke `auto-pipeline` for unmatched requests. If none matches — or when uncertain — **ROUTE ANYWAY** to the closest agent AND stack an explicit skill (`objective-loop` if nothing else fits). Never dispatch Simple+ work with an empty skill slot; the fallback skill is `objective-loop` (`verification-before-completion` is routable when verification IS the task; Phase 3 injects its patterns as enhancements).
-
-**Lazy-completion check (before declaring done).** When an agent returns a "done" claim on an enumerable objective ("all N", a file list, a count), compare claimed scope vs objective scope; if claimed < objective, reject the early "done" and re-dispatch the remainder. See `skills/meta/do/references/lazy-completion-detector.md`. On a re-dispatch from this check, report the route failure (see Learning Capture, "Report routing failures").
-
-**Gate**: Agent invoked, results delivered. Learning capture runs automatically (see note below).
+**Gate**: Agent invoked, results delivered.
 
 ---
 
-### Learning Capture (automatic — no router step)
+### Learning Capture (automatic)
 
-Hooks capture everything automatically. The router records by hand exactly one case: orchestrator-reported route failures it observes directly (see "Report routing failures" below) — the single deliberate manual capture step, by ADR design. Everything else is hook-driven:
+Hooks capture everything. Router records one case manually: observed route failures (below).
 
 | Capture | Hook | Event |
 |---------|------|-------|
-| Routing decision row (`{agent}:{skill}`, `category=effectiveness`) | `routing-decision-recorder` | PostToolUse:Agent |
-| Routing outcome - validate pending (decision-row exists, re-queue late rows) | `routing-outcome-recorder` | SubagentStop |
-| Routing outcome - finalize (boost/decay) on the next user turn | `routing-outcome-finalizer` | UserPromptSubmit |
-| Routing outcome - session-end fallback for autonomous runs | `session-learning-recorder` | Stop |
-| Right-sizing tier feedback (when a `rightsizing:` banner is emitted) | `routing-decision-recorder` | PostToolUse:Agent |
-| Tool errors and fixes | `error-learner` | PostToolUse |
+| Routing decision (`{agent}:{skill}`) | `routing-decision-recorder` | PostToolUse:Agent |
+| Outcome - validate pending | `routing-outcome-recorder` | SubagentStop |
+| Outcome - finalize (boost/decay) | `routing-outcome-finalizer` | UserPromptSubmit |
+| Outcome - session-end fallback | `session-learning-recorder` | Stop |
+| Right-sizing feedback | `routing-decision-recorder` | PostToolUse:Agent |
+| Tool errors | `error-learner` | PostToolUse |
 | Review findings | `review-capture` | PostToolUse:Agent |
 
-These feed the routing loop: `learning-db.py route-health` reads the decision rows (denominator) and boost/decay outcomes (numerator). See ADR `learn-step-to-hook`.
+Feeds `learning-db.py route-health`. See ADR `learn-step-to-hook`.
 
-**Outcome fidelity (note).** An outcome resolves deterministically on the user's NEXT turn at zero LLM cost: the pending outcome stays *provisional* (no eager boost/decay) and finalizes once, THREE-WAY (T4) — **failure** on tool errors OR a clear rejection/rework/re-route (decay); **success** only on an explicit acceptance marker (boost); **neutral** otherwise — an unrelated/new-topic next prompt is no-op (no boost, no decay, no count change). No complaint is NOT acceptance. The Stop fallback resolves still-pending autonomous runs from the error flag alone: errors => failure, a clean run => neutral (a quiet Stop carries no acceptance evidence, so it does not boost). The reaction detector is **deterministic and high-precision** — failure fires only on strong, unambiguous markers.
+**Outcome fidelity.** Deterministic on next user turn, zero LLM cost, THREE-WAY: failure on errors/rejection (decay); success on explicit acceptance (boost); neutral otherwise. No complaint ≠ acceptance. Stop fallback: errors→failure, clean→neutral.
 
-**Report routing failures (router-reported channel).** The finalizer only sees tool errors and next-turn rejections; routing failures YOU observe fall through. On a HIGH-CONFIDENCE routing failure only, run:
+**Report route failures** (HIGH-CONFIDENCE only):
 
 ```bash
 REASON_FILE=$(mktemp); printf '%s' "<cause>" > "$REASON_FILE"
@@ -491,45 +376,26 @@ python3 ~/.claude/scripts/learning-db.py route-failure AGENT:SKILL --reason-file
 rm -f "$REASON_FILE"
 ```
 
-Run it for: re-route after unusable output; lazy-completion re-dispatch; section-validator misroute that reached dispatch; harness-rejected agent type. Bad execution by the RIGHT route -> `--routing-relevant no` (event only, no decay). Ambiguous -> record nothing (precision over recall). `--routing-relevant yes` decays the pair via the finalizer's decay path; one failure per dispatch key (re-runs are no-ops). `<cause>` is written to a temp file to avoid shell-splicing of untrusted text — never pass model- or user-derived text as a shell argument. See ADR `orchestrator-reported-route-failures`.
+Run for: re-route, lazy-completion re-dispatch, section-validator misroute, harness-rejected agent. Right route + bad execution → `--routing-relevant no`. Ambiguous → skip. Decays one per dispatch key. Temp file avoids shell-splicing.
 
-**OPTIONAL (not a gate):** curated free-text insight and review-finding graduation are opt-in via the `retro` skill (`retro graduate`), not a router step:
-
-```bash
-python3 ~/.claude/scripts/learning-db.py learn --skill go-patterns "insight"
-python3 ~/.claude/scripts/learning-db.py learn --agent golang-general-engineer "insight"
-```
-
-Routing rows are `category=effectiveness`, which `retro graduate` excludes — never need graduation.
+**Optional:** curated insight via `retro` skill: `learning-db.py learn --skill <name> "insight"` or `--agent <name> "insight"`. Routing rows (`category=effectiveness`) excluded from `retro graduate`.
 
 ---
 
 ## Error Handling
 
-### Error: "No Agent Matches Request"
-Cause: No agent covers the request domain
-Solution: Check INDEX files for near-matches. Route to the closest agent with verification-before-completion. Report the gap.
-
-### Error: "Force-Route Conflict"
-Cause: Multiple force-route triggers match the same request
-Solution: Apply the most specific force-route first. Stack compatible secondary routes as enhancements.
-
-### Error: "Plan Required But Not Created"
-Cause: Simple+ task attempted without task_plan.md
-Solution: Stop. Create `task_plan.md`. Resume routing once in place.
-
-### Error: "Router Script Failed"
-Cause: `pre-route.py` or `routing-manifest.py` exited non-zero or returned non-JSON.
-Solution: Treat as no-match. Route to `general-purpose` + `verification-before-completion`.
-
----
+| Error | Cause | Solution |
+|-------|-------|----------|
+| No Agent Matches | No agent covers domain | INDEX near-matches → closest agent + verification-before-completion. Report gap. |
+| Force-Route Conflict | Multiple force-routes match | Most specific first; stack compatible secondaries. |
+| Plan Required | Simple+ without task_plan.md | Create plan, resume. |
+| Router Script Failed | Non-zero exit or non-JSON | No-match fallback: `general-purpose` + `verification-before-completion`. |
 
 ## References
 
-### Reference Files
-- `${CLAUDE_SKILL_DIR}/references/progressive-depth.md`: Progressive depth escalation protocol
-- `agents/INDEX.json`: Agent triggers, metadata, and `not_for` disambiguation
-- `skills/INDEX.json`: Skill triggers, force-route flags, pairs_with, and `not_for` disambiguation
-- `skills/workflow/SKILL.md`: Workflow phases, triggers, composition chains
+- `${CLAUDE_SKILL_DIR}/references/progressive-depth.md`: Progressive depth escalation
+- `agents/INDEX.json`: Agent triggers, metadata, `not_for`
+- `skills/INDEX.json`: Skill triggers, force-route flags, pairs_with, `not_for`
+- `skills/workflow/SKILL.md`: Workflow phases, triggers, composition
 - `skills/workflow/references/pipeline-index.json`: Pipeline metadata, triggers, phases
-- `scripts/routing-manifest.py`: Generates compact routing manifest from INDEX files (single source of truth)
+- `scripts/routing-manifest.py`: Generates routing manifest from INDEX files


### PR DESCRIPTION
## Summary
- Reduce /do router SKILL.md 40,924 -> 23,738 B (58.0% of original, -42%) with zero behavior loss.
- Method: 99-item behavior inventory -> independent adversarial behavior-diff review (4 BLOCKER + 8 MAJOR losses found and restored) -> blind A/B on the standard harness.
- Blind A/B (routing-ab-test.py manifest-arm mode, corpus v3, 178 cases x 2 arms, sonnet both arms, blind opus judge, pre-registered gates): accuracy 52.2% -> 59.6% (+7.4), help=24/harm=11 (McNemar p=0.041 favoring reduced), zero new safety-bucket misses (git 6/6, security 4/4 both arms), stub-tier 10->10. VERDICT: PROMOTE (exit 0).
- All executed bash blocks byte-identical; dropped content is rationale/provenance/duplication only.
- Evidence: scripts/routing-ab-results/do-skill-reduction-v1/VERDICT.md (bulk artifacts local per gitignore convention).

## Test plan
- [x] ruff check + format clean
- [x] YAML frontmatter parses; reference paths verified
- [x] Pre-registered gates all PASS (gate-verdict exit 0)
- [ ] Post-merge: watch route-events.jsonl outcomes