### PR TITLE
fix(sync): skip promoted_to skills at deploy so stale symlinks stop recreating

### DIFF
--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -540,6 +540,45 @@ def _sync_runtime_skill_index(src: Path, dst: Path) -> bool:
     return True
 
 
+def _has_promoted_to(skill_dir: Path, skills_root: "Path | None" = None) -> bool:
+    """True when SKILL.md has promoted_to: and the target skill exists.
+
+    Skills with promoted_to: are folded into a parent skill and should not
+    appear as separate entries in ~/.claude/skills/ or mirror runtimes.
+    Returns False when the target skill does not exist yet (forward-looking
+    promotion tag), keeping the source skill deployed until its replacement
+    is live.
+
+    Uses a lightweight regex scan of the frontmatter block (between --- delimiters)
+    to avoid pulling in a YAML parser dependency.
+    """
+    skill_md = skill_dir / "SKILL.md"
+    try:
+        text = skill_md.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    # Frontmatter is between the first two --- lines
+    if not text.startswith("---"):
+        return False
+    end = text.find("\n---", 3)
+    if end == -1:
+        return False
+    frontmatter = text[3:end]
+    m = re.search(r"^promoted_to\s*:\s*(.+)$", frontmatter, re.MULTILINE)
+    if not m:
+        return False
+    # Validate the target skill exists in the repo
+    if skills_root is not None:
+        target_name = m.group(1).strip()
+        # Search category subdirectories for the target skill
+        for category in skills_root.iterdir():
+            if category.is_dir() and (category / target_name / "SKILL.md").exists():
+                return True
+        # Target not found — keep deploying the source skill
+        return False
+    return True
+
+
 def _sync_skills_flat_symlinks(src: Path, dst: Path, repo_root: "Path | list[Path] | None" = None) -> None:
     """Create flat per-skill symlinks from nested category structure.
 
@@ -639,6 +678,8 @@ def _sync_skills_flat_symlinks(src: Path, dst: Path, repo_root: "Path | list[Pat
             # Category folder: create symlinks for each skill inside
             for skill_dir in sorted(category_dir.iterdir()):
                 if skill_dir.is_dir() and (skill_dir / "SKILL.md").exists():
+                    if _has_promoted_to(skill_dir, skills_root=src):
+                        continue  # Folded into parent; skip deployment
                     expected_names.add(skill_dir.name)
                     _ensure_symlink(skill_dir, dst / skill_dir.name, repo_root=repo_root)
                 elif skill_dir.is_dir() and (skill_dir / "profile.json").exists():
@@ -1167,6 +1208,8 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
                     for skill_dir in sorted(child.iterdir()):
                         if not skill_dir.is_dir():
                             continue
+                        if _has_promoted_to(skill_dir, skills_root=repo_skills):
+                            continue  # Folded into parent; skip mirror
                         for item in skill_dir.rglob("*"):
                             if item.is_file():
                                 # Flatten: category/skill-name/SKILL.md → ~/.codex/skills/skill-name/SKILL.md

--- a/hooks/tests/test_sync_to_user_claude.py
+++ b/hooks/tests/test_sync_to_user_claude.py
@@ -675,6 +675,82 @@ class TestMainRuntimeIndex:
         assert "voice-x" in skills
 
 
+class TestHasPromotedTo:
+    """Tests for _has_promoted_to — skip skills folded into a parent."""
+
+    def _make_skills_root(self, tmp_path: Path) -> Path:
+        root = tmp_path / "skills"
+        root.mkdir()
+        return root
+
+    def test_promoted_with_existing_target_is_skipped(self, tmp_path: Path) -> None:
+        root = self._make_skills_root(tmp_path)
+        category = root / "voice"
+        category.mkdir()
+        child = category / "fish-shell-config"
+        child.mkdir()
+        (child / "SKILL.md").write_text("---\nname: fish-shell-config\npromoted_to: shell-config\n---\nbody\n")
+        target = category / "shell-config"
+        target.mkdir()
+        (target / "SKILL.md").write_text("---\nname: shell-config\n---\nbody\n")
+
+        assert sync_mod._has_promoted_to(child, skills_root=root) is True
+
+    def test_promoted_with_missing_target_is_deployed(self, tmp_path: Path) -> None:
+        root = self._make_skills_root(tmp_path)
+        category = root / "voice"
+        category.mkdir()
+        child = category / "fish-shell-config"
+        child.mkdir()
+        (child / "SKILL.md").write_text("---\nname: fish-shell-config\npromoted_to: shell-config\n---\nbody\n")
+        # No target skill created anywhere under root.
+
+        assert sync_mod._has_promoted_to(child, skills_root=root) is False
+
+    def test_no_promoted_to_key_is_deployed(self, tmp_path: Path) -> None:
+        root = self._make_skills_root(tmp_path)
+        category = root / "voice"
+        category.mkdir()
+        child = category / "ordinary-skill"
+        child.mkdir()
+        (child / "SKILL.md").write_text("---\nname: ordinary-skill\n---\nbody\n")
+
+        assert sync_mod._has_promoted_to(child, skills_root=root) is False
+
+    def test_malformed_frontmatter_fails_safe_and_deploys(self, tmp_path: Path) -> None:
+        """A skill with no closing '---' or unreadable frontmatter must not
+        raise — SessionStart hooks must never crash on a bad file. Failing
+        safe means the skill stays deployed (not silently dropped)."""
+        root = self._make_skills_root(tmp_path)
+        category = root / "voice"
+        category.mkdir()
+        child = category / "broken-skill"
+        child.mkdir()
+        (child / "SKILL.md").write_text("---\nname: broken-skill\nno closing delimiter\n")
+
+        assert sync_mod._has_promoted_to(child, skills_root=root) is False
+
+    def test_missing_skill_md_fails_safe_and_deploys(self, tmp_path: Path) -> None:
+        root = self._make_skills_root(tmp_path)
+        category = root / "voice"
+        category.mkdir()
+        child = category / "no-md-skill"
+        child.mkdir()
+        # No SKILL.md at all.
+
+        assert sync_mod._has_promoted_to(child, skills_root=root) is False
+
+    def test_no_frontmatter_delimiter_is_deployed(self, tmp_path: Path) -> None:
+        root = self._make_skills_root(tmp_path)
+        category = root / "voice"
+        category.mkdir()
+        child = category / "plain-skill"
+        child.mkdir()
+        (child / "SKILL.md").write_text("# Just a heading, no frontmatter\n")
+
+        assert sync_mod._has_promoted_to(child, skills_root=root) is False
+
+
 class TestResolvesInside:
     """Tests for _resolves_inside — the repo-path safety guard."""
 

--- a/install.sh
+++ b/install.sh
@@ -1298,6 +1298,24 @@ link_skills_nested() {
                 echo -e "${YELLOW}  Skipping ${entry_name}/${child_name} (disabled by profile)${NC}"
                 continue
             fi
+            # Skip skills folded into a parent via promoted_to: frontmatter,
+            # but only when the target skill exists (forward-looking tags stay deployed).
+            if [ -f "$child/SKILL.md" ]; then
+                _promoted_target=$(head -20 "$child/SKILL.md" | grep '^promoted_to:' | sed 's/^promoted_to:\s*//' | tr -d ' ')
+                if [ -n "$_promoted_target" ]; then
+                    # Check if target skill dir exists anywhere under source
+                    _target_found=false
+                    for _cat in "$source"/*/; do
+                        if [ -f "${_cat}${_promoted_target}/SKILL.md" ]; then
+                            _target_found=true
+                            break
+                        fi
+                    done
+                    if [ "$_target_found" = true ]; then
+                        continue
+                    fi
+                fi
+            fi
             if [ -e "$target/$entry_name/$child_name" ] || [ -L "$target/$entry_name/$child_name" ]; then
                 continue  # external/existing entry; keep it
             fi


### PR DESCRIPTION
## Summary
- Gap: installer (`install.sh`) and mirror sync (`hooks/sync-to-user-claude.py`) had no awareness of `promoted_to:` frontmatter — skills folded into a parent kept getting redeployed as separate `~/.claude/skills/` symlinks and `~/.codex/skills/` mirror entries every session start.
- Fix: `_has_promoted_to()` skips deployment/mirroring for a skill only when its `promoted_to:` target actually exists in the repo (forward-looking tags stay deployed until the replacement ships). `install.sh` gets the equivalent shell-side check.
- Codex mirror sync is additive-only (never deletes), so this change only stops new stale entries from being created there.
- Live cleanup of already-stale symlinks (`fish-shell-config`, `roast`, `csuite`, `kotlin-coroutines`) was done manually this session; this PR makes the fix permanent so they don't come back.

## Risk
`scripts/pr-risk-classify.py --base main` → **HIGH** (touches `hooks/` + `install.sh`). Owner (notque) approved the push/PR/merge flow for this hook's domain.

## Test plan
- [x] `python3 -m pytest hooks/tests/test_sync_to_user_claude.py -q` — 66 passed (6 new: existing-target skip, missing-target deploy, no-key deploy, malformed frontmatter fail-safe, missing SKILL.md fail-safe, no-delimiter fail-safe)
- [x] `ruff check` + `ruff format --check` clean
- [x] Reviewed diff against `_resolves_inside` guard: `_has_promoted_to` only gates the `_ensure_symlink` call and `expected_names` membership — it never calls `unlink`/`rmtree`, so it doesn't bypass or interact with the stale-cleanup safety guard
- [ ] Post-merge: `python3 ~/.claude/hooks/sync-to-user-claude.py` then confirm stale names stay at 0 and new parents (business-ops, shell-config, kotlin) remain