### PR TITLE
Fix Windows hook library deployment

### DIFF
--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -17,7 +17,6 @@ to prevent phantom hook errors when switching branches.
 Unchanged files are skipped via content comparison.
 """
 
-import fcntl
 import filecmp
 import json
 import os
@@ -27,8 +26,56 @@ import subprocess
 import sys
 from pathlib import Path
 
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
-from hook_utils import hook_error
+try:
+    from hook_utils import hook_error
+except ImportError:
+
+    def hook_error(hook_name: str, exc: BaseException) -> None:
+        print(f"[{hook_name}] HOOK-ERROR: {type(exc).__name__}: {exc}", file=sys.stderr)
+
+
+def _try_lock_fd(lock_fd: int) -> bool:
+    if fcntl is not None:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except (OSError, IOError):
+            return False
+
+    try:
+        import msvcrt
+
+        os.write(lock_fd, b"\0")
+        os.lseek(lock_fd, 0, os.SEEK_SET)
+        msvcrt.locking(lock_fd, msvcrt.LK_NBLCK, 1)
+        return True
+    except (ImportError, OSError):
+        return False
+
+
+def _unlock_fd(lock_fd: int | None) -> None:
+    if lock_fd is None:
+        return
+    try:
+        if fcntl is not None:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        else:
+            import msvcrt
+
+            os.lseek(lock_fd, 0, os.SEEK_SET)
+            msvcrt.locking(lock_fd, msvcrt.LK_UNLCK, 1)
+    except (ImportError, OSError):
+        pass
+    try:
+        os.close(lock_fd)
+    except OSError:
+        pass
 
 
 def _tolerant_mkdir(path: Path) -> None:
@@ -803,11 +850,12 @@ def main():
     lock_fd = None
     try:
         lock_fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
-        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except (OSError, IOError):
+        if not _try_lock_fd(lock_fd):
+            raise OSError("sync lock already held")
+    except OSError:
         # Lock held by another process — skip sync
         if lock_fd is not None:
-            os.close(lock_fd)
+            _unlock_fd(lock_fd)
         print("[sync] Skipping: another sync is in progress", file=sys.stderr)
         return
 
@@ -816,8 +864,7 @@ def main():
     finally:
         # Release lock
         try:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            os.close(lock_fd)
+            _unlock_fd(lock_fd)
         except OSError:
             pass
 

--- a/hooks/tests/test_hook_registration_coverage.py
+++ b/hooks/tests/test_hook_registration_coverage.py
@@ -10,7 +10,9 @@ Run with: python3 -m pytest hooks/tests/test_hook_registration_coverage.py -v
 
 from __future__ import annotations
 
+import ast
 import importlib.util
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -20,6 +22,9 @@ VALIDATOR = REPO_ROOT / "scripts" / "validate-hook-health.py"
 _spec = importlib.util.spec_from_file_location("validate_hook_health", VALIDATOR)
 vhh = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(vhh)
+
+HOOKS_LIB = REPO_ROOT / "hooks" / "lib"
+sys.path.insert(0, str(HOOKS_LIB))
 
 
 def _settings() -> dict:
@@ -78,7 +83,7 @@ def test_invisible_unicode_reason_does_not_silence_gate(tmp_path):
     cannot mask a dormant hook — closes the hidden-Unicode bypass."""
     al = tmp_path / "al.txt"
     # ghost.py followed by '#' + a zero-width space (U+200B) only.
-    al.write_text("ghost.py            # ​‌\nreal.py  # legitimate deferred reason here\n")
+    al.write_text("ghost.py            # ​‌\nreal.py  # legitimate deferred reason here\n", encoding="utf-8")
     parsed = vhh.parse_allowlist(al)
     assert "real.py" in parsed
     assert "ghost.py" not in parsed
@@ -318,3 +323,34 @@ def test_real_subprocess_dispatch_is_detected():
     assert _ast_dispatched(inline, {"x.py"}) == {"x.py"}
     assert _ast_dispatched(slot0, {"x.py"}) == {"x.py"}
     assert _ast_dispatched(path_join, {"x.py"}) == {"x.py"}
+
+
+def test_hook_lib_exports_every_imported_helper():
+    """Every hooks/lib named import in hooks/*.py must exist in that module."""
+    lib_modules = {path.stem for path in HOOKS_LIB.glob("*.py") if path.name != "__init__.py"}
+    imported: dict[str, dict[str, set[str]]] = {}
+    for hook_path in sorted((REPO_ROOT / "hooks").glob("*.py")):
+        tree = ast.parse(hook_path.read_text(encoding="utf-8"), filename=str(hook_path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module in lib_modules:
+                imported.setdefault(hook_path.name, {}).setdefault(node.module, set()).update(
+                    alias.name for alias in node.names
+                )
+
+    missing = []
+    loaded_modules = {}
+    for hook_name, modules in imported.items():
+        for module_name, names in modules.items():
+            if module_name not in loaded_modules:
+                module_path = HOOKS_LIB / f"{module_name}.py"
+                spec = importlib.util.spec_from_file_location(f"repo_hook_lib_{module_name}", module_path)
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[spec.name] = module
+                spec.loader.exec_module(module)
+                loaded_modules[module_name] = module
+            module = loaded_modules[module_name]
+            for name in sorted(names):
+                if not hasattr(module, name):
+                    missing.append(f"{hook_name}: {module_name}.{name}")
+
+    assert not missing, "hooks/lib missing imported helper(s):\n" + "\n".join(missing)

--- a/hooks/tests/test_sync_to_user_claude.py
+++ b/hooks/tests/test_sync_to_user_claude.py
@@ -1006,6 +1006,52 @@ class TestWorktreeDetectionSafeDefault:
         assert result is True
 
 
+class TestWindowsImportRecovery:
+    """Windows bootstrap must survive stale deployed hook utility modules."""
+
+    def test_imports_with_stale_hook_utils(self, tmp_path: Path) -> None:
+        hooks_dir = tmp_path / "hooks"
+        lib_dir = hooks_dir / "lib"
+        lib_dir.mkdir(parents=True)
+        shutil.copy2(HOOKS_DIR / "sync-to-user-claude.py", hooks_dir / "sync-to-user-claude.py")
+        (lib_dir / "hook_utils.py").write_text("def log_error(message): pass\n", encoding="utf-8")
+
+        spec = importlib.util.spec_from_file_location(
+            "sync_to_user_claude_stale_helper",
+            hooks_dir / "sync-to-user-claude.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        assert callable(module.hook_error)
+        assert callable(module._try_lock_fd)
+
+    def test_lock_helpers_acquire_release_and_reacquire(self, tmp_path: Path) -> None:
+        lock_path = tmp_path / ".sync.lock"
+        fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+        assert sync_mod._try_lock_fd(fd) is True
+        sync_mod._unlock_fd(fd)
+
+        fd2 = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+        assert sync_mod._try_lock_fd(fd2) is True
+        sync_mod._unlock_fd(fd2)
+
+    def test_windows_lock_backend_is_not_noop(self, tmp_path: Path) -> None:
+        if sys.platform != "win32":
+            pytest.skip("Windows-only msvcrt lock behavior")
+
+        lock_path = tmp_path / ".sync.lock"
+        fd1 = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+        fd2 = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+        try:
+            assert sync_mod._try_lock_fd(fd1) is True
+            assert sync_mod._try_lock_fd(fd2) is False
+        finally:
+            sync_mod._unlock_fd(fd2)
+            sync_mod._unlock_fd(fd1)
+
+
 class TestProtectedRootsWorktreeScenario:
     """Reproduce the worktree bypass scenario that causes voice-shared-references
     deletion.  A worktree that bypassed _is_git_worktree runs sync with

--- a/install.sh
+++ b/install.sh
@@ -1165,6 +1165,23 @@ install_component() {
                     echo -e "${YELLOW}  Skipping ${item_name} (disabled by profile)${NC}"
                     continue
                 fi
+                if [ "$name" = "hooks" ] && [ "$item_name" = "lib" ]; then
+                    if [ -L "$target/$item_name" ] || [ -f "$target/$item_name" ]; then
+                        rm -rf "$target/$item_name"
+                    fi
+                    mkdir -p "$target/$item_name"
+                    local lib_item lib_name
+                    for lib_item in "$item"/*; do
+                        [ -e "$lib_item" ] || [ -L "$lib_item" ] || continue
+                        lib_name=$(basename "$lib_item")
+                        if [ -e "$target/$item_name/$lib_name" ] || [ -L "$target/$item_name/$lib_name" ]; then
+                            rm -rf "$target/$item_name/$lib_name"
+                        fi
+                        ln -s "$lib_item" "$target/$item_name/$lib_name"
+                    done
+                    echo -e "${GREEN}  ✓ Per-item refreshed ${item_name}${NC}"
+                    continue
+                fi
                 if [ -e "$target/$item_name" ]; then
                     echo -e "${YELLOW}  WARNING: $target/$item_name already exists — skipping (kept existing)${NC}"
                     continue
@@ -1352,6 +1369,14 @@ sync_mirror_entry() {
             for item in "$source"/*; do
                 [ -e "$item" ] || [ -L "$item" ] || continue
                 item_name=$(basename "$item")
+                if [ "$name" = "lib" ] && [ "$(basename "$(dirname "$source")")" = "hooks" ]; then
+                    if [ -e "$target/$item_name" ] || [ -L "$target/$item_name" ]; then
+                        rm -rf "$target/$item_name"
+                    fi
+                    ln -s "$item" "$target/$item_name"
+                    echo -e "${GREEN}  ✓ ${label} per-item refreshed ${item_name}${NC}"
+                    continue
+                fi
                 if [ -e "$target/$item_name" ]; then
                     continue  # already present; skip silently
                 fi

--- a/scripts/tests/test_codex_hooks_install.py
+++ b/scripts/tests/test_codex_hooks_install.py
@@ -332,3 +332,47 @@ def test_install_sh_handles_missing_allowlist_gracefully() -> None:
         "Cannot test missing-allowlist path without mutating the repo allowlist file. "
         "Covered by the install.sh bash branch that prints a warning and continues."
     )
+
+
+def test_per_item_install_refreshes_hooks_lib(fake_home: Path, tmp_path: Path) -> None:
+    """Per-item hook installs must refresh hooks/lib, not preserve stale helpers."""
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    try:
+        dst.symlink_to(src)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable for this user/platform: {exc}")
+    dst.unlink()
+
+    stale_lib = fake_home / ".claude" / "hooks" / "lib"
+    stale_lib.mkdir(parents=True)
+    (stale_lib / "hook_utils.py").write_text("def log_error(message): pass\n", encoding="utf-8")
+    (stale_lib / "external_helper.py").write_text("# user-owned helper\n", encoding="utf-8")
+
+    stale_codex_lib = fake_home / ".codex" / "hooks" / "lib"
+    stale_codex_lib.mkdir(parents=True)
+    (stale_codex_lib / "hook_utils.py").write_text("def log_error(message): pass\n", encoding="utf-8")
+    (stale_codex_lib / "external_helper.py").write_text("# user-owned helper\n", encoding="utf-8")
+
+    reasonix_dir = fake_home / ".reasonix"
+    reasonix_dir.mkdir()
+    stale_reasonix_lib = reasonix_dir / "hooks" / "lib"
+    stale_reasonix_lib.mkdir(parents=True)
+    (stale_reasonix_lib / "hook_utils.py").write_text("def log_error(message): pass\n", encoding="utf-8")
+    (stale_reasonix_lib / "external_helper.py").write_text("# user-owned helper\n", encoding="utf-8")
+
+    result = _run_install(fake_home, ["--symlink", "--per-item", "--force"])
+
+    assert result.returncode == 0, f"install.sh failed.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    hook_utils = fake_home / ".claude" / "hooks" / "lib" / "hook_utils.py"
+    assert "def hook_error(" in hook_utils.read_text(encoding="utf-8")
+    assert (stale_lib / "external_helper.py").read_text(encoding="utf-8") == "# user-owned helper\n"
+
+    codex_hook_utils = fake_home / ".codex" / "hooks" / "lib" / "hook_utils.py"
+    assert "def hook_error(" in codex_hook_utils.read_text(encoding="utf-8")
+    assert (stale_codex_lib / "external_helper.py").read_text(encoding="utf-8") == "# user-owned helper\n"
+
+    reasonix_hook_utils = fake_home / ".reasonix" / "hooks" / "lib" / "hook_utils.py"
+    assert "def hook_error(" in reasonix_hook_utils.read_text(encoding="utf-8")
+    assert (stale_reasonix_lib / "external_helper.py").read_text(encoding="utf-8") == "# user-owned helper\n"


### PR DESCRIPTION
## Summary
Fixes Windows hook failures caused by stale deployed `~/.claude/hooks/lib` helper modules.
Makes the sync hook importable on Windows and able to self-heal stale helper deployments.

## Changes
- `install.sh` — refresh toolkit-owned `hooks/lib` helper files in per-item installs while preserving unrelated helper files.
- `hooks/sync-to-user-claude.py` — tolerate stale `hook_utils.py` and use a cross-platform non-blocking sync lock.
- `hooks/tests/test_hook_registration_coverage.py` — validate hook imports against exported helpers from repo `hooks/lib` modules.
- `hooks/tests/test_sync_to_user_claude.py` — add direct stale-helper and lock-helper regression coverage.
- `scripts/tests/test_codex_hooks_install.py` — cover stale helper refresh and external-helper preservation for Claude, Codex, and Reasonix mirrors.

## Notes
`gh` CLI is not authenticated locally, so PR creation and merge operations use the GitHub connector.
Local full-format check is not meaningful on this Windows checkout because existing tracked files are CRLF while CI checks out LF on Ubuntu.