### PR TITLE
feat(review,planning): add audit playbook and executor-ready plan template

### DIFF
--- a/skills/process/planning/SKILL.md
+++ b/skills/process/planning/SKILL.md
@@ -100,7 +100,7 @@ Detect the user's intent and load the appropriate reference file:
 | **Spec** | "write spec", "user stories", "define requirements", "scope this", "acceptance criteria", "define scope", "spec out" | `${CLAUDE_SKILL_DIR}/references/spec.md` |
 | **Pre-plan** | "discuss ambiguities", "resolve gray areas", "clarify before planning", "assumptions mode", "before we plan", "pre-planning discussion" | `${CLAUDE_SKILL_DIR}/references/pre-plan.md` |
 | **Interview** | depth-first decision-tree, one question at a time, recommendation per question. Triggers: "interview me", "grill me", "depth-first review", "depth-first interview", "not sure", "i'm not sure", "where do i start", "want clarity on", "need clarity on", "what am i missing", "poke holes in", "challenge my assumptions", "think this through with me", "lots of moving parts", "many decisions" | `${CLAUDE_SKILL_DIR}/references/depth-first-interview.md` |
-| **Plan-files** | "create plan", "task plan", "working memory", "persistent plan", "file-backed planning" | `${CLAUDE_SKILL_DIR}/references/plan-files.md` |
+| **Plan-files** | "create plan", "task plan", "working memory", "persistent plan", "file-backed planning" | `${CLAUDE_SKILL_DIR}/references/plan-files.md` (+ `${CLAUDE_SKILL_DIR}/references/executor-ready-plan-template.md` when the plan will be executed by subagents (SDD)) |
 | **Check** | "check plan", "validate plan", "plan checker", "review plan", "is this plan ready", "pre-execution check" | `${CLAUDE_SKILL_DIR}/references/check.md` |
 | **Manage** | "list plans", "show plan", "complete plan", "plan status", "manage plans" | `${CLAUDE_SKILL_DIR}/references/manage.md` |
 | **Pause** | "pause", "save progress", "handoff", "stopping for now", "end session", "session handoff", "wrap up session" | `${CLAUDE_SKILL_DIR}/references/pause.md` |
@@ -113,7 +113,7 @@ Detect the user's intent and load the appropriate reference file:
 | "write spec", "user stories", "define requirements", "scope this", "acceptance criteria", "define scope", "spec out" | `spec.md` | **Spec** |
 | "discuss ambiguities", "resolve gray areas", "clarify before planning", "assumptions mode", "before we plan", "pre-planning discussion" | `pre-plan.md` | **Pre-plan** |
 | "interview me", "grill me", "depth-first review", "depth-first interview", "not sure", "i'm not sure", "where do i start", "want clarity on", "need clarity on", "what am i missing", "poke holes in", "challenge my assumptions", "think this through with me", "lots of moving parts", "many decisions" | `depth-first-interview.md` | **Interview** |
-| "create plan", "task plan", "working memory", "persistent plan", "file-backed planning" | `plan-files.md` | **Plan-files** |
+| "create plan", "task plan", "working memory", "persistent plan", "file-backed planning" | `plan-files.md` (+ `executor-ready-plan-template.md` when plan targets SDD execution) | **Plan-files** |
 | "check plan", "validate plan", "plan checker", "review plan", "is this plan ready", "pre-execution check" | `check.md` | **Check** |
 | "list plans", "show plan", "complete plan", "plan status", "manage plans" | `manage.md` | **Manage** |
 | "pause", "save progress", "handoff", "stopping for now", "end session", "session handoff", "wrap up session" | `pause.md` | **Pause** |

--- a/skills/process/planning/references/executor-ready-plan-template.md
+++ b/skills/process/planning/references/executor-ready-plan-template.md
@@ -1,0 +1,182 @@
+# Executor-Ready Plan Template
+
+Plans consumed by subagent executors (via `subagent-driven-development`) must be self-contained. An executor runs in a fresh context with no memory of the planning session. Everything the executor needs — code excerpts, file paths, verification commands, stop conditions — must be inline in the plan. "See file X" is not a plan step; it is a token-burning detour.
+
+"Executor" here is SDD's implementer subagent; the two terms name the same role.
+
+When loaded alongside `plan-files.md`: for SDD-executed plans this skeleton replaces the plan-files skeleton. Keep plan-files' Status line for resumability; the other plan-files sections (Phases, Key Questions) are covered by Steps and STOP Conditions here.
+
+---
+
+## Plan Structure
+
+Every executor-ready plan follows this skeleton. Sections marked **(required)** cause executor failure when absent.
+
+````markdown
+# Plan: [Title]
+
+## Metadata (required)
+- **Created**: YYYY-MM-DD
+- **Base SHA**: [output of `git rev-parse --short HEAD` at plan creation time]
+- **Branch**: [branch name]
+- **Author**: [who created the plan]
+
+## Goal (required)
+[One sentence: the end state this plan produces.]
+
+## Scope (required)
+
+### In-scope files
+[Exhaustive list of files this plan creates or modifies. One per line.]
+- `path/to/file-a.go`
+- `path/to/file-b.go`
+
+### Out-of-scope files
+[Files the executor must leave untouched. Touching these triggers a STOP.]
+- `path/to/unrelated.go`
+- `config/production.yaml`
+
+## Steps (required)
+
+### Step 1: [Title]
+
+**What**: [Concrete description of the change.]
+
+**Context** (inlined):
+```[language]
+// Current state of the code being changed.
+// Paste the relevant excerpt here — 10-30 lines, enough to act on.
+// The executor reads this, not the file.
+```
+
+**Do**:
+1. [Specific instruction]
+2. [Specific instruction]
+
+**Verify**:
+```bash
+[command that confirms this step succeeded]
+```
+**Expected output**: [exact string, pattern, or exit code]
+
+---
+
+### Step N: [Title]
+[Same structure as Step 1]
+
+## STOP Conditions (required)
+
+Executor must STOP and escalate (report status, request human decision) when
+any of these triggers fire:
+
+1. **Drift detected**: the Base SHA in Metadata is no longer an ancestor of
+   HEAD (`git merge-base --is-ancestor <base-sha> HEAD` fails), or a step's
+   Context excerpt no longer matches the current file content. Commits made by
+   the plan's own earlier steps move HEAD forward and are NOT drift; a rebase,
+   reset, branch switch, or edited excerpt means the plan's assumptions may be
+   stale.
+2. **Verification fails twice**: A step's verify command fails, the executor
+   retries once, and it fails again. Two failures signal a plan defect, not a
+   transient error.
+3. **Out-of-scope touch required**: Completing a step requires modifying a file
+   listed in "Out-of-scope files." The plan's boundary was drawn wrong; a human
+   must decide whether to expand scope.
+4. **Ambiguous or missing instruction**: A step's "Do" section is unclear
+   enough that two reasonable interpretations exist, or a section marked
+   (required) is absent from the plan. Guessing risks rework.
+5. **Test regression**: A previously passing test fails after a step. The change
+   broke something outside the step's intent.
+
+## Completion Criteria (required)
+[How to verify the entire plan succeeded — final command + expected output.]
+````
+
+---
+
+## Drift Check Protocol
+
+The Base SHA is the plan's anchor to a specific codebase state. Every code excerpt, file path, and verification command assumes that state.
+
+**Plan author** stamps the SHA at plan creation:
+```bash
+git rev-parse --short HEAD
+```
+
+**Executor** verifies before starting each dispatch:
+```bash
+if ! git merge-base --is-ancestor <base-sha> HEAD; then
+  echo "DRIFT DETECTED: base <base-sha> is not an ancestor of HEAD"
+  echo "STOP: plan assumptions may be stale"
+  exit 1
+fi
+```
+
+The check is an ancestry test, not an equality test, because SDD runs plans as a per-task loop: each task commits and moves HEAD forward, so only the first dispatch can expect HEAD to equal the Base SHA. Commits produced by the plan's own earlier steps keep the Base SHA an ancestor and are not drift. Before editing a file, the executor also confirms the step's inlined Context excerpt still matches the file; a mismatch is drift even when ancestry holds.
+
+If either check fails: STOP. Report the mismatch. The planner must update the plan against the current state or confirm the plan still applies.
+
+---
+
+## Per-Step Verification Rules
+
+Every step ends with a verify block. The verify block is a contract: if the command produces the expected output, the step succeeded. If not, the step failed.
+
+**Good verification** (deterministic, specific):
+````markdown
+**Verify**:
+```bash
+go test ./auth/... -run TestTokenRefresh -count=1
+```
+**Expected output**: `ok  auth  0.XXXs` (exit code 0)
+````
+
+**Bad verification** (vague, untestable):
+```markdown
+**Verify**: "Check that the code looks correct"
+```
+
+Rules:
+1. Every verify command must be runnable without human judgment.
+2. Expected output must be specific enough to distinguish pass from fail.
+3. Prefer exit codes and grep-able strings over visual inspection.
+4. When no command can verify the step (pure refactor with no behavioral change), use: `git diff --stat` + expected file list.
+
+---
+
+## Inlining Context
+
+Executor subagents run in fresh context. File references ("see `auth/token.go` lines 45-60") cost the executor a Read tool call, token budget, and risk reading stale content if another step modified the file.
+
+**Inline instead**:
+- Paste 10-30 lines of the relevant code excerpt directly in the step's Context block.
+- Include enough surrounding context (function signature, imports) for the executor to orient.
+- Mark the excerpt's source: `// from auth/token.go:45-60 at base SHA abc1234`.
+
+**When NOT to inline**:
+- File is > 100 lines and the entire file is relevant: reference the file path but note "read this file in full before starting this step."
+- File will be created from scratch: provide the full intended content in the "Do" section instead.
+
+---
+
+## Scope Boundaries
+
+Explicit scope prevents executor drift — the most common failure mode in multi-step plans.
+
+**In-scope files**: Every file the plan touches. The executor treats this as a whitelist. Creating or modifying a file absent from this list is a scope violation.
+
+**Out-of-scope files**: Files related to the work but intentionally excluded. Naming them prevents the executor from "helpfully" fixing adjacent issues.
+
+**Why both lists**: In-scope alone leaves a gray area — is an unlisted file fair game or forbidden? The out-of-scope list removes ambiguity. Together they form a complete boundary.
+
+---
+
+## Integration with Subagent-Driven Development
+
+SDD's executor loop (Phase 2) consumes plans in this format. The plan's Base SHA (stamped at plan creation, anchors drift detection) is distinct from SDD's `{BASE_SHA}` (captured at execution start, anchors the final integration-review diff); do not conflate them. The contract:
+
+1. **Drift check**: Executor runs the ancestry drift check from Metadata before touching any file, and confirms each step's Context excerpt before editing. Failure triggers STOP condition 1.
+2. **Step-by-step execution**: Executor follows steps in order, running each verify block before proceeding. Failure triggers STOP condition 2.
+3. **Scope enforcement**: Executor checks every file it modifies against the in-scope list. Out-of-scope touch triggers STOP condition 3.
+4. **Escalation path**: On any STOP, the executor reports what it completed, what triggered the stop, and what decision it needs. It waits for human direction rather than improvising.
+
+The planner's job is to make the executor's job mechanical. If the executor needs judgment, the plan is underspecified.

--- a/skills/process/subagent-driven-development/SKILL.md
+++ b/skills/process/subagent-driven-development/SKILL.md
@@ -103,6 +103,8 @@ Use the Task tool with the prompt template from `./implementer-prompt.md`. Inclu
 - Clear deliverables
 - Permission to ask questions
 
+**Verification and STOP contract**: When the plan follows the executor-ready format (see `skills/process/planning/references/executor-ready-plan-template.md`), append the "Executor-Ready Plans" section of `./implementer-prompt.md` to the dispatch prompt — the contract binds only if the implementer receives it. The implementer runs the ancestry drift check before starting, executes each step's verify command before proceeding, and triggers a STOP on any of the template's five STOP conditions (drift, double verification failure, out-of-scope touch, ambiguous or missing instruction, test regression).
+
 **Implementation constraints** (enforced inline):
 - Implementer must understand task fully before coding begins. If they ask questions: answer clearly and completely, provide additional context, re-dispatch with answers. Give them time to fully understand the task.
 - Dispatch follows the Phase 1 scope-overlap decision: parallelize tasks within a non-overlapping group; serialize tasks whose file scopes overlap, because overlapping file edits cause conflicts that are expensive to resolve. When the overlap check reports any conflict, run those tasks sequentially.
@@ -222,5 +224,6 @@ Solution:
 
 ### Prompt Templates
 - `implementer-prompt.md`: Dispatch template for implementation subagents
+- `skills/process/planning/references/executor-ready-plan-template.md`: Self-contained plan format with drift checks, per-step verification, and STOP conditions
 - `adr-reviewer-prompt.md`: Dispatch template for ADR compliance review
 - `code-quality-reviewer-prompt.md`: Dispatch template for code quality review

--- a/skills/process/subagent-driven-development/implementer-prompt.md
+++ b/skills/process/subagent-driven-development/implementer-prompt.md
@@ -156,6 +156,29 @@ When done, report:
 Begin by confirming you understand the task, or asking questions.
 ```
 
+## Executor-Ready Plans
+
+When the plan follows `skills/process/planning/references/executor-ready-plan-template.md`, append this block to the dispatch prompt (fill `{PLAN_BASE_SHA}` from the plan's Metadata — this is the plan-creation SHA, not `{BASE_SHA}` above):
+
+```
+## Executor Contract (executor-ready plan)
+
+Before touching any file, run the drift check:
+- `git merge-base --is-ancestor {PLAN_BASE_SHA} HEAD` must succeed. Commits from this plan's earlier tasks are not drift.
+- Before editing a file, confirm the step's inlined Context excerpt still matches the file.
+
+Execute steps in order. Run each step's Verify command and match its Expected output before proceeding.
+
+STOP and escalate — report what you completed, what triggered the stop, and what decision you need — when any of these fire:
+1. Drift: ancestry check fails or a Context excerpt no longer matches.
+2. A step's Verify command fails twice (one retry allowed).
+3. Completing a step requires touching a file in the plan's Out-of-scope list, or any file absent from the In-scope list.
+4. A step's Do section is ambiguous, or a (required) plan section is missing.
+5. A previously passing test fails after a step.
+
+Do not improvise past a STOP.
+```
+
 ## Handling Questions
 
 When implementer asks questions:

--- a/skills/research/full-repo-review/SKILL.md
+++ b/skills/research/full-repo-review/SKILL.md
@@ -54,7 +54,8 @@ identical.
 
 | Signal | Load These Files | Why |
 |---|---|---|
-| writing full-repo-review-report.md | `report-template.md` | Loads detailed guidance from `report-template.md`. |
+| writing full-repo-review-report.md | `report-template.md` | Report structure and field definitions |
+| dispatching Wave 1 or Wave 2 review agents | `audit-playbook.md` | Per-category checklists, evidence requirements, severity mapping, reviewer role assignments |
 
 ## Instructions
 
@@ -110,8 +111,8 @@ reviewers should not waste tokens rediscovering.
 python3 ~/.claude/scripts/score-component.py --all-agents --all-skills --json
 ```
 
-Parse the JSON output. Flag any component scoring below 60 (grade F) as a
-CRITICAL finding for the final report. Components scoring 60-74 (grade C) are
+Parse the JSON output. Flag any component scoring below 60 (grades F and D) as
+a CRITICAL finding for the final report. Components scoring 60-74 (grade C) are
 HIGH findings.
 
 Save the raw scores -- they go into the report's "Deterministic Health Scores"
@@ -136,8 +137,11 @@ Invoke the `comprehensive-review` skill with these overrides:
 - **Scope**: Pass the full file list from Phase 1 (use `--focus [files]` mode)
 - **Mode**: Use `--review-only` to skip auto-fix. Output is a prioritized backlog for human triage, not patches -- full-repo auto-fix touches too many files at once and risks cascading breakage.
 - **All waves**: Run Wave 0, Wave 1, and Wave 2. Full-repo review needs maximum coverage. Wave 0 per-package context is what makes full-repo review valuable; deterministic checks catch structure, and the full 3-wave review catches logic and design issues.
+- **Checklists**: Load `references/audit-playbook.md` and pass it as prompt context for the wave agents — for each Wave 1/2 agent, include the playbook's category checklists matching that agent's lens (per the playbook's Reviewer Role Cross-Reference) plus each component's Phase 1 score and grade.
 
-The comprehensive-review skill handles Wave 0 (per-package), Wave 1 (foundation agents), and Wave 2 (deep-dive agents) internally.
+The comprehensive-review skill handles Wave 0 (per-package), Wave 1 (foundation agents), and Wave 2 (deep-dive agents) internally; the Checklists override is how the playbook reaches the agents it dispatches, since wave agents run in fresh context and cannot load it themselves.
+
+**Audit playbook**: The playbook maps categories to wave lenses and specifies evidence requirements per pattern. Agents use the checklists in their prompt to ensure systematic coverage rather than ad-hoc judgment about what to check.
 
 **Step 2: Collect findings**
 
@@ -237,3 +241,4 @@ least the severity sections and deterministic scores.
 ## References
 
 - [Report Template](references/report-template.md) -- Full structure for `full-repo-review-report.md` output
+- [Audit Playbook](references/audit-playbook.md) -- Per-category checklists (correctness, security, performance, test coverage, tech debt, dependencies, DX, docs) with evidence requirements and reviewer role assignments

--- a/skills/research/full-repo-review/references/audit-playbook.md
+++ b/skills/research/full-repo-review/references/audit-playbook.md
@@ -1,0 +1,214 @@
+# Audit Playbook
+
+Structured checklists for full-repo review. Each category lists specific patterns to look for and the evidence required to confirm a finding. Findings without evidence are speculation, not findings.
+
+Integrates with `score-component.py` grades: F and D grades (< 60) map to CRITICAL severity, C grade (60-74) maps to HIGH. Each category names a primary reviewer role; overlap is intentional — independent confirmation strengthens findings. See "Reviewer Role Cross-Reference" for how roles map to `parallel-code-review` and to comprehensive-review wave lenses.
+
+---
+
+## How to Use
+
+The orchestrator loads this playbook and pastes the relevant category checklists — plus each component's `score-component.py` score and grade — into every review agent's prompt (agents run in fresh context and cannot load it themselves). Each agent then, for each category it owns:
+
+1. Check every pattern in the "Look for" list against the file under review.
+2. Record a finding only when evidence exists (file path, line number, concrete observation).
+3. Assign severity per the category's severity guide.
+4. Cross-reference the `score-component.py` scores in the prompt — structural issues the script already flagged need confirmation, not rediscovery.
+
+---
+
+## Category 1: Correctness
+
+**Primary reviewer**: Business Logic
+
+**Look for**:
+
+| Pattern | Evidence required |
+|---|---|
+| Off-by-one in loops, slices, ranges | Line number + boundary values that trigger the error |
+| Nil/null dereference on optional returns | Call site that skips the nil check + the function signature |
+| Race condition on shared state | Two goroutines/threads accessing the same variable without synchronization; name both access points |
+| Unchecked error return | `file:line` where error is discarded + what failure it masks |
+| Type coercion that loses precision | The two types involved + a value that would be truncated |
+| Dead code path (unreachable branch) | The condition that is always true/false + why |
+| Incorrect boolean logic (swapped AND/OR, missing negation) | The expression + an input that produces wrong output |
+
+**Severity guide**: Data loss or silent wrong answer = CRITICAL. Logic error with limited blast radius = HIGH. Unreachable code = MEDIUM.
+
+---
+
+## Category 2: Security
+
+**Primary reviewer**: Security
+
+**Defer to the `security-review` skill for comprehensive security audits.** This category catches surface-level security issues during a repo-wide sweep; it does not replace the dedicated 25-pattern regex scanner + 40-class LLM taxonomy in `security-review`.
+
+**Look for**:
+
+| Pattern | Evidence required |
+|---|---|
+| Hardcoded secrets, API keys, tokens | `file:line` + the literal or pattern matched |
+| SQL/command injection (unsanitized input in query/exec) | The input source + the query/command it flows into |
+| Missing authentication on a route/endpoint | The route definition + absence of auth middleware |
+| Overly broad file permissions (world-writable, 777) | The chmod/permission call + the file it affects |
+| Secrets in logs, error messages, or client responses | `file:line` + the variable being logged |
+
+**Severity guide**: Exploitable vulnerability = CRITICAL. Missing defense-in-depth = HIGH. Hardening opportunity = MEDIUM.
+
+**Boundary**: Findings requiring deep threat modeling (attack trees, trust boundary analysis, cryptographic protocol review) belong in `security-review`, not here.
+
+---
+
+## Category 3: Performance
+
+**Primary reviewer**: Architecture
+
+**Look for**:
+
+| Pattern | Evidence required |
+|---|---|
+| N+1 query pattern (loop issuing one query per item) | The loop + the query inside it + the collection size if known |
+| Unbounded collection growth (append without cap or eviction) | The data structure + the growth path + absence of bounds |
+| Blocking call on hot path (synchronous I/O in request handler) | The call + the path it blocks |
+| Redundant computation (same value computed multiple times) | Both computation sites + the shared input |
+| Missing index on frequently queried column | The query + the table + absence of index in schema |
+| Large allocation in tight loop | The allocation + loop bounds |
+
+**Severity guide**: Measurable latency/memory impact on production path = HIGH. Theoretical concern without load evidence = MEDIUM. Micro-optimization = LOW.
+
+---
+
+## Category 4: Test Coverage
+
+**Primary reviewer**: Business Logic
+
+**Look for**:
+
+| Pattern | Evidence required |
+|---|---|
+| Public function with zero test coverage | Function signature + grep confirming no test calls it |
+| Test that asserts nothing (no assertion, only prints) | `file:line` of the test + absence of assert/expect |
+| Test that mocks the thing it tests (tautological) | The mock setup + the assertion that checks the mock |
+| Missing edge-case test (boundary values, empty inputs, errors) | The function's contract + the untested boundary |
+| Flaky test indicators (sleep, time-dependent, order-dependent) | The timing call or shared state + the test name |
+| Test file without corresponding source file (orphaned) | The test path + the missing source path |
+
+**Severity guide**: Core business logic untested = HIGH. Utility/helper untested = MEDIUM. Missing edge case on tested function = LOW.
+
+---
+
+## Category 5: Tech Debt
+
+**Primary reviewer**: Architecture
+
+**Look for**:
+
+| Pattern | Evidence required |
+|---|---|
+| TODO/FIXME/HACK comments older than 6 months | `file:line` + `git log` date of the comment |
+| Duplicated logic across 3+ files | The duplicated block + all file locations |
+| Deprecated API usage (language or library) | The deprecated call + the recommended replacement |
+| Inconsistent patterns for the same operation | Two+ examples of the same operation done differently |
+| Overly complex function (cyclomatic complexity, deep nesting) | The function + nesting depth or branch count |
+| Dead dependencies (imported but unused) | The import + grep confirming no usage |
+
+**Severity guide**: Deprecated API with removal timeline = HIGH. Duplication causing maintenance risk = MEDIUM. Cosmetic inconsistency = LOW.
+
+---
+
+## Category 6: Dependencies
+
+**Primary reviewer**: Security
+
+**Look for**:
+
+| Pattern | Evidence required |
+|---|---|
+| Known vulnerability in pinned version | The package + version + CVE or advisory ID |
+| Unpinned dependency (floating version) | The dependency spec + the lockfile state |
+| Abandoned dependency (no commits in 12+ months) | The package name + last commit date |
+| Unnecessary dependency (functionality available in stdlib) | The import + the stdlib equivalent |
+| Version conflict between direct and transitive deps | The two version specs + the conflict |
+| License incompatibility | The dependency license + the project license |
+
+**Severity guide**: Known CVE = CRITICAL. Abandoned with no alternative = HIGH. Unpinned = MEDIUM. Unnecessary = LOW.
+
+---
+
+## Category 7: Developer Experience
+
+**Primary reviewer**: Architecture
+
+**Look for**:
+
+| Pattern | Evidence required |
+|---|---|
+| Missing or wrong setup instructions (README, CONTRIBUTING) | The instruction + what actually happens when followed |
+| Unclear error messages (codes without context, raw stack traces) | The error output + what the user needs to know instead |
+| Inconsistent naming (mixed camelCase/snake_case in same layer) | Two+ examples from the same package/module |
+| Missing type annotations on public interfaces | The function signature + the language's annotation convention |
+| Complex build/run steps not scripted | The manual steps required + absence of script |
+| Missing CLAUDE.md or stale project conventions | The convention + evidence it no longer matches code |
+
+**Severity guide**: Setup instructions that fail = HIGH. Naming inconsistency = MEDIUM. Missing optional annotations = LOW.
+
+---
+
+## Category 8: Documentation
+
+**Primary reviewer**: Business Logic
+
+**Look for**:
+
+| Pattern | Evidence required |
+|---|---|
+| Stale docstring (describes old behavior) | The docstring + the current code that contradicts it |
+| Missing docstring on public API | The function/class + its public visibility |
+| README that does not match current project state | The README claim + the actual state |
+| Commented-out code without explanation | `file:line` + absence of explanatory comment |
+| Architecture doc that references deleted components | The reference + the missing component |
+
+**Severity guide**: Actively misleading docs = HIGH. Missing docs on public API = MEDIUM. Missing docs on internal code = LOW.
+
+---
+
+## Mapping to score-component.py
+
+Grade bands come from `score-component.py` (A 90-100, B 75-89, C 60-74, D 40-59, F 0-39):
+
+| Grade | Score | Severity in report | Action |
+|---|---|---|---|
+| F | 0-39 | CRITICAL | Fix immediately; structural deficiency |
+| D | 40-59 | CRITICAL | Fix immediately; structural deficiency |
+| C | 60-74 | HIGH | Fix this sprint |
+| B | 75-89 | (informational) | Note in health scores table |
+| A | 90-100 | (informational) | Note in health scores table |
+
+Wave agents use this mapping to avoid double-counting: if `score-component.py` already flagged a structural issue (missing error handling section, broken frontmatter), the reviewer confirms and cites the score rather than writing a new finding from scratch.
+
+---
+
+## Reviewer Role Cross-Reference
+
+When review runs via `parallel-code-review`, its three roles map to audit categories:
+
+| Reviewer | Primary categories | Secondary (cross-check) |
+|---|---|---|
+| Security | Security, Dependencies | Correctness (injection paths) |
+| Business Logic | Correctness, Test Coverage, Documentation | Tech Debt (stale TODOs) |
+| Architecture | Performance, Tech Debt, Developer Experience | Test Coverage (structural gaps) |
+
+When review runs via comprehensive-review waves (the full-repo-review path), the orchestrator maps categories to wave lenses:
+
+| Wave lens | Categories |
+|---|---|
+| security | Security, Dependencies |
+| business-logic, silent-failures | Correctness |
+| test-analyzer | Test Coverage |
+| quality, type-design, language-specialist | Tech Debt |
+| comment-analyzer, docs-validator | Documentation |
+| newcomer, docs-validator | Developer Experience |
+| architecture reviewer | Performance, Tech Debt |
+| Wave 2 deep-dive agents | Re-check the same categories as their Wave 1 counterpart lens, at depth |
+
+Each reviewer covers its primary categories exhaustively and its secondary categories opportunistically. This division prevents both gaps and redundant deep-dives.


### PR DESCRIPTION
## Summary
Adopts two patterns from the shadcn-improve comparison research: an executor-ready plan template for subagent-driven development and an audit playbook for full-repo reviews.

## Changes
- `skills/process/planning/references/executor-ready-plan-template.md` — add self-contained plan format with ancestry drift check, per-step verify commands, and five STOP conditions
- `skills/research/full-repo-review/references/audit-playbook.md` — add per-category audit checklists with evidence requirements and reviewer role/lens mappings
- `skills/process/planning/SKILL.md` — route Plan-files intent to the new template when the plan targets SDD execution
- `skills/process/subagent-driven-development/SKILL.md` — add executor verification and STOP contract for executor-ready plans
- `skills/process/subagent-driven-development/implementer-prompt.md` — add Executor-Ready Plans dispatch block carrying the drift check and five STOP conditions
- `skills/research/full-repo-review/SKILL.md` — add Checklists override passing playbook checklists and component scores into wave agent prompts

## Notes
- Pre-merge review (3 agents) reshaped the drift check to an ancestry test so multi-task SDD plans don't false-STOP, aligned grade bands to `score-component.py`, and gave the playbook an explicit delivery path to wave agents.
