### PR TITLE
Add agent evidence queries

### DIFF
--- a/docs/agent-evidence.md
+++ b/docs/agent-evidence.md
@@ -1,0 +1,46 @@
+# Agent Evidence Queries
+
+The agent evidence layer is a local SQLite read model inside `learning.db`. It
+records compact, queryable facts from existing hooks so the agent can answer
+questions such as:
+
+- Which route has worked or failed recently?
+- What happened in this session?
+- Which tool or file target failed most recently?
+- Is there enough local evidence to keep using a route, watch it, or investigate it?
+
+It is intentionally data-only. There is no server, dashboard, proxy, or external
+sync path.
+
+## Tables
+
+- `evidence_sessions`: one row per observed session, with project path and last
+  seen time.
+- `evidence_events`: append-style events for route decisions, route outcomes,
+  skill invocations, agent invocations, and tool failures.
+- `evidence_route_decisions`: normalized route decision rows with agent, skill,
+  model, health-gate inputs, stack, and eventual outcome.
+
+Text fields are bounded before storage. Metadata is stored as JSON text and
+returned as decoded JSON by the Python API and CLI JSON views.
+
+## CLI
+
+```bash
+python3 scripts/learning-db.py evidence-recent --json --limit 20
+python3 scripts/learning-db.py evidence-route-context python-general-engineer:test-driven-development --json
+python3 scripts/learning-db.py evidence-file-history hooks/lib/learning_db_v2.py --json
+python3 scripts/learning-db.py evidence-failures --json
+python3 scripts/learning-db.py evidence-decide python-general-engineer:test-driven-development --json
+```
+
+The `evidence-decide` command returns an advisory value only:
+
+- `keep`: recent local evidence does not show a meaningful failure signal.
+- `watch`: failures exist at a rate worth watching, especially on low sample
+  counts.
+- `investigate`: failures dominate the local evidence.
+- `no_data`: the route has no local evidence yet.
+
+These commands are safe for scripts and agent context assembly because JSON
+output does not require parsing prose.

--- a/hooks/error-learner.py
+++ b/hooks/error-learner.py
@@ -32,6 +32,7 @@ from learning_db_v2 import (
     decay_confidence,
     generate_signature,
     lookup_error_solution,
+    record_evidence_event,
     record_learning,
     sanitize_for_context,
 )
@@ -156,6 +157,21 @@ def main():
 
         # Sanitize before storing or replaying in context
         error_message = sanitize_for_context(error_message)
+        try:
+            record_evidence_event(
+                event_type="tool_failure",
+                source="hook:error-learner",
+                session_id=event.get("session_id") or None,
+                project_path=cwd,
+                tool_name=tool_name,
+                action="run",
+                target=source_detail,
+                success=False,
+                error=error_message,
+                metadata={"error_type": error_type, "signature": signature},
+            )
+        except Exception:
+            pass
 
         # Check for existing solution in unified DB
         existing = lookup_error_solution(error_message)

--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -17,18 +17,19 @@ Design Principles:
 """
 
 import hashlib
+import json
 import os
 import re
 import sqlite3
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 # ─── Configuration ─────────────────────────────────────────────
 
 _DEFAULT_DB_DIR = Path.home() / ".claude" / "learning"
 
-_CURRENT_SCHEMA_VERSION = 6
+_CURRENT_SCHEMA_VERSION = 7
 
 CATEGORY_DEFAULTS = {
     "error": 0.55,
@@ -199,6 +200,16 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
             "VALUES (6, 'add routing_outcome_basis table for outcome-basis counters')"
         )
 
+    if current < 7:
+        # v6 -> v7: local agent evidence read model for queryable sessions,
+        # hook events, and route decisions. Additive and idempotent.
+        conn.executescript(_EVIDENCE_DDL)
+        conn.execute("PRAGMA user_version = 7")
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version, description) "
+            "VALUES (7, 'add agent evidence event and route decision tables')"
+        )
+
     conn.commit()
 
 
@@ -294,6 +305,129 @@ CREATE TABLE IF NOT EXISTS routing_outcome_basis (
     count INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (key, basis)
 );
+"""
+
+
+_EVIDENCE_DDL = """
+CREATE TABLE IF NOT EXISTS evidence_sessions (
+    session_id    TEXT PRIMARY KEY,
+    project_path  TEXT,
+    started_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    last_seen_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    summary       TEXT
+);
+
+CREATE TABLE IF NOT EXISTS evidence_events (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id      TEXT NOT NULL UNIQUE,
+    session_id    TEXT,
+    ts            TEXT NOT NULL DEFAULT (datetime('now')),
+    event_type    TEXT NOT NULL,
+    source        TEXT NOT NULL,
+    agent         TEXT,
+    skill         TEXT,
+    tool_name     TEXT,
+    route_key     TEXT,
+    action        TEXT,
+    target        TEXT,
+    target_hash   TEXT,
+    success       INTEGER,
+    error         TEXT,
+    model         TEXT,
+    tokens        INTEGER,
+    metadata      TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_evidence_events_ts ON evidence_events(ts);
+CREATE INDEX IF NOT EXISTS idx_evidence_events_session ON evidence_events(session_id);
+CREATE INDEX IF NOT EXISTS idx_evidence_events_type ON evidence_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_evidence_events_route ON evidence_events(route_key);
+CREATE INDEX IF NOT EXISTS idx_evidence_events_agent_skill ON evidence_events(agent, skill);
+CREATE INDEX IF NOT EXISTS idx_evidence_events_target_hash ON evidence_events(target_hash);
+CREATE INDEX IF NOT EXISTS idx_evidence_events_success ON evidence_events(success);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS evidence_events_fts USING fts5(
+    event_type,
+    source,
+    agent,
+    skill,
+    tool_name,
+    route_key,
+    action,
+    target,
+    error,
+    metadata,
+    content='evidence_events',
+    content_rowid='id',
+    tokenize='porter unicode61'
+);
+
+CREATE TRIGGER IF NOT EXISTS evidence_events_ai AFTER INSERT ON evidence_events BEGIN
+    INSERT INTO evidence_events_fts(
+        rowid, event_type, source, agent, skill, tool_name, route_key, action, target, error, metadata
+    )
+    VALUES (
+        new.id, new.event_type, new.source, new.agent, new.skill, new.tool_name, new.route_key,
+        new.action, new.target, new.error, new.metadata
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS evidence_events_ad AFTER DELETE ON evidence_events BEGIN
+    INSERT INTO evidence_events_fts(
+        evidence_events_fts, rowid, event_type, source, agent, skill, tool_name, route_key,
+        action, target, error, metadata
+    )
+    VALUES (
+        'delete', old.id, old.event_type, old.source, old.agent, old.skill, old.tool_name, old.route_key,
+        old.action, old.target, old.error, old.metadata
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS evidence_events_au AFTER UPDATE ON evidence_events BEGIN
+    INSERT INTO evidence_events_fts(
+        evidence_events_fts, rowid, event_type, source, agent, skill, tool_name, route_key,
+        action, target, error, metadata
+    )
+    VALUES (
+        'delete', old.id, old.event_type, old.source, old.agent, old.skill, old.tool_name, old.route_key,
+        old.action, old.target, old.error, old.metadata
+    );
+    INSERT INTO evidence_events_fts(
+        rowid, event_type, source, agent, skill, tool_name, route_key, action, target, error, metadata
+    )
+    VALUES (
+        new.id, new.event_type, new.source, new.agent, new.skill, new.tool_name, new.route_key,
+        new.action, new.target, new.error, new.metadata
+    );
+END;
+
+CREATE TABLE IF NOT EXISTS evidence_route_decisions (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    decision_id          TEXT NOT NULL UNIQUE,
+    session_id           TEXT,
+    route_key            TEXT NOT NULL,
+    agent                TEXT NOT NULL,
+    skill                TEXT,
+    complexity           TEXT,
+    model                TEXT,
+    action               TEXT,
+    health               REAL,
+    n                    INTEGER,
+    failure              INTEGER DEFAULT 0,
+    gate_inputs_present  INTEGER DEFAULT 0,
+    outcome              TEXT,
+    outcome_basis        TEXT,
+    request_snippet      TEXT,
+    stack                TEXT,
+    alternates           TEXT,
+    created_at           TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at           TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_evidence_route_key ON evidence_route_decisions(route_key);
+CREATE INDEX IF NOT EXISTS idx_evidence_route_session ON evidence_route_decisions(session_id);
+CREATE INDEX IF NOT EXISTS idx_evidence_route_created ON evidence_route_decisions(created_at);
+CREATE INDEX IF NOT EXISTS idx_evidence_route_outcome ON evidence_route_decisions(outcome);
 """
 
 
@@ -440,6 +574,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 """
     + _TELEMETRY_DDL
     + _BASIS_DDL
+    + _EVIDENCE_DDL
 )
 
 
@@ -764,6 +899,481 @@ def record_telemetry_run(
             ),
         )
         conn.commit()
+
+
+def _bounded_text(value: object, limit: int = 2000) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text[:limit]
+
+
+def _json_text(value: object) -> str | None:
+    if value is None:
+        return None
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    except TypeError:
+        return json.dumps(str(value))
+
+
+def _parse_json_text(value: str | None) -> object:
+    if not value:
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def _target_hash(target: str | None) -> str | None:
+    if not target:
+        return None
+    return hashlib.sha256(target.encode("utf-8", errors="replace")).hexdigest()[:24]
+
+
+def _route_key(agent: str, skill: str | None = None) -> str:
+    clean_agent = (agent or "").strip()
+    clean_skill = (skill or "").strip()
+    return f"{clean_agent}:{clean_skill}" if clean_skill else f"{clean_agent}:"
+
+
+def _event_id(*parts: object) -> str:
+    raw = "|".join("" if part is None else str(part) for part in parts)
+    return hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()
+
+
+def _bool_or_none(value: object) -> bool | None:
+    if value is None:
+        return None
+    return bool(value)
+
+
+def _event_row(row: sqlite3.Row) -> dict:
+    data = dict(row)
+    data["success"] = _bool_or_none(data.get("success"))
+    data["metadata"] = _parse_json_text(data.get("metadata")) or {}
+    return data
+
+
+def _record_evidence_session(conn: sqlite3.Connection, session_id: str | None, project_path: str | None = None) -> None:
+    if not session_id:
+        return
+    conn.execute(
+        """
+        INSERT INTO evidence_sessions (session_id, project_path, started_at, last_seen_at)
+        VALUES (?, ?, datetime('now'), datetime('now'))
+        ON CONFLICT(session_id) DO UPDATE SET
+            project_path = COALESCE(excluded.project_path, evidence_sessions.project_path),
+            last_seen_at = datetime('now')
+        """,
+        (session_id, project_path),
+    )
+
+
+def record_evidence_event(
+    *,
+    event_type: str,
+    source: str,
+    session_id: str | None = None,
+    project_path: str | None = None,
+    agent: str | None = None,
+    skill: str | None = None,
+    tool_name: str | None = None,
+    route_key: str | None = None,
+    action: str | None = None,
+    target: str | None = None,
+    success: bool | None = None,
+    error: str | None = None,
+    model: str | None = None,
+    tokens: int | None = None,
+    metadata: dict | list | str | None = None,
+    event_id: str | None = None,
+    ts: str | None = None,
+) -> dict:
+    """Record a queryable agent evidence event and return the inserted row."""
+    init_db()
+    event_type = _bounded_text(event_type, 120) or "event"
+    source = _bounded_text(source, 160) or "unknown"
+    session_id = _bounded_text(session_id, 160)
+    project_path = _bounded_text(project_path, 1000)
+    agent = _bounded_text(agent, 160)
+    skill = _bounded_text(skill, 160)
+    tool_name = _bounded_text(tool_name, 160)
+    route_key = _bounded_text(route_key, 320)
+    action = _bounded_text(action, 160)
+    target = _bounded_text(target, 1000)
+    error = _bounded_text(error, 2000)
+    model = _bounded_text(model, 160)
+    metadata_text = _bounded_text(_json_text(metadata), 4000)
+    target_hash = _target_hash(target)
+    ts = _bounded_text(ts, 80)
+    event_id = _bounded_text(
+        event_id
+        or _event_id(
+            datetime.now(UTC).isoformat(timespec="microseconds"),
+            event_type,
+            source,
+            session_id,
+            agent,
+            skill,
+            tool_name,
+            route_key,
+            action,
+            target_hash,
+        ),
+        160,
+    )
+
+    with get_connection() as conn:
+        _record_evidence_session(conn, session_id, project_path)
+        conn.execute(
+            """
+            INSERT INTO evidence_events (
+                event_id, session_id, ts, event_type, source, agent, skill, tool_name,
+                route_key, action, target, target_hash, success, error, model, tokens, metadata
+            )
+            VALUES (?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(event_id) DO UPDATE SET
+                session_id = excluded.session_id,
+                ts = excluded.ts,
+                event_type = excluded.event_type,
+                source = excluded.source,
+                agent = excluded.agent,
+                skill = excluded.skill,
+                tool_name = excluded.tool_name,
+                route_key = excluded.route_key,
+                action = excluded.action,
+                target = excluded.target,
+                target_hash = excluded.target_hash,
+                success = excluded.success,
+                error = excluded.error,
+                model = excluded.model,
+                tokens = excluded.tokens,
+                metadata = excluded.metadata
+            """,
+            (
+                event_id,
+                session_id,
+                ts,
+                event_type,
+                source,
+                agent,
+                skill,
+                tool_name,
+                route_key,
+                action,
+                target,
+                target_hash,
+                None if success is None else int(bool(success)),
+                error,
+                model,
+                tokens,
+                metadata_text,
+            ),
+        )
+        conn.commit()
+        row = conn.execute("SELECT * FROM evidence_events WHERE event_id = ?", (event_id,)).fetchone()
+        return _event_row(row)
+
+
+def record_evidence_route_decision(
+    *,
+    session_id: str | None,
+    agent: str,
+    skill: str | None = None,
+    complexity: str | None = None,
+    model: str | None = None,
+    request_snippet: str | None = None,
+    stack: list[str] | tuple[str, ...] | str | None = None,
+    health: float | None = None,
+    n: int | None = None,
+    failure: bool | None = None,
+    action: str | None = None,
+    alternates: list[str] | tuple[str, ...] | str | None = None,
+    gate_inputs_present: bool = False,
+    decision_id: str | None = None,
+    outcome: str | None = None,
+    outcome_basis: str | None = None,
+) -> dict:
+    """Record a route decision plus a companion evidence event."""
+    init_db()
+    agent = _bounded_text(agent, 160) or "unknown"
+    skill = _bounded_text(skill, 160)
+    route_key = _route_key(agent, skill)
+    session_id = _bounded_text(session_id, 160)
+    decision_id = _bounded_text(
+        decision_id
+        or _event_id(datetime.now(UTC).isoformat(timespec="microseconds"), session_id, route_key, request_snippet),
+        160,
+    )
+    stack_text = _bounded_text(_json_text(stack), 2000)
+    alternates_text = _bounded_text(_json_text(alternates), 2000)
+
+    with get_connection() as conn:
+        _record_evidence_session(conn, session_id)
+        conn.execute(
+            """
+            INSERT INTO evidence_route_decisions (
+                decision_id, session_id, route_key, agent, skill, complexity, model, action,
+                health, n, failure, gate_inputs_present, outcome, outcome_basis,
+                request_snippet, stack, alternates, created_at, updated_at
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now')
+            )
+            ON CONFLICT(decision_id) DO UPDATE SET
+                session_id = excluded.session_id,
+                route_key = excluded.route_key,
+                agent = excluded.agent,
+                skill = excluded.skill,
+                complexity = excluded.complexity,
+                model = excluded.model,
+                action = excluded.action,
+                health = excluded.health,
+                n = excluded.n,
+                failure = excluded.failure,
+                gate_inputs_present = excluded.gate_inputs_present,
+                outcome = excluded.outcome,
+                outcome_basis = excluded.outcome_basis,
+                request_snippet = excluded.request_snippet,
+                stack = excluded.stack,
+                alternates = excluded.alternates,
+                updated_at = datetime('now')
+            """,
+            (
+                decision_id,
+                session_id,
+                route_key,
+                agent,
+                skill,
+                _bounded_text(complexity, 80),
+                _bounded_text(model, 160),
+                _bounded_text(action, 80),
+                health,
+                n,
+                None if failure is None else int(bool(failure)),
+                int(bool(gate_inputs_present)),
+                _bounded_text(outcome, 80),
+                _bounded_text(outcome_basis, 120),
+                _bounded_text(request_snippet, 1000),
+                stack_text,
+                alternates_text,
+            ),
+        )
+        conn.commit()
+        row = conn.execute("SELECT * FROM evidence_route_decisions WHERE decision_id = ?", (decision_id,)).fetchone()
+
+    record_evidence_event(
+        event_type="route_decision",
+        source="hook:routing",
+        session_id=session_id,
+        agent=agent,
+        skill=skill,
+        route_key=route_key,
+        action=action,
+        success=None if failure is None else not bool(failure),
+        model=model,
+        metadata={
+            "complexity": complexity,
+            "health": health,
+            "n": n,
+            "gate_inputs_present": gate_inputs_present,
+            "stack": stack,
+            "outcome": outcome,
+            "outcome_basis": outcome_basis,
+        },
+        event_id=f"route:{decision_id}",
+    )
+    data = dict(row)
+    data["failure"] = _bool_or_none(data.get("failure"))
+    data["gate_inputs_present"] = bool(data.get("gate_inputs_present"))
+    data["stack"] = _parse_json_text(data.get("stack")) or []
+    data["alternates"] = _parse_json_text(data.get("alternates")) or []
+    return data
+
+
+def update_evidence_route_outcome(
+    *,
+    route_key: str,
+    session_id: str | None = None,
+    outcome: str,
+    outcome_basis: str | None = None,
+) -> None:
+    """Attach the latest outcome to the newest matching route decision."""
+    init_db()
+    clauses = ["route_key = ?"]
+    params: list = [route_key]
+    if session_id:
+        clauses.append("session_id = ?")
+        params.append(session_id)
+    where = " AND ".join(clauses)
+    with get_connection() as conn:
+        row = conn.execute(
+            f"SELECT decision_id FROM evidence_route_decisions WHERE {where} ORDER BY id DESC LIMIT 1",  # security-review: ignore (fixed clauses; user values bound as ?)
+            params,
+        ).fetchone()
+        if not row:
+            return
+        conn.execute(
+            """
+            UPDATE evidence_route_decisions
+            SET outcome = ?, outcome_basis = ?, updated_at = datetime('now')
+            WHERE decision_id = ?
+            """,
+            (_bounded_text(outcome, 80), _bounded_text(outcome_basis, 120), row["decision_id"]),
+        )
+        conn.commit()
+
+
+def list_evidence_events(
+    *,
+    limit: int = 50,
+    session_id: str | None = None,
+    event_type: str | None = None,
+    route_key: str | None = None,
+    agent: str | None = None,
+    skill: str | None = None,
+    target: str | None = None,
+    failures_only: bool = False,
+) -> list[dict]:
+    init_db()
+    clauses: list[str] = []
+    params: list = []
+    if session_id:
+        clauses.append("session_id = ?")
+        params.append(session_id)
+    if event_type:
+        clauses.append("event_type = ?")
+        params.append(event_type)
+    if route_key:
+        clauses.append("route_key = ?")
+        params.append(route_key)
+    if agent:
+        clauses.append("agent = ?")
+        params.append(agent)
+    if skill:
+        clauses.append("skill = ?")
+        params.append(skill)
+    if target:
+        clauses.append("(target_hash = ? OR target LIKE ?)")
+        params.extend([_target_hash(target), f"%{target}%"])
+    if failures_only:
+        clauses.append("success = 0")
+    where = "WHERE " + " AND ".join(clauses) if clauses else ""
+    params.append(max(1, min(int(limit), 500)))
+    with get_connection() as conn:
+        rows = conn.execute(
+            f"SELECT * FROM evidence_events {where} ORDER BY id DESC LIMIT ?",  # security-review: ignore (fixed clauses; user values bound as ?)
+            params,
+        ).fetchall()
+    return [_event_row(row) for row in rows]
+
+
+def get_evidence_failures(
+    *,
+    limit: int = 50,
+    route_key: str | None = None,
+    agent: str | None = None,
+    skill: str | None = None,
+) -> list[dict]:
+    return list_evidence_events(
+        limit=limit,
+        route_key=route_key,
+        agent=agent,
+        skill=skill,
+        failures_only=True,
+    )
+
+
+def get_evidence_file_history(target: str, *, limit: int = 50) -> list[dict]:
+    return list_evidence_events(limit=limit, target=target)
+
+
+def _decision_row(row: sqlite3.Row) -> dict:
+    data = dict(row)
+    data["failure"] = _bool_or_none(data.get("failure"))
+    data["gate_inputs_present"] = bool(data.get("gate_inputs_present"))
+    data["stack"] = _parse_json_text(data.get("stack")) or []
+    data["alternates"] = _parse_json_text(data.get("alternates")) or []
+    return data
+
+
+def get_evidence_route_context(route_key: str, *, limit: int = 20) -> dict:
+    init_db()
+    with get_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT * FROM evidence_route_decisions
+            WHERE route_key = ?
+            ORDER BY id DESC
+            LIMIT ?
+            """,
+            (route_key, max(1, min(int(limit), 200))),
+        ).fetchall()
+        totals = conn.execute(
+            """
+            SELECT
+                COUNT(*) AS decisions,
+                COALESCE(SUM(CASE WHEN failure = 1 OR outcome = 'failure' THEN 1 ELSE 0 END), 0) AS failures,
+                COALESCE(SUM(CASE WHEN outcome IN ('success', 'weak_success') THEN 1 ELSE 0 END), 0) AS successes,
+                MAX(updated_at) AS last_seen
+            FROM evidence_route_decisions
+            WHERE route_key = ?
+            """,
+            (route_key,),
+        ).fetchone()
+    total_data = dict(totals)
+    return {
+        "route_key": route_key,
+        "totals": total_data,
+        "recent": [_decision_row(row) for row in rows],
+        "failures": get_evidence_failures(route_key=route_key, limit=limit),
+    }
+
+
+def get_evidence_decision(route_key: str) -> dict:
+    context = get_evidence_route_context(route_key, limit=10)
+    totals = context["totals"]
+    decisions = int(totals.get("decisions") or 0)
+    failures = int(totals.get("failures") or 0)
+    successes = int(totals.get("successes") or 0)
+    if decisions == 0:
+        return {
+            "route_key": route_key,
+            "recommendation": "no_data",
+            "confidence": "none",
+            "reasons": ["No local evidence has been recorded for this route."],
+            "context": context,
+        }
+
+    failure_rate = failures / decisions
+    reasons = [
+        f"{decisions} recorded decision(s)",
+        f"{failure_rate:.0%} failure rate",
+    ]
+    if successes:
+        reasons.append(f"{successes} successful outcome(s)")
+
+    if failure_rate > 0.65:
+        recommendation = "investigate"
+        confidence = "medium" if decisions >= 3 else "low"
+    elif failure_rate >= 0.25:
+        recommendation = "watch"
+        confidence = "medium" if decisions >= 4 else "low"
+    else:
+        recommendation = "keep"
+        confidence = "medium" if decisions >= 3 else "low"
+
+    return {
+        "route_key": route_key,
+        "recommendation": recommendation,
+        "confidence": confidence,
+        "reasons": reasons,
+        "context": context,
+    }
 
 
 def query_learnings(

--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -1106,7 +1106,9 @@ def record_evidence_route_decision(
     session_id = _bounded_text(session_id, 160)
     decision_id = _bounded_text(
         decision_id
-        or _event_id(datetime.now(timezone.utc).isoformat(timespec="microseconds"), session_id, route_key, request_snippet),
+        or _event_id(
+            datetime.now(timezone.utc).isoformat(timespec="microseconds"), session_id, route_key, request_snippet
+        ),
         160,
     )
     stack_text = _bounded_text(_json_text(stack), 2000)

--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -22,7 +22,7 @@ import os
 import re
 import sqlite3
 from contextlib import contextmanager
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 # ─── Configuration ─────────────────────────────────────────────
@@ -1013,7 +1013,7 @@ def record_evidence_event(
     event_id = _bounded_text(
         event_id
         or _event_id(
-            datetime.now(UTC).isoformat(timespec="microseconds"),
+            datetime.now(timezone.utc).isoformat(timespec="microseconds"),
             event_type,
             source,
             session_id,
@@ -1106,7 +1106,7 @@ def record_evidence_route_decision(
     session_id = _bounded_text(session_id, 160)
     decision_id = _bounded_text(
         decision_id
-        or _event_id(datetime.now(UTC).isoformat(timespec="microseconds"), session_id, route_key, request_snippet),
+        or _event_id(datetime.now(timezone.utc).isoformat(timespec="microseconds"), session_id, route_key, request_snippet),
         160,
     )
     stack_text = _bounded_text(_json_text(stack), 2000)

--- a/hooks/routing-decision-recorder.py
+++ b/hooks/routing-decision-recorder.py
@@ -607,6 +607,27 @@ def main() -> None:
                 wall_clock_ms=wall_clock_ms_from(event),
                 tool_errors=has_errors,
             )
+            try:
+                from learning_db_v2 import record_evidence_route_decision
+
+                record_evidence_route_decision(
+                    session_id=session_id or None,
+                    agent=agent,
+                    skill=skill or None,
+                    complexity=complexity or None,
+                    model=model,
+                    request_snippet=request_snippet,
+                    stack=stack,
+                    health=health["health"],
+                    n=health["n"],
+                    failure=bool(has_errors),
+                    action=health["action"],
+                    alternates=health["alternates"],
+                    gate_inputs_present=bool(health["gate_inputs_present"]),
+                    decision_id=f"{session_id or 'no-session'}:{sig}",
+                )
+            except Exception:
+                pass
 
             # Bridge to the outcome resolvers. The dispatch was already claimed
             # (marked seen) atomically above, so no separate mark. Decision row

--- a/hooks/routing-outcome-finalizer.py
+++ b/hooks/routing-outcome-finalizer.py
@@ -490,6 +490,26 @@ def main() -> None:
                 reason=reason,
                 routing_relevant=True,
             )
+            try:
+                from learning_db_v2 import record_evidence_event, update_evidence_route_outcome
+
+                update_evidence_route_outcome(
+                    route_key=key,
+                    session_id=session_id or None,
+                    outcome=outcome,
+                    outcome_basis=basis,
+                )
+                record_evidence_event(
+                    event_type="route_outcome",
+                    source="hook:routing-outcome-finalizer",
+                    session_id=session_id or None,
+                    route_key=key,
+                    action=outcome,
+                    success=outcome != "failure",
+                    metadata={"basis": basis, "reason": reason},
+                )
+            except Exception:
+                pass
             if debug:
                 print(
                     f"[routing-outcome-finalizer] {outcome} routing/{key} ({reason}) conf={new_conf:.4f}",

--- a/hooks/tests/test_agent_evidence.py
+++ b/hooks/tests/test_agent_evidence.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tests for the agent evidence read model in learning_db_v2."""
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+LIB_DIR = Path(__file__).parent.parent / "lib"
+sys.path.insert(0, str(LIB_DIR))
+
+
+@pytest.fixture(autouse=True)
+def isolated_learning_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(tmp_path))
+    import learning_db_v2
+
+    importlib.reload(learning_db_v2)
+    learning_db_v2.init_db()
+    yield learning_db_v2
+
+
+def test_records_and_queries_evidence_events(isolated_learning_db):
+    ldb = isolated_learning_db
+
+    first = ldb.record_evidence_event(
+        event_type="skill_invocation",
+        source="test",
+        session_id="s1",
+        project_path="/repo",
+        skill="test-driven-development",
+        action="invoke",
+        target="hooks/lib/learning_db_v2.py",
+        success=True,
+        metadata={"reason": "red-green-refactor"},
+    )
+    ldb.record_evidence_event(
+        event_type="tool_failure",
+        source="test",
+        session_id="s1",
+        project_path="/repo",
+        tool_name="pytest",
+        action="run",
+        target="hooks/tests/test_agent_evidence.py",
+        success=False,
+        error="assertion failed",
+    )
+
+    assert first["event_type"] == "skill_invocation"
+    rows = ldb.list_evidence_events(session_id="s1", limit=10)
+    assert [row["event_type"] for row in rows] == ["tool_failure", "skill_invocation"]
+    assert rows[1]["metadata"]["reason"] == "red-green-refactor"
+    assert rows[1]["success"] is True
+
+    failures = ldb.get_evidence_failures(limit=10)
+    assert len(failures) == 1
+    assert failures[0]["tool_name"] == "pytest"
+    assert failures[0]["success"] is False
+
+    history = ldb.get_evidence_file_history("hooks/lib/learning_db_v2.py", limit=10)
+    assert [row["skill"] for row in history] == ["test-driven-development"]
+
+
+def test_records_route_decisions_and_context(isolated_learning_db):
+    ldb = isolated_learning_db
+
+    ldb.record_evidence_route_decision(
+        session_id="s1",
+        agent="python-general-engineer",
+        skill="test-driven-development",
+        complexity="Medium",
+        model="gpt-5-codex",
+        request_snippet="Add a focused regression test.",
+        stack=["objective-loop", "verification-before-completion"],
+        health=0.82,
+        n=5,
+        failure=False,
+        action="keep",
+        outcome="success",
+        outcome_basis="acceptance_detected",
+    )
+    ldb.record_evidence_route_decision(
+        session_id="s2",
+        agent="python-general-engineer",
+        skill="test-driven-development",
+        complexity="Medium",
+        model="gpt-5-codex",
+        request_snippet="Retry after a broken assertion.",
+        failure=True,
+        outcome="failure",
+        outcome_basis="tool_errors",
+    )
+
+    context = ldb.get_evidence_route_context("python-general-engineer:test-driven-development")
+    assert context["route_key"] == "python-general-engineer:test-driven-development"
+    assert context["totals"]["decisions"] == 2
+    assert context["totals"]["failures"] == 1
+    assert context["totals"]["successes"] == 1
+    assert context["recent"][0]["session_id"] == "s2"
+
+    decision = ldb.get_evidence_decision("python-general-engineer:test-driven-development")
+    assert decision["recommendation"] == "watch"
+    assert any("failure rate" in reason for reason in decision["reasons"])

--- a/hooks/usage-tracker.py
+++ b/hooks/usage-tracker.py
@@ -55,6 +55,21 @@ def main():
                 project_path=project_path,
                 args_summary=args_summary,
             )
+            try:
+                from learning_db_v2 import record_evidence_event
+
+                record_evidence_event(
+                    event_type="skill_invocation",
+                    source="hook:usage-tracker",
+                    session_id=session_id,
+                    project_path=project_path,
+                    skill=skill_name,
+                    tool_name="Skill",
+                    action="invoke",
+                    target=args_summary,
+                )
+            except Exception:
+                pass
 
         elif tool_name == "Agent":
             # Try subagent_type first (Agent tool), then agentType (Workflow's agent()),
@@ -71,6 +86,22 @@ def main():
                 project_path=project_path,
                 isolation=isolation,
             )
+            try:
+                from learning_db_v2 import record_evidence_event
+
+                record_evidence_event(
+                    event_type="agent_invocation",
+                    source="hook:usage-tracker",
+                    session_id=session_id,
+                    project_path=project_path,
+                    agent=agent_type,
+                    tool_name="Agent",
+                    action="invoke",
+                    target=description or None,
+                    metadata={"isolation": isolation},
+                )
+            except Exception:
+                pass
 
     except Exception as e:
         hook_error("usage-tracker", e)

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -38,6 +38,11 @@ Usage:
     python3 scripts/learning-db.py skip-rate [--json] [--include-test]
     python3 scripts/learning-db.py record-review-fp --reviewer reviewer-code --finding "unused import" --reason "import used in test"
     python3 scripts/learning-db.py review-fps [--json] [--min-confidence 0.5]
+    python3 scripts/learning-db.py evidence-recent [--json]
+    python3 scripts/learning-db.py evidence-route-context AGENT:SKILL [--json]
+    python3 scripts/learning-db.py evidence-file-history PATH [--json]
+    python3 scripts/learning-db.py evidence-failures [--json]
+    python3 scripts/learning-db.py evidence-decide AGENT:SKILL [--json]
     python3 scripts/learning-db.py stack-usage [--json]
     python3 scripts/learning-db.py backfill-stack-usage [--force]
 """
@@ -66,10 +71,15 @@ from learning_db_v2 import (
     export_markdown,
     get_connection,
     get_db_path,
+    get_evidence_decision,
+    get_evidence_failures,
+    get_evidence_file_history,
+    get_evidence_route_context,
     get_stats,
     import_from_patterns_db,
     import_from_retro,
     init_db,
+    list_evidence_events,
     mark_graduated,
     query_instruction_skip_rate,
     query_learnings,
@@ -1081,6 +1091,85 @@ def cmd_telemetry_query(args: argparse.Namespace) -> None:
         print(f"{r['recorded_at']}  {r['topic']}/{r['key']}  git_sha={r['git_sha']}  source={r['source']}")
 
 
+def _print_json(data) -> None:
+    print(json.dumps(data, indent=2, default=str))
+
+
+def _print_evidence_rows(rows: list[dict]) -> None:
+    if not rows:
+        print("No evidence rows found.")
+        return
+    for row in rows:
+        status = ""
+        if row.get("success") is True:
+            status = " ok"
+        elif row.get("success") is False:
+            status = " failed"
+        target = f" target={row['target']}" if row.get("target") else ""
+        route = f" route={row['route_key']}" if row.get("route_key") else ""
+        print(f"{row['ts']}  {row['event_type']}{status} source={row['source']}{route}{target}")
+
+
+def cmd_evidence_recent(args: argparse.Namespace) -> None:
+    rows = list_evidence_events(
+        limit=args.limit,
+        session_id=args.session,
+        event_type=args.type,
+        route_key=args.route_key,
+        agent=args.agent,
+        skill=args.skill,
+        failures_only=args.failures,
+    )
+    if args.json:
+        _print_json(rows)
+    else:
+        _print_evidence_rows(rows)
+
+
+def cmd_evidence_route_context(args: argparse.Namespace) -> None:
+    context = get_evidence_route_context(args.route_key, limit=args.limit)
+    if args.json:
+        _print_json(context)
+        return
+    totals = context["totals"]
+    print(
+        f"{args.route_key}: {totals['decisions']} decision(s), "
+        f"{totals['successes']} success(es), {totals['failures']} failure(s)"
+    )
+    _print_evidence_rows(context["failures"])
+
+
+def cmd_evidence_file_history(args: argparse.Namespace) -> None:
+    rows = get_evidence_file_history(args.target, limit=args.limit)
+    if args.json:
+        _print_json(rows)
+    else:
+        _print_evidence_rows(rows)
+
+
+def cmd_evidence_failures(args: argparse.Namespace) -> None:
+    rows = get_evidence_failures(
+        limit=args.limit,
+        route_key=args.route_key,
+        agent=args.agent,
+        skill=args.skill,
+    )
+    if args.json:
+        _print_json(rows)
+    else:
+        _print_evidence_rows(rows)
+
+
+def cmd_evidence_decide(args: argparse.Namespace) -> None:
+    decision = get_evidence_decision(args.route_key)
+    if args.json:
+        _print_json(decision)
+        return
+    print(f"{decision['route_key']}: {decision['recommendation']} ({decision['confidence']})")
+    for reason in decision["reasons"]:
+        print(f"- {reason}")
+
+
 def cmd_record_routing_outcome(args: argparse.Namespace) -> None:
     """Record whether a routing decision succeeded or failed."""
     init_db()
@@ -2028,6 +2117,47 @@ def main():
     p_tquery.add_argument("--limit", type=int, default=50)
     p_tquery.add_argument("--format", choices=["human", "json"], default="human")
     p_tquery.set_defaults(func=cmd_telemetry_query)
+
+    # evidence-recent — recent queryable agent evidence rows.
+    p_e_recent = subparsers.add_parser("evidence-recent", help="List recent agent evidence events")
+    p_e_recent.add_argument("--limit", type=int, default=50)
+    p_e_recent.add_argument("--session", help="Filter by session id")
+    p_e_recent.add_argument("--type", help="Filter by event type")
+    p_e_recent.add_argument("--route-key", help="Filter by route key (agent:skill)")
+    p_e_recent.add_argument("--agent", help="Filter by agent")
+    p_e_recent.add_argument("--skill", help="Filter by skill")
+    p_e_recent.add_argument("--failures", action="store_true", help="Only failed events")
+    p_e_recent.add_argument("--json", action="store_true", help="Output as JSON")
+    p_e_recent.set_defaults(func=cmd_evidence_recent)
+
+    # evidence-route-context — route-specific decision history and failures.
+    p_e_route = subparsers.add_parser("evidence-route-context", help="Show local evidence for one route")
+    p_e_route.add_argument("route_key", help="Route key (agent:skill)")
+    p_e_route.add_argument("--limit", type=int, default=20)
+    p_e_route.add_argument("--json", action="store_true", help="Output as JSON")
+    p_e_route.set_defaults(func=cmd_evidence_route_context)
+
+    # evidence-file-history — events touching a file/path target.
+    p_e_file = subparsers.add_parser("evidence-file-history", help="Show evidence events for a target path")
+    p_e_file.add_argument("target", help="File path or target text")
+    p_e_file.add_argument("--limit", type=int, default=50)
+    p_e_file.add_argument("--json", action="store_true", help="Output as JSON")
+    p_e_file.set_defaults(func=cmd_evidence_file_history)
+
+    # evidence-failures — recent failed evidence rows.
+    p_e_failures = subparsers.add_parser("evidence-failures", help="List recent failed evidence events")
+    p_e_failures.add_argument("--limit", type=int, default=50)
+    p_e_failures.add_argument("--route-key", help="Filter by route key")
+    p_e_failures.add_argument("--agent", help="Filter by agent")
+    p_e_failures.add_argument("--skill", help="Filter by skill")
+    p_e_failures.add_argument("--json", action="store_true", help="Output as JSON")
+    p_e_failures.set_defaults(func=cmd_evidence_failures)
+
+    # evidence-decide — compact advisory derived from route evidence.
+    p_e_decide = subparsers.add_parser("evidence-decide", help="Summarize the advisory state for one route")
+    p_e_decide.add_argument("route_key", help="Route key (agent:skill)")
+    p_e_decide.add_argument("--json", action="store_true", help="Output as JSON")
+    p_e_decide.set_defaults(func=cmd_evidence_decide)
 
     # record-routing-outcome
     p_rro = subparsers.add_parser("record-routing-outcome", help="Record routing decision outcome")

--- a/scripts/tests/test_learning_db_evidence_cli.py
+++ b/scripts/tests/test_learning_db_evidence_cli.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Tests for evidence query subcommands in scripts/learning-db.py."""
+
+import importlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB_DIR = REPO_ROOT / "hooks" / "lib"
+SCRIPT_PATH = str(REPO_ROOT / "scripts" / "learning-db.py")
+sys.path.insert(0, str(LIB_DIR))
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(tmp_path))
+    import learning_db_v2
+
+    importlib.reload(learning_db_v2)
+    learning_db_v2.init_db()
+    learning_db_v2.record_evidence_route_decision(
+        session_id="s1",
+        agent="python-general-engineer",
+        skill="test-driven-development",
+        complexity="Medium",
+        model="gpt-5-codex",
+        request_snippet="Implement evidence queries.",
+        stack=["objective-loop"],
+        health=0.9,
+        n=8,
+        failure=False,
+        action="keep",
+        outcome="success",
+        outcome_basis="acceptance_detected",
+    )
+    learning_db_v2.record_evidence_event(
+        event_type="tool_failure",
+        source="test",
+        session_id="s1",
+        project_path="/repo",
+        tool_name="pytest",
+        action="run",
+        target="scripts/tests/test_learning_db_evidence_cli.py",
+        success=False,
+        error="assertion failed",
+    )
+    yield tmp_path
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    return subprocess.run(
+        [sys.executable, SCRIPT_PATH, *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+
+
+def test_evidence_recent_json(isolated_db):
+    p = _run_cli("evidence-recent", "--json", "--limit", "5")
+    assert p.returncode == 0, p.stderr
+    rows = json.loads(p.stdout)
+    assert rows[0]["event_type"] == "tool_failure"
+    assert any(row["event_type"] == "route_decision" for row in rows)
+
+
+def test_evidence_route_context_json(isolated_db):
+    p = _run_cli("evidence-route-context", "python-general-engineer:test-driven-development", "--json")
+    assert p.returncode == 0, p.stderr
+    data = json.loads(p.stdout)
+    assert data["totals"]["decisions"] == 1
+    assert data["totals"]["successes"] == 1
+
+
+def test_evidence_file_history_json(isolated_db):
+    p = _run_cli(
+        "evidence-file-history",
+        "scripts/tests/test_learning_db_evidence_cli.py",
+        "--json",
+    )
+    assert p.returncode == 0, p.stderr
+    rows = json.loads(p.stdout)
+    assert rows[0]["tool_name"] == "pytest"
+
+
+def test_evidence_failures_json(isolated_db):
+    p = _run_cli("evidence-failures", "--json")
+    assert p.returncode == 0, p.stderr
+    rows = json.loads(p.stdout)
+    assert rows[0]["error"] == "assertion failed"
+
+
+def test_evidence_decide_json(isolated_db):
+    p = _run_cli("evidence-decide", "python-general-engineer:test-driven-development", "--json")
+    assert p.returncode == 0, p.stderr
+    data = json.loads(p.stdout)
+    assert data["recommendation"] == "keep"
+    assert data["route_key"] == "python-general-engineer:test-driven-development"


### PR DESCRIPTION
## Summary
- add schema v7 evidence tables for sessions, events, and route decisions in learning.db
- add evidence-* CLI query commands for recent events, route context, file history, failures, and route advisories
- passively write evidence from routing, route outcomes, usage tracking, and error learning hooks
- add focused API/CLI tests and internal docs

## Risk
- pr-risk-classify: high, large, full-roster-plus-sign-off
- reason: touches hook paths and learning DB schema; kept cohesive because schema, query API, and passive hook writers are one usable feature

## Verification
- python3 -m pytest hooks/tests/test_agent_evidence.py scripts/tests/test_learning_db_evidence_cli.py -q
- python3 -m pytest hooks/tests/test_agent_evidence.py scripts/tests/test_learning_db_evidence_cli.py hooks/tests/test_routing_decision_recorder.py hooks/tests/test_error_learner.py tests/test_learning_loop_fixes.py scripts/tests/test_route_health_basis.py scripts/tests/test_route_weights.py scripts/tests/test_learning_db_stack_usage.py -q
- python3 -m pytest hooks/tests scripts/tests tests -q
- ruff check . --config pyproject.toml
- ruff format --check . --config pyproject.toml
- git diff --cached --check