### PR TITLE
fix(sync): remove dangling symlinks only; preserve foreign skill symlinks

### DIFF
--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -734,9 +734,22 @@ def _sync_skills_flat_symlinks(src: Path, dst: Path, repo_root: "Path | list[Pat
                     expected_names.add(skill_dir.name)
                     _ensure_symlink(skill_dir, dst / skill_dir.name, repo_root=repo_root)
 
-    # Clean stale entries: remove dangling symlinks (target no longer exists).
+    # Clean stale entries: remove symlinks no longer in expected_names, with
+    # two preservation rules when repo_root is known:
+    #   (a) Preserve if the target resolves INSIDE a known root — it belongs to
+    #       a repo (e.g. canonical main repo when syncing from a worktree).
+    #   (b) Preserve if the target is live and resolves OUTSIDE all known roots
+    #       — it is a foreign symlink (e.g. ~/.agents/skills/foo) that we must
+    #       not touch.
+    # When repo_root is None we cannot apply either guard, so anything not in
+    # expected_names is removed (original behaviour).
     for item in dst.iterdir():
-        if item.is_symlink() and not item.exists():
+        if item.name not in expected_names and item.is_symlink():
+            if repo_root is not None:
+                if _resolves_inside(item, repo_root):
+                    continue  # (a) inside a known repo root — preserve
+                if item.exists():
+                    continue  # (b) live and outside all roots — foreign, preserve
             item.unlink()
 
 

--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -734,16 +734,9 @@ def _sync_skills_flat_symlinks(src: Path, dst: Path, repo_root: "Path | list[Pat
                     expected_names.add(skill_dir.name)
                     _ensure_symlink(skill_dir, dst / skill_dir.name, repo_root=repo_root)
 
-    # Clean stale entries: remove symlinks in dst that no longer map to a source.
-    # Guard: refuse to unlink anything that resolves inside the repo.
+    # Clean stale entries: remove dangling symlinks (target no longer exists).
     for item in dst.iterdir():
-        if item.name not in expected_names and item.is_symlink():
-            if repo_root is not None and _resolves_inside(item, repo_root):
-                print(
-                    f"[sync] BLOCKED: stale-cleanup refusing to unlink {item.name} (resolves inside repo)",
-                    file=sys.stderr,
-                )
-                continue
+        if item.is_symlink() and not item.exists():
             item.unlink()
 
 

--- a/hooks/tests/test_sync_to_user_claude.py
+++ b/hooks/tests/test_sync_to_user_claude.py
@@ -1093,26 +1093,27 @@ class TestProtectedRootsWorktreeScenario:
 
         return main, worktree, claude_skills
 
-    def test_worktree_sync_without_canonical_deletes_symlink(self, tmp_path: Path) -> None:
-        """Without canonical root, stale cleanup would delete the voice-shared-references
-        symlink because it resolves into the main repo, not the worktree."""
+    def test_worktree_sync_without_canonical_preserves_foreign_symlink(self, tmp_path: Path) -> None:
+        """With the foreign-symlink fix, a live symlink whose target is outside
+        the given repo_root is preserved even without canonical root protection.
+        voice-shared-references resolves into main (outside worktree), so it
+        survives the cleanup."""
         main, worktree, claude_skills = self._make_main_and_worktree(tmp_path)
 
-        # Sync from worktree WITHOUT canonical root protection
+        # Sync from worktree with only the worktree as repo_root
         with patch.object(sync_mod, "_is_ephemeral_path", return_value=False):
             sync_mod._sync_skills_flat_symlinks(
                 worktree / "skills",
                 claude_skills,
-                repo_root=worktree,  # Wrong root — only protects worktree paths
+                repo_root=worktree,
             )
 
-        # The symlink was removed because voice-shared-references is not in
-        # worktree's skills, so not in expected_names, and the symlink resolves
-        # into main (not worktree), so the guard didn't catch it.
-        assert not (claude_skills / "voice-shared-references").exists(), (
-            "Expected the symlink to be removed (reproducing the bug)"
-        )
-        # But main repo files must still exist (unlink only removes the link)
+        # voice-shared-references resolves into main (outside worktree root),
+        # so it is treated as a foreign symlink and preserved.
+        vsr_link = claude_skills / "voice-shared-references"
+        assert vsr_link.is_symlink(), "voice-shared-references must be preserved"
+        assert vsr_link.resolve() == (main / "skills" / "voice-shared-references").resolve()
+        # Main repo files untouched
         for name in self.VSR_FILES:
             assert (main / "skills" / "voice-shared-references" / name).exists()
 


### PR DESCRIPTION
## Summary

- **Root cause:** The stale-cleanup loop in `_sync_skills_flat_symlinks` used `item.name not in expected_names` as its deletion condition. `expected_names` is built from vexjoy's own skills inventory only, so any symlink from an external source (e.g. `~/.agents/skills/`) was unconditionally deleted on every SessionStart — including after a `git pull`.
- **Fix:** Replace the inventory-based check with a liveness check: only unlink symlinks whose target no longer exists (`item.is_symlink() and not item.exists()`). This matches the comment above the loop ("remove symlinks that no longer map to a source") and preserves all foreign symlinks as long as their target is alive.

## Changes

`hooks/sync-to-user-claude.py` — stale-cleanup block (9 lines → 2 lines):

```python
# before
for item in dst.iterdir():
    if item.name not in expected_names and item.is_symlink():
        if repo_root is not None and _resolves_inside(item, repo_root):
            print(f"[sync] BLOCKED: ...", file=sys.stderr)
            continue
        item.unlink()

# after
for item in dst.iterdir():
    if item.is_symlink() and not item.exists():
        item.unlink()
```

## Test plan

- [ ] Skills from `~/.agents/skills/` survive a `git pull` + session restart in vexjoy-agent
- [ ] Dangling vexjoy skill symlinks (source deleted from repo) are still cleaned up
- [ ] `ruff check` and `ruff format --check` pass (verified locally)