### PR TITLE
fix(dispatch): accept health="-" sentinel without error

### DIFF
--- a/scripts/build-dispatch.py
+++ b/scripts/build-dispatch.py
@@ -215,9 +215,9 @@ def build_marker(decision: dict) -> str:
             )
         parts.append("model=-")
 
-    health = decision.get("health") or {}
+    health = decision.get("health")
     if not isinstance(health, dict):
-        raise InputError("'health' must be an object")
+        health = {}  # "-" sentinel or absent → no health data
     confidence = health.get("confidence")
     if confidence is None:
         # No weight row for the pick — the recorder writes null but marks the


### PR DESCRIPTION
## Summary
- `health="-"` is the documented sentinel for "no health data" (see script docstring lines 10, 32-33)
- `decision.get("health") or {}` let the truthy string `"-"` bypass the `or {}` fallback
- The subsequent `isinstance(health, dict)` check then raised `'health' must be an object`
- Fix: coerce any non-dict value (including `"-"` and absent) to `{}` before processing

## Changes
- `scripts/build-dispatch.py` lines 218-220 — replace `or {}` fallback with explicit `isinstance` coercion

## Notes
- `health="-"` is a valid input per the documented contract; this was a silent regression, not an edge case
