### PR TITLE
fix(hooks): scope pretool-learning-injector to cut cross-domain noise

### DIFF
--- a/hooks/lib/learning_db_v2.py
+++ b/hooks/lib/learning_db_v2.py
@@ -1264,7 +1264,8 @@ def list_evidence_events(
         params.extend([_target_hash(target), f"%{target}%"])
     if failures_only:
         clauses.append("success = 0")
-    where = "WHERE " + " AND ".join(clauses) if clauses else ""
+    joined_clauses = " AND ".join(clauses)
+    where = ("WHERE " + joined_clauses) if clauses else ""  # security-review: ignore (fixed clauses; pre-existing)
     params.append(max(1, min(int(limit), 500)))
     with get_connection() as conn:
         rows = conn.execute(
@@ -1467,6 +1468,9 @@ def search_learnings(
     *,
     min_confidence: float = 0.0,
     exclude_graduated: bool = True,
+    categories: list[str] | None = None,
+    project_path: str | None = None,
+    exclude_test_sources: bool = True,
     limit: int = 50,
 ) -> list[dict]:
     """Full-text search across learnings with BM25 ranking.
@@ -1479,6 +1483,18 @@ def search_learnings(
             matching (e.g. "goroutine OR channel", "circuit*").
         min_confidence: Minimum confidence threshold for results.
         exclude_graduated: If True, omit entries that have graduated.
+        categories: If given, restrict results to rows whose category is in
+            this list (matches ANY, same semantics as query_learnings()'s
+            `tags` filter). Use this to keep cross-domain categories (e.g.
+            "voice", "review", "design") out of results meant for a
+            different domain (e.g. tool-error hints).
+        project_path: If given, restrict results to rows with a NULL
+            project_path (global knowledge) or an exact match — same
+            semantics as query_learnings()'s `project_path` filter.
+        exclude_test_sources: If True (default), omit entries where source
+            starts with 'test' — same default and rationale as
+            query_learnings() (ADR-191): keeps test fixtures out of
+            production injection. Pass False to include them (e.g. auditing).
         limit: Maximum number of results to return.
 
     Returns:
@@ -1506,6 +1522,20 @@ def search_learnings(
 
     if exclude_graduated:
         conditions.append("l.graduated_to IS NULL")
+
+    if exclude_test_sources:
+        conditions.append("l.source NOT LIKE 'test%'")
+
+    if categories:
+        category_clauses = []
+        for category in categories:
+            category_clauses.append("l.category = ?")
+            params.append(category)
+        conditions.append(f"({' OR '.join(category_clauses)})")
+
+    if project_path:
+        conditions.append("(l.project_path IS NULL OR l.project_path = ?)")
+        params.append(project_path)
 
     where = " AND ".join(conditions)
 

--- a/hooks/pretool-learning-injector.py
+++ b/hooks/pretool-learning-injector.py
@@ -74,6 +74,62 @@ EDIT_FILE_PATTERNS = [
     (re.compile(r"\.ya?ml$"), ["yaml", "kubernetes"]),
 ]
 
+# Bare command names too generic to carry domain signal. A bare "grep" or
+# "test" as the sole tag turns the FTS query into a near-universal match,
+# pulling in unrelated learnings from any topic that happens to mention the
+# word (root cause of cross-domain noise -- see ADR: pretool-injector-scoping).
+# Excluded from the fallback below; commands matched by COMMAND_KEYWORD_PATTERNS
+# above are unaffected since they never reach the fallback.
+#
+# Deliberately excludes rm/mv/cp: those are exactly the commands where a
+# pretool "gotcha" warning has the most safety value, and the category
+# allowlist (INJECTABLE_CATEGORIES) plus project_path scoping already remove
+# the cross-domain noise that motivated this stoplist -- stoplisting
+# destructive commands on top of that would trade away real safety signal
+# for no additional noise reduction (ADR consultation, Concern 7).
+GENERIC_COMMAND_STOPLIST = frozenset(
+    {
+        "grep",
+        "find",
+        "ls",
+        "cat",
+        "cd",
+        "echo",
+        "test",
+        "check",
+        "wc",
+        "pwd",
+        "mkdir",
+        "touch",
+        "head",
+        "tail",
+        "sort",
+        "uniq",
+        "true",
+        "false",
+        "sleep",
+        "date",
+        "env",
+        "export",
+        "source",
+        "which",
+        "type",
+        "printf",
+        "sed",
+        "awk",
+        "jq",
+        "diff",
+        "xargs",
+    }
+)
+
+# Categories relevant to tool-error/gotcha hints. Excludes cross-domain
+# categories (voice, effectiveness, review, design, pivot, misroute) that
+# dominate the confidence pool with content unrelated to tool operation --
+# e.g. character-voice or PR-review learnings from other projects surfacing
+# on a bare `grep` or `find` call. See ADR: pretool-injector-scoping.
+INJECTABLE_CATEGORIES = ["error", "gotcha", "debug"]
+
 
 def extract_bash_tags(command: str) -> list[str]:
     """Extract relevant tags from a Bash command string."""
@@ -88,7 +144,7 @@ def extract_bash_tags(command: str) -> list[str]:
         parts = command.strip().split()
         if parts:
             base_cmd = parts[0].split("/")[-1]  # strip path prefix
-            if len(base_cmd) > 1:
+            if len(base_cmd) > 1 and base_cmd not in GENERIC_COMMAND_STOPLIST:
                 tags.add(base_cmd)
 
     return list(tags)[:10]  # Cap at 10 tags
@@ -162,6 +218,7 @@ def main():
         # this hook from spawning for non-matching tools.
         tool_name = event.get("tool_name", "")
         tool_input = event.get("tool_input", {})
+        cwd = event.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR")
 
         # Extract tags based on tool type
         if tool_name == "Bash":
@@ -186,6 +243,8 @@ def main():
             query_str,
             min_confidence=MIN_CONFIDENCE,
             exclude_graduated=True,
+            categories=INJECTABLE_CATEGORIES,
+            project_path=cwd,
             limit=MAX_RESULTS,
         )
 

--- a/hooks/tests/test_fts5_search.py
+++ b/hooks/tests/test_fts5_search.py
@@ -421,7 +421,8 @@ class TestBackwardCompatibility:
         _record("python-patterns", "dataclass", "Use dataclasses", tags=["python"])
 
         # Exact tag substring matching still works
-        # ADR-191: test fixtures use source="test"; opt back in via exclude_test_sources=False.
+        # _record() defaults to source="manual", so exclude_test_sources=False
+        # is a no-op here; kept for defensiveness if the fixture default changes.
         results = db.query_learnings(tags=["go"], exclude_test_sources=False)
         assert len(results) >= 1
         assert any(r["topic"] == "go-patterns" for r in results)

--- a/hooks/tests/test_fts5_search.py
+++ b/hooks/tests/test_fts5_search.py
@@ -37,7 +37,13 @@ def isolated_db(tmp_path):
 
 
 def _record(topic: str, key: str, value: str, tags: list[str] | None = None, confidence: float = 0.7) -> dict:
-    """Helper to record a learning with defaults."""
+    """Helper to record a learning with defaults.
+
+    source="manual" (not "test*") so these fixture rows survive
+    search_learnings()'s default exclude_test_sources=True -- the dedicated
+    TestExcludeTestSources class below uses an explicit "test*" source to
+    exercise that filter directly.
+    """
     return db.record_learning(
         topic=topic,
         key=key,
@@ -45,7 +51,7 @@ def _record(topic: str, key: str, value: str, tags: list[str] | None = None, con
         category="design",
         confidence=confidence,
         tags=tags,
-        source="test",
+        source="manual",
     )
 
 
@@ -223,6 +229,114 @@ class TestSearchLearnings:
         results = db.search_learnings("xyznonexistent")
         assert results == []
 
+    def test_categories_filter_matches_any(self):
+        """ADR: pretool-injector-scoping -- categories restricts to an allowlist."""
+        _record("topic-a", "key-a", "Error content about deadlocks", tags=["go"])  # category=design (default)
+        db.record_learning(
+            topic="topic-b",
+            key="key-b",
+            value="Deadlock error pattern",
+            category="error",
+            confidence=0.9,
+            tags=["go"],
+            source="manual",
+        )
+        db.record_learning(
+            topic="topic-c",
+            key="key-c",
+            value="Deadlock gotcha note",
+            category="gotcha",
+            confidence=0.9,
+            tags=["go"],
+            source="manual",
+        )
+
+        results = db.search_learnings("deadlock", categories=["error", "gotcha"])
+        topics = {r["topic"] for r in results}
+        assert topics == {"topic-b", "topic-c"}
+
+    def test_categories_filter_excludes_others(self):
+        _record("topic-a", "key-a", "Voice content about deadlocks", tags=["go"])  # category=design
+        results = db.search_learnings("deadlock", categories=["error", "gotcha", "debug"])
+        assert results == []
+
+    def test_categories_filter_none_is_no_op(self):
+        _record("topic-a", "key-a", "Design content about deadlocks", tags=["go"])
+        results = db.search_learnings("deadlock")
+        assert len(results) == 1
+
+    def test_project_path_filter_matches_global_and_exact(self):
+        db.record_learning(
+            topic="topic-global",
+            key="key-a",
+            value="Global content about circuit breakers",
+            category="error",
+            confidence=0.9,
+            source="manual",
+            project_path=None,
+        )
+        db.record_learning(
+            topic="topic-same-project",
+            key="key-b",
+            value="Same-project content about circuit breakers",
+            category="error",
+            confidence=0.9,
+            source="manual",
+            project_path="/home/user/project-a",
+        )
+        db.record_learning(
+            topic="topic-other-project",
+            key="key-c",
+            value="Other-project content about circuit breakers",
+            category="error",
+            confidence=0.9,
+            source="manual",
+            project_path="/home/user/project-b",
+        )
+
+        results = db.search_learnings("circuit breakers", project_path="/home/user/project-a")
+        topics = {r["topic"] for r in results}
+        assert topics == {"topic-global", "topic-same-project"}
+        assert "topic-other-project" not in topics
+
+    def test_project_path_none_is_no_op(self):
+        db.record_learning(
+            topic="topic-other-project",
+            key="key-c",
+            value="Other-project content about circuit breakers",
+            category="error",
+            confidence=0.9,
+            source="manual",
+            project_path="/home/user/project-b",
+        )
+        results = db.search_learnings("circuit breakers")
+        assert len(results) == 1
+
+    def test_exclude_test_sources_default_excludes(self):
+        """ADR: pretool-injector-scoping Concern 1 -- parity with query_learnings()."""
+        db.record_learning(
+            topic="topic-fixture",
+            key="key-a",
+            value="Test fixture content about retries",
+            category="error",
+            confidence=0.9,
+            source="test-fixture",
+        )
+        results = db.search_learnings("retries")
+        assert results == []
+
+    def test_exclude_test_sources_false_includes(self):
+        db.record_learning(
+            topic="topic-fixture",
+            key="key-a",
+            value="Test fixture content about retries",
+            category="error",
+            confidence=0.9,
+            source="test-fixture",
+        )
+        results = db.search_learnings("retries", exclude_test_sources=False)
+        assert len(results) == 1
+
 
 class TestMigrationBackfill:
     """Test _migrate_fts() backfill for pre-existing databases."""
@@ -282,7 +396,7 @@ class TestMigrationBackfill:
                 "old-entry",
                 "This is a pre-existing learning about goroutines",
                 "design",
-                "test",
+                "manual",
                 "go,concurrency",
             ),
         )

--- a/hooks/tests/test_pretool_learning_injector.py
+++ b/hooks/tests/test_pretool_learning_injector.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""
+Tests for the pretool-learning-injector hook.
+
+Covers the cross-domain noise fix (ADR: pretool-injector-scoping):
+- GENERIC_COMMAND_STOPLIST suppresses bare generic executables as fallback tags
+- INJECTABLE_CATEGORIES stays a subset of learning_db_v2's VALID_CATEGORIES
+- category filtering keeps error/gotcha/debug hints, drops cross-domain ones
+- project_path scoping keeps global + same-project hints, drops other-project ones
+- the injector still fires for a matching, in-scope pattern (no silent zero-out)
+
+Run with: python3 -m pytest hooks/tests/test_pretool_learning_injector.py -v
+"""
+
+import importlib.util
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the modules under test
+# ---------------------------------------------------------------------------
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import learning_db_v2 as db
+
+HOOK_PATH = Path(__file__).parent.parent / "pretool-learning-injector.py"
+
+spec = importlib.util.spec_from_file_location("pretool_learning_injector", HOOK_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    """Use a fresh temp learning.db for each test."""
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(tmp_path))
+    db._initialized = False
+    yield tmp_path
+    db._initialized = False
+
+
+def _record(
+    topic: str,
+    key: str,
+    value: str,
+    category: str = "error",
+    confidence: float = 0.9,
+    tags: list[str] | None = None,
+    project_path: str | None = None,
+    source: str = "manual",
+) -> dict:
+    return db.record_learning(
+        topic=topic,
+        key=key,
+        value=value,
+        category=category,
+        confidence=confidence,
+        tags=tags,
+        source=source,
+        project_path=project_path,
+    )
+
+
+def _make_bash_event(command: str, cwd: str | None = None) -> str:
+    event = {"tool_name": "Bash", "tool_input": {"command": command}}
+    if cwd:
+        event["cwd"] = cwd
+    return json.dumps(event)
+
+
+def _run_main(stdin_payload: str, env: dict | None = None) -> dict | None:
+    """Invoke mod.main() in-process. Returns parsed stdout JSON (or None)."""
+    base_env = dict(os.environ)
+    if env:
+        base_env.update(env)
+
+    stdout_capture = io.StringIO()
+    with (
+        patch.dict(os.environ, base_env, clear=True),
+        patch.object(mod, "read_stdin", return_value=stdin_payload),
+        patch("sys.stdout", stdout_capture),
+    ):
+        try:
+            mod.main()
+        except SystemExit:
+            pass
+
+    output = stdout_capture.getvalue().strip()
+    if not output:
+        return None
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError:
+        return None
+
+
+def _additional_context(parsed: dict | None) -> str:
+    if not parsed:
+        return ""
+    return parsed.get("hookSpecificOutput", {}).get("additionalContext", "")
+
+
+# ---------------------------------------------------------------------------
+# GENERIC_COMMAND_STOPLIST
+# ---------------------------------------------------------------------------
+
+
+class TestGenericCommandStoplist:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "grep foo bar.py",
+            "find . -name '*.py'",
+            "ls -la",
+            "cat file.txt",
+            "cd /tmp",
+            "echo hello",
+            "test -f file.txt",
+            "check something",
+            "wc -l file.txt",
+            "sed -n '1,5p' file.txt",
+            "awk '{print $1}' file.txt",
+            "jq '.foo' file.json",
+            "diff a.txt b.txt",
+            "xargs -n1 echo",
+        ],
+    )
+    def test_stoplisted_bare_command_yields_no_tags(self, command):
+        assert mod.extract_bash_tags(command) == []
+
+    def test_stoplist_full_membership(self):
+        expected = {
+            "grep",
+            "find",
+            "ls",
+            "cat",
+            "cd",
+            "echo",
+            "test",
+            "check",
+            "wc",
+            "pwd",
+            "mkdir",
+            "touch",
+            "head",
+            "tail",
+            "sort",
+            "uniq",
+            "true",
+            "false",
+            "sleep",
+            "date",
+            "env",
+            "export",
+            "source",
+            "which",
+            "type",
+            "printf",
+            "sed",
+            "awk",
+            "jq",
+            "diff",
+            "xargs",
+        }
+        assert frozenset(expected) == mod.GENERIC_COMMAND_STOPLIST
+
+    def test_destructive_commands_not_stoplisted(self):
+        """rm/mv/cp keep their fallback tag -- gotcha warnings on destructive
+        commands have real safety value (ADR consultation, Concern 7)."""
+        assert "rm" not in mod.GENERIC_COMMAND_STOPLIST
+        assert "mv" not in mod.GENERIC_COMMAND_STOPLIST
+        assert "cp" not in mod.GENERIC_COMMAND_STOPLIST
+        assert mod.extract_bash_tags("rm file.txt") == ["rm"]
+        assert mod.extract_bash_tags("mv a.txt b.txt") == ["mv"]
+        assert mod.extract_bash_tags("cp a.txt b.txt") == ["cp"]
+
+    def test_non_generic_bare_command_still_tagged(self):
+        """A specific/unusual command name is still a useful fallback tag."""
+        assert mod.extract_bash_tags("terraform plan") == ["terraform"]
+
+    def test_keyword_pattern_match_unaffected_by_stoplist(self):
+        """Commands matched by COMMAND_KEYWORD_PATTERNS never reach the
+        fallback, so the stoplist is irrelevant to them."""
+        tags = mod.extract_bash_tags("go test ./...")
+        assert set(tags) == {"go", "golang"}
+
+    def test_stoplisted_command_empty_tags_short_circuits_main(self):
+        """main() exits without querying the DB when tags come back empty."""
+        _record("go-patterns", "grep-tip", "Some hint mentioning grep", category="error")
+        parsed = _run_main(_make_bash_event("grep foo"))
+        assert _additional_context(parsed) == ""
+
+
+# ---------------------------------------------------------------------------
+# INJECTABLE_CATEGORIES sync with learning_db_v2
+# ---------------------------------------------------------------------------
+
+
+class TestInjectableCategoriesSync:
+    def test_injectable_categories_is_subset_of_valid_categories(self):
+        """A future category rename/removal in the library must fail this
+        test instead of silently desyncing the hook's allowlist
+        (ADR consultation, Concern 2)."""
+        assert set(mod.INJECTABLE_CATEGORIES) <= db.VALID_CATEGORIES
+
+    def test_injectable_categories_matches_spec(self):
+        assert mod.INJECTABLE_CATEGORIES == ["error", "gotcha", "debug"]
+
+
+# ---------------------------------------------------------------------------
+# Category exclusion (cross-domain noise)
+# ---------------------------------------------------------------------------
+
+
+class TestCategoryExclusion:
+    def test_voice_category_excluded(self):
+        _record("mmr-ratings", "canon-check", "Check canon before writing", category="voice")
+        # "voice" is not in learning_db_v2.VALID_CATEGORIES at all -- insert directly.
+        with db.get_connection() as conn:
+            conn.execute("UPDATE learnings SET category = 'voice' WHERE topic = 'mmr-ratings' AND key = 'canon-check'")
+            conn.commit()
+
+        parsed = _run_main(_make_bash_event("terraform plan"))
+        assert _additional_context(parsed) == ""
+
+    def test_review_design_effectiveness_excluded(self):
+        _record("pr-42", "finding", "Reviewer flagged unused import", category="review", tags=["terraform"])
+        _record("layout", "decision", "Use grid over flexbox", category="design", tags=["terraform"])
+        _record("session", "roi", "Injection was useful this session", category="effectiveness", tags=["terraform"])
+
+        parsed = _run_main(_make_bash_event("terraform plan"))
+        assert _additional_context(parsed) == ""
+
+    def test_error_gotcha_debug_pass_through(self):
+        _record("terraform", "state-lock", "Plan fails -> release the state lock first", category="error")
+        parsed = _run_main(_make_bash_event("terraform plan"))
+        assert "state lock" in _additional_context(parsed)
+
+    def test_mixed_categories_only_injectable_ones_surface(self):
+        _record("terraform", "state-lock", "Plan fails -> release the state lock first", category="error")
+        _record("terraform", "voice-note", "Some unrelated voice content about terraform", category="design")
+
+        parsed = _run_main(_make_bash_event("terraform plan"))
+        context = _additional_context(parsed)
+        assert "state lock" in context
+        assert "voice-note" not in context
+        assert "unrelated voice content" not in context
+
+
+# ---------------------------------------------------------------------------
+# exclude_test_sources parity (search_learnings level -- ADR consultation
+# Concern 1)
+# ---------------------------------------------------------------------------
+
+
+class TestExcludeTestSources:
+    def test_test_source_rows_excluded_by_default(self):
+        _record("terraform", "fixture", "Test fixture row", category="error", source="test-fixture")
+        results = db.search_learnings("terraform", categories=["error"])
+        assert results == []
+
+    def test_test_source_rows_included_when_disabled(self):
+        _record("terraform", "fixture", "Test fixture row", category="error", source="test-fixture")
+        results = db.search_learnings("terraform", categories=["error"], exclude_test_sources=False)
+        assert len(results) == 1
+
+    def test_injector_does_not_surface_test_fixtures(self):
+        """End-to-end: a test-source row must not leak through the hook."""
+        _record("terraform", "fixture", "Plan fails -> a fixture-only tip", category="error", source="test-fixture")
+        parsed = _run_main(_make_bash_event("terraform plan"))
+        assert _additional_context(parsed) == ""
+
+
+# ---------------------------------------------------------------------------
+# project_path scoping
+# ---------------------------------------------------------------------------
+
+
+class TestProjectPathScoping:
+    def test_global_learning_surfaces_for_any_project(self):
+        _record("terraform", "state-lock", "Plan fails -> release the state lock first", category="error")
+        parsed = _run_main(_make_bash_event("terraform plan", cwd="/home/user/project-a"))
+        assert "state lock" in _additional_context(parsed)
+
+    def test_same_project_learning_surfaces(self):
+        _record(
+            "terraform",
+            "state-lock",
+            "Plan fails -> release the state lock first",
+            category="error",
+            project_path="/home/user/project-a",
+        )
+        parsed = _run_main(_make_bash_event("terraform plan", cwd="/home/user/project-a"))
+        assert "state lock" in _additional_context(parsed)
+
+    def test_other_project_learning_excluded(self):
+        _record(
+            "terraform",
+            "state-lock",
+            "Plan fails -> release the state lock first",
+            category="error",
+            project_path="/home/user/project-b",
+        )
+        parsed = _run_main(_make_bash_event("terraform plan", cwd="/home/user/project-a"))
+        assert _additional_context(parsed) == ""
+
+    def test_cwd_falls_back_to_claude_project_dir(self):
+        _record(
+            "terraform",
+            "state-lock",
+            "Plan fails -> release the state lock first",
+            category="error",
+            project_path="/home/user/project-a",
+        )
+        parsed = _run_main(
+            _make_bash_event("terraform plan"),
+            env={"CLAUDE_PROJECT_DIR": "/home/user/project-a"},
+        )
+        assert "state lock" in _additional_context(parsed)
+
+
+# ---------------------------------------------------------------------------
+# Positive path: the injector still fires post-fix (no silent zero-out --
+# ADR consultation, Concern 6)
+# ---------------------------------------------------------------------------
+
+
+class TestInjectorStillFires:
+    def test_matching_error_pattern_injects(self):
+        _record("go-patterns", "mutex-usage", "Deadlock -> always release the mutex in a defer", category="error")
+        parsed = _run_main(_make_bash_event("go test ./..."))
+        context = _additional_context(parsed)
+        assert context.startswith("[learning-hint]")
+        assert "release the mutex" in context
+
+    def test_gotcha_category_injects(self):
+        _record(
+            "go-patterns",
+            "slice-append",
+            "Aliasing bug -> don't alias the old slice, append() may reallocate",
+            category="gotcha",
+        )
+        parsed = _run_main(_make_bash_event("go test ./..."))
+        assert "reallocate" in _additional_context(parsed)
+
+    def test_debug_category_injects(self):
+        _record("go-patterns", "race-flag", "Flaky test -> rerun with -race to confirm", category="debug")
+        parsed = _run_main(_make_bash_event("go test ./..."))
+        assert "-race" in _additional_context(parsed)
+
+    def test_low_confidence_pattern_does_not_inject(self):
+        _record("go-patterns", "low-conf", "Low confidence tip", category="error", confidence=0.4)
+        parsed = _run_main(_make_bash_event("go test ./..."))
+        assert _additional_context(parsed) == ""

--- a/scripts/tests/test_learning_db_stale_prune.py
+++ b/scripts/tests/test_learning_db_stale_prune.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Tests for the `stale` / `stale-prune` subcommands in scripts/learning-db.py.
+
+`retro clear` (skills/meta/retro/SKILL.md) wraps these two commands, so this
+file is also the test coverage for that subcommand's dry-run gate
+(ADR: pretool-injector-scoping, acceptance criterion "retro clear dry-run
+gate"). Covers: dry-run-by-default behavior, --confirm archiving, the
+required mutually-exclusive flag gate, and the underlying staleness filter
+(age, confidence, graduation).
+
+Run with: python3 -m pytest scripts/tests/test_learning_db_stale_prune.py -v
+"""
+
+import os
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_repo_root / "hooks" / "lib"))
+
+SCRIPT_PATH = str(_repo_root / "scripts" / "learning-db.py")
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point learning.db at a temp directory for each test."""
+    monkeypatch.setenv("CLAUDE_LEARNING_DIR", str(tmp_path))
+    import importlib
+
+    import learning_db_v2
+
+    importlib.reload(learning_db_v2)
+    learning_db_v2.init_db()
+    yield tmp_path
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    return subprocess.run(
+        [sys.executable, SCRIPT_PATH, *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+
+
+def _connect(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(tmp_path / "learning.db")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _insert(
+    tmp_path: Path,
+    topic: str,
+    key: str,
+    confidence: float = 0.3,
+    age_days: int = 60,
+    graduated_to: str | None = None,
+) -> None:
+    """Insert a learnings row directly with a controlled age/confidence."""
+    ts = (datetime.now() - timedelta(days=age_days)).isoformat()
+    conn = _connect(tmp_path)
+    conn.execute(
+        "INSERT INTO learnings (topic, key, value, category, confidence, source, "
+        "first_seen, last_seen, graduated_to) VALUES (?, ?, ?, 'error', ?, 'test', ?, ?, ?)",
+        (topic, key, f"value for {topic}/{key}", confidence, ts, ts, graduated_to),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _count(tmp_path: Path) -> int:
+    conn = _connect(tmp_path)
+    n = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()[0]
+    conn.close()
+    return n
+
+
+class TestRequiredFlag:
+    def test_neither_dry_run_nor_confirm_is_rejected(self, isolated_db: Path) -> None:
+        """The mutually-exclusive group is `required=True` -- silent deletion
+        by omission is impossible; the CLI refuses to run at all."""
+        result = _run_cli("stale-prune")
+        assert result.returncode != 0
+        assert "required" in result.stderr.lower() or "one of the arguments" in result.stderr.lower()
+
+    def test_both_flags_together_is_rejected(self, isolated_db: Path) -> None:
+        result = _run_cli("stale-prune", "--dry-run", "--confirm")
+        assert result.returncode != 0
+
+
+class TestDryRun:
+    def test_dry_run_deletes_nothing(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "t1", "k1", confidence=0.2, age_days=60)
+
+        result = _run_cli("stale-prune", "--dry-run")
+        assert result.returncode == 0
+        assert "DRY RUN" in result.stdout
+        assert "Run with --confirm" in result.stdout
+        assert _count(isolated_db) == 1
+
+    def test_dry_run_lists_matching_entries(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "stale-topic", "stale-key", confidence=0.2, age_days=60)
+        _insert(isolated_db, "fresh-topic", "fresh-key", confidence=0.9, age_days=1)
+
+        result = _run_cli("stale-prune", "--dry-run")
+        assert result.returncode == 0
+        assert "stale-topic/stale-key" in result.stdout
+        assert "fresh-topic/fresh-key" not in result.stdout
+
+    def test_dry_run_respects_min_age_days(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "t", "young", confidence=0.2, age_days=10)
+
+        result = _run_cli("stale-prune", "--dry-run", "--min-age-days", "30")
+        assert result.returncode == 0
+        assert "No stale entries to archive" in result.stdout
+        assert _count(isolated_db) == 1
+
+    def test_dry_run_no_stale_entries_message(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "t", "k", confidence=0.95, age_days=1)
+
+        result = _run_cli("stale-prune", "--dry-run")
+        assert result.returncode == 0
+        assert "No stale entries to archive" in result.stdout
+
+
+class TestConfirm:
+    def test_confirm_archives_and_deletes(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "t1", "k1", confidence=0.2, age_days=60)
+        _insert(isolated_db, "t2", "k2", confidence=0.9, age_days=1)  # not stale
+
+        result = _run_cli("stale-prune", "--confirm")
+        assert result.returncode == 0
+        assert "Archived 1 stale entries" in result.stdout
+        assert _count(isolated_db) == 1  # only the fresh row remains
+
+        conn = _connect(isolated_db)
+        archived = conn.execute("SELECT topic, key FROM learning_archive").fetchall()
+        conn.close()
+        assert [(r["topic"], r["key"]) for r in archived] == [("t1", "k1")]
+
+    def test_confirm_protects_graduated_rows(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "t", "grad", confidence=0.1, age_days=90, graduated_to="agent:x")
+
+        result = _run_cli("stale-prune", "--confirm")
+        assert result.returncode == 0
+        assert "No stale entries to archive" in result.stdout
+        assert _count(isolated_db) == 1
+
+    def test_confirm_protects_high_confidence_rows(self, isolated_db: Path) -> None:
+        """Staleness requires confidence < 0.5 -- a high-confidence old row is untouched."""
+        _insert(isolated_db, "t", "old-but-trusted", confidence=0.85, age_days=200)
+
+        result = _run_cli("stale-prune", "--confirm")
+        assert result.returncode == 0
+        assert "No stale entries to archive" in result.stdout
+        assert _count(isolated_db) == 1
+
+    def test_confirm_with_no_stale_entries_reports_and_exits_clean(self, isolated_db: Path) -> None:
+        result = _run_cli("stale-prune", "--confirm")
+        assert result.returncode == 0
+        assert "No stale entries to archive" in result.stdout
+
+
+class TestStaleShow:
+    def test_stale_lists_without_deleting(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "t", "k", confidence=0.2, age_days=60)
+
+        result = _run_cli("stale")
+        assert result.returncode == 0
+        assert "t" in result.stdout
+        assert _count(isolated_db) == 1
+
+    def test_stale_json_output(self, isolated_db: Path) -> None:
+        _insert(isolated_db, "t", "k", confidence=0.2, age_days=60)
+
+        result = _run_cli("stale", "--json")
+        assert result.returncode == 0
+        import json
+
+        entries = json.loads(result.stdout)
+        assert len(entries) == 1
+        assert entries[0]["topic"] == "t"

--- a/skills/meta/retro/SKILL.md
+++ b/skills/meta/retro/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: retro
-description: "Learning system interface: stats, search, graduate learnings. Backed by learning.db (SQLite + FTS5)."
+description: "Learning system interface: stats, search, graduate, clear learnings. Backed by learning.db (SQLite + FTS5)."
 user-invocable: true
-argument-hint: "[status|list|search <term>|graduate]"
+argument-hint: "[status|list|search <term>|graduate|clear]"
 allowed-tools:
   - Bash
   - Read
@@ -16,6 +16,11 @@ routing:
     - "graduate knowledge"
     - "learning stats"
     - "search learnings"
+    - "retro clear"
+    - "clear learnings"
+    - "prune learnings"
+    - "clear stale learnings"
+    - "clear learning noise"
   category: meta-tooling
   pairs_with:
     - learn
@@ -41,6 +46,7 @@ Parse the user's argument to determine the subcommand. Default to `status` if no
 | search TERM | **search** |
 | graduate | **graduate** |
 | what-didnt-work | **what-didnt-work** |
+| clear | **clear** |
 
 ### Subcommand: status
 
@@ -195,6 +201,69 @@ Entries marked. They will no longer be injected via the hook
 since they are now part of the agent's permanent knowledge.
 ```
 
+### Subcommand: clear
+
+Remove noise from learning.db: cross-domain rows (via filtered `prune`) or
+old low-confidence rows (via `stale-prune`). Wraps the existing
+`learning-db.py prune` / `stale-prune` CLI — no new deletion code path.
+
+**Key constraints:**
+- Dry-run by default, always. Never pass `--apply`/`--confirm` on the first invocation of a session, regardless of how the user phrased the request ("clear the voice noise", "prune this", "clean up learnings").
+- Show the dry-run counts and a sample of matched rows, then stop and ask the user to explicitly confirm ("apply" / "yes, clear it" / "confirm") before re-invoking with `--apply` or `--confirm`.
+- Never infer confirmation from the original request alone — "clear the voice category" is a request to see what *would* be cleared, not authorization to delete.
+- This command mutates `learning.db`. Do not use it to satisfy a code-level bug fix task that explicitly excludes data mutation — check the task's constraints before running `--apply`/`--confirm`.
+
+**Step 1**: Determine the clear mode from the user's argument.
+
+| User intent | Mode | Underlying command |
+|---|---|---|
+| "clear category X" / "clear topic X" / has `--category`, `--topic`, `--max-confidence`, or `--older-than` | **filtered** | `learning-db.py prune` |
+| "clear stale" / "clear old" / no filter given | **stale** | `learning-db.py stale-prune` |
+
+**Step 2**: Run the dry-run (always, unconditionally, first).
+
+```bash
+# Filtered mode
+python3 ~/.claude/scripts/learning-db.py prune --category CATEGORY [--topic TOPIC] [--max-confidence N] [--older-than DAYS] --dry-run
+
+# Stale mode
+python3 ~/.claude/scripts/learning-db.py stale-prune --dry-run [--min-age-days DAYS]
+```
+
+**Step 3**: Present the dry-run result and stop.
+
+```
+RETRO CLEAR — DRY RUN
+======================
+
+Mode: [filtered | stale]
+Filter: [category=X, topic=Y, ...] or [min-age-days=N]
+
+Matched: [N] entries
+  - [topic/key] (conf: [N], age: [N]d)
+  ...
+
+This is a preview — nothing was deleted. Reply "apply" (or "confirm") to
+actually remove these entries, or refine the filter and re-run.
+```
+
+**Step 4**: Only after the user explicitly confirms in this turn, re-run with `--apply` (filtered) or `--confirm` (stale):
+
+```bash
+python3 ~/.claude/scripts/learning-db.py prune --category CATEGORY ... --apply
+# or
+python3 ~/.claude/scripts/learning-db.py stale-prune --confirm [--min-age-days DAYS]
+```
+
+**Step 5**: Report the outcome.
+
+```
+CLEARED: [N] entries removed ([mode] mode, filter: [...])
+Total learnings: [before] -> [after]
+```
+
+Graduated entries and `routing`/`effectiveness` rows are always protected from `prune` (see `scripts/tests/test_learning_db_prune.py`). `stale-prune` archives to `learning_archive` rather than hard-deleting, and likewise skips graduated rows.
+
 ### Subcommand: what-didnt-work
 
 Print the negative-results registry, the list of experiments that lost. Read it before re-running an experiment so a known-dead path is not retried.
@@ -257,6 +326,10 @@ Actions: Run `learning-db.py search "routing"`, display ranked results.
 User says: "/retro graduate"
 Actions: Query design/gotcha entries, evaluate each against graduation criteria, propose edits to target agents/skills, apply approved changes, mark graduated.
 
+### Example 5: Clear cross-domain noise
+User says: "/retro clear category voice"
+Actions: Run `learning-db.py prune --category voice --dry-run`, present the matched count and sample rows, stop and wait for explicit confirmation. Only on "apply"/"confirm" from the user, re-run with `--apply` and report before/after totals.
+
 ---
 
 ## Error Handling
@@ -278,7 +351,8 @@ Solution: Report the stats and suggest recording more learnings via normal work.
 
 ## References
 
-- `~/.claude/scripts/learning-db.py` — Python CLI for all database operations
+- `~/.claude/scripts/learning-db.py` — Python CLI for all database operations, including `prune` and `stale-prune` (wrapped by the `clear` subcommand)
 - `hooks/session-context.py` — Hook that injects the pre-built dream payload and high-confidence patterns at session start (ADR-147, supersedes retro-knowledge-injector.py)
+- `hooks/pretool-learning-injector.py` — PreToolUse hook that queries `learning.db` for tool-error hints; scoped to `error`/`gotcha`/`debug` categories (ADR: pretool-injector-scoping)
 - `scripts/learning.db` — SQLite database with FTS5 search index
 - `docs/what-didnt-work.md`: Negative-results registry. Printed by the `what-didnt-work` subcommand; the doc is the canonical store.

--- a/tests/test_learning_loop_fixes.py
+++ b/tests/test_learning_loop_fixes.py
@@ -47,7 +47,14 @@ def tmp_learning_dir(tmp_path):
 
 @pytest.fixture()
 def seeded_db(tmp_learning_dir):
-    """Learning DB with a seeded high-confidence error pattern."""
+    """Learning DB with a seeded high-confidence error pattern.
+
+    source="manual-seed" (not "test*") -- search_learnings() defaults to
+    excluding source LIKE 'test%' rows (ADR: pretool-injector-scoping,
+    parity with query_learnings()'s ADR-191 exclude_test_sources), and this
+    row is meant to exercise the real end-to-end injection path, not that
+    filter.
+    """
     import learning_db_v2
 
     learning_db_v2.init_db()
@@ -58,7 +65,7 @@ def seeded_db(tmp_learning_dir):
         category="error",
         confidence=0.9,
         tags=["python", "import_error"],
-        source="test-seed",
+        source="manual-seed",
         error_type="import_error",
         error_signature="test-sig-001",
     )


### PR DESCRIPTION
## Summary
`pretool-learning-injector.py` queried `learning.db` with no category or project scoping, so bare Bash fallback tags (e.g. `grep`) surfaced unrelated-project content (`voice`/`review`/`design`/`effectiveness` categories, other projects) as tool-error hints. Fixes the root cause in `search_learnings()` rather than purging data. ADR: `adr/pretool-injector-scoping.md` (local-only; 3-agent consultation verdict PROCEED).

## Changes
- `hooks/lib/learning_db_v2.py` — add `categories`, `project_path`, `exclude_test_sources` keyword-only filters to `search_learnings()`, mirroring the existing `query_learnings()` filter shape (ADR-191 parity)
- `hooks/pretool-learning-injector.py` — add `INJECTABLE_CATEGORIES` allowlist (`error`/`gotcha`/`debug`), add `GENERIC_COMMAND_STOPLIST` for bare-command fallback tags (30 generic executables; `rm`/`mv`/`cp` deliberately excluded — those are exactly the commands where a pretool gotcha warning has safety value), wire `cwd`/`CLAUDE_PROJECT_DIR` through as `project_path`
- `hooks/tests/test_fts5_search.py` — add category/project_path/exclude_test_sources filter tests; fix pre-existing fixtures' `source` from `"test"` to `"manual"` so the new `exclude_test_sources=True` default doesn't silently drop them
- `hooks/tests/test_pretool_learning_injector.py` (new) — stoplist coverage, category exclusion, project scoping, positive-path "injector still fires" tests, `INJECTABLE_CATEGORIES ⊆ VALID_CATEGORIES` sync guard
- `scripts/tests/test_learning_db_stale_prune.py` (new) — closes prior test gap on `stale`/`stale-prune` CLI subcommands (dry-run gate, `--confirm` archiving, graduated/high-confidence row protection)
- `tests/test_learning_loop_fixes.py` — same `source` fixture fix as above, one seeded-row fixture
- `skills/meta/retro/SKILL.md` — add `retro clear` subcommand wrapping `learning-db.py prune`/`stale-prune`; dry-run by default, requires explicit `--apply`/`--confirm` confirmation, documented in `routing.triggers`

## Notes
- **Operator sign-off required** — `hooks/` is an always-HIGH-risk path per `pr-risk-policy.md`; risk classifier returned `risk: high`, `review_lane: full-roster-plus-sign-off` (862 lines, 7 files). Five-agent review roster (`reviewer-system`, `reviewer-domain`, `reviewer-code`, `reviewer-perspectives`, `python-general-engineer`) ran against this diff: all five verdicts APPROVE, 0 CRITICAL/HIGH findings, 1 MEDIUM (stale comment, fixed in this branch), 3 LOW (test-nit/doc-clarity, non-blocking).
- Allowlist chosen over exclude-list for categories (closed-by-construction against future unknown categories, e.g. `voice` is not even a defined category — it exists in the live DB from another project's custom recording). Denylist chosen for the command stoplist since specific/unusual command names are still useful fallback tags.
- Full repo test suite: 6785 passed, 2 skipped, 152 xfailed. `ruff check` and `ruff format --check` both clean.
- Does not touch `/home/feedgen/private-skills` or delete/mutate any `learning.db` rows — code-level fix only, per task constraints.
