### PR TITLE
perf(do): retire Step 1.5 in-context route-weights read

### DIFF
--- a/docs/route-loop-validation.md
+++ b/docs/route-loop-validation.md
@@ -10,6 +10,22 @@ read_when:
 Branch: `feat/route-sensor`. Date: 2026-06-10. Audience: a skeptical reader
 who wants proof, not prose.
 
+## Update 2026-07-24: in-context weights read retired
+
+The Step 1.5 read (`learning-db.py route-weights --json`) is removed from
+`/do`. Cost: 42,659 bytes (~10,700 tokens) injected into the coordinator on
+every routing decision. Yield across 1,037 routed dispatches: would-action
+`keep` 81/81; `route-signal-check.py` NO-SIGNAL — 0 would-demote,
+0 would-tiebreak. The actuator was already dropped (PR #755), so the read
+bought telemetry the policy never used to change a route.
+
+Still live: the route event log, three-way outcome finalization, the
+orchestrator-reported `route-failure` channel, and the `[do-route]` marker
+format — the marker now always carries `health=-`. The would-action leg of
+the re-propose condition below cannot fire (no would-action is computed);
+re-proposal now keys on the first routing-relevant failure event alone.
+Re-proposing the actuator re-introduces the weights read with it.
+
 Working notes: the `routing-loop-value-eval` ADR (local-only; the `adr/` directory is gitignored).
 
 ---

--- a/scripts/tests/test_sdir_portability.py
+++ b/scripts/tests/test_sdir_portability.py
@@ -44,9 +44,11 @@ def script_name(request):
 
 
 def test_sdir_scripts_are_not_empty():
-    """Sanity: SKILL.md must reference at least the mandatory scripts."""
-    assert len(SDIR_SCRIPTS) >= 3, (
-        f"Expected at least 3 $SDIR scripts in SKILL.md, found {len(SDIR_SCRIPTS)}: {SDIR_SCRIPTS}"
+    """Sanity: SKILL.md must reference the mandatory scripts (pre-route.py,
+    build-dispatch.py). Floor of 2 catches the extraction regex silently
+    matching nothing."""
+    assert len(SDIR_SCRIPTS) >= 2, (
+        f"Expected at least 2 $SDIR scripts in SKILL.md, found {len(SDIR_SCRIPTS)}: {SDIR_SCRIPTS}"
     )
 
 

--- a/scripts/validate-do-references.py
+++ b/scripts/validate-do-references.py
@@ -65,7 +65,7 @@ SKILL_FILE = REPO_ROOT / "skills" / "meta" / "do" / "SKILL.md"
 
 # (region name, start anchor, end anchor). Matched as line prefixes after strip.
 REGIONS = [
-    ("step-0b-verb-map-and-fallback", "**Step 0b: Apply the routing decision**", "**Step 1.5:"),
+    ("step-0b-verb-map-and-fallback", "**Step 0b: Apply the routing decision**", "**Step 1:"),
     ("step-2-overrides", "**Step 2: Apply skill override**", "**Step 3:"),
     ("step-4-fallback", "**Step 4: Auto-Pipeline Fallback**", "**Lazy-completion"),
     ("error-handling", "## Error Handling", "## References"),

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -74,7 +74,7 @@ rm -f "$REQUEST_FILE"
 
 →`PRE_ROUTE_RESULT` (once).
 
-**Fast path:** PRE_ROUTE_RESULT high-conf force_route + pr-workflow/security → skip 0/1.5/1, dispatch direct. Keep banner+overrides+P3+P4. `[do-route]` `health=-`. Agent: pre-route→domain→general-purpose.
+**Fast path:** PRE_ROUTE_RESULT high-conf force_route + pr-workflow/security → skip 0/1, dispatch direct. Keep banner+overrides+P3+P4. `[do-route]` `health=-`. Agent: pre-route→domain→general-purpose.
 
 **Step 0: Self-route**
 
@@ -128,14 +128,6 @@ route.agent ||= "general-purpose"
 ```
 
 No pair→general-purpose+objective-loop. `[cross-repo]`→`.claude/agents/`. Code→domain agents.
-
-**Step 1.5: Health (shadow-only)**
-
-```bash
-python3 "$SDIR/learning-db.py" route-weights --json
-```
-
-`health_adjust()` → keep|demote|tiebreak. **Recorded, never alters route.** Activation gated on first negative signal (`docs/route-loop-validation.md`). Demote: conf<0.30+fail>=3+n>=5. Tiebreak: conf<0.35+healthier alt. Force-route/security→keep. n<5→keep. `build-dispatch.py` emits marker on DECISION.
 
 **Step 1: Safety-net** (reads PRE_ROUTE_RESULT)
 
@@ -227,7 +219,7 @@ python3 "$SDIR/build-dispatch.py" --json '{
   "model_effort": "<low|medium|high|xhigh|max>",
   "provider": "<anthropic|openai|other>",
   "manual_model_override": false,
-  "health": {"confidence": 0.72, "n": 6, "failure": 0, "action": "keep", "alts": ["k1","k2"]},
+  "health": "-",
   "stack": ["s1","s2"],
   "task_spec": {"intent": "...", "constraints": "...", "acceptance": "...",
                 "files": "...", "operator_context": "..."},
@@ -236,7 +228,7 @@ python3 "$SDIR/build-dispatch.py" --json '{
 }'
 ```
 
-`agent`/`skill`/`complexity`: Phase 2 (null→`-`). `model`: **required Medium+** (`-` trivial/simple). Use `model_policy` for automatic selection — resolves via the harness-native provider lane. `model_effort` identifies the benchmark point; advisory for Claude lanes (Agent tool has no per-call effort). `provider`: harness detection (anthropic|openai|other, default anthropic). A manual model change must set both `manual_model_override=true` and `model_effort`; never inherit the policy effort silently. `health`: 1.5 (`-` if none). `stack`: Phase 3. `task_spec`: mandatory Medium+; creation+"match ADR". `thinking_override`: slow=security/arch/5+files; fast=lookups.
+`agent`/`skill`/`complexity`: Phase 2 (null→`-`). `model`: **required Medium+** (`-` trivial/simple). Use `model_policy` for automatic selection — resolves via the harness-native provider lane. `model_effort` identifies the benchmark point; advisory for Claude lanes (Agent tool has no per-call effort). `provider`: harness detection (anthropic|openai|other, default anthropic). A manual model change must set both `manual_model_override=true` and `model_effort`; never inherit the policy effort silently. `health`: `-` (in-context weights read retired — `docs/route-loop-validation.md`). `stack`: Phase 3. `task_spec`: mandatory Medium+; creation+"match ADR". `thinking_override`: slow=security/arch/5+files; fast=lookups.
 
 `[do-route]` = SOLE signal for `routing-decision-recorder`. Sub-agents excluded.
 


### PR DESCRIPTION
## One idea

Remove the /do Phase 2 Step 1.5 shell read (`learning-db.py route-weights --json`) and its health-adjust prose. The skill itself stated the output was **recorded, never alters route**.

## Measured saving

- **42,659 bytes (~10,700 tokens) removed from the coordinator context on every routing decision.**
- SKILL.md: net -8 lines of hot instruction text.

## Evidence

- 1,037 routed dispatches: computed would-action was `keep` 81/81.
- `scripts/route-signal-check.py`: NO-SIGNAL — 0 would-demote, 0 would-tiebreak.
- The actuator was already deleted in PR #755; the read fed a policy with no effector.

## Preserved

- `[do-route]` marker format unchanged — `build-dispatch.py` still emits `health=-` (contract keeps the `health` field; the skill passes `"-"`). All 72 build-dispatch tests green.
- `route-failure` CLI channel, route event log, three-way outcome finalization.
- `docs/route-loop-validation.md` records the retirement; the re-propose condition now keys on the first routing-relevant failure event alone.

## Follow-through

- `scripts/validate-do-references.py` region anchor updated (step-0b now ends at Step 1); validator green (55 names resolve).
- `test_sdir_portability.py` sanity floor 3→2 (learning-db.py no longer $SDIR-referenced in the skill).

Local gates: ruff check + format clean; scripts/tests 4815 passed (2 unrelated transients from concurrent hook-track edits re-verified green in isolation).