### PR TITLE
ci: pin ruff to 0.15.12 in lint job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install ruff pyyaml
+      # ruff pinned: 0.16.0 started reformatting markdown code blocks, failing
+      # every PR on pre-existing .md files. Bump deliberately with a repo-wide
+      # reformat, not via an unpinned install.
+      - run: pip install ruff==0.15.12 pyyaml
       # INDEX.json is generated (untracked); build it before validators read it.
       - run: python scripts/generate-skill-index.py && python scripts/generate-agent-index.py
       - run: ruff check . --config pyproject.toml


### PR DESCRIPTION
## Summary
Unpinned `pip install ruff` in the lint job picked up ruff 0.16.0 (released after main's last green run on 2026-07-20), which now reformats markdown code blocks — every new PR fails `ruff format --check` on pre-existing .md files. Pin to 0.15.12, the version main was last green with.

## Changes
- `.github/workflows/test.yml` — pin `ruff==0.15.12` in the lint job, with a comment on why and how to bump.

## Notes
- Unblocks all in-flight remediation PRs (first observed on #877).
- Bumping ruff later should pair the pin change with a repo-wide reformat in the same PR.