### PR TITLE
fix(hooks): anchor guard whitelist to full commands; protect gate control plane

### DIFF
--- a/hooks/pretool-unified-gate.py
+++ b/hooks/pretool-unified-gate.py
@@ -246,6 +246,10 @@ _SENSITIVE_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
     # Token files
     (re.compile(r"/token\.json$"), "token", "token.json"),
     (re.compile(r"/\.tokens$"), "token", ".tokens file"),
+    # Guard control plane (audit S1): .guard-whitelist/.guard-patterns configure
+    # THIS gate's dangerous/sensitive checks — writing one IS the disarm act, and
+    # no agent flow legitimately writes them (owner-authored config only).
+    (re.compile(r"/\.guard-(?:whitelist|patterns)$"), "guard-config", ".guard-* guard config"),
 ]
 
 _SENSITIVE_EXCEPTIONS: list[re.Pattern[str]] = [
@@ -710,11 +714,15 @@ def _load_guard_whitelist() -> list[str]:
 
 
 def _is_whitelisted(command: str, whitelist: list[str]) -> bool:
-    """Check if the command matches any whitelist entry."""
-    for entry in whitelist:
-        if entry in command:
-            return True
-    return False
+    """True if the FULL command exactly matches a whitelist entry.
+
+    Full-command anchoring, not substring containment: substring matching let
+    any command smuggle a whitelisted string past the guard (a `node_modules`
+    entry allowed `echo node_modules && rm -rf /` — audit S1). One entry
+    whitelists exactly one command, nothing more.
+    """
+    cmd = command.strip()
+    return any(entry == cmd for entry in whitelist)
 
 
 def _load_guard_patterns() -> list[tuple[re.Pattern[str], str, str]]:
@@ -934,7 +942,9 @@ def check_dangerous_command(command: str) -> None:
     for pattern, category, description in _DANGEROUS_PATTERNS:
         if pattern.search(command):
             if _is_whitelisted(command, whitelist):
-                return
+                # Skip THIS rule only — a whitelist hit must never end the whole
+                # scan (`return` here let one hit disarm every later rule, audit S1).
+                continue
             _block(
                 f"[dangerous-command] BLOCKED: {description} ({category})\n"
                 f"[dangerous-command] Command: {command}\n"
@@ -1124,6 +1134,75 @@ def check_sensitive_file(file_path: str, *, deny: bool = True) -> None:
                 f"[sensitive-file-guard] To allow: set SENSITIVE_FILE_GUARD_BYPASS=1 or add exception to .guard-patterns",
                 reason=f"Write to sensitive file blocked ({category}: {description}). Path: {file_path}. Set SENSITIVE_FILE_GUARD_BYPASS=1 or add an exception to .guard-patterns to allow.",
             )
+
+
+# ═══════════════════════════════════════════════════════════════
+# 5b. GUARD SELF-PROTECTION (audit S1)
+# ═══════════════════════════════════════════════════════════════
+#
+# ~/.claude/hooks symlinks into this repo, so a Write/Edit to hooks/<hook>.py —
+# via EITHER path — changes LIVE enforcement code mid-session, and an edit to
+# settings.json can plant *_BYPASS=1 in the env block and disarm every guard.
+# Deny Write/Edit to those files unless the edit happens on a feature branch:
+# the repo's documented development flow (branch → PR → review → merge). Direct
+# edits on main/master, or outside any git repo (the deployed
+# ~/.claude/settings.json), are the disarm shape and are denied.
+#
+# Residual (accepted): a feature-branch edit is still live immediately (same
+# file). This check is a speed bump against casual self-disarm, not a sandbox —
+# the gate fails open by design, so a determined actor is stopped by review and
+# telemetry, not by this check. Every allowed guard edit emits an audit line.
+# The bypass env is honored but deliberately NOT advertised in the deny message
+# (same posture as the sysadmin/public-server guards).
+_GUARD_INTEGRITY_BYPASS_ENV = "GUARD_INTEGRITY_BYPASS"
+_SETTINGS_BASENAMES = frozenset({"settings.json", "settings.local.json"})
+
+
+def _live_hooks_dir() -> Path | None:
+    """Resolved deployed-hooks directory (~/.claude/hooks), or None.
+
+    resolve() follows the deployment symlink into the repo, so a write addressed
+    via either the deployed path or the repo working copy maps to the same
+    protected directory.
+    """
+    try:
+        live = Path.home() / ".claude" / "hooks"
+        return live.resolve() if live.is_dir() else None
+    except OSError:
+        return None
+
+
+def check_guard_integrity(file_path: str) -> None:
+    """Deny Write/Edit to live enforcement files except on a feature branch."""
+    if os.environ.get(_GUARD_INTEGRITY_BYPASS_ENV) == "1":
+        return
+    try:
+        resolved = Path(file_path).resolve()
+    except OSError:
+        resolved = Path(file_path)
+    live = _live_hooks_dir()
+    in_live_hooks = live is not None and (resolved == live or live in resolved.parents)
+    is_settings = resolved.name in _SETTINGS_BASENAMES and resolved.parent.name == ".claude"
+    if not in_live_hooks and not is_settings:
+        return
+    if _is_worktree_on_feature_branch(str(resolved.parent)):
+        # Audit line: every guard-file edit is visible in verbose mode/telemetry.
+        print(
+            f"[guard-integrity] AUDIT: feature-branch edit of enforcement file allowed: {file_path}",
+            file=sys.stderr,
+        )
+        return
+    target_kind = "live hook code" if in_live_hooks else "Claude settings"
+    _block(
+        f"[guard-integrity] BLOCKED: direct edit of {target_kind}: {file_path}\n"
+        f"[guard-integrity] Deployed hooks and settings.json are live enforcement controls.\n"
+        f"[guard-integrity] Edit them on a feature branch (git checkout -b) and land via a reviewed PR.",
+        reason=(
+            f"Editing {target_kind} ({file_path}) outside a feature branch is blocked — "
+            f"deployed hooks and settings.json are live enforcement controls. "
+            f"Create a feature branch (git checkout -b fix/<slug>) and land the change via a reviewed PR."
+        ),
+    )
 
 
 _PUBLIC_SERVER_DENY_MSG = (
@@ -2319,12 +2398,14 @@ def main() -> None:
             return
         cwd = event.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR", "")
         check_creation_gate(file_path, cwd=cwd)
+        check_guard_integrity(file_path)
         check_sensitive_file(file_path)
 
     elif tool == "Edit":
         file_path = tool_input.get("file_path", "")
         if not file_path:
             return
+        check_guard_integrity(file_path)
         check_sensitive_file(file_path)
 
     elif tool == "Read":

--- a/hooks/tests/test_pretool_unified_gate_security.py
+++ b/hooks/tests/test_pretool_unified_gate_security.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+Security-audit regression corpus for the pretool-unified-gate hook.
+
+Table-driven allow/deny cases for each audit finding (tracks S1..S5). Every
+closed bypass gets a DENY row; every legitimate near-miss gets an ALLOW row so
+the fix cannot over-block. Grows one section per remediation PR.
+
+Run with: python3 -m pytest hooks/tests/test_pretool_unified_gate_security.py -v
+"""
+
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+HOOK_PATH = Path(__file__).parent.parent / "pretool-unified-gate.py"
+
+spec = importlib.util.spec_from_file_location("pretool_unified_gate_security", HOOK_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+# All per-check bypass env vars, stripped for a clean baseline in every run.
+_BYPASS_VARS = (
+    "CLAUDE_GATE_BYPASS",
+    "DANGEROUS_GUARD_BYPASS",
+    "CREATION_GATE_BYPASS",
+    "SENSITIVE_FILE_GUARD_BYPASS",
+    "PUBLIC_SERVER_GUARD_BYPASS",
+    "SYSADMIN_GUARD_BYPASS",
+    "GUARD_INTEGRITY_BYPASS",
+)
+
+ALLOW = 0
+DENY = 2
+
+
+def _event(tool: str, **tool_input) -> str:
+    return json.dumps({"tool_name": tool, "tool_input": tool_input})
+
+
+def _run_main(stdin_payload: str, env: dict | None = None) -> int:
+    """Invoke mod.main() in-process; return DENY (2) or ALLOW (0).
+
+    The hook always exits 0 — the deny decision is the JSON permissionDecision
+    on stdout, so that is what is detected here.
+    """
+    base_env = dict(os.environ)
+    for var in _BYPASS_VARS:
+        base_env.pop(var, None)
+    base_env["CLAUDE_OPERATOR_PROFILE"] = "work"
+    if env:
+        base_env.update(env)
+
+    stdout_capture = io.StringIO()
+    with (
+        patch.dict(os.environ, base_env, clear=True),
+        patch.object(mod, "read_stdin", return_value=stdin_payload),
+        patch("sys.stdout", stdout_capture),
+        patch("sys.stderr", io.StringIO()),
+    ):
+        try:
+            mod.main()
+        except SystemExit:
+            pass
+
+    output = stdout_capture.getvalue().strip()
+    if output:
+        try:
+            decision = json.loads(output).get("hookSpecificOutput", {}).get("permissionDecision")
+            if decision == "deny":
+                return DENY
+        except (json.JSONDecodeError, AttributeError):
+            pass
+    return ALLOW
+
+
+# ---------------------------------------------------------------------------
+# S1a — dangerous-command whitelist containment
+#
+# _is_whitelisted was bare substring containment and a hit returned from the
+# whole pattern loop, so a `.guard-whitelist` holding any benign substring
+# (`node_modules`) disarmed every dangerous-command rule for any command that
+# contained it. Now an entry must equal the FULL command, and a hit skips one
+# rule instead of ending the scan.
+# ---------------------------------------------------------------------------
+
+WHITELIST_CASES = [
+    # (case_id, command, whitelist_entries, expected)
+    ("smuggle-substring-and", "echo node_modules && rm -rf /", ["node_modules"], DENY),
+    ("smuggle-substring-semicolon", "echo node_modules; rm -rf /", ["node_modules"], DENY),
+    ("smuggle-entry-is-prefix", "rm -rf . && rm -rf /", ["rm -rf ."], DENY),
+    ("smuggle-entry-not-full-cmd", "echo cleanup && rm -rf /", ["echo cleanup"], DENY),
+    ("exact-entry-allows", "rm -rf .", ["rm -rf ."], ALLOW),
+    ("exact-entry-outer-whitespace", "  rm -rf .  ", ["rm -rf ."], ALLOW),
+    ("unrelated-entry-still-blocks", "rm -rf /", ["rm -rf ./build"], DENY),
+    ("empty-whitelist-still-blocks", "rm -rf /", [], DENY),
+]
+
+
+class TestDangerousWhitelistAnchoring:
+    @pytest.mark.parametrize(("case_id", "command", "entries", "expected"), WHITELIST_CASES)
+    def test_whitelist_case(self, case_id, command, entries, expected):
+        with patch.object(mod, "_load_guard_whitelist", return_value=entries):
+            assert _run_main(_event("Bash", command=command)) == expected, case_id
+
+    def test_is_whitelisted_rejects_substring(self):
+        assert mod._is_whitelisted("echo node_modules && rm -rf /", ["node_modules"]) is False
+
+    def test_is_whitelisted_accepts_exact(self):
+        assert mod._is_whitelisted("rm -rf ./build", ["rm -rf ./build"]) is True
+
+
+# ---------------------------------------------------------------------------
+# S1b(i) — .guard-whitelist / .guard-patterns are guard control-plane files
+#
+# Writing either file IS the disarm act (S1a matches whitelist entries against
+# commands; .guard-patterns adds sensitive-file exceptions). No agent flow
+# legitimately writes them, so Write/Edit deny anywhere; Read stays warn-only.
+# ---------------------------------------------------------------------------
+
+GUARD_CONFIG_CASES = [
+    ("write-guard-whitelist", "Write", "/some/project/.guard-whitelist", DENY),
+    ("write-guard-patterns", "Write", "/some/project/.guard-patterns", DENY),
+    ("edit-guard-whitelist", "Edit", "/some/project/.guard-whitelist", DENY),
+    ("edit-guard-patterns", "Edit", "/some/project/.guard-patterns", DENY),
+    ("read-guard-whitelist-warn-only", "Read", "/some/project/.guard-whitelist", ALLOW),
+    ("write-similar-name-allowed", "Write", "/some/project/.guard-whitelist.md", ALLOW),
+]
+
+
+class TestGuardConfigFilesProtected:
+    @pytest.mark.parametrize(("case_id", "tool", "file_path", "expected"), GUARD_CONFIG_CASES)
+    def test_guard_config_case(self, case_id, tool, file_path, expected):
+        assert _run_main(_event(tool, file_path=file_path)) == expected, case_id
+
+
+# ---------------------------------------------------------------------------
+# S1b(ii) — guard self-protection for live enforcement files
+#
+# ~/.claude/hooks symlinks into the repo, so Write/Edit to hooks/<hook>.py via
+# either path changes LIVE enforcement code; settings.json's env block can set
+# *_BYPASS=1. check_guard_integrity denies both unless the containing repo is
+# on a feature branch (the documented branch → PR → review flow). The deployed
+# ~/.claude/settings.json sits outside any repo, so it is always denied.
+# ---------------------------------------------------------------------------
+
+
+class TestGuardIntegrity:
+    def _run(
+        self,
+        file_path: str,
+        *,
+        tool: str = "Edit",
+        live_dir: Path | None = None,
+        feature_branch: bool = False,
+        env: dict | None = None,
+    ) -> int:
+        with (
+            patch.object(mod, "_live_hooks_dir", return_value=live_dir),
+            patch.object(mod, "_is_worktree_on_feature_branch", return_value=feature_branch),
+        ):
+            return _run_main(_event(tool, file_path=file_path), env=env)
+
+    def test_live_hook_edit_on_main_denied(self, tmp_path):
+        live = tmp_path / "repo" / "hooks"
+        live.mkdir(parents=True)
+        assert self._run(str(live / "pretool-unified-gate.py"), live_dir=live) == DENY
+
+    def test_live_hook_write_on_main_denied(self, tmp_path):
+        live = tmp_path / "repo" / "hooks"
+        live.mkdir(parents=True)
+        assert self._run(str(live / "new-hook.py"), tool="Write", live_dir=live) == DENY
+
+    def test_live_hook_edit_on_feature_branch_allowed(self, tmp_path):
+        live = tmp_path / "repo" / "hooks"
+        live.mkdir(parents=True)
+        assert self._run(str(live / "pretool-unified-gate.py"), live_dir=live, feature_branch=True) == ALLOW
+
+    def test_symlinked_deploy_path_resolves_to_live_dir(self, tmp_path):
+        """The deployed symlink path and the repo path are the SAME protected file."""
+        repo_hooks = tmp_path / "repo" / "hooks"
+        repo_hooks.mkdir(parents=True)
+        (repo_hooks / "gate.py").write_text("x")
+        deployed = tmp_path / "home" / ".claude" / "hooks"
+        deployed.parent.mkdir(parents=True)
+        deployed.symlink_to(repo_hooks)
+        live = deployed.resolve()
+        # Addressed via the deployed symlink path — still detected as live code.
+        assert self._run(str(deployed / "gate.py"), live_dir=live) == DENY
+        # Addressed via the repo working-copy path — same resolved dir, detected.
+        assert self._run(str(repo_hooks / "gate.py"), live_dir=live) == DENY
+
+    def test_deployed_settings_json_denied(self, tmp_path):
+        settings = tmp_path / "home" / ".claude" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        assert self._run(str(settings), tool="Write") == DENY
+
+    def test_settings_local_json_denied(self, tmp_path):
+        settings = tmp_path / "home" / ".claude" / "settings.local.json"
+        settings.parent.mkdir(parents=True)
+        assert self._run(str(settings), tool="Write") == DENY
+
+    def test_repo_settings_json_on_feature_branch_allowed(self, tmp_path):
+        settings = tmp_path / "repo" / ".claude" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        assert self._run(str(settings), feature_branch=True) == ALLOW
+
+    def test_settings_json_outside_claude_dir_allowed(self, tmp_path):
+        settings = tmp_path / "app" / "config" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        assert self._run(str(settings), tool="Write") == ALLOW
+
+    def test_unrelated_file_allowed(self, tmp_path):
+        assert self._run(str(tmp_path / "src" / "app.py"), tool="Write") == ALLOW
+
+    def test_bypass_env_allows(self, tmp_path):
+        live = tmp_path / "repo" / "hooks"
+        live.mkdir(parents=True)
+        assert self._run(str(live / "gate.py"), live_dir=live, env={"GUARD_INTEGRITY_BYPASS": "1"}) == ALLOW
+
+    def test_no_live_dir_skips_hook_protection(self, tmp_path):
+        """CI checkouts without ~/.claude/hooks must not false-positive."""
+        assert self._run(str(tmp_path / "hooks" / "some-hook.py"), tool="Write") == ALLOW
+
+    def test_feature_branch_allow_emits_audit_line(self, tmp_path, capsys):
+        live = tmp_path / "repo" / "hooks"
+        live.mkdir(parents=True)
+        with (
+            patch.object(mod, "_live_hooks_dir", return_value=live),
+            patch.object(mod, "_is_worktree_on_feature_branch", return_value=True),
+        ):
+            mod.check_guard_integrity(str(live / "gate.py"))
+        assert "[guard-integrity] AUDIT" in capsys.readouterr().err
+
+    def test_deny_message_does_not_advertise_bypass(self, tmp_path):
+        """The deny text must not teach the disarm switch (audit S5 posture)."""
+        live = tmp_path / "repo" / "hooks"
+        live.mkdir(parents=True)
+        stdout_capture = io.StringIO()
+        with (
+            patch.object(mod, "_live_hooks_dir", return_value=live),
+            patch.object(mod, "_is_worktree_on_feature_branch", return_value=False),
+            patch("sys.stdout", stdout_capture),
+            patch("sys.stderr", io.StringIO()),
+            pytest.raises(SystemExit),
+        ):
+            mod.check_guard_integrity(str(live / "gate.py"))
+        assert "GUARD_INTEGRITY_BYPASS" not in stdout_capture.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# S1 — still-blocking regression rows (the fix must not loosen anything)
+# ---------------------------------------------------------------------------
+
+STILL_BLOCKING_CASES_S1 = [
+    ("rm-rf-root", "rm -rf /"),
+    ("rm-fr-root", "rm -fr /"),
+    ("rm-rf-root-star", "rm -rf /*"),
+    ("rm-rf-home", "rm -rf ~"),
+    ("rm-rf-dot", "rm -rf ."),
+    ("drop-database", "psql -c 'DROP DATABASE prod'"),
+    ("chmod-777", "chmod 777 /etc/passwd"),
+    ("mkfs", "mkfs.ext4 /dev/sdb1"),
+]
+
+
+class TestStillBlockingS1:
+    @pytest.mark.parametrize(("case_id", "command"), STILL_BLOCKING_CASES_S1)
+    def test_still_blocked_without_whitelist(self, case_id, command):
+        with patch.object(mod, "_load_guard_whitelist", return_value=[]):
+            assert _run_main(_event("Bash", command=command)) == DENY, case_id


### PR DESCRIPTION
## Summary
Security-audit track S1: the dangerous-command whitelist and the gate's own control plane were both disarmable. A `.guard-whitelist` entry matched as a bare substring and a hit ended the whole pattern scan, so `echo node_modules && rm -rf /` passed with a `node_modules` entry; nothing protected `.guard-*`, `settings.json`, or the deployed hook code itself (`~/.claude/hooks` symlinks into this repo).

## Changes
- `hooks/pretool-unified-gate.py` — `_is_whitelisted` now requires a whitelist entry to equal the full command; a hit skips one rule (`continue`) instead of ending the scan.
- `hooks/pretool-unified-gate.py` — add `.guard-whitelist`/`.guard-patterns` to `_SENSITIVE_PATTERNS` (writing them is the disarm act; Write/Edit deny, Read warns).
- `hooks/pretool-unified-gate.py` — new `check_guard_integrity` (Write/Edit): denies edits to files resolving into the deployed `~/.claude/hooks` dir (symlink-aware) and to `.claude/settings*.json`, unless the containing repo is on a feature branch; allowed edits emit an audit line.
- `hooks/tests/test_pretool_unified_gate_security.py` — new table-driven audit regression corpus: 37 allow/deny cases for S1 (whitelist smuggling, guard-config files, guard integrity, still-blocking rows).

## Notes
- Branch-gating (not unconditional deny) is deliberate: `~/.claude/hooks` symlinks into the repo, so an unconditional deny would brick all legitimate hook development, including the remaining audit PRs. Residual: a feature-branch edit is still live immediately; accepted as a speed bump, documented in code, every allow is audit-logged.
- The new `GUARD_INTEGRITY_BYPASS` deny message deliberately does not name the bypass env (matches the sysadmin/public-server guard posture). The older sensitive-file message still advertises its bypass; that is audit track S5.
- Verified empirically: smuggled-whitelist command now denies, exact-entry whitelist still allows, deployed-symlink and repo paths both deny on main and allow on a feature branch, deployed `settings.json` denies.
