### PR TITLE
fix(ci): pin ruff to 0.15.12 in lint job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install ruff pyyaml
+      # ruff pinned: 0.16.0 began reformatting code blocks inside markdown,
+      # failing `ruff format --check` on pre-existing .md files repo-wide.
+      # Unpin only after a dedicated PR reformats under the new version.
+      - run: pip install "ruff==0.15.12" pyyaml
       # INDEX.json is generated (untracked); build it before validators read it.
       - run: python scripts/generate-skill-index.py && python scripts/generate-agent-index.py
       - run: ruff check . --config pyproject.toml


### PR DESCRIPTION
## One idea

Pin the lint job's ruff install to 0.15.12, matching local dev and main's last green run.

## Why

- Unpinned `pip install ruff` resolved to **ruff 0.16.0** (released after main's last green lint on 2026-07-20).
- 0.16.0 newly formats code blocks inside markdown, so `ruff format --check` fails on dozens of pre-existing `agents/*/references/*.md` files.
- Main itself is red under 0.16.0; every open PR's lint job is blocked (observed on #878, which touches none of the flagged files).

## Scope

One workflow line + comment. Unpinning happens in a dedicated PR that reformats the repo under the new version.

LOC: +4/-1 in .github/workflows/test.yml.