### PR TITLE
perf(pre-route): reduce to the deterministic force-route guard

### DIFF
--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -76,7 +76,7 @@ If data needs filtering, aggregation, confidence, retention, or replay, store it
 
 ### Routing confidence and force_route
 
-Skills route at confidence tiers driven by trigger-match count plus a `force_route` bonus; the tier mapping is implementation detail — see `force_bonus` in [`scripts/pre-route.py`](../scripts/pre-route.py) and the per-skill `force_route` flag in skills/INDEX.json (schema: `scripts/generate-skill-index.py`).
+Deterministic pre-route matches `force_route` triggers only: a match that survives the semantic guards routes at high confidence, everything else falls through to the semantic route — see `determine_confidence` in [`scripts/pre-route.py`](../scripts/pre-route.py) and the per-skill `force_route` flag in skills/INDEX.json (schema: `scripts/generate-skill-index.py`).
 
 `force_route: true` belongs on umbrella, setup, and methodology skills where a single high-specificity trigger phrase carries unambiguous intent (`pr-workflow`, `install`, `quick`). Domain task skills earn confidence through multiple trigger matches — preventing misroute when phrases like "fix" or "review" overlap.
 

--- a/scripts/pre-route.py
+++ b/scripts/pre-route.py
@@ -1,24 +1,28 @@
 #!/usr/bin/env python3
-"""Deterministic safety-net + offline drift/benchmark tool for /do routing.
+"""Deterministic force-route guard for /do routing.
 
-Pattern-matches user requests against trigger keywords from INDEX.json files.
-In the /do flow this runs AFTER the semantic routing decision (the
-orchestrator's in-session self-route), not before it: semantic intent routing
-is primary, and this module is the deterministic safety-net. It enforces
-safety-critical force-routes (a high-confidence force_route for pr-workflow or
-a security skill overrides a disagreeing semantic pick so git/security work
-always hits quality gates) and its phrase/unigram guards continue to suppress
-false matches. It no longer short-circuits or skips the semantic route on the
-long tail.
+Matches user requests against the triggers of force_route entries ONLY
+(skills/INDEX.json `force_route: true`, plus SUPPLEMENTAL_TRIGGERS). A match
+that survives the semantic guards reports `match_type: force_route`,
+`confidence: high`; everything else falls through — semantic intent routing
+(the orchestrator's in-session self-route) decides the long tail. The guard
+exists so genuine git/security/codex requests always hit their quality gates:
+a high-confidence force match for pr-workflow or a security skill enables the
+/do fast path and overrides a disagreeing semantic pick.
 
-Offline, the same matching logic powers check-routing-drift.py and
-routing-benchmark.py. The CLI, output shape, confidence levels, and guards are
-a stable contract those tools depend on.
+Non-force keyword routing was retired 2026-07: replaying 49 real /do requests
+it fell through 43/49, and both non-force keyword matches it did produce were
+wrong. The guard/companion tables stay — they are the precision layer of the
+force-route guarantee, pinned by the ADR corpus tests
+(test_pre_route_pr_workflow/planning/public_web_deploy).
+
+Output contract (stable): matched, agent, skill, confidence, match_type,
+reasoning. Consumers: skills/meta/do/SKILL.md Phase 2, routing-ab-test.py,
+router-self-audit.py (load_entries).
 
 Usage:
-    python3 scripts/pre-route.py --request "run go tests"
-    python3 scripts/pre-route.py --request-file /tmp/req.txt --json-compact
     python3 scripts/pre-route.py --request "create a PR" --json-compact
+    python3 scripts/pre-route.py --request-file /tmp/req.txt --json-compact
 
 Exit codes:
     0 -- always (output is JSON to stdout)
@@ -543,11 +547,12 @@ def _build_pattern(trigger_lower: str) -> re.Pattern[str]:
 
 
 def build_match_table(entries: list[dict]) -> list[MatchEntry]:
-    """Compile trigger keywords into regex patterns.
+    """Compile force_route entries' trigger keywords into regex patterns.
 
-    Single-word triggers use exact word-boundary match.
-    Multi-word triggers allow up to 2 intervening words between
-    trigger words (e.g. "create PR" matches "create a PR").
+    Non-force entries are skipped: pre-route matches only force-routes; the
+    semantic router owns the long tail. Single-word triggers use exact
+    word-boundary match. Multi-word triggers allow up to 2 intervening words
+    between trigger words (e.g. "create PR" matches "create a PR").
     """
     table: list[MatchEntry] = []
 
@@ -556,6 +561,8 @@ def build_match_table(entries: list[dict]) -> list[MatchEntry]:
         entry_type = entry["type"]
         agent = entry.get("agent")
         force_route = entry.get("force_route", False)
+        if not force_route:
+            continue
 
         for trigger in entry.get("triggers", []):
             if not isinstance(trigger, str):
@@ -657,11 +664,10 @@ def _is_semantically_guarded(
 
 
 def score_matches(table: list[MatchEntry], request: str) -> dict[str, ScoredMatch]:
-    """Score each entry by matching triggers against the request.
+    """Collect force_route entries whose triggers match, ranked for tie-breaks.
 
-    Scoring:
+    Ranking (only used when multiple force entries match):
     - Each matched trigger adds 1.0 to score
-    - Force-route entries get a 2.0 bonus
     - Longer triggers get a specificity bonus (len/100)
     """
     request_lower = request.lower()
@@ -692,34 +698,21 @@ def score_matches(table: list[MatchEntry], request: str) -> dict[str, ScoredMatc
     for match in candidates.values():
         trigger_count = len(match.matched_triggers)
         specificity_bonus = match.total_chars / 100.0
-        force_bonus = 2.0 if match.force_route else 0.0
-        match.score = trigger_count + specificity_bonus + force_bonus
+        match.score = trigger_count + specificity_bonus
 
     return candidates
 
 
 def determine_confidence(match: ScoredMatch) -> str:
-    """Determine confidence level based on match characteristics.
-
-    Thresholds:
-    - force_route + 1+ trigger matches -> "high"
-    - non-force + 3+ trigger matches -> "medium"
-    - anything less -> "low" (fall through)
+    """Force match with 1+ surviving trigger -> "high"; anything else -> "low".
 
     A force_route match that reaches scoring already passed every semantic
     guard (score_matches discards guarded matches), so one surviving trigger
-    is a deterministic signal. The old ladder capped single-trigger force
-    matches at "medium", but the /do fast path and Step 1(a) safety override
-    (skills/meta/do/SKILL.md:131,258) act only on "high" — so genuine
-    one-trigger git/security requests ("commit these files", "did CI pass on
-    my PR?") were never force-protected.
+    is a deterministic signal. The /do fast path and Step 1(a) safety
+    override act only on "high".
     """
-    trigger_count = len(match.matched_triggers)
-
-    if match.force_route and trigger_count >= 1:
+    if match.force_route and len(match.matched_triggers) >= 1:
         return "high"
-    if not match.force_route and trigger_count >= 3:
-        return "medium"
     return "low"
 
 
@@ -774,7 +767,7 @@ def route(request: str, entries: list[dict] | None = None) -> dict:
         agent = top.name
         skill = None
 
-    match_type = "force_route" if top.force_route else "trigger_keyword"
+    match_type = "force_route"  # only force entries reach the match table
     triggers_str = ", ".join(f"'{t}'" for t in top.matched_triggers)
 
     return {

--- a/scripts/tests/test_pre_route.py
+++ b/scripts/tests/test_pre_route.py
@@ -1,4 +1,8 @@
-"""Tests for scripts/pre-route.py deterministic pre-router."""
+"""Tests for scripts/pre-route.py — the deterministic force-route guard.
+
+pre-route matches force_route entries only; non-force keyword routing was
+retired (2026-07). Force-route corpus pins live in test_pre_route_pr_workflow,
+test_pre_route_planning, and test_pre_route_public_web_deploy."""
 
 from __future__ import annotations
 
@@ -88,17 +92,30 @@ class TestSpecifiedRoutes:
         assert result["match_type"] == "force_route"
 
     def test_review_code_ambiguous_falls_through(self, pre_route, real_entries) -> None:
-        """'review this code' is ambiguous (1 non-force trigger) -- correctly falls through."""
+        """'review this code' hits only non-force triggers -- falls through."""
         result = pre_route.route("review this code", entries=real_entries)
-        # Single non-force trigger match -> low confidence -> fallthrough
         assert result["matched"] is False
         assert result["confidence"] == "low"
 
-    def test_structured_code_review_matches(self, pre_route, real_entries) -> None:
-        """'do a structured code review and code audit' has 3+ triggers -> matches."""
-        result = pre_route.route("do a structured code review and code audit", entries=real_entries)
-        assert result["matched"] is True
-        assert "review" in (result["skill"] or "")
+    def test_non_force_triggers_never_match(self, pre_route) -> None:
+        """Non-force entries fall through even on many trigger hits.
+
+        Pins the 2026-07 reduction: pre-route is a force-route guard; the
+        semantic router owns the long tail (live replay: 2/2 non-force
+        keyword matches were misroutes).
+        """
+        entries = [
+            {
+                "name": "keyword-skill",
+                "type": "skill",
+                "triggers": ["alpha", "beta", "gamma", "delta"],
+                "agent": None,
+                "force_route": False,
+            }
+        ]
+        result = pre_route.route("alpha beta gamma delta", entries=entries)
+        assert result["matched"] is False
+        assert result["match_type"] == "fallthrough"
 
     def test_weather_falls_through(self, pre_route, real_entries) -> None:
         """'what's the weather like' should fall through."""
@@ -235,25 +252,14 @@ class TestConfidence:
         )
         assert pre_route.determine_confidence(match) == "high"
 
-    def test_non_force_medium_confidence(self, pre_route) -> None:
-        """Non-force with 3+ triggers -> medium."""
+    def test_non_force_low_confidence(self, pre_route) -> None:
+        """Non-force never reports above low (the medium tier is retired)."""
         match = pre_route.ScoredMatch(
             name="test",
             entry_type="skill",
             agent=None,
             force_route=False,
             matched_triggers=["a", "b", "c"],
-        )
-        assert pre_route.determine_confidence(match) == "medium"
-
-    def test_non_force_low_confidence(self, pre_route) -> None:
-        """Non-force with <3 triggers -> low."""
-        match = pre_route.ScoredMatch(
-            name="test",
-            entry_type="skill",
-            agent=None,
-            force_route=False,
-            matched_triggers=["a", "b"],
         )
         assert pre_route.determine_confidence(match) == "low"
 
@@ -291,25 +297,24 @@ class TestBuildMatchTable:
 
 
 class TestScoreMatches:
-    """Test the scoring logic."""
+    """Test the force-candidate ranking logic."""
 
-    def test_force_route_bonus(self, pre_route) -> None:
-        """Force-route entries get a 2.0 bonus."""
+    def test_only_force_entries_reach_candidates(self, pre_route) -> None:
+        """Non-force entries are excluded from the match table entirely."""
         entries = [
             {"name": "forced", "type": "skill", "triggers": ["deploy"], "agent": None, "force_route": True},
             {"name": "normal", "type": "skill", "triggers": ["deploy"], "agent": None, "force_route": False},
         ]
         table = pre_route.build_match_table(entries)
         candidates = pre_route.score_matches(table, "deploy now")
-        forced = candidates["skill:forced"]
-        normal = candidates["skill:normal"]
-        assert forced.score > normal.score
+        assert "skill:forced" in candidates
+        assert "skill:normal" not in candidates
 
     def test_more_triggers_higher_score(self, pre_route) -> None:
-        """More matched triggers = higher score."""
+        """Among force entries, more matched triggers = higher rank."""
         entries = [
-            {"name": "multi", "type": "skill", "triggers": ["run", "test", "go"], "agent": None, "force_route": False},
-            {"name": "single", "type": "skill", "triggers": ["run"], "agent": None, "force_route": False},
+            {"name": "multi", "type": "skill", "triggers": ["run", "test", "go"], "agent": None, "force_route": True},
+            {"name": "single", "type": "skill", "triggers": ["run"], "agent": None, "force_route": True},
         ]
         table = pre_route.build_match_table(entries)
         candidates = pre_route.score_matches(table, "run go test")

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -72,7 +72,7 @@ python3 "$SDIR/pre-route.py" --request-file "$REQUEST_FILE" --json-compact
 rm -f "$REQUEST_FILE"
 ```
 
-→`PRE_ROUTE_RESULT` (once).
+→`PRE_ROUTE_RESULT` (once). Force-route guard only: high-conf force_route match or fallthrough — the semantic route owns the long tail.
 
 **Fast path:** PRE_ROUTE_RESULT high-conf force_route + pr-workflow/security → skip 0/1, dispatch direct. Keep banner+overrides+P3+P4. `[do-route]` `health=-`. Agent: pre-route→domain→general-purpose.
 
@@ -131,7 +131,7 @@ No pair→general-purpose+objective-loop. `[cross-repo]`→`.claude/agents/`. Co
 
 **Step 1: Safety-net** (reads PRE_ROUTE_RESULT)
 
-(a) force_route pr-workflow/security disagrees → override. Git/security MUST hit quality gates. (b) Phrase guards suppress false matches → Step 0.
+(a) force_route pr-workflow/security disagrees → override. Git/security MUST hit quality gates. (b) Fallthrough (guards pre-applied in pre-route) → Step 0 decision stands.
 
 **Step 2: Apply skill override** — "review"→systematic-code-review, "debug"→workflow (systematic-debugging pipeline), "refactor"→workflow (systematic-refactoring pipeline), "TDD"→test-driven-development. Full table in INDEX.
 

--- a/skills/meta/skill-creator/SKILL.md
+++ b/skills/meta/skill-creator/SKILL.md
@@ -185,12 +185,13 @@ user_invocable: true  # justification: users type "/pr-workflow" directly as
 No justification = leave it `false`. User-invocable expands the system-prompt
 surface and the slash-command namespace; both are scarce.
 
-**`force_route` -- when to set `true`.** Adds `force_bonus = 2.0` to the router
-match score (see `force_bonus` in `scripts/pre-route.py`). Without it, single-trigger skills cap
-at "low" confidence and may not route at all -- the bug PR #663 fixed for
-`agent-creator`. Confidence ladder: `force_route + 2+ triggers` = high;
-`force_route + 1 trigger` = medium; `3+ triggers without force` = medium;
-otherwise low.
+**`force_route` -- when to set `true`.** The deterministic pre-route guard
+(`scripts/pre-route.py`) matches only entries with `force_route: true`: one
+trigger surviving the semantic guards routes at high confidence; skills
+without the flag are invisible to pre-route and route via the semantic
+router alone. Idiom-prone triggers need guard/companion entries in
+pre-route so ordinary English cannot false-force-route (the pinned corpora
+in `scripts/tests/test_pre_route_*.py` are the contract).
 
 Set `force_route: true` when the skill matches one of these patterns:
 


### PR DESCRIPTION
## One idea

pre-route keeps exactly its load-bearing job — the force-route guarantee that genuine git/security/codex requests hit their quality gates — and stops doing keyword routing for the long tail.

## Measured evidence

- Replaying 49 real `/do` requests: fell through **43/49 (87.8%)**; both non-force keyword matches were wrong ("learn from this for our vexjoy agent" → business-ops; "dispatch all you believe add value" → ui-design-engineer).
- `docs/route-loop-validation.md`: deterministic pre-route 30% exact-pair vs 80% for an LLM router.
- pr-workflow force-route: 42 routes, confidence 0.9 — the part that works, kept intact.

## What changed

- `build_match_table` compiles **force_route entries only** (16 skills); non-force entries fall through to the semantic router.
- Medium-confidence tier and `force_bonus` scorer term retired; a force match surviving the guards = high, else fallthrough.
- **Kept**: all semantic guard / companion-word / phrase-guard tables — they are the precision layer of the force-route guarantee, pinned by the ADR corpus tests (pr-workflow 19 pos + 6 neg, planning 4+6, public-web-deploy 43+52). All corpus cases unchanged and green.
- JSON contract unchanged: `matched, agent, skill, confidence, match_type, reasoning`. Consumers verified: /do Phase 2, routing-ab-test.py (acts only on high+force — behavior identical), router-self-audit.py (`load_entries` untouched), routing-benchmark/check-routing-drift (no dependency; stale docstring claim removed).
- Docs follow: /do Phase 2 text, PHILOSOPHY.md routing-confidence note, skill-creator `force_route` guidance.

## Saving

- Net -1 LOC repo-wide but the hot path drops ~460 non-force entries' trigger compilation per invocation; the deceptive `medium`/`trigger_keyword` output class (measured 0-for-2 live) is gone, so `/do` Step 1(b) reads a two-state signal.
- Tests: every force-route case kept; deleted only scorer-internal assertions (force-bonus, non-force medium ladder); added a pin that non-force entries never match.

Local gates: ruff check+format clean; scripts/tests **4816 passed** (full suite).