### PR TITLE
fix(hooks): pin adr-enforcement NameError fix; widen repeat-offender window

### DIFF
--- a/hooks/pretool-main-thread-discipline.py
+++ b/hooks/pretool-main-thread-discipline.py
@@ -43,7 +43,7 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 from hook_utils import get_session_id, hook_error
 from stdin_timeout import read_stdin
 
-__EVENT_NAME = "PreToolUse"
+_EVENT_NAME = "PreToolUse"
 
 # Bash command patterns that are safe for the main thread during /do sessions.
 # These cover the routing bookkeeping calls described in skills/meta/do/SKILL.md.

--- a/hooks/pretool-section-integrity-validator.py
+++ b/hooks/pretool-section-integrity-validator.py
@@ -29,7 +29,7 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 from hook_utils import context_output, hook_error
 from stdin_timeout import read_stdin
 
-__EVENT_NAME = "PreToolUse"
+_EVENT_NAME = "PreToolUse"
 
 # Cache INDEX data per process (one invocation = one process, so this is just
 # a guard against accidental double-load).
@@ -137,7 +137,7 @@ def main() -> None:
         )
         if debug:
             print(warning, file=sys.stderr)
-        context_output(__EVENT_NAME, warning).print_and_exit(0)
+        context_output(_EVENT_NAME, warning).print_and_exit(0)
 
     # Not in either index -- warn about potential typo.
     warning = (
@@ -146,7 +146,7 @@ def main() -> None:
     )
     if debug:
         print(warning, file=sys.stderr)
-    context_output(__EVENT_NAME, warning).print_and_exit(0)
+    context_output(_EVENT_NAME, warning).print_and_exit(0)
 
 
 if __name__ == "__main__":

--- a/hooks/subagent-completion-guard.py
+++ b/hooks/subagent-completion-guard.py
@@ -44,7 +44,7 @@ sys.path.insert(0, str(Path(__file__).parent / "lib"))
 from hook_utils import hook_error
 from stdin_timeout import read_stdin
 
-__EVENT_NAME = "SubagentStop"
+_EVENT_NAME = "SubagentStop"
 
 # Agents whose names start with this prefix are READ-ONLY by contract
 _REVIEWER_PREFIX = "reviewer-"
@@ -479,7 +479,7 @@ def main() -> None:
 
         # Only process SubagentStop events
         event_type = event.get("hook_event_name") or event.get("type", "")
-        if event_type != __EVENT_NAME:
+        if event_type != _EVENT_NAME:
             sys.exit(0)
 
         cwd = event.get("cwd", str(Path.cwd()))

--- a/hooks/tests/test_adr_enforcement.py
+++ b/hooks/tests/test_adr_enforcement.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Regression tests for the adr-enforcement PostToolUse hook.
+
+Pins the fix for the largest crash source in hook-errors.jsonl: 1,795 logged
+``NameError: name '_EVENT_NAME' is not defined`` crashes (2026-07-03 to
+2026-07-11). The module constant was spelled ``__EVENT_NAME`` while the code
+referenced ``_EVENT_NAME``, so every invocation crashed. The typo shipped in
+the hook's initial release, stayed invisible until #858 added loud error
+logging, and was fixed as a side effect of #874. These tests keep it fixed:
+
+1. Every representative payload must run crash-free: exit 0, valid JSON on
+   stdout, and no HOOK-ERROR line on stderr.
+2. No hook may define a module-level ``__``-prefixed constant. Three other
+   hooks carried the same ``__EVENT_NAME`` spelling; the crash fired exactly
+   when a later edit used the conventional ``_EVENT_NAME`` name.
+
+Run with: python3 -m pytest hooks/tests/test_adr_enforcement.py -v
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_PATH = REPO_ROOT / "hooks" / "adr-enforcement.py"
+HOOKS_DIR = REPO_ROOT / "hooks"
+
+
+def _run_hook(payload: dict | None, tmp_path: Path) -> subprocess.CompletedProcess:
+    """Run the hook with the given payload (None = empty stdin)."""
+    return subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input="" if payload is None else json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={"PATH": "/usr/bin:/bin", "CLAUDE_HOOK_ERRORS_PATH": str(tmp_path / "hook-errors.jsonl")},
+    )
+
+
+def _assert_clean(result: subprocess.CompletedProcess) -> None:
+    """Exit 0, parseable JSON stdout, and no crash line on stderr."""
+    assert result.returncode == 0, f"hook must exit 0, got {result.returncode}: {result.stderr}"
+    assert "HOOK-ERROR" not in result.stderr, f"hook crashed: {result.stderr}"
+    if result.stdout.strip():
+        json.loads(result.stdout)
+
+
+def test_empty_stdin_runs_clean(tmp_path: Path) -> None:
+    """Empty stdin takes the earliest empty_output(_EVENT_NAME) path."""
+    _assert_clean(_run_hook(None, tmp_path))
+
+
+def test_missing_file_path_runs_clean(tmp_path: Path) -> None:
+    """A payload without file_path exercised the crashing NameError line."""
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": ""}, "cwd": str(tmp_path)}
+    _assert_clean(_run_hook(payload, tmp_path))
+
+
+def test_non_component_file_runs_clean(tmp_path: Path) -> None:
+    """Non-pipeline files skip silently, without crashing."""
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": str(tmp_path / "notes.txt")},
+        "cwd": str(tmp_path),
+    }
+    _assert_clean(_run_hook(payload, tmp_path))
+
+
+def test_component_file_without_adr_session_runs_clean(tmp_path: Path) -> None:
+    """A hooks/*.py component path without .adr-session.json skips silently."""
+    (tmp_path / "hooks").mkdir()
+    target = tmp_path / "hooks" / "example.py"
+    target.write_text("print('hi')\n", encoding="utf-8")
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": str(target)}, "cwd": str(tmp_path)}
+    result = _run_hook(payload, tmp_path)
+    _assert_clean(result)
+    assert "COMPLIANCE CHECK" not in result.stdout
+
+
+@pytest.mark.parametrize("hook_file", sorted(HOOKS_DIR.glob("*.py")), ids=lambda p: p.name)
+def test_no_module_level_dunder_constants(hook_file: Path) -> None:
+    """Ban the ``__CONSTANT = ...`` spelling that caused the crash.
+
+    ``__EVENT_NAME`` next to code written against ``_EVENT_NAME`` produced
+    1,795 silent-then-logged NameError crashes. Single leading underscore is
+    the convention; two invite exactly that mismatch (and class-body name
+    mangling besides).
+    """
+    pattern = re.compile(r"^__[A-Z][A-Z0-9_]* *=", re.MULTILINE)
+    matches = pattern.findall(hook_file.read_text(encoding="utf-8"))
+    assert not matches, (
+        f"{hook_file.name} defines module-level dunder constant(s): {matches} — use a single leading underscore"
+    )

--- a/scripts/tests/test_validate_hook_health.py
+++ b/scripts/tests/test_validate_hook_health.py
@@ -21,7 +21,7 @@ def test_repeat_offenders_ignore_old_and_malformed_entries(tmp_path, monkeypatch
     now = datetime.now(timezone.utc)
     path = tmp_path / "hook-errors.jsonl"
     lines = [
-        *[_entry("old-hook", now - timedelta(hours=25)) for _ in range(6)],
+        *[_entry("old-hook", now - timedelta(hours=169)) for _ in range(6)],
         *[_entry("recent-hook", now - timedelta(hours=1)) for _ in range(5)],
         json.dumps({"hook": "missing-ts"}),
         "not-json",
@@ -62,6 +62,26 @@ def test_repeat_offender_lookback_is_configurable(tmp_path, monkeypatch):
 
     assert health.check_hook_error_repeat_offenders(lookback_hours=6, now=now) == []
     assert "twelve-hour-hook" in health.check_hook_error_repeat_offenders(lookback_hours=24, now=now)[0]
+
+
+def test_default_lookback_covers_multi_day_crash_streaks(tmp_path, monkeypatch):
+    """A sustained crash streak from days ago must still surface by default.
+
+    Regression: adr-enforcement crashed 1,795 times over 8 days but the old
+    24-hour default window only ever saw the final day's tail.
+    """
+    now = datetime.now(timezone.utc)
+    path = tmp_path / "hook-errors.jsonl"
+    path.write_text(
+        "\n".join(_entry("six-day-old-hook", now - timedelta(days=6)) for _ in range(20)) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_HOOK_ERRORS_PATH", str(path))
+
+    failures = health.check_hook_error_repeat_offenders(now=now)
+
+    assert len(failures) == 1
+    assert "six-day-old-hook" in failures[0]
 
 
 def test_stop_liveness_probe_does_not_audit_the_current_repo():

--- a/scripts/validate-hook-health.py
+++ b/scripts/validate-hook-health.py
@@ -743,7 +743,10 @@ def check_liveness() -> list[str]:
 
 
 DEFAULT_HOOK_ERRORS_JSONL = Path.home() / ".claude" / "learning" / "hook-errors.jsonl"
-DEFAULT_HOOK_ERROR_LOOKBACK_HOURS = 24.0
+# 7 days: a 24-hour window missed adr-enforcement's 1,795-crash streak (spread
+# over 8 days) while flagging only small same-day offenders. A week of lookback
+# surfaces sustained crash loops without keeping long-fixed hooks failing forever.
+DEFAULT_HOOK_ERROR_LOOKBACK_HOURS = 168.0
 
 # A hook that errors more than this many times is a repeat offender.
 _REPEAT_THRESHOLD = 5
@@ -837,7 +840,7 @@ def main() -> int:
         "--hook-error-lookback-hours",
         type=float,
         default=DEFAULT_HOOK_ERROR_LOOKBACK_HOURS,
-        help="Repeat-offender lookback window (default: 24 hours)",
+        help="Repeat-offender lookback window (default: 168 hours / 7 days)",
     )
     args = parser.parse_args()
     if args.hook_error_lookback_hours <= 0:


### PR DESCRIPTION
## Summary
Pin the fix for the largest crash source in `~/.claude/learning/hook-errors.jsonl` (1,795 of 3,027 entries) and re-scope the repeat-offender health check that missed it. Root cause: `adr-enforcement.py` defined `__EVENT_NAME` (double underscore) while its code referenced `_EVENT_NAME` — NameError on every invocation. The typo shipped in the hook's initial release, was invisible until #858 added loud error logging (2026-07-02), and was already fixed on main as an unremarked side effect of #874 (2026-07-11) — the log's crash window (07-03 to 07-11, zero since) matches exactly. This PR adds the missing regression coverage and closes the same latent trap elsewhere.

## Changes
- `hooks/tests/test_adr_enforcement.py` — new: runs the hook on 4 representative payloads asserting exit 0, valid JSON stdout, no HOOK-ERROR stderr (the broken version fails these); plus a fleet-wide test banning module-level `__CONSTANT =` definitions in hooks
- `hooks/pretool-section-integrity-validator.py`, `hooks/pretool-main-thread-discipline.py`, `hooks/subagent-completion-guard.py` — rename `__EVENT_NAME` to `_EVENT_NAME` (same trap, consistently spelled today so not crashing; the adr-enforcement crash fired exactly when a later edit used the conventional spelling)
- `scripts/validate-hook-health.py` — repeat-offender lookback default 24h → 168h; a 24-hour window flagged a 6-error same-day hook while never surfacing the 1,795-crash 8-day streak
- `scripts/tests/test_validate_hook_health.py` — adjust old-entry fixture past the new window; add a regression test that a 6-day-old crash streak surfaces by default

## Notes
- Contradicts the audit premise "fix the crash loop": the crash itself was already fixed by #874; this PR contributes the regression guard the audit asked for and the validator re-scope.
- Other repeat offenders are different bugs, noted for follow-up, not touched here: `review-false-positive-capture` (JSONDecodeError, still occurring today), `instruction-compliance` (JSONDecodeError, today), `cross-repo-agents` (UnicodeDecodeError on non-UTF-8 file), `mcp-health-check` (AttributeError on bool). A cluster of synthetic entries ("disk full", "Command 'test' timed out", all within one minute on 2026-07-09) is pytest pollution of live telemetry, since isolated by the `_isolate_hook_error_log` conftest fixture (#871).
- Verified empirically: the pre-#874 hook build emits `HOOK-ERROR: NameError: name '_EVENT_NAME' is not defined` on a representative payload; current build returns clean empty output on the same payload.
