### PR TITLE
perf(dispatch): retire the greedy reference-loading instruction

### DIFF
--- a/hooks/reference-loading-enforcer.py
+++ b/hooks/reference-loading-enforcer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.1.0
+# hook-version: 1.2.0
 """
 PreToolUse:Agent Hook: Reference Loading Enforcer
 
@@ -45,13 +45,9 @@ _INJECTION_MARKER = "reference loading"
 
 # The instruction to inject into agent prompts.
 _REFERENCE_LOADING_INSTRUCTION = (
-    "REFERENCE LOADING REQUIREMENT: Before starting work, read your agent .md file "
-    "or skill SKILL.md to find the Reference Loading Table. Load EVERY reference file "
-    "whose signal matches this task — load greedily, not conservatively. Multiple "
-    "matching signals = load all matching references. Reference files contain "
-    "domain-specific patterns, anti-patterns, code examples, and detection commands "
-    "that make your output expert-quality. Skipping this step means operating without "
-    "domain expertise that exists on disk."
+    "REFERENCE LOADING REQUIREMENT: Consult the Reference Loading Table in your "
+    "agent .md file or skill SKILL.md and read the references that match this task "
+    "— they carry the domain patterns and detection commands your output needs."
 )
 
 _BYPASS_ENV = "REFERENCE_ENFORCER_BYPASS"

--- a/scripts/build-dispatch.py
+++ b/scripts/build-dispatch.py
@@ -72,9 +72,8 @@ DEFAULT_TOKEN_BUDGET = 500000
 # ---------------------------------------------------------------------------
 
 INJ_REFERENCE_LOADING = (
-    "Before starting work, read your agent .md file to find the Reference Loading Table. "
-    "Load EVERY reference file whose signal matches this task. "
-    "Load greedily — if multiple signals match, load all matching references."
+    "Before starting work, consult the Reference Loading Table in your agent .md file "
+    "and read the references that match this task."
 )
 
 INJ_COMPLETENESS = "Deliver the finished product. Ship the complete thing."

--- a/skills/engineering/cobalt-core/SKILL.md
+++ b/skills/engineering/cobalt-core/SKILL.md
@@ -41,7 +41,7 @@ Domain skill for the [cobaltcore-dev](https://github.com/cobaltcore-dev) project
 | goroutine, concurrency, semaphore, TryLock, sync.Map, race condition, socket exhaustion, scrape overlap, ClearScrapeCache | `references/concurrency-patterns.md` | ~200 lines |
 | test, mock, moq, unit test, E2E, Kind cluster, race detector, interface_mock_gen, test-metrics.sh | `references/testing-patterns.md` | ~200 lines |
 
-**Load greedily.** If the user's question touches any signal keyword, load the matching reference before responding. Multiple signals matching = load all matching references.
+**Loading rule.** Read the references whose signals match the task before responding.
 
 ---
 

--- a/skills/engineering/kotlin/SKILL.md
+++ b/skills/engineering/kotlin/SKILL.md
@@ -37,4 +37,4 @@ Kotlin coroutine patterns and testing: structured concurrency, Flow, StateFlow/S
 | coroutine skill overview, structured concurrency principles | `references/kotlin-coroutines.md` | ~55 lines |
 | JUnit 5, Kotest, MockK, runTest, parameterized tests, assertions | `references/kotlin-testing.md` | ~290 lines |
 
-**Load greedily.** If the user's question touches any signal keyword, load the matching reference before responding. Multiple signals matching = load all matching references.
+**Loading rule.** Read the references whose signals match the task before responding.

--- a/skills/engineering/php-quality/SKILL.md
+++ b/skills/engineering/php-quality/SKILL.md
@@ -30,7 +30,7 @@ PHP code quality enforcement: strict types, PSR-12 compliance, modern language f
 | Laravel, Eloquent, Collections, Service Container, Symfony, DI attributes, Event Dispatcher, framework | `references/framework-idioms.md` | ~70 lines |
 | PHP-CS-Fixer, PHPStan, Psalm, Rector, static analysis, CI, linting, code style, taint analysis | `references/quality-tools.md` | ~60 lines |
 
-**Load greedily.** If the user's question touches any signal keyword, load the matching reference before responding. Multiple signals matching = load all matching references.
+**Loading rule.** Read the references whose signals match the task before responding.
 
 ---
 

--- a/skills/engineering/php/SKILL.md
+++ b/skills/engineering/php/SKILL.md
@@ -36,7 +36,7 @@ PHP code quality and testing: strict types, PSR-12 compliance, modern language f
 | quality review process, phases, PSR-12 enforcement | `references/php-quality.md` | ~60 lines |
 | test writing process, test doubles, Prophecy, database fixtures | `references/php-testing.md` | ~50 lines |
 
-**Load greedily.** If the user's question touches any signal keyword, load the matching reference before responding. Multiple signals matching = load all matching references.
+**Loading rule.** Read the references whose signals match the task before responding.
 
 ---
 

--- a/skills/engineering/swift/SKILL.md
+++ b/skills/engineering/swift/SKILL.md
@@ -35,7 +35,7 @@ Swift concurrency and testing: async/await, Actors, TaskGroups, Sendable, struct
 | concurrency overview, structured concurrency patterns | `references/swift-concurrency.md` | ~30 lines |
 | XCTest, Swift Testing, test doubles, async tests, UI tests | `references/swift-testing.md` | ~250 lines |
 
-**Load greedily.** If the user's question touches any signal keyword, load the matching reference before responding. Multiple signals matching = load all matching references.
+**Loading rule.** Read the references whose signals match the task before responding.
 
 ---
 

--- a/skills/game/game-sprite-pipeline/SKILL.md
+++ b/skills/game/game-sprite-pipeline/SKILL.md
@@ -94,7 +94,7 @@ Portrait is the road-to-aew immediate need; spritesheet is the forward-looking c
 | `--per-row` subagent orchestration | `references/subagent-delegation.md` | subagent boundary rules: who generates, who composes, who finalizes |
 | VFX issues in per-row prompts | `references/vfx-containment.md` | full containment ruleset: allowed/forbidden effects, per-state rules |
 
-Load greedily when a signal matches — references are only read on demand, so the cost is paid once per execution, not once per routing decision.
+Read the references whose signals match the task — references load on demand, so the cost is paid once per execution, not once per routing decision.
 
 ## Portrait-mode pipeline (5 phases)
 

--- a/skills/infrastructure/kubernetes-debugging/SKILL.md
+++ b/skills/infrastructure/kubernetes-debugging/SKILL.md
@@ -31,7 +31,7 @@ Systematic diagnosis of pod failures, networking issues, and resource problems u
 | service resolution, DNS, nslookup, CoreDNS, port-forward, NetworkPolicy, ingress, egress | `references/network-debugging.md` | ~50 lines |
 | CPU throttling, memory limit, OOMKill, ephemeral storage, DiskPressure, debug container, distroless, kubectl reference, rollout, exec | `references/resource-debugging.md` | ~100 lines |
 
-**Load greedily.** If the user's question touches any signal keyword, load the matching reference before responding. Multiple signals matching = load all matching references.
+**Loading rule.** Read the references whose signals match the task before responding.
 
 ## Instructions
 

--- a/skills/infrastructure/kubernetes-security/SKILL.md
+++ b/skills/infrastructure/kubernetes-security/SKILL.md
@@ -31,7 +31,7 @@ Harden Kubernetes clusters and workloads through RBAC, pod security, network iso
 | NetworkPolicy, default-deny, allow-list, egress, ingress, DNS, lateral movement, namespace isolation | `references/network-policies.md` | ~70 lines |
 | cosign, Kyverno, OPA, admission controller, Sealed Secrets, External Secrets, supply chain, misconfiguration, privileged | `references/supply-chain.md` | ~120 lines |
 
-**Load greedily.** If the user's question touches any signal keyword, load the matching reference before responding. Multiple signals matching = load all matching references.
+**Loading rule.** Read the references whose signals match the task before responding.
 
 ---
 

--- a/skills/infrastructure/kubernetes/SKILL.md
+++ b/skills/infrastructure/kubernetes/SKILL.md
@@ -56,7 +56,7 @@ Kubernetes debugging, security hardening, and infrastructure tooling. Covers pod
 | kubernetes security process, RBAC + pod security + network hardening | `references/kubernetes-security.md` | ~50 lines |
 | cobaltcore overview, KVM exporter architecture, component identification | `references/cobalt-core.md` | ~50 lines |
 
-**Load greedily.** If the user's question touches any signal keyword, load the matching reference before responding. Multiple signals matching = load all matching references.
+**Loading rule.** Read the references whose signals match the task before responding.
 
 ---
 

--- a/skills/meta/agent-creator/references/agent-design-patterns.md
+++ b/skills/meta/agent-creator/references/agent-design-patterns.md
@@ -105,7 +105,7 @@ Required in every agent that has a `references/` directory. Format:
 
 - Signals are phrases or keywords that appear in the user's request or the task context
 - Each signal must map to exactly one or two reference files (progressive disclosure)
-- Signals overlap is acceptable — load greedily when multiple match
+- Signals overlap is acceptable — a task may match more than one reference
 - The Why column states what the file adds, not what it contains
 
 **Example:**


### PR DESCRIPTION
## One idea

Replace every copy of "Load EVERY reference file whose signal matches this task. Load greedily — if multiple signals match, load all matching references" with a short instruction to consult the Reference Loading Table and read the references that match the task.

## Measured saving

- The greedy instruction inflates a ~1.5k-token agent to ~24k tokens before work starts, against a reference corpus measured at **89% generic content** — up to ~22.5k tokens per dispatched subagent recovered when multiple signals match.
- Instruction text itself: /do injection 41 → 24 words; hook injection 68 → 33 words. Net -5 LOC across 12 files.

## Copies made consistent (grep: 'load greedily', 'Load EVERY reference')

- `scripts/build-dispatch.py` `INJ_REFERENCE_LOADING` — rides every /do dispatch
- `hooks/reference-loading-enforcer.py` — rides every Agent dispatch the /do text missed; the `Reference Loading Table` marker phrase is kept so the dedupe-vs-/do-injection logic is unchanged (hook-version 1.1.0 → 1.2.0)
- 8 `SKILL.md` "**Load greedily.**" lines (kubernetes ×3, cobalt-core, php-quality, kotlin, php, swift) → one consistent one-line loading rule
- `game-sprite-pipeline` prose line (rationale kept), `agent-creator` template guidance line

## Preserved

- `references/` directory structure and **every Reference Loading Table** — untouched (their content is being condensed on a separate track)
- `agents/base-instructions.md` loading (INJ_BASE_INSTRUCTIONS) — untouched
- M04 compliance detector keeps its historical patterns so old transcripts still classify; new text matches via `Reference Loading` pattern
- Only remaining greedy-phrase occurrence is the M04 detector test fixture — detector input, not injected text

Local gates: ruff check+format clean; scripts+hooks suites **6719 passed**. Lockstep tests green: test_reference_loading_enforcer (loads INJ verbatim at test time), test_build_dispatch (72), test_instruction_compliance.