### PR TITLE
fix(hooks): bind subagent warmstart to current session; filter credential paths

### DIFF
--- a/hooks/lib/hook_utils.py
+++ b/hooks/lib/hook_utils.py
@@ -433,6 +433,51 @@ def _hook_errors_path() -> Path:
     return Path(override) if override else _DEFAULT_HOOK_ERRORS_PATH
 
 
+# Path components that mark a file as credential-adjacent. Matched against
+# whole path segments (never substrings), so "assh/" or "renv/" cannot match.
+_SENSITIVE_PATH_DIRS = frozenset({".ssh", ".gnupg", ".aws", ".azure", ".kube", ".gcloud"})
+
+# Basename patterns for credential-shaped files.
+_SENSITIVE_BASENAME_RE = None
+
+
+def _sensitive_basename_pattern():
+    """Lazy-compile the sensitive-basename regex."""
+    global _SENSITIVE_BASENAME_RE
+    if _SENSITIVE_BASENAME_RE is None:
+        import re
+
+        _SENSITIVE_BASENAME_RE = re.compile(
+            r"^(\.env(\..*)?|.*\.(pem|key|p12|pfx)|id_[a-z0-9]+(\.pub)?"
+            r"|.*credentials.*|.*secret.*|token\.json|\.tokens|\.netrc|\.npmrc|\.pypirc)$",
+            re.IGNORECASE,
+        )
+    return _SENSITIVE_BASENAME_RE
+
+
+def is_sensitive_path(path: str) -> bool:
+    """True when a file path looks credential- or secret-bearing.
+
+    Hooks that echo file paths into model-visible context (e.g. subagent
+    warmstart) must drop these entirely — surfacing even the *path* of a key
+    file to a subagent prompt leaks information and invites a follow-up read.
+
+    Args:
+        path: Absolute or relative file path string.
+
+    Returns:
+        True if any path segment is a credential directory (.ssh, .gnupg,
+        .aws, ...) or the basename is credential-shaped (.env*, *.pem, *.key,
+        id_*, *credentials*, *secret*, token.json, ...).
+    """
+    if not path:
+        return False
+    segments = [s for s in path.replace("\\", "/").split("/") if s]
+    if any(seg in _SENSITIVE_PATH_DIRS for seg in segments):
+        return True
+    return bool(segments and _sensitive_basename_pattern().match(segments[-1]))
+
+
 # Secrets pattern used to strip sensitive values from error messages.
 _SECRETS_RE = None
 

--- a/hooks/posttool-session-reads.py
+++ b/hooks/posttool-session-reads.py
@@ -1,44 +1,78 @@
 #!/usr/bin/env python3
-# hook-version: 1.0.0
+# hook-version: 2.0.0
 """
 PostToolUse Hook: Session Read Tracker
 
-Tracks files read during the session by appending file paths to
-.claude/session-reads.txt. This provides a lightweight record of
-files the parent session has seen, used by the warmstart hook to
-give subagents context about what's already been read.
+Tracks files read during the session by appending JSONL entries
+({"ts", "session", "path"}) to .claude/session-reads.txt. This provides a
+lightweight record of files the parent session has seen, used by the
+warmstart hook to give subagents context about what's already been read.
+
+v2 (session scoping): entries carry the session id and a UTC timestamp so
+the warmstart reader can restrict itself to the current session. Writes
+prune entries older than RETENTION_DAYS and drop v1 legacy plain-path
+lines, so the file cannot accumulate cross-session state indefinitely.
+Credential-shaped paths (.ssh/, .env, *.pem, ...) are never recorded.
 
 Design Principles:
 - SILENT output (no context injection)
 - Non-blocking (always exits 0)
-- Fast execution (<10ms target)
 - Only processes Read tool results
-- Deduplicates paths within the session file
+- Deduplicates (session, path) pairs
 """
 
 import json
-import os
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
-from hook_utils import empty_output, hook_error
+from hook_utils import empty_output, get_session_id, hook_error, is_sensitive_path
 from stdin_timeout import read_stdin
 
 EVENT_NAME = "PostToolUse"
 
 SESSION_READS_FILE = ".claude/session-reads.txt"
 
+# Entries older than this are pruned on every write.
+RETENTION_DAYS = 7
+
+
+def _parse_entry(line: str) -> dict | None:
+    """Parse one JSONL entry; None for blank, legacy plain-path, or bad lines."""
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        entry = json.loads(line)
+    except json.JSONDecodeError:
+        return None  # v1 legacy plain-path line — dropped by design
+    if not isinstance(entry, dict) or not entry.get("path"):
+        return None
+    return entry
+
+
+def _fresh(entry: dict, cutoff: datetime) -> bool:
+    """True when the entry's timestamp parses and is at or after cutoff."""
+    try:
+        ts = datetime.fromisoformat(entry["ts"])
+    except (KeyError, TypeError, ValueError):
+        return False
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts >= cutoff
+
 
 def main() -> None:
-    """Process PostToolUse events for Read tool file tracking.
+    """Record a Read tool file path for the current session.
 
     Flow:
-    1. Read stdin JSON, check tool_name == "Read"
-    2. Extract file_path from tool_input
-    3. Append to .claude/session-reads.txt (deduplicated)
+    1. Read stdin JSON; extract file_path from tool_input
+    2. Skip credential-shaped paths entirely
+    3. Rewrite .claude/session-reads.txt: fresh entries + the new one,
+       deduplicated on (session, path)
     4. Exit silently (no context injection)
     """
     try:
@@ -51,7 +85,6 @@ def main() -> None:
         # tool_name filter removed — matcher "Read" in settings.json prevents
         # this hook from spawning for non-Read tools.
 
-        # Extract file_path from tool_input
         tool_input = event.get("tool_input", {})
         if isinstance(tool_input, str):
             try:
@@ -62,28 +95,38 @@ def main() -> None:
             return
 
         file_path = tool_input.get("file_path", "")
-        if not file_path:
+        if not file_path or is_sensitive_path(file_path):
             return
 
-        # Resolve the session-reads file path
-        reads_path = Path(SESSION_READS_FILE)
+        session_id = event.get("session_id") or get_session_id()
+        now = datetime.now(timezone.utc)
+        cutoff = now - timedelta(days=RETENTION_DAYS)
 
-        # Ensure parent directory exists
+        reads_path = Path(SESSION_READS_FILE)
         reads_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Check for duplicates by reading existing entries
-        existing_paths: set[str] = set()
+        entries: list[dict] = []
+        seen: set[tuple[str, str]] = set()
         if reads_path.is_file():
             try:
-                content = reads_path.read_text(encoding="utf-8")
-                existing_paths = {line.strip() for line in content.splitlines() if line.strip()}
+                for line in reads_path.read_text(encoding="utf-8").splitlines():
+                    entry = _parse_entry(line)
+                    if entry is None or not _fresh(entry, cutoff):
+                        continue
+                    key = (str(entry.get("session", "")), str(entry["path"]))
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    entries.append(entry)
             except OSError:
                 pass
 
-        # Only append if not already tracked
-        if file_path not in existing_paths:
-            with open(reads_path, "a", encoding="utf-8") as f:
-                f.write(file_path + "\n")
+        if (session_id, file_path) not in seen:
+            entries.append({"ts": now.isoformat(), "session": session_id, "path": file_path})
+
+        tmp_path = reads_path.with_suffix(".tmp")
+        tmp_path.write_text("".join(json.dumps(e) + "\n" for e in entries), encoding="utf-8")
+        tmp_path.replace(reads_path)
 
         # Silent output — no context injection
         empty_output(EVENT_NAME).print_and_exit()

--- a/hooks/pretool-subagent-warmstart.py
+++ b/hooks/pretool-subagent-warmstart.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# hook-version: 1.0.0
+# hook-version: 2.0.0
 """
 PreToolUse Hook: Subagent Warm Start
 
@@ -10,6 +10,14 @@ status, ADR session info, key decisions, and discovery briefs.
 This gives subagents immediate awareness of the parent session's
 state without needing to re-discover context from scratch.
 
+v2 (session scoping): warmstart context is bound to the CURRENT session.
+Files-seen entries come from the v2 JSONL session-reads format and are
+filtered to this session id and the freshness window; v1 legacy plain-path
+lines are ignored. Credential-shaped paths (.ssh/, .env, *.pem, ...) are
+filtered out. task_plan.md, .adr-session.json, and discovery briefs are
+only injected when modified within the freshness window, so a stale plan
+or ADR pointer from a previous task cannot leak into new dispatches.
+
 Design Principles:
 - Non-blocking (always exits 0)
 - Sub-50ms execution (file reads only, no subprocess)
@@ -19,12 +27,14 @@ Design Principles:
 
 import json
 import sys
+import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 # Add lib directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 
-from hook_utils import context_output, empty_output
+from hook_utils import context_output, empty_output, get_session_id, is_sensitive_path
 from stdin_timeout import read_stdin
 
 EVENT_NAME = "PreToolUse"
@@ -37,12 +47,32 @@ DISCOVERIES_DIR = ".planning/discoveries"
 MAX_OUTPUT_CHARS = 4000
 MAX_FILES_SHOWN = 10
 
+# Context older than this is treated as belonging to a previous task.
+FRESHNESS_HOURS = 24
 
-def load_recent_reads(reads_path: Path, max_count: int = MAX_FILES_SHOWN) -> list[str]:
-    """Load up to max_count most recent file paths from session-reads.txt.
+
+def is_fresh_file(path: Path, hours: int = FRESHNESS_HOURS) -> bool:
+    """True when path exists and was modified within the freshness window."""
+    try:
+        return (time.time() - path.stat().st_mtime) <= hours * 3600
+    except OSError:
+        return False
+
+
+def load_recent_reads(
+    reads_path: Path,
+    session_id: str,
+    max_count: int = MAX_FILES_SHOWN,
+) -> list[str]:
+    """Load up to max_count recent file paths for the current session.
+
+    Reads the v2 JSONL format ({"ts", "session", "path"}). Entries from other
+    sessions, entries older than FRESHNESS_HOURS, credential-shaped paths, and
+    v1 legacy plain-path lines are all skipped.
 
     Args:
         reads_path: Path to the session-reads.txt file.
+        session_id: Current session id; only matching entries are returned.
         max_count: Maximum number of paths to return.
 
     Returns:
@@ -51,11 +81,34 @@ def load_recent_reads(reads_path: Path, max_count: int = MAX_FILES_SHOWN) -> lis
     if not reads_path.is_file():
         return []
 
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=FRESHNESS_HOURS)
+    paths: list[str] = []
     try:
-        content = reads_path.read_text(encoding="utf-8")
-        lines = [line.strip() for line in content.splitlines() if line.strip()]
-        # Return the most recent entries (tail of file)
-        return lines[-max_count:]
+        for line in reads_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # v1 legacy plain-path line — no session id, skip
+            if not isinstance(entry, dict):
+                continue
+            if str(entry.get("session", "")) != session_id:
+                continue
+            try:
+                ts = datetime.fromisoformat(entry["ts"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            if ts < cutoff:
+                continue
+            path = str(entry.get("path", ""))
+            if not path or is_sensitive_path(path):
+                continue
+            paths.append(path)
+        return paths[-max_count:]
     except OSError:
         return []
 
@@ -71,7 +124,7 @@ def extract_task_plan(plan_path: Path) -> dict[str, str]:
     """
     result = {"goal": "", "status": ""}
 
-    if not plan_path.is_file():
+    if not plan_path.is_file() or not is_fresh_file(plan_path):
         return result
 
     try:
@@ -108,7 +161,7 @@ def extract_decisions(plan_path: Path) -> list[str]:
     Returns:
         List of decision strings.
     """
-    if not plan_path.is_file():
+    if not plan_path.is_file() or not is_fresh_file(plan_path):
         return []
 
     try:
@@ -144,7 +197,7 @@ def load_adr_session(session_path: Path) -> dict[str, str]:
     """
     result = {"adr_path": "", "domain": ""}
 
-    if not session_path.is_file():
+    if not session_path.is_file() or not is_fresh_file(session_path):
         return result
 
     try:
@@ -171,7 +224,7 @@ def list_discoveries(discoveries_dir: Path) -> list[str]:
         return []
 
     try:
-        return sorted(f.name for f in discoveries_dir.iterdir() if f.is_file())
+        return sorted(f.name for f in discoveries_dir.iterdir() if f.is_file() and is_fresh_file(f))
     except OSError:
         return []
 
@@ -254,8 +307,10 @@ def main() -> None:
         # tool_name filter removed — matcher "Agent" in settings.json prevents
         # this hook from spawning for non-Agent tools.
 
+        session_id = event.get("session_id") or get_session_id()
+
         # Gather context from various sources
-        files = load_recent_reads(Path(SESSION_READS_FILE))
+        files = load_recent_reads(Path(SESSION_READS_FILE), session_id)
         task_plan = extract_task_plan(Path(TASK_PLAN_FILE))
         decisions = extract_decisions(Path(TASK_PLAN_FILE))
         adr_session = load_adr_session(Path(ADR_SESSION_FILE))

--- a/hooks/tests/test_hook_utils_security.py
+++ b/hooks/tests/test_hook_utils_security.py
@@ -320,3 +320,54 @@ class TestAsyncRewake:
         data = json.loads(out.getvalue().strip().splitlines()[0])
         assert data["rewakeSummary"] == "ONE-LINE-SUMMARY"
         assert "CONTEXT-BODY" in err.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# is_sensitive_path
+# ---------------------------------------------------------------------------
+
+
+class TestIsSensitivePath:
+    """Credential-shaped paths are flagged; ordinary source paths are not."""
+
+    def test_credential_directories_flagged(self):
+        from hook_utils import is_sensitive_path
+
+        for p in (
+            "/home/u/.ssh/deploy_ed25519.pub",
+            "/home/u/.ssh/id_rsa",
+            "/home/u/.gnupg/pubring.kbx",
+            "/home/u/.aws/config",
+            "relative/.kube/config",
+        ):
+            assert is_sensitive_path(p), p
+
+    def test_credential_basenames_flagged(self):
+        from hook_utils import is_sensitive_path
+
+        for p in (
+            "/app/.env",
+            "/app/.env.production",
+            "/certs/server.pem",
+            "/certs/tls.key",
+            "/home/u/id_ed25519.pub",
+            "/srv/service-account-credentials.json",
+            "/srv/client_secret.json",
+            "/home/u/token.json",
+            "/home/u/.netrc",
+        ):
+            assert is_sensitive_path(p), p
+
+    def test_ordinary_paths_not_flagged(self):
+        from hook_utils import is_sensitive_path
+
+        for p in (
+            "/app/main.py",
+            "/repo/hooks/adr-enforcement.py",
+            "/docs/environment.md",  # 'env' substring must not match
+            "/src/assh/parser.go",  # '.ssh' must match whole segments only
+            "/lib/monkey.rb",  # '.key' suffix check is on basename pattern, not substring
+            "README.md",
+            "",
+        ):
+            assert not is_sensitive_path(p), p

--- a/hooks/tests/test_posttool_session_reads.py
+++ b/hooks/tests/test_posttool_session_reads.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Tests for the posttool-session-reads hook.
+Tests for the posttool-session-reads hook (v2 JSONL session-scoped format).
 
 Run with: python3 -m pytest hooks/tests/test_posttool_session_reads.py -v
 """
@@ -9,9 +9,8 @@ import importlib.util
 import json
 import subprocess
 import sys
-import tempfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import patch
 
 # ---------------------------------------------------------------------------
 # Import the module under test
@@ -43,6 +42,19 @@ def run_hook(event: dict) -> tuple[str, str, int]:
     return result.stdout, result.stderr, result.returncode
 
 
+def read_event(path: str, session: str = "sess-1") -> dict:
+    """Build a Read tool event with an explicit session id."""
+    return {"tool_name": "Read", "session_id": session, "tool_input": {"file_path": path}}
+
+
+def load_entries(tmp_path: Path) -> list[dict]:
+    """Parse the JSONL session-reads file into a list of entry dicts."""
+    reads_file = tmp_path / ".claude" / "session-reads.txt"
+    if not reads_file.exists():
+        return []
+    return [json.loads(line) for line in reads_file.read_text().splitlines() if line.strip()]
+
+
 # ---------------------------------------------------------------------------
 # Tool Name Filtering
 # ---------------------------------------------------------------------------
@@ -69,21 +81,13 @@ class TestToolNameFiltering:
     def test_ignores_bash_tool(self, tmp_path, monkeypatch):
         """Bash tool events should be ignored (no file_path to extract)."""
         monkeypatch.chdir(tmp_path)
-        event = {
-            "tool_name": "Bash",
-            "tool_input": {"command": "ls"},
-        }
-        stdout, stderr, code = run_hook(event)
+        stdout, stderr, code = run_hook({"tool_name": "Bash", "tool_input": {"command": "ls"}})
         assert code == 0
 
     def test_ignores_agent_tool(self, tmp_path, monkeypatch):
         """Agent tool events should be ignored."""
         monkeypatch.chdir(tmp_path)
-        event = {
-            "tool_name": "Agent",
-            "tool_input": {"prompt": "do something"},
-        }
-        stdout, stderr, code = run_hook(event)
+        stdout, stderr, code = run_hook({"tool_name": "Agent", "tool_input": {"prompt": "do something"}})
         assert code == 0
 
 
@@ -93,66 +97,120 @@ class TestToolNameFiltering:
 
 
 class TestFilePathTracking:
-    """Verify file paths are correctly extracted and written."""
+    """Verify file paths are correctly extracted and written as JSONL."""
 
     def test_tracks_read_file_path(self, tmp_path, monkeypatch):
-        """Read tool event should append the file path to session-reads.txt."""
+        """Read tool event appends a {ts, session, path} entry."""
         monkeypatch.chdir(tmp_path)
-        reads_dir = tmp_path / ".claude"
-        reads_dir.mkdir()
+        (tmp_path / ".claude").mkdir()
 
-        event = {
-            "tool_name": "Read",
-            "tool_input": {"file_path": "/home/user/project/main.py"},
-        }
-        stdout, stderr, code = run_hook(event)
+        stdout, stderr, code = run_hook(read_event("/home/user/project/main.py"))
 
         assert code == 0
-        reads_file = reads_dir / "session-reads.txt"
-        assert reads_file.exists()
-        content = reads_file.read_text()
-        assert "/home/user/project/main.py" in content
+        entries = load_entries(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["path"] == "/home/user/project/main.py"
+        assert entries[0]["session"] == "sess-1"
+        assert datetime.fromisoformat(entries[0]["ts"]).tzinfo is not None
 
     def test_tracks_multiple_reads(self, tmp_path, monkeypatch):
         """Multiple Read events should all be tracked."""
         monkeypatch.chdir(tmp_path)
-        reads_dir = tmp_path / ".claude"
-        reads_dir.mkdir()
+        (tmp_path / ".claude").mkdir()
 
         paths = ["/a/file1.py", "/b/file2.go", "/c/file3.rs"]
         for p in paths:
-            event = {
-                "tool_name": "Read",
-                "tool_input": {"file_path": p},
-            }
-            run_hook(event)
+            run_hook(read_event(p))
 
-        reads_file = reads_dir / "session-reads.txt"
-        content = reads_file.read_text()
-        lines = [line.strip() for line in content.splitlines() if line.strip()]
-        assert len(lines) == 3
-        for p in paths:
-            assert p in lines
+        entries = load_entries(tmp_path)
+        assert [e["path"] for e in entries] == paths
 
     def test_missing_file_path_does_nothing(self, tmp_path, monkeypatch):
         """Read event with no file_path in tool_input should be no-op."""
         monkeypatch.chdir(tmp_path)
-        event = {
-            "tool_name": "Read",
-            "tool_input": {},
-        }
-        stdout, stderr, code = run_hook(event)
+        stdout, stderr, code = run_hook({"tool_name": "Read", "tool_input": {}})
         assert code == 0
+        assert load_entries(tmp_path) == []
 
     def test_empty_file_path_does_nothing(self, tmp_path, monkeypatch):
         """Read event with empty file_path should be no-op."""
         monkeypatch.chdir(tmp_path)
-        event = {
-            "tool_name": "Read",
-            "tool_input": {"file_path": ""},
-        }
-        stdout, stderr, code = run_hook(event)
+        stdout, stderr, code = run_hook({"tool_name": "Read", "tool_input": {"file_path": ""}})
         assert code == 0
+        assert load_entries(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Sensitive Path Filtering
+# ---------------------------------------------------------------------------
+
+
+class TestSensitivePathFiltering:
+    """Credential-shaped paths must never be recorded."""
+
+    def test_ssh_paths_never_recorded(self, tmp_path, monkeypatch):
+        """A .ssh public-key path is dropped (observed live: deploy key path
+        was recorded and later injected into subagent prompts)."""
+        monkeypatch.chdir(tmp_path)
+        run_hook(read_event("/home/user/.ssh/deploy_ed25519.pub"))
+        assert load_entries(tmp_path) == []
+
+    def test_env_and_key_files_never_recorded(self, tmp_path, monkeypatch):
+        """Env files and private keys are dropped; normal files kept."""
+        monkeypatch.chdir(tmp_path)
+        for p in ("/app/.env", "/app/.env.production", "/certs/server.pem", "/home/u/.aws/credentials"):
+            run_hook(read_event(p))
+        run_hook(read_event("/app/main.py"))
+        assert [e["path"] for e in load_entries(tmp_path)] == ["/app/main.py"]
+
+
+# ---------------------------------------------------------------------------
+# Session Scoping and Pruning
+# ---------------------------------------------------------------------------
+
+
+class TestSessionScopingAndPruning:
+    """Entries carry session ids; stale and legacy lines are pruned on write."""
+
+    def test_records_distinct_sessions(self, tmp_path, monkeypatch):
+        """Two sessions writing the same path both keep their entries."""
+        monkeypatch.chdir(tmp_path)
+        run_hook(read_event("/a.py", session="sess-1"))
+        run_hook(read_event("/a.py", session="sess-2"))
+        entries = load_entries(tmp_path)
+        assert {(e["session"], e["path"]) for e in entries} == {("sess-1", "/a.py"), ("sess-2", "/a.py")}
+
+    def test_legacy_plain_lines_are_pruned(self, tmp_path, monkeypatch):
+        """v1 plain-path lines (no session id) are dropped on the next write."""
+        monkeypatch.chdir(tmp_path)
+        reads_dir = tmp_path / ".claude"
+        reads_dir.mkdir()
+        (reads_dir / "session-reads.txt").write_text("/old/v1/path.py\n/another/v1.go\n")
+
+        run_hook(read_event("/new.py"))
+
+        entries = load_entries(tmp_path)
+        assert [e["path"] for e in entries] == ["/new.py"]
+
+    def test_entries_past_retention_are_pruned(self, tmp_path, monkeypatch):
+        """Entries older than RETENTION_DAYS are dropped on write."""
+        monkeypatch.chdir(tmp_path)
+        reads_dir = tmp_path / ".claude"
+        reads_dir.mkdir()
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=mod.RETENTION_DAYS + 1)).isoformat()
+        fresh_ts = datetime.now(timezone.utc).isoformat()
+        (reads_dir / "session-reads.txt").write_text(
+            json.dumps({"ts": old_ts, "session": "sess-0", "path": "/stale.py"})
+            + "\n"
+            + json.dumps({"ts": fresh_ts, "session": "sess-0", "path": "/fresh.py"})
+            + "\n"
+        )
+
+        run_hook(read_event("/new.py", session="sess-1"))
+
+        paths = [e["path"] for e in load_entries(tmp_path)]
+        assert "/stale.py" not in paths
+        assert paths == ["/fresh.py", "/new.py"]
 
 
 # ---------------------------------------------------------------------------
@@ -161,43 +219,22 @@ class TestFilePathTracking:
 
 
 class TestDeduplication:
-    """Same path should not appear twice in the session file."""
+    """Same (session, path) pair should not appear twice."""
 
     def test_duplicate_path_not_appended(self, tmp_path, monkeypatch):
-        """Reading the same file twice should only produce one entry."""
+        """Reading the same file twice in one session produces one entry."""
         monkeypatch.chdir(tmp_path)
-        reads_dir = tmp_path / ".claude"
-        reads_dir.mkdir()
-
-        event = {
-            "tool_name": "Read",
-            "tool_input": {"file_path": "/home/user/main.py"},
-        }
-        run_hook(event)
-        run_hook(event)
-
-        reads_file = reads_dir / "session-reads.txt"
-        content = reads_file.read_text()
-        lines = [line.strip() for line in content.splitlines() if line.strip()]
-        assert lines.count("/home/user/main.py") == 1
+        run_hook(read_event("/home/user/main.py"))
+        run_hook(read_event("/home/user/main.py"))
+        entries = load_entries(tmp_path)
+        assert [e["path"] for e in entries] == ["/home/user/main.py"]
 
     def test_different_paths_both_tracked(self, tmp_path, monkeypatch):
         """Different paths should both be recorded."""
         monkeypatch.chdir(tmp_path)
-        reads_dir = tmp_path / ".claude"
-        reads_dir.mkdir()
-
         for p in ["/a.py", "/b.py"]:
-            event = {
-                "tool_name": "Read",
-                "tool_input": {"file_path": p},
-            }
-            run_hook(event)
-
-        reads_file = reads_dir / "session-reads.txt"
-        content = reads_file.read_text()
-        lines = [line.strip() for line in content.splitlines() if line.strip()]
-        assert len(lines) == 2
+            run_hook(read_event(p))
+        assert len(load_entries(tmp_path)) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -213,11 +250,7 @@ class TestOutputFormat:
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".claude").mkdir()
 
-        event = {
-            "tool_name": "Read",
-            "tool_input": {"file_path": "/some/file.py"},
-        }
-        stdout, stderr, code = run_hook(event)
+        stdout, stderr, code = run_hook(read_event("/some/file.py"))
 
         assert code == 0
         if stdout.strip():
@@ -260,10 +293,9 @@ class TestNonBlocking:
 
     def test_exits_zero_on_missing_tool_input(self):
         """Event with no tool_input should still exit 0."""
-        event = {"tool_name": "Read"}
         result = subprocess.run(
             [sys.executable, str(HOOK_PATH)],
-            input=json.dumps(event),
+            input=json.dumps({"tool_name": "Read"}),
             capture_output=True,
             text=True,
             timeout=10,
@@ -273,9 +305,6 @@ class TestNonBlocking:
     def test_creates_claude_dir_if_missing(self, tmp_path, monkeypatch):
         """Hook should create .claude/ directory if it doesn't exist."""
         monkeypatch.chdir(tmp_path)
-        event = {
-            "tool_name": "Read",
-            "tool_input": {"file_path": "/some/file.py"},
-        }
-        stdout, stderr, code = run_hook(event)
+        stdout, stderr, code = run_hook(read_event("/some/file.py"))
         assert code == 0
+        assert (tmp_path / ".claude" / "session-reads.txt").exists()

--- a/hooks/tests/test_pretool_subagent_warmstart.py
+++ b/hooks/tests/test_pretool_subagent_warmstart.py
@@ -89,45 +89,93 @@ class TestToolNameFiltering:
 # ---------------------------------------------------------------------------
 
 
+def _jsonl(paths: list[str], session: str = "sess-1", ts: str | None = None) -> str:
+    """Build v2 JSONL session-reads content for the given paths."""
+    from datetime import datetime, timezone
+
+    stamp = ts or datetime.now(timezone.utc).isoformat()
+    return "".join(json.dumps({"ts": stamp, "session": session, "path": p}) + "\n" for p in paths)
+
+
 class TestLoadRecentReads:
-    """Test reading session-reads.txt."""
+    """Test reading the v2 JSONL session-reads format."""
 
     def test_missing_file_returns_empty(self, tmp_path):
         """Non-existent file returns empty list."""
-        result = load_recent_reads(tmp_path / "nonexistent.txt")
+        result = load_recent_reads(tmp_path / "nonexistent.txt", "sess-1")
         assert result == []
 
     def test_reads_file_paths(self, tmp_path):
-        """File with paths returns them as list."""
+        """File with current-session entries returns their paths."""
         reads_file = tmp_path / "session-reads.txt"
-        reads_file.write_text("/a.py\n/b.go\n/c.rs\n")
-        result = load_recent_reads(reads_file)
+        reads_file.write_text(_jsonl(["/a.py", "/b.go", "/c.rs"]))
+        result = load_recent_reads(reads_file, "sess-1")
         assert result == ["/a.py", "/b.go", "/c.rs"]
 
     def test_caps_at_max_count(self, tmp_path):
         """Only returns up to max_count most recent entries."""
         reads_file = tmp_path / "session-reads.txt"
-        paths = [f"/file{i}.py" for i in range(30)]
-        reads_file.write_text("\n".join(paths) + "\n")
-        result = load_recent_reads(reads_file, max_count=5)
-        assert len(result) == 5
-        # Should be the last 5 entries
+        reads_file.write_text(_jsonl([f"/file{i}.py" for i in range(30)]))
+        result = load_recent_reads(reads_file, "sess-1", max_count=5)
         assert result == [f"/file{i}.py" for i in range(25, 30)]
 
     def test_skips_empty_lines(self, tmp_path):
         """Empty lines in the file are ignored."""
         reads_file = tmp_path / "session-reads.txt"
-        reads_file.write_text("/a.py\n\n\n/b.py\n")
-        result = load_recent_reads(reads_file)
+        reads_file.write_text(_jsonl(["/a.py"]) + "\n\n" + _jsonl(["/b.py"]))
+        result = load_recent_reads(reads_file, "sess-1")
         assert result == ["/a.py", "/b.py"]
 
-    def test_default_max_is_20(self, tmp_path):
-        """Default max_count should be MAX_FILES_SHOWN (20)."""
+    def test_default_max_is_max_files_shown(self, tmp_path):
+        """Default max_count should be MAX_FILES_SHOWN."""
         reads_file = tmp_path / "session-reads.txt"
-        paths = [f"/file{i}.py" for i in range(25)]
-        reads_file.write_text("\n".join(paths) + "\n")
-        result = load_recent_reads(reads_file)
+        reads_file.write_text(_jsonl([f"/file{i}.py" for i in range(25)]))
+        result = load_recent_reads(reads_file, "sess-1")
         assert len(result) == MAX_FILES_SHOWN
+
+    def test_other_session_entries_excluded(self, tmp_path):
+        """Entries from a different session never leak into warmstart.
+
+        Regression: a fresh repo-audit session received a previous session's
+        file list (and task description) on every dispatch.
+        """
+        reads_file = tmp_path / "session-reads.txt"
+        reads_file.write_text(_jsonl(["/old-task/a.py"], session="sess-OLD") + _jsonl(["/current/b.py"]))
+        assert load_recent_reads(reads_file, "sess-1") == ["/current/b.py"]
+
+    def test_stale_entries_excluded(self, tmp_path):
+        """Same-session entries older than the freshness window are excluded."""
+        from datetime import datetime, timedelta, timezone
+
+        old_ts = (datetime.now(timezone.utc) - timedelta(hours=mod.FRESHNESS_HOURS + 1)).isoformat()
+        reads_file = tmp_path / "session-reads.txt"
+        reads_file.write_text(_jsonl(["/stale.py"], ts=old_ts) + _jsonl(["/fresh.py"]))
+        assert load_recent_reads(reads_file, "sess-1") == ["/fresh.py"]
+
+    def test_legacy_v1_plain_lines_ignored(self, tmp_path):
+        """v1 plain-path lines carry no session id and are never injected."""
+        reads_file = tmp_path / "session-reads.txt"
+        reads_file.write_text("/v1/legacy.py\n" + _jsonl(["/v2/current.py"]))
+        assert load_recent_reads(reads_file, "sess-1") == ["/v2/current.py"]
+
+    def test_sensitive_paths_filtered(self, tmp_path):
+        """Credential-shaped paths are dropped even if present in the file.
+
+        Regression: a .ssh public-key path was surfaced in the injected
+        'files seen' list.
+        """
+        reads_file = tmp_path / "session-reads.txt"
+        reads_file.write_text(
+            _jsonl(
+                [
+                    "/home/u/.ssh/deploy_ed25519.pub",
+                    "/app/.env",
+                    "/certs/tls.key",
+                    "/app/main.py",
+                ]
+            )
+        )
+        assert load_recent_reads(reads_file, "sess-1") == ["/app/main.py"]
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +222,22 @@ class TestExtractTaskPlan:
         result = extract_task_plan(plan)
         assert result["goal"] == ""
         assert "Phase 3" in result["status"]
+
+    def test_stale_plan_excluded(self, tmp_path):
+        """A task_plan.md older than the freshness window is not injected.
+
+        Regression: a stale plan goal from a finished task was injected into
+        every dispatch of an unrelated later session.
+        """
+        import os
+        import time
+
+        plan = tmp_path / "task_plan.md"
+        plan.write_text("# Task Plan\n\n## Goal\nOld unrelated task\n")
+        old = time.time() - (mod.FRESHNESS_HOURS + 1) * 3600
+        os.utime(plan, (old, old))
+        assert extract_task_plan(plan) == {"goal": "", "status": ""}
+        assert extract_decisions(plan) == []
 
 
 # ---------------------------------------------------------------------------
@@ -263,6 +327,17 @@ class TestLoadAdrSession:
         result = load_adr_session(session_file)
         assert result["adr_path"] == ""
         assert result["domain"] == ""
+
+    def test_stale_adr_session_excluded(self, tmp_path):
+        """An .adr-session.json older than the freshness window is not injected."""
+        import os
+        import time
+
+        session_file = tmp_path / ".adr-session.json"
+        session_file.write_text(json.dumps({"adr_path": "adr/old.md", "domain": "hooks"}))
+        old = time.time() - (mod.FRESHNESS_HOURS + 1) * 3600
+        os.utime(session_file, (old, old))
+        assert load_adr_session(session_file) == {"adr_path": "", "domain": ""}
 
 
 # ---------------------------------------------------------------------------
@@ -503,12 +578,12 @@ class TestGracefulDegradation:
         """Some context files present, some missing."""
         monkeypatch.chdir(tmp_path)
 
-        # Only create session-reads.txt
+        # Only create session-reads.txt (v2 format, current session)
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()
-        (claude_dir / "session-reads.txt").write_text("/a.py\n/b.go\n")
+        (claude_dir / "session-reads.txt").write_text(_jsonl(["/a.py", "/b.go"], session="sess-e2e"))
 
-        event = {"tool_name": "Agent", "tool_input": {"prompt": "do work"}}
+        event = {"tool_name": "Agent", "session_id": "sess-e2e", "tool_input": {"prompt": "do work"}}
         stdout, stderr, code = run_hook(event)
 
         assert code == 0
@@ -517,6 +592,21 @@ class TestGracefulDegradation:
         assert "[warmstart] Files seen (2):" in context
         # No task plan or ADR sections since those files don't exist
         assert "[warmstart] ADR session:" not in context
+
+    def test_other_session_reads_not_injected_end_to_end(self, tmp_path, monkeypatch):
+        """A dispatch in a new session sees none of the old session's files."""
+        monkeypatch.chdir(tmp_path)
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "session-reads.txt").write_text(_jsonl(["/old/a.py", "/old/b.py"], session="sess-OLD"))
+
+        event = {"tool_name": "Agent", "session_id": "sess-NEW", "tool_input": {"prompt": "audit repo"}}
+        stdout, stderr, code = run_hook(event)
+
+        assert code == 0
+        context = json.loads(stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "[warmstart] Files seen (0): none" in context
+        assert "/old/a.py" not in context
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Bind subagent warmstart context to the current session and keep credential paths out of it. Observed live: a fresh session's dispatches carried a previous session's task description, a stale ADR pointer, and a `.ssh` public-key path in the "files seen" list — because `session-reads.txt` was a shared cross-session accumulator (2,639 lines on this machine) and `task_plan.md` / `.adr-session.json` were injected regardless of age.

## Changes
- `hooks/posttool-session-reads.py` (v2.0.0) — record `{ts, session, path}` JSONL instead of bare paths; never record credential-shaped paths; prune entries older than 7 days and v1 legacy lines on every write (atomic replace)
- `hooks/pretool-subagent-warmstart.py` (v2.0.0) — files-seen limited to the current `session_id` within a 24h window, credential paths filtered again on read; `task_plan.md`, `.adr-session.json`, and discovery briefs only injected when modified within 24h
- `hooks/lib/hook_utils.py` — new shared `is_sensitive_path()` (segment-match on `.ssh`/`.gnupg`/`.aws`/`.kube`/..., basename match on `.env*`, `*.pem`, `*.key`, `id_*`, `*credentials*`, `*secret*`, `token.json`, ...)
- `hooks/tests/` — session-reads and warmstart suites updated to the v2 format plus regressions: cross-session exclusion, stale-entry expiry, legacy-line pruning, sensitive-path filtering (writer and reader), stale plan/ADR mtime exclusion; `is_sensitive_path` unit tests

## Notes
- Session-scoping was feasible (hook events carry `session_id`; `get_session_id()` is the fallback), so the hook stays enabled — no disable needed.
- Old accumulated v1 files self-heal: the reader ignores legacy lines immediately and the writer prunes them on the next read event.
- Verified empirically: with a seeded stale reads file (including the observed `.ssh` deploy-key path) and a 3-day-old `task_plan.md` carrying the exact stale goal from the audit, the old hook injects all of it into a fresh-session dispatch; the new hook injects "Files seen (0): none" and no plan line, while same-session entries still inject (covered by tests).
