### PR TITLE
feat(do): make Opus 5 the default Anthropic lane selection

### DIFF
--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -344,19 +344,19 @@ The biggest risk: rationalization. "Already done" (assumption). "Code looks corr
 
 Owner model-selection policy (ADR `model-selection-policy`; operational table in `skills/meta/do/SKILL.md`, Model Selection):
 
-**Harness-native routing:** each harness defaults to its own provider's model lane. Cross-provider dispatch is manual-only, never automatic. Start low, escalate on miss — high tiers cost 3-6x per Pass@1 point. Plan budget ($200/month per provider) makes cost a first-class constraint. Two decision axes: DeepSWE Pass@1 (agentic completion) + owner-observed felt quality (fable > sol noticeable, opus > gpt-5.5 marginal); ties resolve in favor of felt quality.
+**Harness-native routing:** each harness defaults to its own provider's model lane. Cross-provider dispatch is manual-only, never automatic. Start low, escalate on miss — high tiers cost 3-6x per Pass@1 point where measured. Plan budget ($200/month per provider) makes cost a first-class constraint. Three decision axes: the current session model (the harness runs Opus 5, the owner-directed Anthropic-lane default at every task class), DeepSWE Pass@1 (agentic completion) where a model has been measured, and owner-observed felt quality (fable > sol noticeable, opus > gpt-5.5 marginal); ties resolve in favor of felt quality.
 
 | Task class | Anthropic lane (Claude Code) | OpenAI lane (Codex CLI) |
 |---|---|---|
 | Deterministic | Scripts — no LLM dispatch | Scripts — no LLM dispatch |
-| Low-risk | `fable` / `low` (60 P@1 / $3.76) | `gpt-5.6-terra` / `high` (54 P@1 / $1.13) |
-| Standard | `fable` / `medium` (65 / $6.09) | `gpt-5.6-sol` / `high` (69 / $3.47) |
-| High-risk | `fable` / `high` (69 / $9.18) | `gpt-5.6-sol` / `xhigh` (71 / $4.70) |
-| Max-power | `fable` / `xhigh` (70 / $13.41) | `gpt-5.6-sol` / `max` (73 / $8.39) |
+| Low-risk | `opus` / `low` (Opus 5, unmeasured) | `gpt-5.6-terra` / `high` (54 P@1 / $1.13) |
+| Standard | `opus` / `medium` (unmeasured) | `gpt-5.6-sol` / `high` (69 / $3.47) |
+| High-risk | `opus` / `high` (unmeasured) | `gpt-5.6-sol` / `xhigh` (71 / $4.70) |
+| Max-power | `opus` / `xhigh` (unmeasured) | `gpt-5.6-sol` / `max` (73 / $8.39) |
 
-The `/do` table is canonical and records the full DeepSWE Pass@1 / cost / tokens / steps data. Max-power requires `manual_model_override=true` in both lanes. Opus/sonnet are manual-only (dominated by fable). Legacy `gpt-5.5` and non-default GPT-5.6 points are manual-only. Haiku is retired (routing was Haiku pre-#777; self-route since — `scripts/routing-ab-results/self-route-v1/VERDICT.md`). Defaults, not limits: escalate when cheaper output misses the bar; for anything that ships, intelligence > taste > cost, with cost a tie-breaker only. Fan-out uses the lane's low-risk point; one synthesis agent may run one tier higher.
+The `/do` table is canonical and records the full DeepSWE Pass@1 / cost / tokens / steps data, including the prior Fable-5 / Opus-4.8 / Sonnet-5 measurements kept for manual picks. Opus 5 has no DeepSWE run yet, so its pts/USD is uncomputable and the selection rests on the session-model and owner-directive axes; effort still follows start-low-escalate-on-miss. Max-power requires `manual_model_override=true` in both lanes. Fable/sonnet are manual-only. Legacy `gpt-5.5` and non-default GPT-5.6 points are manual-only. Haiku is retired (routing was Haiku pre-#777; self-route since — `scripts/routing-ab-results/self-route-v1/VERDICT.md`). Defaults, not limits: escalate when cheaper output misses the bar; for anything that ships, intelligence > taste > cost, with cost a tie-breaker only. Fan-out uses the lane's low-risk point; one synthesis agent may run one tier higher.
 
-**Coordinator model.** The main-thread coordinator routes and evaluates, never executes — its cost is input-dominated and Pass@1 measures execution it never does. Anthropic harness → sonnet; OpenAI harness → gpt-5.6-terra/high; escalate to opus only on observed misroutes, set via harness config (`/model`), not per-turn. Full rule: `skills/meta/do/SKILL.md`, Model Selection.
+**Coordinator model.** The main-thread coordinator routes and evaluates, never executes — its cost is input-dominated and Pass@1 measures execution it never does. Anthropic harness → opus (Opus 5, the session model); OpenAI harness → gpt-5.6-terra/high; downgrade the anthropic coordinator to sonnet only as a deliberate plan-limit measure, set via harness config (`/model`), not per-turn. Full rule: `skills/meta/do/SKILL.md`, Model Selection.
 
 **Token costs are not fungible.** One Opus token costs ~30x one Haiku token. Optimization targets the expensive model, not the cheap one. "Saves Haiku calls" is never a valid justification. Pre-routing's value is determinism (regex can't misroute). Phase gates' value is preventing Opus rework.
 

--- a/scripts/build-dispatch.py
+++ b/scripts/build-dispatch.py
@@ -136,11 +136,15 @@ OPENAI_AUTO_POLICIES = {
     "high-risk": ("gpt-5.6-sol", "xhigh"),  # 71 / $4.70
     "max-power": ("gpt-5.6-sol", "max"),  # 73 / $8.39, explicit only
 }
+# Anthropic lane: Opus 5 is the owner-directed default at every task class
+# (it is the model the harness runs). It has no DeepSWE run yet, so these
+# points carry no Pass@1/cost annotation — effort still follows
+# start-low-escalate-on-miss.
 ANTHROPIC_AUTO_POLICIES = {
-    "low-risk": ("fable", "low"),  # 60 / $3.76
-    "standard": ("fable", "medium"),  # 65 / $6.09
-    "high-risk": ("fable", "high"),  # 69 / $9.18
-    "max-power": ("fable", "xhigh"),  # 70 / $13.41, explicit only
+    "low-risk": ("opus", "low"),
+    "standard": ("opus", "medium"),
+    "high-risk": ("opus", "high"),
+    "max-power": ("opus", "xhigh"),  # explicit only
 }
 AUTO_POLICIES_BY_PROVIDER = {
     "anthropic": ANTHROPIC_AUTO_POLICIES,
@@ -215,9 +219,9 @@ def resolve_model_selection(decision: dict, provider: str = "anthropic") -> tupl
     """Return the validated ``(model, effort)`` for one dispatch decision.
 
     Harness-aware: ``provider`` selects the automatic policy table.
-    Anthropic lane defaults select fable at benchmark-backed effort points;
-    opus/sonnet and fable/max are manual-only (dominated points kept for
-    context-window and latency constraints the benchmark does not measure).
+    Anthropic lane defaults select Opus 5 at every task class (owner
+    directive + current session model); fable and sonnet are manual-only,
+    kept for felt-quality, context-window, and latency constraints.
     OpenAI lane defaults select GPT-5.6 Sol/Terra.  Effort is recorded in
     the marker for all models; for Claude lanes it is advisory (the harness
     Agent tool does not accept per-call effort).
@@ -285,16 +289,14 @@ def resolve_model_selection(decision: dict, provider: str = "anthropic") -> tupl
     # Claude models (fable, opus, sonnet) and codex wrapper.
     # Effort is optional and advisory for Claude lanes — recorded in the
     # marker (model@effort) for telemetry but not passed to the Agent tool.
-    if model in ("opus", "sonnet"):
+    if model in ("fable", "sonnet"):
         if not manual:
             raise InputError(
                 f"'{model}' requires manual_model_override=true "
-                "(dominated by fable in DeepSWE benchmarks; kept for context-window/latency constraints)"
+                "(Opus 5 is the Anthropic-lane default; off-policy picks stay explicit)"
             )
-    if model == "fable" and effort == "max" and not manual:
-        raise InputError(
-            "fable/max requires manual_model_override=true (dominated by fable/xhigh: same Pass@1, higher cost)"
-        )
+    if model == "opus" and effort == "max" and not manual:
+        raise InputError("opus/max requires manual_model_override=true (unmeasured top tier; escalate on a miss)")
     return model, effort
 
 

--- a/scripts/tests/test_build_dispatch.py
+++ b/scripts/tests/test_build_dispatch.py
@@ -49,7 +49,7 @@ def _decision(**overrides):
         "agent": "python-general-engineer",
         "skill": "test-driven-development",
         "complexity": "medium",
-        "model": "fable",
+        "model": "opus",
         "health": {"confidence": 0.72, "n": 6, "failure": 0, "action": "keep"},
         "stack": ["verification-before-completion"],
         "task_spec": {
@@ -109,7 +109,7 @@ ROUND_TRIP_CASES = [
             "agent": "python-general-engineer",
             "skill": "test-driven-development",
             "complexity": "medium",
-            "model": "fable",
+            "model": "opus",
             "health": None,
             "n": None,
             "failure": None,
@@ -126,7 +126,7 @@ ROUND_TRIP_CASES = [
             "agent": "python-general-engineer",
             "skill": "",
             "complexity": "medium",
-            "model": "fable",
+            "model": "opus",
             "health": None,
             "gate_inputs_present": True,
             "stack": None,
@@ -139,7 +139,7 @@ ROUND_TRIP_CASES = [
             "agent": "python-general-engineer",
             "skill": "test-driven-development",
             "complexity": "medium",
-            "model": "fable",
+            "model": "opus",
             "health": 0.5,
             "n": None,
             "failure": None,
@@ -169,7 +169,7 @@ ROUND_TRIP_CASES = [
             "agent": "python-general-engineer",
             "skill": "test-driven-development",
             "complexity": "medium",
-            "model": "fable",
+            "model": "opus",
             "health": 1.0,
             "n": 12,
             "failure": 0,
@@ -261,7 +261,7 @@ def test_marker_is_first_line_at_line_start():
 def test_preamble_contains_every_mandatory_block_in_order():
     preamble = bd.build_preamble(_decision(complexity="complex"))
     ordered = [
-        "[do-route] agent=python-general-engineer skill=test-driven-development complexity=complex model=fable",
+        "[do-route] agent=python-general-engineer skill=test-driven-development complexity=complex model=opus",
         bd.THINKING_SLOW,
         "~480000 tokens available for this task; prioritize accordingly.",
         "## Task Specification (auto-extracted)",
@@ -319,9 +319,9 @@ def test_thinking_directive_by_complexity_and_override(complexity, override, exp
 
 
 def test_missing_optional_fields_omit_their_blocks_only():
-    minimal = {"agent": "claude", "complexity": "medium", "model": "fable"}
+    minimal = {"agent": "claude", "complexity": "medium", "model": "opus"}
     preamble = bd.build_preamble(minimal)
-    assert preamble.startswith("[do-route] agent=claude skill=- complexity=medium model=fable health=-\n")
+    assert preamble.startswith("[do-route] agent=claude skill=- complexity=medium model=opus health=-\n")
     assert "## Task Specification" not in preamble
     assert "stack={" not in preamble
     # Mandatory blocks survive the minimal input.
@@ -495,7 +495,7 @@ def test_exceptional_max_power_requires_explicit_override():
     marker = bd.build_marker(
         _decision(model=None, model_policy="max-power", manual_model_override=True, provider="anthropic")
     )
-    assert "model=fable" in marker
+    assert "model=opus" in marker
     assert "effort=xhigh" in marker
 
 
@@ -554,11 +554,11 @@ SUPPLIED_CLAUDE_POINTS = {
     ("fable", "high"): (69, 9.18, 57_000, 59),
     ("fable", "medium"): (65, 6.09, 40_000, 48),
     ("fable", "low"): (60, 3.76, 25_000, 38),
-    ("opus", "max"): (59, 13.22, 135_000, 120),
-    ("opus", "xhigh"): (54, 8.01, 86_000, 95),
-    ("opus", "high"): (52, 4.28, 50_000, 73),
-    ("opus", "medium"): (49, 3.44, 41_000, 66),
-    ("opus", "low"): (41, 2.29, 29_000, 54),
+    ("opus-4.8", "max"): (59, 13.22, 135_000, 120),
+    ("opus-4.8", "xhigh"): (54, 8.01, 86_000, 95),
+    ("opus-4.8", "high"): (52, 4.28, 50_000, 73),
+    ("opus-4.8", "medium"): (49, 3.44, 41_000, 66),
+    ("opus-4.8", "low"): (41, 2.29, 29_000, 54),
     ("sonnet", "max"): (54, 26.40, 214_000, 268),
     ("sonnet", "xhigh"): (50, 11.89, 121_000, 186),
     ("sonnet", "high"): (48, 7.43, 87_000, 147),
@@ -571,13 +571,13 @@ SUPPLIED_CLAUDE_POINTS = {
 @pytest.mark.parametrize(
     ("task_class", "model", "effort"),
     [
-        ("low-risk", "fable", "low"),
-        ("standard", "fable", "medium"),
-        ("high-risk", "fable", "high"),
+        ("low-risk", "opus", "low"),
+        ("standard", "opus", "medium"),
+        ("high-risk", "opus", "high"),
     ],
 )
-def test_anthropic_policy_selects_the_automatic_pareto_defaults(task_class, model, effort):
-    """Anthropic automatic task classes select fable at benchmark-backed effort points."""
+def test_anthropic_policy_selects_opus_at_every_task_class(task_class, model, effort):
+    """Anthropic automatic task classes select Opus 5, effort rising with risk class."""
     decision = _decision(model=None, model_policy=task_class, provider="anthropic")
     marker = bd.build_marker(decision)
 
@@ -587,45 +587,42 @@ def test_anthropic_policy_selects_the_automatic_pareto_defaults(task_class, mode
     assert recorder.parse_model_effort(marker) == effort
 
 
-def test_anthropic_policy_points_are_not_dominated_on_supplied_metrics():
-    """Anthropic automatic choices are non-dominated within the Anthropic lane."""
-    for policy, point in bd.ANTHROPIC_AUTO_POLICIES.items():
-        assert point in SUPPLIED_CLAUDE_POINTS, f"{policy} is not in the supplied benchmark"
-        target = SUPPLIED_CLAUDE_POINTS[point]
-        assert not any(_dominates(candidate, target) for candidate in SUPPLIED_CLAUDE_POINTS.values()), (
-            f"{policy} selects dominated point {point}"
-        )
+def test_anthropic_policy_points_are_unmeasured_and_effort_rises_with_risk():
+    """Opus 5 carries no DeepSWE point; the policy is grounded on effort ordering."""
+    order = ["low", "medium", "high", "xhigh", "max"]
+    previous = -1
+    for policy in ("low-risk", "standard", "high-risk", "max-power"):
+        model, effort = bd.ANTHROPIC_AUTO_POLICIES[policy]
+        assert model == "opus", f"{policy} selects {model}, not the Opus 5 default"
+        assert (model, effort) not in SUPPLIED_CLAUDE_POINTS, f"{policy} claims a benchmark point Opus 5 does not have"
+        assert order.index(effort) > previous, f"{policy} breaks the start-low effort ordering"
+        previous = order.index(effort)
 
 
-def test_fable_max_dominated_by_xhigh():
-    """fable[max] same Pass@1 as fable[xhigh] at higher cost — manual-only."""
+def test_fable_max_still_costs_more_than_fable_xhigh():
+    """Recorded prior measurement: fable[max] matches fable[xhigh] Pass@1 at higher cost."""
     fmax = SUPPLIED_CLAUDE_POINTS[("fable", "max")]
     fxhigh = SUPPLIED_CLAUDE_POINTS[("fable", "xhigh")]
     assert fmax[0] == fxhigh[0], "precondition: same Pass@1"
     assert fmax[1] > fxhigh[1], "precondition: max costs more"
+
+
+def test_opus_max_requires_manual_override():
+    """The unmeasured top tier stays an explicit escalation."""
     with pytest.raises(bd.InputError, match="manual_model_override"):
-        bd.build_marker(_decision(model="fable", model_effort="max"))
+        bd.build_marker(_decision(model="opus", model_effort="max"))
 
 
-def test_opus_dominated_by_fable():
-    """opus[max] 59% vs fable[low] 60% — every opus point is dominated."""
-    fable_low = SUPPLIED_CLAUDE_POINTS[("fable", "low")]
-    opus_max = SUPPLIED_CLAUDE_POINTS[("opus", "max")]
-    assert _dominates(fable_low, opus_max), "precondition: fable[low] dominates opus[max]"
+def test_prior_measurements_retained_for_manual_picks():
+    """Historical Fable-5 / Opus-4.8 / Sonnet-5 points stay recorded, not deleted."""
+    assert SUPPLIED_CLAUDE_POINTS[("fable", "low")] == (60, 3.76, 25_000, 38)
+    assert SUPPLIED_CLAUDE_POINTS[("opus-4.8", "max")] == (59, 13.22, 135_000, 120)
+    assert SUPPLIED_CLAUDE_POINTS[("sonnet", "high")] == (48, 7.43, 87_000, 147)
 
 
-def test_sonnet_dominated_by_opus():
-    """sonnet-5 is dominated by opus at comparable tiers."""
-    opus_low = SUPPLIED_CLAUDE_POINTS[("opus", "low")]
-    sonnet_high = SUPPLIED_CLAUDE_POINTS[("sonnet", "high")]
-    # opus[low] 41/$2.29 vs sonnet[high] 48/$7.43 — opus loses on Pass@1 but
-    # the entire sonnet range is dominated by fable, making it manual-only.
-    assert sonnet_high[1] > opus_low[1], "precondition: sonnet[high] costs more than opus[low]"
-
-
-@pytest.mark.parametrize("model", ("opus", "sonnet"))
-def test_dominated_claude_models_require_manual_override(model):
-    """opus and sonnet are dominated by fable — manual-only."""
+@pytest.mark.parametrize("model", ("fable", "sonnet"))
+def test_off_policy_claude_models_require_manual_override(model):
+    """Opus 5 is the default; fable and sonnet are the manual-only picks."""
     with pytest.raises(bd.InputError, match="manual_model_override"):
         bd.build_marker(_decision(model=model))
     # With manual_override they work fine
@@ -634,11 +631,11 @@ def test_dominated_claude_models_require_manual_override(model):
 
 
 def test_claude_model_effort_round_trip():
-    """Claude model@effort (fable@high) parses and persists in the marker."""
-    marker = bd.build_marker(_decision(model="fable", model_effort="high"))
-    assert "model=fable" in marker
+    """Claude model@effort (opus@high) parses and persists in the marker."""
+    marker = bd.build_marker(_decision(model="opus", model_effort="high"))
+    assert "model=opus" in marker
     assert "effort=high" in marker
-    assert recorder.parse_model(marker) == "fable"
+    assert recorder.parse_model(marker) == "opus"
     assert recorder.parse_model_effort(marker) == "high"
 
 
@@ -646,8 +643,8 @@ def test_provider_absent_defaults_to_anthropic():
     """Missing provider field defaults to 'anthropic' (Claude Code is primary)."""
     decision = _decision(model=None, model_policy="standard")
     marker = bd.build_marker(decision)
-    # Should resolve via Anthropic table: fable/medium
-    assert "model=fable" in marker
+    # Should resolve via Anthropic table: opus/medium
+    assert "model=opus" in marker
     assert "effort=medium" in marker
 
 

--- a/skills/meta/codex/SKILL.md
+++ b/skills/meta/codex/SKILL.md
@@ -23,7 +23,7 @@ routing:
 
 Run a benchmark-selected GPT-5.6 task through the Codex CLI (`codex exec`) and return the result. This is the OpenAI execution lane — the general-purpose lane for work the model-selection policy sends to GPT-5.6, and the **canonical owner of general `codex exec` mechanics** — when the CLI changes, update here first. GPT selections are reachable only through this CLI; the Agent tool's `model` parameter covers Claude models only.
 
-**Under Claude Code, this skill runs only on explicit invocation or cross-provider escalation, never as the automatic default.** The harness-native model lane under Claude Code is the Anthropic lane (fable). This skill is a deliberate cross-provider tool — codex review as a second-opinion, codex exec for a GPT-specific constraint — not a routing default.
+**Under Claude Code, this skill runs only on explicit invocation or cross-provider escalation, never as the automatic default.** The harness-native model lane under Claude Code is the Anthropic lane (Opus 5). This skill is a deliberate cross-provider tool — codex review as a second-opinion, codex exec for a GPT-specific constraint — not a routing default.
 
 Two flows keep their own specialized codex integration — route to them instead of re-implementing here:
 

--- a/skills/meta/do/SKILL.md
+++ b/skills/meta/do/SKILL.md
@@ -238,27 +238,32 @@ python3 "$SDIR/build-dispatch.py" --json '{
 
 **Harness-native routing.** The SDIR probe (Phase 2 pre-route) identifies the harness: `~/.claude` → provider `anthropic`, `~/.codex` → provider `openai`, `~/.hermes`/`.factory`/`.reasonix` → provider `other`. Default when absent: `anthropic` (Claude Code is primary). Each provider lane has its own automatic policy table; cross-provider dispatch is manual-only (explicit tool invocation, never a silent default).
 
-Run deterministic work with scripts, not an LLM. Two decision axes: (1) DeepSWE Pass@1 / cost / tokens / steps — agentic task completion rate, the quantitative source. (2) Owner-observed felt quality — fable > sol (noticeable gap despite similar Pass@1), opus > gpt-5.5 (marginal). Benchmark ties or near-ties resolve in favor of felt quality. Cells: `Pass@1 / cost / output tokens / steps`; cost = avg USD per task, written as a plain number — slash-command templating substitutes dollar-digit positional parameters in this injected body, so a literal dollar sign before a digit corrupts on every argful invocation. Higher Pass@1 better, other three lower-is-better.
+Run deterministic work with scripts, not an LLM. Three decision axes: (1) the current session model — the harness runs Opus 5, and the owner directs Opus 5 as the Anthropic-lane default for every task class. (2) DeepSWE Pass@1 / cost / tokens / steps — agentic task completion rate, the quantitative source for models that have been measured. (3) Owner-observed felt quality — fable > sol (noticeable gap despite similar Pass@1), opus > gpt-5.5 (marginal). Benchmark ties or near-ties resolve in favor of felt quality. Cells: `Pass@1 / cost / output tokens / steps`; cost = avg USD per task, written as a plain number — slash-command templating substitutes dollar-digit positional parameters in this injected body, so a literal dollar sign before a digit corrupts on every argful invocation. Higher Pass@1 better, other three lower-is-better. Opus 5 has no DeepSWE run yet, so its cells read `n/a — not yet benchmarked` and its pts/USD cannot be computed until it is measured; it is selected on the session-model and owner-directive grounds above, not on a benchmark figure.
 
-**Start low, escalate on miss.** Task-class tables are ceilings by risk class, not starting points. Default = lowest tier whose risk class matches; escalate one tier only when output misses the acceptance bar. High tiers cost 3-6x per Pass@1 point (see pts/$ column) — pre-paying for xhigh/max "to be safe" wastes the 200 USD/month plan budget. Fan-out rule: parallel readers use the lane's low-risk point; one synthesis agent may run one tier higher. User-facing output (docs, prose, reviews the owner reads, design) leans fable even at standard tier; bulk/mechanical/parse-heavy work is where the OpenAI lane's cheaper points earn their keep (under Codex harness or explicit cross-provider call).
+**Start low, escalate on miss.** Task-class tables are ceilings by risk class, not starting points. Default = lowest tier whose risk class matches; escalate one tier only when output misses the acceptance bar. High tiers cost 3-6x per Pass@1 point where measured (see the OpenAI lane's pts/$ column; the Anthropic lane's is pending an Opus 5 benchmark) — pre-paying for xhigh/max "to be safe" wastes the 200 USD/month plan budget. Fan-out rule: parallel readers use the lane's low-risk point; one synthesis agent may run one tier higher. User-facing output (docs, prose, reviews the owner reads, design) leans opus one tier up from the task class; bulk/mechanical/parse-heavy work is where the OpenAI lane's cheaper points earn their keep (under Codex harness or explicit cross-provider call).
 
 **Anthropic lane** (automatic under Claude Code). Effort is advisory — recorded in marker as model@effort for telemetry; the Agent tool has no per-call effort parameter.
 
+Current default: **Opus 5** (`opus`) at every task class. It is the model this session runs and the owner's directed default; it replaced fable across the lane on 2026-07-24.
+
 | Variant | max | xhigh | high | medium | low |
 |---|---|---|---|---|---|
-| Fable-5 | 70 / 21.63 / 119k / 88 | 70 / 13.41 / 80k / 68 | 69 / 9.18 / 57k / 59 | 65 / 6.09 / 40k / 48 | 60 / 3.76 / 25k / 38 |
-| Opus-4.8 | 59 / 13.22 / 135k / 120 | 54 / 8.01 / 86k / 95 | 52 / 4.28 / 50k / 73 | 49 / 3.44 / 41k / 66 | 41 / 2.29 / 29k / 54 |
-| Sonnet-5 | 54 / 26.40 / 214k / 268 | 50 / 11.89 / 121k / 186 | 48 / 7.43 / 87k / 147 | 40 / 4.08 / 57k / 108 | 31 / 2.19 / 36k / 77 |
+| Opus-5 (current default, unmeasured) | n/a — not yet benchmarked | n/a — not yet benchmarked | n/a — not yet benchmarked | n/a — not yet benchmarked | n/a — not yet benchmarked |
+| Fable-5 (prior measurement) | 70 / 21.63 / 119k / 88 | 70 / 13.41 / 80k / 68 | 69 / 9.18 / 57k / 59 | 65 / 6.09 / 40k / 48 | 60 / 3.76 / 25k / 38 |
+| Opus-4.8 (prior measurement) | 59 / 13.22 / 135k / 120 | 54 / 8.01 / 86k / 95 | 52 / 4.28 / 50k / 73 | 49 / 3.44 / 41k / 66 | 41 / 2.29 / 29k / 54 |
+| Sonnet-5 (prior measurement) | 54 / 26.40 / 214k / 268 | 50 / 11.89 / 121k / 186 | 48 / 7.43 / 87k / 147 | 40 / 4.08 / 57k / 108 | 31 / 2.19 / 36k / 77 |
+
+The Fable-5 / Opus-4.8 / Sonnet-5 rows are recorded DeepSWE measurements from the 2026-07-09 policy, kept as history for manual picks. Opus 5 has no DeepSWE run, so every cell reads `n/a — not yet benchmarked` and its pts/USD stays uncomputable until it is measured.
 
 | Task class | Selection | pts/$ | Why |
 |---|---|---|---|
 | deterministic | no LLM | — | Run the script directly. |
-| low-risk | `fable` / `low` | 16.0 | 60 Pass@1 at 3.76, 25k tokens, 38 steps. |
-| standard | `fable` / `medium` | 10.7 | 65 Pass@1 at 6.09, 40k tokens, 48 steps. |
-| high-risk | `fable` / `high` | 7.5 | 69 Pass@1 at 9.18, 57k tokens, 59 steps. |
-| max-power | `fable` / `xhigh` | 5.2 | 70 Pass@1 at 13.41, 80k tokens, 68 steps; `manual_model_override=true`; state justification in task_spec intent. |
+| low-risk | `opus` / `low` | n/a | Current session model, owner-directed default; effort floor per start-low. |
+| standard | `opus` / `medium` | n/a | Current session model, owner-directed default; one tier up for standard work. |
+| high-risk | `opus` / `high` | n/a | Current session model, owner-directed default; high effort for risk-bearing work. |
+| max-power | `opus` / `xhigh` | n/a | Current session model, owner-directed default; `manual_model_override=true`; state justification in task_spec intent. |
 
-Fable[max] dominated by [xhigh] (same Pass@1, higher cost) — manual-only. Opus dominated by fable at every tier (opus[max] 59/13.22 vs fable[low] 60/3.76). Sonnet-5 dominated by opus. All opus/sonnet points → `manual_model_override=true`, kept for context-window, latency, and fan-out breadth constraints the benchmark does not measure. Haiku is retired.
+Effort selection still follows **start low, escalate on miss** — the effort column is a ceiling by risk class, and a miss against the acceptance bar is what buys the next tier. Opus 5 at `max` stays manual-only pending measurement. Fable-5, Sonnet-5, and Opus-4.8 points are now the manual-only ones: they need `manual_model_override=true` plus `model_effort`, and stay available for felt-quality escalation (fable), context-window, latency, and fan-out breadth constraints the benchmark does not measure. Haiku is retired.
 
 **OpenAI lane** (automatic under Codex CLI).
 
@@ -281,9 +286,9 @@ All GPT-5.5 choices are manual-only. Off-policy GPT-5.6 points (Sol medium/low, 
 
 **Other harnesses** (provider=`other`): `model_policy` is unavailable — choose the highest non-dominated Pass@1 point among models the harness exposes, applying the same start-low-escalate-on-miss discipline. Set model explicitly.
 
-**Cross-provider escalation** — manual only, never automatic. Escalating anthropic → sol is a cost/limits lever or independent-second-opinion lever, not a quality upgrade (fable wins on felt quality at comparable Pass@1). Under Claude Code, codex-wrapper dispatches (`codex` skill, pr-workflow codex second-opinion review) remain valid as EXPLICIT tools — deliberate cross-provider calls, not defaults. Escalation targets: anthropic max-power miss → sol/xhigh or sol/max (second opinion, cheaper per point); openai max-power miss → fable/xhigh (quality upgrade on felt quality axis). Manual-pick ordering among legacy/manual points: opus-4.8 above gpt-5.5 where they otherwise tie.
+**Cross-provider escalation** — manual only, never automatic. Escalating anthropic → sol is a cost/limits lever or independent-second-opinion lever, not a quality upgrade. Under Claude Code, codex-wrapper dispatches (`codex` skill, pr-workflow codex second-opinion review) remain valid as EXPLICIT tools — deliberate cross-provider calls, not defaults. Escalation targets: anthropic max-power miss → sol/xhigh or sol/max (second opinion, cheaper per point); openai max-power miss → opus/xhigh (the Anthropic-lane default), or fable/xhigh as a manual felt-quality pick. Manual-pick ordering among legacy/manual points: fable above opus-4.8 above gpt-5.5 where they otherwise tie.
 
-**Coordinator model.** The main-thread coordinator routes and evaluates but never executes; its cost is input-dominated (largest context, short outputs), and DeepSWE Pass@1 measures execution it never does. Picks: anthropic harness → `sonnet`; openai harness → `gpt-5.6-terra`/`high`. Safe because deterministic scripts (pre-route, manifest, build-dispatch, health weights) absorb routing complexity and the learning loop bounds misroute cost. Escalate the coordinator (sonnet → opus) only on observed misroutes or repeated lazy-completion acceptance, never preemptively. Session model is set via harness config (`/model`), not per-turn.
+**Coordinator model.** The main-thread coordinator routes and evaluates but never executes; its cost is input-dominated (largest context, short outputs), and DeepSWE Pass@1 measures execution it never does. Picks: anthropic harness → `opus` (Opus 5, the session model — it replaces the prior sonnet pick); openai harness → `gpt-5.6-terra`/`high`. Safe because deterministic scripts (pre-route, manifest, build-dispatch, health weights) absorb routing complexity and the learning loop bounds misroute cost. Downgrade the anthropic coordinator to `sonnet` only as a deliberate plan-limit measure. Session model is set via harness config (`/model`), not per-turn.
 
 **Medium+ MUST set a model or policy.** Codex prompts stay read-only and public unless a task requires otherwise.
 

--- a/skills/workflow/references/workflow-patterns.md
+++ b/skills/workflow/references/workflow-patterns.md
@@ -57,4 +57,4 @@ When a workflow reads untrusted/public content, isolate the reader from privileg
 
 ## Model-Routing Classifier
 
-For mixed-difficulty batches, dispatch a classifier agent that researches each task, then routes it: scripts for deterministic work, harness-native low-risk readers (fable/low under Claude Code, terra/high under Codex CLI), and harness-native high-risk for synthesis. Cross-provider dispatch is manual-only. The canonical model-selection table in `/do` defines exceptions, escalation targets, and the start-low-escalate-on-miss discipline.
+For mixed-difficulty batches, dispatch a classifier agent that researches each task, then routes it: scripts for deterministic work, harness-native low-risk readers (opus/low under Claude Code, terra/high under Codex CLI), and harness-native high-risk for synthesis. Cross-provider dispatch is manual-only. The canonical model-selection table in `/do` defines exceptions, escalation targets, and the start-low-escalate-on-miss discipline.


### PR DESCRIPTION
## What

Opus 5 replaces fable as the Anthropic-lane default at every task class (owner directive: "we are currently running opus 5. we need to update that opus 5 replaces fable for every task here").

- `/do` Model Selection: task-class table now selects `opus` at `low`/`medium`/`high`/`xhigh`.
- Fable-5 and Sonnet-5 become the manual-only picks (`manual_model_override=true` + `model_effort`); Opus-4.8 stays a manual legacy point.
- `opus`/`max` remains manual-only (unmeasured top tier).
- Coordinator (anthropic harness) sonnet → `opus`; sonnet kept as a deliberate plan-limit downgrade.
- Cross-provider escalation target for an OpenAI max-power miss → `opus`/`xhigh`, with fable/xhigh as a manual felt-quality pick.

## No fabricated benchmarks

Opus 5 has no DeepSWE run. Its cells read `n/a — not yet benchmarked`, the pts/USD column reads `n/a`, and the text says explicitly that pts/USD cannot be computed until it is measured. The Fable-5 / Opus-4.8 / Sonnet-5 rows are retained verbatim and relabelled as recorded prior measurements. The selection is justified on the session-model and owner-directive axes. "Start low, escalate on miss" still governs effort selection.

## Known traps preserved

- Costs stay plain numbers — no dollar sign before a digit anywhere in the injected `/do` body (commit 758b8621). Verified: `grep -n '\$[0-9]' skills/meta/do/SKILL.md` is clean.
- `manual_model_override` semantics kept: any off-policy pick sets both `manual_model_override=true` and `model_effort`. The off-policy set flipped from opus/sonnet to fable/sonnet.

## Files

`skills/meta/do/SKILL.md`, `scripts/build-dispatch.py`, `scripts/tests/test_build_dispatch.py`, `docs/PHILOSOPHY.md`, `skills/workflow/references/workflow-patterns.md`, `skills/meta/codex/SKILL.md`. ADR `model-selection-policy` amended locally (adr/ is gitignored).

## Gates

ruff check, ruff format --check (0.15.12), `scripts/tests/` (4790 passed), `scripts/validate-do-references.py`, skill-content audit, doc-counts — all green.