### PR TITLE
fix(hooks): stop newline and first-bind-flag from disabling public-bind guard (S3)

### DIFF
--- a/hooks/pretool-unified-gate.py
+++ b/hooks/pretool-unified-gate.py
@@ -773,6 +773,10 @@ _SERVER_SHORT_FLAGS: dict[str, re.Pattern[str]] = {
     "http-server": _short_flag_re("a"),
     "gunicorn": _short_flag_re("b"),
     "flask": _short_flag_re("h"),  # `flask run -h <host>` is short for --host
+    # `serve -l <listen>` takes `tcp://HOST:PORT`, a bare port, or a unix socket
+    # (audit S3). Scoped to the `serve` command token, never scanned globally:
+    # `-l` is far too common an unrelated flag (`ls -l`) to put in _HOST_FLAG_RE.
+    "serve": _short_flag_re("l"),
 }
 
 # php -S <host>:<port>  (built-in PHP dev server; binds exactly the given host).
@@ -798,6 +802,10 @@ _JS_DEV_SERVERS = frozenset(
         "remix",
         "svelte-kit",
         "vue-cli-service",
+        # `serve` (the npm static-file server). The home CLAUDE.md names
+        # `npx serve -l tcp://0.0.0.0` as forbidden by default, but the command
+        # was not recognized as a server at all, so it was ALLOWED (audit S3).
+        "serve",
     }
 )
 
@@ -806,6 +814,31 @@ _JS_DEV_SERVERS = frozenset(
 # -b short flag). Recognized either as their own console-script command token or
 # via `python -m <module>`, resolved by the token-anchored _python_m_module.
 _PY_WEB_SERVERS = frozenset({"flask", "uvicorn", "gunicorn"})
+
+
+# A `scheme://` prefix on a bind value (`serve -l tcp://0.0.0.0:3000`).
+_HOST_SCHEME_RE = re.compile(r"^[a-z][a-z0-9+.-]*://")
+# A trailing `:port` on an unbracketed host (`0.0.0.0:3000`). Not applied to a
+# bare IPv6 address (`::`, `fe80::1`), which is why bracketing is required for
+# IPv6-with-port and why a multi-colon value is left alone.
+_HOST_PORT_RE = re.compile(r"^([^:]+):\d+$")
+
+
+def _normalize_host_value(low: str) -> str:
+    """Reduce a bind value to its bare host: drop `scheme://` and `:port`.
+
+    Without this, `serve -l tcp://127.0.0.1:3000` reads as a non-loopback host
+    and over-blocks, while the loopback checks below only ever saw bare
+    addresses. `[::]:8080` keeps its brackets so the IPv6 wildcard still matches.
+    """
+    low = _HOST_SCHEME_RE.sub("", low)
+    if low.startswith("["):  # `[::1]:8080` → `[::1]`
+        end = low.find("]")
+        if end != -1:
+            return low[: end + 1]
+        return low
+    m = _HOST_PORT_RE.match(low)
+    return m.group(1) if m else low
 
 
 def _host_is_public(host: str) -> bool:
@@ -821,7 +854,7 @@ def _host_is_public(host: str) -> bool:
         return True  # flag present with no usable value — fail safe (block)
     if h.startswith("-"):
         return False  # captured token is a flag, not a host address
-    low = h.lower()
+    low = _normalize_host_value(h.lower())
     if low in _LOCAL_HOSTS:
         return False
     if low.startswith("127."):  # IPv4 loopback range (127.x)
@@ -1562,15 +1595,22 @@ def _scan_host_flags(seg: str, short_re: re.Pattern[str] | None = None) -> bool:
 
     Always scans long flags (--bind/--host/--listen/--address). Additionally
     scans `short_re` (the specific short bind flag this server uses) when given.
+
+    LAST flag wins (audit S3). Every one of these servers takes the final
+    occurrence when a bind flag is repeated, so `--bind 127.0.0.1 --bind
+    0.0.0.0` binds ALL interfaces. Scanning for any public match would be
+    right there but wrong in reverse; short-circuiting on the first match was
+    wrong in exactly the dangerous direction (that command was ALLOWED). Both
+    flag families are collected and ordered by position so the decision
+    reflects what the server will actually do.
     """
-    for m in _HOST_FLAG_RE.finditer(seg):
-        if _host_is_public(m.group(1)):
-            return True
+    matches = list(_HOST_FLAG_RE.finditer(seg))
     if short_re is not None:
-        for m in short_re.finditer(seg):
-            if _host_is_public(m.group(1)):
-                return True
-    return False
+        matches += list(short_re.finditer(seg))
+    if not matches:
+        return False
+    last = max(matches, key=lambda m: m.start())
+    return _host_is_public(last.group(1))
 
 
 def _check_public_dev_server_segment(segment: str, _depth: int = 0) -> None:
@@ -1580,6 +1620,24 @@ def _check_public_dev_server_segment(segment: str, _depth: int = 0) -> None:
         return
     if _depth > 4:  # death-loop guard for pathological nesting (fail open: stop)
         return
+
+    # Multiline input (audit S3): a newline separates shell commands, but
+    # `_SEGMENT_SPLIT_RE` deliberately does NOT split on it (heredoc/quoted-
+    # multiline safety, #719). So the display-command suppression below saw a
+    # leading `echo`/`cat`/`#` on line 1 and silently discarded every later
+    # line — one newline disabled this entire guard (`echo hi\npython3 -m
+    # http.server` was ALLOWED). Scan each NON-heredoc line independently.
+    # This mirrors the identical fix already applied in
+    # `_check_sysadmin_segment` for the codex round-9 bypass.
+    if "\n" in seg:
+        lines = [ln for ln in _non_heredoc_lines(seg) if ln.strip()]
+        # Only recurse when the split actually produced something different.
+        # A newline that lives entirely inside a quoted argument yields the
+        # segment back unchanged, and recursing on it would never terminate.
+        if lines != [seg]:
+            for line in lines:
+                _check_public_dev_server_segment(line, _depth + 1)
+            return
 
     # MEDIUM-1: evaluate command-substitution bodies ($(...), `...`, <(...))
     # independently FIRST. A display command (echo/grep/…) suppresses its OWN
@@ -1623,7 +1681,11 @@ def _check_public_dev_server_segment(segment: str, _depth: int = 0) -> None:
     # python http.server: block by default unless an explicit loopback --bind.
     # Only fires when the COMMAND is a python interpreter running `-m http.server`.
     if py_module in _PY_HTTP_SERVER_MODULES:
-        m = _PY_BIND_RE.search(seg)
+        # LAST `--bind` wins (audit S3): `--bind 127.0.0.1 --bind 0.0.0.0`
+        # binds all interfaces, but a first-match `.search()` saw the loopback
+        # and allowed it.
+        found = list(_PY_BIND_RE.finditer(seg))
+        m = found[-1] if found else None
         if m is None or _host_is_public(m.group(1)):
             _block_public_server()
         return  # explicit loopback bind → allow
@@ -1664,7 +1726,11 @@ def _check_public_dev_server_segment(segment: str, _depth: int = 0) -> None:
     # `-a` is caught by the short-flag scan below; a bare `http-server` (no `-a`)
     # would otherwise slip through, so it must block here.
     if server == "http-server":
-        m = _SERVER_SHORT_FLAGS["http-server"].search(seg)
+        # LAST `-a` wins (audit S3): `http-server -a 127.0.0.1 -a 0.0.0.0`
+        # binds all interfaces, but a first-match `.search()` saw the loopback
+        # and allowed it.
+        found = list(_SERVER_SHORT_FLAGS["http-server"].finditer(seg))
+        m = found[-1] if found else None
         if m is None or _host_is_public(m.group(1)):
             _block_public_server()
         return  # explicit loopback `-a` → allow
@@ -2277,6 +2343,41 @@ def _strip_unquoted_comment(line: str) -> str:
     return line
 
 
+def _unquoted_line_split(text: str) -> list[str]:
+    """Split `text` on newlines that are NOT inside a quoted string.
+
+    A newline inside a quoted argument is DATA, not a command separator
+    (`printf '%s\\n' 'python3 -m http.server'` is one command). Splitting on it
+    naively manufactures a fake second command out of the quoted tail — a false
+    positive. Only an unquoted newline actually starts a new command.
+    """
+    lines: list[str] = []
+    buf: list[str] = []
+    in_single = in_double = False
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == "\\" and not in_single and i + 1 < n:
+            buf.append(c)
+            buf.append(text[i + 1])  # escaped char is literal, never a delimiter
+            i += 2
+            continue
+        if c == "'" and not in_double:
+            in_single = not in_single
+        elif c == '"' and not in_single:
+            in_double = not in_double
+        elif c == "\n" and not in_single and not in_double:
+            lines.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(c)
+        i += 1
+    lines.append("".join(buf))
+    return lines
+
+
 def _non_heredoc_lines(text: str) -> list[str]:
     """Split `text` into command lines, dropping heredoc BODY lines.
 
@@ -2284,10 +2385,13 @@ def _non_heredoc_lines(text: str) -> list[str]:
     stdin, not a sequence of commands, so its lines must not be scanned as footguns.
     The line that OPENS the heredoc is kept (it is a real command); body lines up to
     and including the terminator are skipped.
+
+    Lines are split quote-aware (`_unquoted_line_split`) so a newline inside a
+    quoted argument does not manufacture a fake command line.
     """
     out: list[str] = []
     pending_terms: list[str] = []
-    for line in text.split("\n"):
+    for line in _unquoted_line_split(text):
         if pending_terms:
             if line.strip() == pending_terms[-1]:
                 pending_terms.pop()  # heredoc terminator — body ends here
@@ -2337,10 +2441,14 @@ def _check_sysadmin_segment(segment: str) -> None:
     # independently. Heredoc bodies (`cmd <<EOF … EOF`) are skipped so their text is
     # not misread as commands. Only recurse when there is a real extra command line.
     if "\n" in seg:
-        for line in _non_heredoc_lines(seg):
-            if line.strip():
+        lines = [ln for ln in _non_heredoc_lines(seg) if ln.strip()]
+        # `_non_heredoc_lines` is quote-aware, so a newline inside a quoted
+        # argument leaves the segment intact — recursing on that identical
+        # segment would never terminate (this function has no depth guard).
+        if lines != [seg]:
+            for line in lines:
                 _check_sysadmin_segment(line)
-        return
+            return
 
     # Drop a trailing unquoted shell comment: `true # ufw disable` ignores the
     # footgun text, so scanning it produced a false positive (codex #724 round-1).

--- a/hooks/tests/test_pretool_unified_gate_security.py
+++ b/hooks/tests/test_pretool_unified_gate_security.py
@@ -414,3 +414,148 @@ class TestCompoundCommandToken:
     )
     def test_command_token_resolves_through_compound_syntax(self, segment, expected):
         assert mod._command_token(segment) == expected
+
+
+# ---------------------------------------------------------------------------
+# S3 — public-bind guard
+#
+# Three gaps, all verified ALLOWED before the fix:
+#
+# 1. One newline disabled the whole guard. `_SEGMENT_SPLIT_RE` does not split
+#    on `\n` (heredoc safety), so `_DISPLAY_CMD_RE` saw a leading `echo`/`cat`/
+#    `#` on line 1 and suppressed every later line. Fixed with the same
+#    per-line recursion `_check_sysadmin_segment` already used for this class.
+#
+# 2. Bind-flag scans short-circuited on the FIRST match, but shells honor the
+#    LAST flag, so `--bind 127.0.0.1 --bind 0.0.0.0` (which binds all
+#    interfaces) was allowed. Now the last occurrence decides — matching
+#    `_scan_host_flags`' documented intent in both directions.
+#
+# 3. `serve` was not a known server and `-l` was not a bind flag, so
+#    `npx serve -l tcp://0.0.0.0:3000` — named forbidden by the home
+#    CLAUDE.md — was allowed.
+# ---------------------------------------------------------------------------
+
+NEWLINE_SUPPRESSION_CASES = [
+    # (case_id, command, expected)
+    # -- bypasses closed by this PR --
+    ("echo-then-server", "echo hi\npython3 -m http.server", DENY),
+    ("cat-then-server", "cat README.md\npython3 -m http.server 8080", DENY),
+    ("comment-then-vite", "# note\nvite --host 0.0.0.0", DENY),
+    ("echo-then-uvicorn", "echo starting\nuvicorn app:app --host 0.0.0.0", DENY),
+    ("server-on-third-line", "echo a\necho b\nvite --host 0.0.0.0", DENY),
+    # -- display-command suppression still works within a single line --
+    ("echo-quoting-server", "echo 'python3 -m http.server'", ALLOW),
+    ("cat-alone", "cat README.md", ALLOW),
+    ("echo-then-benign", "echo hi\nls -la", ALLOW),
+    ("comment-then-benign", "# note\necho hi", ALLOW),
+]
+
+
+class TestNewlineDoesNotSuppressPublicBindGuard:
+    @pytest.mark.parametrize(("case_id", "command", "expected"), NEWLINE_SUPPRESSION_CASES)
+    def test_newline_case(self, case_id, command, expected):
+        assert _run_main(_event("Bash", command=command)) == expected, case_id
+
+
+LAST_BIND_FLAG_CASES = [
+    # -- bypasses closed by this PR: public flag LAST wins --
+    ("py-loopback-then-public", "python3 -m http.server --bind 127.0.0.1 --bind 0.0.0.0", DENY),
+    ("http-server-loopback-then-public", "http-server -a 127.0.0.1 -a 0.0.0.0", DENY),
+    ("uvicorn-loopback-then-public", "uvicorn app:app --host 127.0.0.1 --host 0.0.0.0", DENY),
+    # -- the mirror case: loopback LAST genuinely binds loopback --
+    ("py-public-then-loopback", "python3 -m http.server --bind 0.0.0.0 --bind 127.0.0.1", ALLOW),
+    ("http-server-public-then-loopback", "http-server -a 0.0.0.0 -a 127.0.0.1", ALLOW),
+    # -- single-flag behavior unchanged --
+    ("py-public-only", "python3 -m http.server --bind 0.0.0.0", DENY),
+    ("py-loopback-only", "python3 -m http.server --bind 127.0.0.1", ALLOW),
+    ("py-no-flag-blocks-by-default", "python3 -m http.server", DENY),
+    ("http-server-no-flag-blocks-by-default", "http-server", DENY),
+    ("uvicorn-loopback-only", "uvicorn app:app --host 127.0.0.1", ALLOW),
+]
+
+
+class TestLastBindFlagWins:
+    @pytest.mark.parametrize(("case_id", "command", "expected"), LAST_BIND_FLAG_CASES)
+    def test_last_flag_case(self, case_id, command, expected):
+        assert _run_main(_event("Bash", command=command)) == expected, case_id
+
+
+SERVE_CASES = [
+    # -- bypass closed by this PR --
+    ("npx-serve-public", "npx serve -l tcp://0.0.0.0:3000", DENY),
+    ("serve-public", "serve -l tcp://0.0.0.0:3000", DENY),
+    ("serve-public-ipv6", "serve -l tcp://[::]:3000", DENY),
+    ("serve-valueless-host", "serve --host", DENY),
+    # -- loopback serve stays allowed (scheme/port must not read as a host) --
+    ("npx-serve-loopback", "npx serve -l tcp://127.0.0.1:3000", ALLOW),
+    ("serve-loopback", "serve -l tcp://localhost:3000", ALLOW),
+    ("serve-loopback-ipv6", "serve -l tcp://[::1]:3000", ALLOW),
+    # -- `-l` is scoped to the serve command, never scanned globally --
+    ("ls-l-not-a-bind-flag", "ls -l /tmp", ALLOW),
+    ("git-log-l-not-a-bind-flag", "git log -1 --oneline", ALLOW),
+]
+
+
+class TestServeStaticServer:
+    @pytest.mark.parametrize(("case_id", "command", "expected"), SERVE_CASES)
+    def test_serve_case(self, case_id, command, expected):
+        assert _run_main(_event("Bash", command=command)) == expected, case_id
+
+
+class TestHostValueNormalization:
+    @pytest.mark.parametrize(
+        ("value", "expected_public"),
+        [
+            ("tcp://0.0.0.0:3000", True),
+            ("tcp://127.0.0.1:3000", False),
+            ("tcp://localhost:3000", False),
+            ("tcp://[::1]:3000", False),
+            ("tcp://[::]:3000", True),
+            ("0.0.0.0:8080", True),
+            ("127.0.0.1:8080", False),
+            ("0.0.0.0", True),
+            ("127.0.0.1", False),
+            ("::1", False),
+            ("[::]", True),
+            ("localhost", False),
+            ("192.168.1.10", True),
+        ],
+    )
+    def test_host_is_public(self, value, expected_public):
+        assert mod._host_is_public(value) is expected_public
+
+
+class TestQuoteAwareLineSplit:
+    """Per-line recursion must split only on UNQUOTED newlines.
+
+    A newline inside a quoted argument is data. Splitting on it manufactures a
+    fake second command out of the quoted tail (false positive), and a split
+    that returns the segment unchanged would recurse forever.
+    """
+
+    @pytest.mark.parametrize(
+        ("case_id", "command", "expected"),
+        [
+            ("printf-quoted-newline", "printf '%s\n' 'python3 -m http.server'", ALLOW),
+            ("heredoc-body-is-data", "cat <<'EOF'\npython3 -m http.server\nEOF", ALLOW),
+            ("double-quoted-newline", 'echo "line1\npython3 -m http.server"', ALLOW),
+            ("unquoted-newline-still-splits", "echo hi\npython3 -m http.server", DENY),
+            ("quoted-then-unquoted", "echo 'a\nb'\nvite --host 0.0.0.0", DENY),
+        ],
+    )
+    def test_line_split_case(self, case_id, command, expected):
+        assert _run_main(_event("Bash", command=command)) == expected, case_id
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("a\nb", ["a", "b"]),
+            ("printf '%s\n' x", ["printf '%s\n' x"]),
+            ('echo "a\nb"', ['echo "a\nb"']),
+            ("echo 'a\nb'\nls", ["echo 'a\nb'", "ls"]),
+            ("one line", ["one line"]),
+        ],
+    )
+    def test_unquoted_line_split(self, text, expected):
+        assert mod._unquoted_line_split(text) == expected


### PR DESCRIPTION
## Problem

Track S security audit, finding S3. Three gaps in the public dev-server bind guard, all verified ALLOWED before this change.

**1. One newline disabled the entire guard.** `_SEGMENT_SPLIT_RE` deliberately does not split on `\n` (heredoc/quoted-multiline safety, #719), so `_DISPLAY_CMD_RE` saw a leading `echo`/`cat`/`#` on line 1 and suppressed everything after it:

| Command (newline between the two parts) | Before |
|---|---|
| `echo hi` → `python3 -m http.server` | ALLOW |
| `cat README.md` → `python3 -m http.server 8080` | ALLOW |
| `# note` → `vite --host 0.0.0.0` | ALLOW |

`_check_sysadmin_segment` already fixed this exact class (codex round-9 bypass) with per-line recursion; this applies the same fix to `_check_public_dev_server_segment`.

**2. Bind-flag scans took the FIRST match; shells honor the LAST flag.** `--bind 127.0.0.1 --bind 0.0.0.0` on the python server, and `-a 127.0.0.1 -a 0.0.0.0` on `http-server`, both bind all interfaces and both passed. `_scan_host_flags` documented last-wins intent but short-circuited on any public match; the python-server and `http-server` paths used a bare `.search()`. All three now evaluate the last occurrence.

**3. `serve` was not recognized at all.** `npx serve -l tcp://0.0.0.0:3000` — named forbidden by the home CLAUDE.md — passed. Added `serve` to `_JS_DEV_SERVERS` plus a `-l` short bind flag **scoped to that command token**; `-l` is deliberately not added to the global `_HOST_FLAG_RE` because it collides with `ls -l`. Bind values are now normalized (`scheme://` prefix, trailing `:port`) so `tcp://127.0.0.1:3000` reads as loopback instead of over-blocking.

## Care taken not to over-block

- Line splitting is **quote-aware**: a newline inside a quoted argument is data. Quoted `printf` payloads and heredoc bodies stay allowed (both had existing tests; the naive split broke them and the quote-aware splitter restores them).
- Both per-line recursions bail when the split returns the segment unchanged — otherwise a quoted newline recursed forever (`_check_sysadmin_segment` has no depth guard, so this was a real hang, caught by the existing suite).
- Last-flag-wins is tested in **both** directions: a public flag followed by a loopback flag genuinely binds loopback and is now correctly allowed.

## Tests

51 new table-driven rows in `hooks/tests/test_pretool_unified_gate_security.py`: newline suppression, last-bind-flag (both directions), `serve`, host-value normalization, and quote-aware split unit rows. Every bypass verified empirically by piping crafted payloads into the hook before and after.

## Gates

`ruff check` clean, `ruff format --check` clean (0.15.12), `pytest hooks/tests/` 2158 passed, `smoke-test-hooks --ci` 74/74 PASS, `benchmark-hooks` 96.7ms (threshold 200ms).

The fail-open error contract is unchanged; this PR fixes matching gaps only.
