### PR TITLE
fix(sync): preserve unowned files

### DIFF
--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -17,11 +17,14 @@ to prevent phantom hook errors when switching branches.
 Unchanged files are skipped via content comparison.
 """
 
+import errno
 import filecmp
 import json
 import os
 import re
+import secrets
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -171,61 +174,289 @@ def _read_sync_manifest(path: Path, destinations: set[str]) -> dict[str, set[Pat
     return owned
 
 
-def _safe_destination_file(root: Path, relative: Path, *, create_parents: bool) -> Path | None:
-    """Resolve a file below root without accepting symlinked path components."""
+_DIR_FD_CALLS = (os.open, os.mkdir, os.stat, os.unlink, os.rmdir, os.rename)
+_SECURE_DIR_FD_AVAILABLE = (
+    os.name == "posix"
+    and hasattr(os, "O_DIRECTORY")
+    and hasattr(os, "O_NOFOLLOW")
+    and all(call in os.supports_dir_fd for call in _DIR_FD_CALLS)
+    and os.stat in os.supports_follow_symlinks
+    and os.utime in os.supports_fd
+    and hasattr(os, "fchmod")
+)
+
+
+def _secure_dir_fd_available() -> bool:
+    """Return whether this platform can pin no-follow directory traversal."""
+    return _SECURE_DIR_FD_AVAILABLE
+
+
+def _same_identity(left: os.stat_result, right: os.stat_result) -> bool:
+    return left.st_dev == right.st_dev and left.st_ino == right.st_ino
+
+
+def _close_fds(fds: list[int]) -> None:
+    for fd in reversed(fds):
+        try:
+            os.close(fd)
+        except OSError as e:
+            print(f"[sync] WARNING: failed to close directory descriptor: {e}", file=sys.stderr)
+
+
+class _PinnedDestination:
+    """Open directory chain for one destination-relative file."""
+
+    def __init__(self, root: Path, relative: Path, directory_fds: list[int]):
+        self.root = root
+        self.relative = relative
+        self._directory_fds = directory_fds
+
+    @property
+    def parent_fd(self) -> int:
+        return self._directory_fds[-1]
+
+    @property
+    def filename(self) -> str:
+        return self.relative.name
+
+    def close(self) -> None:
+        fds, self._directory_fds = self._directory_fds, []
+        _close_fds(fds)
+
+    def __enter__(self) -> "_PinnedDestination":
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        self.close()
+
+    def _directory_entry_matches(self, index: int) -> bool:
+        try:
+            named = os.stat(
+                self.relative.parts[index - 1],
+                dir_fd=self._directory_fds[index - 1],
+                follow_symlinks=False,
+            )
+            opened = os.fstat(self._directory_fds[index])
+        except OSError:
+            return False
+        return stat.S_ISDIR(named.st_mode) and _same_identity(named, opened)
+
+    def chain_is_current(self) -> bool:
+        try:
+            named_root = os.stat(self.root, follow_symlinks=False)
+            opened_root = os.fstat(self._directory_fds[0])
+        except OSError:
+            return False
+        if not stat.S_ISDIR(named_root.st_mode) or not _same_identity(named_root, opened_root):
+            return False
+        return all(self._directory_entry_matches(index) for index in range(1, len(self._directory_fds)))
+
+    def file_entry_matches(self, opened: os.stat_result) -> bool:
+        try:
+            named = os.stat(self.filename, dir_fd=self.parent_fd, follow_symlinks=False)
+        except OSError:
+            return False
+        return stat.S_ISREG(named.st_mode) and _same_identity(named, opened)
+
+    def file_is_current(self, opened: os.stat_result | None) -> bool:
+        return opened is not None and self.chain_is_current() and self.file_entry_matches(opened)
+
+    def prune_empty_parents(self) -> None:
+        """Remove only pinned empty ancestors, deepest first."""
+        for index in range(len(self._directory_fds) - 1, 0, -1):
+            if not self._directory_entry_matches(index):
+                return
+            name = self.relative.parts[index - 1]
+            try:
+                os.rmdir(name, dir_fd=self._directory_fds[index - 1])
+            except FileNotFoundError:
+                return
+            except OSError as e:
+                if e.errno in {errno.ENOTEMPTY, errno.EEXIST, errno.ENOTDIR}:
+                    return
+                raise
+
+
+def _open_pinned_destination(root: Path, relative: Path, *, create_parents: bool) -> _PinnedDestination | None:
+    """Open a no-follow directory chain and retain every descriptor."""
+    if not _secure_dir_fd_available():
+        raise OSError(errno.ENOTSUP, "secure descriptor-relative operations unavailable")
     validated = _manifest_rel_path(relative.as_posix())
     if validated != relative:
         return None
-    if root.is_symlink() or not root.is_dir():
-        return None
-    try:
-        resolved_root = root.resolve(strict=True)
-    except OSError:
-        return None
 
-    parent = root
-    for part in relative.parts[:-1]:
-        parent /= part
-        if parent.is_symlink():
-            return None
-        if parent.exists():
-            if not parent.is_dir():
-                return None
-        elif create_parents:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    directory_fds: list[int] = []
+    try:
+        directory_fds.append(os.open(root, flags))
+        for part in relative.parts[:-1]:
             try:
-                parent.mkdir()
-            except OSError:
-                return None
-        else:
+                child_fd = os.open(part, flags, dir_fd=directory_fds[-1])
+            except FileNotFoundError:
+                if not create_parents:
+                    _close_fds(directory_fds)
+                    return None
+                try:
+                    os.mkdir(part, dir_fd=directory_fds[-1])
+                except FileExistsError:
+                    pass
+                child_fd = os.open(part, flags, dir_fd=directory_fds[-1])
+            directory_fds.append(child_fd)
+    except OSError as e:
+        _close_fds(directory_fds)
+        if e.errno in {errno.ENOENT, errno.ENOTDIR, errno.ELOOP}:
             return None
-        try:
-            if parent.is_symlink() or not parent.resolve(strict=True).is_relative_to(resolved_root):
-                return None
-        except OSError:
-            return None
+        raise
+    return _PinnedDestination(root, relative, directory_fds)
 
-    target = parent / relative.name
-    if target.is_symlink() or (target.exists() and not target.is_file()):
-        return None
+
+def _read_all(fd: int) -> bytes:
+    os.lseek(fd, 0, os.SEEK_SET)
+    chunks = []
+    while chunk := os.read(fd, 1024 * 1024):
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _read_destination_bytes(
+    destination: _PinnedDestination, *, allow_symlink_replace: bool = False
+) -> tuple[bytes | None, os.stat_result | None]:
     try:
-        if not parent.resolve(strict=True).is_relative_to(resolved_root):
-            return None
-    except OSError:
-        return None
-    return target
+        named = os.stat(destination.filename, dir_fd=destination.parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return None, None
+    if stat.S_ISLNK(named.st_mode) and allow_symlink_replace:
+        return None, None
+    if not stat.S_ISREG(named.st_mode):
+        raise OSError(errno.ELOOP if stat.S_ISLNK(named.st_mode) else errno.EISDIR, "unsafe file destination")
+
+    flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    fd = os.open(destination.filename, flags, dir_fd=destination.parent_fd)
+    try:
+        opened = os.fstat(fd)
+        if not _same_identity(named, opened):
+            raise OSError(getattr(errno, "ESTALE", errno.EIO), "destination changed before open")
+        content = _read_all(fd)
+        if not destination.chain_is_current() or not destination.file_entry_matches(opened):
+            raise OSError(getattr(errno, "ESTALE", errno.EIO), "destination changed while reading")
+        return content, opened
+    finally:
+        os.close(fd)
 
 
-def _prune_empty_owned_parents(file_path: Path, root: Path) -> None:
-    """Remove empty ancestors of one pruned file, stopping before root."""
-    current = file_path.parent
-    while current != root:
-        if current.is_symlink():
-            return
+def _create_pinned_temp(destination: _PinnedDestination, mode: int) -> tuple[str, int]:
+    flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    for _ in range(8):
+        name = f".sync-{secrets.token_hex(16)}.tmp"
         try:
-            current.rmdir()
-        except OSError:
-            return
-        current = current.parent
+            return name, os.open(name, flags, mode, dir_fd=destination.parent_fd)
+        except FileExistsError:
+            continue
+    raise OSError(errno.EEXIST, "could not allocate secure destination temp file")
+
+
+def _write_all(fd: int, content: bytes) -> None:
+    view = memoryview(content)
+    while view:
+        written = os.write(fd, view)
+        if written == 0:
+            raise OSError(errno.EIO, "short destination write")
+        view = view[written:]
+
+
+def _replace_pinned_bytes(
+    destination: _PinnedDestination,
+    content: bytes,
+    *,
+    mode: int,
+    timestamps_ns: tuple[int, int] | None = None,
+) -> None:
+    temp_name, temp_fd = _create_pinned_temp(destination, mode)
+    renamed = False
+    try:
+        _write_all(temp_fd, content)
+        os.fchmod(temp_fd, mode)
+        if timestamps_ns is not None:
+            os.utime(temp_fd, ns=timestamps_ns)
+        os.fsync(temp_fd)
+        if not destination.chain_is_current():
+            raise OSError(getattr(errno, "ESTALE", errno.EIO), "destination parent changed during write")
+        opened = os.fstat(temp_fd)
+        os.rename(
+            temp_name,
+            destination.filename,
+            src_dir_fd=destination.parent_fd,
+            dst_dir_fd=destination.parent_fd,
+        )
+        renamed = True
+        if not destination.chain_is_current() or not destination.file_entry_matches(opened):
+            raise OSError(getattr(errno, "ESTALE", errno.EIO), "destination changed during replace")
+    finally:
+        try:
+            os.close(temp_fd)
+        except OSError as e:
+            print(f"[sync] WARNING: failed to close destination temp file: {e}", file=sys.stderr)
+        if not renamed:
+            try:
+                os.unlink(temp_name, dir_fd=destination.parent_fd)
+            except FileNotFoundError:
+                pass
+            except OSError as e:
+                print(f"[sync] WARNING: failed to remove destination temp file: {e}", file=sys.stderr)
+
+
+def _copy_file_contents(source: Path) -> tuple[bytes, os.stat_result]:
+    source_stat = source.stat()
+    with open(source, "rb") as stream:
+        return stream.read(), source_stat
+
+
+def _copy_file_pinned(source: Path, destination: _PinnedDestination) -> None:
+    existing, existing_stat = _read_destination_bytes(destination)
+    content, source_stat = _copy_file_contents(source)
+    if existing == content:
+        if not destination.file_is_current(existing_stat):
+            raise OSError(getattr(errno, "ESTALE", errno.EIO), "destination changed during compare")
+        return
+    _replace_pinned_bytes(
+        destination,
+        content,
+        mode=stat.S_IMODE(source_stat.st_mode),
+        timestamps_ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
+    )
+
+
+def _write_bytes_pinned(
+    root: Path,
+    relative: Path,
+    content: bytes,
+    *,
+    mode: int,
+    allow_symlink_replace: bool = False,
+) -> bool:
+    destination = _open_pinned_destination(root, relative, create_parents=True)
+    if destination is None:
+        return False
+    with destination:
+        existing, existing_stat = _read_destination_bytes(destination, allow_symlink_replace=allow_symlink_replace)
+        if existing == content:
+            if not destination.file_is_current(existing_stat):
+                raise OSError(getattr(errno, "ESTALE", errno.EIO), "destination changed during compare")
+            return True
+        _replace_pinned_bytes(destination, content, mode=mode)
+        return True
+
+
+def _unlink_file_pinned(destination: _PinnedDestination) -> bool:
+    try:
+        named = os.stat(destination.filename, dir_fd=destination.parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return False
+    if not stat.S_ISREG(named.st_mode) or not destination.chain_is_current():
+        return False
+    os.unlink(destination.filename, dir_fd=destination.parent_fd)
+    destination.prune_empty_parents()
+    return True
 
 
 def _parse_retro_entries(text: str) -> tuple[str, list[tuple[str, str]]]:
@@ -249,21 +480,7 @@ def _parse_retro_entries(text: str) -> tuple[str, list[tuple[str, str]]]:
     return header, entries
 
 
-def merge_retro_file(src_path: Path, dst_path: Path) -> None:
-    """Merge a retro markdown file: union of ### entries from both src and dst.
-
-    Entries are identified by their ### heading name. If both files have an
-    entry with the same name, the source (repo) version wins. Entries that
-    exist only in the destination are preserved.
-    """
-    src_text = src_path.read_text()
-
-    if not dst_path.exists():
-        dst_path.write_text(src_text)
-        return
-
-    dst_text = dst_path.read_text()
-
+def _merge_retro_text(src_text: str, dst_text: str) -> str:
     src_header, src_entries = _parse_retro_entries(src_text)
     _, dst_entries = _parse_retro_entries(dst_text)
 
@@ -280,23 +497,45 @@ def merge_retro_file(src_path: Path, dst_path: Path) -> None:
         result += block
 
     # Ensure single trailing newline
-    result = result.rstrip("\n") + "\n"
-    dst_path.write_text(result)
+    return result.rstrip("\n") + "\n"
 
 
-def regenerate_l1_at_dst(dst_retro: Path) -> None:
-    """Regenerate L1.md at the destination from merged L2 files.
+def merge_retro_file(src_path: Path, dst_path: Path) -> None:
+    """Merge a retro markdown file: union of ### entries from both src and dst.
 
-    Mirrors the logic in feature-state.py _regenerate_l1() but runs
-    at sync time against ~/.claude/retro/.
+    Entries are identified by their ### heading name. If both files have an
+    entry with the same name, the source (repo) version wins. Entries that
+    exist only in the destination are preserved.
     """
+    src_text = src_path.read_text()
+    if not dst_path.exists():
+        dst_path.write_text(src_text)
+        return
+    dst_path.write_text(_merge_retro_text(src_text, dst_path.read_text()))
+
+
+def _merge_retro_file_pinned(source: Path, destination: _PinnedDestination) -> None:
+    existing, existing_stat = _read_destination_bytes(destination)
+    source_text = source.read_text()
+    result = source_text if existing is None else _merge_retro_text(source_text, existing.decode())
+    content = result.encode()
+    if existing == content:
+        if not destination.file_is_current(existing_stat):
+            raise OSError(getattr(errno, "ESTALE", errno.EIO), "destination changed during merge")
+        return
+    mode = stat.S_IMODE(existing_stat.st_mode) if existing_stat is not None else stat.S_IMODE(source.stat().st_mode)
+    _replace_pinned_bytes(destination, content, mode=mode)
+
+
+def _render_l1_at_dst(dst_retro: Path) -> str | None:
+    """Render L1.md content from merged destination L2 files."""
     l2_dir = dst_retro / "L2"
     if not l2_dir.is_dir():
-        return
+        return None
 
     l2_files = sorted(l2_dir.glob("*.md"))
     if not l2_files:
-        return
+        return None
 
     topic_groups: dict[str, list[str]] = {}
 
@@ -348,8 +587,36 @@ def regenerate_l1_at_dst(dst_retro: Path) -> None:
         lines.append("")
         lines_used += 1
 
-    l1_path = dst_retro / "L1.md"
-    l1_path.write_text("\n".join(lines) + "\n")
+    return "\n".join(lines) + "\n"
+
+
+def regenerate_l1_at_dst(dst_retro: Path) -> None:
+    """Regenerate L1.md at the destination from merged L2 files.
+
+    Mirrors the logic in feature-state.py _regenerate_l1() but runs
+    at sync time against ~/.claude/retro/.
+    """
+    content = _render_l1_at_dst(dst_retro)
+    if content is not None:
+        (dst_retro / "L1.md").write_text(content)
+
+
+def _regenerate_l1_at_dst_pinned(dst_retro: Path) -> None:
+    destination = _open_pinned_destination(dst_retro, Path("L1.md"), create_parents=True)
+    if destination is None:
+        raise OSError("unsafe L1 destination path")
+    with destination:
+        existing, existing_stat = _read_destination_bytes(destination)
+        rendered = _render_l1_at_dst(dst_retro)
+        if rendered is None:
+            return
+        content = rendered.encode()
+        if existing == content:
+            if not destination.file_is_current(existing_stat):
+                raise OSError(getattr(errno, "ESTALE", errno.EIO), "L1 destination changed during render")
+            return
+        mode = stat.S_IMODE(existing_stat.st_mode) if existing_stat is not None else 0o644
+        _replace_pinned_bytes(destination, content, mode=mode)
 
 
 # NOTE: Hook sync uses repo-as-source-of-truth (replace, not merge) to prevent
@@ -658,7 +925,7 @@ def _merged_runtime_index(tracked: Path, local: Path) -> dict | None:
     return merged
 
 
-def _sync_runtime_skill_index(src: Path, dst: Path) -> bool:
+def _sync_runtime_skill_index(src: Path, dst: Path, *, secure_destination: bool = False) -> bool:
     """Write ~/.claude/skills/INDEX.json as a real merged file.
 
     The runtime index the harness reads — and may rewrite in place — must be
@@ -676,6 +943,15 @@ def _sync_runtime_skill_index(src: Path, dst: Path) -> bool:
     if merged is None:
         return False
     runtime = dst / "INDEX.json"
+    if secure_destination:
+        content = (json.dumps(merged, indent=2) + "\n").encode()
+        return _write_bytes_pinned(
+            dst,
+            Path("INDEX.json"),
+            content,
+            mode=0o600,
+            allow_symlink_replace=True,
+        )
     # Skip the write when content already matches. Only compare a real file:
     # reading through a symlink would compare repo content and leave the
     # leaking symlink in place.
@@ -1046,6 +1322,9 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
     dst_source_paths: dict[str, set[Path]] = {name: set() for name in owned_destinations}
     dst_owned_paths: dict[str, set[Path]] = {name: set() for name in owned_destinations}
     failed_destinations: set[str] = set()
+    secure_dir_fd = _secure_dir_fd_available()
+    if install_mode == "copy" and not secure_dir_fd:
+        failed_destinations.update(owned_destinations)
 
     for src_name, dst_name in components:
         src = repo_root / src_name
@@ -1077,6 +1356,9 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
                     synced.append(f"{dst_name}(symlink)")
                 continue
 
+            if not secure_dir_fd:
+                raise OSError(errno.ENOTSUP, "secure descriptor-relative operations unavailable")
+
             # Copy mode: resolve any existing symlinks to a real directory before
             # file-by-file sync. This handles the transition from symlink to copy mode.
             if dst.is_symlink():
@@ -1094,25 +1376,25 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
                 if item.is_file():
                     rel = item.relative_to(src)
                     src_relative_paths.add(rel)
-                    target: Path | None = None
+                    destination: _PinnedDestination | None = None
                     try:
-                        target = _safe_destination_file(dst, rel, create_parents=True)
-                        if target is None:
+                        if use_merge and item.name == "L1.md":
+                            count += 1
+                            continue  # Skip L1 — regenerated below
+                        destination = _open_pinned_destination(dst, rel, create_parents=True)
+                        if destination is None:
                             raise OSError("unsafe destination path")
-                        if use_merge and item.suffix == ".md" and item.name != "L1.md":
-                            merge_retro_file(item, target)
-                            merge_count += 1
-                        elif use_merge and item.name == "L1.md":
-                            pass  # Skip L1 — regenerated below
-                        elif target.exists() and filecmp.cmp(item, target, shallow=False):
-                            pass  # Unchanged — skip copy
-                        else:
-                            shutil.copy2(item, target)
+                        with destination:
+                            if use_merge and item.suffix == ".md":
+                                _merge_retro_file_pinned(item, destination)
+                                merge_count += 1
+                            else:
+                                _copy_file_pinned(item, destination)
                         count += 1
                         if tracks_ownership:
                             successfully_owned_paths.add(rel)
                     except Exception as file_err:
-                        if target is not None and rel in prior_owned.get(dst_name, set()):
+                        if destination is not None and rel in prior_owned.get(dst_name, set()):
                             successfully_owned_paths.add(rel)
                         print(
                             f"[sync] ERROR: {dst_name}/{rel}: {file_err}",
@@ -1123,14 +1405,14 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
             # tracked+local merge (same invariants as symlink mode). Record
             # its path so deferred stale cleanup spares it even when the repo
             # has only INDEX.local.json.
-            if src_name == "skills" and _sync_runtime_skill_index(src, dst):
+            if src_name == "skills" and _sync_runtime_skill_index(src, dst, secure_destination=True):
                 src_relative_paths.add(Path("INDEX.json"))
                 if tracks_ownership:
                     successfully_owned_paths.add(Path("INDEX.json"))
 
             # For merge components, regenerate L1 from merged L2 files
             if use_merge and merge_count > 0:
-                regenerate_l1_at_dst(dst)
+                _regenerate_l1_at_dst_pinned(dst)
                 synced.append(f"{dst_name}({count}, {merge_count} merged)")
             else:
                 synced.append(f"{dst_name}({count})")
@@ -1157,9 +1439,7 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
             stale_paths = prior_owned.get(dst_name, set()) - dst_source_paths[dst_name]
             dst = user_claude / dst_name
             for rel in sorted(stale_paths):
-                stale_file = _safe_destination_file(dst, rel, create_parents=False)
-                if stale_file is None or not stale_file.is_file():
-                    continue
+                stale_file = dst / rel
                 if _resolves_inside(stale_file, protected_roots):
                     print(
                         f"[sync] BLOCKED: stale-cleanup refusing to unlink {dst_name}/{rel} (resolves inside repo)",
@@ -1167,12 +1447,14 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
                     )
                     continue
                 try:
-                    stale_file.unlink()
+                    destination = _open_pinned_destination(dst, rel, create_parents=False)
+                    if destination is None:
+                        continue
+                    with destination:
+                        _unlink_file_pinned(destination)
                 except OSError as e:
                     next_owned[dst_name].add(rel)
                     errors.append(f"stale-cleanup-{dst_name}/{rel}: {e}")
-                else:
-                    _prune_empty_owned_parents(stale_file, dst)
 
         manifest_data = {name: sorted(path.as_posix() for path in paths) for name, paths in sorted(next_owned.items())}
         try:

--- a/hooks/sync-to-user-claude.py
+++ b/hooks/sync-to-user-claude.py
@@ -24,7 +24,7 @@ import re
 import shutil
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 try:
     import fcntl
@@ -109,7 +109,16 @@ def _atomic_json_write(path: Path, data: dict) -> None:
     """
     tmp_path = path.with_suffix(".json.tmp")
     try:
-        with open(tmp_path, "w") as f:
+        # Remove only the known temp entry, then create a new file exclusively.
+        # O_EXCL prevents a raced symlink from redirecting the write.
+        tmp_path.unlink(missing_ok=True)
+        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            stream = os.fdopen(fd, "w", encoding="utf-8")
+        except Exception:
+            os.close(fd)
+            raise
+        with stream as f:
             json.dump(data, f, indent=2)
             f.write("\n")
             f.flush()
@@ -122,6 +131,101 @@ def _atomic_json_write(path: Path, data: dict) -> None:
         except OSError:
             pass
         raise
+
+
+def _manifest_rel_path(value: object) -> Path | None:
+    """Return a canonical relative manifest path, or None when unsafe."""
+    if not isinstance(value, str) or not value or "\\" in value:
+        return None
+
+    posix_path = PurePosixPath(value)
+    windows_path = PureWindowsPath(value)
+    if (
+        not posix_path.parts
+        or posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or windows_path.drive
+        or ".." in posix_path.parts
+        or value != posix_path.as_posix()
+    ):
+        return None
+    return Path(*posix_path.parts)
+
+
+def _read_sync_manifest(path: Path, destinations: set[str]) -> dict[str, set[Path]]:
+    """Load valid owned paths for approved destinations; bad state owns nothing."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+
+    owned: dict[str, set[Path]] = {}
+    for destination in destinations:
+        values = raw.get(destination)
+        if not isinstance(values, list):
+            continue
+        paths = {_manifest_rel_path(value) for value in values}
+        owned[destination] = {relative for relative in paths if relative is not None}
+    return owned
+
+
+def _safe_destination_file(root: Path, relative: Path, *, create_parents: bool) -> Path | None:
+    """Resolve a file below root without accepting symlinked path components."""
+    validated = _manifest_rel_path(relative.as_posix())
+    if validated != relative:
+        return None
+    if root.is_symlink() or not root.is_dir():
+        return None
+    try:
+        resolved_root = root.resolve(strict=True)
+    except OSError:
+        return None
+
+    parent = root
+    for part in relative.parts[:-1]:
+        parent /= part
+        if parent.is_symlink():
+            return None
+        if parent.exists():
+            if not parent.is_dir():
+                return None
+        elif create_parents:
+            try:
+                parent.mkdir()
+            except OSError:
+                return None
+        else:
+            return None
+        try:
+            if parent.is_symlink() or not parent.resolve(strict=True).is_relative_to(resolved_root):
+                return None
+        except OSError:
+            return None
+
+    target = parent / relative.name
+    if target.is_symlink() or (target.exists() and not target.is_file()):
+        return None
+    try:
+        if not parent.resolve(strict=True).is_relative_to(resolved_root):
+            return None
+    except OSError:
+        return None
+    return target
+
+
+def _prune_empty_owned_parents(file_path: Path, root: Path) -> None:
+    """Remove empty ancestors of one pruned file, stopping before root."""
+    current = file_path.parent
+    while current != root:
+        if current.is_symlink():
+            return
+        try:
+            current.rmdir()
+        except OSError:
+            return
+        current = current.parent
 
 
 def _parse_retro_entries(text: str) -> tuple[str, list[tuple[str, str]]]:
@@ -934,20 +1038,27 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
     synced = []
     errors = []
 
-    # Track all source-relative paths per destination for deferred stale cleanup.
-    # Multiple sources can map to the same destination (e.g., skills/ and pipelines/
-    # both sync to ~/.claude/skills/). Stale cleanup must see the UNION of all
-    # source paths before deleting, otherwise the second sync deletes files from
-    # the first sync.
-    dst_all_paths: dict[str, set] = {}
+    # Copy-mode cleanup uses an ownership record. A first run seeds the record
+    # without claiming or deleting pre-existing foreign files.
+    owned_destinations = {dst for src, dst in components if src not in additive_only}
+    sync_manifest_path = user_claude / ".sync-manifest.json"
+    prior_owned = _read_sync_manifest(sync_manifest_path, owned_destinations) if install_mode == "copy" else {}
+    dst_source_paths: dict[str, set[Path]] = {name: set() for name in owned_destinations}
+    dst_owned_paths: dict[str, set[Path]] = {name: set() for name in owned_destinations}
+    failed_destinations: set[str] = set()
 
     for src_name, dst_name in components:
         src = repo_root / src_name
         dst = user_claude / dst_name
+        tracks_ownership = install_mode == "copy" and src_name not in additive_only
 
         if not src.exists():
+            if tracks_ownership:
+                failed_destinations.add(dst_name)
             continue
 
+        src_relative_paths: set[Path] = set()
+        successfully_owned_paths: set[Path] = set()
         try:
             # Symlink mode: create a directory-level symlink for eligible components.
             # This preserves the symlinks created by install.sh --symlink instead of
@@ -978,15 +1089,16 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
             # Files with identical content are skipped to reduce I/O.
             count = 0
             merge_count = 0
-            src_relative_paths = set()
             use_merge = src_name in merge_components
             for item in src.rglob("*"):
                 if item.is_file():
                     rel = item.relative_to(src)
                     src_relative_paths.add(rel)
+                    target: Path | None = None
                     try:
-                        target = dst / rel
-                        _tolerant_mkdir(target.parent)
+                        target = _safe_destination_file(dst, rel, create_parents=True)
+                        if target is None:
+                            raise OSError("unsafe destination path")
                         if use_merge and item.suffix == ".md" and item.name != "L1.md":
                             merge_retro_file(item, target)
                             merge_count += 1
@@ -997,7 +1109,11 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
                         else:
                             shutil.copy2(item, target)
                         count += 1
+                        if tracks_ownership:
+                            successfully_owned_paths.add(rel)
                     except Exception as file_err:
+                        if target is not None and rel in prior_owned.get(dst_name, set()):
+                            successfully_owned_paths.add(rel)
                         print(
                             f"[sync] ERROR: {dst_name}/{rel}: {file_err}",
                             file=sys.stderr,
@@ -1009,12 +1125,8 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
             # has only INDEX.local.json.
             if src_name == "skills" and _sync_runtime_skill_index(src, dst):
                 src_relative_paths.add(Path("INDEX.json"))
-
-            # Accumulate paths per destination for deferred stale cleanup
-            if src_name not in additive_only:
-                if dst_name not in dst_all_paths:
-                    dst_all_paths[dst_name] = set()
-                dst_all_paths[dst_name].update(src_relative_paths)
+                if tracks_ownership:
+                    successfully_owned_paths.add(Path("INDEX.json"))
 
             # For merge components, regenerate L1 from merged L2 files
             if use_merge and merge_count > 0:
@@ -1024,40 +1136,49 @@ def _main_inner(repo_root: Path, user_claude: Path) -> None:
                 synced.append(f"{dst_name}({count})")
         except Exception as e:
             errors.append(f"{dst_name}: {e}")
+            if tracks_ownership:
+                failed_destinations.add(dst_name)
+        finally:
+            if tracks_ownership:
+                dst_source_paths[dst_name].update(src_relative_paths)
+                dst_owned_paths[dst_name].update(successfully_owned_paths)
 
-    # Deferred stale cleanup: remove files from destinations that no longer
-    # exist in ANY source mapping to that destination. This must run AFTER
-    # all sources have been synced.
-    for dst_name, all_paths in dst_all_paths.items():
-        dst = user_claude / dst_name
-        if not dst.is_dir():
-            continue
+    # Deferred stale cleanup considers only paths this sync recorded after a
+    # successful install. Invalid, missing, or unsafe state never grants ownership.
+    if install_mode == "copy":
+        next_owned: dict[str, set[Path]] = {}
+        for dst_name in sorted(owned_destinations):
+            installed_paths = dst_owned_paths[dst_name]
+            if dst_name in failed_destinations:
+                next_owned[dst_name] = prior_owned.get(dst_name, set()) | installed_paths
+                continue
+
+            next_owned[dst_name] = set(installed_paths)
+            stale_paths = prior_owned.get(dst_name, set()) - dst_source_paths[dst_name]
+            dst = user_claude / dst_name
+            for rel in sorted(stale_paths):
+                stale_file = _safe_destination_file(dst, rel, create_parents=False)
+                if stale_file is None or not stale_file.is_file():
+                    continue
+                if _resolves_inside(stale_file, protected_roots):
+                    print(
+                        f"[sync] BLOCKED: stale-cleanup refusing to unlink {dst_name}/{rel} (resolves inside repo)",
+                        file=sys.stderr,
+                    )
+                    continue
+                try:
+                    stale_file.unlink()
+                except OSError as e:
+                    next_owned[dst_name].add(rel)
+                    errors.append(f"stale-cleanup-{dst_name}/{rel}: {e}")
+                else:
+                    _prune_empty_owned_parents(stale_file, dst)
+
+        manifest_data = {name: sorted(path.as_posix() for path in paths) for name, paths in sorted(next_owned.items())}
         try:
-            for item in dst.rglob("*"):
-                if item.is_file():
-                    rel = item.relative_to(dst)
-                    if rel not in all_paths:
-                        # Guard: refuse to delete files that resolve inside
-                        # the repo (symlink traversal data-loss prevention).
-                        if _resolves_inside(item, protected_roots):
-                            print(
-                                f"[sync] BLOCKED: stale-cleanup refusing to "
-                                f"unlink {dst_name}/{rel} (resolves inside repo)",
-                                file=sys.stderr,
-                            )
-                            continue
-                        try:
-                            item.unlink()
-                        except OSError:
-                            pass
-            # Clean up empty directories left behind
-            for dirpath in sorted(dst.rglob("*"), reverse=True):
-                if dirpath.is_dir() and not any(dirpath.iterdir()):
-                    if _resolves_inside(dirpath, protected_roots):
-                        continue
-                    dirpath.rmdir()
-        except Exception as e:
-            errors.append(f"stale-cleanup-{dst_name}: {e}")
+            _atomic_json_write(sync_manifest_path, manifest_data)
+        except OSError as e:
+            errors.append(f"sync-manifest: {e}")
 
     # Sync settings.json — repo hooks replace global hooks
     repo_settings_path = repo_root / ".claude" / "settings.json"

--- a/hooks/tests/test_sync_eexist_tolerance.py
+++ b/hooks/tests/test_sync_eexist_tolerance.py
@@ -272,19 +272,19 @@ class TestPerFileErrorHandling:
         """Per-file errors should produce a stderr warning line."""
         repo, user_claude, base = self._setup(tmp_path)
 
-        original_copy2 = __import__("shutil").copy2
+        original_copy = sync_mod._copy_file_contents
 
-        def failing_copy2(src, dst, **kwargs):
+        def failing_copy(src):
             if str(src).endswith("b.md") and "agents" in str(src):
                 raise PermissionError("simulated")
-            return original_copy2(src, dst, **kwargs)
+            return original_copy(src)
 
         with (
             patch.object(Path, "home", return_value=base / "home"),
             patch.object(Path, "cwd", return_value=repo),
             patch.object(sync_mod, "_is_git_worktree", return_value=False),
             patch.object(sync_mod, "_is_ephemeral_path", return_value=False),
-            patch("shutil.copy2", side_effect=failing_copy2),
+            patch.object(sync_mod, "_copy_file_contents", side_effect=failing_copy),
         ):
             sync_mod.main()
 

--- a/hooks/tests/test_sync_to_user_claude.py
+++ b/hooks/tests/test_sync_to_user_claude.py
@@ -674,6 +674,291 @@ class TestMainRuntimeIndex:
         assert "voice-x" in skills
 
 
+class TestOwnedStaleCleanup:
+    """Copy-mode cleanup removes only files recorded as safely installed."""
+
+    def _setup(self, tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+        repo = tmp_path / "repo"
+        home = tmp_path / "home"
+        user_claude = home / ".claude"
+
+        for component in ["agents", "hooks", "commands", "scripts"]:
+            source = repo / component
+            source.mkdir(parents=True)
+            (source / "owned.txt").write_text(component)
+
+        skill_file = repo / "skills" / "meta" / "toolkit" / "SKILL.md"
+        skill_file.parent.mkdir(parents=True)
+        skill_file.write_text("# toolkit\n")
+
+        (repo / ".claude").mkdir()
+        (repo / ".claude" / "settings.json").write_text(json.dumps({"hooks": {}}))
+
+        user_claude.mkdir(parents=True)
+        (user_claude / ".install-manifest.json").write_text(json.dumps({"mode": "copy", "toolkit_path": str(repo)}))
+        return repo, home, user_claude, skill_file
+
+    def _run(self, repo: Path, home: Path, user_claude: Path) -> None:
+        with patch.object(Path, "home", return_value=home):
+            sync_mod._main_inner(repo, user_claude)
+
+    def test_upgrade_from_no_manifest_preserves_foreign_content(self, tmp_path: Path) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        foreign_file = user_claude / "skills" / "cloudflare" / "SKILL.md"
+        foreign_file.parent.mkdir(parents=True)
+        foreign_file.write_text("# foreign\n")
+        foreign_empty_dir = user_claude / "skills" / "plugin-empty"
+        foreign_empty_dir.mkdir()
+
+        self._run(repo, home, user_claude)
+
+        manifest = json.loads((user_claude / ".sync-manifest.json").read_text())
+        assert foreign_file.read_text() == "# foreign\n"
+        assert foreign_empty_dir.is_dir()
+        assert "meta/toolkit/SKILL.md" in manifest["skills"]
+
+    def test_second_run_prunes_owned_stale_file(self, tmp_path: Path) -> None:
+        repo, home, user_claude, skill_file = self._setup(tmp_path)
+        foreign_empty_dir = user_claude / "skills" / "plugin-empty"
+        foreign_empty_dir.mkdir(parents=True)
+        self._run(repo, home, user_claude)
+        installed = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
+        assert installed.is_file()
+
+        skill_file.unlink()
+        self._run(repo, home, user_claude)
+
+        manifest = json.loads((user_claude / ".sync-manifest.json").read_text())
+        assert not installed.exists()
+        assert not installed.parent.exists()
+        assert foreign_empty_dir.is_dir()
+        assert "meta/toolkit/SKILL.md" not in manifest["skills"]
+
+    def test_repeated_sync_is_idempotent(self, tmp_path: Path) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        foreign_file = user_claude / "skills" / "foreign.txt"
+        foreign_file.parent.mkdir(parents=True)
+        foreign_file.write_text("keep\n")
+        self._run(repo, home, user_claude)
+        first_manifest = (user_claude / ".sync-manifest.json").read_text()
+
+        self._run(repo, home, user_claude)
+
+        assert (user_claude / ".sync-manifest.json").read_text() == first_manifest
+        assert foreign_file.read_text() == "keep\n"
+
+    @pytest.mark.parametrize(
+        "value",
+        ["", ".", "../victim", "meta/../../victim", "/tmp/victim", r"..\victim", r"C:\victim", r"\\host\share\victim"],
+    )
+    def test_manifest_path_parser_rejects_unsafe_paths(self, value: str) -> None:
+        assert sync_mod._manifest_rel_path(value) is None
+
+    def test_manifest_path_parser_accepts_canonical_relative_path(self) -> None:
+        assert sync_mod._manifest_rel_path("meta/toolkit/SKILL.md") == Path("meta/toolkit/SKILL.md")
+
+    def test_parent_traversal_manifest_entry_is_ignored(self, tmp_path: Path) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        (user_claude / "skills").mkdir()
+        victim = user_claude / "victim.txt"
+        victim.write_text("keep\n")
+        (user_claude / ".sync-manifest.json").write_text(json.dumps({"skills": ["../victim.txt"]}))
+
+        self._run(repo, home, user_claude)
+
+        assert victim.read_text() == "keep\n"
+
+    def test_absolute_manifest_entry_is_ignored(self, tmp_path: Path) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        victim = tmp_path / "outside-victim.txt"
+        victim.write_text("keep\n")
+        (user_claude / ".sync-manifest.json").write_text(json.dumps({"skills": [str(victim)]}))
+
+        self._run(repo, home, user_claude)
+
+        assert victim.read_text() == "keep\n"
+
+    def test_wrong_schema_manifest_entry_is_ignored(self, tmp_path: Path) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        foreign_file = user_claude / "skills" / "x"
+        foreign_file.parent.mkdir(parents=True)
+        foreign_file.write_text("keep\n")
+        (user_claude / ".sync-manifest.json").write_text(json.dumps({"skills": "x"}))
+
+        self._run(repo, home, user_claude)
+
+        assert foreign_file.read_text() == "keep\n"
+
+    def test_corrupt_manifest_preserves_foreign_content(self, tmp_path: Path) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        foreign_file = user_claude / "skills" / "foreign.txt"
+        foreign_file.parent.mkdir(parents=True)
+        foreign_file.write_text("keep\n")
+        (user_claude / ".sync-manifest.json").write_text("{broken")
+
+        self._run(repo, home, user_claude)
+
+        assert foreign_file.read_text() == "keep\n"
+        assert isinstance(json.loads((user_claude / ".sync-manifest.json").read_text()), dict)
+
+    def test_manifest_entry_below_foreign_parent_symlink_is_ignored(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        outside = tmp_path / "plugin-data"
+        outside.mkdir()
+        victim = outside / "data.txt"
+        victim.write_text("keep\n")
+        skills = user_claude / "skills"
+        skills.mkdir()
+        (skills / "foreign").symlink_to(outside, target_is_directory=True)
+        (user_claude / ".sync-manifest.json").write_text(json.dumps({"skills": ["foreign/data.txt"]}))
+
+        self._run(repo, home, user_claude)
+
+        manifest = json.loads((user_claude / ".sync-manifest.json").read_text())
+        assert victim.read_text() == "keep\n"
+        assert "foreign/data.txt" not in manifest["skills"]
+        assert "stale-cleanup-skills" not in capsys.readouterr().err
+
+    def test_copy_does_not_follow_foreign_parent_symlink(self, tmp_path: Path) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        outside = tmp_path / "plugin-data"
+        victim = outside / "toolkit" / "SKILL.md"
+        victim.parent.mkdir(parents=True)
+        victim.write_text("# foreign\n")
+        skills = user_claude / "skills"
+        skills.mkdir()
+        (skills / "meta").symlink_to(outside, target_is_directory=True)
+
+        self._run(repo, home, user_claude)
+
+        manifest = json.loads((user_claude / ".sync-manifest.json").read_text())
+        assert victim.read_text() == "# foreign\n"
+        assert "meta/toolkit/SKILL.md" not in manifest["skills"]
+
+    def test_copy_rejects_directory_at_file_destination(self, tmp_path: Path) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        foreign_dir = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
+        foreign_dir.mkdir(parents=True)
+        victim = foreign_dir / "SKILL.md"
+        victim.write_text("# foreign\n")
+
+        self._run(repo, home, user_claude)
+
+        manifest = json.loads((user_claude / ".sync-manifest.json").read_text())
+        assert victim.read_text() == "# foreign\n"
+        assert "meta/toolkit/SKILL.md" not in manifest["skills"]
+
+    def test_failed_copy_does_not_claim_foreign_file(self, tmp_path: Path) -> None:
+        repo, home, user_claude, skill_file = self._setup(tmp_path)
+        installed = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
+        installed.parent.mkdir(parents=True)
+        installed.write_text("# foreign collision\n")
+        real_copy2 = shutil.copy2
+
+        def fail_skill_copy(src, dst, *args, **kwargs):
+            if Path(src) == skill_file:
+                raise OSError("forced copy failure")
+            return real_copy2(src, dst, *args, **kwargs)
+
+        with (
+            patch.object(Path, "home", return_value=home),
+            patch.object(sync_mod.shutil, "copy2", side_effect=fail_skill_copy),
+        ):
+            sync_mod._main_inner(repo, user_claude)
+
+        manifest = json.loads((user_claude / ".sync-manifest.json").read_text())
+        assert installed.read_text() == "# foreign collision\n"
+        assert "meta/toolkit/SKILL.md" not in manifest["skills"]
+
+        skill_file.unlink()
+        self._run(repo, home, user_claude)
+        assert installed.read_text() == "# foreign collision\n"
+
+    def test_failed_update_keeps_prior_ownership(self, tmp_path: Path) -> None:
+        repo, home, user_claude, skill_file = self._setup(tmp_path)
+        self._run(repo, home, user_claude)
+        installed = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
+        skill_file.write_text("# updated\n")
+        real_copy2 = shutil.copy2
+
+        def fail_skill_copy(src, dst, *args, **kwargs):
+            if Path(src) == skill_file:
+                raise OSError("forced copy failure")
+            return real_copy2(src, dst, *args, **kwargs)
+
+        with (
+            patch.object(Path, "home", return_value=home),
+            patch.object(sync_mod.shutil, "copy2", side_effect=fail_skill_copy),
+        ):
+            sync_mod._main_inner(repo, user_claude)
+
+        manifest = json.loads((user_claude / ".sync-manifest.json").read_text())
+        assert installed.read_text() == "# toolkit\n"
+        assert "meta/toolkit/SKILL.md" in manifest["skills"]
+
+        skill_file.unlink()
+        self._run(repo, home, user_claude)
+        assert not installed.exists()
+
+    def test_incomplete_source_scan_preserves_prior_state(self, tmp_path: Path) -> None:
+        repo, home, user_claude, skill_file = self._setup(tmp_path)
+        self._run(repo, home, user_claude)
+        installed = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
+        skill_file.unlink()
+        real_rglob = Path.rglob
+
+        def fail_skill_scan(path: Path, pattern: str):
+            if path == repo / "skills":
+                raise OSError("forced scan failure")
+            return real_rglob(path, pattern)
+
+        with patch.object(Path, "home", return_value=home), patch.object(Path, "rglob", new=fail_skill_scan):
+            sync_mod._main_inner(repo, user_claude)
+
+        manifest = json.loads((user_claude / ".sync-manifest.json").read_text())
+        assert installed.is_file()
+        assert "meta/toolkit/SKILL.md" in manifest["skills"]
+
+    def test_interrupted_manifest_replace_keeps_prior_state(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        self._run(repo, home, user_claude)
+        manifest_path = user_claude / ".sync-manifest.json"
+        prior = manifest_path.read_text()
+        real_replace = os.replace
+
+        def fail_manifest_replace(src: str, dst: str) -> None:
+            if Path(dst) == manifest_path:
+                raise OSError("forced manifest replace failure")
+            real_replace(src, dst)
+
+        with (
+            patch.object(Path, "home", return_value=home),
+            patch.object(sync_mod.os, "replace", side_effect=fail_manifest_replace),
+        ):
+            sync_mod._main_inner(repo, user_claude)
+
+        assert manifest_path.read_text() == prior
+        assert not manifest_path.with_suffix(".json.tmp").exists()
+        assert "sync-manifest: forced manifest replace failure" in capsys.readouterr().err
+
+    def test_manifest_write_replaces_temp_symlink_without_following_it(self, tmp_path: Path) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        manifest_path = user_claude / ".sync-manifest.json"
+        victim = tmp_path / "outside.txt"
+        victim.write_text("keep\n")
+        manifest_path.with_suffix(".json.tmp").symlink_to(victim)
+
+        self._run(repo, home, user_claude)
+
+        assert victim.read_text() == "keep\n"
+        assert manifest_path.is_file() and not manifest_path.is_symlink()
+        assert "meta/toolkit/SKILL.md" in json.loads(manifest_path.read_text())["skills"]
+
+
 class TestHasPromotedTo:
     """Tests for _has_promoted_to — skip skills folded into a parent."""
 

--- a/hooks/tests/test_sync_to_user_claude.py
+++ b/hooks/tests/test_sync_to_user_claude.py
@@ -837,6 +837,90 @@ class TestOwnedStaleCleanup:
         assert victim.read_text() == "# foreign\n"
         assert "meta/toolkit/SKILL.md" not in manifest["skills"]
 
+    def test_parent_swap_before_copy_cannot_redirect_write(self, tmp_path: Path) -> None:
+        repo, home, user_claude, skill_file = self._setup(tmp_path)
+        skills = user_claude / "skills"
+        (skills / "meta").mkdir(parents=True)
+        parked = skills / "meta-parked"
+        outside = tmp_path / "plugin-data"
+        victim = outside / "toolkit" / "SKILL.md"
+        victim.parent.mkdir(parents=True)
+        victim.write_text("# foreign\n")
+        real_open = open
+        swap_triggered = False
+
+        def swap_before_source_open(file, *args, **kwargs):
+            nonlocal swap_triggered
+            if Path(file) == skill_file and not swap_triggered:
+                (skills / "meta").rename(parked)
+                (skills / "meta").symlink_to(outside, target_is_directory=True)
+                swap_triggered = True
+            return real_open(file, *args, **kwargs)
+
+        with patch.object(Path, "home", return_value=home), patch("builtins.open", side_effect=swap_before_source_open):
+            sync_mod._main_inner(repo, user_claude)
+
+        manifest = json.loads((user_claude / ".sync-manifest.json").read_text())
+        assert swap_triggered
+        assert victim.read_text() == "# foreign\n"
+        assert not (parked / "toolkit" / "SKILL.md").exists()
+        assert "meta/toolkit/SKILL.md" not in manifest["skills"]
+
+    def test_file_swap_during_unchanged_copy_is_not_claimed(self, tmp_path: Path) -> None:
+        repo, home, user_claude, skill_file = self._setup(tmp_path)
+        installed = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
+        installed.parent.mkdir(parents=True)
+        installed.write_text(skill_file.read_text())
+        parked = installed.with_name("SKILL-parked.md")
+        real_copy = sync_mod._copy_file_contents
+        swap_triggered = False
+
+        def swap_before_source_read(source: Path):
+            nonlocal swap_triggered
+            if source == skill_file and not swap_triggered:
+                installed.rename(parked)
+                installed.write_text("# foreign\n")
+                swap_triggered = True
+            return real_copy(source)
+
+        with patch.object(sync_mod, "_copy_file_contents", side_effect=swap_before_source_read):
+            self._run(repo, home, user_claude)
+
+        manifest = json.loads((user_claude / ".sync-manifest.json").read_text())
+        assert swap_triggered
+        assert installed.read_text() == "# foreign\n"
+        assert "meta/toolkit/SKILL.md" not in manifest["skills"]
+
+    def test_parent_swap_before_l1_replace_cannot_redirect_write(self, tmp_path: Path) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        l2_source = repo / "retro" / "L2" / "topic.md"
+        l2_source.parent.mkdir(parents=True)
+        l2_source.write_text("**Tags**: safety\n\n### Rule\nKeep the boundary.\n")
+        retro = user_claude / "retro"
+        parked = user_claude / "retro-parked"
+        outside = tmp_path / "plugin-data"
+        outside.mkdir()
+        victim = outside / "L1.md"
+        victim.write_text("# foreign\n")
+        real_render = sync_mod._render_l1_at_dst
+        swap_triggered = False
+
+        def swap_before_l1_replace(destination: Path):
+            nonlocal swap_triggered
+            rendered = real_render(destination)
+            if not swap_triggered:
+                retro.rename(parked)
+                retro.symlink_to(outside, target_is_directory=True)
+                swap_triggered = True
+            return rendered
+
+        with patch.object(sync_mod, "_render_l1_at_dst", side_effect=swap_before_l1_replace):
+            self._run(repo, home, user_claude)
+
+        assert swap_triggered
+        assert victim.read_text() == "# foreign\n"
+        assert not (parked / "L1.md").exists()
+
     def test_copy_rejects_directory_at_file_destination(self, tmp_path: Path) -> None:
         repo, home, user_claude, _ = self._setup(tmp_path)
         foreign_dir = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
@@ -850,21 +934,161 @@ class TestOwnedStaleCleanup:
         assert victim.read_text() == "# foreign\n"
         assert "meta/toolkit/SKILL.md" not in manifest["skills"]
 
+    def test_parent_swap_before_unlink_cannot_redirect_delete(self, tmp_path: Path) -> None:
+        repo, home, user_claude, skill_file = self._setup(tmp_path)
+        self._run(repo, home, user_claude)
+        installed = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
+        skill_file.unlink()
+        parent = installed.parent
+        parked = parent.with_name("toolkit-parked")
+        outside = tmp_path / "plugin-data"
+        victim = outside / "SKILL.md"
+        outside.mkdir()
+        victim.write_text("# foreign\n")
+        real_unlink = os.unlink
+        swap_triggered = False
+
+        def swap_before_unlink(path, *args, **kwargs):
+            nonlocal swap_triggered
+            is_owned_target = Path(path) == installed or (path == installed.name and kwargs.get("dir_fd") is not None)
+            if is_owned_target and not swap_triggered:
+                parent.rename(parked)
+                parent.symlink_to(outside, target_is_directory=True)
+                swap_triggered = True
+            return real_unlink(path, *args, **kwargs)
+
+        with (
+            patch.object(Path, "home", return_value=home),
+            patch.object(sync_mod.os, "unlink", side_effect=swap_before_unlink),
+        ):
+            sync_mod._main_inner(repo, user_claude)
+
+        assert swap_triggered
+        assert victim.read_text() == "# foreign\n"
+        assert not (parked / "SKILL.md").exists()
+
+    def test_parent_swap_before_prune_cannot_remove_foreign_directory(self, tmp_path: Path) -> None:
+        repo, home, user_claude, skill_file = self._setup(tmp_path)
+        self._run(repo, home, user_claude)
+        installed = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
+        skill_file.unlink()
+        meta = installed.parent.parent
+        parked = meta.with_name("meta-parked")
+        outside = tmp_path / "plugin-data"
+        foreign_empty_dir = outside / "toolkit"
+        foreign_empty_dir.mkdir(parents=True)
+        real_rmdir = os.rmdir
+        swap_triggered = False
+
+        def swap_before_rmdir(path, *args, **kwargs):
+            nonlocal swap_triggered
+            is_owned_parent = Path(path) == installed.parent or (
+                path == installed.parent.name and kwargs.get("dir_fd") is not None
+            )
+            if is_owned_parent and not swap_triggered:
+                meta.rename(parked)
+                meta.symlink_to(outside, target_is_directory=True)
+                swap_triggered = True
+            return real_rmdir(path, *args, **kwargs)
+
+        with (
+            patch.object(Path, "home", return_value=home),
+            patch.object(sync_mod.os, "rmdir", side_effect=swap_before_rmdir),
+        ):
+            sync_mod._main_inner(repo, user_claude)
+
+        assert swap_triggered
+        assert foreign_empty_dir.is_dir()
+        assert not (parked / "toolkit").exists()
+
+    def test_unsupported_platform_skips_copy_and_claim(self, tmp_path: Path) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        installed = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
+        installed.parent.mkdir(parents=True)
+        installed.write_text("# foreign\n")
+
+        with patch.object(sync_mod, "_secure_dir_fd_available", return_value=False, create=True):
+            self._run(repo, home, user_claude)
+
+        manifest = json.loads((user_claude / ".sync-manifest.json").read_text())
+        assert installed.read_text() == "# foreign\n"
+        assert "meta/toolkit/SKILL.md" not in manifest["skills"]
+
+    def test_unsupported_platform_retains_owned_stale_file(self, tmp_path: Path) -> None:
+        repo, home, user_claude, skill_file = self._setup(tmp_path)
+        self._run(repo, home, user_claude)
+        installed = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
+        skill_file.unlink()
+
+        with patch.object(sync_mod, "_secure_dir_fd_available", return_value=False, create=True):
+            self._run(repo, home, user_claude)
+
+        manifest = json.loads((user_claude / ".sync-manifest.json").read_text())
+        assert installed.read_text() == "# toolkit\n"
+        assert "meta/toolkit/SKILL.md" in manifest["skills"]
+
+    @pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="requires procfs descriptor accounting")
+    def test_sync_does_not_leak_descriptors(self, tmp_path: Path) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        before = len(list(Path("/proc/self/fd").iterdir()))
+
+        self._run(repo, home, user_claude)
+
+        after = len(list(Path("/proc/self/fd").iterdir()))
+        assert after == before
+
+    @pytest.mark.skipif(not Path("/proc/self/fd").is_dir(), reason="requires procfs descriptor accounting")
+    def test_failed_parent_traversal_closes_descriptors(self, tmp_path: Path) -> None:
+        repo, home, user_claude, _ = self._setup(tmp_path)
+        real_open = os.open
+        before = len(list(Path("/proc/self/fd").iterdir()))
+
+        def fail_nested_open(path, flags, *args, **kwargs):
+            if path == "toolkit" and flags & os.O_DIRECTORY and kwargs.get("dir_fd") is not None:
+                raise PermissionError("forced directory open failure")
+            return real_open(path, flags, *args, **kwargs)
+
+        with patch.object(sync_mod.os, "open", side_effect=fail_nested_open):
+            self._run(repo, home, user_claude)
+
+        after = len(list(Path("/proc/self/fd").iterdir()))
+        assert after == before
+
+    def test_failed_secure_replace_preserves_target_and_cleans_temp(self, tmp_path: Path) -> None:
+        repo, home, user_claude, skill_file = self._setup(tmp_path)
+        self._run(repo, home, user_claude)
+        installed = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
+        skill_file.write_text("# updated\n")
+        real_rename = os.rename
+
+        def fail_skill_replace(src, dst, *args, **kwargs):
+            if str(src).startswith(".sync-") and dst == "SKILL.md":
+                raise OSError("forced secure replace failure")
+            return real_rename(src, dst, *args, **kwargs)
+
+        with patch.object(sync_mod.os, "rename", side_effect=fail_skill_replace):
+            self._run(repo, home, user_claude)
+
+        manifest = json.loads((user_claude / ".sync-manifest.json").read_text())
+        assert installed.read_text() == "# toolkit\n"
+        assert "meta/toolkit/SKILL.md" in manifest["skills"]
+        assert not list(installed.parent.glob(".sync-*.tmp"))
+
     def test_failed_copy_does_not_claim_foreign_file(self, tmp_path: Path) -> None:
         repo, home, user_claude, skill_file = self._setup(tmp_path)
         installed = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
         installed.parent.mkdir(parents=True)
         installed.write_text("# foreign collision\n")
-        real_copy2 = shutil.copy2
+        real_copy = sync_mod._copy_file_contents
 
-        def fail_skill_copy(src, dst, *args, **kwargs):
+        def fail_skill_copy(src):
             if Path(src) == skill_file:
                 raise OSError("forced copy failure")
-            return real_copy2(src, dst, *args, **kwargs)
+            return real_copy(src)
 
         with (
             patch.object(Path, "home", return_value=home),
-            patch.object(sync_mod.shutil, "copy2", side_effect=fail_skill_copy),
+            patch.object(sync_mod, "_copy_file_contents", side_effect=fail_skill_copy),
         ):
             sync_mod._main_inner(repo, user_claude)
 
@@ -881,16 +1105,16 @@ class TestOwnedStaleCleanup:
         self._run(repo, home, user_claude)
         installed = user_claude / "skills" / "meta" / "toolkit" / "SKILL.md"
         skill_file.write_text("# updated\n")
-        real_copy2 = shutil.copy2
+        real_copy = sync_mod._copy_file_contents
 
-        def fail_skill_copy(src, dst, *args, **kwargs):
+        def fail_skill_copy(src):
             if Path(src) == skill_file:
                 raise OSError("forced copy failure")
-            return real_copy2(src, dst, *args, **kwargs)
+            return real_copy(src)
 
         with (
             patch.object(Path, "home", return_value=home),
-            patch.object(sync_mod.shutil, "copy2", side_effect=fail_skill_copy),
+            patch.object(sync_mod, "_copy_file_contents", side_effect=fail_skill_copy),
         ):
             sync_mod._main_inner(repo, user_claude)
 


### PR DESCRIPTION
## Summary

Prevent copy-mode stale cleanup from deleting files installed by other tools.

## Changes

- Track only files successfully installed by sync.
- Reject escaping paths, symlink targets, and invalid ownership state.
- Prune only owned stale files and their empty parent directories.
- Persist state atomically and preserve prior ownership after partial failures.
- Add regression coverage for upgrades, corrupt state, failed copies, symlinks, and interruptions.

## Notes

Supersedes #902. Credit to @S-Keilani for reporting the issue and proposing ownership tracking.

Tested: 7,463 passed, 6 skipped, 127 expected failures.

High-risk sync-hook change; requires independent review before merge.
