### PR TITLE
fix: protect per-item hook mirrors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -232,33 +232,51 @@ is_command_available() {
     command -V -- "$1" >/dev/null 2>&1
 }
 
-_symlink_points_to() {
+_symlink_target_state() {
     local link=$1
     local expected=$2
     local actual actual_canonical expected_canonical
 
     [ -L "$link" ] || return 1
-    actual=$(readlink "$link") || return 1
+    actual=$(readlink "$link") || return 2
     case "$actual" in
         /*) ;;
         *) actual="$(dirname "$link")/$actual" ;;
     esac
-    actual_canonical=$(_canonical_path "$actual") || return 1
-    expected_canonical=$(_canonical_path "$expected") || return 1
-    [ -n "$actual_canonical" ] || return 1
-    [ -n "$expected_canonical" ] || return 1
-    [ "$actual_canonical" = "$expected_canonical" ]
+    actual_canonical=$(_canonical_path "$actual") || return 2
+    expected_canonical=$(_canonical_path "$expected") || return 2
+    [ -n "$actual_canonical" ] || return 2
+    [ -n "$expected_canonical" ] || return 2
+    [ "$actual_canonical" = "$expected_canonical" ] && return 0
+    return 1
+}
+
+_symlink_points_to() {
+    _symlink_target_state "$1" "$2" && return 0
+    return 1
 }
 
 clean_hooks_mirror_if_source_link() {
     local hook_dir="$1"
     local hook_source_dir="$2"
+    local link_state
 
     if [ -z "$hook_dir" ] || [ -z "$hook_source_dir" ]; then
-        return
+        return 2
     fi
 
-    if _symlink_points_to "$hook_dir" "$hook_source_dir"; then
+    if _symlink_target_state "$hook_dir" "$hook_source_dir"; then
+        link_state=0
+    else
+        link_state=$?
+    fi
+
+    if [ "$link_state" -eq 2 ]; then
+        echo -e "${YELLOW}  Skipping hooks mirror: could not verify symlink target: ${hook_dir}${NC}"
+        return 2
+    fi
+
+    if [ "$link_state" -eq 0 ]; then
         if [ "$DRY_RUN" = true ]; then
             echo -e "${YELLOW}  Would remove stale hooks mirror symlink: ${hook_dir}${NC}"
             echo -e "${YELLOW}  (points back into source hooks: ${hook_source_dir})${NC}"
@@ -268,6 +286,7 @@ clean_hooks_mirror_if_source_link() {
         echo -e "${YELLOW}  (points back into source hooks: ${hook_source_dir})${NC}"
         unlink "$hook_dir"
     fi
+    return 0
 }
 
 # unlink_skills_nested TARGET — tear down a nested skills tree built by
@@ -1734,7 +1753,7 @@ if [ "$MIRROR_CODEX" = true ]; then
     CODEX_MANAGED_HOOKS_MANIFEST="${CODEX_HOOKS_DIR}/.vexjoy-managed-hooks"
 
     if [ -f "$CODEX_HOOKS_ALLOWLIST" ]; then
-        clean_hooks_mirror_if_source_link "$CODEX_HOOKS_DIR" "${SCRIPT_DIR}/hooks"
+        if clean_hooks_mirror_if_source_link "$CODEX_HOOKS_DIR" "${SCRIPT_DIR}/hooks"; then
 
         # Remove only files recorded by the previous VexJoy install. This
         # refreshes hooks removed from the current compatibility inventory
@@ -1884,6 +1903,9 @@ ${filename}"
             fi
         else
             echo -e "${BLUE}  (codex CLI not installed; hooks will activate when Codex is installed)${NC}"
+        fi
+        else
+            echo -e "${YELLOW}  ⚠ Codex hooks mirror left unchanged because its target could not be verified.${NC}"
         fi
     else
         echo -e "${YELLOW}  ⚠ Codex hooks allowlist not found at ${CODEX_HOOKS_ALLOWLIST}; skipping hooks mirror${NC}"
@@ -2222,7 +2244,7 @@ REASONIX_HOOK_FAILED=false       # settings.json generator failed → hooks neve
 REASONIX_HOOKS_ALLOWLIST="${SCRIPT_DIR}/scripts/reasonix-hooks-allowlist.txt"
 
 if [ -f "$REASONIX_HOOKS_ALLOWLIST" ]; then
-    clean_hooks_mirror_if_source_link "$REASONIX_HOOKS_DIR" "${SCRIPT_DIR}/hooks"
+    if clean_hooks_mirror_if_source_link "$REASONIX_HOOKS_DIR" "${SCRIPT_DIR}/hooks"; then
 
     if [ "$DRY_RUN" = true ]; then
         echo -e "${BLUE}  Would create: ${REASONIX_HOOKS_DIR}${NC}"
@@ -2285,6 +2307,9 @@ if [ -f "$REASONIX_HOOKS_ALLOWLIST" ]; then
             echo -e "${RED}  ✗ Failed to generate ${REASONIX_SETTINGS} — Reasonix hooks are NOT wired in.${NC}"
             echo -e "${RED}${gen_err}${NC}"
         fi
+    fi
+    else
+        echo -e "${YELLOW}  ⚠ Reasonix hooks mirror left unchanged because its target could not be verified.${NC}"
     fi
 else
     echo -e "${YELLOW}  ⚠ Reasonix hooks allowlist not found at ${REASONIX_HOOKS_ALLOWLIST}; skipping hooks mirror${NC}"

--- a/install.sh
+++ b/install.sh
@@ -213,7 +213,19 @@ print_manual_pip_command() {
 }
 
 _canonical_path() {
-    python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$1"
+    local python_cmd=${PYTHON_CMD:-}
+
+    if [ -z "$python_cmd" ]; then
+        if command -v python3 > /dev/null 2>&1; then
+            python_cmd="python3"
+        elif command -v python > /dev/null 2>&1; then
+            python_cmd="python"
+        else
+            return 1
+        fi
+    fi
+
+    "$python_cmd" -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$1"
 }
 
 is_command_available() {
@@ -223,7 +235,7 @@ is_command_available() {
 _symlink_points_to() {
     local link=$1
     local expected=$2
-    local actual
+    local actual actual_canonical expected_canonical
 
     [ -L "$link" ] || return 1
     actual=$(readlink "$link") || return 1
@@ -231,7 +243,11 @@ _symlink_points_to() {
         /*) ;;
         *) actual="$(dirname "$link")/$actual" ;;
     esac
-    [ "$(_canonical_path "$actual")" = "$(_canonical_path "$expected")" ]
+    actual_canonical=$(_canonical_path "$actual") || return 1
+    expected_canonical=$(_canonical_path "$expected") || return 1
+    [ -n "$actual_canonical" ] || return 1
+    [ -n "$expected_canonical" ] || return 1
+    [ "$actual_canonical" = "$expected_canonical" ]
 }
 
 clean_hooks_mirror_if_source_link() {

--- a/install.sh
+++ b/install.sh
@@ -234,7 +234,7 @@ _symlink_points_to() {
     [ "$(_canonical_path "$actual")" = "$(_canonical_path "$expected")" ]
 }
 
-clean_codex_hooks_mirror_if_looped() {
+clean_hooks_mirror_if_source_link() {
     local hook_dir="$1"
     local hook_source_dir="$2"
 
@@ -244,11 +244,11 @@ clean_codex_hooks_mirror_if_looped() {
 
     if _symlink_points_to "$hook_dir" "$hook_source_dir"; then
         if [ "$DRY_RUN" = true ]; then
-            echo -e "${YELLOW}  Would remove stale Codex hooks mirror symlink: ${hook_dir}${NC}"
+            echo -e "${YELLOW}  Would remove stale hooks mirror symlink: ${hook_dir}${NC}"
             echo -e "${YELLOW}  (points back into source hooks: ${hook_source_dir})${NC}"
             return
         fi
-        echo -e "${YELLOW}  Removing stale Codex hooks mirror symlink: ${hook_dir}${NC}"
+        echo -e "${YELLOW}  Removing stale hooks mirror symlink: ${hook_dir}${NC}"
         echo -e "${YELLOW}  (points back into source hooks: ${hook_source_dir})${NC}"
         unlink "$hook_dir"
     fi
@@ -1718,7 +1718,7 @@ if [ "$MIRROR_CODEX" = true ]; then
     CODEX_MANAGED_HOOKS_MANIFEST="${CODEX_HOOKS_DIR}/.vexjoy-managed-hooks"
 
     if [ -f "$CODEX_HOOKS_ALLOWLIST" ]; then
-        clean_codex_hooks_mirror_if_looped "$CODEX_HOOKS_DIR" "${SCRIPT_DIR}/hooks"
+        clean_hooks_mirror_if_source_link "$CODEX_HOOKS_DIR" "${SCRIPT_DIR}/hooks"
 
         # Remove only files recorded by the previous VexJoy install. This
         # refreshes hooks removed from the current compatibility inventory
@@ -2206,6 +2206,8 @@ REASONIX_HOOK_FAILED=false       # settings.json generator failed → hooks neve
 REASONIX_HOOKS_ALLOWLIST="${SCRIPT_DIR}/scripts/reasonix-hooks-allowlist.txt"
 
 if [ -f "$REASONIX_HOOKS_ALLOWLIST" ]; then
+    clean_hooks_mirror_if_source_link "$REASONIX_HOOKS_DIR" "${SCRIPT_DIR}/hooks"
+
     if [ "$DRY_RUN" = true ]; then
         echo -e "${BLUE}  Would create: ${REASONIX_HOOKS_DIR}${NC}"
     else

--- a/scripts/tests/test_install_hook_mirror_safety.py
+++ b/scripts/tests/test_install_hook_mirror_safety.py
@@ -222,6 +222,34 @@ def test_python_only_source_link_is_replaced(
 
 
 @pytest.mark.parametrize(("args", "stdin", "expect_link"), MODES)
+@pytest.mark.parametrize("canonicalization", ["fail", "empty"])
+def test_source_link_is_preserved_when_resolution_is_unknown(
+    installer_tree: Path,
+    tmp_path: Path,
+    args: list[str],
+    stdin: str | None,
+    expect_link: bool,
+    canonicalization: str,
+) -> None:
+    del expect_link
+    home = tmp_path / f"{canonicalization} source home"
+    reasonix = home / ".reasonix"
+    reasonix.mkdir(parents=True)
+    hooks_dir = reasonix / "hooks"
+    hooks_dir.symlink_to(installer_tree / "hooks", target_is_directory=True)
+    source_hook = installer_tree / "hooks" / HOOK_NAME
+    original = source_hook.read_bytes()
+    python_bin = _isolated_python_bin(tmp_path / canonicalization, canonicalization)
+
+    result = _run_install(installer_tree, home, python_bin, args, stdin, isolated_path=True)
+
+    assert result.returncode == 0, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert hooks_dir.is_symlink() and hooks_dir.resolve() == (installer_tree / "hooks").resolve()
+    assert source_hook.is_file() and not source_hook.is_symlink()
+    assert source_hook.read_bytes() == original
+
+
+@pytest.mark.parametrize(("args", "stdin", "expect_link"), MODES)
 @pytest.mark.parametrize("canonicalization", ["ok", "fail", "empty"])
 def test_python_only_external_link_is_preserved_when_resolution_is_not_proven(
     installer_tree: Path,
@@ -248,8 +276,12 @@ def test_python_only_external_link_is_preserved_when_resolution_is_not_proven(
     assert hooks_dir.is_symlink() and hooks_dir.resolve() == external_hooks.resolve()
     assert sentinel.read_text(encoding="utf-8") == "keep me\n"
     installed_hook = external_hooks / HOOK_NAME
-    assert installed_hook.read_bytes() == (installer_tree / "hooks" / HOOK_NAME).read_bytes()
-    assert installed_hook.is_symlink() is expect_link
+    if canonicalization == "ok":
+        assert installed_hook.read_bytes() == (installer_tree / "hooks" / HOOK_NAME).read_bytes()
+        assert installed_hook.is_symlink() is expect_link
+    else:
+        assert not installed_hook.exists()
+        assert not installed_hook.is_symlink()
 
 
 @pytest.mark.parametrize(("args", "stdin", "expect_link"), MODES)

--- a/scripts/tests/test_install_hook_mirror_safety.py
+++ b/scripts/tests/test_install_hook_mirror_safety.py
@@ -6,15 +6,17 @@ import shutil
 import subprocess  # nosec B404 - fixed installer argv; no shell execution
 import sys
 from pathlib import Path
+from typing import cast
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_NAME = "user-correction-capture.py"
-BASH: str = shutil.which("bash") or ""
+BASH_PATH = shutil.which("bash")
 
-if BASH is None:
+if BASH_PATH is None:
     pytest.skip("bash not available on this platform", allow_module_level=True)
+BASH = cast(str, BASH_PATH)
 
 MODES = [
     pytest.param(["--copy", "--force"], None, False, id="copy"),
@@ -26,7 +28,7 @@ MODES = [
 @pytest.fixture
 def installer_tree(tmp_path: Path) -> Path:
     """Build the smallest isolated source tree that exercises Reasonix hooks."""
-    root = tmp_path / "repo"
+    root = tmp_path / "repo with spaces"
     for directory in ("hooks", "scripts", "skills"):
         (root / directory).mkdir(parents=True)
 
@@ -41,22 +43,64 @@ def installer_tree(tmp_path: Path) -> Path:
     return root
 
 
-@pytest.fixture
-def fake_python_bin(tmp_path: Path) -> Path:
-    """Stub pip calls while delegating installer Python work to pytest's interpreter."""
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    wrapper = bin_dir / "python3"
+def _write_python_wrapper(bin_dir: Path, name: str, canonicalization: str = "ok") -> None:
+    canonicalization_case = {
+        "ok": "",
+        "fail": 'case "$2" in *"os.path.realpath"*) exit 9 ;; esac\n',
+        "empty": 'case "$2" in *"os.path.realpath"*) exit 0 ;; esac\n',
+    }[canonicalization]
+    wrapper = bin_dir / name
     wrapper.write_text(
         "#!/bin/sh\n"
         'if [ "$1" = "-m" ] && [ "$2" = "pip" ]; then\n'
         '  [ "$3" = "--version" ] && echo "pip test-stub"\n'
         "  exit 0\n"
         "fi\n"
+        f"{canonicalization_case}"
         f'exec {shlex.quote(sys.executable)} "$@"\n',
         encoding="utf-8",
     )
     wrapper.chmod(0o755)
+
+
+def _isolated_python_bin(tmp_path: Path, canonicalization: str = "ok") -> Path:
+    """Provide installer tools with `python`, but no `python3`, on PATH."""
+    bin_dir = tmp_path / f"python-only-{canonicalization}"
+    bin_dir.mkdir(parents=True)
+    for name in (
+        "basename",
+        "chmod",
+        "cp",
+        "cut",
+        "date",
+        "dirname",
+        "find",
+        "grep",
+        "head",
+        "ln",
+        "ls",
+        "mkdir",
+        "readlink",
+        "rm",
+        "sed",
+        "sort",
+        "tr",
+        "unlink",
+        "wc",
+    ):
+        executable = shutil.which(name)
+        assert executable is not None
+        (bin_dir / name).symlink_to(executable)
+    _write_python_wrapper(bin_dir, "python", canonicalization)
+    return bin_dir
+
+
+@pytest.fixture
+def fake_python_bin(tmp_path: Path) -> Path:
+    """Stub pip calls while delegating installer Python work to pytest's interpreter."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_python_wrapper(bin_dir, "python3")
     return bin_dir
 
 
@@ -66,11 +110,14 @@ def _run_install(
     python_bin: Path,
     args: list[str],
     stdin: str | None,
+    *,
+    isolated_path: bool = False,
 ) -> subprocess.CompletedProcess[str]:
+    path = str(python_bin) if isolated_path else f"{python_bin}:/usr/bin:/bin"
     env = {
         **os.environ,
         "HOME": str(home),
-        "PATH": f"{python_bin}:/usr/bin:/bin",
+        "PATH": path,
         "TERM": "dumb",
     }
     return subprocess.run(  # nosec B603 - fixed executable and argument list
@@ -93,7 +140,7 @@ def test_source_hook_link_is_replaced_without_source_damage(
     stdin: str | None,
     expect_link: bool,
 ) -> None:
-    home = tmp_path / "home"
+    home = tmp_path / "home with spaces"
     reasonix = home / ".reasonix"
     reasonix.mkdir(parents=True)
     hooks_dir = reasonix / "hooks"
@@ -122,16 +169,16 @@ def test_distinct_hook_link_and_user_files_are_preserved(
     stdin: str | None,
     expect_link: bool,
 ) -> None:
-    home = tmp_path / "home"
+    home = tmp_path / "home with spaces"
     reasonix = home / ".reasonix"
-    external_hooks = tmp_path / "external-hooks"
+    external_hooks = tmp_path / "external hooks"
     reasonix.mkdir(parents=True)
     external_hooks.mkdir()
     hooks_dir = reasonix / "hooks"
     hooks_dir.symlink_to(external_hooks, target_is_directory=True)
     sentinel = external_hooks / "user-note.txt"
     sentinel.write_text("keep me\n", encoding="utf-8")
-    user_hook_source = tmp_path / "user-hook.py"
+    user_hook_source = tmp_path / "user hook.py"
     user_hook_source.write_text("# user hook\n", encoding="utf-8")
     user_hook = external_hooks / "user-hook.py"
     user_hook.symlink_to(user_hook_source)
@@ -145,3 +192,118 @@ def test_distinct_hook_link_and_user_files_are_preserved(
     installed_hook = external_hooks / HOOK_NAME
     assert installed_hook.read_bytes() == (installer_tree / "hooks" / HOOK_NAME).read_bytes()
     assert installed_hook.is_symlink() is expect_link
+
+
+@pytest.mark.parametrize(("args", "stdin", "expect_link"), MODES)
+def test_python_only_source_link_is_replaced(
+    installer_tree: Path,
+    tmp_path: Path,
+    args: list[str],
+    stdin: str | None,
+    expect_link: bool,
+) -> None:
+    home = tmp_path / "python only home"
+    reasonix = home / ".reasonix"
+    reasonix.mkdir(parents=True)
+    hooks_dir = reasonix / "hooks"
+    hooks_dir.symlink_to(installer_tree / "hooks", target_is_directory=True)
+    source_hook = installer_tree / "hooks" / HOOK_NAME
+    original = source_hook.read_bytes()
+    python_bin = _isolated_python_bin(tmp_path)
+
+    result = _run_install(installer_tree, home, python_bin, args, stdin, isolated_path=True)
+
+    assert result.returncode == 0, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert hooks_dir.is_dir() and not hooks_dir.is_symlink()
+    assert source_hook.read_bytes() == original
+    installed_hook = hooks_dir / HOOK_NAME
+    assert installed_hook.read_bytes() == original
+    assert installed_hook.is_symlink() is expect_link
+
+
+@pytest.mark.parametrize(("args", "stdin", "expect_link"), MODES)
+@pytest.mark.parametrize("canonicalization", ["ok", "fail", "empty"])
+def test_python_only_external_link_is_preserved_when_resolution_is_not_proven(
+    installer_tree: Path,
+    tmp_path: Path,
+    args: list[str],
+    stdin: str | None,
+    expect_link: bool,
+    canonicalization: str,
+) -> None:
+    home = tmp_path / f"{canonicalization} home"
+    reasonix = home / ".reasonix"
+    external_hooks = tmp_path / f"{canonicalization} external hooks"
+    reasonix.mkdir(parents=True)
+    external_hooks.mkdir()
+    hooks_dir = reasonix / "hooks"
+    hooks_dir.symlink_to(external_hooks, target_is_directory=True)
+    sentinel = external_hooks / "user note.txt"
+    sentinel.write_text("keep me\n", encoding="utf-8")
+    python_bin = _isolated_python_bin(tmp_path / canonicalization, canonicalization)
+
+    result = _run_install(installer_tree, home, python_bin, args, stdin, isolated_path=True)
+
+    assert result.returncode == 0, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert hooks_dir.is_symlink() and hooks_dir.resolve() == external_hooks.resolve()
+    assert sentinel.read_text(encoding="utf-8") == "keep me\n"
+    installed_hook = external_hooks / HOOK_NAME
+    assert installed_hook.read_bytes() == (installer_tree / "hooks" / HOOK_NAME).read_bytes()
+    assert installed_hook.is_symlink() is expect_link
+
+
+@pytest.mark.parametrize(("args", "stdin", "expect_link"), MODES)
+@pytest.mark.parametrize("link_kind", ["dangling", "loop"])
+def test_unresolvable_hook_link_is_preserved(
+    installer_tree: Path,
+    fake_python_bin: Path,
+    tmp_path: Path,
+    args: list[str],
+    stdin: str | None,
+    expect_link: bool,
+    link_kind: str,
+) -> None:
+    del expect_link
+    home = tmp_path / f"{link_kind} home"
+    reasonix = home / ".reasonix"
+    reasonix.mkdir(parents=True)
+    hooks_dir = reasonix / "hooks"
+    target = tmp_path / "missing external hooks" if link_kind == "dangling" else hooks_dir
+    hooks_dir.symlink_to(target, target_is_directory=True)
+    original_target = os.readlink(hooks_dir)
+    source_hook = installer_tree / "hooks" / HOOK_NAME
+    original_source = source_hook.read_bytes()
+
+    result = _run_install(installer_tree, home, fake_python_bin, args, stdin)
+
+    assert result.returncode != 0
+    assert hooks_dir.is_symlink()
+    assert os.readlink(hooks_dir) == original_target
+    assert source_hook.read_bytes() == original_source
+
+
+def test_module_skips_collection_without_bash(tmp_path: Path) -> None:
+    empty_path = tmp_path / "empty-path"
+    empty_path.mkdir()
+    probe = tmp_path / "test_no_bash_probe.py"
+    probe.write_text(
+        "import importlib.util\n"
+        f"spec = importlib.util.spec_from_file_location('hook_mirror_safety', {str(Path(__file__))!r})\n"
+        "assert spec is not None and spec.loader is not None\n"
+        "module = importlib.util.module_from_spec(spec)\n"
+        "spec.loader.exec_module(module)\n",
+        encoding="utf-8",
+    )
+    env = {**os.environ, "PATH": str(empty_path)}
+
+    result = subprocess.run(  # nosec B603 - fixed interpreter and pytest argv
+        [sys.executable, "-m", "pytest", str(probe), "-q"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode in {0, 5}, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert "1 skipped" in result.stdout

--- a/scripts/tests/test_install_hook_mirror_safety.py
+++ b/scripts/tests/test_install_hook_mirror_safety.py
@@ -1,0 +1,147 @@
+"""Regression tests for hook-mirror symlink safety in install.sh."""
+
+import os
+import shlex
+import shutil
+import subprocess  # nosec B404 - fixed installer argv; no shell execution
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_NAME = "user-correction-capture.py"
+BASH: str = shutil.which("bash") or ""
+
+if BASH is None:
+    pytest.skip("bash not available on this platform", allow_module_level=True)
+
+MODES = [
+    pytest.param(["--copy", "--force"], None, False, id="copy"),
+    pytest.param(["--symlink", "--force"], "2\n", True, id="symlink"),
+    pytest.param(["--symlink", "--per-item", "--force"], None, True, id="symlink-per-item"),
+]
+
+
+@pytest.fixture
+def installer_tree(tmp_path: Path) -> Path:
+    """Build the smallest isolated source tree that exercises Reasonix hooks."""
+    root = tmp_path / "repo"
+    for directory in ("hooks", "scripts", "skills"):
+        (root / directory).mkdir(parents=True)
+
+    shutil.copy2(REPO_ROOT / "install.sh", root / "install.sh")
+    shutil.copy2(REPO_ROOT / "hooks" / HOOK_NAME, root / "hooks" / HOOK_NAME)
+    shutil.copy2(
+        REPO_ROOT / "scripts" / "generate-reasonix-settings-hooks.py",
+        root / "scripts" / "generate-reasonix-settings-hooks.py",
+    )
+    (root / "scripts" / "reasonix-hooks-allowlist.txt").write_text(f"UserPromptSubmit:{HOOK_NAME}\n", encoding="utf-8")
+    (root / "requirements.txt").write_text("", encoding="utf-8")
+    return root
+
+
+@pytest.fixture
+def fake_python_bin(tmp_path: Path) -> Path:
+    """Stub pip calls while delegating installer Python work to pytest's interpreter."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    wrapper = bin_dir / "python3"
+    wrapper.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "-m" ] && [ "$2" = "pip" ]; then\n'
+        '  [ "$3" = "--version" ] && echo "pip test-stub"\n'
+        "  exit 0\n"
+        "fi\n"
+        f'exec {shlex.quote(sys.executable)} "$@"\n',
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+    return bin_dir
+
+
+def _run_install(
+    root: Path,
+    home: Path,
+    python_bin: Path,
+    args: list[str],
+    stdin: str | None,
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{python_bin}:/usr/bin:/bin",
+        "TERM": "dumb",
+    }
+    return subprocess.run(  # nosec B603 - fixed executable and argument list
+        [BASH, str(root / "install.sh"), *args],
+        cwd=root,
+        env=env,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+@pytest.mark.parametrize(("args", "stdin", "expect_link"), MODES)
+def test_source_hook_link_is_replaced_without_source_damage(
+    installer_tree: Path,
+    fake_python_bin: Path,
+    tmp_path: Path,
+    args: list[str],
+    stdin: str | None,
+    expect_link: bool,
+) -> None:
+    home = tmp_path / "home"
+    reasonix = home / ".reasonix"
+    reasonix.mkdir(parents=True)
+    hooks_dir = reasonix / "hooks"
+    hooks_dir.symlink_to(installer_tree / "hooks", target_is_directory=True)
+    source_hook = installer_tree / "hooks" / HOOK_NAME
+    original = source_hook.read_bytes()
+
+    for _ in range(2):
+        result = _run_install(installer_tree, home, fake_python_bin, args, stdin)
+        assert result.returncode == 0, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+
+    installed_hook = hooks_dir / HOOK_NAME
+    assert hooks_dir.is_dir() and not hooks_dir.is_symlink()
+    assert source_hook.is_file() and not source_hook.is_symlink()
+    assert source_hook.read_bytes() == original
+    assert installed_hook.read_bytes() == original
+    assert installed_hook.is_symlink() is expect_link
+
+
+@pytest.mark.parametrize(("args", "stdin", "expect_link"), MODES)
+def test_distinct_hook_link_and_user_files_are_preserved(
+    installer_tree: Path,
+    fake_python_bin: Path,
+    tmp_path: Path,
+    args: list[str],
+    stdin: str | None,
+    expect_link: bool,
+) -> None:
+    home = tmp_path / "home"
+    reasonix = home / ".reasonix"
+    external_hooks = tmp_path / "external-hooks"
+    reasonix.mkdir(parents=True)
+    external_hooks.mkdir()
+    hooks_dir = reasonix / "hooks"
+    hooks_dir.symlink_to(external_hooks, target_is_directory=True)
+    sentinel = external_hooks / "user-note.txt"
+    sentinel.write_text("keep me\n", encoding="utf-8")
+    user_hook_source = tmp_path / "user-hook.py"
+    user_hook_source.write_text("# user hook\n", encoding="utf-8")
+    user_hook = external_hooks / "user-hook.py"
+    user_hook.symlink_to(user_hook_source)
+
+    result = _run_install(installer_tree, home, fake_python_bin, args, stdin)
+
+    assert result.returncode == 0, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert hooks_dir.is_symlink() and hooks_dir.resolve() == external_hooks.resolve()
+    assert sentinel.read_text(encoding="utf-8") == "keep me\n"
+    assert user_hook.is_symlink() and user_hook.resolve() == user_hook_source.resolve()
+    installed_hook = external_hooks / HOOK_NAME
+    assert installed_hook.read_bytes() == (installer_tree / "hooks" / HOOK_NAME).read_bytes()
+    assert installed_hook.is_symlink() is expect_link


### PR DESCRIPTION
## Summary
Prevent hook mirrors from writing through directory symlinks that resolve to the checkout's source hooks.

## Changes
- `install.sh` — reuse exact-source cleanup for Codex and Reasonix hook mirrors.
- `scripts/tests/test_install_hook_mirror_safety.py` — cover copy, symlink, per-item, idempotency, and external-content preservation.

## Notes
Supersedes #901 with a narrow owner-branch fix. Credit to @thecodingshrimp for reporting the issue.
Operator sign-off is required because this changes the installer.
