### PR TITLE
Fix plan gate path resolution

### DIFF
--- a/hooks/pretool-plan-gate.py
+++ b/hooks/pretool-plan-gate.py
@@ -10,7 +10,7 @@ This is a HARD GATE — exits 0 with JSON permissionDecision:deny to block the W
 
 Detection logic:
 - Tool is Write or Edit
-- Target path is in agents/, skills/
+- Target resolves inside the project-root agents/ or skills/ directory
 - task_plan.md does not exist in the project root
 
 Allow-through conditions:
@@ -24,25 +24,148 @@ import os
 import sys
 import traceback
 from pathlib import Path
+from typing import NoReturn
 
 sys.path.insert(0, str(Path(__file__).parent / "lib"))
 from hook_utils import deny_tool_use, hook_error
 from stdin_timeout import read_stdin
 
 _BYPASS_ENV = "PLAN_GATE_BYPASS"
+_PROJECT_DIR_ENV = "CLAUDE_PROJECT_DIR"
 
-# Paths that ARE implementation code — only these get gated.
-# Everything else (docs, config, CI, plans, tests, scripts, hooks) passes through.
-_GATED_PREFIXES = (
-    "/agents/",
-    "/skills/",
-)
+_GATED_DIRECTORIES = ("agents", "skills")
+_GATED = "gated"
+_ALLOW = "allow"
+_UNSAFE = "unsafe"
 
 
-def _is_gated(file_path: str) -> bool:
-    """Return True if this file is in an implementation directory that requires a plan."""
-    normalised = file_path.replace("\\", "/")
-    return any(prefix in normalised for prefix in _GATED_PREFIXES)
+def _input_path(value: str) -> Path:
+    """Return a platform path for a hook path using either slash style."""
+    return Path(value.replace("\\", "/"))
+
+
+def _existing_directory(value: object) -> Path | None:
+    """Resolve an absolute directory from trusted hook context."""
+    if not isinstance(value, str) or not value or "\x00" in value:
+        return None
+    try:
+        path = _input_path(value)
+        if not path.is_absolute():
+            return None
+        resolved = path.resolve(strict=True)
+        return resolved if resolved.is_dir() else None
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _git_root(start: Path) -> Path | None:
+    """Find the nearest Git root, including worktrees with a .git file."""
+    for candidate in (start, *start.parents):
+        try:
+            if (candidate / ".git").exists():
+                return candidate
+        except OSError:
+            continue
+    return None
+
+
+def _project_root(event_cwd: object) -> Path | None:
+    """Resolve the project root from the hook contract, then Git metadata."""
+    project_dir = _existing_directory(os.environ.get(_PROJECT_DIR_ENV))
+    if project_dir is not None:
+        return _git_root(project_dir) or project_dir
+
+    cwd = _existing_directory(event_cwd)
+    if cwd is not None:
+        return _git_root(cwd)
+    return None
+
+
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _mentions_gated_directory(file_path: str) -> bool:
+    """Identify a gated-looking path when no safe root can be resolved."""
+    try:
+        return any(part in _GATED_DIRECTORIES for part in _input_path(file_path).parts)
+    except (OSError, ValueError):
+        return False
+
+
+def _target_status(file_path: str, event_cwd: object, root: Path) -> str:
+    """Classify a normalized target as allowed, gated, or unsafe."""
+    if not file_path or "\x00" in file_path:
+        return _UNSAFE
+
+    raw_path = _input_path(file_path)
+    is_relative = not raw_path.is_absolute()
+    if is_relative:
+        base_dir = _existing_directory(event_cwd)
+        if base_dir is None:
+            return _UNSAFE
+        candidate = base_dir / raw_path
+    else:
+        candidate = raw_path
+
+    try:
+        lexical = Path(os.path.normpath(str(candidate)))
+        canonical = candidate.resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return _UNSAFE
+
+    lexical_in_project = _is_within(lexical, root)
+    canonical_in_project = _is_within(canonical, root)
+
+    # A relative tool path belongs to this project. Do not let traversal or a
+    # symlink move it outside the root selected by the hook contract.
+    if is_relative and (not lexical_in_project or not canonical_in_project):
+        return _UNSAFE
+    if lexical_in_project and not canonical_in_project:
+        return _UNSAFE
+
+    root_plan = root / "task_plan.md"
+    if lexical == root_plan and canonical == root_plan:
+        return _ALLOW
+
+    for directory in _GATED_DIRECTORIES:
+        lexical_root = root / directory
+        try:
+            canonical_root = lexical_root.resolve(strict=False)
+        except (OSError, RuntimeError, ValueError):
+            return _UNSAFE
+
+        lexically_gated = _is_within(lexical, lexical_root)
+        if lexically_gated and not _is_within(canonical_root, root):
+            return _UNSAFE
+        if _is_within(canonical, canonical_root):
+            return _GATED
+        if lexically_gated:
+            return _UNSAFE
+
+    return _ALLOW
+
+
+def _deny(reason: str, *, stderr_message: str, fix_with_plans: bool = False) -> NoReturn:
+    print(f"[plan-gate] BLOCKED: {stderr_message}", file=sys.stderr)
+    if fix_with_plans:
+        print("[fix-with-skill] plans", file=sys.stderr)
+    deny_tool_use("PreToolUse", reason)
+    sys.exit(0)
+
+
+def _root_plan_exists(root: Path) -> bool:
+    """Return whether the exact root plan is a regular file, not a symlink."""
+    plan_path = root / "task_plan.md"
+    try:
+        resolved = plan_path.resolve(strict=True)
+        return resolved == plan_path and resolved.is_file()
+    except (OSError, RuntimeError, ValueError):
+        return False
 
 
 def main() -> None:
@@ -63,40 +186,50 @@ def main() -> None:
             print(f"[plan-gate] Bypassed via {_BYPASS_ENV}=1", file=sys.stderr)
         sys.exit(0)
 
-    tool_input = event.get("tool_input", {})
-    file_path = tool_input.get("file_path", "")
-    if not file_path:
+    if not isinstance(event, dict):
         sys.exit(0)
 
-    # Only gate implementation code (agents/, skills/, pipelines/).
-    # Everything else (docs, config, CI, plans, tests, scripts, hooks) passes through.
-    if not _is_gated(file_path):
+    tool_input = event.get("tool_input", {})
+    if not isinstance(tool_input, dict):
+        sys.exit(0)
+    file_path = tool_input.get("file_path", "")
+    if not isinstance(file_path, str) or not file_path:
+        sys.exit(0)
+
+    root = _project_root(event.get("cwd"))
+    if root is None:
+        if _input_path(file_path).is_absolute() and not _mentions_gated_directory(file_path):
+            sys.exit(0)
+        _deny(
+            "Cannot resolve the project root safely for this edit.",
+            stderr_message="Cannot resolve the project root safely.",
+        )
+
+    status = _target_status(file_path, event.get("cwd"), root)
+    if status == _UNSAFE:
+        _deny(
+            "Target path cannot be resolved safely inside the project.",
+            stderr_message="Target path escapes the project or cannot be resolved safely.",
+        )
+    if status == _ALLOW:
         if debug:
             print(f"[plan-gate] Not a gated path, allowing: {file_path}", file=sys.stderr)
         sys.exit(0)
 
-    # Resolve project root: prefer event["cwd"], then CLAUDE_PROJECT_DIR, then cwd.
-    cwd_str = event.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR", ".")
-    base_dir = Path(cwd_str).resolve()
-
-    plan_path = base_dir / "task_plan.md"
-    if plan_path.is_file():
+    if _root_plan_exists(root):
         if debug:
-            print(f"[plan-gate] task_plan.md found at {plan_path} — allowing through", file=sys.stderr)
+            print(
+                f"[plan-gate] task_plan.md found at {root / 'task_plan.md'} — allowing through",
+                file=sys.stderr,
+            )
         sys.exit(0)
 
-    # task_plan.md is missing — block.
-    print(
-        "[plan-gate] BLOCKED: Create task_plan.md before modifying implementation code.",
-        file=sys.stderr,
-    )
-    print("[fix-with-skill] plans", file=sys.stderr)
-    deny_tool_use(
-        "PreToolUse",
+    _deny(
         "Create task_plan.md before modifying implementation code in agents/ or skills/. "
         "Use the planning skill to create one.",
+        stderr_message="Create task_plan.md before modifying implementation code.",
+        fix_with_plans=True,
     )
-    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/hooks/pretool-plan-gate.py
+++ b/hooks/pretool-plan-gate.py
@@ -21,6 +21,7 @@ Allow-through conditions:
 
 import json
 import os
+import stat
 import sys
 import traceback
 from pathlib import Path
@@ -32,6 +33,7 @@ from stdin_timeout import read_stdin
 
 _BYPASS_ENV = "PLAN_GATE_BYPASS"
 _PROJECT_DIR_ENV = "CLAUDE_PROJECT_DIR"
+_MAX_GIT_METADATA_BYTES = 4096
 
 _GATED_DIRECTORIES = ("agents", "skills")
 _GATED = "gated"
@@ -58,26 +60,170 @@ def _existing_directory(value: object) -> Path | None:
         return None
 
 
-def _git_root(start: Path) -> Path | None:
-    """Find the nearest Git root, including worktrees with a .git file."""
+def _real_directory(path: Path) -> bool:
+    """Return whether path is a directory, excluding symlinks."""
+    try:
+        return stat.S_ISDIR(path.lstat().st_mode)
+    except OSError:
+        return False
+
+
+def _regular_file(path: Path) -> bool:
+    """Return whether path is a regular file, excluding symlinks."""
+    try:
+        return stat.S_ISREG(path.lstat().st_mode)
+    except OSError:
+        return False
+
+
+def _entry_present(path: Path) -> bool:
+    """Treat inaccessible entries as present so root selection fails closed."""
+    try:
+        path.lstat()
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True
+
+
+def _metadata_line(path: Path) -> str | None:
+    """Read one bounded metadata line without following a final symlink."""
+    if not _regular_file(path):
+        return None
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except (OSError, TypeError, ValueError):
+        return None
+
+    try:
+        file_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(file_stat.st_mode) or file_stat.st_size > _MAX_GIT_METADATA_BYTES:
+            return None
+        data = os.read(descriptor, _MAX_GIT_METADATA_BYTES + 1)
+    except OSError:
+        return None
+    finally:
+        os.close(descriptor)
+
+    if len(data) > _MAX_GIT_METADATA_BYTES or b"\x00" in data:
+        return None
+    try:
+        lines = data.decode("utf-8").splitlines()
+    except UnicodeDecodeError:
+        return None
+    if len(lines) != 1 or not lines[0].strip():
+        return None
+    return lines[0].strip()
+
+
+def _valid_head(git_dir: Path) -> bool:
+    head = _metadata_line(git_dir / "HEAD")
+    if head is None:
+        return False
+    if len(head) in {40, 64} and all(character in "0123456789abcdefABCDEF" for character in head):
+        return True
+    if not head.startswith("ref: refs/"):
+        return False
+    ref = head.removeprefix("ref: ")
+    invalid = ("..", "//", "@{", "\\", "~", "^", ":", "?", "*", "[")
+    if any(token in ref for token in invalid) or any(
+        ord(character) <= 32 or ord(character) == 127 for character in ref
+    ):
+        return False
+    parts = ref.split("/")
+    return all(part and not part.startswith(".") and not part.endswith((".", ".lock")) for part in parts)
+
+
+def _valid_common_git_dir(git_dir: Path) -> bool:
+    return (
+        _real_directory(git_dir)
+        and _valid_head(git_dir)
+        and _real_directory(git_dir / "objects")
+        and _real_directory(git_dir / "refs")
+        and _regular_file(git_dir / "config")
+    )
+
+
+def _resolve_metadata_path(value: str, base: Path) -> Path | None:
+    try:
+        path = _input_path(value)
+        if not path.is_absolute():
+            path = base / path
+        return path.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _valid_linked_worktree(candidate: Path, marker: Path) -> bool:
+    marker_line = _metadata_line(marker)
+    if marker_line is None or not marker_line.startswith("gitdir: "):
+        return False
+
+    git_dir = _resolve_metadata_path(marker_line.removeprefix("gitdir: "), candidate)
+    if git_dir is None or not _real_directory(git_dir) or not _valid_head(git_dir):
+        return False
+
+    common_line = _metadata_line(git_dir / "commondir")
+    backlink_line = _metadata_line(git_dir / "gitdir")
+    if common_line is None or backlink_line is None:
+        return False
+
+    common_dir = _resolve_metadata_path(common_line, git_dir)
+    backlink = _resolve_metadata_path(backlink_line, git_dir)
+    try:
+        marker_path = marker.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    if common_dir is None or backlink is None or backlink != marker_path:
+        return False
+    if not _valid_common_git_dir(common_dir):
+        return False
+
+    worktrees_dir = common_dir / "worktrees"
+    if not _real_directory(worktrees_dir) or git_dir.parent != worktrees_dir:
+        return False
+
+    outer_markers = [parent / ".git" for parent in candidate.parents if _entry_present(parent / ".git")]
+    if not outer_markers:
+        return True
+    outer_git_dirs = [marker for marker in outer_markers if _valid_common_git_dir(marker)]
+    return common_dir in outer_git_dirs
+
+
+def _git_root(start: Path, *, reject_nested: bool) -> Path | None:
+    """Find one structurally valid repository or linked-worktree root."""
+    linked_roots: list[Path] = []
+    repository_roots: list[Path] = []
     for candidate in (start, *start.parents):
-        try:
-            if (candidate / ".git").exists():
-                return candidate
-        except OSError:
-            continue
-    return None
+        marker = candidate / ".git"
+        if _valid_linked_worktree(candidate, marker):
+            linked_roots.append(candidate)
+        elif _valid_common_git_dir(marker):
+            repository_roots.append(candidate)
+
+    if len(linked_roots) == 1:
+        return linked_roots[0]
+    if linked_roots or not repository_roots:
+        return None
+    if reject_nested and len(repository_roots) != 1:
+        return None
+    return repository_roots[0]
 
 
-def _project_root(event_cwd: object) -> Path | None:
+def _project_root(event_cwd: object, *, require_repository: bool) -> Path | None:
     """Resolve the project root from the hook contract, then Git metadata."""
     project_dir = _existing_directory(os.environ.get(_PROJECT_DIR_ENV))
     if project_dir is not None:
-        return _git_root(project_dir) or project_dir
+        git_root = _git_root(project_dir, reject_nested=require_repository)
+        if git_root is not None:
+            return git_root
+        return None if require_repository else project_dir
 
     cwd = _existing_directory(event_cwd)
     if cwd is not None:
-        return _git_root(cwd)
+        return _git_root(cwd, reject_nested=require_repository)
     return None
 
 
@@ -196,7 +342,8 @@ def main() -> None:
     if not isinstance(file_path, str) or not file_path:
         sys.exit(0)
 
-    root = _project_root(event.get("cwd"))
+    require_repository = not _input_path(file_path).is_absolute() or "codex_tool_name" in event
+    root = _project_root(event.get("cwd"), require_repository=require_repository)
     if root is None:
         if _input_path(file_path).is_absolute() and not _mentions_gated_directory(file_path):
             sys.exit(0)

--- a/hooks/tests/test_pretool_plan_gate.py
+++ b/hooks/tests/test_pretool_plan_gate.py
@@ -1,0 +1,410 @@
+"""Behavior and protocol tests for the implementation plan gate."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+HOOK = ROOT / "hooks" / "pretool-plan-gate.py"
+ADAPTER = ROOT / "hooks" / "codex-hook-adapter.py"
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    root = tmp_path / "project"
+    (root / ".git").mkdir(parents=True)
+    (root / "agents" / "example").mkdir(parents=True)
+    (root / "skills" / "example").mkdir(parents=True)
+    return root
+
+
+def _run_hook(
+    file_path: object,
+    *,
+    event_cwd: object | None,
+    project_dir: object | None,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    event: dict[str, object] = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Write",
+        "tool_input": {"file_path": file_path},
+    }
+    if event_cwd is not None:
+        event["cwd"] = event_cwd
+
+    env = dict(os.environ)
+    for key in (
+        "CLAUDE_HOOKS_DEBUG",
+        "CLAUDE_PROJECT_DIR",
+        "PLAN_GATE_BYPASS",
+    ):
+        env.pop(key, None)
+    if project_dir is not None:
+        env["CLAUDE_PROJECT_DIR"] = str(project_dir)
+    if extra_env:
+        env.update(extra_env)
+
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(event),
+        capture_output=True,
+        text=True,
+        cwd="/",
+        env=env,
+        timeout=10,
+        check=False,
+    )
+
+
+def _decision(result: subprocess.CompletedProcess[str]) -> str | None:
+    assert result.returncode == 0, result.stderr
+    if not result.stdout.strip():
+        return None
+    output = json.loads(result.stdout)
+    inner = output.get("hookSpecificOutput")
+    if not isinstance(inner, dict):
+        return None
+    decision = inner.get("permissionDecision")
+    return decision if isinstance(decision, str) else None
+
+
+def _assert_allowed(result: subprocess.CompletedProcess[str]) -> None:
+    assert _decision(result) is None
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def _assert_denied(result: subprocess.CompletedProcess[str]) -> None:
+    assert _decision(result) == "deny"
+    assert "permissionDecisionReason" in json.loads(result.stdout)["hookSpecificOutput"]
+
+
+def test_missing_root_plan_denies_absolute_gated_path(project: Path) -> None:
+    result = _run_hook(
+        str(project / "skills" / "example" / "SKILL.md"),
+        event_cwd=str(project),
+        project_dir=str(project),
+    )
+
+    _assert_denied(result)
+
+
+def test_root_plan_allows_absolute_path_from_nested_cwd(project: Path) -> None:
+    nested = project / "skills" / "example"
+    (project / "task_plan.md").write_text("# Plan\n", encoding="utf-8")
+
+    result = _run_hook(
+        str(nested / "SKILL.md"),
+        event_cwd=str(nested),
+        project_dir=str(project),
+    )
+
+    _assert_allowed(result)
+
+
+def test_nested_plan_does_not_replace_root_plan(project: Path) -> None:
+    nested = project / "skills" / "example"
+    (nested / "task_plan.md").write_text("# Wrong plan\n", encoding="utf-8")
+
+    result = _run_hook(
+        str(nested / "SKILL.md"),
+        event_cwd=str(nested),
+        project_dir=str(project),
+    )
+
+    _assert_denied(result)
+
+
+def test_environment_root_without_git_is_supported(tmp_path: Path) -> None:
+    project = tmp_path / "non-git-project"
+    nested = project / "skills" / "example"
+    nested.mkdir(parents=True)
+    (project / "task_plan.md").write_text("# Plan\n", encoding="utf-8")
+
+    result = _run_hook(
+        str(nested / "SKILL.md"),
+        event_cwd=str(nested),
+        project_dir=str(project),
+    )
+
+    _assert_allowed(result)
+
+
+def test_worktree_git_file_anchors_nested_codex_cwd(tmp_path: Path) -> None:
+    worktree = tmp_path / "worktree"
+    nested = worktree / "skills" / "example"
+    nested.mkdir(parents=True)
+    (worktree / ".git").write_text("gitdir: /tmp/common/worktrees/example\n", encoding="utf-8")
+    (worktree / "task_plan.md").write_text("# Plan\n", encoding="utf-8")
+
+    result = _run_hook(
+        "SKILL.md",
+        event_cwd=str(nested),
+        project_dir=str(nested),
+    )
+
+    _assert_allowed(result)
+
+
+def test_cwd_git_ancestor_is_used_when_project_environment_is_missing(project: Path) -> None:
+    nested = project / "skills" / "example"
+    (project / "task_plan.md").write_text("# Plan\n", encoding="utf-8")
+
+    result = _run_hook(
+        str(nested / "SKILL.md"),
+        event_cwd=str(nested),
+        project_dir=None,
+    )
+
+    _assert_allowed(result)
+
+
+def test_non_git_cwd_without_project_environment_fails_closed(tmp_path: Path) -> None:
+    nested = tmp_path / "non-git-project" / "skills" / "example"
+    nested.mkdir(parents=True)
+
+    result = _run_hook(
+        str(nested / "SKILL.md"),
+        event_cwd=str(nested),
+        project_dir=None,
+    )
+
+    _assert_denied(result)
+
+
+@pytest.mark.parametrize(
+    "file_path",
+    [
+        "skills/example/SKILL.md",
+        "skills\\example\\SKILL.md",
+    ],
+)
+def test_relative_codex_paths_are_gated(project: Path, file_path: str) -> None:
+    result = _run_hook(
+        file_path,
+        event_cwd=str(project),
+        project_dir=str(project),
+    )
+
+    _assert_denied(result)
+
+
+def test_relative_traversal_into_gated_directory_is_gated(project: Path) -> None:
+    scratch = project / "scratch"
+    scratch.mkdir()
+
+    result = _run_hook(
+        "../skills/example/SKILL.md",
+        event_cwd=str(scratch),
+        project_dir=str(project),
+    )
+
+    _assert_denied(result)
+
+
+def test_relative_traversal_outside_project_fails_closed(project: Path) -> None:
+    result = _run_hook(
+        "../outside/skills/example/SKILL.md",
+        event_cwd=str(project),
+        project_dir=str(project),
+    )
+
+    _assert_denied(result)
+
+
+def test_symlink_escape_from_gated_directory_fails_closed(project: Path, tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (project / "skills" / "escape").symlink_to(outside, target_is_directory=True)
+
+    result = _run_hook(
+        str(project / "skills" / "escape" / "SKILL.md"),
+        event_cwd=str(project),
+        project_dir=str(project),
+    )
+
+    _assert_denied(result)
+
+
+def test_symlink_into_gated_directory_cannot_hide_target(project: Path) -> None:
+    docs = project / "docs"
+    docs.mkdir()
+    (docs / "skill-link").symlink_to(project / "skills" / "example", target_is_directory=True)
+
+    result = _run_hook(
+        str(docs / "skill-link" / "SKILL.md"),
+        event_cwd=str(project),
+        project_dir=str(project),
+    )
+
+    _assert_denied(result)
+
+
+def test_absolute_skills_segment_outside_project_is_not_gated(project: Path, tmp_path: Path) -> None:
+    outside = tmp_path / "outside" / "skills" / "example"
+    outside.mkdir(parents=True)
+
+    result = _run_hook(
+        str(outside / "SKILL.md"),
+        event_cwd=str(project),
+        project_dir=str(project),
+    )
+
+    _assert_allowed(result)
+
+
+@pytest.mark.parametrize(
+    ("event_cwd", "project_dir"),
+    [
+        (None, None),
+        ("/path/that/does/not/exist", "/also/missing"),
+        ("bad\x00cwd", None),
+    ],
+)
+def test_missing_or_invalid_root_fails_closed_for_gated_path(
+    event_cwd: str | None,
+    project_dir: str | None,
+) -> None:
+    result = _run_hook(
+        "skills/example/SKILL.md",
+        event_cwd=event_cwd,
+        project_dir=project_dir,
+    )
+
+    _assert_denied(result)
+
+
+def test_missing_root_fails_closed_for_unclassifiable_relative_path() -> None:
+    result = _run_hook(
+        "docs/example.md",
+        event_cwd=None,
+        project_dir=None,
+    )
+
+    _assert_denied(result)
+
+
+def test_relative_path_without_cwd_fails_closed_with_known_root(project: Path) -> None:
+    result = _run_hook(
+        "docs/example.md",
+        event_cwd=None,
+        project_dir=str(project),
+    )
+
+    _assert_denied(result)
+
+
+def test_exact_root_plan_creation_is_allowed(project: Path) -> None:
+    result = _run_hook(
+        str(project / "task_plan.md"),
+        event_cwd=str(project),
+        project_dir=str(project),
+    )
+
+    _assert_allowed(result)
+
+
+def test_nested_task_plan_name_does_not_bypass_gate(project: Path) -> None:
+    result = _run_hook(
+        str(project / "skills" / "example" / "task_plan.md"),
+        event_cwd=str(project),
+        project_dir=str(project),
+    )
+
+    _assert_denied(result)
+
+
+def test_plan_symlink_outside_root_does_not_satisfy_gate(project: Path, tmp_path: Path) -> None:
+    outside_plan = tmp_path / "outside-plan.md"
+    outside_plan.write_text("# Not the root plan\n", encoding="utf-8")
+    (project / "task_plan.md").symlink_to(outside_plan)
+
+    result = _run_hook(
+        str(project / "skills" / "example" / "SKILL.md"),
+        event_cwd=str(project),
+        project_dir=str(project),
+    )
+
+    _assert_denied(result)
+
+
+def test_non_gated_project_file_is_allowed_without_plan(project: Path) -> None:
+    result = _run_hook(
+        str(project / "hooks" / "example.py"),
+        event_cwd=str(project),
+        project_dir=str(project),
+    )
+
+    _assert_allowed(result)
+
+
+def test_explicit_bypass_preserves_no_output_protocol(project: Path) -> None:
+    result = _run_hook(
+        "skills/example/SKILL.md",
+        event_cwd=str(project),
+        project_dir=str(project),
+        extra_env={"PLAN_GATE_BYPASS": "1"},
+    )
+
+    _assert_allowed(result)
+
+
+def test_invalid_json_preserves_no_output_protocol() -> None:
+    result = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input="not-json",
+        capture_output=True,
+        text=True,
+        cwd="/",
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_codex_adapter_denies_relative_patch_without_plan(project: Path) -> None:
+    event = {
+        "hook_event_name": "PreToolUse",
+        "session_id": "plan-gate-test",
+        "cwd": str(project),
+        "tool_name": "apply_patch",
+        "tool_input": {"command": ("*** Begin Patch\n*** Add File: skills/example/SKILL.md\n+content\n*** End Patch")},
+    }
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ADAPTER),
+            "--hook",
+            str(HOOK),
+            "--event",
+            "PreToolUse",
+            "--matcher",
+            "Write|Edit",
+            "--mode",
+            "patch",
+            "--failure-policy",
+            "closed",
+            "--timeout",
+            "2",
+        ],
+        input=json.dumps(event),
+        capture_output=True,
+        text=True,
+        cwd=project,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _decision(result) == "deny"

--- a/hooks/tests/test_pretool_plan_gate.py
+++ b/hooks/tests/test_pretool_plan_gate.py
@@ -18,10 +18,55 @@ ADAPTER = ROOT / "hooks" / "codex-hook-adapter.py"
 @pytest.fixture
 def project(tmp_path: Path) -> Path:
     root = tmp_path / "project"
-    (root / ".git").mkdir(parents=True)
+    _init_repository(root)
     (root / "agents" / "example").mkdir(parents=True)
     (root / "skills" / "example").mkdir(parents=True)
     return root
+
+
+def _git_environment() -> dict[str, str]:
+    env = dict(os.environ)
+    for key in ("GIT_COMMON_DIR", "GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE"):
+        env.pop(key, None)
+    env.update(
+        {
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_SYSTEM": os.devnull,
+        }
+    )
+    return env
+
+
+def _run_git(*args: str, cwd: Path) -> None:
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        env=_git_environment(),
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def _init_repository(root: Path) -> None:
+    root.parent.mkdir(parents=True, exist_ok=True)
+    _run_git("init", "--quiet", str(root), cwd=root.parent)
+
+
+def _write_linked_metadata(marker: Path, common: Path) -> None:
+    admin = common / "worktrees" / "forged"
+    (common / "objects").mkdir(parents=True)
+    (common / "refs").mkdir()
+    admin.mkdir(parents=True)
+    (common / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (common / "config").write_text("[core]\n\trepositoryformatversion = 0\n", encoding="utf-8")
+    (admin / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (admin / "commondir").write_text("../..\n", encoding="utf-8")
+    (admin / "gitdir").write_text(f"{marker}\n", encoding="utf-8")
+    marker.write_text(f"gitdir: {admin}\n", encoding="utf-8")
 
 
 def _run_hook(
@@ -58,6 +103,40 @@ def _run_hook(
         text=True,
         cwd="/",
         env=env,
+        timeout=10,
+        check=False,
+    )
+
+
+def _run_adapter(file_path: str, *, event_cwd: Path) -> subprocess.CompletedProcess[str]:
+    event = {
+        "hook_event_name": "PreToolUse",
+        "session_id": "plan-gate-test",
+        "cwd": str(event_cwd),
+        "tool_name": "apply_patch",
+        "tool_input": {"command": f"*** Begin Patch\n*** Add File: {file_path}\n+content\n*** End Patch"},
+    }
+    return subprocess.run(
+        [
+            sys.executable,
+            str(ADAPTER),
+            "--hook",
+            str(HOOK),
+            "--event",
+            "PreToolUse",
+            "--matcher",
+            "Write|Edit",
+            "--mode",
+            "patch",
+            "--failure-policy",
+            "closed",
+            "--timeout",
+            "2",
+        ],
+        input=json.dumps(event),
+        capture_output=True,
+        text=True,
+        cwd=event_cwd,
         timeout=10,
         check=False,
     )
@@ -138,10 +217,36 @@ def test_environment_root_without_git_is_supported(tmp_path: Path) -> None:
 
 
 def test_worktree_git_file_anchors_nested_codex_cwd(tmp_path: Path) -> None:
-    worktree = tmp_path / "worktree"
+    repository = tmp_path / "repository"
+    worktree = tmp_path / "linked-worktree"
+    _init_repository(repository)
+    _run_git(
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "user.name=Plan Gate Test",
+        "-c",
+        "user.email=plan-gate@example.invalid",
+        "commit",
+        "--quiet",
+        "--allow-empty",
+        "-m",
+        "fixture",
+        cwd=repository,
+    )
+    _run_git(
+        "-c",
+        "core.hooksPath=/dev/null",
+        "worktree",
+        "add",
+        "--quiet",
+        "--detach",
+        str(worktree),
+        "HEAD",
+        cwd=repository,
+    )
     nested = worktree / "skills" / "example"
     nested.mkdir(parents=True)
-    (worktree / ".git").write_text("gitdir: /tmp/common/worktrees/example\n", encoding="utf-8")
     (worktree / "task_plan.md").write_text("# Plan\n", encoding="utf-8")
 
     result = _run_hook(
@@ -151,6 +256,113 @@ def test_worktree_git_file_anchors_nested_codex_cwd(tmp_path: Path) -> None:
     )
 
     _assert_allowed(result)
+
+
+def test_valid_repository_directory_anchors_nested_codex_cwd(project: Path) -> None:
+    nested = project / "skills" / "example"
+    (project / "task_plan.md").write_text("# Plan\n", encoding="utf-8")
+
+    result = _run_hook(
+        "SKILL.md",
+        event_cwd=str(nested),
+        project_dir=str(nested),
+    )
+
+    _assert_allowed(result)
+
+
+def test_invalid_nested_git_file_cannot_reanchor_adapter(project: Path) -> None:
+    nested = project / "skills" / "example"
+    (nested / ".git").write_text("not valid git metadata\n", encoding="utf-8")
+
+    result = _run_adapter("SKILL.md", event_cwd=nested)
+
+    _assert_denied(result)
+
+
+def test_nested_gitdir_file_with_missing_target_cannot_reanchor_adapter(project: Path) -> None:
+    nested = project / "skills" / "example"
+    (nested / ".git").write_text(
+        "gitdir: /missing/git/worktree/metadata\n",
+        encoding="utf-8",
+    )
+
+    result = _run_adapter("SKILL.md", event_cwd=nested)
+
+    _assert_denied(result)
+
+
+def test_empty_nested_git_directory_cannot_reanchor_adapter(project: Path) -> None:
+    nested = project / "skills" / "example"
+    (nested / ".git").mkdir()
+
+    result = _run_adapter("SKILL.md", event_cwd=nested)
+
+    _assert_denied(result)
+
+
+def test_plausible_nested_git_directory_is_ambiguous_and_denied(project: Path) -> None:
+    nested = project / "skills" / "example"
+    marker = nested / ".git"
+    (marker / "objects").mkdir(parents=True)
+    (marker / "refs").mkdir()
+    (marker / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (marker / "config").write_text(
+        "[core]\n\trepositoryformatversion = 0\n",
+        encoding="utf-8",
+    )
+
+    result = _run_adapter("SKILL.md", event_cwd=nested)
+
+    _assert_denied(result)
+
+
+def test_forged_linked_worktree_cannot_override_outer_repository(project: Path, tmp_path: Path) -> None:
+    nested = project / "skills" / "example"
+    marker = nested / ".git"
+    common = tmp_path / "forged-common"
+    _write_linked_metadata(marker, common)
+
+    result = _run_adapter("SKILL.md", event_cwd=nested)
+
+    _assert_denied(result)
+
+
+def test_linked_marker_with_inaccessible_outer_marker_fails_closed(project: Path, tmp_path: Path) -> None:
+    nested = project / "skills" / "example"
+    _write_linked_metadata(nested / ".git", tmp_path / "forged-common")
+    outer_marker = project / ".git"
+    outer_marker.chmod(0)
+    try:
+        result = _run_adapter("SKILL.md", event_cwd=nested)
+    finally:
+        outer_marker.chmod(0o700)
+
+    _assert_denied(result)
+
+
+def test_unreadable_nested_git_file_cannot_reanchor_adapter(project: Path) -> None:
+    nested = project / "skills" / "example"
+    marker = nested / ".git"
+    marker.write_text("gitdir: /untrusted/location\n", encoding="utf-8")
+    marker.chmod(0)
+
+    result = _run_adapter("SKILL.md", event_cwd=nested)
+
+    _assert_denied(result)
+
+
+def test_relative_path_without_repository_marker_fails_closed(tmp_path: Path) -> None:
+    nested = tmp_path / "non-repository" / "skills" / "example"
+    nested.mkdir(parents=True)
+
+    result = _run_hook(
+        "SKILL.md",
+        event_cwd=str(nested),
+        project_dir=str(nested),
+    )
+
+    _assert_denied(result)
 
 
 def test_cwd_git_ancestor_is_used_when_project_environment_is_missing(project: Path) -> None:
@@ -373,38 +585,7 @@ def test_invalid_json_preserves_no_output_protocol() -> None:
 
 
 def test_codex_adapter_denies_relative_patch_without_plan(project: Path) -> None:
-    event = {
-        "hook_event_name": "PreToolUse",
-        "session_id": "plan-gate-test",
-        "cwd": str(project),
-        "tool_name": "apply_patch",
-        "tool_input": {"command": ("*** Begin Patch\n*** Add File: skills/example/SKILL.md\n+content\n*** End Patch")},
-    }
-
-    result = subprocess.run(
-        [
-            sys.executable,
-            str(ADAPTER),
-            "--hook",
-            str(HOOK),
-            "--event",
-            "PreToolUse",
-            "--matcher",
-            "Write|Edit",
-            "--mode",
-            "patch",
-            "--failure-policy",
-            "closed",
-            "--timeout",
-            "2",
-        ],
-        input=json.dumps(event),
-        capture_output=True,
-        text=True,
-        cwd=project,
-        timeout=10,
-        check=False,
-    )
+    result = _run_adapter("skills/example/SKILL.md", event_cwd=project)
 
     assert result.returncode == 0, result.stderr
     assert _decision(result) == "deny"

--- a/scripts/tests/test_codex_hooks_runtime_compat.py
+++ b/scripts/tests/test_codex_hooks_runtime_compat.py
@@ -356,6 +356,19 @@ def _prepare_case(
             "Please preserve this authentic runtime request while checking that the Codex prompt capture hook "
             "records natural language from a real development repository without mistaking it for generated text."
         )
+    elif filename == "pretool-plan-gate.py":
+        git_env = dict(env)
+        for key in ("GIT_COMMON_DIR", "GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE"):
+            git_env.pop(key, None)
+        git_env.update({"GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_SYSTEM": os.devnull})
+        completed = subprocess.run(
+            ["git", "-c", "core.hooksPath=/dev/null", "init", "--quiet"],
+            cwd=cwd,
+            env=git_env,
+            capture_output=True,
+            check=False,
+        )
+        assert completed.returncode == 0, completed.stderr
     elif filename in {"routing-outcome-finalizer.py", "routing-outcome-recorder.py"}:
         evidence["routing_state"] = _seed_pending_route(env, session_id)
         if filename == "routing-outcome-finalizer.py":


### PR DESCRIPTION
## Summary

- anchor plan checks to the project root
- normalize native and Codex paths safely
- cover root, worktree, traversal, symlink, and protocol cases

Replaces #876. Credit to @thecodingshrimp for identifying the root-resolution bug.

## Checks

- focused: 26 passed
- relevant hook stack: 183 passed
- full suite: 7,465 passed, 6 skipped, 127 xfailed
- Ruff, format, mypy, compile, and security scan passed
