### PR TITLE
fix: enforce README Four Layers counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ Strips built-in tool-use instructions. The toolkit's agents, skills, hooks, and 
 | Layer | Count | Does |
 |---|---|---|
 | Agents | 44 | Domain knowledge: idiom tables, failure mode catalogs, error-to-fix mappings |
-| Skills | 120 | Phased methodology with gates. Can't skip steps. Each phase has exit criteria requiring evidence. |
-| Hooks | 88 | Fire on lifecycle events. Block incomplete work. Zero LLM cost. |
-| Scripts | 129 | Determinism: test runners, linters, validators. No LLM judgment. |
+| Skills | 119 | Phased methodology with gates. Can't skip steps. Each phase has exit criteria requiring evidence. |
+| Hooks | 86 | Fire on lifecycle events. Block incomplete work. Zero LLM cost. |
+| Scripts | 131 | Determinism: test runners, linters, validators. No LLM judgment. |
 
 Full skill catalog: [docs/skills.md](docs/skills.md).
 

--- a/docs/acceptance/2026-08-14-01-doc-count-validator.md
+++ b/docs/acceptance/2026-08-14-01-doc-count-validator.md
@@ -1,0 +1,57 @@
+# Acceptance: README doc-count validator
+
+- Date: 2026-08-14
+- Peer: `e3c5b3b8-505a-41de-a2c0-bd56c815a2f0` (`Implement README count validation`)
+- Brief/branch: make `scripts/validate-doc-counts.py` gate the README Four Layers table, add success and mismatch coverage, and keep the final tree internally consistent; `peer/doc-count-validator`
+- Candidate commits: `4ad8ad9940ee68fe28b048f4a26b1d3c93938771`, `2d32a9cd131850195b23f7762dda6e08435ac52e`
+
+## Evidence
+
+- `python3 scripts/validate-doc-counts.py` -> exit 0; tail: `All count claims agree with filesystem.`
+- `uvx --isolated --from pytest pytest -q scripts/tests/test_validate_doc_counts.py` -> exit 0; tail: `3 passed in 0.18s`
+- `uvx --isolated --from pytest pytest -q scripts/tests/test_validate_doc_counts.py::test_four_layers_mismatch_is_actionable_and_fails` -> exit 0; tail: `1 passed in 0.10s`; the test asserts the validator itself exits 1 and prints the exact filesystem-versus-README values.
+- `uvx --isolated --from ruff==0.15.12 ruff check . --config pyproject.toml` -> exit 0; tail: `All checks passed!`
+- `uvx --isolated --from ruff==0.15.12 ruff format --check . --config pyproject.toml` -> exit 0; tail: `594 files already formatted`
+- `uvx --isolated --from pytest --with-requirements requirements.lock --with pillow --with numpy --with pip pytest --tb=short -q` -> exit 0; tail: `7600 passed, 25 skipped, 146 xfailed, 7 warnings in 375.53s`
+- `git diff --check fix/verify-doc-counts...HEAD` -> exit 0; no output.
+- `git status --short --branch` -> exit 0; tail: `## peer/doc-count-validator`.
+
+## Verdict
+
+Accepted after corrective round 1.
+
+The initial candidate correctly implemented comparison and failure output but left the clean repository gate red because the Four Layers table itself was stale. The corrective round changed only the stale count cells, after which targeted, lint, formatting, validator, and full-suite gates passed.
+
+## Defects Found And Fixed
+
+- The pre-change validator reported filesystem truth without parsing or enforcing the Four Layers table.
+- The table had three stale values while the README intro already held the current filesystem values.
+- The first candidate preserved the stale table because the Lead brief incorrectly excluded all README edits; the corrected brief authorized only those table cells.
+
+## Premises Disproved
+
+- "README must remain unchanged" was false for the final deliverable. Preserving intended README semantics required aligning its stale table with the already-correct intro and filesystem truth.
+
+## Cost Of Recurrence
+
+Measured: a recurrence would again permit stale public figures to survive the named CI validator and would require another table audit, deliberate-failure proof, and corrective review round. This occurrence involved three stale cells and one corrective round.
+
+Structural signal: suspected
+
+Lens: mechanism-free claim
+
+Bounded checkpoint: Checked whether the named validator converted the Four Layers documentation claim into a failing comparison rather than only printing filesystem truth.
+
+Causal mechanism: A validator that never parses the claimed table can remain green while the public figures drift.
+
+Observed cost: Measured - three stale table cells and one corrective round before the clean gate passed.
+
+Strongest counterargument: The generic prose-count scanner already covered many documentation claims, and the table's label-before-number shape simply fell outside that established grammar.
+
+Structural verdict: confirmed
+
+Memory: experience-candidate
+
+## Archive Authorization
+
+Authorized after the accepted commits merge cleanly into the Lead integration branch.

--- a/scripts/tests/test_validate_doc_counts.py
+++ b/scripts/tests/test_validate_doc_counts.py
@@ -8,6 +8,48 @@ import sys
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parent.parent / "validate-doc-counts.py"
+VALIDATOR = SCRIPT
+
+
+def make_repo(tmp_path: Path, table_counts: tuple[int, int, int, int]) -> Path:
+    root = tmp_path / "repo"
+    for directory, count, suffix in (
+        ("agents", 2, ".md"),
+        ("hooks", 1, ".py"),
+        ("scripts", 4, ".py"),
+    ):
+        target = root / directory
+        target.mkdir(parents=True)
+        for index in range(count):
+            (target / f"item-{index}{suffix}").write_text("", encoding="utf-8")
+
+    skill_root = root / "skills" / "example"
+    for index in range(3):
+        skill_dir = skill_root / f"skill-{index}"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("", encoding="utf-8")
+
+    agents, skills, hooks, scripts = table_counts
+    (root / "README.md").write_text(
+        "## Four Layers\n\n"
+        "| Layer | Count | Does |\n"
+        "|---|---|---|\n"
+        f"| Agents | {agents} | agent layer |\n"
+        f"| Skills | {skills} | skill layer |\n"
+        f"| Hooks | {hooks} | hook layer |\n"
+        f"| Scripts | {scripts} | script layer |\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def run_validator(repo: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(VALIDATOR), "--repo-root", str(repo)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
 
 def test_repo_root_option_counts_target_as_data(tmp_path: Path) -> None:
@@ -31,3 +73,19 @@ def test_repo_root_option_counts_target_as_data(tmp_path: Path) -> None:
     assert report["truth"]["agents"] == 1
     assert report["truth"]["scripts"] == 1
     assert report["truth"]["hooks"] == 1
+
+
+def test_four_layers_table_matches_filesystem(tmp_path: Path) -> None:
+    result = run_validator(make_repo(tmp_path, (2, 3, 1, 4)))
+
+    assert result.returncode == 0
+    assert "All count claims agree with filesystem." in result.stdout
+
+
+def test_four_layers_mismatch_is_actionable_and_fails(tmp_path: Path) -> None:
+    result = run_validator(make_repo(tmp_path, (2, 4, 1, 4)))
+
+    assert result.returncode == 1
+    assert "README.md:6" in result.stdout
+    assert "Four Layers / Skills" in result.stdout
+    assert "expected=3 (filesystem), actual=4 (README)" in result.stdout

--- a/scripts/validate-doc-counts.py
+++ b/scripts/validate-doc-counts.py
@@ -29,6 +29,13 @@ DOCS_DIR = REPO_ROOT / "docs"
 ROOT_MARKDOWN = ["README.md", "CONTRIBUTING.md", "CLAUDE.md"]
 SETTINGS = REPO_ROOT / ".claude" / "settings.json"
 BANNED_PATTERNS = REPO_ROOT / "scripts" / "data" / "banned-patterns.json"
+FOUR_LAYERS = ("agents", "skills", "hooks", "scripts")
+FOUR_LAYERS_HEADING = re.compile(r"^\s*##\s+Four Layers\s*$", re.IGNORECASE)
+NEXT_SECTION = re.compile(r"^\s*##\s+")
+FOUR_LAYERS_ROW = re.compile(
+    r"^\s*\|\s*(Agents|Skills|Hooks|Scripts)\s*\|\s*([^|]+?)\s*\|",
+    re.IGNORECASE,
+)
 
 
 def configure_repo_root(repo_root: Path) -> None:
@@ -142,6 +149,97 @@ def collect_markdown_files() -> list[Path]:
     return files
 
 
+def validate_four_layers() -> tuple[list[dict], int]:
+    """Compare the README Four Layers table with the filesystem counts."""
+    readme = REPO_ROOT / "README.md"
+    if not readme.is_file():
+        return [], 0
+
+    lines = readme.read_text(encoding="utf-8", errors="replace").splitlines()
+    heading_line = next(
+        (index for index, line in enumerate(lines) if FOUR_LAYERS_HEADING.match(line)),
+        None,
+    )
+    if heading_line is None:
+        return [
+            {
+                "kind": "four_layers",
+                "source": "README.md",
+                "line": 1,
+                "message": "Four Layers table is missing; add the `## Four Layers` section",
+            }
+        ], 0
+
+    rows: dict[str, tuple[int, str, int | None]] = {}
+    drifts: list[dict] = []
+    for offset, line in enumerate(lines[heading_line + 1 :], start=heading_line + 2):
+        if NEXT_SECTION.match(line):
+            break
+        match = FOUR_LAYERS_ROW.match(line)
+        if not match:
+            continue
+        layer = match.group(1).lower()
+        raw_count = match.group(2).strip()
+        if layer in rows:
+            drifts.append(
+                {
+                    "kind": "four_layers",
+                    "source": "README.md",
+                    "line": offset,
+                    "layer": layer,
+                    "message": f"duplicate {layer.title()} row; keep exactly one Four Layers row",
+                }
+            )
+            continue
+        claimed = int(raw_count) if raw_count.isdigit() else None
+        rows[layer] = (offset, raw_count, claimed)
+
+    truth = ground_truth()
+    for layer in FOUR_LAYERS:
+        row = rows.get(layer)
+        if row is None:
+            drifts.append(
+                {
+                    "kind": "four_layers",
+                    "source": "README.md",
+                    "line": heading_line + 1,
+                    "layer": layer,
+                    "expected": truth[layer],
+                    "actual": None,
+                    "message": f"missing {layer.title()} row; add it with the filesystem count",
+                }
+            )
+            continue
+
+        line_no, raw_count, claimed = row
+        if claimed is None:
+            drifts.append(
+                {
+                    "kind": "four_layers",
+                    "source": "README.md",
+                    "line": line_no,
+                    "layer": layer,
+                    "expected": truth[layer],
+                    "actual": raw_count,
+                    "message": f"{layer.title()} count must be a decimal integer",
+                }
+            )
+        elif claimed != truth[layer]:
+            drifts.append(
+                {
+                    "kind": "four_layers",
+                    "source": "README.md",
+                    "line": line_no,
+                    "layer": layer,
+                    "expected": truth[layer],
+                    "actual": claimed,
+                    "message": f"{layer.title()} count differs from filesystem ground truth",
+                }
+            )
+
+    return drifts, len(rows)
+
+
 def normalize(thing: str) -> str:
     t = thing.lower().rstrip("s")
     if t == "hook event":
@@ -203,6 +301,10 @@ def main() -> int:
     drifts: list[dict] = []
     checked = 0
 
+    four_layers_drifts, four_layers_checked = validate_four_layers()
+    drifts.extend(four_layers_drifts)
+    checked += four_layers_checked
+
     for md in collect_markdown_files():
         text = md.read_text(encoding="utf-8", errors="replace")
         rel = md.relative_to(REPO_ROOT)
@@ -250,7 +352,17 @@ def main() -> int:
         if drifts:
             print(f"\nDrifts: {len(drifts)}")
             for d in drifts:
-                print(f"  {d['source']}:{d['line']}  {d['claim']!r}  actual={d['actual']}")
+                if d.get("kind") == "four_layers":
+                    layer_label = d.get("layer", "table").title()
+                    if "expected" in d and "actual" in d:
+                        print(
+                            f"  {d['source']}:{d['line']}  Four Layers / {layer_label}: "
+                            f"expected={d['expected']} (filesystem), actual={d['actual']} (README)"
+                        )
+                    else:
+                        print(f"  {d['source']}:{d['line']}  Four Layers / {layer_label}: {d['message']}")
+                else:
+                    print(f"  {d['source']}:{d['line']}  {d['claim']!r}  actual={d['actual']}")
         else:
             print("All count claims agree with filesystem.")
 


### PR DESCRIPTION
## Summary

Make the documentation count validator enforce the README Four Layers table and fail with an actionable filesystem-versus-README diff.

## Changes

- `scripts/validate-doc-counts.py` — parse every Four Layers row, reject missing, duplicate, malformed, or stale values, and return a failing exit status.
- `scripts/tests/test_validate_doc_counts.py` — cover matching and deliberately mismatched tables through the CLI.
- `README.md` — align the stale table cells with filesystem truth and the already-correct intro.
- `docs/acceptance/2026-08-14-01-doc-count-validator.md` — record acceptance evidence and corrective history.

## Notes

- Deliberate mismatch coverage asserts exit 1 and exact expected-versus-actual output without modifying the final README.
- Full local suite: 7600 passed, 25 skipped, 146 xfailed.
