### PR TITLE
feat: query saved skill eval runs

### DIFF
--- a/docs/acceptance/2026-08-15-01-saved-run-query.md
+++ b/docs/acceptance/2026-08-15-01-saved-run-query.md
@@ -1,0 +1,33 @@
+# Acceptance: saved ablation run query
+
+- Brief: Add a small repository-appropriate query surface for runs written by `scripts/skill-eval-ablation.py`, with meaningful automated coverage and project quality gates. Excluded storage redesign, hook behavior changes, and unrelated cleanup.
+- Peer / branch: `73137d1b-67b8-4789-b7d8-608418badd3e` / `peer/saved-run-query`
+- Accepted commit: `70dade07038205b3c77a64d9e44e59616df4a26e`
+
+## Evidence
+
+- `uv run --no-project --with pytest --with pyyaml --with ruff python -m pytest scripts/tests/test_skill_eval_ablation.py hooks/tests/test_telemetry_envelope.py -q` — exit 0; tail: `37 passed in 2.31s`.
+- `uvx ruff check scripts/learning-db.py scripts/tests/test_skill_eval_ablation.py --config pyproject.toml` — exit 0; tail: `All checks passed!`.
+- `uvx ruff format --check scripts/learning-db.py scripts/tests/test_skill_eval_ablation.py --config pyproject.toml` — exit 0; tail: `2 files already formatted`.
+- `uvx ruff check . --config pyproject.toml` — exit 0; tail: `All checks passed!`.
+- `git diff --check 586f89bc..70dade07038205b3c77a64d9e44e59616df4a26e` — exit 0; no output.
+- `git status --short --branch` in the Peer worktree — exit 0; tail: `## peer/saved-run-query`.
+- Peer broad gate: `uv run --with ruff ruff format --check . --config pyproject.toml` — exit 1; 62 unrelated pre-existing files were reported unformatted.
+- Peer broad gate: `uv run --with pytest --with pyyaml --with pillow --with numpy python -m pytest --tb=short -q` — exit 1; tail: `7499 passed, 22 failed, 28 skipped, 146 xfailed`; reported failures were outside changed files and tied to missing `jsonschema`, system `pip`, or generated-index isolation.
+
+## Verdict
+
+- Acceptance verdict: accepted; corrective rounds: 0.
+- Defects found and fixed: the Peer corrected one Ruff formatting issue in the new query code before commit. Lead review found no remaining scope defect.
+- Premises disproved: repository-wide format and pytest commands are not currently fully green in this environment, despite focused and adjacent gates passing.
+- Cost of recurrence: each small Python change would repeat a full-suite run and triage 62 formatter findings plus 22 unrelated test failures before establishing changed-scope health.
+- Archive authorization: authorized after merge; accepted verdict.
+
+Structural signal: suspected
+Lens: avoidable taxes
+Bounded checkpoint: repository-wide Ruff format and pytest evidence for this bounded Python change.
+Causal mechanism: broad gates include existing format debt and environment-sensitive tests outside the changed scope.
+Observed cost: measured one 62-file format failure and one dependency-complete run ending with 22 failures after 7,499 passes.
+Strongest counterargument: the repository defines tool configuration but no Make target declaring these exact broad commands as mandatory gates.
+Structural verdict: confirmed
+Memory: local-defect

--- a/evals/README.md
+++ b/evals/README.md
@@ -83,11 +83,20 @@ The command restores the working tree on every exit path; a crashed run leaves
 no base content checked out.
 
 `RECORD=1` writes one row per run to `learning.db` (topic `eval:<dir>`,
-`git_commit_sha` = head SHA), so eval history becomes a queryable time-series:
+`git_commit_sha` = head SHA), so eval history becomes a queryable time-series.
+Use the repository's learning DB CLI to query it:
 
 ```bash
-python3 scripts/learning-db.py query --topic "eval:evals/new-skills-ab-test"
+python3 scripts/learning-db.py telemetry-query \
+  --topic "eval:evals/new-skills-ab-test" --git-sha <head-sha> --format json
 ```
+
+The command reads the per-run `telemetry_runs` rows on current databases. It
+also reads the older `learnings` fallback written by degraded ablation runs;
+fallback JSON rows have `"storage": "learnings"`, parsed `pass_rate`, `runs`,
+`base_sha`, and `head_sha` fields. When both representations exist for the
+same topic/key, the per-run telemetry rows are authoritative and the fallback
+summary is not duplicated.
 
 If PR-A's telemetry envelope columns are absent, `--record` degrades to a no-op
 against those columns: it still writes the row (envelope packed into `value`)

--- a/scripts/learning-db.py
+++ b/scripts/learning-db.py
@@ -28,7 +28,7 @@ Usage:
     python3 scripts/learning-db.py route-stats --by agent|skill|force-route|errors|override|week|day [--json]
     python3 scripts/learning-db.py review-roi [--json]
     python3 scripts/learning-db.py route-delta --from REF --to REF [--key AGENT:SKILL] [--metric error|tokens] [--json]
-    python3 scripts/learning-db.py telemetry-query --topic eval:evals/<dir> [--git-sha SHA] [--format json]
+    python3 scripts/learning-db.py telemetry-query --topic eval:evals/<dir> [--git-sha SHA] [--key KEY] [--format json]
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --success
     python3 scripts/learning-db.py record-routing-outcome AGENT_SKILL --failure --reason "user re-routed"
     python3 scripts/learning-db.py route-failure AGENT:SKILL --reason "re-route after unusable output" --routing-relevant yes [--session SID --marker MK]
@@ -1052,12 +1052,34 @@ def cmd_route_delta(args: argparse.Namespace) -> None:
             print(f"WARNING: cohort {label} has only {n} run(s) (< MIN_N={MIN_N}); treat the delta as low-confidence.")
 
 
-def cmd_telemetry_query(args: argparse.Namespace) -> None:
-    """telemetry-query --topic T [--git-sha SHA]: read per-run rows from telemetry_runs.
+def _parse_ablation_value(value: str) -> dict[str, object]:
+    """Parse the key=value envelope used by pre-telemetry ablation records."""
+    fields: dict[str, object] = {}
+    for part in (value or "").split():
+        name, separator, raw = part.partition("=")
+        if not separator:
+            continue
+        fields[name] = raw
 
-    PR-A's envelope (git_sha/model_id/skill_version) lives in telemetry_runs, not
-    on learnings. This reads those rows back by topic, optionally scoped to a
-    git-SHA prefix. Used to verify an ablation run landed under its head SHA.
+    for name in ("pass_rate",):
+        try:
+            fields[name] = float(fields[name])
+        except (KeyError, TypeError, ValueError):
+            fields[name] = None
+    try:
+        fields["runs"] = int(fields["runs"])
+    except (KeyError, TypeError, ValueError):
+        fields["runs"] = None
+    return fields
+
+
+def cmd_telemetry_query(args: argparse.Namespace) -> None:
+    """Read telemetry_runs rows and compatible ablation fallback records.
+
+    Current ablation runs store their per-run envelope in telemetry_runs. Older
+    or degraded runs store one packed summary in learnings; those rows are
+    returned only when a matching telemetry row is not present. JSON fallback
+    rows include ``storage=learnings`` plus the parsed pass rate and run count.
     Report-only; exit 0.
     """
     init_db()
@@ -1073,7 +1095,7 @@ def cmd_telemetry_query(args: argparse.Namespace) -> None:
     where = " AND ".join(clauses)
     params.append(args.limit)
     with get_connection() as conn:
-        rows = [
+        telemetry_rows = [
             dict(r)
             for r in conn.execute(
                 f"SELECT * FROM telemetry_runs WHERE {where} ORDER BY recorded_at DESC LIMIT ?",  # security-review: ignore (fixed clauses; user values bound as ?)
@@ -1081,14 +1103,75 @@ def cmd_telemetry_query(args: argparse.Namespace) -> None:
             ).fetchall()
         ]
 
+        for row in telemetry_rows:
+            row["storage"] = "telemetry_runs"
+
+        fallback_params = [args.topic, "effectiveness", "manual:skill-eval-ablation"]
+        fallback_sql = (
+            "SELECT rowid AS learning_id, topic, key, value, source, category, "
+            "first_seen, last_seen, observation_count "
+            "FROM learnings WHERE topic = ? AND category = ? AND source = ?"
+        )
+        if args.key:
+            fallback_sql += " AND key = ?"
+            fallback_params.append(args.key)
+        fallback_sql += " ORDER BY last_seen DESC LIMIT ?"
+        fallback_params.append(args.limit)
+        fallback_rows = [dict(r) for r in conn.execute(fallback_sql, fallback_params).fetchall()]
+
+    rows = list(telemetry_rows)
+    telemetry_identity = {(r["topic"], r["key"], r.get("git_sha")) for r in telemetry_rows}
+    telemetry_keys = {(r["topic"], r["key"]) for r in telemetry_rows}
+    for learning in fallback_rows:
+        parsed = _parse_ablation_value(learning["value"])
+        git_sha = parsed.get("git_commit_sha") or parsed.get("head")
+        if args.git_sha and (not isinstance(git_sha, str) or not git_sha.startswith(args.git_sha)):
+            continue
+        if not args.git_sha and (learning["topic"], learning["key"]) in telemetry_keys:
+            continue
+        if args.git_sha and (learning["topic"], learning["key"], git_sha) in telemetry_identity:
+            continue
+        rows.append(
+            {
+                "id": None,
+                "run_id": None,
+                "batch_id": None,
+                "topic": learning["topic"],
+                "key": learning["key"],
+                "session_id": None,
+                "git_sha": git_sha,
+                "model_id": parsed.get("model_id"),
+                "skill_version": parsed.get("skill_version"),
+                "token_count": None,
+                "wall_clock_ms": None,
+                "tool_errors": 0,
+                "recorded_at": learning["last_seen"],
+                "source": learning["source"],
+                "storage": "learnings",
+                "learning_id": learning["learning_id"],
+                "pass_rate": parsed.get("pass_rate"),
+                "runs": parsed.get("runs"),
+                "base_sha": parsed.get("base"),
+                "head_sha": parsed.get("head"),
+                "observation_count": learning["observation_count"],
+                "value": learning["value"],
+            }
+        )
+
+    rows.sort(key=lambda row: row.get("recorded_at") or "", reverse=True)
+    rows = rows[: args.limit]
+
     if args.format == "json":
         print(json.dumps(rows, indent=2, default=str))
         return
     if not rows:
-        print(f"No telemetry runs for topic={args.topic}.")
+        print(f"No telemetry or ablation fallback runs for topic={args.topic}.")
         return
     for r in rows:
-        print(f"{r['recorded_at']}  {r['topic']}/{r['key']}  git_sha={r['git_sha']}  source={r['source']}")
+        line = f"{r['recorded_at']}  {r['topic']}/{r['key']}  git_sha={r['git_sha']}  source={r['source']}"
+        if r["storage"] == "learnings":
+            line += f"  pass_rate={r['pass_rate']}  runs={r['runs']}  storage=learnings"
+        print(line)
 
 
 def _print_json(data) -> None:
@@ -2109,8 +2192,10 @@ def main():
     p_route_delta.add_argument("--json", action="store_true", help="Output as JSON")
     p_route_delta.set_defaults(func=cmd_route_delta)
 
-    # telemetry-query — read per-run envelope rows (incl. git_sha) from telemetry_runs.
-    p_tquery = subparsers.add_parser("telemetry-query", help="Query per-run telemetry_runs rows by topic")
+    # telemetry-query — read telemetry_runs rows and ablation compatibility fallbacks.
+    p_tquery = subparsers.add_parser(
+        "telemetry-query", help="Query telemetry_runs and saved ablation fallback rows by topic"
+    )
     p_tquery.add_argument("--topic", required=True, help="Filter by topic (e.g., eval:evals/<dir>)")
     p_tquery.add_argument("--git-sha", dest="git_sha", help="Filter to a git-SHA prefix")
     p_tquery.add_argument("--key", help="Filter to one key (e.g., <skill>@<head>:<arm>)")

--- a/scripts/tests/test_skill_eval_ablation.py
+++ b/scripts/tests/test_skill_eval_ablation.py
@@ -138,6 +138,51 @@ def test_record_no_envelope_still_writes_db_row(temp_db_no_envelope, tmp_path, m
     assert "git_commit_sha=" + "h" * 40 in rows[0]["value"]
 
 
+def test_telemetry_query_reads_no_envelope_fallback(temp_db_no_envelope, tmp_path, monkeypatch):
+    """The established CLI returns the packed pre-telemetry ablation record."""
+    mod = _load_module()
+    monkeypatch.setattr(mod, "ABLATION_LOG", tmp_path / "log.jsonl", raising=False)
+    head = "h" * 40
+    mod.record_run(
+        eval_dir="evals/x",
+        skill="quick",
+        arm="base",
+        pass_rate=0.5,
+        runs=2,
+        base_sha="b" * 40,
+        head_sha=head,
+        model_id="claude-x",
+        skill_version="1.0.0",
+    )
+
+    res = subprocess.run(
+        [
+            sys.executable,
+            str(LEARNING_DB_CLI),
+            "telemetry-query",
+            "--topic",
+            "eval:evals/x",
+            "--git-sha",
+            head,
+            "--key",
+            f"quick@{head}:base",
+            "--format",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        env={**_clean_env(), "CLAUDE_LEARNING_DIR": str(temp_db_no_envelope.parent)},
+    )
+    assert res.returncode == 0, res.stderr
+    rows = json.loads(res.stdout)
+    assert len(rows) == 1
+    assert rows[0]["storage"] == "learnings"
+    assert rows[0]["git_sha"] == head
+    assert rows[0]["base_sha"] == "b" * 40
+    assert rows[0]["pass_rate"] == 0.5
+    assert rows[0]["runs"] == 2
+
+
 # ---------------------------------------------------------------------------
 # --record promotion (PR-A envelope present) -- Validation Requirement 5.
 #
@@ -184,6 +229,8 @@ def test_record_with_envelope_writes_telemetry_run(temp_db_with_envelope, tmp_pa
     assert res.returncode == 0, res.stderr
     rows = json.loads(res.stdout)
     assert rows, "expected at least one telemetry_runs row"
+    assert len(rows) == 1, "telemetry row is authoritative over its learnings summary"
+    assert rows[0]["storage"] == "telemetry_runs"
     assert any(r.get("git_sha") == head for r in rows)
     assert all(r.get("git_sha") == head for r in rows)
     # The human summary row still lands in learnings for queryability.


### PR DESCRIPTION
## Scope A

- extend the existing learning DB telemetry-query command to include skill-eval-ablation fallback rows
- preserve telemetry_runs as authoritative while normalizing legacy learning summaries
- document the interface and add focused current/fallback storage coverage
- add the Lead acceptance record

## Validation

- focused pytest: 37 passed
- scoped Ruff lint and format: passed
- repository-wide Ruff lint: passed
- git diff check: passed
- broad repository format and pytest commands retain unrelated baseline/environment failures documented in the acceptance record

## Scope B

The hook-to-harness audit was investigation-only and caused no repository changes; its evidence matrix is delivered in the Lead handback rather than this diff.
